### PR TITLE
Chore/4114 wrap icons

### DIFF
--- a/packages/react-core/src/components/Accordion/AccordionToggle.tsx
+++ b/packages/react-core/src/components/Accordion/AccordionToggle.tsx
@@ -37,7 +37,9 @@ export const AccordionToggle: React.FunctionComponent<AccordionToggleProps> = ({
             aria-expanded={isExpanded}
           >
             <span className={css(styles.accordionToggleText)}>{children}</span>
-            <AngleRightIcon className={css(styles.accordionToggleIcon)} />
+            <span className={css(styles.accordionToggleIcon)}>
+              <AngleRightIcon />
+            </span>
           </button>
         </Container>
       );

--- a/packages/react-core/src/components/Accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/react-core/src/components/Accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
@@ -23,21 +23,24 @@ exports[`Accordion Accordion with non-default headingLevel 1`] = `
       >
         Item One
       </span>
-      <svg
-        aria-hidden="true"
+      <span
         class="pf-c-accordion__toggle-icon"
-        fill="currentColor"
-        height="1em"
-        role="img"
-        style="vertical-align:-0.125em"
-        viewBox="0 0 256 512"
-        width="1em"
       >
-        <path
-          d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-          transform=""
-        />
-      </svg>
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align:-0.125em"
+          viewBox="0 0 256 512"
+          width="1em"
+        >
+          <path
+            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+            transform=""
+          />
+        </svg>
+      </span>
     </button>
   </h2>
   <div

--- a/packages/react-core/src/components/ContextSelector/ContextSelectorToggle.tsx
+++ b/packages/react-core/src/components/ContextSelector/ContextSelectorToggle.tsx
@@ -110,7 +110,9 @@ export class ContextSelectorToggle extends React.Component<ContextSelectorToggle
         onKeyDown={this.onKeyDown}
       >
         <span className={css(styles.contextSelectorToggleText)}>{toggleText}</span>
-        <CaretDownIcon className={css(styles.contextSelectorToggleIcon)} aria-hidden />
+        <span className={css(styles.contextSelectorToggleIcon)}>
+          <CaretDownIcon aria-hidden />
+        </span>
       </button>
     );
   }

--- a/packages/react-core/src/components/ContextSelector/__tests__/Generated/__snapshots__/ContextSelectorToggle.test.tsx.snap
+++ b/packages/react-core/src/components/ContextSelector/__tests__/Generated/__snapshots__/ContextSelectorToggle.test.tsx.snap
@@ -16,12 +16,15 @@ exports[`ContextSelectorToggle should match snapshot (auto-generated) 1`] = `
   >
     ''
   </span>
-  <CaretDownIcon
-    aria-hidden={true}
+  <span
     className="pf-c-context-selector__toggle-icon"
-    color="currentColor"
-    noVerticalAlign={false}
-    size="sm"
-  />
+  >
+    <CaretDownIcon
+      aria-hidden={true}
+      color="currentColor"
+      noVerticalAlign={false}
+      size="sm"
+    />
+  </span>
 </button>
 `;

--- a/packages/react-core/src/components/ContextSelector/__tests__/__snapshots__/ContextSelectorToggle.test.tsx.snap
+++ b/packages/react-core/src/components/ContextSelector/__tests__/__snapshots__/ContextSelectorToggle.test.tsx.snap
@@ -12,13 +12,16 @@ exports[`Renders ContextSelectorToggle 1`] = `
   <span
     className="pf-c-context-selector__toggle-text"
   />
-  <CaretDownIcon
-    aria-hidden={true}
+  <span
     className="pf-c-context-selector__toggle-icon"
-    color="currentColor"
-    noVerticalAlign={false}
-    size="sm"
-  />
+  >
+    <CaretDownIcon
+      aria-hidden={true}
+      color="currentColor"
+      noVerticalAlign={false}
+      size="sm"
+    />
+  </span>
 </button>
 `;
 
@@ -44,34 +47,36 @@ exports[`Verify ESC press  1`] = `
     <span
       className="pf-c-context-selector__toggle-text"
     />
-    <CaretDownIcon
-      aria-hidden={true}
+    <span
       className="pf-c-context-selector__toggle-icon"
-      color="currentColor"
-      noVerticalAlign={false}
-      size="sm"
     >
-      <svg
+      <CaretDownIcon
         aria-hidden={true}
-        aria-labelledby={null}
-        className="pf-c-context-selector__toggle-icon"
-        fill="currentColor"
-        height="1em"
-        role="img"
-        style={
-          Object {
-            "verticalAlign": "-0.125em",
-          }
-        }
-        viewBox="0 0 320 512"
-        width="1em"
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
       >
-        <path
-          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-          transform=""
-        />
-      </svg>
-    </CaretDownIcon>
+        <svg
+          aria-hidden={true}
+          aria-labelledby={null}
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style={
+            Object {
+              "verticalAlign": "-0.125em",
+            }
+          }
+          viewBox="0 0 320 512"
+          width="1em"
+        >
+          <path
+            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+            transform=""
+          />
+        </svg>
+      </CaretDownIcon>
+    </span>
   </button>
 </ContextSelectorToggle>
 `;
@@ -98,34 +103,36 @@ exports[`Verify ESC press with not isOpen 1`] = `
     <span
       className="pf-c-context-selector__toggle-text"
     />
-    <CaretDownIcon
-      aria-hidden={true}
+    <span
       className="pf-c-context-selector__toggle-icon"
-      color="currentColor"
-      noVerticalAlign={false}
-      size="sm"
     >
-      <svg
+      <CaretDownIcon
         aria-hidden={true}
-        aria-labelledby={null}
-        className="pf-c-context-selector__toggle-icon"
-        fill="currentColor"
-        height="1em"
-        role="img"
-        style={
-          Object {
-            "verticalAlign": "-0.125em",
-          }
-        }
-        viewBox="0 0 320 512"
-        width="1em"
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
       >
-        <path
-          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-          transform=""
-        />
-      </svg>
-    </CaretDownIcon>
+        <svg
+          aria-hidden={true}
+          aria-labelledby={null}
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style={
+            Object {
+              "verticalAlign": "-0.125em",
+            }
+          }
+          viewBox="0 0 320 512"
+          width="1em"
+        >
+          <path
+            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+            transform=""
+          />
+        </svg>
+      </CaretDownIcon>
+    </span>
   </button>
 </ContextSelectorToggle>
 `;
@@ -152,34 +159,36 @@ exports[`Verify keydown enter  1`] = `
     <span
       className="pf-c-context-selector__toggle-text"
     />
-    <CaretDownIcon
-      aria-hidden={true}
+    <span
       className="pf-c-context-selector__toggle-icon"
-      color="currentColor"
-      noVerticalAlign={false}
-      size="sm"
     >
-      <svg
+      <CaretDownIcon
         aria-hidden={true}
-        aria-labelledby={null}
-        className="pf-c-context-selector__toggle-icon"
-        fill="currentColor"
-        height="1em"
-        role="img"
-        style={
-          Object {
-            "verticalAlign": "-0.125em",
-          }
-        }
-        viewBox="0 0 320 512"
-        width="1em"
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
       >
-        <path
-          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-          transform=""
-        />
-      </svg>
-    </CaretDownIcon>
+        <svg
+          aria-hidden={true}
+          aria-labelledby={null}
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style={
+            Object {
+              "verticalAlign": "-0.125em",
+            }
+          }
+          viewBox="0 0 320 512"
+          width="1em"
+        >
+          <path
+            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+            transform=""
+          />
+        </svg>
+      </CaretDownIcon>
+    </span>
   </button>
 </ContextSelectorToggle>
 `;
@@ -206,34 +215,36 @@ exports[`Verify keydown tab  1`] = `
     <span
       className="pf-c-context-selector__toggle-text"
     />
-    <CaretDownIcon
-      aria-hidden={true}
+    <span
       className="pf-c-context-selector__toggle-icon"
-      color="currentColor"
-      noVerticalAlign={false}
-      size="sm"
     >
-      <svg
+      <CaretDownIcon
         aria-hidden={true}
-        aria-labelledby={null}
-        className="pf-c-context-selector__toggle-icon"
-        fill="currentColor"
-        height="1em"
-        role="img"
-        style={
-          Object {
-            "verticalAlign": "-0.125em",
-          }
-        }
-        viewBox="0 0 320 512"
-        width="1em"
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
       >
-        <path
-          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-          transform=""
-        />
-      </svg>
-    </CaretDownIcon>
+        <svg
+          aria-hidden={true}
+          aria-labelledby={null}
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style={
+            Object {
+              "verticalAlign": "-0.125em",
+            }
+          }
+          viewBox="0 0 320 512"
+          width="1em"
+        >
+          <path
+            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+            transform=""
+          />
+        </svg>
+      </CaretDownIcon>
+    </span>
   </button>
 </ContextSelectorToggle>
 `;

--- a/packages/react-core/src/components/DataList/DataListToggle.tsx
+++ b/packages/react-core/src/components/DataList/DataListToggle.tsx
@@ -40,7 +40,7 @@ export const DataListToggle: React.FunctionComponent<DataListToggleProps> = ({
         aria-labelledby={ariaLabel !== 'Details' ? null : `${rowid} ${id}`}
         aria-expanded={isExpanded}
       >
-        <div className="pf-c-data-list__toggle-icon">
+        <div className={css(styles.dataListToggleIcon)}>
           <AngleRightIcon />
         </div>
       </Button>

--- a/packages/react-core/src/components/DataList/DataListToggle.tsx
+++ b/packages/react-core/src/components/DataList/DataListToggle.tsx
@@ -40,7 +40,9 @@ export const DataListToggle: React.FunctionComponent<DataListToggleProps> = ({
         aria-labelledby={ariaLabel !== 'Details' ? null : `${rowid} ${id}`}
         aria-expanded={isExpanded}
       >
-        <AngleRightIcon />
+        <div className="pf-c-data-list__toggle-icon">
+          <AngleRightIcon />
+        </div>
       </Button>
     </div>
   </div>

--- a/packages/react-core/src/components/DataList/__tests__/Generated/__snapshots__/DataListToggle.test.tsx.snap
+++ b/packages/react-core/src/components/DataList/__tests__/Generated/__snapshots__/DataListToggle.test.tsx.snap
@@ -16,11 +16,15 @@ exports[`DataListToggle should match snapshot (auto-generated) 1`] = `
       id="string"
       variant="plain"
     >
-      <AngleRightIcon
-        color="currentColor"
-        noVerticalAlign={false}
-        size="sm"
-      />
+      <div
+        className="pf-c-data-list__toggle-icon"
+      >
+        <AngleRightIcon
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
+        />
+      </div>
     </Button>
   </div>
 </div>

--- a/packages/react-core/src/components/DataToolbar/__tests__/__snapshots__/DataToolbar.test.tsx.snap
+++ b/packages/react-core/src/components/DataToolbar/__tests__/__snapshots__/DataToolbar.test.tsx.snap
@@ -199,21 +199,24 @@ exports[`data toolbar DataToolbarFilter 1`] = `
                                             Running
                                           </span>
                                         </div>
-                                        <svg
-                                          aria-hidden="true"
+                                        <span
                                           class="pf-c-select__toggle-arrow"
-                                          fill="currentColor"
-                                          height="1em"
-                                          role="img"
-                                          style="vertical-align: -0.125em;"
-                                          viewBox="0 0 320 512"
-                                          width="1em"
                                         >
-                                          <path
-                                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                            transform=""
-                                          />
-                                        </svg>
+                                          <svg
+                                            aria-hidden="true"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            style="vertical-align: -0.125em;"
+                                            viewBox="0 0 320 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                              transform=""
+                                            />
+                                          </svg>
+                                        </span>
                                       </button>
                                     </div>,
                                   }
@@ -241,33 +244,35 @@ exports[`data toolbar DataToolbarFilter 1`] = `
                                       Running
                                     </span>
                                   </div>
-                                  <CaretDownIcon
+                                  <span
                                     className="pf-c-select__toggle-arrow"
-                                    color="currentColor"
-                                    noVerticalAlign={false}
-                                    size="sm"
                                   >
-                                    <svg
-                                      aria-hidden={true}
-                                      aria-labelledby={null}
-                                      className="pf-c-select__toggle-arrow"
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      style={
-                                        Object {
-                                          "verticalAlign": "-0.125em",
-                                        }
-                                      }
-                                      viewBox="0 0 320 512"
-                                      width="1em"
+                                    <CaretDownIcon
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      size="sm"
                                     >
-                                      <path
-                                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                        transform=""
-                                      />
-                                    </svg>
-                                  </CaretDownIcon>
+                                      <svg
+                                        aria-hidden={true}
+                                        aria-labelledby={null}
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        style={
+                                          Object {
+                                            "verticalAlign": "-0.125em",
+                                          }
+                                        }
+                                        viewBox="0 0 320 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                          transform=""
+                                        />
+                                      </svg>
+                                    </CaretDownIcon>
+                                  </span>
                                 </button>
                               </SelectToggle>
                             </div>
@@ -759,21 +764,24 @@ exports[`data toolbar DataToolbarFilter 1`] = `
                                             Low
                                           </span>
                                         </div>
-                                        <svg
-                                          aria-hidden="true"
+                                        <span
                                           class="pf-c-select__toggle-arrow"
-                                          fill="currentColor"
-                                          height="1em"
-                                          role="img"
-                                          style="vertical-align: -0.125em;"
-                                          viewBox="0 0 320 512"
-                                          width="1em"
                                         >
-                                          <path
-                                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                            transform=""
-                                          />
-                                        </svg>
+                                          <svg
+                                            aria-hidden="true"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            style="vertical-align: -0.125em;"
+                                            viewBox="0 0 320 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                              transform=""
+                                            />
+                                          </svg>
+                                        </span>
                                       </button>
                                     </div>,
                                   }
@@ -801,33 +809,35 @@ exports[`data toolbar DataToolbarFilter 1`] = `
                                       Low
                                     </span>
                                   </div>
-                                  <CaretDownIcon
+                                  <span
                                     className="pf-c-select__toggle-arrow"
-                                    color="currentColor"
-                                    noVerticalAlign={false}
-                                    size="sm"
                                   >
-                                    <svg
-                                      aria-hidden={true}
-                                      aria-labelledby={null}
-                                      className="pf-c-select__toggle-arrow"
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      style={
-                                        Object {
-                                          "verticalAlign": "-0.125em",
-                                        }
-                                      }
-                                      viewBox="0 0 320 512"
-                                      width="1em"
+                                    <CaretDownIcon
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      size="sm"
                                     >
-                                      <path
-                                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                        transform=""
-                                      />
-                                    </svg>
-                                  </CaretDownIcon>
+                                      <svg
+                                        aria-hidden={true}
+                                        aria-labelledby={null}
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        style={
+                                          Object {
+                                            "verticalAlign": "-0.125em",
+                                          }
+                                        }
+                                        viewBox="0 0 320 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                          transform=""
+                                        />
+                                      </svg>
+                                    </CaretDownIcon>
+                                  </span>
                                 </button>
                               </SelectToggle>
                             </div>
@@ -2001,21 +2011,24 @@ exports[`data toolbar DataToolbarToggleGroup 1`] = `
                                           Running
                                         </span>
                                       </div>
-                                      <svg
-                                        aria-hidden="true"
+                                      <span
                                         class="pf-c-select__toggle-arrow"
-                                        fill="currentColor"
-                                        height="1em"
-                                        role="img"
-                                        style="vertical-align: -0.125em;"
-                                        viewBox="0 0 320 512"
-                                        width="1em"
                                       >
-                                        <path
-                                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                          transform=""
-                                        />
-                                      </svg>
+                                        <svg
+                                          aria-hidden="true"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          style="vertical-align: -0.125em;"
+                                          viewBox="0 0 320 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                            transform=""
+                                          />
+                                        </svg>
+                                      </span>
                                     </button>
                                   </div>,
                                 }
@@ -2043,33 +2056,35 @@ exports[`data toolbar DataToolbarToggleGroup 1`] = `
                                     Running
                                   </span>
                                 </div>
-                                <CaretDownIcon
+                                <span
                                   className="pf-c-select__toggle-arrow"
-                                  color="currentColor"
-                                  noVerticalAlign={false}
-                                  size="sm"
                                 >
-                                  <svg
-                                    aria-hidden={true}
-                                    aria-labelledby={null}
-                                    className="pf-c-select__toggle-arrow"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    style={
-                                      Object {
-                                        "verticalAlign": "-0.125em",
-                                      }
-                                    }
-                                    viewBox="0 0 320 512"
-                                    width="1em"
+                                  <CaretDownIcon
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
                                   >
-                                    <path
-                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                      transform=""
-                                    />
-                                  </svg>
-                                </CaretDownIcon>
+                                    <svg
+                                      aria-hidden={true}
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 320 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                        transform=""
+                                      />
+                                    </svg>
+                                  </CaretDownIcon>
+                                </span>
                               </button>
                             </SelectToggle>
                           </div>
@@ -2162,21 +2177,24 @@ exports[`data toolbar DataToolbarToggleGroup 1`] = `
                                           Low
                                         </span>
                                       </div>
-                                      <svg
-                                        aria-hidden="true"
+                                      <span
                                         class="pf-c-select__toggle-arrow"
-                                        fill="currentColor"
-                                        height="1em"
-                                        role="img"
-                                        style="vertical-align: -0.125em;"
-                                        viewBox="0 0 320 512"
-                                        width="1em"
                                       >
-                                        <path
-                                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                          transform=""
-                                        />
-                                      </svg>
+                                        <svg
+                                          aria-hidden="true"
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          style="vertical-align: -0.125em;"
+                                          viewBox="0 0 320 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                            transform=""
+                                          />
+                                        </svg>
+                                      </span>
                                     </button>
                                   </div>,
                                 }
@@ -2204,33 +2222,35 @@ exports[`data toolbar DataToolbarToggleGroup 1`] = `
                                     Low
                                   </span>
                                 </div>
-                                <CaretDownIcon
+                                <span
                                   className="pf-c-select__toggle-arrow"
-                                  color="currentColor"
-                                  noVerticalAlign={false}
-                                  size="sm"
                                 >
-                                  <svg
-                                    aria-hidden={true}
-                                    aria-labelledby={null}
-                                    className="pf-c-select__toggle-arrow"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    style={
-                                      Object {
-                                        "verticalAlign": "-0.125em",
-                                      }
-                                    }
-                                    viewBox="0 0 320 512"
-                                    width="1em"
+                                  <CaretDownIcon
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
                                   >
-                                    <path
-                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                      transform=""
-                                    />
-                                  </svg>
-                                </CaretDownIcon>
+                                    <svg
+                                      aria-hidden={true}
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 320 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                        transform=""
+                                      />
+                                    </svg>
+                                  </CaretDownIcon>
+                                </span>
                               </button>
                             </SelectToggle>
                           </div>

--- a/packages/react-core/src/components/Dropdown/DropdownToggle.tsx
+++ b/packages/react-core/src/components/Dropdown/DropdownToggle.tsx
@@ -85,7 +85,11 @@ export const DropdownToggle: React.FunctionComponent<DropdownToggleProps> = ({
         >
           {icon && <span className={css(toggleIconClass)}>{icon}</span>}
           {children && <span className={ToggleIndicator && css(toggleTextClass)}>{children}</span>}
-          {ToggleIndicator && <ToggleIndicator className={css(children && toggleIndicatorClass)} />}
+          {ToggleIndicator && (
+            <span className={css(children && toggleIndicatorClass)}>
+              <ToggleIndicator />
+            </span>
+          )}
         </Toggle>
       )}
     </DropdownContext.Consumer>

--- a/packages/react-core/src/components/Dropdown/DropdownToggle.tsx
+++ b/packages/react-core/src/components/Dropdown/DropdownToggle.tsx
@@ -86,7 +86,7 @@ export const DropdownToggle: React.FunctionComponent<DropdownToggleProps> = ({
           {icon && <span className={css(toggleIconClass)}>{icon}</span>}
           {children && <span className={ToggleIndicator && css(toggleTextClass)}>{children}</span>}
           {ToggleIndicator && (
-            <span className={css(children && toggleIndicatorClass)}>
+            <span className={css(toggleIndicatorClass)}>
               <ToggleIndicator />
             </span>
           )}

--- a/packages/react-core/src/components/Dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/react-core/src/components/Dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
@@ -3250,21 +3250,24 @@ exports[`dropdown basic 1`] = `
                 >
                   Dropdown
                 </span>
-                <svg
-                  aria-hidden="true"
+                <span
                   class="pf-c-dropdown__toggle-icon"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 320 512"
-                  width="1em"
                 >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                    transform=""
-                  />
-                </svg>
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                      transform=""
+                    />
+                  </svg>
+                </span>
               </button>
               <div
                 class="pf-c-dropdown__menu"
@@ -3310,21 +3313,24 @@ exports[`dropdown basic 1`] = `
                   >
                     Dropdown
                   </span>
-                  <svg
-                    aria-hidden="true"
+                  <span
                     class="pf-c-dropdown__toggle-icon"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style="vertical-align: -0.125em;"
-                    viewBox="0 0 320 512"
-                    width="1em"
                   >
-                    <path
-                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                      transform=""
-                    />
-                  </svg>
+                    <svg
+                      aria-hidden="true"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 320 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                        transform=""
+                      />
+                    </svg>
+                  </span>
                 </button>
                 <div
                   class="pf-c-dropdown__menu"
@@ -3352,33 +3358,35 @@ exports[`dropdown basic 1`] = `
             >
               Dropdown
             </span>
-            <CaretDownIcon
+            <span
               className="pf-c-dropdown__toggle-icon"
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                className="pf-c-dropdown__toggle-icon"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 320 512"
-                width="1em"
+              <CaretDownIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  transform=""
-                />
-              </svg>
-            </CaretDownIcon>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    transform=""
+                  />
+                </svg>
+              </CaretDownIcon>
+            </span>
           </button>
         </Toggle>
       </DropdownToggle>
@@ -3734,21 +3742,24 @@ exports[`dropdown dropup + right aligned 1`] = `
                 >
                   Dropdown
                 </span>
-                <svg
-                  aria-hidden="true"
+                <span
                   class="pf-c-dropdown__toggle-icon"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 320 512"
-                  width="1em"
                 >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                    transform=""
-                  />
-                </svg>
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                      transform=""
+                    />
+                  </svg>
+                </span>
               </button>
             </div>,
           }
@@ -3787,21 +3798,24 @@ exports[`dropdown dropup + right aligned 1`] = `
                   >
                     Dropdown
                   </span>
-                  <svg
-                    aria-hidden="true"
+                  <span
                     class="pf-c-dropdown__toggle-icon"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style="vertical-align: -0.125em;"
-                    viewBox="0 0 320 512"
-                    width="1em"
                   >
-                    <path
-                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                      transform=""
-                    />
-                  </svg>
+                    <svg
+                      aria-hidden="true"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 320 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                        transform=""
+                      />
+                    </svg>
+                  </span>
                 </button>
               </div>,
             }
@@ -3822,33 +3836,35 @@ exports[`dropdown dropup + right aligned 1`] = `
             >
               Dropdown
             </span>
-            <CaretDownIcon
+            <span
               className="pf-c-dropdown__toggle-icon"
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                className="pf-c-dropdown__toggle-icon"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 320 512"
-                width="1em"
+              <CaretDownIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  transform=""
-                />
-              </svg>
-            </CaretDownIcon>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    transform=""
+                  />
+                </svg>
+              </CaretDownIcon>
+            </span>
           </button>
         </Toggle>
       </DropdownToggle>
@@ -4181,21 +4197,24 @@ exports[`dropdown dropup 1`] = `
                 >
                   Dropdown
                 </span>
-                <svg
-                  aria-hidden="true"
+                <span
                   class="pf-c-dropdown__toggle-icon"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 320 512"
-                  width="1em"
                 >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                    transform=""
-                  />
-                </svg>
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                      transform=""
+                    />
+                  </svg>
+                </span>
               </button>
             </div>,
           }
@@ -4234,21 +4253,24 @@ exports[`dropdown dropup 1`] = `
                   >
                     Dropdown
                   </span>
-                  <svg
-                    aria-hidden="true"
+                  <span
                     class="pf-c-dropdown__toggle-icon"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style="vertical-align: -0.125em;"
-                    viewBox="0 0 320 512"
-                    width="1em"
                   >
-                    <path
-                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                      transform=""
-                    />
-                  </svg>
+                    <svg
+                      aria-hidden="true"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 320 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                        transform=""
+                      />
+                    </svg>
+                  </span>
                 </button>
               </div>,
             }
@@ -4269,33 +4291,35 @@ exports[`dropdown dropup 1`] = `
             >
               Dropdown
             </span>
-            <CaretDownIcon
+            <span
               className="pf-c-dropdown__toggle-icon"
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                className="pf-c-dropdown__toggle-icon"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 320 512"
-                width="1em"
+              <CaretDownIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  transform=""
-                />
-              </svg>
-            </CaretDownIcon>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    transform=""
+                  />
+                </svg>
+              </CaretDownIcon>
+            </span>
           </button>
         </Toggle>
       </DropdownToggle>
@@ -4628,21 +4652,24 @@ exports[`dropdown expanded 1`] = `
                 >
                   Dropdown
                 </span>
-                <svg
-                  aria-hidden="true"
+                <span
                   class="pf-c-dropdown__toggle-icon"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 320 512"
-                  width="1em"
                 >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                    transform=""
-                  />
-                </svg>
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                      transform=""
+                    />
+                  </svg>
+                </span>
               </button>
               <ul
                 aria-labelledby="Dropdown Toggle"
@@ -4756,21 +4783,24 @@ exports[`dropdown expanded 1`] = `
                   >
                     Dropdown
                   </span>
-                  <svg
-                    aria-hidden="true"
+                  <span
                     class="pf-c-dropdown__toggle-icon"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style="vertical-align: -0.125em;"
-                    viewBox="0 0 320 512"
-                    width="1em"
                   >
-                    <path
-                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                      transform=""
-                    />
-                  </svg>
+                    <svg
+                      aria-hidden="true"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 320 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                        transform=""
+                      />
+                    </svg>
+                  </span>
                 </button>
                 <ul
                   aria-labelledby="Dropdown Toggle"
@@ -4866,33 +4896,35 @@ exports[`dropdown expanded 1`] = `
             >
               Dropdown
             </span>
-            <CaretDownIcon
+            <span
               className="pf-c-dropdown__toggle-icon"
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                className="pf-c-dropdown__toggle-icon"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 320 512"
-                width="1em"
+              <CaretDownIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  transform=""
-                />
-              </svg>
-            </CaretDownIcon>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    transform=""
+                  />
+                </svg>
+              </CaretDownIcon>
+            </span>
           </button>
         </Toggle>
       </DropdownToggle>
@@ -5493,21 +5525,24 @@ exports[`dropdown primary 1`] = `
                 >
                   Dropdown
                 </span>
-                <svg
-                  aria-hidden="true"
+                <span
                   class="pf-c-dropdown__toggle-icon"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 320 512"
-                  width="1em"
                 >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                    transform=""
-                  />
-                </svg>
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                      transform=""
+                    />
+                  </svg>
+                </span>
               </button>
             </div>,
           }
@@ -5546,21 +5581,24 @@ exports[`dropdown primary 1`] = `
                   >
                     Dropdown
                   </span>
-                  <svg
-                    aria-hidden="true"
+                  <span
                     class="pf-c-dropdown__toggle-icon"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style="vertical-align: -0.125em;"
-                    viewBox="0 0 320 512"
-                    width="1em"
                   >
-                    <path
-                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                      transform=""
-                    />
-                  </svg>
+                    <svg
+                      aria-hidden="true"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 320 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                        transform=""
+                      />
+                    </svg>
+                  </span>
                 </button>
               </div>,
             }
