### PR TITLE
fix(DataToolbar): max depth fix

### DIFF
--- a/packages/react-core/src/components/DataToolbar/DataToolbar.tsx
+++ b/packages/react-core/src/components/DataToolbar/DataToolbar.tsx
@@ -39,6 +39,7 @@ interface FilterInfo {
 export class DataToolbar extends React.Component<DataToolbarProps, DataToolbarState> {
   private chipGroupContentRef = React.createRef<HTMLDivElement>();
   static hasWarnBeta = false;
+  private staticFilterInfo = {};
   constructor(props: DataToolbarProps) {
     super(props);
 
@@ -82,15 +83,15 @@ export class DataToolbar extends React.Component<DataToolbarProps, DataToolbarSt
   }
 
   updateNumberFilters = (categoryName: string, numberOfFilters: number) => {
-    const filterInfoToUpdate: FilterInfo = { ...this.state.filterInfo };
-
+    const filterInfoToUpdate: FilterInfo = { ...this.staticFilterInfo };
     if (!filterInfoToUpdate.hasOwnProperty(categoryName) || filterInfoToUpdate[categoryName] !== numberOfFilters) {
       filterInfoToUpdate[categoryName] = numberOfFilters;
+      this.staticFilterInfo = filterInfoToUpdate;
       this.setState({ filterInfo: filterInfoToUpdate });
     }
   };
 
-  getNumberOfFilters = () => Object.values(this.state.filterInfo).reduce((acc, cur) => acc + cur, 0);
+  getNumberOfFilters = () => Object.values(this.state.filterInfo).reduce((acc: any, cur: any) => acc + cur, 0);
 
   render() {
     const {

--- a/packages/react-core/src/components/DataToolbar/__tests__/__snapshots__/DataToolbar.test.tsx.snap
+++ b/packages/react-core/src/components/DataToolbar/__tests__/__snapshots__/DataToolbar.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`data toolbar DataToolbarFilter 1`] = `
                 className="pf-c-data-toolbar__toggle"
               >
                 <Component
-                  aria-controls="data-toolbar-expandable-content-7"
+                  aria-controls="data-toolbar-expandable-content-6"
                   aria-haspopup={false}
                   aria-label="Show Filters"
                   onClick={[Function]}
@@ -54,7 +54,7 @@ exports[`data toolbar DataToolbarFilter 1`] = `
                     component={[Function]}
                     componentProps={
                       Object {
-                        "aria-controls": "data-toolbar-expandable-content-7",
+                        "aria-controls": "data-toolbar-expandable-content-6",
                         "aria-haspopup": false,
                         "aria-label": "Show Filters",
                         "children": <FilterIcon
@@ -70,7 +70,7 @@ exports[`data toolbar DataToolbarFilter 1`] = `
                     consumerContext={null}
                   >
                     <Button
-                      aria-controls="data-toolbar-expandable-content-7"
+                      aria-controls="data-toolbar-expandable-content-6"
                       aria-haspopup={false}
                       aria-label="Show Filters"
                       onClick={[Function]}
@@ -83,7 +83,7 @@ exports[`data toolbar DataToolbarFilter 1`] = `
                       variant="plain"
                     >
                       <button
-                        aria-controls="data-toolbar-expandable-content-7"
+                        aria-controls="data-toolbar-expandable-content-6"
                         aria-disabled={null}
                         aria-haspopup={false}
                         aria-label="Show Filters"
@@ -1455,7 +1455,7 @@ exports[`data toolbar DataToolbarFilter 1`] = `
             Object {
               "current": <div
                 class="pf-c-data-toolbar__expandable-content"
-                id="data-toolbar-expandable-content-7"
+                id="data-toolbar-expandable-content-6"
               >
                 <div
                   class="pf-c-data-toolbar__group"
@@ -1484,13 +1484,13 @@ exports[`data toolbar DataToolbarFilter 1`] = `
               </div>,
             }
           }
-          id="data-toolbar-expandable-content-7"
+          id="data-toolbar-expandable-content-6"
           isExpanded={false}
           showClearFiltersButton={true}
         >
           <div
             className="pf-c-data-toolbar__expandable-content"
-            id="data-toolbar-expandable-content-7"
+            id="data-toolbar-expandable-content-6"
           >
             <ForwardRef>
               <DataToolbarGroupWithRef


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #3770

Alternate fix for 3770. Uses a private variable instead of state to decide if state should update in `updateNumberFilters`. The state is still used inside the function to get the proper re-rendering for chip updates (clear all button / chip group appearances).

What I think was happening was that the `filterInfo` state was being updated and overridden while all of the filters were being evaluated and updated, so the initial iteration of the filters wasn't getting completed properly and recursing.