### PR TITLE
fix(icons): clean old generated files before regenerating

### DIFF
--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/patternfly/patternfly-react#readme",
   "scripts": {
-    "generate": "node scripts/writeIcons.js",
+    "generate": "rimraf dist/esm/icons dist/js/icons && node scripts/writeIcons.js",
     "clean": "rimraf dist src/icons src/index.js src/index.d.ts"
   },
   "devDependencies": {

--- a/packages/react-styles/package.json
+++ b/packages/react-styles/package.json
@@ -15,7 +15,7 @@
     "tag": "prerelease-v4"
   },
   "scripts": {
-    "generate": "node scripts/writeClassMaps.js && node scripts/copyStyles.js",
+    "generate": "rimraf css && node scripts/writeClassMaps.js && node scripts/copyStyles.js",
     "clean": "rimraf dist css"
   },
   "devDependencies": {

--- a/packages/react-tokens/package.json
+++ b/packages/react-tokens/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/patternfly/patternfly-react#readme",
   "scripts": {
-    "generate": "node scripts/writeTokens.js",
+    "generate": "yarn clean && node scripts/writeTokens.js",
     "clean": "rimraf dist"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: #4158 did work, but it didn't remove the existing `index.ts` because of a stale `dist` folder. This forces ALL generated folders to be removed before new files are written to avoid stale `dist` folders in the future.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