@@ -5581,33 +5619,35 @@ exports[`dropdown primary 1`] = `
             >
               Dropdown
             </span>
-            <CaretDownIcon
+            <span
               className="pf-c-dropdown__toggle-icon"
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                className="pf-c-dropdown__toggle-icon"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 320 512"
-                width="1em"
+              <CaretDownIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  transform=""
-                />
-              </svg>
-            </CaretDownIcon>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    transform=""
+                  />
+                </svg>
+              </CaretDownIcon>
+            </span>
           </button>
         </Toggle>
       </DropdownToggle>
@@ -5939,21 +5979,24 @@ exports[`dropdown regular 1`] = `
                 >
                   Dropdown
                 </span>
-                <svg
-                  aria-hidden="true"
+                <span
                   class="pf-c-dropdown__toggle-icon"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 320 512"
-                  width="1em"
                 >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                    transform=""
-                  />
-                </svg>
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                      transform=""
+                    />
+                  </svg>
+                </span>
               </button>
             </div>,
           }
@@ -5992,21 +6035,24 @@ exports[`dropdown regular 1`] = `
                   >
                     Dropdown
                   </span>
-                  <svg
-                    aria-hidden="true"
+                  <span
                     class="pf-c-dropdown__toggle-icon"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style="vertical-align: -0.125em;"
-                    viewBox="0 0 320 512"
-                    width="1em"
                   >
-                    <path
-                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                      transform=""
-                    />
-                  </svg>
+                    <svg
+                      aria-hidden="true"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 320 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                        transform=""
+                      />
+                    </svg>
+                  </span>
                 </button>
               </div>,
             }
@@ -6027,33 +6073,35 @@ exports[`dropdown regular 1`] = `
             >
               Dropdown
             </span>
-            <CaretDownIcon
+            <span
               className="pf-c-dropdown__toggle-icon"
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                className="pf-c-dropdown__toggle-icon"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 320 512"
-                width="1em"
+              <CaretDownIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  transform=""
-                />
-              </svg>
-            </CaretDownIcon>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    transform=""
+                  />
+                </svg>
+              </CaretDownIcon>
+            </span>
           </button>
         </Toggle>
       </DropdownToggle>
@@ -6386,21 +6434,24 @@ exports[`dropdown right aligned 1`] = `
                 >
                   Dropdown
                 </span>
-                <svg
-                  aria-hidden="true"
+                <span
                   class="pf-c-dropdown__toggle-icon"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 320 512"
-                  width="1em"
                 >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                    transform=""
-                  />
-                </svg>
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                      transform=""
+                    />
+                  </svg>
+                </span>
               </button>
             </div>,
           }
@@ -6439,21 +6490,24 @@ exports[`dropdown right aligned 1`] = `
                   >
                     Dropdown
                   </span>
-                  <svg
-                    aria-hidden="true"
+                  <span
                     class="pf-c-dropdown__toggle-icon"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style="vertical-align: -0.125em;"
-                    viewBox="0 0 320 512"
-                    width="1em"
                   >
-                    <path
-                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                      transform=""
-                    />
-                  </svg>
+                    <svg
+                      aria-hidden="true"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 320 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                        transform=""
+                      />
+                    </svg>
+                  </span>
                 </button>
               </div>,
             }
@@ -6474,33 +6528,35 @@ exports[`dropdown right aligned 1`] = `
             >
               Dropdown
             </span>
-            <CaretDownIcon
+            <span
               className="pf-c-dropdown__toggle-icon"
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                className="pf-c-dropdown__toggle-icon"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 320 512"
-                width="1em"
+              <CaretDownIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  transform=""
-                />
-              </svg>
-            </CaretDownIcon>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    transform=""
+                  />
+                </svg>
+              </CaretDownIcon>
+            </span>
           </button>
         </Toggle>
       </DropdownToggle>

--- a/packages/react-core/src/components/Dropdown/__tests__/__snapshots__/DropdownToggle.test.tsx.snap
+++ b/packages/react-core/src/components/Dropdown/__tests__/__snapshots__/DropdownToggle.test.tsx.snap
@@ -34,33 +34,35 @@ exports[`state active 1`] = `
       >
         Dropdown
       </span>
-      <CaretDownIcon
+      <span
         className=""
-        color="currentColor"
-        noVerticalAlign={false}
-        size="sm"
       >
-        <svg
-          aria-hidden={true}
-          aria-labelledby={null}
-          className=""
-          fill="currentColor"
-          height="1em"
-          role="img"
-          style={
-            Object {
-              "verticalAlign": "-0.125em",
-            }
-          }
-          viewBox="0 0 320 512"
-          width="1em"
+        <CaretDownIcon
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
         >
-          <path
-            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-            transform=""
-          />
-        </svg>
-      </CaretDownIcon>
+          <svg
+            aria-hidden={true}
+            aria-labelledby={null}
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
+            viewBox="0 0 320 512"
+            width="1em"
+          >
+            <path
+              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+              transform=""
+            />
+          </svg>
+        </CaretDownIcon>
+      </span>
     </button>
   </Toggle>
 </DropdownToggle>
@@ -102,33 +104,35 @@ exports[`state class changes 1`] = `
       >
         Dropdown
       </span>
-      <CaretDownIcon
+      <span
         className="another-test-class"
-        color="currentColor"
-        noVerticalAlign={false}
-        size="sm"
       >
-        <svg
-          aria-hidden={true}
-          aria-labelledby={null}
-          className="another-test-class"
-          fill="currentColor"
-          height="1em"
-          role="img"
-          style={
-            Object {
-              "verticalAlign": "-0.125em",
-            }
-          }
-          viewBox="0 0 320 512"
-          width="1em"
+        <CaretDownIcon
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
         >
-          <path
-            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-            transform=""
-          />
-        </svg>
-      </CaretDownIcon>
+          <svg
+            aria-hidden={true}
+            aria-labelledby={null}
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
+            viewBox="0 0 320 512"
+            width="1em"
+          >
+            <path
+              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+              transform=""
+            />
+          </svg>
+        </CaretDownIcon>
+      </span>
     </button>
   </Toggle>
 </DropdownToggle>
@@ -170,33 +174,35 @@ exports[`state class changes 2`] = `
       >
         Dropdown
       </span>
-      <CaretDownIcon
+      <span
         className="another-test-class"
-        color="currentColor"
-        noVerticalAlign={false}
-        size="sm"
       >
-        <svg
-          aria-hidden={true}
-          aria-labelledby={null}
-          className="another-test-class"
-          fill="currentColor"
-          height="1em"
-          role="img"
-          style={
-            Object {
-              "verticalAlign": "-0.125em",
-            }
-          }
-          viewBox="0 0 320 512"
-          width="1em"
+        <CaretDownIcon
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
         >
-          <path
-            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-            transform=""
-          />
-        </svg>
-      </CaretDownIcon>
+          <svg
+            aria-hidden={true}
+            aria-labelledby={null}
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
+            viewBox="0 0 320 512"
+            width="1em"
+          >
+            <path
+              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+              transform=""
+            />
+          </svg>
+        </CaretDownIcon>
+      </span>
     </button>
   </Toggle>
 </DropdownToggle>
@@ -238,33 +244,35 @@ exports[`state focus 1`] = `
       >
         Dropdown
       </span>
-      <CaretDownIcon
+      <span
         className=""
-        color="currentColor"
-        noVerticalAlign={false}
-        size="sm"
       >
-        <svg
-          aria-hidden={true}
-          aria-labelledby={null}
-          className=""
-          fill="currentColor"
-          height="1em"
-          role="img"
-          style={
-            Object {
-              "verticalAlign": "-0.125em",
-            }
-          }
-          viewBox="0 0 320 512"
-          width="1em"
+        <CaretDownIcon
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
         >
-          <path
-            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-            transform=""
-          />
-        </svg>
-      </CaretDownIcon>
+          <svg
+            aria-hidden={true}
+            aria-labelledby={null}
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
+            viewBox="0 0 320 512"
+            width="1em"
+          >
+            <path
+              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+              transform=""
+            />
+          </svg>
+        </CaretDownIcon>
+      </span>
     </button>
   </Toggle>
 </DropdownToggle>
@@ -306,33 +314,35 @@ exports[`state hover 1`] = `
       >
         Dropdown
       </span>
-      <CaretDownIcon
+      <span
         className=""
-        color="currentColor"
-        noVerticalAlign={false}
-        size="sm"
       >
-        <svg
-          aria-hidden={true}
-          aria-labelledby={null}
-          className=""
-          fill="currentColor"
-          height="1em"
-          role="img"
-          style={
-            Object {
-              "verticalAlign": "-0.125em",
-            }
-          }
-          viewBox="0 0 320 512"
-          width="1em"
+        <CaretDownIcon
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
         >
-          <path
-            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-            transform=""
-          />
-        </svg>
-      </CaretDownIcon>
+          <svg
+            aria-hidden={true}
+            aria-labelledby={null}
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
+            viewBox="0 0 320 512"
+            width="1em"
+          >
+            <path
+              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+              transform=""
+            />
+          </svg>
+        </CaretDownIcon>
+      </span>
     </button>
   </Toggle>
 </DropdownToggle>

--- a/packages/react-core/src/components/Dropdown/__tests__/__snapshots__/Toggle.test.tsx.snap
+++ b/packages/react-core/src/components/Dropdown/__tests__/__snapshots__/Toggle.test.tsx.snap
@@ -32,33 +32,35 @@ exports[`Dropdown toggle 1`] = `
       >
         Dropdown
       </span>
-      <CaretDownIcon
+      <span
         className=""
-        color="currentColor"
-        noVerticalAlign={false}
-        size="sm"
       >
-        <svg
-          aria-hidden={true}
-          aria-labelledby={null}
-          className=""
-          fill="currentColor"
-          height="1em"
-          role="img"
-          style={
-            Object {
-              "verticalAlign": "-0.125em",
-            }
-          }
-          viewBox="0 0 320 512"
-          width="1em"
+        <CaretDownIcon
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
         >
-          <path
-            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-            transform=""
-          />
-        </svg>
-      </CaretDownIcon>
+          <svg
+            aria-hidden={true}
+            aria-labelledby={null}
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
+            viewBox="0 0 320 512"
+            width="1em"
+          >
+            <path
+              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+              transform=""
+            />
+          </svg>
+        </CaretDownIcon>
+      </span>
     </button>
   </Toggle>
 </DropdownToggle>

--- a/packages/react-core/src/components/ExpandableSection/ExpandableSection.tsx
+++ b/packages/react-core/src/components/ExpandableSection/ExpandableSection.tsx
@@ -106,7 +106,7 @@ export class ExpandableSection extends React.Component<ExpandableSectionProps, E
           <span className={css(styles.expandableSectionToggleIcon)}>
             <AngleRightIcon aria-hidden />
           </span>
-          <span className="pf-c-expandable-section__toggle-text">{computedToggleText}</span>
+          <span className={css(styles.expandableSectionToggleText)}>{computedToggleText}</span>
         </button>
         <div className={css(styles.expandableSectionContent)} hidden={!propOrStateIsExpanded}>
           {children}

--- a/packages/react-core/src/components/ExpandableSection/ExpandableSection.tsx
+++ b/packages/react-core/src/components/ExpandableSection/ExpandableSection.tsx
@@ -103,8 +103,10 @@ export class ExpandableSection extends React.Component<ExpandableSectionProps, E
           aria-expanded={propOrStateIsExpanded}
           onClick={onToggle}
         >
-          <AngleRightIcon className={css(styles.expandableSectionToggleIcon)} aria-hidden />
-          <span>{computedToggleText}</span>
+          <span className={css(styles.expandableSectionToggleIcon)}>
+            <AngleRightIcon aria-hidden />
+          </span>
+          <span className="pf-c-expandable-section__toggle-text">{computedToggleText}</span>
         </button>
         <div className={css(styles.expandableSectionContent)} hidden={!propOrStateIsExpanded}>
           {children}

--- a/packages/react-core/src/components/ExpandableSection/__tests__/Generated/__snapshots__/ExpandableSection.test.tsx.snap
+++ b/packages/react-core/src/components/ExpandableSection/__tests__/Generated/__snapshots__/ExpandableSection.test.tsx.snap
@@ -10,14 +10,19 @@ exports[`ExpandableSection should match snapshot (auto-generated) 1`] = `
     onClick={[Function]}
     type="button"
   >
-    <AngleRightIcon
-      aria-hidden={true}
+    <span
       className="pf-c-expandable-section__toggle-icon"
-      color="currentColor"
-      noVerticalAlign={false}
-      size="sm"
-    />
-    <span>
+    >
+      <AngleRightIcon
+        aria-hidden={true}
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />
+    </span>
+    <span
+      className="pf-c-expandable-section__toggle-text"
+    >
       ''
     </span>
   </button>

--- a/packages/react-core/src/components/ExpandableSection/__tests__/__snapshots__/ExpandableSection.test.tsx.snap
+++ b/packages/react-core/src/components/ExpandableSection/__tests__/__snapshots__/ExpandableSection.test.tsx.snap
@@ -9,12 +9,18 @@ exports[`ExpandableSection 1`] = `
     onClick={[Function]}
     type="button"
   >
-    <AngleRightIcon
-      aria-hidden={true}
+    <span
       className="pf-c-expandable-section__toggle-icon"
-      color="currentColor"
-      noVerticalAlign={false}
-      size="sm"
+    >
+      <AngleRightIcon
+        aria-hidden={true}
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />
+    </span>
+    <span
+      className="pf-c-expandable-section__toggle-text"
     />
   </button>
   <div
@@ -36,12 +42,18 @@ exports[`Renders ExpandableSection expanded 1`] = `
     onClick={[Function]}
     type="button"
   >
