### PR TITLE
feat(Label): refactor for updated design and features

### DIFF
--- a/packages/react-core/src/components/Label/Label.tsx
+++ b/packages/react-core/src/components/Label/Label.tsx
@@ -17,12 +17,10 @@ export interface LabelProps extends React.HTMLProps<HTMLSpanElement> {
   icon?: React.ReactNode;
   /** Close click callback for removable labels. If present, label will have a close button. */
   onClose?: (event: React.MouseEvent) => void;
-  /** Aria label of the close button. */
-  closeBtnAriaLabel?: string;
-  /** Id of the close button. */
-  closeBtnId?: string;
-  /** Text id of the text within the label for the close button aria-labelledby field. */
-  closeBtnTextId?: string;
+  /** Node for custom close button. */
+  closeBtn?: React.ReactNode;
+  /** Additional properties for the default close button. */
+  closeBtnProps?: any;
   /** Href for a label that is a link. If present, the label will change to an anchor element. */
   href?: string;
 }
@@ -44,22 +42,16 @@ export const Label: React.FunctionComponent<LabelProps> = ({
   variant = 'filled',
   icon,
   onClose,
-  closeBtnAriaLabel,
-  closeBtnId,
-  closeBtnTextId,
+  closeBtn,
+  closeBtnProps,
   href,
   ...props
 }: LabelProps) => {
   const Component = href ? 'a' : 'span';
-  const closeBtn = (
-    <Button
-      type="button"
-      variant="plain"
-      onClick={onClose}
-      aria-label={closeBtnAriaLabel}
-      id={closeBtnId}
-      aria-labelledby={`${closeBtnId} ${closeBtnTextId}`}
-    >
+  const button = closeBtn ? (
+    closeBtn
+  ) : (
+    <Button type="button" variant="plain" onClick={onClose} {...closeBtnProps}>
       <TimesIcon />
     </Button>
   );
@@ -73,7 +65,7 @@ export const Label: React.FunctionComponent<LabelProps> = ({
         {icon && <span className={css(styles.labelIcon)}>{icon}</span>}
         {children}
       </Component>
-      {onClose && closeBtn}
+      {onClose && button}
     </span>
   );
 };

--- a/packages/react-core/src/components/Label/Label.tsx
+++ b/packages/react-core/src/components/Label/Label.tsx
@@ -9,13 +9,21 @@ export interface LabelProps extends React.HTMLProps<HTMLSpanElement> {
   children: React.ReactNode;
   /** Additional classes added to the label. */
   className?: string;
+  /** Color of the label. */
   color?: 'blue' | 'cyan' | 'green' | 'orange' | 'purple' | 'red' | 'grey';
+  /** Variant of the label. */
   variant?: 'outline' | 'filled';
+  /** Icon added to the left of the label text. */
   icon?: React.ReactNode;
+  /** Close click callback for removable labels. If present, label will have a close button. */
   onClose?: (event: React.MouseEvent) => void;
+  /** Aria label of the close button. */
   closeBtnAriaLabel?: string;
+  /** Id of the close button. */
   closeBtnId?: string;
+  /** Text id of the text within the label for the close button aria-labelledby field. */
   closeBtnTextId?: string;
+  /** Href for a label that is a link. If present, the label will change to an anchor element. */
   href?: string;
 }
 

--- a/packages/react-core/src/components/Label/Label.tsx
+++ b/packages/react-core/src/components/Label/Label.tsx
@@ -43,9 +43,7 @@ export const Label: React.FunctionComponent<LabelProps> = ({
   icon,
   onClose,
   closeBtn,
-  closeBtnProps = {
-    'aria-label': 'label-close-button'
-  },
+  closeBtnProps,
   href,
   ...props
 }: LabelProps) => {
@@ -53,7 +51,12 @@ export const Label: React.FunctionComponent<LabelProps> = ({
   const button = closeBtn ? (
     closeBtn
   ) : (
-    <Button type="button" variant="plain" onClick={onClose} {...closeBtnProps}>
+    <Button
+      type="button"
+      variant="plain"
+      onClick={onClose}
+      {...{ 'aria-label': 'label-close-button', ...closeBtnProps }}
+    >
       <TimesIcon />
     </Button>
   );

--- a/packages/react-core/src/components/Label/Label.tsx
+++ b/packages/react-core/src/components/Label/Label.tsx
@@ -1,16 +1,71 @@
 import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/Label/label';
+import { Button } from '../Button';
 import { css } from '@patternfly/react-styles';
+import TimesIcon from '@patternfly/react-icons/dist/js/icons/times-icon';
 
 export interface LabelProps extends React.HTMLProps<HTMLSpanElement> {
   /** Content rendered inside the label. */
   children: React.ReactNode;
   /** Additional classes added to the label. */
   className?: string;
+  color?: 'blue' | 'cyan' | 'green' | 'orange' | 'purple' | 'red' | 'grey';
+  variant?: 'outline' | 'filled';
+  icon?: React.ReactNode;
+  onClose?: (event: React.MouseEvent) => void;
+  closeBtnAriaLabel?: string;
+  closeBtnId?: string;
+  closeBtnTextId?: string;
+  href?: string;
 }
 
-export const Label: React.FunctionComponent<LabelProps> = ({ children, className = '', ...props }: LabelProps) => (
-  <span {...props} className={css(styles.label, className)}>
-    {children}
-  </span>
-);
+const colorStyles = {
+  blue: styles.modifiers.blue,
+  cyan: styles.modifiers.cyan,
+  green: styles.modifiers.green,
+  orange: styles.modifiers.orange,
+  purple: styles.modifiers.purple,
+  red: styles.modifiers.red,
+  grey: ''
+};
+
+export const Label: React.FunctionComponent<LabelProps> = ({
+  children,
+  className = '',
+  color = 'grey',
+  variant = 'filled',
+  icon,
+  onClose,
+  closeBtnAriaLabel,
+  closeBtnId,
+  closeBtnTextId,
+  href,
+  ...props
+}: LabelProps) => {
+  const Component = href ? 'a' : 'span';
+  const closeBtn = (
+    <Button
+      type="button"
+      variant="plain"
+      onClick={onClose}
+      aria-label={closeBtnAriaLabel}
+      id={closeBtnId}
+      aria-labelledby={`${closeBtnId} ${closeBtnTextId}`}
+    >
+      <TimesIcon />
+    </Button>
+  );
+
+  return (
+    <span
+      {...props}
+      className={css(styles.label, colorStyles[color], variant === 'outline' && styles.modifiers.outline, className)}
+    >
+      <Component className={css(styles.labelContent)} {...(href && { href })}>
+        {icon && <span className={css(styles.labelIcon)}>{icon}</span>}
+        {children}
+      </Component>
+      {onClose && closeBtn}
+    </span>
+  );
+};

--- a/packages/react-core/src/components/Label/Label.tsx
+++ b/packages/react-core/src/components/Label/Label.tsx
@@ -43,7 +43,9 @@ export const Label: React.FunctionComponent<LabelProps> = ({
   icon,
   onClose,
   closeBtn,
-  closeBtnProps,
+  closeBtnProps = {
+    'aria-label': 'label-close-button'
+  },
   href,
   ...props
 }: LabelProps) => {

--- a/packages/react-core/src/components/Label/__tests__/Generated/__snapshots__/Label.test.tsx.snap
+++ b/packages/react-core/src/components/Label/__tests__/Generated/__snapshots__/Label.test.tsx.snap
@@ -5,8 +5,12 @@ exports[`Label should match snapshot (auto-generated) 1`] = `
   className="pf-c-label ''"
   isCompact={false}
 >
-  <div>
-    ReactNode
-  </div>
+  <span
+    className="pf-c-label__content"
+  >
+    <div>
+      ReactNode
+    </div>
+  </span>
 </span>
 `;

--- a/packages/react-core/src/components/Label/__tests__/Label.test.tsx
+++ b/packages/react-core/src/components/Label/__tests__/Label.test.tsx
@@ -5,11 +5,96 @@ import { Label } from '../Label';
 test('label', () => {
   const view = shallow(<Label>Something</Label>);
   expect(view).toMatchSnapshot();
+  const outline = shallow(<Label variant="outline">Something</Label>);
+  expect(outline).toMatchSnapshot();
 });
 
-test('compact label', () => {
-  const view = shallow(<Label isCompact>Something</Label>);
+test('label with href', () => {
+  const view = shallow(<Label href="#">Something</Label>);
   expect(view).toMatchSnapshot();
+  const outline = shallow(
+    <Label href="#" variant="outline">
+      Something
+    </Label>
+  );
+  expect(outline).toMatchSnapshot();
+});
+
+test('label with close button', () => {
+  const view = shallow(<Label onClose={jest.fn()}>Something</Label>);
+  expect(view).toMatchSnapshot();
+  const outline = shallow(
+    <Label onClose={jest.fn()} variant="outline">
+      Something
+    </Label>
+  );
+  expect(outline).toMatchSnapshot();
+});
+
+test('label with blue color', () => {
+  const view = shallow(<Label color="blue">Something</Label>);
+  expect(view).toMatchSnapshot();
+  const outline = shallow(
+    <Label color="blue" variant="outline">
+      Something
+    </Label>
+  );
+  expect(outline).toMatchSnapshot();
+});
+
+test('label with green color', () => {
+  const view = shallow(<Label color="green">Something</Label>);
+  expect(view).toMatchSnapshot();
+  const outline = shallow(
+    <Label color="green" variant="outline">
+      Something
+    </Label>
+  );
+  expect(outline).toMatchSnapshot();
+});
+
+test('label with orange color', () => {
+  const view = shallow(<Label color="orange">Something</Label>);
+  expect(view).toMatchSnapshot();
+  const outline = shallow(
+    <Label color="orange" variant="outline">
+      Something
+    </Label>
+  );
+  expect(outline).toMatchSnapshot();
+});
+
+test('label with red color', () => {
+  const view = shallow(<Label color="red">Something</Label>);
+  expect(view).toMatchSnapshot();
+  const outline = shallow(
+    <Label color="red" variant="outline">
+      Something
+    </Label>
+  );
+  expect(outline).toMatchSnapshot();
+});
+
+test('label with purple color', () => {
+  const view = shallow(<Label color="purple">Something</Label>);
+  expect(view).toMatchSnapshot();
+  const outline = shallow(
+    <Label color="purple" variant="outline">
+      Something
+    </Label>
+  );
+  expect(outline).toMatchSnapshot();
+});
+
+test('label with cyan color', () => {
+  const view = shallow(<Label color="cyan">Something</Label>);
+  expect(view).toMatchSnapshot();
+  const outline = shallow(
+    <Label color="cyan" variant="outline">
+      Something
+    </Label>
+  );
+  expect(outline).toMatchSnapshot();
 });
 
 test('label with additional class name', () => {

--- a/packages/react-core/src/components/Label/__tests__/Label.test.tsx
+++ b/packages/react-core/src/components/Label/__tests__/Label.test.tsx
@@ -31,71 +31,19 @@ test('label with close button', () => {
   expect(outline).toMatchSnapshot();
 });
 
-test('label with blue color', () => {
-  const view = shallow(<Label color="blue">Something</Label>);
-  expect(view).toMatchSnapshot();
-  const outline = shallow(
-    <Label color="blue" variant="outline">
-      Something
-    </Label>
-  );
-  expect(outline).toMatchSnapshot();
-});
-
-test('label with green color', () => {
-  const view = shallow(<Label color="green">Something</Label>);
-  expect(view).toMatchSnapshot();
-  const outline = shallow(
-    <Label color="green" variant="outline">
-      Something
-    </Label>
-  );
-  expect(outline).toMatchSnapshot();
-});
-
-test('label with orange color', () => {
-  const view = shallow(<Label color="orange">Something</Label>);
-  expect(view).toMatchSnapshot();
-  const outline = shallow(
-    <Label color="orange" variant="outline">
-      Something
-    </Label>
-  );
-  expect(outline).toMatchSnapshot();
-});
-
-test('label with red color', () => {
-  const view = shallow(<Label color="red">Something</Label>);
-  expect(view).toMatchSnapshot();
-  const outline = shallow(
-    <Label color="red" variant="outline">
-      Something
-    </Label>
-  );
-  expect(outline).toMatchSnapshot();
-});
-
-test('label with purple color', () => {
-  const view = shallow(<Label color="purple">Something</Label>);
-  expect(view).toMatchSnapshot();
-  const outline = shallow(
-    <Label color="purple" variant="outline">
-      Something
-    </Label>
-  );
-  expect(outline).toMatchSnapshot();
-});
-
-test('label with cyan color', () => {
-  const view = shallow(<Label color="cyan">Something</Label>);
-  expect(view).toMatchSnapshot();
-  const outline = shallow(
-    <Label color="cyan" variant="outline">
-      Something
-    </Label>
-  );
-  expect(outline).toMatchSnapshot();
-});
+['blue', 'cyan', 'green', 'orange', 'purple', 'red', 'grey'].forEach(
+  (color: 'blue' | 'cyan' | 'green' | 'orange' | 'purple' | 'red' | 'grey') =>
+    test(`label with ${color} color`, () => {
+      const view = shallow(<Label color={color}>Something</Label>);
+      expect(view).toMatchSnapshot();
+      const outline = shallow(
+        <Label color={color} variant="outline">
+          Something
+        </Label>
+      );
+      expect(outline).toMatchSnapshot();
+    })
+);
 
 test('label with additional class name', () => {
   const view = shallow(<Label className="klass1">Something</Label>);

--- a/packages/react-core/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
+++ b/packages/react-core/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
@@ -1,19 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`compact label 1`] = `
-<span
-  className="pf-c-label"
-  isCompact={true}
->
-  Something
-</span>
-`;
-
 exports[`label 1`] = `
 <span
   className="pf-c-label"
 >
-  Something
+  <span
+    className="pf-c-label__content"
+  >
+    Something
+  </span>
+</span>
+`;
+
+exports[`label 2`] = `
+<span
+  className="pf-c-label pf-m-outline"
+>
+  <span
+    className="pf-c-label__content"
+  >
+    Something
+  </span>
 </span>
 `;
 
@@ -21,7 +28,11 @@ exports[`label with additional class name 1`] = `
 <span
   className="pf-c-label klass1"
 >
-  Something
+  <span
+    className="pf-c-label__content"
+  >
+    Something
+  </span>
 </span>
 `;
 
@@ -31,6 +42,228 @@ exports[`label with additional class name and props 1`] = `
   data-label-name="something"
   id="label-1"
 >
-  Something
+  <span
+    className="pf-c-label__content"
+  >
+    Something
+  </span>
+</span>
+`;
+
+exports[`label with blue color 1`] = `
+<span
+  className="pf-c-label pf-m-blue"
+>
+  <span
+    className="pf-c-label__content"
+  >
+    Something
+  </span>
+</span>
+`;
+
+exports[`label with blue color 2`] = `
+<span
+  className="pf-c-label pf-m-blue pf-m-outline"
+>
+  <span
+    className="pf-c-label__content"
+  >
+    Something
+  </span>
+</span>
+`;
+
+exports[`label with close button 1`] = `
+<span
+  className="pf-c-label"
+>
+  <span
+    className="pf-c-label__content"
+  >
+    Something
+  </span>
+  <Button
+    aria-labelledby="undefined undefined"
+    onClick={[MockFunction]}
+    type="button"
+    variant="plain"
+  >
+    <TimesIcon
+      color="currentColor"
+      noVerticalAlign={false}
+      size="sm"
+    />
+  </Button>
+</span>
+`;
+
+exports[`label with close button 2`] = `
+<span
+  className="pf-c-label pf-m-outline"
+>
+  <span
+    className="pf-c-label__content"
+  >
+    Something
+  </span>
+  <Button
+    aria-labelledby="undefined undefined"
+    onClick={[MockFunction]}
+    type="button"
+    variant="plain"
+  >
+    <TimesIcon
+      color="currentColor"
+      noVerticalAlign={false}
+      size="sm"
+    />
+  </Button>
+</span>
+`;
+
+exports[`label with cyan color 1`] = `
+<span
+  className="pf-c-label pf-m-cyan"
+>
+  <span
+    className="pf-c-label__content"
+  >
+    Something
+  </span>
+</span>
+`;
+
+exports[`label with cyan color 2`] = `
+<span
+  className="pf-c-label pf-m-cyan pf-m-outline"
+>
+  <span
+    className="pf-c-label__content"
+  >
+    Something
+  </span>
+</span>
+`;
+
+exports[`label with green color 1`] = `
+<span
+  className="pf-c-label pf-m-green"
+>
+  <span
+    className="pf-c-label__content"
+  >
+    Something
+  </span>
+</span>
+`;
+
+exports[`label with green color 2`] = `
+<span
+  className="pf-c-label pf-m-green pf-m-outline"
+>
+  <span
+    className="pf-c-label__content"
+  >
+    Something
+  </span>
+</span>
+`;
+
+exports[`label with href 1`] = `
+<span
+  className="pf-c-label"
+>
+  <a
+    className="pf-c-label__content"
+    href="#"
+  >
+    Something
+  </a>
+</span>
+`;
+
+exports[`label with href 2`] = `
+<span
+  className="pf-c-label pf-m-outline"
+>
+  <a
+    className="pf-c-label__content"
+    href="#"
+  >
+    Something
+  </a>
+</span>
+`;
+
+exports[`label with orange color 1`] = `
+<span
+  className="pf-c-label pf-m-orange"
+>
+  <span
+    className="pf-c-label__content"
+  >
+    Something
+  </span>
+</span>
+`;
+
+exports[`label with orange color 2`] = `
+<span
+  className="pf-c-label pf-m-orange pf-m-outline"
+>
+  <span
+    className="pf-c-label__content"
+  >
+    Something
+  </span>
+</span>
+`;
+
+exports[`label with purple color 1`] = `
+<span
+  className="pf-c-label pf-m-purple"
+>
+  <span
+    className="pf-c-label__content"
+  >
+    Something
+  </span>
+</span>
+`;
+
+exports[`label with purple color 2`] = `
+<span
+  className="pf-c-label pf-m-purple pf-m-outline"
+>
+  <span
+    className="pf-c-label__content"
+  >
+    Something
+  </span>
+</span>
+`;
+
+exports[`label with red color 1`] = `
+<span
+  className="pf-c-label pf-m-red"
+>
+  <span
+    className="pf-c-label__content"
+  >
+    Something
+  </span>
+</span>
+`;
+
+exports[`label with red color 2`] = `
+<span
+  className="pf-c-label pf-m-red pf-m-outline"
+>
+  <span
+    className="pf-c-label__content"
+  >
+    Something
+  </span>
 </span>
 `;

--- a/packages/react-core/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
+++ b/packages/react-core/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
@@ -84,7 +84,6 @@ exports[`label with close button 1`] = `
     Something
   </span>
   <Button
-    aria-labelledby="undefined undefined"
     onClick={[MockFunction]}
     type="button"
     variant="plain"
@@ -108,7 +107,6 @@ exports[`label with close button 2`] = `
     Something
   </span>
   <Button
-    aria-labelledby="undefined undefined"
     onClick={[MockFunction]}
     type="button"
     variant="plain"
@@ -161,6 +159,30 @@ exports[`label with green color 1`] = `
 exports[`label with green color 2`] = `
 <span
   className="pf-c-label pf-m-green pf-m-outline"
+>
+  <span
+    className="pf-c-label__content"
+  >
+    Something
+  </span>
+</span>
+`;
+
+exports[`label with grey color 1`] = `
+<span
+  className="pf-c-label"
+>
+  <span
+    className="pf-c-label__content"
+  >
+    Something
+  </span>
+</span>
+`;
+
+exports[`label with grey color 2`] = `
+<span
+  className="pf-c-label pf-m-outline"
 >
   <span
     className="pf-c-label__content"

--- a/packages/react-core/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
+++ b/packages/react-core/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
@@ -84,6 +84,7 @@ exports[`label with close button 1`] = `
     Something
   </span>
   <Button
+    aria-label="label-close-button"
     onClick={[MockFunction]}
     type="button"
     variant="plain"
@@ -107,6 +108,7 @@ exports[`label with close button 2`] = `
     Something
   </span>
   <Button
+    aria-label="label-close-button"
     onClick={[MockFunction]}
     type="button"
     variant="plain"

--- a/packages/react-core/src/components/Label/examples/Label.md
+++ b/packages/react-core/src/components/Label/examples/Label.md
@@ -23,8 +23,8 @@ FilledLabels = () => (
     <Label icon={<InfoCircleIcon />} onClose={Function.prototype}>
       Grey icon removeable
     </Label>{' '}
-    <Label href="#">Grey link</Label>{' '}
-    <Label href="#" onClose={Function.prototype}>
+    <Label href="#filled">Grey link</Label>{' '}
+    <Label href="#filled" onClose={Function.prototype}>
       Grey link removeable
     </Label>
     <br />
@@ -35,9 +35,9 @@ FilledLabels = () => (
       Blue removeable
     </Label> <Label color="blue" icon={<InfoCircleIcon />} onClose={Function.prototype}>
       Blue icon removeable
-    </Label> <Label color="blue" href="#">
+    </Label> <Label color="blue" href="#filled">
       Blue link
-    </Label> <Label color="blue" href="#" onClose={Function.prototype}>
+    </Label> <Label color="blue" href="#filled" onClose={Function.prototype}>
       Blue link removeable
     </Label>
     <br />
@@ -52,10 +52,10 @@ FilledLabels = () => (
     <Label color="green" icon={<InfoCircleIcon />} onClose={Function.prototype}>
       Green icon removeable
     </Label>{' '}
-    <Label color="green" href="#">
+    <Label color="green" href="#filled">
       Green link
     </Label>{' '}
-    <Label color="green" href="#" onClose={Function.prototype}>
+    <Label color="green" href="#filled" onClose={Function.prototype}>
       Green link removeable
     </Label>
     <br />
@@ -66,9 +66,9 @@ FilledLabels = () => (
       Orange removeable
     </Label> <Label color="orange" icon={<InfoCircleIcon />} onClose={Function.prototype}>
       Orange icon removeable
-    </Label> <Label color="orange" href="#">
+    </Label> <Label color="orange" href="#filled">
       Orange link
-    </Label> <Label color="orange" href="#" onClose={Function.prototype}>
+    </Label> <Label color="orange" href="#filled" onClose={Function.prototype}>
       Orange link removeable
     </Label>
     <br />
@@ -83,10 +83,10 @@ FilledLabels = () => (
     <Label color="red" icon={<InfoCircleIcon />} onClose={Function.prototype}>
       Red icon removeable
     </Label>{' '}
-    <Label color="red" href="#">
+    <Label color="red" href="#filled">
       Red link
     </Label>{' '}
-    <Label color="red" href="#" onClose={Function.prototype}>
+    <Label color="red" href="#filled" onClose={Function.prototype}>
       Red link removeable
     </Label>
     <br />
@@ -97,9 +97,9 @@ FilledLabels = () => (
       Purple removeable
     </Label> <Label color="purple" icon={<InfoCircleIcon />} onClose={Function.prototype}>
       Purple icon removeable
-    </Label> <Label color="purple" href="#">
+    </Label> <Label color="purple" href="#filled">
       Purple link
-    </Label> <Label color="purple" href="#" onClose={Function.prototype}>
+    </Label> <Label color="purple" href="#filled" onClose={Function.prototype}>
       Purple link removeable
     </Label>
     <br />
@@ -114,10 +114,10 @@ FilledLabels = () => (
     <Label color="cyan" icon={<InfoCircleIcon />} onClose={Function.prototype}>
       Cyan icon removeable
     </Label>{' '}
-    <Label color="cyan" href="#">
+    <Label color="cyan" href="#filled">
       Cyan link
     </Label>{' '}
-    <Label color="cyan" href="#" onClose={Function.prototype}>
+    <Label color="cyan" href="#filled" onClose={Function.prototype}>
       Cyan link removeable
     </Label>
   </React.Fragment>
@@ -129,7 +129,7 @@ import React from 'react';
 import { Label } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons';
 
-FilledLabels = () => (
+OutlinedLabels = () => (
   <React.Fragment>
     <Label variant="outline">Grey</Label>{' '}
     <Label variant="outline" icon={<InfoCircleIcon />}>
@@ -141,10 +141,10 @@ FilledLabels = () => (
     <Label variant="outline" icon={<InfoCircleIcon />} onClose={Function.prototype}>
       Grey icon removeable
     </Label>{' '}
-    <Label variant="outline" href="#">
+    <Label variant="outline" href="#outline">
       Grey link
     </Label>{' '}
-    <Label variant="outline" href="#" onClose={Function.prototype}>
+    <Label variant="outline" href="#outline" onClose={Function.prototype}>
       Grey link removeable
     </Label>
     <br />
@@ -157,9 +157,9 @@ FilledLabels = () => (
       Blue removeable
     </Label> <Label variant="outline" color="blue" icon={<InfoCircleIcon />} onClose={Function.prototype}>
       Blue icon removeable
-    </Label> <Label variant="outline" color="blue" href="#">
+    </Label> <Label variant="outline" color="blue" href="#outline">
       Blue link
-    </Label> <Label variant="outline" color="blue" href="#" onClose={Function.prototype}>
+    </Label> <Label variant="outline" color="blue" href="#outline" onClose={Function.prototype}>
       Blue link removeable
     </Label>
     <br />
@@ -176,10 +176,10 @@ FilledLabels = () => (
     <Label variant="outline" color="green" icon={<InfoCircleIcon />} onClose={Function.prototype}>
       Green icon removeable
     </Label>{' '}
-    <Label variant="outline" color="green" href="#">
+    <Label variant="outline" color="green" href="#outline">
       Green link
     </Label>{' '}
-    <Label variant="outline" color="green" href="#" onClose={Function.prototype}>
+    <Label variant="outline" color="green" href="#outline" onClose={Function.prototype}>
       Green link removeable
     </Label>
     <br />
@@ -192,9 +192,9 @@ FilledLabels = () => (
       Orange removeable
     </Label> <Label variant="outline" color="orange" icon={<InfoCircleIcon />} onClose={Function.prototype}>
       Orange icon removeable
-    </Label> <Label variant="outline" color="orange" href="#">
+    </Label> <Label variant="outline" color="orange" href="#outline">
       Orange link
-    </Label> <Label variant="outline" color="orange" href="#" onClose={Function.prototype}>
+    </Label> <Label variant="outline" color="orange" href="#outline" onClose={Function.prototype}>
       Orange link removeable
     </Label>
     <br />
@@ -211,10 +211,10 @@ FilledLabels = () => (
     <Label variant="outline" color="red" icon={<InfoCircleIcon />} onClose={Function.prototype}>
       Red icon removeable
     </Label>{' '}
-    <Label variant="outline" color="red" href="#">
+    <Label variant="outline" color="red" href="#outline">
       Red link
     </Label>{' '}
-    <Label variant="outline" color="red" href="#" onClose={Function.prototype}>
+    <Label variant="outline" color="red" href="#outline" onClose={Function.prototype}>
       Red link removeable
     </Label>
     <br />
@@ -227,9 +227,9 @@ FilledLabels = () => (
       Purple removeable
     </Label> <Label variant="outline" color="purple" icon={<InfoCircleIcon />} onClose={Function.prototype}>
       Purple icon removeable
-    </Label> <Label variant="outline" color="purple" href="#">
+    </Label> <Label variant="outline" color="purple" href="#outline">
       Purple link
-    </Label> <Label variant="outline" color="purple" href="#" onClose={Function.prototype}>
+    </Label> <Label variant="outline" color="purple" href="#outline" onClose={Function.prototype}>
       Purple link removeable
     </Label>
     <br />
@@ -246,10 +246,10 @@ FilledLabels = () => (
     <Label variant="outline" color="cyan" icon={<InfoCircleIcon />} onClose={Function.prototype}>
       Cyan icon removeable
     </Label>{' '}
-    <Label variant="outline" color="cyan" href="#">
+    <Label variant="outline" color="cyan" href="#outline">
       Cyan link
     </Label>{' '}
-    <Label variant="outline" color="cyan" href="#" onClose={Function.prototype}>
+    <Label variant="outline" color="cyan" href="#outline" onClose={Function.prototype}>
       Cyan link removeable
     </Label>
   </React.Fragment>

--- a/packages/react-core/src/components/Label/examples/Label.md
+++ b/packages/react-core/src/components/Label/examples/Label.md
@@ -7,15 +7,251 @@ propComponents: ['Label']
 ---
 
 import { Label } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
 
 ## Examples
-```js title=Basic
+
+```js title=Filled
 import React from 'react';
 import { Label } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
 
-SimpleLabel = () => (
+FilledLabels = () => (
   <React.Fragment>
-    <Label>Default Label</Label> <Label isCompact>Compact Label</Label>
+    <Label>Grey</Label> <Label icon={<InfoCircleIcon />}>Grey icon</Label>{' '}
+    <Label onClose={Function.prototype}>Grey removeable</Label>{' '}
+    <Label icon={<InfoCircleIcon />} onClose={Function.prototype}>
+      Grey icon removeable
+    </Label>{' '}
+    <Label href="#">Grey link</Label>{' '}
+    <Label href="#" onClose={Function.prototype}>
+      Grey link removeable
+    </Label>
+    <br />
+    <br />
+    <Label color="blue">Blue</Label> <Label color="blue" icon={<InfoCircleIcon />}>
+      Blue icon
+    </Label> <Label color="blue" onClose={Function.prototype}>
+      Blue removeable
+    </Label> <Label color="blue" icon={<InfoCircleIcon />} onClose={Function.prototype}>
+      Blue icon removeable
+    </Label> <Label color="blue" href="#">
+      Blue link
+    </Label> <Label color="blue" href="#" onClose={Function.prototype}>
+      Blue link removeable
+    </Label>
+    <br />
+    <br />
+    <Label color="green">Green</Label>{' '}
+    <Label color="green" icon={<InfoCircleIcon />}>
+      Green icon
+    </Label>{' '}
+    <Label color="green" onClose={Function.prototype}>
+      Green removeable
+    </Label>{' '}
+    <Label color="green" icon={<InfoCircleIcon />} onClose={Function.prototype}>
+      Green icon removeable
+    </Label>{' '}
+    <Label color="green" href="#">
+      Green link
+    </Label>{' '}
+    <Label color="green" href="#" onClose={Function.prototype}>
+      Green link removeable
+    </Label>
+    <br />
+    <br />
+    <Label color="orange">Orange</Label> <Label color="orange" icon={<InfoCircleIcon />}>
+      Orange icon
+    </Label> <Label color="orange" onClose={Function.prototype}>
+      Orange removeable
+    </Label> <Label color="orange" icon={<InfoCircleIcon />} onClose={Function.prototype}>
+      Orange icon removeable
+    </Label> <Label color="orange" href="#">
+      Orange link
+    </Label> <Label color="orange" href="#" onClose={Function.prototype}>
+      Orange link removeable
+    </Label>
+    <br />
+    <br />
+    <Label color="red">Red</Label>{' '}
+    <Label color="red" icon={<InfoCircleIcon />}>
+      Red icon
+    </Label>{' '}
+    <Label color="red" onClose={Function.prototype}>
+      Red removeable
+    </Label>{' '}
+    <Label color="red" icon={<InfoCircleIcon />} onClose={Function.prototype}>
+      Red icon removeable
+    </Label>{' '}
+    <Label color="red" href="#">
+      Red link
+    </Label>{' '}
+    <Label color="red" href="#" onClose={Function.prototype}>
+      Red link removeable
+    </Label>
+    <br />
+    <br />
+    <Label color="purple">Purple</Label> <Label color="purple" icon={<InfoCircleIcon />}>
+      Purple icon
+    </Label> <Label color="purple" onClose={Function.prototype}>
+      Purple removeable
+    </Label> <Label color="purple" icon={<InfoCircleIcon />} onClose={Function.prototype}>
+      Purple icon removeable
+    </Label> <Label color="purple" href="#">
+      Purple link
+    </Label> <Label color="purple" href="#" onClose={Function.prototype}>
+      Purple link removeable
+    </Label>
+    <br />
+    <br />
+    <Label color="cyan">Cyan</Label>{' '}
+    <Label color="cyan" icon={<InfoCircleIcon />}>
+      Cyan icon
+    </Label>{' '}
+    <Label color="cyan" onClose={Function.prototype}>
+      Cyan removeable
+    </Label>{' '}
+    <Label color="cyan" icon={<InfoCircleIcon />} onClose={Function.prototype}>
+      Cyan icon removeable
+    </Label>{' '}
+    <Label color="cyan" href="#">
+      Cyan link
+    </Label>{' '}
+    <Label color="cyan" href="#" onClose={Function.prototype}>
+      Cyan link removeable
+    </Label>
+  </React.Fragment>
+);
+```
+
+```js title=Outline
+import React from 'react';
+import { Label } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
+
+FilledLabels = () => (
+  <React.Fragment>
+    <Label variant="outline">Grey</Label>{' '}
+    <Label variant="outline" icon={<InfoCircleIcon />}>
+      Grey icon
+    </Label>{' '}
+    <Label variant="outline" onClose={Function.prototype}>
+      Grey removeable
+    </Label>{' '}
+    <Label variant="outline" icon={<InfoCircleIcon />} onClose={Function.prototype}>
+      Grey icon removeable
+    </Label>{' '}
+    <Label variant="outline" href="#">
+      Grey link
+    </Label>{' '}
+    <Label variant="outline" href="#" onClose={Function.prototype}>
+      Grey link removeable
+    </Label>
+    <br />
+    <br />
+    <Label variant="outline" color="blue">
+      Blue
+    </Label> <Label variant="outline" color="blue" icon={<InfoCircleIcon />}>
+      Blue icon
+    </Label> <Label variant="outline" color="blue" onClose={Function.prototype}>
+      Blue removeable
+    </Label> <Label variant="outline" color="blue" icon={<InfoCircleIcon />} onClose={Function.prototype}>
+      Blue icon removeable
+    </Label> <Label variant="outline" color="blue" href="#">
+      Blue link
+    </Label> <Label variant="outline" color="blue" href="#" onClose={Function.prototype}>
+      Blue link removeable
+    </Label>
+    <br />
+    <br />
+    <Label variant="outline" color="green">
+      Green
+    </Label>{' '}
+    <Label variant="outline" color="green" icon={<InfoCircleIcon />}>
+      Green icon
+    </Label>{' '}
+    <Label variant="outline" color="green" onClose={Function.prototype}>
+      Green removeable
+    </Label>{' '}
+    <Label variant="outline" color="green" icon={<InfoCircleIcon />} onClose={Function.prototype}>
+      Green icon removeable
+    </Label>{' '}
+    <Label variant="outline" color="green" href="#">
+      Green link
+    </Label>{' '}
+    <Label variant="outline" color="green" href="#" onClose={Function.prototype}>
+      Green link removeable
+    </Label>
+    <br />
+    <br />
+    <Label variant="outline" color="orange">
+      Orange
+    </Label> <Label variant="outline" color="orange" icon={<InfoCircleIcon />}>
+      Orange icon
+    </Label> <Label variant="outline" color="orange" onClose={Function.prototype}>
+      Orange removeable
+    </Label> <Label variant="outline" color="orange" icon={<InfoCircleIcon />} onClose={Function.prototype}>
+      Orange icon removeable
+    </Label> <Label variant="outline" color="orange" href="#">
+      Orange link
+    </Label> <Label variant="outline" color="orange" href="#" onClose={Function.prototype}>
+      Orange link removeable
+    </Label>
+    <br />
+    <br />
+    <Label variant="outline" color="red">
+      Red
+    </Label>{' '}
+    <Label variant="outline" color="red" icon={<InfoCircleIcon />}>
+      Red icon
+    </Label>{' '}
+    <Label variant="outline" color="red" onClose={Function.prototype}>
+      Red removeable
+    </Label>{' '}
+    <Label variant="outline" color="red" icon={<InfoCircleIcon />} onClose={Function.prototype}>
+      Red icon removeable
+    </Label>{' '}
+    <Label variant="outline" color="red" href="#">
+      Red link
+    </Label>{' '}
+    <Label variant="outline" color="red" href="#" onClose={Function.prototype}>
+      Red link removeable
+    </Label>
+    <br />
+    <br />
+    <Label variant="outline" color="purple">
+      Purple
+    </Label> <Label variant="outline" color="purple" icon={<InfoCircleIcon />}>
+      Purple icon
+    </Label> <Label variant="outline" color="purple" onClose={Function.prototype}>
+      Purple removeable
+    </Label> <Label variant="outline" color="purple" icon={<InfoCircleIcon />} onClose={Function.prototype}>
+      Purple icon removeable
+    </Label> <Label variant="outline" color="purple" href="#">
+      Purple link
+    </Label> <Label variant="outline" color="purple" href="#" onClose={Function.prototype}>
+      Purple link removeable
+    </Label>
+    <br />
+    <br />
+    <Label variant="outline" color="cyan">
+      Cyan
+    </Label>{' '}
+    <Label variant="outline" color="cyan" icon={<InfoCircleIcon />}>
+      Cyan icon
+    </Label>{' '}
+    <Label variant="outline" color="cyan" onClose={Function.prototype}>
+      Cyan removeable
+    </Label>{' '}
+    <Label variant="outline" color="cyan" icon={<InfoCircleIcon />} onClose={Function.prototype}>
+      Cyan icon removeable
+    </Label>{' '}
+    <Label variant="outline" color="cyan" href="#">
+      Cyan link
+    </Label>{' '}
+    <Label variant="outline" color="cyan" href="#" onClose={Function.prototype}>
+      Cyan link removeable
+    </Label>
   </React.Fragment>
 );
 ```

--- a/packages/react-integration/cypress/integration/label.spec.ts
+++ b/packages/react-integration/cypress/integration/label.spec.ts
@@ -8,6 +8,6 @@ describe('Label Demo Test', () => {
   it('Verify default label', () => {
     cy.get('.pf-c-label')
       .first()
-      .contains('Default label');
+      .contains('Grey');
   });
 });

--- a/packages/react-integration/demo-app-ts/src/components/demos/LabelDemo/LabelDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/LabelDemo/LabelDemo.tsx
@@ -1,5 +1,6 @@
 import { Label } from '@patternfly/react-core';
 import React, { Component } from 'react';
+import { InfoCircleIcon } from '@patternfly/react-icons';
 
 export class LabelDemo extends Component {
   componentDidMount() {
@@ -9,8 +10,35 @@ export class LabelDemo extends Component {
   render() {
     return (
       <React.Fragment>
-        <Label>Default label</Label>
-        <Label>Compact label</Label>
+        <Label>Grey</Label> <Label icon={<InfoCircleIcon />}>Grey icon</Label>{' '}
+        <Label onClose={() => {}}>Grey removeable</Label>{' '}
+        <Label icon={<InfoCircleIcon />} onClose={() => {}}>
+          Grey icon removeable
+        </Label>{' '}
+        <Label href="#">Grey link</Label>{' '}
+        <Label href="#" onClose={() => {}}>
+          Grey link removeable
+        </Label>
+        <Label variant="outline">Grey</Label>{' '}
+        <Label variant="outline" icon={<InfoCircleIcon />}>
+          Grey icon
+        </Label>{' '}
+        <Label variant="outline" onClose={() => {}}>
+          Grey removeable
+        </Label>{' '}
+        <Label variant="outline" icon={<InfoCircleIcon />} onClose={() => {}}>
+          Grey icon removeable
+        </Label>{' '}
+        <Label variant="outline" href="#">
+          Grey link
+        </Label>{' '}
+        <Label variant="outline" href="#" onClose={() => {}}>
+          Grey link removeable
+        </Label>
+        <Label color="blue">Blue</Label>{' '}
+        <Label color="blue" icon={<InfoCircleIcon />}>
+          Blue icon
+        </Label>
       </React.Fragment>
     );
   }

--- a/packages/react-integration/demo-app-ts/src/components/demos/LabelDemo/LabelDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/LabelDemo/LabelDemo.tsx
@@ -1,6 +1,6 @@
 import { Label } from '@patternfly/react-core';
 import React, { Component } from 'react';
-import { InfoCircleIcon } from '@patternfly/react-icons/dist/js/icons/info-circle-icon';
+import InfoCircleIcon from '@patternfly/react-icons/dist/js/icons/info-circle-icon';
 
 export class LabelDemo extends Component {
   componentDidMount() {

--- a/packages/react-integration/demo-app-ts/src/components/demos/LabelDemo/LabelDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/LabelDemo/LabelDemo.tsx
@@ -1,6 +1,6 @@
 import { Label } from '@patternfly/react-core';
 import React, { Component } from 'react';
-import { InfoCircleIcon } from '@patternfly/react-icons';
+import { InfoCircleIcon } from '@patternfly/react-icons/dist/js/icons/info-circle-icon';
 
 export class LabelDemo extends Component {
   componentDidMount() {


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #3688

The `onClose` prop, if present, will add the close button to the label, and the `href` prop, if present, will change the <span> to an <a> element.

## Breaking changes
1. Default color changed to grey. Design also adjusted.