### PR TITLE
feat(Drawer, DataList, Page): rename noPadding to hasNoPadding

### DIFF
--- a/packages/react-core/src/components/DataList/DataListContent.tsx
+++ b/packages/react-core/src/components/DataList/DataListContent.tsx
@@ -14,7 +14,7 @@ export interface DataListContentProps extends React.HTMLProps<HTMLElement> {
   /** Flag to show if the expanded content of the DataList item is visible */
   isHidden?: boolean;
   /** Flag to remove padding from the expandable content */
-  noPadding?: boolean;
+  hasNoPadding?: boolean;
   /** Adds accessible text to the DataList toggle */
   'aria-label': string;
 }
@@ -25,7 +25,7 @@ export const DataListContent: React.FunctionComponent<DataListContentProps> = ({
   id = '',
   isHidden = false,
   'aria-label': ariaLabel,
-  noPadding = false,
+  hasNoPadding = false,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   rowid = '',
   ...props
@@ -37,6 +37,8 @@ export const DataListContent: React.FunctionComponent<DataListContentProps> = ({
     aria-label={ariaLabel}
     {...props}
   >
-    <div className={css(styles.dataListExpandableContentBody, noPadding && styles.modifiers.noPadding)}>{children}</div>
+    <div className={css(styles.dataListExpandableContentBody, hasNoPadding && styles.modifiers.noPadding)}>
+      {children}
+    </div>
   </section>
 );

--- a/packages/react-core/src/components/DataList/__tests__/DataList.test.tsx
+++ b/packages/react-core/src/components/DataList/__tests__/DataList.test.tsx
@@ -101,9 +101,7 @@ describe('DataList', () => {
   });
 
   test('Toggle default with aria label', () => {
-    const view = shallow(
-      <DataListToggle aria-label="Toggle details for" id="ex-toggle2" />
-    );
+    const view = shallow(<DataListToggle aria-label="Toggle details for" id="ex-toggle2" />);
 
     expect(view.find(Button).props()['aria-label']).toBe('Toggle details for');
     expect(view.find(Button).props()['aria-labelledby']).toBe(null);
@@ -181,9 +179,9 @@ describe('DataList', () => {
     expect(view).toMatchSnapshot();
   });
 
-  test('DataListContent noPadding', () => {
+  test('DataListContent hasNoPadding', () => {
     const view = shallow(
-      <DataListContent aria-label="Primary Content Details" hidden noPadding>
+      <DataListContent aria-label="Primary Content Details" hidden hasNoPadding>
         test
       </DataListContent>
     );

--- a/packages/react-core/src/components/DataList/__tests__/Generated/DataListContent.test.tsx
+++ b/packages/react-core/src/components/DataList/__tests__/Generated/DataListContent.test.tsx
@@ -15,7 +15,7 @@ it('DataListContent should match snapshot (auto-generated)', () => {
       id={"''"}
       rowid={"''"}
       isHidden={false}
-      noPadding={false}
+      hasNoPadding={false}
       aria-label={'string'}
     />
   );

--- a/packages/react-core/src/components/DataList/__tests__/__snapshots__/DataList.test.tsx.snap
+++ b/packages/react-core/src/components/DataList/__tests__/__snapshots__/DataList.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`DataList DataListContent 1`] = `
 </section>
 `;
 
-exports[`DataList DataListContent noPadding 1`] = `
+exports[`DataList DataListContent hasNoPadding 1`] = `
 <section
   aria-label="Primary Content Details"
   className="pf-c-data-list__expandable-content"

--- a/packages/react-core/src/components/DataList/examples/DataList.md
+++ b/packages/react-core/src/components/DataList/examples/DataList.md
@@ -689,7 +689,7 @@ class ExpandableDataList extends React.Component {
             aria-label="Primary Content Details"
             id="ex-expand3"
             isHidden={!this.state.expanded.includes('ex-toggle3')}
-            noPadding
+            hasNoPadding
           >
             This expanded section has no padding.
           </DataListContent>

--- a/packages/react-core/src/components/Drawer/DrawerHead.tsx
+++ b/packages/react-core/src/components/Drawer/DrawerHead.tsx
@@ -9,17 +9,17 @@ export interface DrawerHeadProps extends React.HTMLProps<HTMLDivElement> {
   /** Content to be rendered in the drawer head */
   children?: React.ReactNode;
   /** Indicates if there should be no padding around the drawer panel body of the head*/
-  noPadding?: boolean;
+  hasNoPadding?: boolean;
 }
 
 export const DrawerHead: React.SFC<DrawerHeadProps> = ({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   className = '',
   children,
-  noPadding = false,
+  hasNoPadding = false,
   ...props
 }: DrawerHeadProps) => (
-  <DrawerPanelBody noPadding={noPadding}>
+  <DrawerPanelBody hasNoPadding={hasNoPadding}>
     <div className={css(styles.drawerHead, className)} {...props}>
       {children}
     </div>

--- a/packages/react-core/src/components/Drawer/DrawerPanelBody.tsx
+++ b/packages/react-core/src/components/Drawer/DrawerPanelBody.tsx
@@ -8,17 +8,17 @@ export interface DrawerPanelBodyProps extends React.HTMLProps<HTMLDivElement> {
   /** Content to be rendered in the drawer */
   children?: React.ReactNode;
   /** Indicates if there should be no padding around the drawer panel body */
-  noPadding?: boolean;
+  hasNoPadding?: boolean;
 }
 
 export const DrawerPanelBody: React.SFC<DrawerPanelBodyProps> = ({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   className = '',
   children,
-  noPadding = false,
+  hasNoPadding = false,
   ...props
 }: DrawerPanelBodyProps) => (
-  <div className={css(styles.drawerBody, noPadding && styles.modifiers.noPadding, className)} {...props}>
+  <div className={css(styles.drawerBody, hasNoPadding && styles.modifiers.noPadding, className)} {...props}>
     {children}
   </div>
 );

--- a/packages/react-core/src/components/Drawer/__tests__/Generated/DrawerPanelContent.test.tsx
+++ b/packages/react-core/src/components/Drawer/__tests__/Generated/DrawerPanelContent.test.tsx
@@ -8,6 +8,6 @@ import { DrawerPanelContent } from '../../DrawerPanelContent';
 import {} from '../..';
 
 it('DrawerPanelContent should match snapshot (auto-generated)', () => {
-  const view = shallow(<DrawerPanelContent className={"''"} children={<div>ReactNode</div>} />);
+  const view = shallow(<DrawerPanelContent className={"''"} children={<div>ReactNode</div>} hasNoPadding={false} />);
   expect(view).toMatchSnapshot();
 });

--- a/packages/react-core/src/components/Drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/react-core/src/components/Drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`Drawer isExpanded = false and isInline = false and isStatic = false 1`]
             >
               <DrawerHead>
                 <DrawerPanelBody
-                  noPadding={false}
+                  hasNoPadding={false}
                 >
                   <div
                     className="pf-c-drawer__body"
@@ -179,7 +179,7 @@ exports[`Drawer isExpanded = false and isInline = true and isStatic = false 1`] 
             >
               <DrawerHead>
                 <DrawerPanelBody
-                  noPadding={false}
+                  hasNoPadding={false}
                 >
                   <div
                     className="pf-c-drawer__body"
@@ -312,7 +312,7 @@ exports[`Drawer isExpanded = true and isInline = false and isStatic = false 1`] 
             >
               <DrawerHead>
                 <DrawerPanelBody
-                  noPadding={false}
+                  hasNoPadding={false}
                 >
                   <div
                     className="pf-c-drawer__body"
@@ -445,7 +445,7 @@ exports[`Drawer isExpanded = true and isInline = false and isStatic = true 1`] =
             >
               <DrawerHead>
                 <DrawerPanelBody
-                  noPadding={false}
+                  hasNoPadding={false}
                 >
                   <div
                     className="pf-c-drawer__body"
@@ -578,7 +578,7 @@ exports[`Drawer isExpanded = true and isInline = true and isStatic = false 1`] =
             >
               <DrawerHead>
                 <DrawerPanelBody
-                  noPadding={false}
+                  hasNoPadding={false}
                 >
                   <div
                     className="pf-c-drawer__body"

--- a/packages/react-core/src/components/Drawer/examples/Drawer.md
+++ b/packages/react-core/src/components/Drawer/examples/Drawer.md
@@ -2,10 +2,22 @@
 title: 'Drawer'
 cssPrefix: 'pf-c-drawer'
 typescript: true
-propComponents: [Drawer, DrawerContent, DrawerPanelContent, DrawerContentBody, DrawerPanelBody, DrawerSection, DrawerHead, DrawerActions, DrawerCloseButton]
+propComponents:
+  [
+    Drawer,
+    DrawerContent,
+    DrawerPanelContent,
+    DrawerContentBody,
+    DrawerPanelBody,
+    DrawerSection,
+    DrawerHead,
+    DrawerActions,
+    DrawerCloseButton,
+  ]
 section: 'components'
 beta: true
 ---
+
 import { Drawer, DrawerPanelContent, DrawerContent, DrawerContentBody, DrawerPanelBody, DrawerSection, DrawerHead, DrawerActions, DrawerCloseButton } from '@patternfly/react-core';
 
 ## Examples
@@ -63,7 +75,9 @@ class SimpleDrawer extends React.Component {
 
     return (
       <React.Fragment>
-        <Button aria-expanded={isExpanded} onClick={this.onClick}>Toggle Drawer</Button>
+        <Button aria-expanded={isExpanded} onClick={this.onClick}>
+          Toggle Drawer
+        </Button>
         <Drawer isExpanded={isExpanded}>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>{drawerContent}</DrawerContentBody>
@@ -128,9 +142,11 @@ class SimpleDrawerPanelLeft extends React.Component {
 
     return (
       <React.Fragment>
-        <Button aria-expanded={isExpanded} onClick={this.onClick}>Toggle Drawer</Button>
+        <Button aria-expanded={isExpanded} onClick={this.onClick}>
+          Toggle Drawer
+        </Button>
         <Drawer isExpanded={isExpanded}>
-          <DrawerContent  panelContent={panelContent}>
+          <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>{drawerContent}</DrawerContentBody>
           </DrawerContent>
         </Drawer>
@@ -142,7 +158,17 @@ class SimpleDrawerPanelLeft extends React.Component {
 
 ```js title=Panel-on-left
 import React, { ReactFragment } from 'react';
-import { Drawer, DrawerPanelContent, DrawerContent, DrawerContentBody, DrawerPanelBody, DrawerHead, DrawerActions, DrawerCloseButton, Button } from '@patternfly/react-core';
+import {
+  Drawer,
+  DrawerPanelContent,
+  DrawerContent,
+  DrawerContentBody,
+  DrawerPanelBody,
+  DrawerHead,
+  DrawerActions,
+  DrawerCloseButton,
+  Button
+} from '@patternfly/react-core';
 
 class SimpleDrawerPanelLeft extends React.Component {
   constructor(props) {
@@ -168,23 +194,26 @@ class SimpleDrawerPanelLeft extends React.Component {
   render() {
     const { isExpanded } = this.state;
     const panelContent = (
-      <DrawerPanelContent> 
+      <DrawerPanelContent>
         <DrawerHead>
           <span>drawer-panel</span>
           <DrawerActions>
-            <DrawerCloseButton onClick={this.onCloseClick}/>
+            <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
         </DrawerHead>
       </DrawerPanelContent>
     );
 
-    const drawerContent = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.";
+    const drawerContent =
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.';
 
     return (
       <React.Fragment>
-        <Button aria-expanded={isExpanded} onClick={this.onClick}>Toggle Drawer</Button>
+        <Button aria-expanded={isExpanded} onClick={this.onClick}>
+          Toggle Drawer
+        </Button>
         <Drawer isExpanded={isExpanded} position="left">
-          <DrawerContent  panelContent={panelContent}>
+          <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>{drawerContent}</DrawerContentBody>
           </DrawerContent>
         </Drawer>
@@ -247,7 +276,9 @@ class SimpleDrawerInlineContent extends React.Component {
 
     return (
       <React.Fragment>
-        <Button aria-expanded={isExpanded} onClick={this.onClick}>Toggle Drawer</Button>
+        <Button aria-expanded={isExpanded} onClick={this.onClick}>
+          Toggle Drawer
+        </Button>
         <Drawer isExpanded={isExpanded} isInline>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>{drawerContent}</DrawerContentBody>
@@ -312,7 +343,9 @@ class DrawerInlineContentPanelLeft extends React.Component {
 
     return (
       <React.Fragment>
-        <Button aria-expanded={isExpanded} onClick={this.onClick}>Toggle Drawer</Button>
+        <Button aria-expanded={isExpanded} onClick={this.onClick}>
+          Toggle Drawer
+        </Button>
         <Drawer isExpanded={isExpanded} isInline>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>{drawerContent}</DrawerContentBody>
@@ -326,11 +359,20 @@ class DrawerInlineContentPanelLeft extends React.Component {
 
 ```js title=-Inline-panel-on-left
 import React, { ReactFragment } from 'react';
-import { Drawer, DrawerPanelContent, DrawerContent, DrawerContentBody, DrawerPanelBody, DrawerHead, DrawerActions, DrawerCloseButton, Button } from '@patternfly/react-core';
+import {
+  Drawer,
+  DrawerPanelContent,
+  DrawerContent,
+  DrawerContentBody,
+  DrawerPanelBody,
+  DrawerHead,
+  DrawerActions,
+  DrawerCloseButton,
+  Button
+} from '@patternfly/react-core';
 
 class DrawerInlineContentPanelLeft extends React.Component {
-
-   constructor(props) {
+  constructor(props) {
     super(props);
     this.state = {
       isExpanded: false
@@ -348,27 +390,30 @@ class DrawerInlineContentPanelLeft extends React.Component {
         isExpanded: false
       });
     };
-   }
+  }
 
   render() {
     const { isExpanded } = this.state;
     const panelContent = (
-      <DrawerPanelContent> 
+      <DrawerPanelContent>
         <DrawerHead>
           <span>drawer-panel</span>
           <DrawerActions>
-            <DrawerCloseButton onClick={this.onCloseClick}/>
+            <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
         </DrawerHead>
       </DrawerPanelContent>
     );
 
-    const drawerContent = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.";
+    const drawerContent =
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.';
 
     return (
       <React.Fragment>
-        <Button aria-expanded={isExpanded} onClick={this.onClick}>Toggle Drawer</Button>
-        <Drawer isExpanded={isExpanded} isInline position='left'>
+        <Button aria-expanded={isExpanded} onClick={this.onClick}>
+          Toggle Drawer
+        </Button>
+        <Drawer isExpanded={isExpanded} isInline position="left">
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>{drawerContent}</DrawerContentBody>
           </DrawerContent>
@@ -381,11 +426,20 @@ class DrawerInlineContentPanelLeft extends React.Component {
 
 ```js title=Stacked-content-body-elements
 import React, { ReactFragment } from 'react';
-import { Drawer, DrawerPanelContent, DrawerContent, DrawerContentBody, DrawerPanelBody, DrawerHead, DrawerActions, DrawerCloseButton, Button } from '@patternfly/react-core';
+import {
+  Drawer,
+  DrawerPanelContent,
+  DrawerContent,
+  DrawerContentBody,
+  DrawerPanelBody,
+  DrawerHead,
+  DrawerActions,
+  DrawerCloseButton,
+  Button
+} from '@patternfly/react-core';
 
 class DrawerStackedContentBodyElements extends React.Component {
-
-   constructor(props) {
+  constructor(props) {
     super(props);
     this.state = {
       isExpanded: false
@@ -403,7 +457,7 @@ class DrawerStackedContentBodyElements extends React.Component {
         isExpanded: false
       });
     };
-   }
+  }
 
   render() {
     const { isExpanded } = this.state;
@@ -411,20 +465,22 @@ class DrawerStackedContentBodyElements extends React.Component {
       <DrawerPanelContent>
         <DrawerHead>
           <DrawerActions>
-            <DrawerCloseButton onClick={this.onCloseClick}/>
+            <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
           drawer-panel
-        </DrawerHead> 
-        <DrawerPanelBody noPadding>drawer-panel with no padding</DrawerPanelBody> 
-        <DrawerPanelBody>drawer-panel</DrawerPanelBody> 
+        </DrawerHead>
+        <DrawerPanelBody hasNoPadding>drawer-panel with no padding</DrawerPanelBody>
+        <DrawerPanelBody>drawer-panel</DrawerPanelBody>
       </DrawerPanelContent>
     );
 
     return (
       <React.Fragment>
-        <Button aria-expanded={isExpanded} onClick={this.onClick}>Toggle Drawer</Button>
+        <Button aria-expanded={isExpanded} onClick={this.onClick}>
+          Toggle Drawer
+        </Button>
         <Drawer isExpanded={isExpanded}>
-          <DrawerContent  panelContent={panelContent}>
+          <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>content-body</DrawerContentBody>
             <DrawerContentBody hasPadding>content-body with padding</DrawerContentBody>
             <DrawerContentBody>content-body</DrawerContentBody>
@@ -481,14 +537,16 @@ class DrawerStackedContentBodyElements extends React.Component {
           </DrawerActions>
           drawer-panel
         </DrawerHead>
-        <DrawerPanelBody noPadding>drawer-panel with no padding</DrawerPanelBody>
+        <DrawerPanelBody hasNoPadding>drawer-panel with no padding</DrawerPanelBody>
         <DrawerPanelBody>drawer-panel</DrawerPanelBody>
       </DrawerPanelContent>
     );
 
     return (
       <React.Fragment>
-        <Button aria-expanded={isExpanded} onClick={this.onClick}>Toggle Drawer</Button>
+        <Button aria-expanded={isExpanded} onClick={this.onClick}>
+          Toggle Drawer
+        </Button>
         <Drawer isExpanded={isExpanded}>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>content-body</DrawerContentBody>
@@ -555,7 +613,9 @@ class DrawerModifiedContentPadding extends React.Component {
 
     return (
       <React.Fragment>
-        <Button aria-expanded={isExpanded} onClick={this.onClick}>Toggle Drawer</Button>
+        <Button aria-expanded={isExpanded} onClick={this.onClick}>
+          Toggle Drawer
+        </Button>
         <Drawer isExpanded={isExpanded}>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody hasPadding>
@@ -608,7 +668,7 @@ class DrawerModifiedPanelPadding extends React.Component {
     const { isExpanded } = this.state;
     const panelContent = (
       <DrawerPanelContent>
-        <DrawerHead noPadding>
+        <DrawerHead hasNoPadding>
           <span>drawer-panel</span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
@@ -622,7 +682,9 @@ class DrawerModifiedPanelPadding extends React.Component {
 
     return (
       <React.Fragment>
-        <Button aria-expanded={isExpanded} onClick={this.onClick}>Toggle Drawer</Button>
+        <Button aria-expanded={isExpanded} onClick={this.onClick}>
+          Toggle Drawer
+        </Button>
         <Drawer isExpanded={isExpanded}>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>{drawerContent}</DrawerContentBody>
@@ -688,7 +750,9 @@ class DrawerWithSection extends React.Component {
 
     return (
       <React.Fragment>
-        <Button aria-expanded={isExpanded} onClick={this.onClick}>Toggle Drawer</Button>
+        <Button aria-expanded={isExpanded} onClick={this.onClick}>
+          Toggle Drawer
+        </Button>
         <Drawer isExpanded={isExpanded}>
           <DrawerSection>drawer-section</DrawerSection>
           <DrawerContent panelContent={panelContent}>

--- a/packages/react-core/src/components/Page/PageSection.tsx
+++ b/packages/react-core/src/components/Page/PageSection.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/Page/page';
 import { css } from '@patternfly/react-styles';
+import { formatBreakpointMods } from '../../helpers/util';
 
 export enum PageSectionVariants {
   default = 'default',
@@ -14,12 +15,11 @@ export enum PageSectionTypes {
   nav = 'nav'
 }
 
-export enum PageSectionBreakpoints {
-  sm = 'sm',
-  md = 'md',
-  lg = 'lg',
-  xl = 'xl',
-  '2xl' = '2xl'
+export interface PageSectionBreakpointMod {
+  /** The attribute to modify  */
+  modifier: 'padding' | 'no-padding';
+  /** The breakpoint at which to apply the modifier */
+  breakpoint?: 'sm' | 'md' | 'lg' | 'xl' | '2xl';
 }
 
 export interface PageSectionProps extends React.HTMLProps<HTMLDivElement> {
@@ -35,10 +35,8 @@ export interface PageSectionProps extends React.HTMLProps<HTMLDivElement> {
   isFilled?: boolean;
   /** Modifies a main page section to have no padding */
   hasNoPadding?: boolean;
-  /** Modifies a main page section to have padding on specific screen size breakpoints */
-  hasPaddingOn?: ('sm' | 'md' | 'lg' | 'xl' | '2xl')[] | ('sm' | 'md' | 'lg' | 'xl' | '2xl');
-  /** Modifies a main page section to not have padding on specific screen size breakpoints */
-  hasNoPaddingOn?: ('sm' | 'md' | 'lg' | 'xl' | '2xl')[] | ('sm' | 'md' | 'lg' | 'xl' | '2xl');
+  /** An array of objects representing modifiers to apply to the page section at various breakpoints */
+  breakpointMods?: PageSectionBreakpointMod[];
 }
 
 const variantType = {
@@ -53,30 +51,13 @@ const variantStyle = {
   [PageSectionVariants.darker]: styles.modifiers.dark_100
 };
 
-const paddingBreakpoints = {
-  [PageSectionBreakpoints.sm]: styles.modifiers.paddingOnSm,
-  [PageSectionBreakpoints.md]: styles.modifiers.paddingOnMd,
-  [PageSectionBreakpoints.lg]: styles.modifiers.paddingOnLg,
-  [PageSectionBreakpoints.xl]: styles.modifiers.paddingOnXl,
-  [PageSectionBreakpoints['2xl']]: styles.modifiers.paddingOn_2xl
-};
-
-const noPaddingBreakpoints = {
-  [PageSectionBreakpoints.sm]: styles.modifiers.noPaddingOnSm,
-  [PageSectionBreakpoints.md]: styles.modifiers.noPaddingOnMd,
-  [PageSectionBreakpoints.lg]: styles.modifiers.noPaddingOnLg,
-  [PageSectionBreakpoints.xl]: styles.modifiers.noPaddingOnXl,
-  [PageSectionBreakpoints['2xl']]: styles.modifiers.noPaddingOn_2xl
-};
-
 export const PageSection: React.FunctionComponent<PageSectionProps> = ({
   className = '',
   children,
   variant = 'default',
   type = 'default',
   hasNoPadding = false,
-  hasPaddingOn,
-  hasNoPaddingOn,
+  breakpointMods = [] as PageSectionBreakpointMod[],
   isFilled,
   ...props
 }: PageSectionProps) => (
@@ -85,14 +66,7 @@ export const PageSection: React.FunctionComponent<PageSectionProps> = ({
     className={css(
       variantType[type],
       hasNoPadding && styles.modifiers.noPadding,
-      hasPaddingOn &&
-        (hasPaddingOn.constructor !== Array
-          ? paddingBreakpoints[hasPaddingOn as PageSectionBreakpoints]
-          : (hasPaddingOn as PageSectionBreakpoints[]).map(breakpoint => paddingBreakpoints[breakpoint])),
-      hasNoPaddingOn &&
-        (hasNoPaddingOn.constructor !== Array
-          ? noPaddingBreakpoints[hasNoPaddingOn as PageSectionBreakpoints]
-          : (hasNoPaddingOn as PageSectionBreakpoints[]).map(breakpoint => noPaddingBreakpoints[breakpoint])),
+      formatBreakpointMods(breakpointMods, styles),
       variantStyle[variant],
       isFilled === false && styles.modifiers.noFill,
       isFilled === true && styles.modifiers.fill,

--- a/packages/react-core/src/components/Page/PageSection.tsx
+++ b/packages/react-core/src/components/Page/PageSection.tsx
@@ -14,6 +14,14 @@ export enum PageSectionTypes {
   nav = 'nav'
 }
 
+export enum PageSectionBreakpoints {
+  sm = 'sm',
+  md = 'md',
+  lg = 'lg',
+  xl = 'xl',
+  '2xl' = '2xl'
+}
+
 export interface PageSectionProps extends React.HTMLProps<HTMLDivElement> {
   /** Content rendered inside the section */
   children?: React.ReactNode;
@@ -26,7 +34,11 @@ export interface PageSectionProps extends React.HTMLProps<HTMLDivElement> {
   /** Enables the page section to fill the available vertical space */
   isFilled?: boolean;
   /** Modifies a main page section to have no padding */
-  noPadding?: boolean;
+  hasNoPadding?: boolean;
+  /** Modifies a main page section to have padding on specific screen size breakpoints */
+  hasPaddingOn?: ('sm' | 'md' | 'lg' | 'xl' | '2xl')[] | ('sm' | 'md' | 'lg' | 'xl' | '2xl');
+  /** Modifies a main page section to not have padding on specific screen size breakpoints */
+  hasNoPaddingOn?: ('sm' | 'md' | 'lg' | 'xl' | '2xl')[] | ('sm' | 'md' | 'lg' | 'xl' | '2xl');
 }
 
 const variantType = {
@@ -41,21 +53,46 @@ const variantStyle = {
   [PageSectionVariants.darker]: styles.modifiers.dark_100
 };
 
+const paddingBreakpoints = {
+  [PageSectionBreakpoints.sm]: styles.modifiers.paddingOnSm,
+  [PageSectionBreakpoints.md]: styles.modifiers.paddingOnMd,
+  [PageSectionBreakpoints.lg]: styles.modifiers.paddingOnLg,
+  [PageSectionBreakpoints.xl]: styles.modifiers.paddingOnXl,
+  [PageSectionBreakpoints['2xl']]: styles.modifiers.paddingOn_2xl
+};
+
+const noPaddingBreakpoints = {
+  [PageSectionBreakpoints.sm]: styles.modifiers.noPaddingOnSm,
+  [PageSectionBreakpoints.md]: styles.modifiers.noPaddingOnMd,
+  [PageSectionBreakpoints.lg]: styles.modifiers.noPaddingOnLg,
+  [PageSectionBreakpoints.xl]: styles.modifiers.noPaddingOnXl,
+  [PageSectionBreakpoints['2xl']]: styles.modifiers.noPaddingOn_2xl
+};
+
 export const PageSection: React.FunctionComponent<PageSectionProps> = ({
   className = '',
   children,
   variant = 'default',
   type = 'default',
-  noPadding = false,
+  hasNoPadding = false,
+  hasPaddingOn,
+  hasNoPaddingOn,
   isFilled,
   ...props
 }: PageSectionProps) => (
-  // TODO: Implement https://github.com/patternfly/patternfly/pull/2816
   <section
     {...props}
     className={css(
       variantType[type],
-      noPadding && styles.modifiers.noPadding,
+      hasNoPadding && styles.modifiers.noPadding,
+      hasPaddingOn &&
+        (hasPaddingOn.constructor !== Array
+          ? paddingBreakpoints[hasPaddingOn as PageSectionBreakpoints]
+          : (hasPaddingOn as PageSectionBreakpoints[]).map(breakpoint => paddingBreakpoints[breakpoint])),
+      hasNoPaddingOn &&
+        (hasNoPaddingOn.constructor !== Array
+          ? noPaddingBreakpoints[hasNoPaddingOn as PageSectionBreakpoints]
+          : (hasNoPaddingOn as PageSectionBreakpoints[]).map(breakpoint => noPaddingBreakpoints[breakpoint])),
       variantStyle[variant],
       isFilled === false && styles.modifiers.noFill,
       isFilled === true && styles.modifiers.fill,

--- a/packages/react-core/src/components/Page/__tests__/Generated/PageSection.test.tsx
+++ b/packages/react-core/src/components/Page/__tests__/Generated/PageSection.test.tsx
@@ -15,7 +15,7 @@ it('PageSection should match snapshot (auto-generated)', () => {
       variant={'default'}
       type={'default'}
       isFilled={true}
-      noPadding={false}
+      hasNoPadding={false}
     />
   );
   expect(view).toMatchSnapshot();

--- a/packages/react-core/src/components/Page/__tests__/PageSection.test.tsx
+++ b/packages/react-core/src/components/Page/__tests__/PageSection.test.tsx
@@ -5,7 +5,7 @@ import { PageSection, PageSectionTypes } from '../PageSection';
 jest.mock('../Page');
 
 test('Check page section with no padding example against snapshot', () => {
-  const Section = <PageSection noPadding />;
+  const Section = <PageSection hasNoPadding />;
   const view = mount(Section);
   expect(view).toMatchSnapshot();
 });
@@ -29,7 +29,7 @@ test('Check page section with fill example against snapshot', () => {
 });
 
 test('Check page section with fill and no padding example against snapshot', () => {
-  const Section = <PageSection isFilled noPadding />;
+  const Section = <PageSection isFilled hasNoPadding />;
   const view = mount(Section);
   expect(view).toMatchSnapshot();
 });

--- a/packages/react-core/src/components/Page/__tests__/__snapshots__/PageSection.test.tsx.snap
+++ b/packages/react-core/src/components/Page/__tests__/__snapshots__/PageSection.test.tsx.snap
@@ -12,8 +12,8 @@ exports[`Check page main nav section against snapshot 1`] = `
 
 exports[`Check page section with fill and no padding example against snapshot 1`] = `
 <PageSection
+  hasNoPadding={true}
   isFilled={true}
-  noPadding={true}
 >
   <section
     className="pf-c-page__main-section pf-m-no-padding pf-m-fill"
@@ -43,7 +43,7 @@ exports[`Check page section with no fill example against snapshot 1`] = `
 
 exports[`Check page section with no padding example against snapshot 1`] = `
 <PageSection
-  noPadding={true}
+  hasNoPadding={true}
 >
   <section
     className="pf-c-page__main-section pf-m-no-padding"

--- a/packages/react-core/src/components/Page/examples/Page.md
+++ b/packages/react-core/src/components/Page/examples/Page.md
@@ -134,10 +134,16 @@ class VerticalPage extends React.Component {
         <PageSection variant={PageSectionVariants.light} hasNoPadding>
           Section with no padding
         </PageSection>
-        <PageSection hasNoPadding hasPaddingOn={[PageSectionBreakpoints.md, PageSectionBreakpoints.lg]}>
+        <PageSection
+          hasNoPadding
+          breakpointMods={[{ modifier: 'padding', breakpoint: 'md' }, { modifier: 'padding', breakpoint: 'lg' }]}
+        >
           Section with padding only on medium/large
         </PageSection>
-        <PageSection variant={PageSectionVariants.light} hasNoPaddingOn={PageSectionBreakpoints.md}>
+        <PageSection
+          variant={PageSectionVariants.light}
+          breakpointMods={[{ modifier: 'no-padding', breakpoint: 'md' }]}
+        >
           Section with no padding on medium
         </PageSection>
       </Page>

--- a/packages/react-core/src/components/Page/examples/Page.md
+++ b/packages/react-core/src/components/Page/examples/Page.md
@@ -6,12 +6,20 @@ typescript: true
 propComponents: ['Page', 'PageHeader', 'PageSidebar', 'PageSection']
 ---
 
-import { Page, PageHeader, PageSidebar, PageSection, PageSectionVariants } from '@patternfly/react-core';
+import { Page, PageHeader, PageSidebar, PageSection, PageSectionVariants, PageSectionBreakpoints } from '@patternfly/react-core';
 
 ## Examples
+
 ```js title=Vertical-nav
 import React from 'react';
-import { Page, PageHeader, PageSidebar, PageSection, PageSectionVariants } from '@patternfly/react-core';
+import {
+  Page,
+  PageHeader,
+  PageSidebar,
+  PageSection,
+  PageSectionVariants,
+  PageSectionBreakpoints
+} from '@patternfly/react-core';
 
 class VerticalPage extends React.Component {
   constructor(props) {
@@ -123,12 +131,21 @@ class VerticalPage extends React.Component {
     return (
       <Page header={Header} sidebar={Sidebar}>
         <PageSection>Section with default padding</PageSection>
-        <PageSection variant={PageSectionVariants.light} noPadding={true}>Section with no padding</PageSection>
+        <PageSection variant={PageSectionVariants.light} hasNoPadding>
+          Section with no padding
+        </PageSection>
+        <PageSection hasNoPadding hasPaddingOn={[PageSectionBreakpoints.md, PageSectionBreakpoints.lg]}>
+          Section with padding only on medium/large
+        </PageSection>
+        <PageSection variant={PageSectionVariants.light} hasNoPaddingOn={PageSectionBreakpoints.md}>
+          Section with no padding on medium
+        </PageSection>
       </Page>
     );
   }
 }
 ```
+
 ```js title=With-or-without-fill
 import React from 'react';
 import { Page, PageHeader, PageSidebar, PageSection, PageSectionVariants } from '@patternfly/react-core';
@@ -169,9 +186,14 @@ class FillPage extends React.Component {
 
     return (
       <Page header={Header} sidebar={Sidebar}>
-        <PageSection style={{height: '10em'}}>This section is set to the default fill variant</PageSection>
-        <PageSection style={{height: '10em'}} isFilled={true}>This section fills the available space.</PageSection>
-        <PageSection style={{height: '10em'}} isFilled={false}> This section does not fill the available space.</PageSection>
+        <PageSection style={{ height: '10em' }}>This section is set to the default fill variant</PageSection>
+        <PageSection style={{ height: '10em' }} isFilled={true}>
+          This section fills the available space.
+        </PageSection>
+        <PageSection style={{ height: '10em' }} isFilled={false}>
+          {' '}
+          This section does not fill the available space.
+        </PageSection>
       </Page>
     );
   }

--- a/packages/react-core/src/helpers/util.ts
+++ b/packages/react-core/src/helpers/util.ts
@@ -2,6 +2,7 @@ import * as ReactDOM from 'react-dom';
 import { SIDE } from './constants';
 import { ToolbarBreakpointMod } from '../components/Toolbar/ToolbarUtils';
 import { FlexBreakpointMod, FlexItemBreakpointMod } from '../layouts/Flex/FlexUtils';
+import { PageSectionBreakpointMod } from '../components/Page/PageSection';
 
 /**
  * @param {string} input - String to capitalize
@@ -237,11 +238,11 @@ export function pluralize(i: number, singular: string, plural?: string) {
 
 /** This function is a helper for turning arrays of breakpointMod objects for data toolbar and flex into classes
  *
- * @param {(ToolbarBreakpointMod | FlexBreakpointMod | FlexItemBreakpointMod)[]} breakpointMods The modifiers object
+ * @param {(ToolbarBreakpointMod | FlexBreakpointMod | FlexItemBreakpointMod | PageSectionBreakpointMod)[]} breakpointMods The modifiers object
  * @param {any} styles The appropriate styles object for the component
  */
 export const formatBreakpointMods = (
-  breakpointMods: (ToolbarBreakpointMod | FlexBreakpointMod | FlexItemBreakpointMod)[],
+  breakpointMods: (ToolbarBreakpointMod | FlexBreakpointMod | FlexItemBreakpointMod | PageSectionBreakpointMod)[],
   styles: any
 ) =>
   breakpointMods

--- a/packages/react-integration/cypress/integration/page.spec.ts
+++ b/packages/react-integration/cypress/integration/page.spec.ts
@@ -25,6 +25,8 @@ describe('Page Demo Test', () => {
       cy.get('.pf-c-page__main-section.pf-m-dark-100').should('exist');
       cy.get('.pf-c-page__main-section.pf-m-dark-200').should('exist');
       cy.get('.pf-c-page__main-section.pf-m-light').should('exist');
+      cy.get('.pf-c-page__main-section.pf-m-no-padding').should('exist');
+      cy.get('.pf-c-page__main-section.pf-m-no-padding-on-md').should('exist');
     });
   });
 });

--- a/packages/react-integration/demo-app-ts/src/components/demos/PageDemo/PageDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/PageDemo/PageDemo.tsx
@@ -56,6 +56,18 @@ export class PageDemo extends React.Component {
         <PageSection variant={PageSectionVariants.darker}>Section with darker background</PageSection>
         <PageSection variant={PageSectionVariants.dark}>Section with dark background</PageSection>
         <PageSection variant={PageSectionVariants.light}>Section with light background</PageSection>
+        <PageSection
+          hasNoPadding
+          breakpointMods={[{ modifier: 'padding', breakpoint: 'md' }, { modifier: 'padding', breakpoint: 'lg' }]}
+        >
+          Section with padding only on medium/large
+        </PageSection>
+        <PageSection
+          variant={PageSectionVariants.light}
+          breakpointMods={[{ modifier: 'no-padding', breakpoint: 'md' }]}
+        >
+          Section with no padding on medium
+        </PageSection>
       </Page>
     );
   }


### PR DESCRIPTION
And add Page padding breakpoint logic

<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4013, #4039, #4040

<!-- Are there any upstream issues or separate issues you need to reference? -->
## Breaking changes
1. Renamed `noPadding` to `hasNoPadding` for Drawer, DataList and Page components.
2. Added `hasPaddingOn` and `hasNoPaddingOn` properties to PageSection, accounting for page size breakpoints. Breakpoints are defined in the `PageSectionBreakpoints` enum.
