### PR TITLE
chore(lint): add import-tokens-icons rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,8 @@
         "@typescript-eslint",
         "jsdoc",
         "react",
-        "prettier"
+        "prettier",
+        "patternfly-react"
     ],
     "extends": [
         "eslint:recommended",
@@ -106,6 +107,7 @@
             "error",
             "never"
         ],
+        "patternfly-react/import-tokens-icons": "error",
         "prefer-const": "error",
         "prettier/prettier": "error",
         "radix": [

--- a/packages/eslint-plugin-patternfly-react/CHANGELOG.md
+++ b/packages/eslint-plugin-patternfly-react/CHANGELOG.md
@@ -1,0 +1,60 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.4.1](https://github.com/patternfly/patternfly-react/compare/eslint-plugin-patternfly-react@0.4.0...eslint-plugin-patternfly-react@0.4.1) (2020-03-02)
+
+
+### Bug Fixes
+
+* **eslint:** fix eslint recommendations ([#3858](https://github.com/patternfly/patternfly-react/issues/3858)) ([09cd0b8](https://github.com/patternfly/patternfly-react/commit/09cd0b8ca1495a1c4f9c870259b250ad3450e6ec))
+
+
+
+
+
+# [0.4.0](https://github.com/patternfly/patternfly-react/compare/eslint-plugin-patternfly-react@0.3.0...eslint-plugin-patternfly-react@0.4.0) (2020-02-03)
+
+
+### Features
+
+* **eslint:** add react-hooks to eslint-plugin-patternfly-react ([#3636](https://github.com/patternfly/patternfly-react/issues/3636)) ([fb62dc1](https://github.com/patternfly/patternfly-react/commit/fb62dc11fea53222334d8708f0ff41db8eadaafa))
+
+
+
+
+
+# [0.3.0](https://github.com/patternfly/patternfly-react/compare/eslint-plugin-patternfly-react@0.2.3...eslint-plugin-patternfly-react@0.3.0) (2019-10-16)
+
+
+### Features
+
+* **eslint:** add eslint-plugin-react-hooks ([#3083](https://github.com/patternfly/patternfly-react/issues/3083)) ([c47f143](https://github.com/patternfly/patternfly-react/commit/c47f143))
+
+
+
+
+
+## 0.2.3 (2019-04-15)
+
+
+### Bug Fixes
+
+* Update React with changes from core ([#1703](https://github.com/patternfly/patternfly-react/issues/1703)) ([a219cae](https://github.com/patternfly/patternfly-react/commit/a219cae)), closes [#1680](https://github.com/patternfly/patternfly-react/issues/1680) [#1684](https://github.com/patternfly/patternfly-react/issues/1684) [#1684](https://github.com/patternfly/patternfly-react/issues/1684)
+
+
+
+
+
+## 0.2.2 (2019-03-04)
+
+**Note:** Version bump only for package eslint-plugin-patternfly-react
+
+
+
+
+
+## [0.2.1](https://github.com/patternfly/patternfly-react/compare/eslint-plugin-patternfly-react@0.2.0...eslint-plugin-patternfly-react@0.2.1) (2019-01-18)
+
+**Note:** Version bump only for package eslint-plugin-patternfly-react

--- a/packages/eslint-plugin-patternfly-react/README.md
+++ b/packages/eslint-plugin-patternfly-react/README.md
@@ -1,0 +1,50 @@
+# eslint-plugin-patternfly-react
+
+This package provides PatternFly React all ESLint rules bundled together for use in PatternFly React and downstream applications.
+
+### Installing
+
+```
+yarn add -D eslint-plugin-patternfly-react
+```
+
+or
+
+```
+npm install eslint-plugin-patternfly-react --save-dev
+```
+
+### Usage
+
+Add eslint-plugin-patternfly-react to your `.eslintrc.json` or `.eslintrc.js`.
+
+.eslintrc.json:
+
+```json
+{
+  "plugins": ["plugin:patternfly-react/recommended"]
+}
+```
+
+.eslintrc.js:
+
+```javascript
+module.exports = {
+  root: true,
+  extends: ['plugin:patternfly-react/recommended']
+};
+```
+
+### Building
+
+```
+yarn build
+```
+
+Note the build scripts for this are located in the root package.json under `yarn build`.
+
+### Publishing
+
+```
+yarn publish
+```

--- a/packages/eslint-plugin-patternfly-react/lib/config/recommended.js
+++ b/packages/eslint-plugin-patternfly-react/lib/config/recommended.js
@@ -1,0 +1,72 @@
+module.exports = {
+  rules: {
+    'patternfly-react/import-default-name': [
+      'error',
+      {
+        classnames: 'classNames',
+        'prop-types': 'PropTypes'
+      }
+    ],
+    'jsx-a11y/heading-has-content': 'off',
+    'jsx-a11y/anchor-has-content': 'off',
+    'jsx-a11y/anchor-is-valid': 'off',
+    'jsx-a11y/label-has-for': 'off',
+    'jsx-a11y/click-events-have-key-events': 'off',
+    'jsx-a11y/no-static-element-interactions': 'off',
+    'jsx-a11y/no-noninteractive-element-interactions': 'off',
+    'import/no-extraneous-dependencies': [
+      'error',
+      {
+        devDependencies: true
+      }
+    ],
+    'import/no-named-default': 'off',
+    'import/prefer-default-export': 'off',
+    'no-alert': 'off',
+    'no-param-reassign': 'off',
+    'no-plusplus': 'off',
+    'no-prototype-builtins': 'off',
+    'no-restricted-syntax': 'off',
+    'no-underscore-dangle': 'off',
+    'no-unused-expressions': ['error', { allowShortCircuit: true, allowTernary: true }],
+    'no-unused-vars': [
+      'error',
+      {
+        vars: 'all',
+        args: 'none',
+        ignoreRestSiblings: true
+      }
+    ],
+    'no-use-before-define': 'off',
+    'prettier/prettier': [
+      'error',
+      { semi: true, singleQuote: true, tabWidth: 2, trailingComma: 'none', useTabs: false, printWidth: 120 }
+    ],
+    'react/no-array-index-key': 'off',
+    'react/forbid-prop-types': 'off',
+    'react/jsx-filename-extension': 'off',
+    'react/jsx-uses-vars': 'error',
+    'react/no-danger': 'off',
+    'react/sort-comp': 'off',
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn'
+  },
+  extends: [
+    'standard',
+    'standard-react',
+    'standard-jsx',
+    'airbnb',
+    'plugin:jest/recommended',
+    'prettier',
+    'prettier/react',
+    'plugin:react-hooks/recommended'
+  ],
+  env: {
+    es6: true,
+    browser: true,
+    node: true,
+    jest: true
+  },
+  plugins: ['prettier', 'jest', 'react', 'react-hooks', 'patternfly-react'],
+  parser: 'babel-eslint'
+};

--- a/packages/eslint-plugin-patternfly-react/lib/index.js
+++ b/packages/eslint-plugin-patternfly-react/lib/index.js
@@ -1,0 +1,11 @@
+const recommended = require('./config/recommended');
+
+module.exports = {
+  rules: {
+    'import-default-name': require('./rules/import-default-name'),
+    'import-tokens-icons': require('./rules/import-tokens-icons')
+  },
+  configs: {
+    recommended
+  }
+};

--- a/packages/eslint-plugin-patternfly-react/lib/rules/import-default-name.js
+++ b/packages/eslint-plugin-patternfly-react/lib/rules/import-default-name.js
@@ -1,0 +1,47 @@
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Force default import names to match specified values',
+      category: 'Possible Errors',
+      recommended: true
+    },
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {},
+        additionalProperties: true
+      }
+    ]
+  },
+  create(context) {
+    const [importMap = {}] = context.options;
+    return {
+      ImportDeclaration(node) {
+        const defaultImport = node.specifiers.find(spec => spec.type === 'ImportDefaultSpecifier');
+        if (!defaultImport) {
+          return;
+        }
+        const expectedName = importMap[node.source.value];
+        const receivedName = defaultImport.local.name;
+        if (expectedName && expectedName !== receivedName) {
+          context.report({
+            node,
+            message: 'Expected default import to be named "{{ expected }}" but received "{{ received }}"',
+            data: {
+              expected: expectedName,
+              received: receivedName
+            },
+            fix(fixer) {
+              const [varDecl] = context.getDeclaredVariables(node);
+              return [
+                ...varDecl.references.map(ref => fixer.replaceText(ref.identifier, expectedName)),
+                fixer.replaceText(defaultImport, expectedName)
+              ];
+            }
+          });
+        }
+      }
+    };
+  }
+};

--- a/packages/eslint-plugin-patternfly-react/lib/rules/import-tokens-icons.js
+++ b/packages/eslint-plugin-patternfly-react/lib/rules/import-tokens-icons.js
@@ -1,0 +1,46 @@
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Do not rely on ESM treeshaking for icons and tokens',
+      category: 'Possible Errors',
+      recommended: true
+    },
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {},
+        additionalProperties: true
+      }
+    ]
+  },
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        if (/@patternfly\/react-(tokens|icons)(\/dist\/(js|esm))?/.test(node.source.value)) {
+          const esmSpecifiers = node.specifiers.filter(specifier => specifier.type === 'ImportSpecifier');
+          if (esmSpecifiers.length > 0) {
+            context.report({
+              node,
+              message: `Importing from the barrel ${node.source.value} file will blow up CJS bundle sizes. Import directly from dist/js file instead.`,
+              fix(fixer) {
+                return fixer.replaceText(
+                  node,
+                  esmSpecifiers
+                    .map(
+                      specifier =>
+                        `import ${specifier.local.name} from '${node.source.value.replace(
+                          /\/dist\/(js|esm)/,
+                          ''
+                        )}/dist/js/${specifier.imported.name}';`
+                    )
+                    .join('\n')
+                );
+              }
+            });
+          }
+        }
+      }
+    };
+  }
+};