-    <AngleRightIcon
-      aria-hidden={true}
+    <span
       className="pf-c-expandable-section__toggle-icon"
-      color="currentColor"
-      noVerticalAlign={false}
-      size="sm"
+    >
+      <AngleRightIcon
+        aria-hidden={true}
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />
+    </span>
+    <span
+      className="pf-c-expandable-section__toggle-text"
     />
   </button>
   <div
@@ -62,14 +74,19 @@ exports[`Renders Uncontrolled ExpandableSection 1`] = `
     onClick={[Function]}
     type="button"
   >
-    <AngleRightIcon
-      aria-hidden={true}
+    <span
       className="pf-c-expandable-section__toggle-icon"
-      color="currentColor"
-      noVerticalAlign={false}
-      size="sm"
-    />
-    <span>
+    >
+      <AngleRightIcon
+        aria-hidden={true}
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />
+    </span>
+    <span
+      className="pf-c-expandable-section__toggle-text"
+    >
       Show More
     </span>
   </button>

--- a/packages/react-core/src/components/ExpandableSection/__tests__/__snapshots__/ExpandableSection.test.tsx.snap
+++ b/packages/react-core/src/components/ExpandableSection/__tests__/__snapshots__/ExpandableSection.test.tsx.snap
@@ -16,7 +16,6 @@ exports[`ExpandableSection 1`] = `
       noVerticalAlign={false}
       size="sm"
     />
-    <span />
   </button>
   <div
     className="pf-c-expandable-section__content"
@@ -44,7 +43,6 @@ exports[`Renders ExpandableSection expanded 1`] = `
       noVerticalAlign={false}
       size="sm"
     />
-    <span />
   </button>
   <div
     className="pf-c-expandable-section__content"

--- a/packages/react-core/src/components/Nav/NavExpandable.tsx
+++ b/packages/react-core/src/components/Nav/NavExpandable.tsx
@@ -116,7 +116,7 @@ export class NavExpandable extends React.Component<NavExpandableProps, NavExpand
             >
               {title}
               <span className={css(styles.navToggle)}>
-                <span className="pf-c-nav__toggle-icon">
+                <span className={css(styles.navToggleIcon)}>
                   <AngleRightIcon aria-hidden="true" />
                 </span>
               </span>

--- a/packages/react-core/src/components/Nav/NavExpandable.tsx
+++ b/packages/react-core/src/components/Nav/NavExpandable.tsx
@@ -116,7 +116,9 @@ export class NavExpandable extends React.Component<NavExpandableProps, NavExpand
             >
               {title}
               <span className={css(styles.navToggle)}>
-                <AngleRightIcon aria-hidden="true" />
+                <span className="pf-c-nav__toggle-icon">
+                  <AngleRightIcon aria-hidden="true" />
+                </span>
               </span>
             </a>
             <section className={css(styles.navSubnav)} aria-labelledby={this.id} hidden={expandedState ? null : true}>

--- a/packages/react-core/src/components/Nav/__tests__/__snapshots__/Nav.test.tsx.snap
+++ b/packages/react-core/src/components/Nav/__tests__/__snapshots__/Nav.test.tsx.snap
@@ -352,32 +352,36 @@ exports[`Expandable Nav List - Trigger toggle 1`] = `
               <span
                 className="pf-c-nav__toggle"
               >
-                <AngleRightIcon
-                  aria-hidden="true"
-                  color="currentColor"
-                  noVerticalAlign={false}
-                  size="sm"
+                <span
+                  className="pf-c-nav__toggle-icon"
                 >
-                  <svg
+                  <AngleRightIcon
                     aria-hidden="true"
-                    aria-labelledby={null}
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style={
-                      Object {
-                        "verticalAlign": "-0.125em",
-                      }
-                    }
-                    viewBox="0 0 256 512"
-                    width="1em"
+                    color="currentColor"
+                    noVerticalAlign={false}
+                    size="sm"
                   >
-                    <path
-                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                      transform=""
-                    />
-                  </svg>
-                </AngleRightIcon>
+                    <svg
+                      aria-hidden="true"
+                      aria-labelledby={null}
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style={
+                        Object {
+                          "verticalAlign": "-0.125em",
+                        }
+                      }
+                      viewBox="0 0 256 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                        transform=""
+                      />
+                    </svg>
+                  </AngleRightIcon>
+                </span>
               </span>
             </a>
             <section
@@ -516,32 +520,36 @@ exports[`Expandable Nav List 1`] = `
               <span
                 className="pf-c-nav__toggle"
               >
-                <AngleRightIcon
-                  aria-hidden="true"
-                  color="currentColor"
-                  noVerticalAlign={false}
-                  size="sm"
+                <span
+                  className="pf-c-nav__toggle-icon"
                 >
-                  <svg
+                  <AngleRightIcon
                     aria-hidden="true"
-                    aria-labelledby={null}
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style={
-                      Object {
-                        "verticalAlign": "-0.125em",
-                      }
-                    }
-                    viewBox="0 0 256 512"
-                    width="1em"
+                    color="currentColor"
+                    noVerticalAlign={false}
+                    size="sm"
                   >
-                    <path
-                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                      transform=""
-                    />
-                  </svg>
-                </AngleRightIcon>
+                    <svg
+                      aria-hidden="true"
+                      aria-labelledby={null}
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style={
+                        Object {
+                          "verticalAlign": "-0.125em",
+                        }
+                      }
+                      viewBox="0 0 256 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                        transform=""
+                      />
+                    </svg>
+                  </AngleRightIcon>
+                </span>
               </span>
             </a>
             <section
@@ -680,32 +688,36 @@ exports[`Expandable Nav List with aria label 1`] = `
               <span
                 className="pf-c-nav__toggle"
               >
-                <AngleRightIcon
-                  aria-hidden="true"
-                  color="currentColor"
-                  noVerticalAlign={false}
-                  size="sm"
+                <span
+                  className="pf-c-nav__toggle-icon"
                 >
-                  <svg
+                  <AngleRightIcon
                     aria-hidden="true"
-                    aria-labelledby={null}
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style={
-                      Object {
-                        "verticalAlign": "-0.125em",
-                      }
-                    }
-                    viewBox="0 0 256 512"
-                    width="1em"
+                    color="currentColor"
+                    noVerticalAlign={false}
+                    size="sm"
                   >
-                    <path
-                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                      transform=""
-                    />
-                  </svg>
-                </AngleRightIcon>
+                    <svg
+                      aria-hidden="true"
+                      aria-labelledby={null}
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style={
+                        Object {
+                          "verticalAlign": "-0.125em",
+                        }
+                      }
+                      viewBox="0 0 256 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                        transform=""
+                      />
+                    </svg>
+                  </AngleRightIcon>
+                </span>
               </span>
             </a>
             <section

--- a/packages/react-core/src/components/OptionsMenu/OptionsMenuItem.tsx
+++ b/packages/react-core/src/components/OptionsMenu/OptionsMenuItem.tsx
@@ -37,6 +37,10 @@ export const OptionsMenuItem: React.FunctionComponent<OptionsMenuItemProps> = ({
     {...props}
   >
     {children}
-    {isSelected && <CheckIcon className={css(styles.optionsMenuMenuItemIcon)} aria-hidden={isSelected} />}
+    {isSelected && (
+      <span className={css(styles.optionsMenuMenuItemIcon)}>
+        <CheckIcon aria-hidden={isSelected} />
+      </span>
+    )}
   </DropdownItem>
 );

--- a/packages/react-core/src/components/OptionsMenu/OptionsMenuToggleWithText.tsx
+++ b/packages/react-core/src/components/OptionsMenu/OptionsMenuToggleWithText.tsx
@@ -70,7 +70,7 @@ export const OptionsMenuToggleWithText: React.FunctionComponent<OptionsMenuToggl
       aria-expanded={isOpen}
       onClick={() => onToggle(!isOpen)}
     >
-      {toggleButtonContents}
+      <span className="pf-c-options-menu__toggle-button-icon">{toggleButtonContents}</span>
     </button>
   </div>
 );

--- a/packages/react-core/src/components/OptionsMenu/OptionsMenuToggleWithText.tsx
+++ b/packages/react-core/src/components/OptionsMenu/OptionsMenuToggleWithText.tsx
@@ -70,7 +70,7 @@ export const OptionsMenuToggleWithText: React.FunctionComponent<OptionsMenuToggl
       aria-expanded={isOpen}
       onClick={() => onToggle(!isOpen)}
     >
-      <span className="pf-c-options-menu__toggle-button-icon">{toggleButtonContents}</span>
+      <span className={css(styles.optionsMenuToggleButtonIcon)}>{toggleButtonContents}</span>
     </button>
   </div>
 );

--- a/packages/react-core/src/components/OptionsMenu/__tests__/Generated/__snapshots__/OptionsMenuToggleWithText.test.tsx.snap
+++ b/packages/react-core/src/components/OptionsMenu/__tests__/Generated/__snapshots__/OptionsMenuToggleWithText.test.tsx.snap
@@ -21,9 +21,13 @@ exports[`OptionsMenuToggleWithText should match snapshot (auto-generated) 1`] = 
     id="''-toggle"
     onClick={[Function]}
   >
-    <div>
-      ReactNode
-    </div>
+    <span
+      className="pf-c-options-menu__toggle-button-icon"
+    >
+      <div>
+        ReactNode
+      </div>
+    </span>
   </button>
 </div>
 `;

--- a/packages/react-core/src/components/OptionsMenu/__tests__/__snapshots__/OptionsMenu.test.tsx.snap
+++ b/packages/react-core/src/components/OptionsMenu/__tests__/__snapshots__/OptionsMenu.test.tsx.snap
@@ -3009,7 +3009,11 @@ exports[`optionsMenu text 1`] = `
                   class="pf-c-options-menu__toggle-button"
                   id="-toggle"
                 >
-                  Test
+                  <span
+                    class="pf-c-options-menu__toggle-button-icon"
+                  >
+                    Test
+                  </span>
                 </button>
               </div>
             </div>,
@@ -3039,7 +3043,11 @@ exports[`optionsMenu text 1`] = `
             id="-toggle"
             onClick={[Function]}
           >
-            Test
+            <span
+              className="pf-c-options-menu__toggle-button-icon"
+            >
+              Test
+            </span>
           </button>
         </div>
       </OptionsMenuToggleWithText>

--- a/packages/react-core/src/components/OptionsMenu/__tests__/__snapshots__/OptionsMenu.test.tsx.snap
+++ b/packages/react-core/src/components/OptionsMenu/__tests__/__snapshots__/OptionsMenu.test.tsx.snap
@@ -129,21 +129,24 @@ exports[`optionsMenu expanded 1`] = `
                 <span
                   class="pf-c-options-menu__toggle-text"
                 />
-                <svg
-                  aria-hidden="true"
+                <span
                   class="pf-c-options-menu__toggle-icon"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 320 512"
-                  width="1em"
                 >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                    transform=""
-                  />
-                </svg>
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                      transform=""
+                    />
+                  </svg>
+                </span>
               </button>
               <ul
                 aria-labelledby="expanded-toggle"
@@ -298,21 +301,24 @@ exports[`optionsMenu expanded 1`] = `
                   <span
                     class="pf-c-options-menu__toggle-text"
                   />
-                  <svg
-                    aria-hidden="true"
+                  <span
                     class="pf-c-options-menu__toggle-icon"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style="vertical-align: -0.125em;"
-                    viewBox="0 0 320 512"
-                    width="1em"
                   >
-                    <path
-                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                      transform=""
-                    />
-                  </svg>
+                    <svg
+                      aria-hidden="true"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 320 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                        transform=""
+                      />
+                    </svg>
+                  </span>
                 </button>
                 <ul
                   aria-labelledby="expanded-toggle"
@@ -472,21 +478,24 @@ exports[`optionsMenu expanded 1`] = `
                     <span
                       class="pf-c-options-menu__toggle-text"
                     />
-                    <svg
-                      aria-hidden="true"
+                    <span
                       class="pf-c-options-menu__toggle-icon"
-                      fill="currentColor"
-                      height="1em"
-                      role="img"
-                      style="vertical-align: -0.125em;"
-                      viewBox="0 0 320 512"
-                      width="1em"
                     >
-                      <path
-                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                        transform=""
-                      />
-                    </svg>
+                      <svg
+                        aria-hidden="true"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        style="vertical-align: -0.125em;"
+                        viewBox="0 0 320 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                          transform=""
+                        />
+                      </svg>
+                    </span>
                   </button>
                   <ul
                     aria-labelledby="expanded-toggle"
@@ -625,33 +634,35 @@ exports[`optionsMenu expanded 1`] = `
               <span
                 className="pf-c-options-menu__toggle-text"
               />
-              <CaretDownIcon
+              <span
                 className="pf-c-options-menu__toggle-icon"
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  className="pf-c-options-menu__toggle-icon"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 320 512"
-                  width="1em"
+                <CaretDownIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                    transform=""
-                  />
-                </svg>
-              </CaretDownIcon>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                      transform=""
+                    />
+                  </svg>
+                </CaretDownIcon>
+              </span>
             </button>
           </Toggle>
         </DropdownToggle>
@@ -1180,21 +1191,24 @@ exports[`optionsMenu isDisabled 1`] = `
                 <span
                   class="pf-c-options-menu__toggle-text"
                 />
-                <svg
-                  aria-hidden="true"
+                <span
                   class="pf-c-options-menu__toggle-icon"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 320 512"
-                  width="1em"
                 >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                    transform=""
-                  />
-                </svg>
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                      transform=""
+                    />
+                  </svg>
+                </span>
               </button>
             </div>,
           }
@@ -1231,21 +1245,24 @@ exports[`optionsMenu isDisabled 1`] = `
                   <span
                     class="pf-c-options-menu__toggle-text"
                   />
-                  <svg
-                    aria-hidden="true"
+                  <span
                     class="pf-c-options-menu__toggle-icon"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style="vertical-align: -0.125em;"
-                    viewBox="0 0 320 512"
-                    width="1em"
                   >
-                    <path
-                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                      transform=""
-                    />
-                  </svg>
+                    <svg
+                      aria-hidden="true"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 320 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                        transform=""
+                      />
+                    </svg>
+                  </span>
                 </button>
               </div>,
             }
@@ -1287,21 +1304,24 @@ exports[`optionsMenu isDisabled 1`] = `
                     <span
                       class="pf-c-options-menu__toggle-text"
                     />
-                    <svg
-                      aria-hidden="true"
+                    <span
                       class="pf-c-options-menu__toggle-icon"
-                      fill="currentColor"
-                      height="1em"
-                      role="img"
-                      style="vertical-align: -0.125em;"
-                      viewBox="0 0 320 512"
-                      width="1em"
                     >
-                      <path
-                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                        transform=""
-                      />
-                    </svg>
+                      <svg
+                        aria-hidden="true"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        style="vertical-align: -0.125em;"
+                        viewBox="0 0 320 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                          transform=""
+                        />
+                      </svg>
+                    </span>
                   </button>
                 </div>,
               }
@@ -1321,33 +1341,35 @@ exports[`optionsMenu isDisabled 1`] = `
               <span
                 className="pf-c-options-menu__toggle-text"
               />
-              <CaretDownIcon
+              <span
                 className="pf-c-options-menu__toggle-icon"
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  className="pf-c-options-menu__toggle-icon"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 320 512"
-                  width="1em"
+                <CaretDownIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                    transform=""
-                  />
-                </svg>
-              </CaretDownIcon>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                      transform=""
+                    />
+                  </svg>
+                </CaretDownIcon>
+              </span>
             </button>
           </Toggle>
         </DropdownToggle>
@@ -1486,21 +1508,24 @@ exports[`optionsMenu open up 1`] = `
                 <span
                   class="pf-c-options-menu__toggle-text"
                 />
-                <svg
-                  aria-hidden="true"
+                <span
                   class="pf-c-options-menu__toggle-icon"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 320 512"
-                  width="1em"
                 >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                    transform=""
-                  />
-                </svg>
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                      transform=""
+                    />
+                  </svg>
+                </span>
               </button>
             </div>,
           }
@@ -1536,21 +1561,24 @@ exports[`optionsMenu open up 1`] = `
                   <span
                     class="pf-c-options-menu__toggle-text"
                   />
-                  <svg
-                    aria-hidden="true"
+                  <span
                     class="pf-c-options-menu__toggle-icon"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style="vertical-align: -0.125em;"
-                    viewBox="0 0 320 512"
-                    width="1em"
                   >
-                    <path
-                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                      transform=""
-                    />
-                  </svg>
+                    <svg
+                      aria-hidden="true"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 320 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                        transform=""
+                      />
+                    </svg>
+                  </span>
                 </button>
               </div>,
             }
@@ -1591,21 +1619,24 @@ exports[`optionsMenu open up 1`] = `
                     <span
                       class="pf-c-options-menu__toggle-text"
                     />
-                    <svg
-                      aria-hidden="true"
+                    <span
                       class="pf-c-options-menu__toggle-icon"
-                      fill="currentColor"
-                      height="1em"
-                      role="img"
-                      style="vertical-align: -0.125em;"
-                      viewBox="0 0 320 512"
-                      width="1em"
                     >
-                      <path
-                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                        transform=""
-                      />
-                    </svg>
+                      <svg
+                        aria-hidden="true"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        style="vertical-align: -0.125em;"
+                        viewBox="0 0 320 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                          transform=""
+                        />
+                      </svg>
+                    </span>
                   </button>
                 </div>,
               }
@@ -1625,33 +1656,35 @@ exports[`optionsMenu open up 1`] = `
               <span
                 className="pf-c-options-menu__toggle-text"
               />
-              <CaretDownIcon
+              <span
                 className="pf-c-options-menu__toggle-icon"
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  className="pf-c-options-menu__toggle-icon"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 320 512"
-                  width="1em"
+                <CaretDownIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                    transform=""
-                  />
-                </svg>
-              </CaretDownIcon>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                      transform=""
+                    />
+                  </svg>
+                </CaretDownIcon>
+              </span>
             </button>
           </Toggle>
         </DropdownToggle>
@@ -2016,21 +2049,24 @@ exports[`optionsMenu regular 1`] = `
                 <span
                   class="pf-c-options-menu__toggle-text"
                 />
-                <svg
-                  aria-hidden="true"
+                <span
                   class="pf-c-options-menu__toggle-icon"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 320 512"
-                  width="1em"
                 >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                    transform=""
-                  />
-                </svg>
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                      transform=""
+                    />
+                  </svg>
+                </span>
               </button>
             </div>,
           }
@@ -2066,21 +2102,24 @@ exports[`optionsMenu regular 1`] = `
                   <span
                     class="pf-c-options-menu__toggle-text"
                   />
-                  <svg
-                    aria-hidden="true"
+                  <span
                     class="pf-c-options-menu__toggle-icon"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style="vertical-align: -0.125em;"
-                    viewBox="0 0 320 512"
-                    width="1em"
                   >
-                    <path
-                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                      transform=""
-                    />
-                  </svg>
+                    <svg
+                      aria-hidden="true"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 320 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                        transform=""
+                      />
+                    </svg>
+                  </span>
                 </button>
               </div>,
             }
@@ -2121,21 +2160,24 @@ exports[`optionsMenu regular 1`] = `
                     <span
                       class="pf-c-options-menu__toggle-text"
                     />
-                    <svg
-                      aria-hidden="true"
+                    <span
                       class="pf-c-options-menu__toggle-icon"
-                      fill="currentColor"
-                      height="1em"
-                      role="img"
-                      style="vertical-align: -0.125em;"
-                      viewBox="0 0 320 512"
-                      width="1em"
                     >
-                      <path
-                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                        transform=""
-                      />
-                    </svg>
+                      <svg
+                        aria-hidden="true"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        style="vertical-align: -0.125em;"
+                        viewBox="0 0 320 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                          transform=""
+                        />
+                      </svg>
+                    </span>
                   </button>
                 </div>,
               }
