### PR TITLE
chore(Divider): add vertical dividers and use Divider in DataToolbar

### DIFF
--- a/packages/react-core/src/components/Divider/Divider.md
+++ b/packages/react-core/src/components/Divider/Divider.md
@@ -5,7 +5,7 @@ cssPrefix: 'pf-c-divider'
 typescript: true 
 propComponents: ['Divider']
 ---
-import { Divider } from '@patternfly/react-core';
+import { Divider, Flex, FlexItem } from '@patternfly/react-core';
 
 ```js title=Using-hr-(default)
 import React from 'react';
@@ -35,5 +35,18 @@ import { Divider } from '@patternfly/react-core';
 
 DividerDiv = () => (
   <Divider component="div"/>
+);
+```
+
+```js title=Vertical-in-flex-layout
+import React from 'react';
+import { Divider, Flex, FlexItem } from '@patternfly/react-core';
+
+DividerHr = () => (
+  <Flex>
+    <FlexItem>first item</FlexItem>
+    <Divider isVertical/>
+    <FlexItem>second item</FlexItem>
+  </Flex>
 );
 ```

--- a/packages/react-core/src/components/Divider/Divider.tsx
+++ b/packages/react-core/src/components/Divider/Divider.tsx
@@ -13,18 +13,21 @@ export interface DividerProps extends React.HTMLProps<HTMLElement> {
   className?: string;
   /** The component type to use */
   component?: 'hr' | 'li' | 'div';
+  /** Flag to indicate the divider is vertical (must be in a flex layout) */
+  isVertical?: boolean;
 }
 
 export const Divider: React.FunctionComponent<DividerProps> = ({
   className = '',
   component = DividerVariant.hr,
+  isVertical = false,
   ...props
 }: DividerProps) => {
   const Component: any = component;
 
   return (
     <Component
-      className={css(styles.divider, className)}
+      className={css(styles.divider, isVertical && styles.modifiers.vertical, className)}
       {...(component !== 'hr' && { role: 'separator' })}
       {...props}
     />

--- a/packages/react-core/src/components/Divider/__tests__/Divider.test.tsx
+++ b/packages/react-core/src/components/Divider/__tests__/Divider.test.tsx
@@ -1,4 +1,5 @@
 import { Divider } from '../Divider';
+import { Flex, FlexItem} from '../../../layouts/Flex';
 import * as React from 'react';
 import { shallow } from 'enzyme';
 
@@ -14,5 +15,16 @@ test('divider using li', () => {
 
 test('divider using div', () => {
   const view = shallow(<Divider component="div" />);
+  expect(view).toMatchSnapshot();
+});
+
+test('vertical divider', () => {
+  const view = shallow(
+    <Flex>
+      <FlexItem>first item</FlexItem>
+      <Divider isVertical/>
+      <FlexItem>second item</FlexItem>
+    </Flex>
+  );
   expect(view).toMatchSnapshot();
 });

--- a/packages/react-core/src/components/Divider/__tests__/__snapshots__/Divider.test.tsx.snap
+++ b/packages/react-core/src/components/Divider/__tests__/__snapshots__/Divider.test.tsx.snap
@@ -19,3 +19,19 @@ exports[`divider using li 1`] = `
   role="separator"
 />
 `;
+
+exports[`vertical divider 1`] = `
+<div
+  className="pf-l-flex"
+>
+  <FlexItem>
+    first item
+  </FlexItem>
+  <Divider
+    isVertical={true}
+  />
+  <FlexItem>
+    second item
+  </FlexItem>
+</div>
+`;

--- a/packages/react-core/src/components/Toolbar/ToolbarItem.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarItem.tsx
@@ -19,6 +19,7 @@ export enum ToolbarItemVariant {
 export interface ToolbarItemProps extends React.HTMLProps<HTMLDivElement> {
   /** Classes applied to root element of the data toolbar item */
   className?: string;
+  /** A type modifier which modifies spacing specifically depending on the type of item */
   variant?:
     | ToolbarItemVariant
     | 'bulk-select'

--- a/packages/react-core/src/components/Toolbar/ToolbarItem.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarItem.tsx
@@ -4,6 +4,7 @@ import { css } from '@patternfly/react-styles';
 
 import { ToolbarBreakpointMod } from './ToolbarUtils';
 import { formatBreakpointMods, toCamel } from '../../helpers/util';
+import { Divider } from '../Divider';
 
 export enum ToolbarItemVariant {
   separator = 'separator',
@@ -18,7 +19,6 @@ export enum ToolbarItemVariant {
 export interface ToolbarItemProps extends React.HTMLProps<HTMLDivElement> {
   /** Classes applied to root element of the data toolbar item */
   className?: string;
-  /** TODO: Support 'separator' element as a <Divider component="div" variant="horizontal" />. A type modifier which modifies spacing specifically depending on the type of item */
   variant?:
     | ToolbarItemVariant
     | 'bulk-select'
@@ -26,7 +26,8 @@ export interface ToolbarItemProps extends React.HTMLProps<HTMLDivElement> {
     | 'pagination'
     | 'search-filter'
     | 'label'
-    | 'chip-group';
+    | 'chip-group'
+    | 'separator';
   /** An array of objects representing the various modifiers to apply to the data toolbar item at various breakpoints */
   breakpointMods?: ToolbarBreakpointMod[];
   /** id for this data toolbar item */
@@ -42,6 +43,7 @@ export const ToolbarItem: React.FunctionComponent<ToolbarItemProps> = ({
   id,
   children,
   ...props
+<<<<<<< HEAD:packages/react-core/src/components/Toolbar/ToolbarItem.tsx
 }: ToolbarItemProps) => (
   <div
     className={css(
@@ -60,3 +62,29 @@ export const ToolbarItem: React.FunctionComponent<ToolbarItemProps> = ({
     {children}
   </div>
 );
+=======
+}: DataToolbarItemProps) => {
+  if (variant === DataToolbarItemVariant.separator) {
+    return <Divider className={css(styles.modifiers.vertical, className)} {...props} />;
+  }
+
+  return (
+    <div
+      className={css(
+        styles.dataToolbarItem,
+        variant &&
+          styles.modifiers[
+            toCamel(variant) as 'bulkSelect' | 'overflowMenu' | 'pagination' | 'searchFilter' | 'label' | 'chipGroup'
+          ],
+        formatBreakpointMods(breakpointMods, styles),
+        className
+      )}
+      {...(variant === 'label' && { 'aria-hidden': true })}
+      id={id}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+};
+>>>>>>> chore(Divider): add vertical dividers and use Divider in DataToolbar:packages/react-core/src/components/DataToolbar/DataToolbarItem.tsx

--- a/packages/react-core/src/components/Toolbar/ToolbarItem.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarItem.tsx
@@ -43,35 +43,15 @@ export const ToolbarItem: React.FunctionComponent<ToolbarItemProps> = ({
   id,
   children,
   ...props
-<<<<<<< HEAD:packages/react-core/src/components/Toolbar/ToolbarItem.tsx
-}: ToolbarItemProps) => (
-  <div
-    className={css(
-      styles.toolbarItem,
-      variant &&
-        styles.modifiers[
-          toCamel(variant) as 'bulkSelect' | 'overflowMenu' | 'pagination' | 'searchFilter' | 'label' | 'chipGroup'
-        ],
-      formatBreakpointMods(breakpointMods, styles),
-      className
-    )}
-    {...(variant === 'label' && { 'aria-hidden': true })}
-    id={id}
-    {...props}
-  >
-    {children}
-  </div>
-);
-=======
-}: DataToolbarItemProps) => {
-  if (variant === DataToolbarItemVariant.separator) {
+}: ToolbarItemProps) => {
+  if (variant === ToolbarItemVariant.separator) {
     return <Divider className={css(styles.modifiers.vertical, className)} {...props} />;
   }
 
   return (
     <div
       className={css(
-        styles.dataToolbarItem,
+        styles.toolbarItem,
         variant &&
           styles.modifiers[
             toCamel(variant) as 'bulkSelect' | 'overflowMenu' | 'pagination' | 'searchFilter' | 'label' | 'chipGroup'
@@ -87,4 +67,3 @@ export const ToolbarItem: React.FunctionComponent<ToolbarItemProps> = ({
     </div>
   );
 };
->>>>>>> chore(Divider): add vertical dividers and use Divider in DataToolbar:packages/react-core/src/components/DataToolbar/DataToolbarItem.tsx

--- a/packages/react-core/src/components/Toolbar/examples/Toolbar.md
+++ b/packages/react-core/src/components/Toolbar/examples/Toolbar.md
@@ -7,9 +7,8 @@ section: 'components'
 ---
 
 import { Toolbar , ToolbarItem, ToolbarGroup, ToolbarContent, ToolbarToggleGroup, ToolbarFilter } from '@patternfly/react-core';
-import { Alert, Button, ButtonVariant, InputGroup, TextInput, Select, SelectOption } from '@patternfly/react-core';
+import { Alert, Button, ButtonVariant, Divider, InputGroup, TextInput, Select, SelectOption } from '@patternfly/react-core';
 import { EditIcon, CloneIcon, SyncIcon, SearchIcon, FilterIcon } from '@patternfly/react-icons'
-import '@patternfly/react-styles/css/components/Divider/divider';
 
 ## Examples
 Toolbar items are individual components that can be placed inside of a toolbar. Buttons or select lists are examples of items. (Note: This example does not demonstrate the desired responsive behavior of the toolbar. That is handled in later examples.)
@@ -826,7 +825,7 @@ There may be situations where all of the required elements simply cannot fit in 
 ```js title=Stacked-example
 import React from 'react';
 import { Toolbar, ToolbarContent, ToolbarToggleGroup, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
-import { Button, Select, SelectOption, Pagination, Dropdown, DropdownToggle, DropdownToggleCheckbox, DropdownItem, Divider } from '@patternfly/react-core';
+import { Button, Divider, Select, SelectOption, Pagination, Dropdown, DropdownToggle, DropdownToggleCheckbox, DropdownItem, Divider } from '@patternfly/react-core';
 import { FilterIcon, CloneIcon, SyncIcon } from '@patternfly/react-icons'
 
 class ToolbarStacked extends React.Component {

--- a/packages/react-core/src/components/Toolbar/examples/Toolbar.md
+++ b/packages/react-core/src/components/Toolbar/examples/Toolbar.md
@@ -825,7 +825,7 @@ There may be situations where all of the required elements simply cannot fit in 
 ```js title=Stacked-example
 import React from 'react';
 import { Toolbar, ToolbarContent, ToolbarToggleGroup, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
-import { Button, Divider, Select, SelectOption, Pagination, Dropdown, DropdownToggle, DropdownToggleCheckbox, DropdownItem, Divider } from '@patternfly/react-core';
+import { Button, Select, SelectOption, Pagination, Dropdown, DropdownToggle, DropdownToggleCheckbox, DropdownItem, Divider } from '@patternfly/react-core';
 import { FilterIcon, CloneIcon, SyncIcon } from '@patternfly/react-icons'
 
 class ToolbarStacked extends React.Component {

--- a/packages/react-integration/cypress/integration/divider.spec.ts
+++ b/packages/react-integration/cypress/integration/divider.spec.ts
@@ -16,4 +16,8 @@ describe('Divider Demo Test', () => {
   it('Verify divider with div', () => {
     cy.get('li.pf-c-divider').should('have.attr', 'role', 'separator');
   });
+
+  it('Verify vertical divider', () => {
+    cy.get('.pf-c-divider#vertical-divider').should('have.class', 'pf-m-vertical');
+  });
 });

--- a/packages/react-integration/demo-app-ts/src/components/demos/DividerDemo/DividerDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DividerDemo/DividerDemo.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Divider } from '@patternfly/react-core';
+import { Divider, Flex, FlexItem } from '@patternfly/react-core';
 
 export class DividerDemo extends React.Component {
   componentDidMount() {
@@ -18,6 +18,12 @@ export class DividerDemo extends React.Component {
         </ul>
 
         <Divider component="div" />
+
+        <Flex>
+          <FlexItem>first item</FlexItem>
+          <Divider id="vertical-divider" isVertical />
+          <FlexItem>second item</FlexItem>
+        </Flex>
       </React.Fragment>
     );
   }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #3736 and #3679

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
I imagine we would want to introduce as few breaking changes as possible. And just change the implementations of any components with their own separators so they render a Divider. Much of that work has already been done.

So I don't plan to make more breaking changes unless we'd prefer I remove the whole DropdownSeparator component and other component specific separators (even if they all ultimately use the Divider component). This would require consumers to replace all instances with a Divider component.
