### PR TITLE
fix(css): change gutter="x" to hasGutter

### DIFF
--- a/packages/react-docs/src/training.md
+++ b/packages/react-docs/src/training.md
@@ -8,7 +8,7 @@ import { TrainingCard } from 'gatsby-theme-patternfly-org/components';
 
 ## Fundamentals
 
-<Gallery gutter="md">
+<Gallery hasGutter>
   <GalleryItem>
     <TrainingCard
       trainingType="react"
@@ -32,7 +32,7 @@ import { TrainingCard } from 'gatsby-theme-patternfly-org/components';
 </Gallery>
 
 ## Components
-<Gallery gutter="md">
+<Gallery hasGutter>
   <GalleryItem>
     <TrainingCard
       trainingType="react-components"
@@ -67,7 +67,7 @@ import { TrainingCard } from 'gatsby-theme-patternfly-org/components';
 
 ## Charts
 
-<Gallery gutter="md">
+<Gallery hasGutter>
   <GalleryItem>
     <TrainingCard
       trainingType="react-charts"


### PR DESCRIPTION
Closes #4139 

fixed the Training page with the new "hasGutter" prop. 

![image](https://user-images.githubusercontent.com/57504257/80522261-466f9080-895a-11ea-9fc2-ff16fcf92673.png)
