### PR TITLE
strict mode enabled, removed duplicate sub-rules from tsconfig

### DIFF
--- a/packages/react-integration/demo-app-ts/tsconfig.json
+++ b/packages/react-integration/demo-app-ts/tsconfig.json
@@ -18,13 +18,6 @@
     "noEmit": true,
     "jsx": "preserve",
     "strict": true,
-    "noImplicitThis": true,
-    "alwaysStrict": true,
-    "strictBindCallApply": true,
-    "strictPropertyInitialization": false,
-    "noImplicitAny": true,
-    "strictNullChecks": false,
-    "strictFunctionTypes": true,
   },
   "include": [
     "src"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**:
Closes #3223 
Closes #3230 

This PR enables `strictNullChecks` and `strictPropertyInitialization`.

These were the only sub-rules of `strict` mode that were disabled, so this also cleans up `tsconfig` by removing unnecessary sub-rules in favor of simply `strict: true`:
```
noImplicitAny
noImplicitThis
alwaysStrict
strictBindCallApply
strictNullChecks
strictFunctionTypes
strictPropertyInitialization
```

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
Follow-up to work done in #4019 
Enabled by updates to `react-charts` in #4138 