### PR TITLE
Update react-charts types

### DIFF
--- a/packages/react-charts/package.json
+++ b/packages/react-charts/package.json
@@ -36,7 +36,20 @@
     "lodash": "^4.17.15",
     "tslib": "^1.11.1",
     "victory": "^34.1.3",
-    "victory-core": "^34.1.3"
+    "victory-area": "^34.1.3",
+    "victory-axis": "^34.1.3",
+    "victory-bar": "^34.1.3",
+    "victory-chart": "^34.1.3",
+    "victory-core": "^34.1.3",
+    "victory-pie": "^34.1.3",
+    "victory-group": "^34.1.3",
+    "victory-legend": "^34.1.3",
+    "victory-line": "^34.1.3",
+    "victory-scatter": "^34.1.3",
+    "victory-stack": "^34.1.3",
+    "victory-tooltip": "^34.1.3",
+    "victory-voronoi-container": "^34.1.3",
+    "victory-zoom-container": "^34.1.3"
   },
   "peerDependencies": {
     "react": "^16.4.0"
@@ -46,7 +59,6 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.138",
-    "@types/victory": "^33.1.4",
     "css": "^2.2.3",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",

--- a/packages/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/react-charts/src/components/Chart/Chart.tsx
@@ -10,11 +10,10 @@ import {
   PaddingProps,
   ScalePropType,
   StringOrNumberOrCallback,
-  VictoryChart,
-  VictoryChartProps,
-  VictoryStyleInterface,
-  VictoryZoomContainer
-} from 'victory';
+  VictoryZoomContainer,
+  VictoryStyleInterface
+} from 'victory-core';
+import { VictoryChart, VictoryChartProps } from 'victory-chart';
 import { ChartContainer } from '../ChartContainer';
 import { ChartLegend, ChartLegendOrientation, ChartLegendPosition } from '../ChartLegend';
 import { ChartCommonStyles, ChartThemeDefinition } from '../ChartTheme';

--- a/packages/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/react-charts/src/components/Chart/Chart.tsx
@@ -329,7 +329,7 @@ export interface ChartProps extends VictoryChartProps {
    * for data, labels and parent. Any valid svg styles are supported, but width, height, and padding should be specified
    * via props as they determine relative layout for components in Chart.
    */
-  style?: VictoryStyleInterface;
+  style?: Pick<VictoryStyleInterface, 'parent'>;
   /**
    * The theme prop specifies a theme to use for determining styles and layout properties for a component. Any styles or
    * props defined in theme may be overwritten by props specified on the component instance.

--- a/packages/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/react-charts/src/components/Chart/Chart.tsx
@@ -10,10 +10,10 @@ import {
   PaddingProps,
   ScalePropType,
   StringOrNumberOrCallback,
-  VictoryZoomContainer,
   VictoryStyleInterface
 } from 'victory-core';
 import { VictoryChart, VictoryChartProps } from 'victory-chart';
+import { VictoryZoomContainer } from 'victory-zoom-container';
 import { ChartContainer } from '../ChartContainer';
 import { ChartLegend, ChartLegendOrientation, ChartLegendPosition } from '../ChartLegend';
 import { ChartCommonStyles, ChartThemeDefinition } from '../ChartTheme';

--- a/packages/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/react-charts/src/components/Chart/Chart.tsx
@@ -445,7 +445,7 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
     });
   };
 
-  // Note: containerComponent is required for theme, but @types/victory is missing a prop type
+  // Note: containerComponent is required for theme
   const VictoryChartWithContainerComponent = VictoryChart as any;
   return (
     <VictoryChartWithContainerComponent

--- a/packages/react-charts/src/components/ChartArea/ChartArea.tsx
+++ b/packages/react-charts/src/components/ChartArea/ChartArea.tsx
@@ -3,7 +3,6 @@ import hoistNonReactStatics from 'hoist-non-react-statics';
 import {
   AnimatePropTypeInterface,
   CategoryPropType,
-  D3Scale,
   DataGetterPropType,
   DomainPropType,
   DomainPaddingPropType,
@@ -11,11 +10,11 @@ import {
   InterpolationPropType,
   PaddingProps,
   ScalePropType,
+  D3Scale,
   StringOrNumberOrCallback,
-  VictoryStyleInterface,
-  VictoryArea,
-  VictoryAreaProps
-} from 'victory';
+  VictoryStyleInterface
+} from 'victory-core';
+import { VictoryArea, VictoryAreaProps } from 'victory-area';
 import { ChartContainer } from '../ChartContainer';
 import { ChartThemeDefinition } from '../ChartTheme';
 import { getTheme } from '../ChartUtils';
@@ -145,7 +144,7 @@ export interface ChartAreaProps extends VictoryAreaProps {
    *   }
    * ]}
    */
-  events?: EventPropTypeInterface<'data' | 'labels' | 'parent', 'all'>[];
+  events?: EventPropTypeInterface<"data" | "labels" | "parent", string | number>[];
   /**
    * ChartArea uses the standard externalEventMutations prop.
    */

--- a/packages/react-charts/src/components/ChartArea/ChartArea.tsx
+++ b/packages/react-charts/src/components/ChartArea/ChartArea.tsx
@@ -3,6 +3,7 @@ import hoistNonReactStatics from 'hoist-non-react-statics';
 import {
   AnimatePropTypeInterface,
   CategoryPropType,
+  D3Scale,
   DataGetterPropType,
   DomainPropType,
   DomainPaddingPropType,
@@ -10,7 +11,6 @@ import {
   InterpolationPropType,
   PaddingProps,
   ScalePropType,
-  D3Scale,
   StringOrNumberOrCallback,
   VictoryStyleInterface
 } from 'victory-core';
@@ -144,7 +144,7 @@ export interface ChartAreaProps extends VictoryAreaProps {
    *   }
    * ]}
    */
