### PR TITLE
fix(build): lint for breaking changes off v4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,7 @@ workflows:
         - build_docs_pf4
     - deploy_prerelease:
         requires:
+        - lint_pf4
         - test_jest_pf4
         - test_integration
         - build_docs_pf4
@@ -221,7 +222,7 @@ jobs:
         name: Breaking Change Lint
         # https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
         command: |
-            if git log origin/master..HEAD --format="%b" | grep -i "breaking change";
+            if git log origin/${CIRCLE_BRANCH}..HEAD --format="%b" | grep -i "breaking change";
             then
                 echo "Breaking change above detected"
                 exit 1


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Fixed failing builds since #4190 was merged 2 hours ago: https://circleci.com/gh/patternfly/patternfly-react/34192 https://circleci.com/gh/patternfly/patternfly-react/34126 .

Require lint to pass before publishing to be extra safe in preventing accidental major version bumps in the future.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
