### PR TITLE
chore(packages): bump react peer dep to 16.8.0

### DIFF
--- a/packages/react-catalog-view-extension/package.json
+++ b/packages/react-catalog-view-extension/package.json
@@ -50,7 +50,7 @@
     "typescript": "^3.8.3"
   },
   "peerDependencies": {
-    "react": "^16.4.0",
-    "react-dom": "^15.6.2 || ^16.4.0"
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0"
   }
 }

--- a/packages/react-charts/package.json
+++ b/packages/react-charts/package.json
@@ -52,7 +52,8 @@
     "victory-zoom-container": "^34.1.3"
   },
   "peerDependencies": {
-    "react": "^16.4.0"
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0"
   },
   "scripts": {
     "clean": "rimraf dist"

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -60,7 +60,7 @@
     "yo": "^3.1.1"
   },
   "peerDependencies": {
-    "react": "^16.4.0",
-    "react-dom": "^15.6.2 || ^16.4.0"
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0"
   }
 }

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -39,7 +39,7 @@
     "typescript": "^3.8.3"
   },
   "peerDependencies": {
-    "react": "^16.4.0",
-    "react-dom": "^15.6.2 || ^16.4.0"
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0"
   }
 }

--- a/packages/react-inline-edit-extension/package.json
+++ b/packages/react-inline-edit-extension/package.json
@@ -26,6 +26,9 @@
     "url": "https://github.com/patternfly/patternfly-react/issues"
   },
   "homepage": "https://github.com/patternfly/patternfly-react/tree/master/packages/patternfly-4/",
+  "scripts": {
+    "clean": "rimraf dist"
+  },
   "dependencies": {
     "@patternfly/patternfly": "4.8.6",
     "@patternfly/react-core": "^4.9.1",
@@ -36,11 +39,8 @@
     "reactabular-table": "^8.14.0"
   },
   "peerDependencies": {
-    "react": "^16.4.0",
-    "react-dom": "^15.6.2 || ^16.4.0"
-  },
-  "scripts": {
-    "clean": "rimraf dist"
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0"
   },
   "devDependencies": {
     "rimraf": "^2.6.2",

--- a/packages/react-integration/package.json
+++ b/packages/react-integration/package.json
@@ -5,9 +5,6 @@
   "description": "Integration testing for PF4 using demo applications",
   "main": "lib/index.js",
   "sideEffects": false,
-  "publishConfig": {
-    "access": "private"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/patternfly/patternfly-react.git"

--- a/packages/react-table/package.json
+++ b/packages/react-table/package.json
@@ -26,6 +26,9 @@
     "url": "https://github.com/patternfly/patternfly-react/issues"
   },
   "homepage": "https://github.com/patternfly/patternfly-react/tree/master/packages/react-table#readme",
+  "scripts": {
+    "clean": "rimraf dist"
+  },
   "dependencies": {
     "@patternfly/patternfly": "4.8.6",
     "@patternfly/react-core": "^4.9.1",
@@ -38,11 +41,8 @@
     "tslib": "^1.11.1"
   },
   "peerDependencies": {
-    "react": "^16.4.0",
-    "react-dom": "^15.6.2 || ^16.4.0"
-  },
-  "scripts": {
-    "clean": "rimraf dist"
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0"
   },
   "devDependencies": {
     "rimraf": "^2.6.2",

--- a/packages/react-topology/package.json
+++ b/packages/react-topology/package.json
@@ -24,6 +24,9 @@
     "url": "https://github.com/patternfly/patternfly-react/issues"
   },
   "homepage": "https://github.com/patternfly/patternfly-react/tree/master/packages/react-topology#readme",
+  "scripts": {
+    "clean": "rimraf dist"
+  },
   "dependencies": {
     "@patternfly/patternfly": "4.8.6",
     "@patternfly/react-core": "^4.9.1",
@@ -32,11 +35,8 @@
     "tslib": "^1.11.1"
   },
   "peerDependencies": {
-    "react": "^16.4.0",
-    "react-dom": "^15.6.2 || ^16.4.0"
-  },
-  "scripts": {
-    "clean": "rimraf dist"
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0"
   },
   "devDependencies": {
     "rimraf": "^2.6.2",

--- a/packages/react-virtualized-extension/package.json
+++ b/packages/react-virtualized-extension/package.json
@@ -26,6 +26,9 @@
     "url": "https://github.com/patternfly/patternfly-react/issues"
   },
   "homepage": "https://github.com/patternfly/patternfly-react/tree/master/packages/react-virtualized-extension/",
+  "scripts": {
+    "clean": "rimraf dist"
+  },
   "dependencies": {
     "@patternfly/patternfly": "4.8.6",
     "@patternfly/react-core": "^4.9.1",
@@ -40,12 +43,8 @@
     "tslib": "^1.11.1"
   },
   "peerDependencies": {
-    "@patternfly/react-table": "^2.10.0",
-    "react": "^16.4.0",
-    "react-dom": "^15.6.2 || ^16.4.0"
-  },
-  "scripts": {
-    "clean": "rimraf dist"
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0"
   },
   "devDependencies": {
     "@types/dom-helpers": "^3.4.1",

--- a/scripts/generators/package/package.json.hbs
+++ b/scripts/generators/package/package.json.hbs
@@ -41,7 +41,7 @@
     {{/if}}
   },
   "peerDependencies": {
-    "react": "^16.4.0",
-    "react-dom": "^15.6.2 || ^16.4.0"
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0"
   }
 }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Upgrade our peer dependency from `react@^16.4.0` (2 years old) to `react@^16.8.0` (1 year old) as a part of our breaking changes. This change would allow our library code to use React hooks moving forward. Previous discussion is in the #patternfly-react channel on Slack.

Closes patternfly/patternfly-org#1712

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: There are some concerns with products having to upgrade React, which in turn would break other 3rd party dependencies like Redux. These products are on a timeline where upgrading is feasible in the future, and the price to pay of not upgrading to `@patternfly/react-core@^4.0.0` is only that our components with hooks will not work (which currently, there are none).

## Breaking changes
- Our packages now can possibly use hooks, which requires `react@^16.8.0` instead of `react@^16.4.0`. We recommend upgrading your version of React if it is below 16.8.0.