-  events?: EventPropTypeInterface<"data" | "labels" | "parent", string | number>[];
+  events?: EventPropTypeInterface<'data' | 'labels' | 'parent', string | number>[];
   /**
    * ChartArea uses the standard externalEventMutations prop.
    */

--- a/packages/react-charts/src/components/ChartArea/ChartArea.tsx
+++ b/packages/react-charts/src/components/ChartArea/ChartArea.tsx
@@ -402,12 +402,8 @@ export const ChartArea: React.FunctionComponent<ChartAreaProps> = ({
     ...containerComponent.props
   });
 
-  // Note: containerComponent is required for theme, but @types/victory is missing a prop type
-  return (
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
-    <VictoryArea containerComponent={container} theme={theme} {...rest} />
-  );
+  // Note: containerComponent is required for theme
+  return <VictoryArea containerComponent={container} theme={theme} {...rest} />;
 };
 
 // Note: VictoryArea.role must be hoisted

--- a/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
+++ b/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
@@ -420,10 +420,9 @@ export const ChartAxis: React.FunctionComponent<ChartAxisProps> = ({
     ...containerComponent.props
   });
 
-  // Note: containerComponent is required for theme, but @types/victory is missing a prop type
-  const VictoryAxisWithContainerComponent = VictoryAxis as any;
+  // Note: containerComponent is required for theme
   return (
-    <VictoryAxisWithContainerComponent
+    <VictoryAxis
       containerComponent={container}
       theme={showGrid ? getAxisTheme(themeColor, themeVariant) : theme}
       {...rest}

--- a/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
+++ b/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
@@ -7,10 +7,9 @@ import {
   DomainPropType,
   EventPropTypeInterface,
   PaddingProps,
-  ScalePropType,
-  VictoryAxis,
-  VictoryAxisProps
-} from 'victory';
+  ScalePropType
+} from 'victory-core';
+import { VictoryAxis, VictoryAxisProps } from 'victory-axis';
 import { ChartContainer } from '../ChartContainer';
 import { ChartThemeDefinition } from '../ChartTheme';
 import { getAxisTheme, getTheme } from '../ChartUtils';

--- a/packages/react-charts/src/components/ChartBar/ChartBar.tsx
+++ b/packages/react-charts/src/components/ChartBar/ChartBar.tsx
@@ -12,10 +12,9 @@ import {
   PaddingProps,
   ScalePropType,
   StringOrNumberOrCallback,
-  VictoryStyleInterface,
-  VictoryBar,
-  VictoryBarProps
-} from 'victory';
+  VictoryStyleInterface
+} from 'victory-core';
+import { VictoryBar, VictoryBarProps } from 'victory-bar';
 import { ChartContainer } from '../ChartContainer';
 import { ChartThemeDefinition } from '../ChartTheme';
 import { getTheme } from '../ChartUtils';

--- a/packages/react-charts/src/components/ChartBar/ChartBar.tsx
+++ b/packages/react-charts/src/components/ChartBar/ChartBar.tsx
@@ -429,12 +429,8 @@ export const ChartBar: React.FunctionComponent<ChartBarProps> = ({
     ...containerComponent.props
   });
 
-  // Note: containerComponent is required for theme, but @types/victory is missing a prop type
-  return (
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
-    <VictoryBar containerComponent={container} theme={theme} {...rest} />
-  );
+  // Note: containerComponent is required for theme
+  return <VictoryBar containerComponent={container} theme={theme} {...rest} />;
 };
 
 // Note: VictoryBar.getDomain & VictoryBar.role must be hoisted