@@ -2155,33 +2197,35 @@ exports[`optionsMenu regular 1`] = `
               <span
                 className="pf-c-options-menu__toggle-text"
               />
-              <CaretDownIcon
+              <span
                 className="pf-c-options-menu__toggle-icon"
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  className="pf-c-options-menu__toggle-icon"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 320 512"
-                  width="1em"
+                <CaretDownIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                    transform=""
-                  />
-                </svg>
-              </CaretDownIcon>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                      transform=""
+                    />
+                  </svg>
+                </CaretDownIcon>
+              </span>
             </button>
           </Toggle>
         </DropdownToggle>
@@ -2321,21 +2365,24 @@ exports[`optionsMenu right aligned + open up 1`] = `
                 <span
                   class="pf-c-options-menu__toggle-text"
                 />
-                <svg
-                  aria-hidden="true"
+                <span
                   class="pf-c-options-menu__toggle-icon"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 320 512"
-                  width="1em"
                 >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                    transform=""
-                  />
-                </svg>
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                      transform=""
+                    />
+                  </svg>
+                </span>
               </button>
             </div>,
           }
@@ -2371,21 +2418,24 @@ exports[`optionsMenu right aligned + open up 1`] = `
                   <span
                     class="pf-c-options-menu__toggle-text"
                   />
-                  <svg
-                    aria-hidden="true"
+                  <span
                     class="pf-c-options-menu__toggle-icon"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style="vertical-align: -0.125em;"
-                    viewBox="0 0 320 512"
-                    width="1em"
                   >
-                    <path
-                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                      transform=""
-                    />
-                  </svg>
+                    <svg
+                      aria-hidden="true"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 320 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                        transform=""
+                      />
+                    </svg>
+                  </span>
                 </button>
               </div>,
             }
@@ -2426,21 +2476,24 @@ exports[`optionsMenu right aligned + open up 1`] = `
                     <span
                       class="pf-c-options-menu__toggle-text"
                     />
-                    <svg
-                      aria-hidden="true"
+                    <span
                       class="pf-c-options-menu__toggle-icon"
-                      fill="currentColor"
-                      height="1em"
-                      role="img"
-                      style="vertical-align: -0.125em;"
-                      viewBox="0 0 320 512"
-                      width="1em"
                     >
-                      <path
-                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                        transform=""
-                      />
-                    </svg>
+                      <svg
+                        aria-hidden="true"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        style="vertical-align: -0.125em;"
+                        viewBox="0 0 320 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                          transform=""
+                        />
+                      </svg>
+                    </span>
                   </button>
                 </div>,
               }
@@ -2460,33 +2513,35 @@ exports[`optionsMenu right aligned + open up 1`] = `
               <span
                 className="pf-c-options-menu__toggle-text"
               />
-              <CaretDownIcon
+              <span
                 className="pf-c-options-menu__toggle-icon"
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  className="pf-c-options-menu__toggle-icon"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 320 512"
-                  width="1em"
+                <CaretDownIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                    transform=""
-                  />
-                </svg>
-              </CaretDownIcon>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                      transform=""
+                    />
+                  </svg>
+                </CaretDownIcon>
+              </span>
             </button>
           </Toggle>
         </DropdownToggle>
@@ -2625,21 +2680,24 @@ exports[`optionsMenu right aligned 1`] = `
                 <span
                   class="pf-c-options-menu__toggle-text"
                 />
-                <svg
-                  aria-hidden="true"
+                <span
                   class="pf-c-options-menu__toggle-icon"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 320 512"
-                  width="1em"
                 >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                    transform=""
-                  />
-                </svg>
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                      transform=""
+                    />
+                  </svg>
+                </span>
               </button>
             </div>,
           }
@@ -2675,21 +2733,24 @@ exports[`optionsMenu right aligned 1`] = `
                   <span
                     class="pf-c-options-menu__toggle-text"
                   />
-                  <svg
-                    aria-hidden="true"
+                  <span
                     class="pf-c-options-menu__toggle-icon"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style="vertical-align: -0.125em;"
-                    viewBox="0 0 320 512"
-                    width="1em"
                   >
-                    <path
-                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                      transform=""
-                    />
-                  </svg>
+                    <svg
+                      aria-hidden="true"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 320 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                        transform=""
+                      />
+                    </svg>
+                  </span>
                 </button>
               </div>,
             }
@@ -2730,21 +2791,24 @@ exports[`optionsMenu right aligned 1`] = `
                     <span
                       class="pf-c-options-menu__toggle-text"
                     />
-                    <svg
-                      aria-hidden="true"
+                    <span
                       class="pf-c-options-menu__toggle-icon"
-                      fill="currentColor"
-                      height="1em"
-                      role="img"
-                      style="vertical-align: -0.125em;"
-                      viewBox="0 0 320 512"
-                      width="1em"
                     >
-                      <path
-                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                        transform=""
-                      />
-                    </svg>
+                      <svg
+                        aria-hidden="true"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        style="vertical-align: -0.125em;"
+                        viewBox="0 0 320 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                          transform=""
+                        />
+                      </svg>
+                    </span>
                   </button>
                 </div>,
               }
@@ -2764,33 +2828,35 @@ exports[`optionsMenu right aligned 1`] = `
               <span
                 className="pf-c-options-menu__toggle-text"
               />
-              <CaretDownIcon
+              <span
                 className="pf-c-options-menu__toggle-icon"
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  className="pf-c-options-menu__toggle-icon"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 320 512"
-                  width="1em"
+                <CaretDownIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                    transform=""
-                  />
-                </svg>
-              </CaretDownIcon>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                      transform=""
+                    />
+                  </svg>
+                </CaretDownIcon>
+              </span>
             </button>
           </Toggle>
         </DropdownToggle>

--- a/packages/react-core/src/components/Pagination/PaginationOptionsMenu.tsx
+++ b/packages/react-core/src/components/Pagination/PaginationOptionsMenu.tsx
@@ -128,9 +128,9 @@ export class PaginationOptionsMenu extends React.Component<PaginationOptionsMenu
         {title}
         <span className={css(paginationStyles.paginationMenuText)}>{` ${perPageSuffix}`}</span>
         {perPage === value && (
-          <span className={css(styles.optionsMenuMenuItemIcon)}>
+          <div className={css(styles.optionsMenuMenuItemIcon)}>
             <CheckIcon />
-          </span>
+          </div>
         )}
       </DropdownItem>
     ));

--- a/packages/react-core/src/components/Pagination/PaginationOptionsMenu.tsx
+++ b/packages/react-core/src/components/Pagination/PaginationOptionsMenu.tsx
@@ -128,9 +128,9 @@ export class PaginationOptionsMenu extends React.Component<PaginationOptionsMenu
         {title}
         <span className={css(paginationStyles.paginationMenuText)}>{` ${perPageSuffix}`}</span>
         {perPage === value && (
-          <i className={css(styles.optionsMenuMenuItemIcon)}>
+          <span className={css(styles.optionsMenuMenuItemIcon)}>
             <CheckIcon />
-          </i>
+          </span>
         )}
       </DropdownItem>
     ));

--- a/packages/react-core/src/components/Pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/react-core/src/components/Pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -266,21 +266,24 @@ exports[`component render custom pagination toggle 1`] = `
                       id="pagination-options-menu-toggle-11"
                       type="button"
                     >
-                      <svg
-                        aria-hidden="true"
+                      <span
                         class=""
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style="vertical-align: -0.125em;"
-                        viewBox="0 0 320 512"
-                        width="1em"
                       >
-                        <path
-                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                          transform=""
-                        />
-                      </svg>
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            transform=""
+                          />
+                        </svg>
+                      </span>
                     </button>
                   </div>
                 </div>,
@@ -329,21 +332,24 @@ exports[`component render custom pagination toggle 1`] = `
                           id="pagination-options-menu-toggle-11"
                           type="button"
                         >
-                          <svg
-                            aria-hidden="true"
+                          <span
                             class=""
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: -0.125em;"
-                            viewBox="0 0 320 512"
-                            width="1em"
                           >
-                            <path
-                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                              transform=""
-                            />
-                          </svg>
+                            <svg
+                              aria-hidden="true"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              style="vertical-align: -0.125em;"
+                              viewBox="0 0 320 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                transform=""
+                              />
+                            </svg>
+                          </span>
                         </button>
                       </div>
                     </div>,
@@ -386,21 +392,24 @@ exports[`component render custom pagination toggle 1`] = `
                             id="pagination-options-menu-toggle-11"
                             type="button"
                           >
-                            <svg
-                              aria-hidden="true"
+                            <span
                               class=""
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              style="vertical-align: -0.125em;"
-                              viewBox="0 0 320 512"
-                              width="1em"
                             >
-                              <path
-                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                transform=""
-                              />
-                            </svg>
+                              <svg
+                                aria-hidden="true"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                style="vertical-align: -0.125em;"
+                                viewBox="0 0 320 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                  transform=""
+                                />
+                              </svg>
+                            </span>
                           </button>
                         </div>
                       </div>,
@@ -417,33 +426,35 @@ exports[`component render custom pagination toggle 1`] = `
                     onKeyDown={[Function]}
                     type="button"
                   >
-                    <CaretDownIcon
+                    <span
                       className=""
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="sm"
                     >
-                      <svg
-                        aria-hidden={true}
-                        aria-labelledby={null}
-                        className=""
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style={
-                          Object {
-                            "verticalAlign": "-0.125em",
-                          }
-                        }
-                        viewBox="0 0 320 512"
-                        width="1em"
+                      <CaretDownIcon
+                        color="currentColor"
+                        noVerticalAlign={false}
+                        size="sm"
                       >
-                        <path
-                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                          transform=""
-                        />
-                      </svg>
-                    </CaretDownIcon>
+                        <svg
+                          aria-hidden={true}
+                          aria-labelledby={null}
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style={
+                            Object {
+                              "verticalAlign": "-0.125em",
+                            }
+                          }
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            transform=""
+                          />
+                        </svg>
+                      </CaretDownIcon>
+                    </span>
                   </button>
                 </Toggle>
               </DropdownToggle>
@@ -898,21 +909,24 @@ exports[`component render custom perPageOptions 1`] = `
                       id="pagination-options-menu-toggle-7"
                       type="button"
                     >
-                      <svg
-                        aria-hidden="true"
+                      <span
                         class=""
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style="vertical-align: -0.125em;"
-                        viewBox="0 0 320 512"
-                        width="1em"
                       >
-                        <path
-                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                          transform=""
-                        />
-                      </svg>
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            transform=""
+                          />
+                        </svg>
+                      </span>
                     </button>
                   </div>
                 </div>,
@@ -989,21 +1003,24 @@ exports[`component render custom perPageOptions 1`] = `
                           id="pagination-options-menu-toggle-7"
                           type="button"
                         >
-                          <svg
-                            aria-hidden="true"
+                          <span
                             class=""
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: -0.125em;"
-                            viewBox="0 0 320 512"
-                            width="1em"
                           >
-                            <path
-                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                              transform=""
-                            />
-                          </svg>
+                            <svg
+                              aria-hidden="true"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              style="vertical-align: -0.125em;"
+                              viewBox="0 0 320 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                transform=""
+                              />
+                            </svg>
+                          </span>
                         </button>
                       </div>
                     </div>,
@@ -1057,21 +1074,24 @@ exports[`component render custom perPageOptions 1`] = `
                             id="pagination-options-menu-toggle-7"
                             type="button"
                           >
-                            <svg
-                              aria-hidden="true"
+                            <span
                               class=""
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              style="vertical-align: -0.125em;"
-                              viewBox="0 0 320 512"
-                              width="1em"
                             >
-                              <path
-                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                transform=""
-                              />
-                            </svg>
+                              <svg
+                                aria-hidden="true"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                style="vertical-align: -0.125em;"
+                                viewBox="0 0 320 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                  transform=""
+                                />
+                              </svg>
+                            </span>
                           </button>
                         </div>
                       </div>,
@@ -1088,33 +1108,35 @@ exports[`component render custom perPageOptions 1`] = `
                     onKeyDown={[Function]}
                     type="button"
                   >
-                    <CaretDownIcon
+                    <span
                       className=""
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="sm"
                     >
-                      <svg
-                        aria-hidden={true}
-                        aria-labelledby={null}
-                        className=""
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style={
-                          Object {
-                            "verticalAlign": "-0.125em",
-                          }
-                        }
-                        viewBox="0 0 320 512"
-                        width="1em"
+                      <CaretDownIcon
+                        color="currentColor"
+                        noVerticalAlign={false}
+                        size="sm"
                       >
-                        <path
-                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                          transform=""
-                        />
-                      </svg>
-                    </CaretDownIcon>
+                        <svg
+                          aria-hidden={true}
+                          aria-labelledby={null}
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style={
+                            Object {
+                              "verticalAlign": "-0.125em",
+                            }
+                          }
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            transform=""
+                          />
+                        </svg>
+                      </CaretDownIcon>
+                    </span>
                   </button>
                 </Toggle>
               </DropdownToggle>
@@ -1641,21 +1663,24 @@ exports[`component render custom start end 1`] = `
                       id="pagination-options-menu-toggle-9"
                       type="button"
                     >
-                      <svg
-                        aria-hidden="true"
+                      <span
                         class=""
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style="vertical-align: -0.125em;"
-                        viewBox="0 0 320 512"
-                        width="1em"
                       >
-                        <path
-                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                          transform=""
-                        />
-                      </svg>
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            transform=""
+                          />
+                        </svg>
+                      </span>
                     </button>
                   </div>
                 </div>,
@@ -1732,21 +1757,24 @@ exports[`component render custom start end 1`] = `
                           id="pagination-options-menu-toggle-9"
                           type="button"
                         >
-                          <svg
-                            aria-hidden="true"
+                          <span
                             class=""
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: -0.125em;"
-                            viewBox="0 0 320 512"
-                            width="1em"
                           >
-                            <path
-                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                              transform=""
-                            />
-                          </svg>
+                            <svg
+                              aria-hidden="true"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              style="vertical-align: -0.125em;"
+                              viewBox="0 0 320 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                transform=""
+                              />
+                            </svg>
+                          </span>
                         </button>
                       </div>
                     </div>,
@@ -1800,21 +1828,24 @@ exports[`component render custom start end 1`] = `
                             id="pagination-options-menu-toggle-9"
                             type="button"
                           >
-                            <svg
-                              aria-hidden="true"
+                            <span
                               class=""
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              style="vertical-align: -0.125em;"
-                              viewBox="0 0 320 512"
-                              width="1em"
                             >
-                              <path
-                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                transform=""
-                              />
-                            </svg>
+                              <svg
+                                aria-hidden="true"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                style="vertical-align: -0.125em;"
+                                viewBox="0 0 320 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                  transform=""
+                                />
+                              </svg>
+                            </span>
                           </button>
                         </div>
                       </div>,
@@ -1831,33 +1862,35 @@ exports[`component render custom start end 1`] = `
                     onKeyDown={[Function]}
                     type="button"
                   >
-                    <CaretDownIcon
+                    <span
                       className=""
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="sm"
                     >
-                      <svg
-                        aria-hidden={true}
-                        aria-labelledby={null}
-                        className=""
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style={
-                          Object {
-                            "verticalAlign": "-0.125em",
-                          }
-                        }
-                        viewBox="0 0 320 512"
-                        width="1em"
+                      <CaretDownIcon
+                        color="currentColor"
+                        noVerticalAlign={false}
+                        size="sm"
                       >
-                        <path
-                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                          transform=""
-                        />
-                      </svg>
-                    </CaretDownIcon>
+                        <svg
+                          aria-hidden={true}
+                          aria-labelledby={null}
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style={
+                            Object {
+                              "verticalAlign": "-0.125em",
+                            }
+                          }
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            transform=""
+                          />
+                        </svg>
+                      </CaretDownIcon>
+                    </span>
                   </button>
                 </Toggle>
               </DropdownToggle>
@@ -2791,21 +2824,24 @@ exports[`component render last page 1`] = `
                       id="pagination-options-menu-toggle-6"
                       type="button"
                     >
-                      <svg
-                        aria-hidden="true"
+                      <span
                         class=""
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style="vertical-align: -0.125em;"
-                        viewBox="0 0 320 512"
-                        width="1em"
                       >
-                        <path
-                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                          transform=""
-                        />
-                      </svg>
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            transform=""
+                          />
+                        </svg>
+                      </span>
                     </button>
                   </div>
                 </div>,
@@ -2882,21 +2918,24 @@ exports[`component render last page 1`] = `
                           id="pagination-options-menu-toggle-6"
                           type="button"
                         >
-                          <svg
-                            aria-hidden="true"
+                          <span
                             class=""
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: -0.125em;"
-                            viewBox="0 0 320 512"
-                            width="1em"
                           >
-                            <path
-                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                              transform=""
-                            />
-                          </svg>
+                            <svg
+                              aria-hidden="true"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              style="vertical-align: -0.125em;"
+                              viewBox="0 0 320 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                transform=""
+                              />
+                            </svg>
+                          </span>
                         </button>
                       </div>
                     </div>,
@@ -2950,21 +2989,24 @@ exports[`component render last page 1`] = `
                             id="pagination-options-menu-toggle-6"
                             type="button"
                           >
-                            <svg
-                              aria-hidden="true"
+                            <span
                               class=""
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              style="vertical-align: -0.125em;"
-                              viewBox="0 0 320 512"
-                              width="1em"
                             >
-                              <path
-                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                transform=""
-                              />
-                            </svg>
+                              <svg
+                                aria-hidden="true"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                style="vertical-align: -0.125em;"
+                                viewBox="0 0 320 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                  transform=""
+                                />
+                              </svg>
+                            </span>
                           </button>
                         </div>
                       </div>,
@@ -2981,33 +3023,35 @@ exports[`component render last page 1`] = `
                     onKeyDown={[Function]}
                     type="button"
                   >
-                    <CaretDownIcon
+                    <span
                       className=""
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="sm"
                     >
-                      <svg
-                        aria-hidden={true}
-                        aria-labelledby={null}
-                        className=""
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style={
-                          Object {
-                            "verticalAlign": "-0.125em",
-                          }
-                        }
-                        viewBox="0 0 320 512"
-                        width="1em"
+                      <CaretDownIcon
+                        color="currentColor"
+                        noVerticalAlign={false}
+                        size="sm"
                       >
-                        <path
-                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                          transform=""
-                        />
-                      </svg>
-                    </CaretDownIcon>
+                        <svg
+                          aria-hidden={true}
+                          aria-labelledby={null}
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style={
+                            Object {
+                              "verticalAlign": "-0.125em",
+                            }
+                          }
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            transform=""
+                          />
+                        </svg>
+                      </CaretDownIcon>
+                    </span>
                   </button>
                 </Toggle>
               </DropdownToggle>
@@ -3534,21 +3578,24 @@ exports[`component render limited number of pages 1`] = `
                       id="pagination-options-menu-toggle-4"
                       type="button"
                     >
-                      <svg
-                        aria-hidden="true"
+                      <span
                         class=""
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style="vertical-align: -0.125em;"
-                        viewBox="0 0 320 512"
-                        width="1em"
                       >
-                        <path
-                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                          transform=""
-                        />
-                      </svg>
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            transform=""
+                          />
+                        </svg>
+                      </span>
                     </button>
                   </div>
                 </div>,
@@ -3625,21 +3672,24 @@ exports[`component render limited number of pages 1`] = `
                           id="pagination-options-menu-toggle-4"
                           type="button"
                         >
-                          <svg
-                            aria-hidden="true"
+                          <span
                             class=""
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: -0.125em;"
-                            viewBox="0 0 320 512"
-                            width="1em"
                           >
-                            <path
-                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                              transform=""
-                            />
-                          </svg>
+                            <svg
+                              aria-hidden="true"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              style="vertical-align: -0.125em;"
+                              viewBox="0 0 320 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                transform=""
+                              />
+                            </svg>
+                          </span>
                         </button>
                       </div>
                     </div>,
@@ -3693,21 +3743,24 @@ exports[`component render limited number of pages 1`] = `
                             id="pagination-options-menu-toggle-4"
                             type="button"
                           >
-                            <svg
-                              aria-hidden="true"
+                            <span
                               class=""
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              style="vertical-align: -0.125em;"
-                              viewBox="0 0 320 512"
-                              width="1em"
                             >
-                              <path
-                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                transform=""
-                              />
-                            </svg>
+                              <svg
+                                aria-hidden="true"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                style="vertical-align: -0.125em;"
+                                viewBox="0 0 320 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                  transform=""
+                                />
+                              </svg>
+                            </span>
                           </button>
                         </div>
                       </div>,
