### PR TITLE
fix(wizard): remove old prop "isCompactNav"

### DIFF
--- a/packages/react-core/src/components/Wizard/Wizard.tsx
+++ b/packages/react-core/src/components/Wizard/Wizard.tsx
@@ -48,8 +48,6 @@ export interface WizardProps extends React.HTMLProps<HTMLDivElement> {
   isOpen?: boolean;
   /** True to show the wizard without the modal */
   isInPage?: boolean;
-  /** If true makes the navigation more compact */
-  isCompactNav?: boolean;
   /** Custom width of the wizard */
   width?: number | string;
   /** Custom height of the wizard */
@@ -102,7 +100,6 @@ export class Wizard extends React.Component<WizardProps, WizardState> {
   static defaultProps: PickOptional<WizardProps> = {
     isOpen: false,
     isInPage: false,
-    isCompactNav: false,
     title: '',
     description: '',
     className: '',
@@ -351,7 +348,6 @@ export class Wizard extends React.Component<WizardProps, WizardState> {
       navAriaLabel,
       hasBodyPadding,
       footer,
-      isCompactNav,
       appendTo,
       ...rest
       /* eslint-enable @typescript-eslint/no-unused-vars */
@@ -453,7 +449,6 @@ export class Wizard extends React.Component<WizardProps, WizardState> {
           {...rest}
           className={css(
             styles.wizard,
-            isCompactNav && 'pf-m-compact-nav',
             activeStep.isFinishedStep && 'pf-m-finished',
             className
           )}

--- a/packages/react-core/src/components/Wizard/Wizard.tsx
+++ b/packages/react-core/src/components/Wizard/Wizard.tsx
@@ -447,11 +447,7 @@ export class Wizard extends React.Component<WizardProps, WizardState> {
       <WizardContextProvider value={context}>
         <div
           {...rest}
-          className={css(
-            styles.wizard,
-            activeStep.isFinishedStep && 'pf-m-finished',
-            className
-          )}
+          className={css(styles.wizard, activeStep.isFinishedStep && 'pf-m-finished', className)}
           {...(this.isModal && {
             role: 'dialog',
             'aria-modal': 'true',

--- a/packages/react-core/src/components/Wizard/__tests__/Generated/Wizard.test.tsx
+++ b/packages/react-core/src/components/Wizard/__tests__/Generated/Wizard.test.tsx
@@ -12,7 +12,6 @@ it('Wizard should match snapshot (auto-generated)', () => {
     <Wizard
       isOpen={false}
       isInPage={false}
-      isCompactNav={false}
       isFullHeight={false}
       isFullWidth={false}
       width={null}

--- a/packages/react-core/src/components/Wizard/examples/Wizard.md
+++ b/packages/react-core/src/components/Wizard/examples/Wizard.md
@@ -59,55 +59,6 @@ class SimpleWizard extends React.Component {
 }
 ```
 
-```js title=Compact-nav
-import React from 'react';
-import { Button, Wizard } from '@patternfly/react-core';
-
-class CompactWizard extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      isOpen: false
-    };
-    this.toggleOpen = () => {
-      this.setState({
-        isOpen: !this.state.isOpen
-      });
-    };
-  }
-
-  render() {
-    const { isOpen } = this.state;
-
-    const steps = [
-      { name: 'Step 1', component: <p>Step 1</p> },
-      { name: 'Step 2', component: <p>Step 2</p> },
-      { name: 'Step 3', component: <p>Step 3</p> },
-      { name: 'Step 4', component: <p>Step 4</p> },
-      { name: 'Review', component: <p>Review Step</p>, nextButtonText: 'Finish' }
-    ];
-
-    return (
-      <React.Fragment>
-        <Button variant="primary" onClick={this.toggleOpen}>
-          Show Wizard
-        </Button>
-        {isOpen && (
-          <Wizard
-            isOpen={isOpen}
-            isCompactNav
-            onClose={this.toggleOpen}
-            title="Simple Wizard"
-            description="Simple Wizard Description"
-            steps={steps}
-          />
-        )}
-      </React.Fragment>
-    );
-  }
-}
-```
-
 ```js title=Incrementally-enabled-steps
 import React from 'react';
 import { Button, Wizard } from '@patternfly/react-core';


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes https://github.com/patternfly/patternfly-react/issues/3686

## Breaking changes
1. **WizardNav**: Removes prop `isCompactNav `. This prop is no longer used.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: https://github.com/patternfly/patternfly/pull/2936