--- a/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import { DataGetterPropType, DomainPropType, PaddingProps, VictoryChart } from 'victory';
+import { DataGetterPropType, DomainPropType, PaddingProps } from 'victory-core';
+import { VictoryChart } from 'victory-chart';
 import {
   getComparativeMeasureErrorWidth,
   getComparativeMeasureWidth,

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletComparativeErrorMeasure.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletComparativeErrorMeasure.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import { DataGetterPropType, DomainPropType, NumberOrCallback, PaddingProps, VictoryBar } from 'victory';
+import { DataGetterPropType, DomainPropType, NumberOrCallback, PaddingProps } from 'victory-core';
+import { VictoryBar } from 'victory-bar';
 import { ChartContainer } from '../ChartContainer';
 import { ChartThemeDefinition } from '../ChartTheme';
 import { getBulletComparativeErrorMeasureTheme } from '../ChartUtils';

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletComparativeMeasure.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletComparativeMeasure.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import { DataGetterPropType, DomainPropType, NumberOrCallback, PaddingProps, VictoryBar } from 'victory';
+import { DataGetterPropType, DomainPropType, NumberOrCallback, PaddingProps } from 'victory-core';
+import { VictoryBar } from 'victory-bar';
 import { getComparativeMeasureData } from './utils';
 import { ChartBar } from '../ChartBar';
 import { ChartContainer } from '../ChartContainer';

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletComparativeWarningMeasure.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletComparativeWarningMeasure.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import { DataGetterPropType, DomainPropType, NumberOrCallback, PaddingProps, VictoryBar } from 'victory';
+import { DataGetterPropType, DomainPropType, NumberOrCallback, PaddingProps } from 'victory-core';
+import { VictoryBar } from 'victory-bar';
 import { ChartContainer } from '../ChartContainer';
 import { ChartThemeDefinition } from '../ChartTheme';
 import { getBulletComparativeWarningMeasureTheme } from '../ChartUtils';

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletGroupTitle.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletGroupTitle.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Data, PaddingProps, Line, StringOrNumberOrCallback } from 'victory-core';
+import { PaddingProps, Line, StringOrNumberOrCallback } from 'victory-core';
 import { ChartContainer } from '../ChartContainer';
 import { ChartLabel } from '../ChartLabel';
 import { ChartBulletStyles, ChartThemeDefinition } from '../ChartTheme';

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletGroupTitle.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletGroupTitle.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { PaddingProps, StringOrNumberOrCallback } from 'victory';
-import { Line } from 'victory-core';
+import { PaddingProps, StringOrNumberOrCallback } from 'victory-core';
+import { Line } from 'victory-line';
 import { ChartContainer } from '../ChartContainer';
 import { ChartLabel } from '../ChartLabel';
 import { ChartBulletStyles, ChartThemeDefinition } from '../ChartTheme';

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletGroupTitle.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletGroupTitle.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { PaddingProps, StringOrNumberOrCallback } from 'victory-core';
-import { Line } from 'victory-line';
+import { Data, PaddingProps, Line, StringOrNumberOrCallback } from 'victory-core';
 import { ChartContainer } from '../ChartContainer';
 import { ChartLabel } from '../ChartLabel';
 import { ChartBulletStyles, ChartThemeDefinition } from '../ChartTheme';

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletPrimaryDotMeasure.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletPrimaryDotMeasure.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import { DataGetterPropType, DomainPropType, PaddingProps, VictoryScatter } from 'victory';
+import { DataGetterPropType, DomainPropType, PaddingProps } from 'victory-core';
+import { VictoryScatter } from 'victory-scatter';
 import { getPrimaryDotMeasureData } from './utils';
 import { ChartContainer } from '../ChartContainer';
 import { ChartScatter } from '../ChartScatter';

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletPrimarySegmentedMeasure.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletPrimarySegmentedMeasure.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import { DataGetterPropType, DomainPropType, NumberOrCallback, PaddingProps, VictoryBar } from 'victory';
+import { DataGetterPropType, DomainPropType, NumberOrCallback, PaddingProps } from 'victory-core';
+import { VictoryBar } from 'victory-bar';
 import { getPrimarySegmentedMeasureData } from './utils';
 import { ChartBar } from '../ChartBar';
 import { ChartContainer } from '../ChartContainer';

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletQualitativeRange.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletQualitativeRange.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import { DataGetterPropType, DomainPropType, NumberOrCallback, PaddingProps, VictoryBar } from 'victory';
+import { DataGetterPropType, DomainPropType, NumberOrCallback, PaddingProps } from 'victory-core';
+import { VictoryBar } from 'victory-bar';
 import { getQualitativeRangeData } from './utils';
 import { ChartBar } from '../ChartBar';
 import { ChartContainer } from '../ChartContainer';

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletTitle.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletTitle.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { PaddingProps, StringOrNumberOrCallback } from 'victory';
+import { PaddingProps, StringOrNumberOrCallback } from 'victory-core';
 import { ChartContainer } from '../ChartContainer';
 import { ChartLabel } from '../ChartLabel';
 import { ChartLegendPosition } from '../ChartLegend';