@@ -3724,33 +3777,35 @@ exports[`component render limited number of pages 1`] = `
                     onKeyDown={[Function]}
                     type="button"
                   >
-                    <CaretDownIcon
+                    <span
                       className=""
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="sm"
                     >
-                      <svg
-                        aria-hidden={true}
-                        aria-labelledby={null}
-                        className=""
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style={
-                          Object {
-                            "verticalAlign": "-0.125em",
-                          }
-                        }
-                        viewBox="0 0 320 512"
-                        width="1em"
+                      <CaretDownIcon
+                        color="currentColor"
+                        noVerticalAlign={false}
+                        size="sm"
                       >
-                        <path
-                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                          transform=""
-                        />
-                      </svg>
-                    </CaretDownIcon>
+                        <svg
+                          aria-hidden={true}
+                          aria-labelledby={null}
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style={
+                            Object {
+                              "verticalAlign": "-0.125em",
+                            }
+                          }
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            transform=""
+                          />
+                        </svg>
+                      </CaretDownIcon>
+                    </span>
                   </button>
                 </Toggle>
               </DropdownToggle>
@@ -4278,21 +4333,24 @@ exports[`component render no items 1`] = `
                       id="pagination-options-menu-toggle-8"
                       type="button"
                     >
-                      <svg
-                        aria-hidden="true"
+                      <span
                         class=""
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style="vertical-align: -0.125em;"
-                        viewBox="0 0 320 512"
-                        width="1em"
                       >
-                        <path
-                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                          transform=""
-                        />
-                      </svg>
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            transform=""
+                          />
+                        </svg>
+                      </span>
                     </button>
                   </div>
                 </div>,
@@ -4370,21 +4428,24 @@ exports[`component render no items 1`] = `
                           id="pagination-options-menu-toggle-8"
                           type="button"
                         >
-                          <svg
-                            aria-hidden="true"
+                          <span
                             class=""
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: -0.125em;"
-                            viewBox="0 0 320 512"
-                            width="1em"
                           >
-                            <path
-                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                              transform=""
-                            />
-                          </svg>
+                            <svg
+                              aria-hidden="true"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              style="vertical-align: -0.125em;"
+                              viewBox="0 0 320 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                transform=""
+                              />
+                            </svg>
+                          </span>
                         </button>
                       </div>
                     </div>,
@@ -4439,21 +4500,24 @@ exports[`component render no items 1`] = `
                             id="pagination-options-menu-toggle-8"
                             type="button"
                           >
-                            <svg
-                              aria-hidden="true"
+                            <span
                               class=""
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              style="vertical-align: -0.125em;"
-                              viewBox="0 0 320 512"
-                              width="1em"
                             >
-                              <path
-                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                transform=""
-                              />
-                            </svg>
+                              <svg
+                                aria-hidden="true"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                style="vertical-align: -0.125em;"
+                                viewBox="0 0 320 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                  transform=""
+                                />
+                              </svg>
+                            </span>
                           </button>
                         </div>
                       </div>,
@@ -4470,33 +4534,35 @@ exports[`component render no items 1`] = `
                     onKeyDown={[Function]}
                     type="button"
                   >
-                    <CaretDownIcon
+                    <span
                       className=""
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="sm"
                     >
-                      <svg
-                        aria-hidden={true}
-                        aria-labelledby={null}
-                        className=""
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style={
-                          Object {
-                            "verticalAlign": "-0.125em",
-                          }
-                        }
-                        viewBox="0 0 320 512"
-                        width="1em"
+                      <CaretDownIcon
+                        color="currentColor"
+                        noVerticalAlign={false}
+                        size="sm"
                       >
-                        <path
-                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                          transform=""
-                        />
-                      </svg>
-                    </CaretDownIcon>
+                        <svg
+                          aria-hidden={true}
+                          aria-labelledby={null}
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style={
+                            Object {
+                              "verticalAlign": "-0.125em",
+                            }
+                          }
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            transform=""
+                          />
+                        </svg>
+                      </CaretDownIcon>
+                    </span>
                   </button>
                 </Toggle>
               </DropdownToggle>
@@ -5001,21 +5067,24 @@ exports[`component render should render correctly bottom 1`] = `
                       id="pagination-options-menu-toggle-1"
                       type="button"
                     >
-                      <svg
-                        aria-hidden="true"
+                      <span
                         class=""
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style="vertical-align: -0.125em;"
-                        viewBox="0 0 320 512"
-                        width="1em"
                       >
-                        <path
-                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                          transform=""
-                        />
-                      </svg>
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            transform=""
+                          />
+                        </svg>
+                      </span>
                     </button>
                   </div>
                 </div>,
@@ -5092,21 +5161,24 @@ exports[`component render should render correctly bottom 1`] = `
                           id="pagination-options-menu-toggle-1"
                           type="button"
                         >
-                          <svg
-                            aria-hidden="true"
+                          <span
                             class=""
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: -0.125em;"
-                            viewBox="0 0 320 512"
-                            width="1em"
                           >
-                            <path
-                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                              transform=""
-                            />
-                          </svg>
+                            <svg
+                              aria-hidden="true"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              style="vertical-align: -0.125em;"
+                              viewBox="0 0 320 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                transform=""
+                              />
+                            </svg>
+                          </span>
                         </button>
                       </div>
                     </div>,
@@ -5160,21 +5232,24 @@ exports[`component render should render correctly bottom 1`] = `
                             id="pagination-options-menu-toggle-1"
                             type="button"
                           >
-                            <svg
-                              aria-hidden="true"
+                            <span
                               class=""
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              style="vertical-align: -0.125em;"
-                              viewBox="0 0 320 512"
-                              width="1em"
                             >
-                              <path
-                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                transform=""
-                              />
-                            </svg>
+                              <svg
+                                aria-hidden="true"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                style="vertical-align: -0.125em;"
+                                viewBox="0 0 320 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                  transform=""
+                                />
+                              </svg>
+                            </span>
                           </button>
                         </div>
                       </div>,
@@ -5191,33 +5266,35 @@ exports[`component render should render correctly bottom 1`] = `
                     onKeyDown={[Function]}
                     type="button"
                   >
-                    <CaretDownIcon
+                    <span
                       className=""
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="sm"
                     >
-                      <svg
-                        aria-hidden={true}
-                        aria-labelledby={null}
-                        className=""
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style={
-                          Object {
-                            "verticalAlign": "-0.125em",
-                          }
-                        }
-                        viewBox="0 0 320 512"
-                        width="1em"
+                      <CaretDownIcon
+                        color="currentColor"
+                        noVerticalAlign={false}
+                        size="sm"
                       >
-                        <path
-                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                          transform=""
-                        />
-                      </svg>
-                    </CaretDownIcon>
+                        <svg
+                          aria-hidden={true}
+                          aria-labelledby={null}
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style={
+                            Object {
+                              "verticalAlign": "-0.125em",
+                            }
+                          }
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            transform=""
+                          />
+                        </svg>
+                      </CaretDownIcon>
+                    </span>
                   </button>
                 </Toggle>
               </DropdownToggle>
@@ -5744,21 +5821,24 @@ exports[`component render should render correctly compact 1`] = `
                       id="pagination-options-menu-toggle-2"
                       type="button"
                     >
-                      <svg
-                        aria-hidden="true"
+                      <span
                         class=""
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style="vertical-align: -0.125em;"
-                        viewBox="0 0 320 512"
-                        width="1em"
                       >
-                        <path
-                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                          transform=""
-                        />
-                      </svg>
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            transform=""
+                          />
+                        </svg>
+                      </span>
                     </button>
                   </div>
                 </div>,
@@ -5835,21 +5915,24 @@ exports[`component render should render correctly compact 1`] = `
                           id="pagination-options-menu-toggle-2"
                           type="button"
                         >
-                          <svg
-                            aria-hidden="true"
+                          <span
                             class=""
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: -0.125em;"
-                            viewBox="0 0 320 512"
-                            width="1em"
                           >
-                            <path
-                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                              transform=""
-                            />
-                          </svg>
+                            <svg
+                              aria-hidden="true"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              style="vertical-align: -0.125em;"
+                              viewBox="0 0 320 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                transform=""
+                              />
+                            </svg>
+                          </span>
                         </button>
                       </div>
                     </div>,
@@ -5903,21 +5986,24 @@ exports[`component render should render correctly compact 1`] = `
                             id="pagination-options-menu-toggle-2"
                             type="button"
                           >
-                            <svg
-                              aria-hidden="true"
+                            <span
                               class=""
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              style="vertical-align: -0.125em;"
-                              viewBox="0 0 320 512"
-                              width="1em"
                             >
-                              <path
-                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                transform=""
-                              />
-                            </svg>
+                              <svg
+                                aria-hidden="true"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                style="vertical-align: -0.125em;"
+                                viewBox="0 0 320 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                  transform=""
+                                />
+                              </svg>
+                            </span>
                           </button>
                         </div>
                       </div>,
@@ -5934,33 +6020,35 @@ exports[`component render should render correctly compact 1`] = `
                     onKeyDown={[Function]}
                     type="button"
                   >
-                    <CaretDownIcon
+                    <span
                       className=""
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="sm"
                     >
-                      <svg
-                        aria-hidden={true}
-                        aria-labelledby={null}
-                        className=""
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style={
-                          Object {
-                            "verticalAlign": "-0.125em",
-                          }
-                        }
-                        viewBox="0 0 320 512"
-                        width="1em"
+                      <CaretDownIcon
+                        color="currentColor"
+                        noVerticalAlign={false}
+                        size="sm"
                       >
-                        <path
-                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                          transform=""
-                        />
-                      </svg>
-                    </CaretDownIcon>
+                        <svg
+                          aria-hidden={true}
+                          aria-labelledby={null}
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style={
+                            Object {
+                              "verticalAlign": "-0.125em",
+                            }
+                          }
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            transform=""
+                          />
+                        </svg>
+                      </CaretDownIcon>
+                    </span>
                   </button>
                 </Toggle>
               </DropdownToggle>
@@ -6373,21 +6461,24 @@ exports[`component render should render correctly disabled 1`] = `
                       id="pagination-options-menu-toggle-3"
                       type="button"
                     >
-                      <svg
-                        aria-hidden="true"
+                      <span
                         class=""
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style="vertical-align: -0.125em;"
-                        viewBox="0 0 320 512"
-                        width="1em"
                       >
-                        <path
-                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                          transform=""
-                        />
-                      </svg>
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            transform=""
+                          />
+                        </svg>
+                      </span>
                     </button>
                   </div>
                 </div>,
@@ -6465,21 +6556,24 @@ exports[`component render should render correctly disabled 1`] = `
                           id="pagination-options-menu-toggle-3"
                           type="button"
                         >
-                          <svg
-                            aria-hidden="true"
+                          <span
                             class=""
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: -0.125em;"
-                            viewBox="0 0 320 512"
-                            width="1em"
                           >
-                            <path
-                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                              transform=""
-                            />
-                          </svg>
+                            <svg
+                              aria-hidden="true"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              style="vertical-align: -0.125em;"
+                              viewBox="0 0 320 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                transform=""
+                              />
+                            </svg>
+                          </span>
                         </button>
                       </div>
                     </div>,
@@ -6534,21 +6628,24 @@ exports[`component render should render correctly disabled 1`] = `
                             id="pagination-options-menu-toggle-3"
                             type="button"
                           >
-                            <svg
-                              aria-hidden="true"
+                            <span
                               class=""
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              style="vertical-align: -0.125em;"
-                              viewBox="0 0 320 512"
-                              width="1em"
                             >
-                              <path
-                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                transform=""
-                              />
-                            </svg>
+                              <svg
+                                aria-hidden="true"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                style="vertical-align: -0.125em;"
+                                viewBox="0 0 320 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                  transform=""
+                                />
+                              </svg>
+                            </span>
                           </button>
                         </div>
                       </div>,
@@ -6565,33 +6662,35 @@ exports[`component render should render correctly disabled 1`] = `
                     onKeyDown={[Function]}
                     type="button"
                   >
-                    <CaretDownIcon
+                    <span
                       className=""
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="sm"
                     >
-                      <svg
-                        aria-hidden={true}
-                        aria-labelledby={null}
-                        className=""
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style={
-                          Object {
-                            "verticalAlign": "-0.125em",
-                          }
-                        }
-                        viewBox="0 0 320 512"
-                        width="1em"
+                      <CaretDownIcon
+                        color="currentColor"
+                        noVerticalAlign={false}
+                        size="sm"
                       >
-                        <path
-                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                          transform=""
-                        />
-                      </svg>
-                    </CaretDownIcon>
+                        <svg
+                          aria-hidden={true}
+                          aria-labelledby={null}
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style={
+                            Object {
+                              "verticalAlign": "-0.125em",
+                            }
+                          }
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            transform=""
+                          />
+                        </svg>
+                      </CaretDownIcon>
+                    </span>
                   </button>
                 </Toggle>
               </DropdownToggle>
@@ -7118,21 +7217,24 @@ exports[`component render should render correctly top 1`] = `
                       id="pagination-options-menu-toggle-0"
                       type="button"
                     >
-                      <svg
-                        aria-hidden="true"
+                      <span
                         class=""
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style="vertical-align: -0.125em;"
-                        viewBox="0 0 320 512"
-                        width="1em"
                       >
-                        <path
-                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                          transform=""
-                        />
-                      </svg>
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            transform=""
+                          />
+                        </svg>
+                      </span>
                     </button>
                   </div>
                 </div>,
@@ -7209,21 +7311,24 @@ exports[`component render should render correctly top 1`] = `
                           id="pagination-options-menu-toggle-0"
                           type="button"
                         >
-                          <svg
-                            aria-hidden="true"
+                          <span
                             class=""
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: -0.125em;"
-                            viewBox="0 0 320 512"
-                            width="1em"
                           >
-                            <path
-                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                              transform=""
-                            />
-                          </svg>
+                            <svg
+                              aria-hidden="true"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              style="vertical-align: -0.125em;"
+                              viewBox="0 0 320 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                transform=""
+                              />
+                            </svg>
+                          </span>
                         </button>
                       </div>
                     </div>,
@@ -7277,21 +7382,24 @@ exports[`component render should render correctly top 1`] = `
                             id="pagination-options-menu-toggle-0"
                             type="button"
                           >
-                            <svg
-                              aria-hidden="true"
+                            <span
                               class=""
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              style="vertical-align: -0.125em;"
-                              viewBox="0 0 320 512"
-                              width="1em"
                             >
-                              <path
-                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                transform=""
-                              />
-                            </svg>
+                              <svg
+                                aria-hidden="true"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                style="vertical-align: -0.125em;"
+                                viewBox="0 0 320 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                  transform=""
+                                />
+                              </svg>
+                            </span>
                           </button>
                         </div>
                       </div>,
@@ -7308,33 +7416,35 @@ exports[`component render should render correctly top 1`] = `
                     onKeyDown={[Function]}
                     type="button"
                   >
-                    <CaretDownIcon
+                    <span
                       className=""
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="sm"
                     >
-                      <svg
-                        aria-hidden={true}
-                        aria-labelledby={null}
-                        className=""
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style={
-                          Object {
-                            "verticalAlign": "-0.125em",
-                          }
-                        }
-                        viewBox="0 0 320 512"
-                        width="1em"
+                      <CaretDownIcon
+                        color="currentColor"
+                        noVerticalAlign={false}
+                        size="sm"
                       >
-                        <path
-                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                          transform=""
-                        />
-                      </svg>
-                    </CaretDownIcon>
+                        <svg
+                          aria-hidden={true}
+                          aria-labelledby={null}
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style={
+                            Object {
+                              "verticalAlign": "-0.125em",
+                            }
+                          }
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            transform=""
+                          />
+                        </svg>
+                      </CaretDownIcon>
+                    </span>
                   </button>
                 </Toggle>
               </DropdownToggle>
@@ -7853,21 +7963,24 @@ exports[`component render titles 1`] = `
                       id="pagination-options-menu-toggle-10"
                       type="button"
                     >
-                      <svg
-                        aria-hidden="true"
+                      <span
                         class=""
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style="vertical-align: -0.125em;"
-                        viewBox="0 0 320 512"
-                        width="1em"
                       >
-                        <path
-                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                          transform=""
-                        />
-                      </svg>
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            transform=""
+                          />
+                        </svg>
+                      </span>
                     </button>
                   </div>
                 </div>,
@@ -7945,21 +8058,24 @@ exports[`component render titles 1`] = `
                           id="pagination-options-menu-toggle-10"
                           type="button"
                         >
-                          <svg
-                            aria-hidden="true"
+                          <span
                             class=""
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: -0.125em;"
-                            viewBox="0 0 320 512"
-                            width="1em"
                           >
-                            <path
-                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                              transform=""
-                            />
-                          </svg>
+                            <svg
+                              aria-hidden="true"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              style="vertical-align: -0.125em;"
+                              viewBox="0 0 320 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                transform=""
+                              />
+                            </svg>
+                          </span>
                         </button>
                       </div>
                     </div>,
@@ -8013,21 +8129,24 @@ exports[`component render titles 1`] = `
                             id="pagination-options-menu-toggle-10"
                             type="button"
                           >
-                            <svg
-                              aria-hidden="true"
+                            <span
                               class=""
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              style="vertical-align: -0.125em;"
-                              viewBox="0 0 320 512"
-                              width="1em"
                             >
-                              <path
-                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                transform=""
-                              />
-                            </svg>
+                              <svg
+                                aria-hidden="true"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                style="vertical-align: -0.125em;"
+                                viewBox="0 0 320 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                  transform=""
+                                />
+                              </svg>
+                            </span>
                           </button>
                         </div>
                       </div>,
@@ -8044,33 +8163,35 @@ exports[`component render titles 1`] = `
                     onKeyDown={[Function]}
                     type="button"
                   >
-                    <CaretDownIcon
+                    <span
                       className=""
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="sm"
                     >
-                      <svg
-                        aria-hidden={true}
-                        aria-labelledby={null}
-                        className=""
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style={
-                          Object {
-                            "verticalAlign": "-0.125em",
-                          }
-                        }
-                        viewBox="0 0 320 512"
-                        width="1em"
+                      <CaretDownIcon
+                        color="currentColor"
+                        noVerticalAlign={false}
+                        size="sm"
                       >
-                        <path
-                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                          transform=""
-                        />
-                      </svg>
-                    </CaretDownIcon>
+                        <svg
+                          aria-hidden={true}
+                          aria-labelledby={null}
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style={
+                            Object {
+                              "verticalAlign": "-0.125em",
+                            }
+                          }
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            transform=""
+                          />
+                        </svg>
+                      </CaretDownIcon>
+                    </span>
                   </button>
                 </Toggle>
               </DropdownToggle>
@@ -8597,21 +8718,24 @@ exports[`component render up drop direction 1`] = `
                       id="pagination-options-menu-toggle-12"
                       type="button"
                     >
-                      <svg
-                        aria-hidden="true"
+                      <span
                         class=""
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style="vertical-align: -0.125em;"
-                        viewBox="0 0 320 512"
-                        width="1em"
                       >
-                        <path
-                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                          transform=""
-                        />
-                      </svg>
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            transform=""
+                          />
+                        </svg>
+                      </span>
                     </button>
                   </div>
                 </div>,
@@ -8688,21 +8812,24 @@ exports[`component render up drop direction 1`] = `
                           id="pagination-options-menu-toggle-12"
                           type="button"
                         >
-                          <svg
-                            aria-hidden="true"
+                          <span
                             class=""
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: -0.125em;"
-                            viewBox="0 0 320 512"
-                            width="1em"
                           >
-                            <path
-                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                              transform=""
-                            />
-                          </svg>
+                            <svg
+                              aria-hidden="true"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              style="vertical-align: -0.125em;"
+                              viewBox="0 0 320 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                transform=""
+                              />
+                            </svg>
+                          </span>
                         </button>
                       </div>
                     </div>,
@@ -8756,21 +8883,24 @@ exports[`component render up drop direction 1`] = `
                             id="pagination-options-menu-toggle-12"
                             type="button"
                           >
-                            <svg
-                              aria-hidden="true"
+                            <span
                               class=""
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              style="vertical-align: -0.125em;"
-                              viewBox="0 0 320 512"
-                              width="1em"
                             >
-                              <path
-                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                transform=""
-                              />
-                            </svg>
+                              <svg
+                                aria-hidden="true"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                style="vertical-align: -0.125em;"
+                                viewBox="0 0 320 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                  transform=""
+                                />
+                              </svg>
+                            </span>
                           </button>
                         </div>
                       </div>,
