### PR TITLE
fix(experimental): remove experimental directory

### DIFF
--- a/packages/react-core/src/components/index.ts
+++ b/packages/react-core/src/components/index.ts
@@ -18,6 +18,7 @@ export * from './ClipboardCopy';
 export * from './ContextSelector';
 export * from './DataList';
 export * from './Divider';
+export * from './Drawer';
 export * from './Dropdown';
 export * from './EmptyState';
 export * from './ExpandableSection';

--- a/packages/react-core/src/experimental/components/DataToolbar/index.ts
+++ b/packages/react-core/src/experimental/components/DataToolbar/index.ts
@@ -1,1 +1,0 @@
-export * from '../../../components/Toolbar';

--- a/packages/react-core/src/experimental/components/Drawer/index.ts
+++ b/packages/react-core/src/experimental/components/Drawer/index.ts
@@ -1,1 +1,0 @@
-export * from '../../../components/Drawer';

--- a/packages/react-core/src/experimental/components/index.ts
+++ b/packages/react-core/src/experimental/components/index.ts
@@ -1,2 +1,0 @@
-export * from '../../components/Toolbar';
-export * from '../../components/Drawer';

--- a/packages/react-core/src/experimental/index.ts
+++ b/packages/react-core/src/experimental/index.ts
@@ -1,2 +1,0 @@
-export * from '../components/Drawer';
-export * from '../components/Toolbar';

--- a/packages/react-core/src/index.ts
+++ b/packages/react-core/src/index.ts
@@ -1,5 +1,4 @@
 export * from './components';
-export * from './experimental';
 export * from './layouts';
 export * from './helpers';
 export { BaseSizes, DeviceSizes } from './styles/sizes';


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes https://github.com/patternfly/patternfly-react/issues/4167

This PR removes the experimental directory and moves those exports to react-core pkg.

## Breaking changes
1. **Drawer**: Removes import path `'@patternfly/react-core/dist/js/experimental'`. The import path `'@patternfly/react-core'` should be used instead.