--- a/packages/react-charts/src/components/ChartBullet/utils/chart-bullet-data.ts
+++ b/packages/react-charts/src/components/ChartBullet/utils/chart-bullet-data.ts
@@ -1,5 +1,4 @@
-import { DataGetterPropType } from 'victory';
-import { Data } from 'victory-core';
+import { Data, DataGetterPropType } from 'victory-core';
 import { ChartThemeDefinition } from '../../ChartTheme';
 import {
   getBulletComparativeErrorMeasureTheme,

--- a/packages/react-charts/src/components/ChartContainer/ChartContainer.tsx
+++ b/packages/react-charts/src/components/ChartContainer/ChartContainer.tsx
@@ -119,7 +119,7 @@ export const ChartContainer: React.FunctionComponent<ChartContainerProps> = ({
 }: ChartContainerProps) => {
   const chartClassName = getClassName({ className });
 
-  // Note: theme is valid, but @types/victory is missing a prop type
+  // Note: className is valid, but Victory is missing a type
   // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
   // @ts-ignore
   return <VictoryContainer className={chartClassName} theme={theme} {...rest} />;

--- a/packages/react-charts/src/components/ChartContainer/ChartContainer.tsx
+++ b/packages/react-charts/src/components/ChartContainer/ChartContainer.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import { VictoryContainer, VictoryContainerProps } from 'victory';
+import { VictoryContainer, VictoryContainerProps } from 'victory-core';
 import { ChartThemeDefinition } from '../ChartTheme';
 import { getClassName, getTheme } from '../ChartUtils';
 

--- a/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -6,12 +6,12 @@ import {
   ColorScalePropType,
   DataGetterPropType,
   EventPropTypeInterface,
+  Helpers,
   PaddingProps,
   StringOrNumberOrCallback,
-  VictoryPie,
   VictoryStyleInterface
-} from 'victory';
-import { Helpers } from 'victory-core';
+} from 'victory-core';
+import { VictoryPie } from 'victory-pie';
 import { getDonutTheme } from '../ChartUtils/chart-theme';
 import { ChartContainer } from '../ChartContainer';
 import { ChartLabel } from '../ChartLabel';

--- a/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -11,7 +11,7 @@ import {
   StringOrNumberOrCallback,
   VictoryStyleInterface
 } from 'victory-core';
-import { VictoryPie } from 'victory-pie';
+import { VictoryPie, VictorySliceProps } from 'victory-pie';
 import { getDonutTheme } from '../ChartUtils/chart-theme';
 import { ChartContainer } from '../ChartContainer';
 import { ChartLabel } from '../ChartLabel';
@@ -224,7 +224,7 @@ export interface ChartDonutProps extends ChartPieProps {
    * When creating a donut chart, this prop determines the number of pixels between
    * the center of the chart and the inner edge.
    */
-  innerRadius?: number;
+  innerRadius?: number | ((props: VictorySliceProps) => number);
   /**
    * The labelComponent prop takes in an entire label component which will be used
    * to create a label for the area. The new element created from the passed labelComponent
@@ -241,12 +241,12 @@ export interface ChartDonutProps extends ChartPieProps {
    * The labelPosition prop specifies the angular position of each label relative to its corresponding slice.
    * When this prop is not given, the label will be positioned at the centroid of each slice.
    */
-  labelPosition?: 'startAngle' | 'endAngle' | 'centroid';
+  labelPosition?: 'startAngle' | 'centroid' | 'endAngle' | ((props: VictorySliceProps) => string);
   /**
    * The labelRadius prop defines the radius of the arc that will be used for positioning each slice label.
    * If this prop is not set, the label radius will default to the radius of the pie + label padding.
    */
-  labelRadius?: number;
+  labelRadius?: number | ((props: VictorySliceProps) => number);
   /**
    * The labels prop defines labels that will appear above each bar in your chart.
    * This prop should be given as an array of values or as a function of data.
@@ -327,7 +327,7 @@ export interface ChartDonutProps extends ChartPieProps {
    * Specifies the radius of the chart. If this property is not provided it is computed
    * from width, height, and padding props
    */
-  radius?: number;
+  radius?: number | ((props: VictorySliceProps) => number);
   /**
    * The sharedEvents prop is used internally to coordinate events between components. It should not be set manually.
    */

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
@@ -11,7 +11,7 @@ import {
   StringOrNumberOrCallback,
   VictoryStyleInterface
 } from 'victory-core';
-import { VictoryPie } from 'victory-pie';
+import { VictoryPie, VictorySliceProps } from 'victory-pie';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import { ChartContainer } from '../ChartContainer';
 import { ChartDonut, ChartDonutProps } from '../ChartDonut';
@@ -236,7 +236,7 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    * When creating a donut chart, this prop determines the number of pixels between
    * the center of the chart and the inner edge.
    */
-  innerRadius?: number;
+  innerRadius?: number | ((props: VictorySliceProps) => number);
   /**
    * Invert the threshold color scale used to represent warnings, errors, etc.
    */
@@ -245,7 +245,7 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    * The labelRadius prop defines the radius of the arc that will be used for positioning each slice label.
    * If this prop is not set, the label radius will default to the radius of the pie + label padding.
    */
-  labelRadius?: number;
+  labelRadius?: number | ((props: VictorySliceProps) => number);
   /**
    * The labels prop defines labels that will appear above each bar in your chart.
    * This prop should be given as an array of values or as a function of data.
@@ -281,7 +281,7 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    * Specifies the radius of the chart. If this property is not provided it is computed
    * from width, height, and padding props
    */
-  radius?: number;
+  radius?: number | ((props: VictorySliceProps) => number);
   /**
    * The sharedEvents prop is used internally to coordinate events between components. It should not be set manually.
    */

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
@@ -3,14 +3,16 @@ import {
   AnimatePropTypeInterface,
   CategoryPropType,
   ColorScalePropType,
+  Data,
   DataGetterPropType,
   EventPropTypeInterface,
+  Helpers,
+  InterpolationPropType,
   PaddingProps,
   StringOrNumberOrCallback,
-  VictoryPie,
   VictoryStyleInterface
-} from 'victory';
-import { Data, Helpers } from 'victory-core';
+} from 'victory-core';
+import { VictoryPie } from 'victory-pie';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import { ChartContainer } from '../ChartContainer';
 import { ChartDonut, ChartDonutProps } from '../ChartDonut';

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
@@ -7,7 +7,6 @@ import {
   DataGetterPropType,
   EventPropTypeInterface,
   Helpers,
-  InterpolationPropType,
   PaddingProps,
   StringOrNumberOrCallback,
   VictoryStyleInterface

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
@@ -12,7 +12,7 @@ import {
   EventPropTypeInterface,
   VictoryStyleInterface
 } from 'victory-core';
-import { VictoryPie } from 'victory-pie';
+import { VictoryPie, VictorySliceProps } from 'victory-pie';
 import { ChartContainer } from '../ChartContainer';
 import { ChartDonut, ChartDonutProps } from '../ChartDonut';
 import { ChartCommonStyles, ChartThemeDefinition, ChartDonutUtilizationStyles } from '../ChartTheme';
@@ -240,7 +240,7 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    * When creating a donut chart, this prop determines the number of pixels between
    * the center of the chart and the inner edge.
    */
-  innerRadius?: number;
+  innerRadius?: number | ((props: VictorySliceProps) => number);
   /**
    * Invert the threshold color scale used to represent warnings, errors, etc.
    *
@@ -271,7 +271,7 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    * The labelPosition prop specifies the angular position of each label relative to its corresponding slice.
    * When this prop is not given, the label will be positioned at the centroid of each slice.
    */
-  labelPosition?: 'startAngle' | 'endAngle' | 'centroid';
+  labelPosition?: 'startAngle' | 'centroid' | 'endAngle' | ((props: VictorySliceProps) => string);
   /**
    * The legend component to render with chart.
    *
@@ -314,7 +314,7 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    * The labelRadius prop defines the radius of the arc that will be used for positioning each slice label.
    * If this prop is not set, the label radius will default to the radius of the pie + label padding.
    */
-  labelRadius?: number;
+  labelRadius?: number | ((props: VictorySliceProps) => number);
   /**
    * The labels prop defines labels that will appear above each bar in your chart.
    * This prop should be given as an array of values or as a function of data.
@@ -350,7 +350,7 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    * Specifies the radius of the chart. If this property is not provided it is computed
    * from width, height, and padding props
    */
-  radius?: number;
+  radius?: number | ((props: VictorySliceProps) => number);
   /**
    * The sharedEvents prop is used internally to coordinate events between components. It should not be set manually.
    */

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
@@ -5,12 +5,12 @@ import {
   AnimatePropTypeInterface,
   CategoryPropType,
   ColorScalePropType,
+  Data,
   DataGetterPropType,
   PaddingProps,
   StringOrNumberOrCallback,
   EventPropTypeInterface,
-  VictoryStyleInterface,
-  Data
+  VictoryStyleInterface
 } from 'victory-core';
 import { VictoryPie } from 'victory-pie';
 import { ChartContainer } from '../ChartContainer';

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
@@ -6,13 +6,13 @@ import {
   CategoryPropType,
   ColorScalePropType,
   DataGetterPropType,
-  EventPropTypeInterface,
   PaddingProps,
   StringOrNumberOrCallback,
-  VictoryPie,
-  VictoryStyleInterface
-} from 'victory';
-import { Data } from 'victory-core';
+  EventPropTypeInterface,
+  VictoryStyleInterface,
+  Data
+} from 'victory-core';
+import { VictoryPie } from 'victory-pie';
 import { ChartContainer } from '../ChartContainer';
 import { ChartDonut, ChartDonutProps } from '../ChartDonut';
 import { ChartCommonStyles, ChartThemeDefinition, ChartDonutUtilizationStyles } from '../ChartTheme';
@@ -215,6 +215,7 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    * ]}
    */
   events?: EventPropTypeInterface<'data' | 'labels' | 'parent', StringOrNumberOrCallback | string[] | number[]>[];