@@ -8787,33 +8917,35 @@ exports[`component render up drop direction 1`] = `
                     onKeyDown={[Function]}
                     type="button"
                   >
-                    <CaretDownIcon
+                    <span
                       className=""
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="sm"
                     >
-                      <svg
-                        aria-hidden={true}
-                        aria-labelledby={null}
-                        className=""
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style={
-                          Object {
-                            "verticalAlign": "-0.125em",
-                          }
-                        }
-                        viewBox="0 0 320 512"
-                        width="1em"
+                      <CaretDownIcon
+                        color="currentColor"
+                        noVerticalAlign={false}
+                        size="sm"
                       >
-                        <path
-                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                          transform=""
-                        />
-                      </svg>
-                    </CaretDownIcon>
+                        <svg
+                          aria-hidden={true}
+                          aria-labelledby={null}
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style={
+                            Object {
+                              "verticalAlign": "-0.125em",
+                            }
+                          }
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            transform=""
+                          />
+                        </svg>
+                      </CaretDownIcon>
+                    </span>
                   </button>
                 </Toggle>
               </DropdownToggle>
@@ -9341,21 +9473,24 @@ exports[`component render zero results 1`] = `
                       id="pagination-options-menu-toggle-5"
                       type="button"
                     >
-                      <svg
-                        aria-hidden="true"
+                      <span
                         class=""
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style="vertical-align: -0.125em;"
-                        viewBox="0 0 320 512"
-                        width="1em"
                       >
-                        <path
-                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                          transform=""
-                        />
-                      </svg>
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            transform=""
+                          />
+                        </svg>
+                      </span>
                     </button>
                   </div>
                 </div>,
@@ -9433,21 +9568,24 @@ exports[`component render zero results 1`] = `
                           id="pagination-options-menu-toggle-5"
                           type="button"
                         >
-                          <svg
-                            aria-hidden="true"
+                          <span
                             class=""
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            style="vertical-align: -0.125em;"
-                            viewBox="0 0 320 512"
-                            width="1em"
                           >
-                            <path
-                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                              transform=""
-                            />
-                          </svg>
+                            <svg
+                              aria-hidden="true"
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              style="vertical-align: -0.125em;"
+                              viewBox="0 0 320 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                transform=""
+                              />
+                            </svg>
+                          </span>
                         </button>
                       </div>
                     </div>,
@@ -9502,21 +9640,24 @@ exports[`component render zero results 1`] = `
                             id="pagination-options-menu-toggle-5"
                             type="button"
                           >
-                            <svg
-                              aria-hidden="true"
+                            <span
                               class=""
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              style="vertical-align: -0.125em;"
-                              viewBox="0 0 320 512"
-                              width="1em"
                             >
-                              <path
-                                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                transform=""
-                              />
-                            </svg>
+                              <svg
+                                aria-hidden="true"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                style="vertical-align: -0.125em;"
+                                viewBox="0 0 320 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                  transform=""
+                                />
+                              </svg>
+                            </span>
                           </button>
                         </div>
                       </div>,
@@ -9533,33 +9674,35 @@ exports[`component render zero results 1`] = `
                     onKeyDown={[Function]}
                     type="button"
                   >
-                    <CaretDownIcon
+                    <span
                       className=""
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="sm"
                     >
-                      <svg
-                        aria-hidden={true}
-                        aria-labelledby={null}
-                        className=""
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style={
-                          Object {
-                            "verticalAlign": "-0.125em",
-                          }
-                        }
-                        viewBox="0 0 320 512"
-                        width="1em"
+                      <CaretDownIcon
+                        color="currentColor"
+                        noVerticalAlign={false}
+                        size="sm"
                       >
-                        <path
-                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                          transform=""
-                        />
-                      </svg>
-                    </CaretDownIcon>
+                        <svg
+                          aria-hidden={true}
+                          aria-labelledby={null}
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style={
+                            Object {
+                              "verticalAlign": "-0.125em",
+                            }
+                          }
+                          viewBox="0 0 320 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            transform=""
+                          />
+                        </svg>
+                      </CaretDownIcon>
+                    </span>
                   </button>
                 </Toggle>
               </DropdownToggle>

--- a/packages/react-core/src/components/Pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/react-core/src/components/Pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -147,7 +147,7 @@ exports[`component render custom pagination toggle 1`] = `
               >
                  per page
               </span>
-              <i
+              <span
                 className="pf-c-options-menu__menu-item-icon"
               >
                 <CheckIcon
@@ -155,7 +155,7 @@ exports[`component render custom pagination toggle 1`] = `
                   noVerticalAlign={false}
                   size="sm"
                 />
-              </i>
+              </span>
             </DropdownItem>,
             <DropdownItem
               className=""
@@ -1511,7 +1511,7 @@ exports[`component render custom start end 1`] = `
               >
                  per page
               </span>
-              <i
+              <span
                 className="pf-c-options-menu__menu-item-icon"
               >
                 <CheckIcon
@@ -1519,7 +1519,7 @@ exports[`component render custom start end 1`] = `
                   noVerticalAlign={false}
                   size="sm"
                 />
-              </i>
+              </span>
             </DropdownItem>,
             <DropdownItem
               className=""
@@ -2661,7 +2661,7 @@ exports[`component render last page 1`] = `
               >
                  per page
               </span>
-              <i
+              <span
                 className="pf-c-options-menu__menu-item-icon"
               >
                 <CheckIcon
@@ -2669,7 +2669,7 @@ exports[`component render last page 1`] = `
                   noVerticalAlign={false}
                   size="sm"
                 />
-              </i>
+              </span>
             </DropdownItem>,
             <DropdownItem
               className=""
@@ -3417,7 +3417,7 @@ exports[`component render limited number of pages 1`] = `
               >
                  per page
               </span>
-              <i
+              <span
                 className="pf-c-options-menu__menu-item-icon"
               >
                 <CheckIcon
@@ -3425,7 +3425,7 @@ exports[`component render limited number of pages 1`] = `
                   noVerticalAlign={false}
                   size="sm"
                 />
-              </i>
+              </span>
             </DropdownItem>,
             <DropdownItem
               className=""
@@ -4147,7 +4147,7 @@ exports[`component render no items 1`] = `
               >
                  per page
               </span>
-              <i
+              <span
                 className="pf-c-options-menu__menu-item-icon"
               >
                 <CheckIcon
@@ -4155,7 +4155,7 @@ exports[`component render no items 1`] = `
                   noVerticalAlign={false}
                   size="sm"
                 />
-              </i>
+              </span>
             </DropdownItem>,
             <DropdownItem
               className=""
@@ -4871,7 +4871,7 @@ exports[`component render should render correctly bottom 1`] = `
               >
                  per page
               </span>
-              <i
+              <span
                 className="pf-c-options-menu__menu-item-icon"
               >
                 <CheckIcon
@@ -4879,7 +4879,7 @@ exports[`component render should render correctly bottom 1`] = `
                   noVerticalAlign={false}
                   size="sm"
                 />
-              </i>
+              </span>
             </DropdownItem>,
             <DropdownItem
               className=""
@@ -5614,7 +5614,7 @@ exports[`component render should render correctly compact 1`] = `
               >
                  per page
               </span>
-              <i
+              <span
                 className="pf-c-options-menu__menu-item-icon"
               >
                 <CheckIcon
@@ -5622,7 +5622,7 @@ exports[`component render should render correctly compact 1`] = `
                   noVerticalAlign={false}
                   size="sm"
                 />
-              </i>
+              </span>
             </DropdownItem>,
             <DropdownItem
               className=""
@@ -6242,7 +6242,7 @@ exports[`component render should render correctly disabled 1`] = `
               >
                  per page
               </span>
-              <i
+              <span
                 className="pf-c-options-menu__menu-item-icon"
               >
                 <CheckIcon
@@ -6250,7 +6250,7 @@ exports[`component render should render correctly disabled 1`] = `
                   noVerticalAlign={false}
                   size="sm"
                 />
-              </i>
+              </span>
             </DropdownItem>,
             <DropdownItem
               className=""
@@ -6988,7 +6988,7 @@ exports[`component render should render correctly top 1`] = `
               >
                  per page
               </span>
-              <i
+              <span
                 className="pf-c-options-menu__menu-item-icon"
               >
                 <CheckIcon
@@ -6996,7 +6996,7 @@ exports[`component render should render correctly top 1`] = `
                   noVerticalAlign={false}
                   size="sm"
                 />
-              </i>
+              </span>
             </DropdownItem>,
             <DropdownItem
               className=""
@@ -7723,7 +7723,7 @@ exports[`component render titles 1`] = `
               >
                  per page
               </span>
-              <i
+              <span
                 className="pf-c-options-menu__menu-item-icon"
               >
                 <CheckIcon
@@ -7731,7 +7731,7 @@ exports[`component render titles 1`] = `
                   noVerticalAlign={false}
                   size="sm"
                 />
-              </i>
+              </span>
             </DropdownItem>,
             <DropdownItem
               className=""
@@ -8467,7 +8467,7 @@ exports[`component render up drop direction 1`] = `
               >
                  per page
               </span>
-              <i
+              <span
                 className="pf-c-options-menu__menu-item-icon"
               >
                 <CheckIcon
@@ -8475,7 +8475,7 @@ exports[`component render up drop direction 1`] = `
                   noVerticalAlign={false}
                   size="sm"
                 />
-              </i>
+              </span>
             </DropdownItem>,
             <DropdownItem
               className=""
@@ -9210,7 +9210,7 @@ exports[`component render zero results 1`] = `
               >
                  per page
               </span>
-              <i
+              <span
                 className="pf-c-options-menu__menu-item-icon"
               >
                 <CheckIcon
@@ -9218,7 +9218,7 @@ exports[`component render zero results 1`] = `
                   noVerticalAlign={false}
                   size="sm"
                 />
-              </i>
+              </span>
             </DropdownItem>,
             <DropdownItem
               className=""

--- a/packages/react-core/src/components/Pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/react-core/src/components/Pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -147,7 +147,7 @@ exports[`component render custom pagination toggle 1`] = `
               >
                  per page
               </span>
-              <span
+              <div
                 className="pf-c-options-menu__menu-item-icon"
               >
                 <CheckIcon
@@ -155,7 +155,7 @@ exports[`component render custom pagination toggle 1`] = `
                   noVerticalAlign={false}
                   size="sm"
                 />
-              </span>
+              </div>
             </DropdownItem>,
             <DropdownItem
               className=""
@@ -267,7 +267,7 @@ exports[`component render custom pagination toggle 1`] = `
                       type="button"
                     >
                       <span
-                        class=""
+                        class="pf-c-options-menu__toggle-icon"
                       >
                         <svg
                           aria-hidden="true"
@@ -333,7 +333,7 @@ exports[`component render custom pagination toggle 1`] = `
                           type="button"
                         >
                           <span
-                            class=""
+                            class="pf-c-options-menu__toggle-icon"
                           >
                             <svg
                               aria-hidden="true"
@@ -393,7 +393,7 @@ exports[`component render custom pagination toggle 1`] = `
                             type="button"
                           >
                             <span
-                              class=""
+                              class="pf-c-options-menu__toggle-icon"
                             >
                               <svg
                                 aria-hidden="true"
@@ -427,7 +427,7 @@ exports[`component render custom pagination toggle 1`] = `
                     type="button"
                   >
                     <span
-                      className=""
+                      className="pf-c-options-menu__toggle-icon"
                     >
                       <CaretDownIcon
                         color="currentColor"
@@ -910,7 +910,7 @@ exports[`component render custom perPageOptions 1`] = `
                       type="button"
                     >
                       <span
-                        class=""
+                        class="pf-c-options-menu__toggle-icon"
                       >
                         <svg
                           aria-hidden="true"
@@ -1004,7 +1004,7 @@ exports[`component render custom perPageOptions 1`] = `
                           type="button"
                         >
                           <span
-                            class=""
+                            class="pf-c-options-menu__toggle-icon"
                           >
                             <svg
                               aria-hidden="true"
@@ -1075,7 +1075,7 @@ exports[`component render custom perPageOptions 1`] = `
                             type="button"
                           >
                             <span
-                              class=""
+                              class="pf-c-options-menu__toggle-icon"
                             >
                               <svg
                                 aria-hidden="true"
@@ -1109,7 +1109,7 @@ exports[`component render custom perPageOptions 1`] = `
                     type="button"
                   >
                     <span
-                      className=""
+                      className="pf-c-options-menu__toggle-icon"
                     >
                       <CaretDownIcon
                         color="currentColor"
@@ -1533,7 +1533,7 @@ exports[`component render custom start end 1`] = `
               >
                  per page
               </span>
-              <span
+              <div
                 className="pf-c-options-menu__menu-item-icon"
               >
                 <CheckIcon
@@ -1541,7 +1541,7 @@ exports[`component render custom start end 1`] = `
                   noVerticalAlign={false}
                   size="sm"
                 />
-              </span>
+              </div>
             </DropdownItem>,
             <DropdownItem
               className=""
@@ -1664,7 +1664,7 @@ exports[`component render custom start end 1`] = `
                       type="button"
                     >
                       <span
-                        class=""
+                        class="pf-c-options-menu__toggle-icon"
                       >
                         <svg
                           aria-hidden="true"
@@ -1758,7 +1758,7 @@ exports[`component render custom start end 1`] = `
                           type="button"
                         >
                           <span
-                            class=""
+                            class="pf-c-options-menu__toggle-icon"
                           >
                             <svg
                               aria-hidden="true"
@@ -1829,7 +1829,7 @@ exports[`component render custom start end 1`] = `
                             type="button"
                           >
                             <span
-                              class=""
+                              class="pf-c-options-menu__toggle-icon"
                             >
                               <svg
                                 aria-hidden="true"
@@ -1863,7 +1863,7 @@ exports[`component render custom start end 1`] = `
                     type="button"
                   >
                     <span
-                      className=""
+                      className="pf-c-options-menu__toggle-icon"
                     >
                       <CaretDownIcon
                         color="currentColor"
@@ -2694,7 +2694,7 @@ exports[`component render last page 1`] = `
               >
                  per page
               </span>
-              <span
+              <div
                 className="pf-c-options-menu__menu-item-icon"
               >
                 <CheckIcon
@@ -2702,7 +2702,7 @@ exports[`component render last page 1`] = `
                   noVerticalAlign={false}
                   size="sm"
                 />
-              </span>
+              </div>
             </DropdownItem>,
             <DropdownItem
               className=""
@@ -2825,7 +2825,7 @@ exports[`component render last page 1`] = `
                       type="button"
                     >
                       <span
-                        class=""
+                        class="pf-c-options-menu__toggle-icon"
                       >
                         <svg
                           aria-hidden="true"
@@ -2919,7 +2919,7 @@ exports[`component render last page 1`] = `
                           type="button"
                         >
                           <span
-                            class=""
+                            class="pf-c-options-menu__toggle-icon"
                           >
                             <svg
                               aria-hidden="true"
@@ -2990,7 +2990,7 @@ exports[`component render last page 1`] = `
                             type="button"
                           >
                             <span
-                              class=""
+                              class="pf-c-options-menu__toggle-icon"
                             >
                               <svg
                                 aria-hidden="true"
@@ -3024,7 +3024,7 @@ exports[`component render last page 1`] = `
                     type="button"
                   >
                     <span
-                      className=""
+                      className="pf-c-options-menu__toggle-icon"
                     >
                       <CaretDownIcon
                         color="currentColor"
@@ -3461,7 +3461,7 @@ exports[`component render limited number of pages 1`] = `
               >
                  per page
               </span>
-              <span
+              <div
                 className="pf-c-options-menu__menu-item-icon"
               >
                 <CheckIcon
@@ -3469,7 +3469,7 @@ exports[`component render limited number of pages 1`] = `
                   noVerticalAlign={false}
                   size="sm"
                 />
-              </span>
+              </div>
             </DropdownItem>,
             <DropdownItem
               className=""
@@ -3579,7 +3579,7 @@ exports[`component render limited number of pages 1`] = `
                       type="button"
                     >
                       <span
-                        class=""
+                        class="pf-c-options-menu__toggle-icon"
                       >
                         <svg
                           aria-hidden="true"
@@ -3673,7 +3673,7 @@ exports[`component render limited number of pages 1`] = `
                           type="button"
                         >
                           <span
-                            class=""
+                            class="pf-c-options-menu__toggle-icon"
                           >
                             <svg
                               aria-hidden="true"
@@ -3744,7 +3744,7 @@ exports[`component render limited number of pages 1`] = `
                             type="button"
                           >
                             <span
-                              class=""
+                              class="pf-c-options-menu__toggle-icon"
                             >
                               <svg
                                 aria-hidden="true"
@@ -3778,7 +3778,7 @@ exports[`component render limited number of pages 1`] = `
                     type="button"
                   >
                     <span
-                      className=""
+                      className="pf-c-options-menu__toggle-icon"
                     >
                       <CaretDownIcon
                         color="currentColor"
@@ -4202,7 +4202,7 @@ exports[`component render no items 1`] = `
               >
                  per page
               </span>
-              <span
+              <div
                 className="pf-c-options-menu__menu-item-icon"
               >
                 <CheckIcon
@@ -4210,7 +4210,7 @@ exports[`component render no items 1`] = `
                   noVerticalAlign={false}
                   size="sm"
                 />
-              </span>
+              </div>
             </DropdownItem>,
             <DropdownItem
               className=""
@@ -4334,7 +4334,7 @@ exports[`component render no items 1`] = `
                       type="button"
                     >
                       <span
-                        class=""
+                        class="pf-c-options-menu__toggle-icon"
                       >
                         <svg
                           aria-hidden="true"
@@ -4429,7 +4429,7 @@ exports[`component render no items 1`] = `
                           type="button"
                         >
                           <span
-                            class=""
+                            class="pf-c-options-menu__toggle-icon"
                           >
                             <svg
                               aria-hidden="true"
@@ -4501,7 +4501,7 @@ exports[`component render no items 1`] = `
                             type="button"
                           >
                             <span
-                              class=""
+                              class="pf-c-options-menu__toggle-icon"
                             >
                               <svg
                                 aria-hidden="true"
@@ -4535,7 +4535,7 @@ exports[`component render no items 1`] = `
                     type="button"
                   >
                     <span
-                      className=""
+                      className="pf-c-options-menu__toggle-icon"
                     >
                       <CaretDownIcon
                         color="currentColor"
@@ -4937,7 +4937,7 @@ exports[`component render should render correctly bottom 1`] = `
               >
                  per page
               </span>
-              <span
+              <div
                 className="pf-c-options-menu__menu-item-icon"
               >
                 <CheckIcon
@@ -4945,7 +4945,7 @@ exports[`component render should render correctly bottom 1`] = `
                   noVerticalAlign={false}
                   size="sm"
                 />
-              </span>
+              </div>
             </DropdownItem>,
             <DropdownItem
               className=""
@@ -5068,7 +5068,7 @@ exports[`component render should render correctly bottom 1`] = `
                       type="button"
                     >
                       <span
-                        class=""
+                        class="pf-c-options-menu__toggle-icon"
                       >
                         <svg
                           aria-hidden="true"
@@ -5162,7 +5162,7 @@ exports[`component render should render correctly bottom 1`] = `
                           type="button"
                         >
                           <span
-                            class=""
+                            class="pf-c-options-menu__toggle-icon"
                           >
                             <svg
                               aria-hidden="true"
@@ -5233,7 +5233,7 @@ exports[`component render should render correctly bottom 1`] = `
                             type="button"
                           >
                             <span
-                              class=""
+                              class="pf-c-options-menu__toggle-icon"
                             >
                               <svg
                                 aria-hidden="true"
@@ -5267,7 +5267,7 @@ exports[`component render should render correctly bottom 1`] = `
                     type="button"
                   >
                     <span
-                      className=""
+                      className="pf-c-options-menu__toggle-icon"
                     >
                       <CaretDownIcon
                         color="currentColor"
@@ -5691,7 +5691,7 @@ exports[`component render should render correctly compact 1`] = `
               >
                  per page
               </span>
-              <span
+              <div
                 className="pf-c-options-menu__menu-item-icon"
               >
                 <CheckIcon
@@ -5699,7 +5699,7 @@ exports[`component render should render correctly compact 1`] = `
                   noVerticalAlign={false}
                   size="sm"
                 />
-              </span>
+              </div>
             </DropdownItem>,
             <DropdownItem
               className=""
@@ -5822,7 +5822,7 @@ exports[`component render should render correctly compact 1`] = `
                       type="button"
                     >
                       <span
-                        class=""
+                        class="pf-c-options-menu__toggle-icon"
                       >
                         <svg
                           aria-hidden="true"
@@ -5916,7 +5916,7 @@ exports[`component render should render correctly compact 1`] = `
                           type="button"
                         >
                           <span
-                            class=""
+                            class="pf-c-options-menu__toggle-icon"
                           >
                             <svg
                               aria-hidden="true"
@@ -5987,7 +5987,7 @@ exports[`component render should render correctly compact 1`] = `
                             type="button"
                           >
                             <span
