### PR TITLE
fix(tabs): properly check children before setting hidden

### DIFF
--- a/packages/react-core/src/components/NotificationDrawer/NotificationDrawerGroup.tsx
+++ b/packages/react-core/src/components/NotificationDrawer/NotificationDrawerGroup.tsx
@@ -34,7 +34,10 @@ export const NotificationDrawerGroup: React.FunctionComponent<NotificationDrawer
   title,
   ...props
 }: NotificationDrawerGroupProps) => (
-  <section {...props} className={css(styles.notificationDrawerGroup, isExpanded && styles.modifiers.expanded)}>
+  <section
+    {...props}
+    className={css(styles.notificationDrawerGroup, isExpanded && styles.modifiers.expanded, className)}
+  >
     <h1>
       <button
         className={css(styles.notificationDrawerGroupToggle)}

--- a/packages/react-core/src/components/NotificationDrawer/__tests__/Generated/__snapshots__/NotificationDrawerGroup.test.tsx.snap
+++ b/packages/react-core/src/components/NotificationDrawer/__tests__/Generated/__snapshots__/NotificationDrawerGroup.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`NotificationDrawerGroup should match snapshot (auto-generated) 1`] = `
 <section
-  className="pf-c-notification-drawer__group pf-m-expanded"
+  className="pf-c-notification-drawer__group pf-m-expanded ''"
 >
   <h1>
     <button

--- a/packages/react-core/src/components/NotificationDrawer/__tests__/__snapshots__/NotificationDrawerGroup.test.tsx.snap
+++ b/packages/react-core/src/components/NotificationDrawer/__tests__/__snapshots__/NotificationDrawerGroup.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`className is added to the root element 1`] = `"pf-c-notification-drawer__group"`;
+exports[`className is added to the root element 1`] = `"pf-c-notification-drawer__group extra-class"`;
 
 exports[`drawer group with isExpanded applied  1`] = `
 <section

--- a/packages/react-core/src/components/Tabs/Tabs.tsx
+++ b/packages/react-core/src/components/Tabs/Tabs.tsx
@@ -89,12 +89,13 @@ class Tabs extends React.Component<TabsProps & InjectedOuiaProps, TabsState> {
     this.props.onSelect(event, eventKey);
     // process any tab content sections outside of the component
     if (tabContentRef) {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      React.Children.map(this.props.children, (child: any, i) => {
-        child.props.tabContentRef.current.hidden = true;
-      });
+      React.Children.toArray<any>(this.props.children)
+        .filter(child => child.props && child.props.tabContentRef && child.props.tabContentRef.current)
+        .forEach(child => child.props.tabContentRef.current.hidden = true);
       // most recently selected tabContent
-      tabContentRef.current.hidden = false;
+      if (tabContentRef.current) {
+        tabContentRef.current.hidden = false;
+      }
     }
     // Update scroll button state and which button to highlight
     setTimeout(() => {

--- a/packages/react-core/src/components/Tabs/Tabs.tsx
+++ b/packages/react-core/src/components/Tabs/Tabs.tsx
@@ -91,7 +91,7 @@ class Tabs extends React.Component<TabsProps & InjectedOuiaProps, TabsState> {
     if (tabContentRef) {
       React.Children.toArray<any>(this.props.children)
         .filter(child => child.props && child.props.tabContentRef && child.props.tabContentRef.current)
-        .forEach(child => child.props.tabContentRef.current.hidden = true);
+        .forEach(child => (child.props.tabContentRef.current.hidden = true));
       // most recently selected tabContent
       if (tabContentRef.current) {
         tabContentRef.current.hidden = false;


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4074 . Fixes lint issue in NotificationDrawerGroup.tsx.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: Verified this in cost management thanks to @dlabrecq !