+
   /**
    * ChartDonutUtilization uses the standard externalEventMutations prop.
    */

--- a/packages/react-charts/src/components/ChartGroup/ChartGroup.tsx
+++ b/packages/react-charts/src/components/ChartGroup/ChartGroup.tsx
@@ -172,7 +172,7 @@ export interface ChartGroupProps extends VictoryGroupProps {
    *   }
    * ]}
    */
-  events?: EventPropTypeInterface<'data' | 'labels' | 'parent', 'all'>[];
+  events?: EventPropTypeInterface<'data' | 'labels' | 'parent', StringOrNumberOrCallback>[];
   /**
    * ChartGroup uses the standard externalEventMutations prop.
    */

--- a/packages/react-charts/src/components/ChartGroup/ChartGroup.tsx
+++ b/packages/react-charts/src/components/ChartGroup/ChartGroup.tsx
@@ -436,10 +436,8 @@ export const ChartGroup: React.FunctionComponent<ChartGroupProps> = ({
     className: getClassName({ className: containerComponent.props.className }) // Override VictoryContainer class name
   });
 
-  // Note: containerComponent is required for theme, but @types/victory is missing a prop type
+  // Note: containerComponent is required for theme
   return (
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
     <VictoryGroup containerComponent={container} theme={theme} {...rest}>
       {children}
     </VictoryGroup>

--- a/packages/react-charts/src/components/ChartGroup/ChartGroup.tsx
+++ b/packages/react-charts/src/components/ChartGroup/ChartGroup.tsx
@@ -12,11 +12,10 @@ import {
   PaddingProps,
   ScalePropType,
   StringOrNumberOrCallback,
-  VictoryStyleInterface,
-  VictoryGroup,
-  VictoryGroupProps,
-  VictoryZoomContainer
-} from 'victory';
+  VictoryStyleInterface
+} from 'victory-core';
+import { VictoryGroup, VictoryGroupProps } from 'victory-group';
+import { VictoryZoomContainer } from 'victory-zoom-container';
 import { ChartContainer } from '../ChartContainer';
 import { ChartThemeDefinition } from '../ChartTheme';
 import { getClassName, getTheme } from '../ChartUtils';