-                              class=""
+                              class="pf-c-options-menu__toggle-icon"
                             >
                               <svg
                                 aria-hidden="true"
@@ -6021,7 +6021,7 @@ exports[`component render should render correctly compact 1`] = `
                     type="button"
                   >
                     <span
-                      className=""
+                      className="pf-c-options-menu__toggle-icon"
                     >
                       <CaretDownIcon
                         color="currentColor"
@@ -6330,7 +6330,7 @@ exports[`component render should render correctly disabled 1`] = `
               >
                  per page
               </span>
-              <span
+              <div
                 className="pf-c-options-menu__menu-item-icon"
               >
                 <CheckIcon
@@ -6338,7 +6338,7 @@ exports[`component render should render correctly disabled 1`] = `
                   noVerticalAlign={false}
                   size="sm"
                 />
-              </span>
+              </div>
             </DropdownItem>,
             <DropdownItem
               className=""
@@ -6462,7 +6462,7 @@ exports[`component render should render correctly disabled 1`] = `
                       type="button"
                     >
                       <span
-                        class=""
+                        class="pf-c-options-menu__toggle-icon"
                       >
                         <svg
                           aria-hidden="true"
@@ -6557,7 +6557,7 @@ exports[`component render should render correctly disabled 1`] = `
                           type="button"
                         >
                           <span
-                            class=""
+                            class="pf-c-options-menu__toggle-icon"
                           >
                             <svg
                               aria-hidden="true"
@@ -6629,7 +6629,7 @@ exports[`component render should render correctly disabled 1`] = `
                             type="button"
                           >
                             <span
-                              class=""
+                              class="pf-c-options-menu__toggle-icon"
                             >
                               <svg
                                 aria-hidden="true"
@@ -6663,7 +6663,7 @@ exports[`component render should render correctly disabled 1`] = `
                     type="button"
                   >
                     <span
-                      className=""
+                      className="pf-c-options-menu__toggle-icon"
                     >
                       <CaretDownIcon
                         color="currentColor"
@@ -7087,7 +7087,7 @@ exports[`component render should render correctly top 1`] = `
               >
                  per page
               </span>
-              <span
+              <div
                 className="pf-c-options-menu__menu-item-icon"
               >
                 <CheckIcon
@@ -7095,7 +7095,7 @@ exports[`component render should render correctly top 1`] = `
                   noVerticalAlign={false}
                   size="sm"
                 />
-              </span>
+              </div>
             </DropdownItem>,
             <DropdownItem
               className=""
@@ -7218,7 +7218,7 @@ exports[`component render should render correctly top 1`] = `
                       type="button"
                     >
                       <span
-                        class=""
+                        class="pf-c-options-menu__toggle-icon"
                       >
                         <svg
                           aria-hidden="true"
@@ -7312,7 +7312,7 @@ exports[`component render should render correctly top 1`] = `
                           type="button"
                         >
                           <span
-                            class=""
+                            class="pf-c-options-menu__toggle-icon"
                           >
                             <svg
                               aria-hidden="true"
@@ -7383,7 +7383,7 @@ exports[`component render should render correctly top 1`] = `
                             type="button"
                           >
                             <span
-                              class=""
+                              class="pf-c-options-menu__toggle-icon"
                             >
                               <svg
                                 aria-hidden="true"
@@ -7417,7 +7417,7 @@ exports[`component render should render correctly top 1`] = `
                     type="button"
                   >
                     <span
-                      className=""
+                      className="pf-c-options-menu__toggle-icon"
                     >
                       <CaretDownIcon
                         color="currentColor"
@@ -7833,7 +7833,7 @@ exports[`component render titles 1`] = `
               >
                  per page
               </span>
-              <span
+              <div
                 className="pf-c-options-menu__menu-item-icon"
               >
                 <CheckIcon
@@ -7841,7 +7841,7 @@ exports[`component render titles 1`] = `
                   noVerticalAlign={false}
                   size="sm"
                 />
-              </span>
+              </div>
             </DropdownItem>,
             <DropdownItem
               className=""
@@ -7964,7 +7964,7 @@ exports[`component render titles 1`] = `
                       type="button"
                     >
                       <span
-                        class=""
+                        class="pf-c-options-menu__toggle-icon"
                       >
                         <svg
                           aria-hidden="true"
@@ -8059,7 +8059,7 @@ exports[`component render titles 1`] = `
                           type="button"
                         >
                           <span
-                            class=""
+                            class="pf-c-options-menu__toggle-icon"
                           >
                             <svg
                               aria-hidden="true"
@@ -8130,7 +8130,7 @@ exports[`component render titles 1`] = `
                             type="button"
                           >
                             <span
-                              class=""
+                              class="pf-c-options-menu__toggle-icon"
                             >
                               <svg
                                 aria-hidden="true"
@@ -8164,7 +8164,7 @@ exports[`component render titles 1`] = `
                     type="button"
                   >
                     <span
-                      className=""
+                      className="pf-c-options-menu__toggle-icon"
                     >
                       <CaretDownIcon
                         color="currentColor"
@@ -8588,7 +8588,7 @@ exports[`component render up drop direction 1`] = `
               >
                  per page
               </span>
-              <span
+              <div
                 className="pf-c-options-menu__menu-item-icon"
               >
                 <CheckIcon
@@ -8596,7 +8596,7 @@ exports[`component render up drop direction 1`] = `
                   noVerticalAlign={false}
                   size="sm"
                 />
-              </span>
+              </div>
             </DropdownItem>,
             <DropdownItem
               className=""
@@ -8719,7 +8719,7 @@ exports[`component render up drop direction 1`] = `
                       type="button"
                     >
                       <span
-                        class=""
+                        class="pf-c-options-menu__toggle-icon"
                       >
                         <svg
                           aria-hidden="true"
@@ -8813,7 +8813,7 @@ exports[`component render up drop direction 1`] = `
                           type="button"
                         >
                           <span
-                            class=""
+                            class="pf-c-options-menu__toggle-icon"
                           >
                             <svg
                               aria-hidden="true"
@@ -8884,7 +8884,7 @@ exports[`component render up drop direction 1`] = `
                             type="button"
                           >
                             <span
-                              class=""
+                              class="pf-c-options-menu__toggle-icon"
                             >
                               <svg
                                 aria-hidden="true"
@@ -8918,7 +8918,7 @@ exports[`component render up drop direction 1`] = `
                     type="button"
                   >
                     <span
-                      className=""
+                      className="pf-c-options-menu__toggle-icon"
                     >
                       <CaretDownIcon
                         color="currentColor"
@@ -9342,7 +9342,7 @@ exports[`component render zero results 1`] = `
               >
                  per page
               </span>
-              <span
+              <div
                 className="pf-c-options-menu__menu-item-icon"
               >
                 <CheckIcon
@@ -9350,7 +9350,7 @@ exports[`component render zero results 1`] = `
                   noVerticalAlign={false}
                   size="sm"
                 />
-              </span>
+              </div>
             </DropdownItem>,
             <DropdownItem
               className=""
@@ -9474,7 +9474,7 @@ exports[`component render zero results 1`] = `
                       type="button"
                     >
                       <span
-                        class=""
+                        class="pf-c-options-menu__toggle-icon"
                       >
                         <svg
                           aria-hidden="true"
@@ -9569,7 +9569,7 @@ exports[`component render zero results 1`] = `
                           type="button"
                         >
                           <span
-                            class=""
+                            class="pf-c-options-menu__toggle-icon"
                           >
                             <svg
                               aria-hidden="true"
@@ -9641,7 +9641,7 @@ exports[`component render zero results 1`] = `
                             type="button"
                           >
                             <span
-                              class=""
+                              class="pf-c-options-menu__toggle-icon"
                             >
                               <svg
                                 aria-hidden="true"
@@ -9675,7 +9675,7 @@ exports[`component render zero results 1`] = `
                     type="button"
                   >
                     <span
-                      className=""
+                      className="pf-c-options-menu__toggle-icon"
                     >
                       <CaretDownIcon
                         color="currentColor"

--- a/packages/react-core/src/components/Select/SelectOption.tsx
+++ b/packages/react-core/src/components/Select/SelectOption.tsx
@@ -130,7 +130,11 @@ export class SelectOption extends React.Component<SelectOptionProps> {
                   type="button"
                 >
                   {children || value.toString()}
-                  {isSelected && <CheckIcon className={css(styles.selectMenuItemIcon)} aria-hidden />}
+                  {isSelected && (
+                    <span className={css(styles.selectMenuItemIcon)}>
+                      <CheckIcon aria-hidden />
+                    </span>
+                  )}
                 </Component>
               </li>
             )}

--- a/packages/react-core/src/components/Select/SelectToggle.tsx
+++ b/packages/react-core/src/components/Select/SelectToggle.tsx
@@ -207,7 +207,9 @@ export class SelectToggle extends React.Component<SelectToggleProps> {
             disabled={isDisabled}
           >
             {children}
-            <CaretDownIcon className={css(styles.selectToggleArrow)} />
+            <span className={css(styles.selectToggleArrow)}>
+              <CaretDownIcon />
+            </span>
           </button>
         )}
         {isTypeahead && (

--- a/packages/react-core/src/components/Select/__tests__/Generated/__snapshots__/SelectToggle.test.tsx.snap
+++ b/packages/react-core/src/components/Select/__tests__/Generated/__snapshots__/SelectToggle.test.tsx.snap
@@ -19,12 +19,15 @@ exports[`SelectToggle should match snapshot (auto-generated) 1`] = `
     <div>
       ReactNode
     </div>
-    <CaretDownIcon
+    <span
       className="pf-c-select__toggle-arrow"
-      color="currentColor"
-      noVerticalAlign={false}
-      size="sm"
-    />
+    >
+      <CaretDownIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />
+    </span>
   </button>
 </Fragment>
 `;

--- a/packages/react-core/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/packages/react-core/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
@@ -79,21 +79,24 @@ exports[`checkbox select renders checkbox select groups successfully 1`] = `
                   class="pf-c-select__toggle-text"
                 />
               </div>
-              <svg
-                aria-hidden="true"
+              <span
                 class="pf-c-select__toggle-arrow"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 320 512"
-                width="1em"
               >
-                <path
-                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  transform=""
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    transform=""
+                  />
+                </svg>
+              </span>
             </button>
             <div>
               <div
@@ -274,33 +277,35 @@ exports[`checkbox select renders checkbox select groups successfully 1`] = `
             className="pf-c-select__toggle-text"
           />
         </div>
-        <CaretDownIcon
+        <span
           className="pf-c-select__toggle-arrow"
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
         >
-          <svg
-            aria-hidden={true}
-            aria-labelledby={null}
-            className="pf-c-select__toggle-arrow"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style={
-              Object {
-                "verticalAlign": "-0.125em",
-              }
-            }
-            viewBox="0 0 320 512"
-            width="1em"
+          <CaretDownIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
           >
-            <path
-              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-              transform=""
-            />
-          </svg>
-        </CaretDownIcon>
+            <svg
+              aria-hidden={true}
+              aria-labelledby={null}
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
+              viewBox="0 0 320 512"
+              width="1em"
+            >
+              <path
+                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                transform=""
+              />
+            </svg>
+          </CaretDownIcon>
+        </span>
       </button>
     </SelectToggle>
     <SelectMenu
@@ -765,21 +770,24 @@ exports[`checkbox select renders checkbox select selections properly 1`] = `
                   </span>
                 </div>
               </div>
-              <svg
-                aria-hidden="true"
+              <span
                 class="pf-c-select__toggle-arrow"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 320 512"
-                width="1em"
               >
-                <path
-                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  transform=""
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    transform=""
+                  />
+                </svg>
+              </span>
             </button>
           </div>,
         }
@@ -814,33 +822,35 @@ exports[`checkbox select renders checkbox select selections properly 1`] = `
             </span>
           </div>
         </div>
-        <CaretDownIcon
+        <span
           className="pf-c-select__toggle-arrow"
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
         >
-          <svg
-            aria-hidden={true}
-            aria-labelledby={null}
-            className="pf-c-select__toggle-arrow"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style={
-              Object {
-                "verticalAlign": "-0.125em",
-              }
-            }
-            viewBox="0 0 320 512"
-            width="1em"
+          <CaretDownIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
           >
-            <path
-              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-              transform=""
-            />
-          </svg>
-        </CaretDownIcon>
+            <svg
+              aria-hidden={true}
+              aria-labelledby={null}
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
+              viewBox="0 0 320 512"
+              width="1em"
+            >
+              <path
+                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                transform=""
+              />
+            </svg>
+          </CaretDownIcon>
+        </span>
       </button>
     </SelectToggle>
   </div>
@@ -943,21 +953,24 @@ exports[`checkbox select renders checkbox select selections properly when isChec
                   class="pf-c-select__toggle-text"
                 />
               </div>
-              <svg
-                aria-hidden="true"
+              <span
                 class="pf-c-select__toggle-arrow"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 320 512"
-                width="1em"
               >
-                <path
-                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  transform=""
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    transform=""
+                  />
+                </svg>
+              </span>
             </button>
           </div>,
         }
@@ -983,33 +996,35 @@ exports[`checkbox select renders checkbox select selections properly when isChec
             className="pf-c-select__toggle-text"
           />
         </div>
-        <CaretDownIcon
+        <span
           className="pf-c-select__toggle-arrow"
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
         >
-          <svg
-            aria-hidden={true}
-            aria-labelledby={null}
-            className="pf-c-select__toggle-arrow"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style={
-              Object {
-                "verticalAlign": "-0.125em",
-              }
-            }
-            viewBox="0 0 320 512"
-            width="1em"
+          <CaretDownIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
           >
-            <path
-              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-              transform=""
-            />
-          </svg>
-        </CaretDownIcon>
+            <svg
+              aria-hidden={true}
+              aria-labelledby={null}
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
+              viewBox="0 0 320 512"
+              width="1em"
+            >
+              <path
+                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                transform=""
+              />
+            </svg>
+          </CaretDownIcon>
+        </span>
       </button>
     </SelectToggle>
   </div>
@@ -1095,21 +1110,24 @@ exports[`checkbox select renders closed successfully 1`] = `
                   class="pf-c-select__toggle-text"
                 />
               </div>
-              <svg
-                aria-hidden="true"
+              <span
                 class="pf-c-select__toggle-arrow"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 320 512"
-                width="1em"
               >
-                <path
-                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  transform=""
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    transform=""
+                  />
+                </svg>
+              </span>
             </button>
           </div>,
         }
@@ -1135,33 +1153,35 @@ exports[`checkbox select renders closed successfully 1`] = `
             className="pf-c-select__toggle-text"
           />
         </div>
-        <CaretDownIcon
+        <span
           className="pf-c-select__toggle-arrow"
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
         >
-          <svg
-            aria-hidden={true}
-            aria-labelledby={null}
-            className="pf-c-select__toggle-arrow"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style={
-              Object {
-                "verticalAlign": "-0.125em",
-              }
-            }
-            viewBox="0 0 320 512"
-            width="1em"
+          <CaretDownIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
           >
-            <path
-              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-              transform=""
-            />
-          </svg>
-        </CaretDownIcon>
+            <svg
+              aria-hidden={true}
+              aria-labelledby={null}
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
+              viewBox="0 0 320 512"
+              width="1em"
+            >
+              <path
+                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                transform=""
+              />
+            </svg>
+          </CaretDownIcon>
+        </span>
       </button>
     </SelectToggle>
   </div>
@@ -1247,21 +1267,24 @@ exports[`checkbox select renders expanded successfully 1`] = `
                   class="pf-c-select__toggle-text"
                 />
               </div>
-              <svg
-                aria-hidden="true"
+              <span
                 class="pf-c-select__toggle-arrow"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 320 512"
-                width="1em"
               >
-                <path
-                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  transform=""
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    transform=""
+                  />
+                </svg>
+              </span>
             </button>
             <div>
               <div
@@ -1354,33 +1377,35 @@ exports[`checkbox select renders expanded successfully 1`] = `
             className="pf-c-select__toggle-text"
           />
         </div>
-        <CaretDownIcon
+        <span
           className="pf-c-select__toggle-arrow"
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
         >
-          <svg
-            aria-hidden={true}
-            aria-labelledby={null}
-            className="pf-c-select__toggle-arrow"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style={
-              Object {
-                "verticalAlign": "-0.125em",
-              }
-            }
-            viewBox="0 0 320 512"
-            width="1em"
+          <CaretDownIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
           >
-            <path
-              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-              transform=""
-            />
-          </svg>
-        </CaretDownIcon>
+            <svg
+              aria-hidden={true}
+              aria-labelledby={null}
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
+              viewBox="0 0 320 512"
+              width="1em"
+            >
+              <path
+                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                transform=""
+              />
+            </svg>
+          </CaretDownIcon>
+        </span>
       </button>
     </SelectToggle>
     <SelectMenu
@@ -1640,21 +1665,24 @@ exports[`checkbox select renders expanded successfully with custom objects 1`] =
                   class="pf-c-select__toggle-text"
                 />
               </div>
-              <svg
-                aria-hidden="true"
+              <span
                 class="pf-c-select__toggle-arrow"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 320 512"
-                width="1em"
               >
-                <path
-                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  transform=""
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    transform=""
+                  />
+                </svg>
+              </span>
             </button>
             <div>
               <div
@@ -1733,33 +1761,35 @@ exports[`checkbox select renders expanded successfully with custom objects 1`] =
             className="pf-c-select__toggle-text"
           />
         </div>
-        <CaretDownIcon
+        <span
           className="pf-c-select__toggle-arrow"
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
         >
-          <svg
-            aria-hidden={true}
-            aria-labelledby={null}
-            className="pf-c-select__toggle-arrow"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style={
-              Object {
-                "verticalAlign": "-0.125em",
-              }
-            }
-            viewBox="0 0 320 512"
-            width="1em"
+          <CaretDownIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
           >
-            <path
-              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-              transform=""
-            />
-          </svg>
-        </CaretDownIcon>
+            <svg
+              aria-hidden={true}
+              aria-labelledby={null}
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
+              viewBox="0 0 320 512"
+              width="1em"
+            >
+              <path
+                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                transform=""
+              />
+            </svg>
+          </CaretDownIcon>
+        </span>
       </button>
     </SelectToggle>
     <SelectMenu
@@ -3010,21 +3040,24 @@ exports[`select renders select groups successfully 1`] = `
                   class="pf-c-select__toggle-text"
                 />
               </div>
-              <svg
-                aria-hidden="true"
+              <span
                 class="pf-c-select__toggle-arrow"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 320 512"
-                width="1em"
               >
-                <path
-                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  transform=""
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    transform=""
+                  />
+                </svg>
+              </span>
             </button>
             <ul
               class="pf-c-select__menu"
@@ -3169,33 +3202,35 @@ exports[`select renders select groups successfully 1`] = `
             className="pf-c-select__toggle-text"
           />
         </div>
-        <CaretDownIcon
+        <span
           className="pf-c-select__toggle-arrow"
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
         >
-          <svg
-            aria-hidden={true}
-            aria-labelledby={null}
-            className="pf-c-select__toggle-arrow"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style={
-              Object {
-                "verticalAlign": "-0.125em",
-              }
-            }
-            viewBox="0 0 320 512"
-            width="1em"
+          <CaretDownIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
           >
-            <path
-              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-              transform=""
-            />
-          </svg>
-        </CaretDownIcon>
+            <svg
+              aria-hidden={true}
+              aria-labelledby={null}
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
+              viewBox="0 0 320 512"
+              width="1em"
+            >
+              <path
+                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                transform=""
+              />
+            </svg>
+          </CaretDownIcon>
+        </span>
       </button>
     </SelectToggle>
     <SelectMenu
@@ -3596,21 +3631,24 @@ exports[`select renders up direction successfully 1`] = `
                   Mr
                 </span>
               </div>
-              <svg
-                aria-hidden="true"
+              <span
                 class="pf-c-select__toggle-arrow"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 320 512"
-                width="1em"
               >
-                <path
-                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  transform=""
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    transform=""
+                  />
+                </svg>
+              </span>
             </button>
           </div>,
         }
