### PR TITLE
fix(version): mis-match in readme

### DIFF
--- a/packages/react-core/README.md
+++ b/packages/react-core/README.md
@@ -8,7 +8,7 @@ This package provides Core PatternFly components for the [PatternFly 4][patternf
 
 This project currently supports Node [Active LTS](https://github.com/nodejs/Release#release-schedule) releases. Please stay current with Node Active LTS when developing patternfly-react.
 
-For example, to develop with Node 8, use the following:
+For example, to develop with Node 10, use the following:
 
 ```
 nvm install 10


### PR DESCRIPTION
Closes #4118 

Issue:
![Screen Shot 2020-04-23 at 11 13 22 AM](https://user-images.githubusercontent.com/57504257/80119575-df1ba000-8557-11ea-9b6c-eb6282bf3a0f.png)

Fix:
    All three node version now match...