--- a/packages/react-charts/src/components/ChartLabel/ChartLabel.tsx
+++ b/packages/react-charts/src/components/ChartLabel/ChartLabel.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import { defaults } from 'lodash';
-import { StringOrNumberOrCallback, TextAnchorType, VerticalAnchorType, VictoryLabel, VictoryLabelProps } from 'victory';
+import { StringOrNumberOrCallback, TextAnchorType, VerticalAnchorType } from 'victory-core';
+import { VictoryLabel, VictoryLabelProps } from 'victory-core';
 import { ChartCommonStyles } from '../ChartTheme';
 
 export enum ChartLabelDirection {

--- a/packages/react-charts/src/components/ChartLabel/ChartLabel.tsx
+++ b/packages/react-charts/src/components/ChartLabel/ChartLabel.tsx
@@ -139,7 +139,7 @@ export interface ChartLabelProps extends VictoryLabelProps {
    * The transform prop applies a transform to the rendered `<text>` element.
    * In addition to being a string, it can be an object containing transform definitions for easier authoring.
    */
-  transform?: string | {} | (() => string);
+  transform?: string | {} | (() => string | {});
   /**
    * The verticalAnchor prop defines how the text is vertically positioned relative to the given `x` and `y` coordinates
    */

--- a/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
+++ b/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
@@ -10,7 +10,7 @@ import {
   VictoryLegend,
   VictoryLegendProps,
   VictoryStyleInterface
-} from 'victory';
+} from 'victory-core';
 import { ChartContainer } from '../ChartContainer';
 import { ChartLabel } from '../ChartLabel';
 import { ChartPoint } from '../ChartPoint';

--- a/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
+++ b/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
@@ -7,7 +7,8 @@ import {
   OrientationTypes,
   PaddingProps,
   StringOrNumberOrCallback,
-  VictoryStyleInterface
+  VictoryStyleInterface,
+  VictoryStyleObject
 } from 'victory-core';
 import { VictoryLegend, VictoryLegendProps } from 'victory-legend';
 import { ChartContainer } from '../ChartContainer';
@@ -214,7 +215,7 @@ export interface ChartLegendProps extends VictoryLegendProps {
    *
    * @example {data: {stroke: "black"}, label: {fontSize: 10}}
    */
-  style?: VictoryStyleInterface;
+  style?: VictoryStyleInterface & { title?: VictoryStyleObject };
   /**
    * The symbolSpacer prop defines the number of pixels between data
    * components and label components.

--- a/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
+++ b/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
@@ -302,12 +302,8 @@ export const ChartLegend: React.FunctionComponent<ChartLegendProps> = ({
     ...containerComponent.props
   });
 
-  // Note: containerComponent is required for theme, but @types/victory is missing a prop type
-  return (
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
-    <VictoryLegend containerComponent={container} dataComponent={dataComponent} theme={theme} {...rest} />
-  );
+  // Note: containerComponent is required for theme
+  return <VictoryLegend containerComponent={container} dataComponent={dataComponent} theme={theme} {...rest} />;
 };
 
 // Note: VictoryLegend.role must be hoisted, but getBaseProps causes error with ChartVoronoiContainer

--- a/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
+++ b/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
@@ -7,10 +7,9 @@ import {
   OrientationTypes,
   PaddingProps,
   StringOrNumberOrCallback,
-  VictoryLegend,
-  VictoryLegendProps,
   VictoryStyleInterface
 } from 'victory-core';
+import { VictoryLegend, VictoryLegendProps } from 'victory-legend';
 import { ChartContainer } from '../ChartContainer';
 import { ChartLabel } from '../ChartLabel';
 import { ChartPoint } from '../ChartPoint';

--- a/packages/react-charts/src/components/ChartLine/ChartLine.tsx
+++ b/packages/react-charts/src/components/ChartLine/ChartLine.tsx
@@ -398,12 +398,8 @@ export const ChartLine: React.FunctionComponent<ChartLineProps> = ({
     theme,
     ...containerComponent.props
   });
-  // Note: containerComponent is required for theme, but @types/victory is missing a prop type
-  return (
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
-    <VictoryLine containerComponent={container} theme={theme} {...rest} />
-  );
+  // Note: containerComponent is required for theme
+  return <VictoryLine containerComponent={container} theme={theme} {...rest} />;
 };
 
 // Note: VictoryLine.role must be hoisted

--- a/packages/react-charts/src/components/ChartLine/ChartLine.tsx
+++ b/packages/react-charts/src/components/ChartLine/ChartLine.tsx
@@ -12,10 +12,9 @@ import {
   PaddingProps,
   ScalePropType,
   StringOrNumberOrCallback,
-  VictoryStyleInterface,
-  VictoryLine,
-  VictoryLineProps
-} from 'victory';
+  VictoryStyleInterface
+} from 'victory-core';
+import { VictoryLine, VictoryLineProps } from 'victory-line';
 import { ChartContainer } from '../ChartContainer';
 import { ChartThemeDefinition } from '../ChartTheme';
 import { getTheme } from '../ChartUtils';

--- a/packages/react-charts/src/components/ChartPie/ChartPie.tsx
+++ b/packages/react-charts/src/components/ChartPie/ChartPie.tsx
@@ -6,13 +6,12 @@ import {
   ColorScalePropType,
   DataGetterPropType,
   EventPropTypeInterface,
+  Helpers,
   PaddingProps,
   StringOrNumberOrCallback,
-  VictoryPie,
-  VictoryPieProps,
   VictoryStyleInterface
-} from 'victory';
-import { Helpers } from 'victory-core';
+} from 'victory-core';
+import { VictoryPie, VictoryPieProps } from 'victory-pie';
 import { ChartContainer } from '../ChartContainer';
 import { ChartLegend, ChartLegendOrientation } from '../ChartLegend';
 import { ChartCommonStyles, ChartThemeDefinition } from '../ChartTheme';

--- a/packages/react-charts/src/components/ChartPie/ChartPie.tsx
+++ b/packages/react-charts/src/components/ChartPie/ChartPie.tsx
@@ -465,7 +465,7 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
       standalone={false}
       theme={theme}
       width={width}
-      {...(rest as any)} // @types/victory has a type mismatch with colorScale
+      {...rest}
     />
   );
 

--- a/packages/react-charts/src/components/ChartPie/ChartPie.tsx
+++ b/packages/react-charts/src/components/ChartPie/ChartPie.tsx
@@ -11,7 +11,7 @@ import {
   StringOrNumberOrCallback,
   VictoryStyleInterface
 } from 'victory-core';
-import { VictoryPie, VictoryPieProps } from 'victory-pie';
+import { VictoryPie, VictoryPieProps, VictorySliceProps } from 'victory-pie';
 import { ChartContainer } from '../ChartContainer';
 import { ChartLegend, ChartLegendOrientation } from '../ChartLegend';
 import { ChartCommonStyles, ChartThemeDefinition } from '../ChartTheme';
@@ -216,7 +216,7 @@ export interface ChartPieProps extends VictoryPieProps {
    * the center of the chart and the inner edge. When this prop is set to zero
    * a regular pie chart is rendered.
    */
-  innerRadius?: number;
+  innerRadius?: number | ((props: VictorySliceProps) => number);
   /**
    * The labelComponent prop takes in an entire label component which will be used
    * to create a label for the area. The new element created from the passed labelComponent
@@ -233,12 +233,12 @@ export interface ChartPieProps extends VictoryPieProps {
    * The labelPosition prop specifies the angular position of each label relative to its corresponding slice.
    * When this prop is not given, the label will be positioned at the centroid of each slice.
    */
-  labelPosition?: 'startAngle' | 'endAngle' | 'centroid';
+  labelPosition?: 'startAngle' | 'centroid' | 'endAngle' | ((props: VictorySliceProps) => string);
   /**
    * The labelRadius prop defines the radius of the arc that will be used for positioning each slice label.
    * If this prop is not set, the label radius will default to the radius of the pie + label padding.
    */
-  labelRadius?: number;
+  labelRadius?: number | ((props: VictorySliceProps) => number);
   /**
    * The labels prop defines labels that will appear above each bar in your chart.
    * This prop should be given as an array of values or as a function of data.
@@ -319,7 +319,7 @@ export interface ChartPieProps extends VictoryPieProps {
    * Specifies the radius of the chart. If this property is not provided it is computed
    * from width, height, and padding props
    */
-  radius?: number;
+  radius?: number | ((props: VictorySliceProps) => number);
   /**
    * The sharedEvents prop is used internally to coordinate events between components. It should not be set manually.
    */

--- a/packages/react-charts/src/components/ChartScatter/ChartScatter.tsx
+++ b/packages/react-charts/src/components/ChartScatter/ChartScatter.tsx
@@ -14,7 +14,6 @@ import {
   StringOrNumberOrCallback,
   VictoryStyleInterface
 } from 'victory-core';
-import {  } from 'victory-core';
 import { VictoryScatter, VictoryScatterProps } from 'victory-scatter';
 import { ChartContainer } from '../ChartContainer';
 import { ChartScatterStyles, ChartThemeDefinition } from '../ChartTheme';

--- a/packages/react-charts/src/components/ChartScatter/ChartScatter.tsx
+++ b/packages/react-charts/src/components/ChartScatter/ChartScatter.tsx
@@ -12,10 +12,10 @@ import {
   ScalePropType,
   ScatterSymbolType,
   StringOrNumberOrCallback,
-  VictoryStyleInterface,
-  VictoryScatter,
-  VictoryScatterProps
-} from 'victory';
+  VictoryStyleInterface
+} from 'victory-core';
+import {  } from 'victory-core';
+import { VictoryScatter, VictoryScatterProps } from 'victory-scatter';
 import { ChartContainer } from '../ChartContainer';
 import { ChartScatterStyles, ChartThemeDefinition } from '../ChartTheme';
 import { getTheme } from '../ChartUtils';

--- a/packages/react-charts/src/components/ChartScatter/ChartScatter.tsx
+++ b/packages/react-charts/src/components/ChartScatter/ChartScatter.tsx
@@ -417,12 +417,8 @@ export const ChartScatter: React.FunctionComponent<ChartScatterProps> = ({
     ...containerComponent.props
   });
 
-  // Note: containerComponent is required for theme, but @types/victory is missing a prop type
-  return (
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
-    <VictoryScatter containerComponent={container} size={size} theme={theme} {...rest} />
-  );
+  // Note: containerComponent is required for theme
+  return <VictoryScatter containerComponent={container} size={size} theme={theme} {...rest} />;
 };
 
 // Note: VictoryLine.role must be hoisted