@@ -3638,33 +3676,35 @@ exports[`select renders up direction successfully 1`] = `
             Mr
           </span>
         </div>
-        <CaretDownIcon
+        <span
           className="pf-c-select__toggle-arrow"
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
         >
-          <svg
-            aria-hidden={true}
-            aria-labelledby={null}
-            className="pf-c-select__toggle-arrow"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style={
-              Object {
-                "verticalAlign": "-0.125em",
-              }
-            }
-            viewBox="0 0 320 512"
-            width="1em"
+          <CaretDownIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
           >
-            <path
-              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-              transform=""
-            />
-          </svg>
-        </CaretDownIcon>
+            <svg
+              aria-hidden={true}
+              aria-labelledby={null}
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
+              viewBox="0 0 320 512"
+              width="1em"
+            >
+              <path
+                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                transform=""
+              />
+            </svg>
+          </CaretDownIcon>
+        </span>
       </button>
     </SelectToggle>
   </div>
@@ -3753,21 +3793,24 @@ exports[`select single select renders closed successfully 1`] = `
                   Mr
                 </span>
               </div>
-              <svg
-                aria-hidden="true"
+              <span
                 class="pf-c-select__toggle-arrow"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 320 512"
-                width="1em"
               >
-                <path
-                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  transform=""
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    transform=""
+                  />
+                </svg>
+              </span>
             </button>
           </div>,
         }
@@ -3795,33 +3838,35 @@ exports[`select single select renders closed successfully 1`] = `
             Mr
           </span>
         </div>
-        <CaretDownIcon
+        <span
           className="pf-c-select__toggle-arrow"
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
         >
-          <svg
-            aria-hidden={true}
-            aria-labelledby={null}
-            className="pf-c-select__toggle-arrow"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style={
-              Object {
-                "verticalAlign": "-0.125em",
-              }
-            }
-            viewBox="0 0 320 512"
-            width="1em"
+          <CaretDownIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
           >
-            <path
-              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-              transform=""
-            />
-          </svg>
-        </CaretDownIcon>
+            <svg
+              aria-hidden={true}
+              aria-labelledby={null}
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
+              viewBox="0 0 320 512"
+              width="1em"
+            >
+              <path
+                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                transform=""
+              />
+            </svg>
+          </CaretDownIcon>
+        </span>
       </button>
     </SelectToggle>
   </div>
@@ -3911,21 +3956,24 @@ exports[`select single select renders disabled successfully 1`] = `
                   Mr
                 </span>
               </div>
-              <svg
-                aria-hidden="true"
+              <span
                 class="pf-c-select__toggle-arrow"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 320 512"
-                width="1em"
               >
-                <path
-                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  transform=""
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    transform=""
+                  />
+                </svg>
+              </span>
             </button>
           </div>,
         }
@@ -3953,33 +4001,35 @@ exports[`select single select renders disabled successfully 1`] = `
             Mr
           </span>
         </div>
-        <CaretDownIcon
+        <span
           className="pf-c-select__toggle-arrow"
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
         >
-          <svg
-            aria-hidden={true}
-            aria-labelledby={null}
-            className="pf-c-select__toggle-arrow"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style={
-              Object {
-                "verticalAlign": "-0.125em",
-              }
-            }
-            viewBox="0 0 320 512"
-            width="1em"
+          <CaretDownIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
           >
-            <path
-              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-              transform=""
-            />
-          </svg>
-        </CaretDownIcon>
+            <svg
+              aria-hidden={true}
+              aria-labelledby={null}
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
+              viewBox="0 0 320 512"
+              width="1em"
+            >
+              <path
+                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                transform=""
+              />
+            </svg>
+          </CaretDownIcon>
+        </span>
       </button>
     </SelectToggle>
   </div>
@@ -4068,21 +4118,24 @@ exports[`select single select renders expanded successfully 1`] = `
                   Mr
                 </span>
               </div>
-              <svg
-                aria-hidden="true"
+              <span
                 class="pf-c-select__toggle-arrow"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 320 512"
-                width="1em"
               >
-                <path
-                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  transform=""
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    transform=""
+                  />
+                </svg>
+              </span>
             </button>
             <ul
               class="pf-c-select__menu"
@@ -4163,33 +4216,35 @@ exports[`select single select renders expanded successfully 1`] = `
             Mr
           </span>
         </div>
-        <CaretDownIcon
+        <span
           className="pf-c-select__toggle-arrow"
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
         >
-          <svg
-            aria-hidden={true}
-            aria-labelledby={null}
-            className="pf-c-select__toggle-arrow"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style={
-              Object {
-                "verticalAlign": "-0.125em",
-              }
-            }
-            viewBox="0 0 320 512"
-            width="1em"
+          <CaretDownIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
           >
-            <path
-              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-              transform=""
-            />
-          </svg>
-        </CaretDownIcon>
+            <svg
+              aria-hidden={true}
+              aria-labelledby={null}
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
+              viewBox="0 0 320 512"
+              width="1em"
+            >
+              <path
+                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                transform=""
+              />
+            </svg>
+          </CaretDownIcon>
+        </span>
       </button>
     </SelectToggle>
     <SelectMenu
@@ -4426,21 +4481,24 @@ exports[`select single select renders expanded successfully with custom objects 
                   Mr: User One
                 </span>
               </div>
-              <svg
-                aria-hidden="true"
+              <span
                 class="pf-c-select__toggle-arrow"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 320 512"
-                width="1em"
               >
-                <path
-                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  transform=""
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    transform=""
+                  />
+                </svg>
+              </span>
             </button>
             <ul
               class="pf-c-select__menu"
@@ -4509,33 +4567,35 @@ exports[`select single select renders expanded successfully with custom objects 
             Mr: User One
           </span>
         </div>
-        <CaretDownIcon
+        <span
           className="pf-c-select__toggle-arrow"
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
         >
-          <svg
-            aria-hidden={true}
-            aria-labelledby={null}
-            className="pf-c-select__toggle-arrow"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style={
-              Object {
-                "verticalAlign": "-0.125em",
-              }
-            }
-            viewBox="0 0 320 512"
-            width="1em"
+          <CaretDownIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
           >
-            <path
-              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-              transform=""
-            />
-          </svg>
-        </CaretDownIcon>
+            <svg
+              aria-hidden={true}
+              aria-labelledby={null}
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
+              viewBox="0 0 320 512"
+              width="1em"
+            >
+              <path
+                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                transform=""
+              />
+            </svg>
+          </CaretDownIcon>
+        </span>
       </button>
     </SelectToggle>
     <SelectMenu
@@ -4761,21 +4821,24 @@ exports[`select with custom content renders closed successfully 1`] = `
                   class="pf-c-select__toggle-text"
                 />
               </div>
-              <svg
-                aria-hidden="true"
+              <span
                 class="pf-c-select__toggle-arrow"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 320 512"
-                width="1em"
               >
-                <path
-                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  transform=""
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    transform=""
+                  />
+                </svg>
+              </span>
             </button>
           </div>,
         }
@@ -4801,33 +4864,35 @@ exports[`select with custom content renders closed successfully 1`] = `
             className="pf-c-select__toggle-text"
           />
         </div>
-        <CaretDownIcon
+        <span
           className="pf-c-select__toggle-arrow"
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
         >
-          <svg
-            aria-hidden={true}
-            aria-labelledby={null}
-            className="pf-c-select__toggle-arrow"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style={
-              Object {
-                "verticalAlign": "-0.125em",
-              }
-            }
-            viewBox="0 0 320 512"
-            width="1em"
+          <CaretDownIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
           >
-            <path
-              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-              transform=""
-            />
-          </svg>
-        </CaretDownIcon>
+            <svg
+              aria-hidden={true}
+              aria-labelledby={null}
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
+              viewBox="0 0 320 512"
+              width="1em"
+            >
+              <path
+                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                transform=""
+              />
+            </svg>
+          </CaretDownIcon>
+        </span>
       </button>
     </SelectToggle>
   </div>
@@ -4913,21 +4978,24 @@ exports[`select with custom content renders expanded successfully 1`] = `
                   class="pf-c-select__toggle-text"
                 />
               </div>
-              <svg
-                aria-hidden="true"
+              <span
                 class="pf-c-select__toggle-arrow"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 320 512"
-                width="1em"
               >
-                <path
-                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  transform=""
-                />
-              </svg>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    transform=""
+                  />
+                </svg>
+              </span>
             </button>
             <div
               class="pf-c-select__menu"
@@ -4958,33 +5026,35 @@ exports[`select with custom content renders expanded successfully 1`] = `
             className="pf-c-select__toggle-text"
           />
         </div>
-        <CaretDownIcon
+        <span
           className="pf-c-select__toggle-arrow"
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
         >
-          <svg
-            aria-hidden={true}
-            aria-labelledby={null}
-            className="pf-c-select__toggle-arrow"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style={
-              Object {
-                "verticalAlign": "-0.125em",
-              }
-            }
-            viewBox="0 0 320 512"
-            width="1em"
+          <CaretDownIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
           >
-            <path
-              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-              transform=""
-            />
-          </svg>
-        </CaretDownIcon>
+            <svg
+              aria-hidden={true}
+              aria-labelledby={null}
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
+              viewBox="0 0 320 512"
+              width="1em"
+            >
+              <path
+                d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                transform=""
+              />
+            </svg>
+          </CaretDownIcon>
+        </span>
       </button>
     </SelectToggle>
     <SelectMenu

--- a/packages/react-core/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/packages/react-core/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
@@ -5917,21 +5917,24 @@ exports[`typeahead multi select renders selected successfully 1`] = `
                   type="button"
                 >
                   Mr
-                  <svg
-                    aria-hidden="true"
+                  <span
                     class="pf-c-select__menu-item-icon"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style="vertical-align: -0.125em;"
-                    viewBox="0 0 512 512"
-                    width="1em"
                   >
-                    <path
-                      d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
-                      transform=""
-                    />
-                  </svg>
+                    <svg
+                      aria-hidden="true"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 512 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
+                        transform=""
+                      />
+                    </svg>
+                  </span>
                 </button>
               </li>
               <li
@@ -5945,21 +5948,24 @@ exports[`typeahead multi select renders selected successfully 1`] = `
                   type="button"
                 >
                   Mrs
-                  <svg
-                    aria-hidden="true"
+                  <span
                     class="pf-c-select__menu-item-icon"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style="vertical-align: -0.125em;"
-                    viewBox="0 0 512 512"
-                    width="1em"
                   >
-                    <path
-                      d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
-                      transform=""
-                    />
-                  </svg>
+                    <svg
+                      aria-hidden="true"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 512 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
+                        transform=""
+                      />
+                    </svg>
+                  </span>
                 </button>
               </li>
               <li
@@ -6339,34 +6345,36 @@ exports[`typeahead multi select renders selected successfully 1`] = `
               type="button"
             >
               Mr
-              <CheckIcon
-                aria-hidden={true}
+              <span
                 className="pf-c-select__menu-item-icon"
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
               >
-                <svg
+                <CheckIcon
                   aria-hidden={true}
-                  aria-labelledby={null}
-                  className="pf-c-select__menu-item-icon"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 512 512"
-                  width="1em"
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
-                    transform=""
-                  />
-                </svg>
-              </CheckIcon>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
+                      transform=""
+                    />
+                  </svg>
+                </CheckIcon>
+              </span>
             </button>
           </li>
         </SelectOption>
@@ -6401,34 +6409,36 @@ exports[`typeahead multi select renders selected successfully 1`] = `
               type="button"
             >
               Mrs
-              <CheckIcon
-                aria-hidden={true}
+              <span
                 className="pf-c-select__menu-item-icon"
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
               >
-                <svg
+                <CheckIcon
                   aria-hidden={true}
-                  aria-labelledby={null}
-                  className="pf-c-select__menu-item-icon"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 512 512"
-                  width="1em"
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
-                    transform=""
-                  />
-                </svg>
-              </CheckIcon>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
+                      transform=""
+                    />
+                  </svg>
+                </CheckIcon>
+              </span>
             </button>
           </li>
         </SelectOption>
@@ -7525,21 +7535,24 @@ exports[`typeahead select renders selected successfully 1`] = `
                   type="button"
                 >
                   Mr
-                  <svg
-                    aria-hidden="true"
+                  <span
                     class="pf-c-select__menu-item-icon"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style="vertical-align: -0.125em;"
-                    viewBox="0 0 512 512"
-                    width="1em"
                   >
-                    <path
-                      d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
-                      transform=""
-                    />
-                  </svg>
+                    <svg
+                      aria-hidden="true"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 512 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
+                        transform=""
+                      />
+                    </svg>
+                  </span>
                 </button>
               </li>
               <li
@@ -7732,34 +7745,36 @@ exports[`typeahead select renders selected successfully 1`] = `
               type="button"
             >
               Mr
-              <CheckIcon
-                aria-hidden={true}
+              <span
                 className="pf-c-select__menu-item-icon"
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
               >
-                <svg
+                <CheckIcon
                   aria-hidden={true}
-                  aria-labelledby={null}
-                  className="pf-c-select__menu-item-icon"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 512 512"
-                  width="1em"
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
-                    transform=""
-                  />
-                </svg>
-              </CheckIcon>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
+                      transform=""
+                    />
+                  </svg>
+                </CheckIcon>
+              </span>
             </button>
           </li>
         </SelectOption>

--- a/packages/react-core/src/components/Select/__tests__/__snapshots__/SelectToggle.test.tsx.snap
+++ b/packages/react-core/src/components/Select/__tests__/__snapshots__/SelectToggle.test.tsx.snap
@@ -34,33 +34,35 @@ exports[`state active 1`] = `
     type="button"
   >
     Select
-    <CaretDownIcon
+    <span
       className="pf-c-select__toggle-arrow"
-      color="currentColor"
-      noVerticalAlign={false}
-      size="sm"
     >
-      <svg
-        aria-hidden={true}
-        aria-labelledby={null}
-        className="pf-c-select__toggle-arrow"
-        fill="currentColor"
-        height="1em"
-        role="img"
-        style={
-          Object {
-            "verticalAlign": "-0.125em",
-          }
-        }
-        viewBox="0 0 320 512"
-        width="1em"
+      <CaretDownIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
       >
-        <path
-          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-          transform=""
-        />
-      </svg>
-    </CaretDownIcon>
+        <svg
+          aria-hidden={true}
+          aria-labelledby={null}
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style={
+            Object {
+              "verticalAlign": "-0.125em",
+            }
+          }
+          viewBox="0 0 320 512"
+          width="1em"
+        >
+          <path
+            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+            transform=""
+          />
+        </svg>
+      </CaretDownIcon>
+    </span>
   </button>
 </SelectToggle>
 `;
@@ -101,33 +103,35 @@ exports[`state focus 1`] = `
     type="button"
   >
     Select
-    <CaretDownIcon
+    <span
       className="pf-c-select__toggle-arrow"
-      color="currentColor"
-      noVerticalAlign={false}
-      size="sm"
     >
-      <svg
-        aria-hidden={true}
-        aria-labelledby={null}
-        className="pf-c-select__toggle-arrow"
-        fill="currentColor"
-        height="1em"
-        role="img"
-        style={
-          Object {
-            "verticalAlign": "-0.125em",
-          }
-        }
-        viewBox="0 0 320 512"
-        width="1em"
+      <CaretDownIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
       >
-        <path
-          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-          transform=""
-        />
-      </svg>
-    </CaretDownIcon>
+        <svg
+          aria-hidden={true}
+          aria-labelledby={null}
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style={
+            Object {
+              "verticalAlign": "-0.125em",
+            }
+          }
+          viewBox="0 0 320 512"
+          width="1em"
+        >
+          <path
+            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+            transform=""
+          />
+        </svg>
+      </CaretDownIcon>
+    </span>
   </button>
 </SelectToggle>
 `;
@@ -168,33 +172,35 @@ exports[`state hover 1`] = `
     type="button"
   >
     Select
-    <CaretDownIcon
+    <span
       className="pf-c-select__toggle-arrow"
-      color="currentColor"
-      noVerticalAlign={false}
-      size="sm"
     >
-      <svg
-        aria-hidden={true}
-        aria-labelledby={null}
-        className="pf-c-select__toggle-arrow"
-        fill="currentColor"
-        height="1em"
-        role="img"
-        style={
-          Object {
-            "verticalAlign": "-0.125em",
-          }
-        }
-        viewBox="0 0 320 512"
-        width="1em"
+      <CaretDownIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
       >
-        <path
-          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-          transform=""
-        />
-      </svg>
-    </CaretDownIcon>
+        <svg
+          aria-hidden={true}
+          aria-labelledby={null}
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style={
+            Object {
+              "verticalAlign": "-0.125em",
+            }
+          }
+          viewBox="0 0 320 512"
+          width="1em"
+        >
+          <path
+            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+            transform=""
+          />
+        </svg>
+      </CaretDownIcon>
+    </span>
   </button>
 </SelectToggle>
 `;

--- a/packages/react-core/src/components/Wizard/WizardToggle.tsx
+++ b/packages/react-core/src/components/Wizard/WizardToggle.tsx
@@ -69,7 +69,9 @@ export const WizardToggle: React.FunctionComponent<WizardToggleProps> = ({
           </li>
           {activeStepSubName && <li className={css(styles.wizardToggleListItem)}>{activeStepSubName}</li>}
         </ol>
-        <CaretDownIcon className={css(styles.wizardToggleIcon)} aria-hidden="true" />
+        <span className={css(styles.wizardToggleIcon)}>
+          <CaretDownIcon aria-hidden="true" />
+        </span>
       </button>
       <div className={css(styles.wizardOuterWrap)}>
         <div className={css(styles.wizardInnerWrap)}>

--- a/packages/react-core/src/components/Wizard/__tests__/Generated/__snapshots__/WizardToggle.test.tsx.snap
+++ b/packages/react-core/src/components/Wizard/__tests__/Generated/__snapshots__/WizardToggle.test.tsx.snap
@@ -20,13 +20,16 @@ exports[`WizardToggle should match snapshot (auto-generated) 1`] = `
          
       </li>
     </ol>
-    <CaretDownIcon
-      aria-hidden="true"
+    <span
       className="pf-c-wizard__toggle-icon"
-      color="currentColor"
-      noVerticalAlign={false}
-      size="sm"
-    />
+    >
+      <CaretDownIcon
+        aria-hidden="true"
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />
+    </span>
   </button>
   <div
     className="pf-c-wizard__outer-wrap"

--- a/packages/react-core/src/components/Wizard/__tests__/__snapshots__/Wizard.test.tsx.snap
+++ b/packages/react-core/src/components/Wizard/__tests__/__snapshots__/Wizard.test.tsx.snap
@@ -209,21 +209,24 @@ exports[`Wizard should match snapshot 1`] = `
                     A
                   </li>
                 </ol>
-                <svg
-                  aria-hidden="true"
+                <span
                   class="pf-c-wizard__toggle-icon"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 320 512"
-                  width="1em"
                 >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                    transform=""
-                  />
-                </svg>
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                      transform=""
+                    />
+                  </svg>
+                </span>
               </button>
               <div
                 class="pf-c-wizard__outer-wrap"
@@ -428,21 +431,24 @@ exports[`Wizard should match snapshot 1`] = `
                     A
                   </li>
                 </ol>
-                <svg
-                  aria-hidden="true"
+                <span
                   class="pf-c-wizard__toggle-icon"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 320 512"
-                  width="1em"
                 >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                    transform=""
-                  />
-                </svg>
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                      transform=""
+                    />
+                  </svg>
+                </span>
               </button>
               <div
                 class="pf-c-wizard__outer-wrap"

--- a/packages/react-table/src/components/Table/CollapseColumn.tsx
+++ b/packages/react-table/src/components/Table/CollapseColumn.tsx
@@ -29,7 +29,9 @@ export const CollapseColumn: React.FunctionComponent<CollapseColumnProps> = ({
         onClick={onToggle}
         aria-expanded={isOpen}
       >
-        <AngleDownIcon />
+        <span className="pf-c-table__toggle-icon">
+          <AngleDownIcon />
+        </span>
       </Button>
     )}
     {children}

--- a/packages/react-table/src/components/Table/CollapseColumn.tsx
+++ b/packages/react-table/src/components/Table/CollapseColumn.tsx
@@ -29,7 +29,7 @@ export const CollapseColumn: React.FunctionComponent<CollapseColumnProps> = ({
         onClick={onToggle}
         aria-expanded={isOpen}
       >
-        <span className="pf-c-table__toggle-icon">
+        <span className={css(styles.tableToggleIcon)}>
           <AngleDownIcon />
         </span>
       </Button>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4114 

This PR removes classes from icons used in several components and moves the class instead into a wrapping element, in most cases moving a class from the icon itself into a wrapper `<span>` component.  See [description in #4114](https://github.com/patternfly/patternfly-react/issues/4114#issue-604391501) for full list of changes.