--- a/packages/eslint-plugin-patternfly-react/package.json
+++ b/packages/eslint-plugin-patternfly-react/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "eslint-plugin-patternfly-react",
+  "version": "0.4.1",
+  "private": false,
+  "main": "./lib/index.js",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/patternfly/patternfly-react.git"
+  },
+  "author": "Red Hat",
+  "keywords": [
+    "react",
+    "patternfly",
+    "eslint"
+  ],
+  "bugs": {
+    "url": "https://github.com/patternfly/patternfly-react/issues"
+  },
+  "homepage": "https://github.com/patternfly/patternfly-react/blob/master/packages/eslint-plugin/README.md",
+  "dependencies": {
+    "babel-eslint": "^9.0.0",
+    "eslint-config-airbnb": "^16.1.0",
+    "eslint-config-prettier": "^2.9.0",
+    "eslint-config-standard": "^11.0.0",
+    "eslint-config-standard-jsx": "^5.0.0",
+    "eslint-config-standard-react": "^6.0.0",
+    "eslint-plugin-import": "^2.13.0",
+    "eslint-plugin-jest": "^21.15.0",
+    "eslint-plugin-jsx-a11y": "^6.0.3",
+    "eslint-plugin-node": "^6.0.1",
+    "eslint-plugin-prettier": "^2.6.0",
+    "eslint-plugin-promise": "^3.7.0",
+    "eslint-plugin-react": "^7.7.0",
+    "eslint-plugin-react-hooks": "^2.5.0",
+    "eslint-plugin-rulesdir": "^0.1.0",
+    "eslint-plugin-standard": "^3.0.1"
+  },
+  "peerDependencies": {
+    "eslint": ">=5"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5146,7 +5146,7 @@ babel-core@^6.0.0, babel-core@^6.26.0, babel-core@^6.7.2:
     slash "^1.0.0"
     source-map "^0.5.7"
 
-babel-eslint@9.0.0:
+babel-eslint@9.0.0, babel-eslint@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-9.0.0.tgz#7d9445f81ed9f60aff38115f838970df9f2b6220"
   dependencies:
@@ -9273,6 +9273,27 @@ escodegen@^1.11.1, escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-config-airbnb-base@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-12.1.0.tgz#386441e54a12ccd957b0a92564a4bafebd747944"
+  integrity sha512-/vjm0Px5ZCpmJqnjIzcFb9TKZrKWz0gnuG/7Gfkt0Db1ELJR51xkZth+t14rYdqWgX836XbuxtArbIHlVhbLBA==
+  dependencies:
+    eslint-restricted-globals "^0.1.1"
+
+eslint-config-airbnb@^16.1.0:
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb/-/eslint-config-airbnb-16.1.0.tgz#2546bfb02cc9fe92284bf1723ccf2e87bc45ca46"
+  integrity sha512-zLyOhVWhzB/jwbz7IPSbkUuj7X2ox4PHXTcZkEmDqTvd0baJmJyuxlFPDlZOE/Y5bC+HQRaEkT3FoHo9wIdRiw==
+  dependencies:
+    eslint-config-airbnb-base "^12.1.0"
+
+eslint-config-prettier@^2.9.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.10.0.tgz#ec07bc1d01f87d09f61d3840d112dc8a9791e30b"
+  integrity sha512-Mhl90VLucfBuhmcWBgbUNtgBiK955iCDK1+aHAz7QfDQF6wuzWZ6JjihZ3ejJoGlJWIuko7xLqNm8BA5uenKhA==
+  dependencies:
+    get-stdin "^5.0.1"
+
 eslint-config-react-app@^3.0.6:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-3.0.8.tgz#6f606828ba30bafee7d744c41cd07a3fea8f3035"
@@ -9285,6 +9306,23 @@ eslint-config-react-app@^5.2.1:
   integrity sha512-pGIZ8t0mFLcV+6ZirRgYK6RVqUIKRIi9MmgzUEmrIknsn3AdO0I32asO86dJgloHq+9ZPl8UIg8mYrvgP5u2wQ==
   dependencies:
     confusing-browser-globals "^1.0.9"
+
+eslint-config-standard-jsx@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-standard-jsx/-/eslint-config-standard-jsx-5.0.0.tgz#4abfac554f38668e0078c664569e7b2384e5d2aa"
+  integrity sha512-rLToPAEqLMPBfWnYTu6xRhm2OWziS2n40QFqJ8jAM8NSVzeVKTa3nclhsU4DpPJQRY60F34Oo1wi/71PN/eITg==
+
+eslint-config-standard-react@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-standard-react/-/eslint-config-standard-react-6.0.0.tgz#d366d6c3c092426fd3ae794a4ca0b3cb131f2964"
+  integrity sha512-YWlqfvREbH1r6SaRTgFOq+VE3f8/ZQypkfnpDpSmZjztEjxnzznm4xeE2/mDQRx77Okhd/pKHXNZLMsSneJH8A==
+  dependencies:
+    eslint-config-standard-jsx "^5.0.0"
+
+eslint-config-standard@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-11.0.0.tgz#87ee0d3c9d95382dc761958cbb23da9eea31e0ba"
+  integrity sha512-oDdENzpViEe5fwuRCWla7AXQd++/oyIp8zP+iP9jiUPG6NBj3SHgdgtl/kTn00AjeN+1HNvavTKmYbMo+xMOlw==
 
 eslint-import-resolver-node@^0.3.1, eslint-import-resolver-node@^0.3.2:
   version "0.3.2"
@@ -9362,7 +9400,7 @@ eslint-plugin-import@2.14.0:
     read-pkg-up "^2.0.0"
     resolve "^1.6.0"
 
-eslint-plugin-import@^2.20.2:
+eslint-plugin-import@^2.13.0, eslint-plugin-import@^2.20.2:
   version "2.20.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.20.2.tgz#91fc3807ce08be4837141272c8b99073906e588d"
   integrity sha512-FObidqpXrR8OnCh4iNsxy+WACztJLXAHBO5hK79T1Hc77PgQZkyDGA5Ag9xAvRpglvLNxhH/zSmZ70/pZ31dHg==
@@ -9379,6 +9417,11 @@ eslint-plugin-import@^2.20.2:
     object.values "^1.1.0"
     read-pkg-up "^2.0.0"
     resolve "^1.12.0"
+
+eslint-plugin-jest@^21.15.0:
+  version "21.27.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-21.27.2.tgz#2a795b7c3b5e707df48a953d651042bd01d7b0a8"
+  integrity sha512-0E4OIgBJVlAmf1KfYFtZ3gYxgUzC5Eb3Jzmrc9ikI1OY+/cM8Kh72Ti7KfpeHNeD3HJNf9SmEfmvQLIz44Hrhw==
 
 eslint-plugin-jsdoc@^21.0.0:
   version "21.0.0"
@@ -9405,7 +9448,7 @@ eslint-plugin-jsx-a11y@6.1.2:
     has "^1.0.3"
     jsx-ast-utils "^2.0.1"
 
-eslint-plugin-jsx-a11y@^6.2.3:
+eslint-plugin-jsx-a11y@^6.0.3, eslint-plugin-jsx-a11y@^6.2.3:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz#b872a09d5de51af70a97db1eea7dc933043708aa"
   dependencies:
@@ -9427,7 +9470,17 @@ eslint-plugin-markdown@^1.0.1:
     remark-parse "^5.0.0"
     unified "^6.1.2"
 
-eslint-plugin-prettier@^2.2.0:
+eslint-plugin-node@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz#bf19642298064379315d7a4b2a75937376fa05e4"
+  integrity sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==
+  dependencies:
+    ignore "^3.3.6"
+    minimatch "^3.0.4"
+    resolve "^1.3.3"
+    semver "^5.4.1"
+
+eslint-plugin-prettier@^2.2.0, eslint-plugin-prettier@^2.6.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.7.0.tgz#b4312dcf2c1d965379d7f9d5b5f8aaadc6a45904"
   dependencies:
@@ -9440,9 +9493,19 @@ eslint-plugin-prettier@^3.1.2:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-promise@^3.7.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.8.0.tgz#65ebf27a845e3c1e9d6f6a5622ddd3801694b621"
+  integrity sha512-JiFL9UFR15NKpHyGii1ZcvmtIqa3UTwiDAGb8atSffe43qJ3+1czVGN6UtkklpcJ2DVnqvTMzEKRaJdBkAL2aQ==
+
 eslint-plugin-react-hooks@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz#6210b6d5a37205f0b92858f895a4e827020a7d04"
+
+eslint-plugin-react-hooks@^2.5.0:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.5.1.tgz#4ef5930592588ce171abeb26f400c7fbcbc23cd0"
+  integrity sha512-Y2c4b55R+6ZzwtTppKwSmK/Kar8AdLiC2f9NADCuxbcTgPPg41Gyqa6b9GppgXSvCtkRw43ZE86CT5sejKC6/g==
 
 eslint-plugin-react@7.11.1:
   version "7.11.1"
@@ -9468,7 +9531,7 @@ eslint-plugin-react@^7.18.0:
     prop-types "^15.7.2"
     resolve "^1.14.2"
 
-eslint-plugin-react@^7.19.0:
+eslint-plugin-react@^7.19.0, eslint-plugin-react@^7.7.0:
   version "7.19.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.19.0.tgz#6d08f9673628aa69c5559d33489e855d83551666"
   integrity sha512-SPT8j72CGuAP+JFbT0sJHOB80TX/pu44gQ4vXH/cq+hQTiY2PuZ6IHkqXJV6x1b28GDdo1lbInjKUrrdUf0LOQ==
@@ -9485,6 +9548,21 @@ eslint-plugin-react@^7.19.0:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.2"
     xregexp "^4.3.0"
+
+eslint-plugin-rulesdir@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-rulesdir/-/eslint-plugin-rulesdir-0.1.0.tgz#ad144d7e98464fda82963eff3fab331aecb2bf08"
+  integrity sha1-rRRNfphGT9qClj7/P6szGuyyvwg=
+
+eslint-plugin-standard@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-3.1.0.tgz#2a9e21259ba4c47c02d53b2d0c9135d4b1022d47"
+  integrity sha512-fVcdyuKRr0EZ4fjWl3c+gp1BANFJD1+RaWa2UPYfMZ6jCtp5RG00kSaXnK/dE5sYzt4kaWJ9qdxqUfc0d9kX0w==
+
+eslint-restricted-globals@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz#35f0d5cbc64c2e3ed62e93b4b1a7af05ba7ed4d7"
+  integrity sha1-NfDVy8ZMLj7WLpO0saevBbp+1Nc=
 
 eslint-scope@3.7.1:
   version "3.7.1"
@@ -11275,6 +11353,11 @@ get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
 
+get-stdin@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
+  integrity sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=
+
 get-stream@3.0.0, get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
@@ -12406,7 +12489,7 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
-ignore@^3.3.5:
+ignore@^3.3.5, ignore@^3.3.6:
   version "3.3.10"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
 
@@ -20348,6 +20431,13 @@ resolve@^1.11.0, resolve@^1.15.1:
 resolve@^1.14.2:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.0.tgz#1b7ca96073ebb52e741ffd799f6b39ea462c67f5"
+  dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.3.3:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
+  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
   dependencies:
     path-parse "^1.0.6"
 


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4184

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: When importing from the token or icon ESM index files, CJS bundles will include the entirety of react-tokens or react-icons. This rule prevents that.