--- a/packages/react-charts/src/components/ChartStack/ChartStack.tsx
+++ b/packages/react-charts/src/components/ChartStack/ChartStack.tsx
@@ -11,10 +11,9 @@ import {
   PaddingProps,
   ScalePropType,
   StringOrNumberOrCallback,
-  VictoryStyleInterface,
-  VictoryStack,
-  VictoryStackProps
-} from 'victory';
+  VictoryStyleInterface
+} from 'victory-core';
+import { VictoryStack, VictoryStackProps } from 'victory-stack';
 import { ChartContainer } from '../ChartContainer';
 import { ChartThemeDefinition } from '../ChartTheme';
 import { getClassName, getTheme } from '../ChartUtils';

--- a/packages/react-charts/src/components/ChartStack/ChartStack.tsx
+++ b/packages/react-charts/src/components/ChartStack/ChartStack.tsx
@@ -364,10 +364,8 @@ export const ChartStack: React.FunctionComponent<ChartStackProps> = ({
     className: getClassName({ className: containerComponent.props.className }) // Override VictoryContainer class name
   });
 
-  // Note: containerComponent is required for theme, but @types/victory is missing a prop type
+  // Note: containerComponent is required for theme
   return (
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
     <VictoryStack containerComponent={container} theme={theme} {...rest}>
       {children}
     </VictoryStack>

--- a/packages/react-charts/src/components/ChartTheme/ChartTheme.ts
+++ b/packages/react-charts/src/components/ChartTheme/ChartTheme.ts
@@ -1,4 +1,4 @@
-import { VictoryThemeDefinition } from 'victory';
+import { VictoryThemeDefinition } from 'victory-core';
 import { AxisTheme } from './themes/axis-theme';
 import { BaseTheme } from './themes/base-theme';
 import {

--- a/packages/react-charts/src/components/ChartThreshold/ChartThreshold.tsx
+++ b/packages/react-charts/src/components/ChartThreshold/ChartThreshold.tsx
@@ -13,10 +13,9 @@ import {
   PaddingProps,
   ScalePropType,
   StringOrNumberOrCallback,
-  VictoryStyleInterface,
-  VictoryLine,
-  VictoryLineProps
-} from 'victory';
+  VictoryStyleInterface
+} from 'victory-core';
+import { VictoryLine, VictoryLineProps } from 'victory-line';
 import { ChartLine } from '../ChartLine';
 import { ChartThemeDefinition } from '../ChartTheme';
 import { getThresholdTheme } from '../ChartUtils';

--- a/packages/react-charts/src/components/ChartTooltip/ChartTooltip.tsx
+++ b/packages/react-charts/src/components/ChartTooltip/ChartTooltip.tsx
@@ -1,13 +1,7 @@
 import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import {
-  NumberOrCallback,
-  OrientationTypes,
-  StringOrNumberOrCallback,
-  VictoryStyleObject,
-  VictoryTooltip,
-  VictoryTooltipProps
-} from 'victory';
+import { NumberOrCallback, OrientationTypes, StringOrNumberOrCallback, VictoryStyleObject } from 'victory-core';
+import { VictoryTooltip, VictoryTooltipProps } from 'victory-tooltip';
 import { ChartThemeDefinition } from '../ChartTheme';
 import { getTheme } from '../ChartUtils';
 

--- a/packages/react-charts/src/components/ChartTooltip/ChartTooltip.tsx
+++ b/packages/react-charts/src/components/ChartTooltip/ChartTooltip.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import { NumberOrCallback, OrientationTypes, StringOrNumberOrCallback, VictoryStyleObject } from 'victory-core';
+import {
+  NumberOrCallback,
+  OrientationTypes,
+  StringOrNumberOrCallback,
+  VictoryNumberCallback,
+  VictoryStyleObject
+} from 'victory-core';
 import { VictoryTooltip, VictoryTooltipProps } from 'victory-tooltip';
 import { ChartThemeDefinition } from '../ChartTheme';
 import { getTheme } from '../ChartUtils';
@@ -129,7 +135,7 @@ export interface ChartTooltipProps extends VictoryTooltipProps {
    * values. If this prop is not provided it will be determined from the sign of the datum, and the value of the
    * horizontal prop.
    */
-  orientation?: OrientationTypes;
+  orientation?: OrientationTypes | VictoryNumberCallback;
   /**
    * The pointerLength prop determines the length of the triangular pointer extending from the flyout. This prop may be
    * given as a positive number or a function of datum.

--- a/packages/react-charts/src/components/ChartTooltip/ChartTooltip.tsx
+++ b/packages/react-charts/src/components/ChartTooltip/ChartTooltip.tsx
@@ -200,12 +200,7 @@ export const ChartTooltip: React.FunctionComponent<ChartTooltipProps> = ({
   // destructure last
   theme = getTheme(themeColor, themeVariant),
   ...rest
-}: ChartTooltipProps) => (
-  // Note: constrainToVisibleArea is valid, but @types/victory is missing a prop type
-  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-  // @ts-ignore
-  <VictoryTooltip constrainToVisibleArea={constrainToVisibleArea} theme={theme} {...rest} />
-);
+}: ChartTooltipProps) => <VictoryTooltip constrainToVisibleArea={constrainToVisibleArea} theme={theme} {...rest} />;
 
 // Note: VictoryTooltip.defaultEvents must be hoisted
 hoistNonReactStatics(ChartTooltip, VictoryTooltip);

--- a/packages/react-charts/src/components/ChartUtils/chart-domain.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-domain.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { DataGetterPropType } from 'victory';
-import { Data } from 'victory-core';
+import { Data, DataGetterPropType } from 'victory-core';
 
 interface DomainInterface {
   data?: any;

--- a/packages/react-charts/src/components/ChartUtils/chart-legend.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-legend.ts
@@ -1,6 +1,6 @@
 import { defaults } from 'lodash';
-import { PaddingProps, VictoryLegend } from 'victory';
-import { Helpers, TextSize } from 'victory-core';
+import { Helpers, PaddingProps, TextSize } from 'victory-core';
+import { VictoryLegend } from 'victory-legend';
 import { ChartLegendOrientation, ChartLegendPosition, ChartLegendProps } from '../ChartLegend';
 import { ChartCommonStyles, ChartThemeDefinition } from '../ChartTheme';
 import { overpassFontCharacterConstant } from './chart-label';

--- a/packages/react-charts/src/components/ChartUtils/chart-padding.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-padding.ts
@@ -1,5 +1,5 @@
 import { get, isEmpty, isFinite } from 'lodash';
-import { PaddingProps } from 'victory';
+import { PaddingProps } from 'victory-core';
 
 export const getPaddingForSide = (
   side: 'bottom' | 'left' | 'right' | 'top',

--- a/packages/react-charts/src/components/ChartVoronoiContainer/ChartVoronoiContainer.tsx
+++ b/packages/react-charts/src/components/ChartVoronoiContainer/ChartVoronoiContainer.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import { VictoryVoronoiContainer, VictoryVoronoiContainerProps } from 'victory';
+import { VictoryVoronoiContainer, VictoryVoronoiContainerProps } from 'victory-voronoi-container';
 import { ChartThemeDefinition } from '../ChartTheme';
 import { ChartTooltip } from '../ChartTooltip';
 import { getClassName, getTheme } from '../ChartUtils';

--- a/packages/react-charts/src/components/ChartVoronoiContainer/ChartVoronoiContainer.tsx
+++ b/packages/react-charts/src/components/ChartVoronoiContainer/ChartVoronoiContainer.tsx
@@ -164,8 +164,9 @@ export const ChartVoronoiContainer: React.FunctionComponent<ChartVoronoiContaine
     ...labelComponent.props
   });
 
-  // Note: theme is required by voronoiContainerMixin, but @types/victory is missing a prop type
+  // Note: theme is required by voronoiContainerMixin
   return (
+    // Note: className is valid, but Victory is missing a type
     // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
     // @ts-ignore
     <VictoryVoronoiContainer className={chartClassName} labelComponent={chartLabelComponent} theme={theme} {...rest} />

--- a/packages/react-charts/src/typings/hoist.d.ts
+++ b/packages/react-charts/src/typings/hoist.d.ts
@@ -1,0 +1,4 @@
+declare module 'hoist-non-react-statics' {
+  const hoist: any;
+  export default hoist;
+}

--- a/packages/react-charts/src/typings/victory.d.ts
+++ b/packages/react-charts/src/typings/victory.d.ts
@@ -1,12 +1,9 @@
+import 'victory-core';
+
 declare module 'victory-core' {
   export const Data: any;
   export const Helpers: any;
   export const Line: any;
   export const Path: any;
   export const TextSize: any;
-}
-
-declare module 'hoist-non-react-statics' {
-  const hoist: any;
-  export default hoist;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3699,13 +3699,6 @@
     "@types/unist" "*"
     "@types/vfile-message" "*"
 
-"@types/victory@^33.1.4":
-  version "33.1.4"
-  resolved "https://registry.yarnpkg.com/@types/victory/-/victory-33.1.4.tgz#b843b7cee8ed1ab846d4dd03eb048a178e197b4c"
-  integrity sha512-y0uROW9/p2ltaZW+VcH1llrtu6Uwp1lSJ8zZbVjcXJJgddU3Is2aUvU6PxFQhbjBMtjaqNdw1tH/44c5bn/Zsw==
-  dependencies:
-    "@types/react" "*"
-
 "@types/yargs-parser@*":
   version "13.1.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-13.1.0.tgz#c563aa192f39350a1d18da36c5a8da382bbd8228"


### PR DESCRIPTION
Removed the @types/victory dependency and updated the PatternFly charts to use the types introduced with Victory 34.x

Tested with Cost management.

https://github.com/patternfly/patternfly-react/issues/4080