### PR TITLE
feat(Wizard): update hasBodyPadding

### DIFF
--- a/packages/react-core/src/components/Wizard/Wizard.tsx
+++ b/packages/react-core/src/components/Wizard/Wizard.tsx
@@ -70,7 +70,7 @@ export interface WizardProps extends React.HTMLProps<HTMLDivElement> {
   startAtStep?: number;
   /** Aria-label for the Nav */
   navAriaLabel?: string;
-  /** Can remove the default padding around the main body content by setting this to false */
+  /** Can remove the default padding around the main body content by setting this to true */
   hasNoBodyPadding?: boolean;
   /** (Use to control the footer) Passing in a footer component lets you control the buttons yourself */
   footer?: React.ReactNode;

--- a/packages/react-core/src/components/Wizard/Wizard.tsx
+++ b/packages/react-core/src/components/Wizard/Wizard.tsx
@@ -71,7 +71,7 @@ export interface WizardProps extends React.HTMLProps<HTMLDivElement> {
   /** Aria-label for the Nav */
   navAriaLabel?: string;
   /** Can remove the default padding around the main body content by setting this to false */
-  hasBodyPadding?: boolean;
+  hasNoBodyPadding?: boolean;
   /** (Use to control the footer) Passing in a footer component lets you control the buttons yourself */
   footer?: React.ReactNode;
   /** (Unused if footer is controlled) Callback function to save at the end of the wizard, if not specified uses onClose */
@@ -112,7 +112,7 @@ export class Wizard extends React.Component<WizardProps, WizardState> {
     cancelButtonText: 'Cancel',
     closeButtonAriaLabel: 'Close',
     navAriaLabel: 'Steps',
-    hasBodyPadding: true,
+    hasNoBodyPadding: false,
     onBack: null as WizardStepFunctionType,
     onNext: null as WizardStepFunctionType,
     onGoToStep: null as WizardStepFunctionType,
@@ -349,7 +349,7 @@ export class Wizard extends React.Component<WizardProps, WizardState> {
       cancelButtonText = 'Cancel',
       closeButtonAriaLabel = 'Close',
       navAriaLabel,
-      hasBodyPadding,
+      hasNoBodyPadding,
       footer,
       isCompactNav,
       appendTo,
@@ -480,7 +480,7 @@ export class Wizard extends React.Component<WizardProps, WizardState> {
             nav={nav}
             steps={steps}
             activeStep={activeStep}
-            hasBodyPadding={hasBodyPadding}
+            hasNoBodyPadding={hasNoBodyPadding}
           >
             {footer || (
               <WizardFooterInternal

--- a/packages/react-core/src/components/Wizard/WizardBody.tsx
+++ b/packages/react-core/src/components/Wizard/WizardBody.tsx
@@ -5,15 +5,15 @@ import { css } from '@patternfly/react-styles';
 export interface WizardBodyProps {
   /** Anything that can be rendered in the Wizard body */
   children: any;
-  /** Set to false to remove the default body padding */
-  hasBodyPadding: boolean;
+  /** Set to true to remove the default body padding */
+  hasNoBodyPadding: boolean;
 }
 
 export const WizardBody: React.FunctionComponent<WizardBodyProps> = ({
   children,
-  hasBodyPadding = true
+  hasNoBodyPadding = false
 }: WizardBodyProps) => (
-  <main className={css(styles.wizardMain, !hasBodyPadding && styles.modifiers.noPadding)}>
-    <div className={css(styles.wizardMainBody)}>{children}</div>
+  <main className={css(styles.wizardMain)}>
+    <div className={css(styles.wizardMainBody, hasNoBodyPadding && styles.modifiers.noPadding)}>{children}</div>
   </main>
 );

--- a/packages/react-core/src/components/Wizard/WizardToggle.tsx
+++ b/packages/react-core/src/components/Wizard/WizardToggle.tsx
@@ -15,8 +15,8 @@ export interface WizardToggleProps {
   activeStep: WizardStep;
   /** The WizardFooter */
   children: React.ReactNode;
-  /** Set to false to remove body padding */
-  hasBodyPadding: boolean;
+  /** Set to true to remove body padding */
+  hasNoBodyPadding: boolean;
   /** If the nav is open */
   isNavOpen: boolean;
   /** Callback function for when the nav is toggled */
@@ -32,7 +32,7 @@ export const WizardToggle: React.FunctionComponent<WizardToggleProps> = ({
   steps,
   activeStep,
   children,
-  hasBodyPadding = true,
+  hasNoBodyPadding = false,
   'aria-label': ariaLabel = 'Wizard Toggle'
 }: WizardToggleProps) => {
   let activeStepIndex;
@@ -76,7 +76,7 @@ export const WizardToggle: React.FunctionComponent<WizardToggleProps> = ({
       <div className={css(styles.wizardOuterWrap)}>
         <div className={css(styles.wizardInnerWrap)}>
           {nav(isNavOpen)}
-          <WizardBody hasBodyPadding={hasBodyPadding}>{activeStep.component}</WizardBody>
+          <WizardBody hasNoBodyPadding={hasNoBodyPadding}>{activeStep.component}</WizardBody>
         </div>
         {children}
       </div>

--- a/packages/react-core/src/components/Wizard/__tests__/Generated/__snapshots__/WizardToggle.test.tsx.snap
+++ b/packages/react-core/src/components/Wizard/__tests__/Generated/__snapshots__/WizardToggle.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`WizardToggle should match snapshot (auto-generated) 1`] = `
       className="pf-c-wizard__inner-wrap"
     >
       <WizardBody
-        hasBodyPadding={true}
+        hasNoBodyPadding={false}
       />
     </div>
     <div>

--- a/packages/react-core/src/components/Wizard/__tests__/__snapshots__/Wizard.test.tsx.snap
+++ b/packages/react-core/src/components/Wizard/__tests__/__snapshots__/Wizard.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`Wizard should match snapshot 1`] = `
                     "name": "A",
                   }
                 }
-                hasBodyPadding={true}
+                hasNoBodyPadding={false}
                 isNavOpen={false}
                 nav={[Function]}
                 onNavToggle={[Function]}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4052 -- moves padding to wizard body.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: #4039, renamed prop to remain consistent with @kmcfaul's `hasNoPadding` changes in #4133. 
