### PR TITLE
Make tooltip examples keyboard accessible

### DIFF
--- a/packages/react-core/src/components/Tooltip/examples/Tooltip.md
+++ b/packages/react-core/src/components/Tooltip/examples/Tooltip.md
@@ -21,7 +21,7 @@ BasicTooltip = () => (
       <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.</div>
     }
   >
-    <span>I have a tooltip!</span>
+    <span tabIndex="0">I have a tooltip!</span>
   </Tooltip>
 )
 ```
@@ -37,7 +37,7 @@ LeftAlignedTooltip = () => (
       <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.</div>
     }
   >
-    <span>I have a tooltip!</span>
+    <span tabIndex="0">I have a tooltip!</span>
   </Tooltip>
 )
 ```


### PR DESCRIPTION
What: Closes #3961
Simple update to tooltip examples to allow them to be keyboard accessible.

(Same as https://github.com/patternfly/patternfly-react/pull/3962 that got accidentally reverted.)