### PR TITLE
ChartDonut subTitleComponent is ignored in some cases

### DIFF
--- a/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -542,11 +542,7 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
   };
 
   // Returns subtitle
-  const getSubTitle = ({
-    textComponent = <ChartLabel/>
-  }: {
-    textComponent?: React.ReactElement<any>;
-  }) => {
+  const getSubTitle = ({ textComponent = <ChartLabel /> }: { textComponent?: React.ReactElement<any> }) => {
     if (!subTitle) {
       return null;
     }
@@ -578,7 +574,7 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
   // Returns title
   const getTitle = ({
     styles = ChartDonutStyles.label.title,
-    titles = title,
+    titles = title
   }: {
     styles?: any;
     titles?: string | string[];
@@ -589,7 +585,7 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
     const titleProps = titleComponent ? titleComponent.props : {};
 
     return React.cloneElement(titleComponent, {
-      ...Array.isArray(titles) && { capHeight }, // Use capHeight with multiple labels
+      ...(Array.isArray(titles) && { capHeight }), // Use capHeight with multiple labels
       key: 'pf-chart-donut-title',
       style: styles,
       text: titles,

--- a/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -19,6 +19,18 @@ import { ChartPie, ChartPieLegendPosition, ChartPieProps } from '../ChartPie';
 import { ChartCommonStyles, ChartDonutStyles, ChartThemeDefinition } from '../ChartTheme';
 import { getPieLabelX, getPieLabelY, getPaddingForSide } from '../ChartUtils';
 
+interface ChartDonutSubTitleInterface {
+  dy?: number;
+  textComponent: React.ReactElement<any>;
+}
+
+interface ChartDonutTitleInterface {
+  dy?: number;
+  styles?: any;
+  textComponent?: React.ReactElement<any>;
+  titles?: string | string[];
+}
+
 export enum ChartDonutLabelPosition {
   centroid = 'centroid',
   endAngle = 'endAngle',
@@ -524,10 +536,11 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
         padding: defaultPadding
       });
   const chartInnerRadius = innerRadius ? innerRadius : chartRadius - 9; // Todo: Add pf-core variable
+  const centerSubTitle = subTitle && subTitlePosition === ChartDonutSubTitlePosition.center;
 
   // Returns title and subtitle
   const getAllTitles = () => {
-    if (!subTitleComponent && subTitle && subTitlePosition === ChartDonutSubTitlePosition.center) {
+    if (!subTitleComponent && centerSubTitle) {
       return getTitle({
         styles: [ChartDonutStyles.label.title, ChartDonutStyles.label.subTitle],
         titles: [title, subTitle]
@@ -535,14 +548,14 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
     }
     return (
       <>
-        {getTitle({ titles: title })}
-        {getSubTitle(subTitleComponent)}
+        {getTitle({ titles: title, dy: centerSubTitle ? -8 : 0 })}
+        {getSubTitle({ textComponent: subTitleComponent, dy: centerSubTitle ? 15 : 0 })}
       </>
     );
   };
 
   // Returns subtitle
-  const getSubTitle = (textComponent: React.ReactElement<any> = <ChartLabel />) => {
+  const getSubTitle = ({ dy = 0, textComponent = <ChartLabel /> }: ChartDonutSubTitleInterface) => {
     if (!subTitle) {
       return null;
     }
@@ -562,6 +575,7 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
         width
       }),
       y: getPieLabelY({
+        dy,
         height,
         labelPosition: subTitlePosition,
         padding: defaultPadding,
@@ -572,13 +586,7 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
   };
 
   // Returns title
-  const getTitle = ({
-    styles = ChartDonutStyles.label.title,
-    titles = title
-  }: {
-    styles?: any;
-    titles?: string | string[];
-  }) => {
+  const getTitle = ({ dy = 0, styles = ChartDonutStyles.label.title, titles = title }: ChartDonutTitleInterface) => {
     if (!titles) {
       return null;
     }
@@ -599,6 +607,7 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
         width
       }),
       y: getPieLabelY({
+        dy,
         height,
         labelPosition: 'center',
         padding: defaultPadding,

--- a/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -497,7 +497,7 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
   radius,
   standalone = true,
   subTitle,
-  subTitleComponent, // = <ChartLabel />,
+  subTitleComponent,
   subTitlePosition = ChartDonutStyles.label.subTitlePosition as ChartDonutSubTitlePosition,
   themeColor,
   themeVariant,

--- a/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -536,7 +536,7 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
     return (
       <>
         {getTitle({ titles: title })}
-        {getSubTitle({ textComponent: subTitleComponent ? subTitleComponent : <ChartLabel/> })}
+        {getSubTitle({ textComponent: subTitleComponent ? subTitleComponent : <ChartLabel /> })}
       </>
     );
   };

--- a/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -536,13 +536,13 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
     return (
       <>
         {getTitle({ titles: title })}
-        {getSubTitle({ textComponent: subTitleComponent ? subTitleComponent : <ChartLabel /> })}
+        {getSubTitle(subTitleComponent)}
       </>
     );
   };
 
   // Returns subtitle
-  const getSubTitle = ({ textComponent = <ChartLabel /> }: { textComponent?: React.ReactElement<any> }) => {
+  const getSubTitle = (textComponent: React.ReactElement<any> = <ChartLabel />) => {
     if (!subTitle) {
       return null;
     }

--- a/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -21,13 +21,12 @@ import { getPieLabelX, getPieLabelY, getPaddingForSide } from '../ChartUtils';
 
 interface ChartDonutSubTitleInterface {
   dy?: number;
-  textComponent: React.ReactElement<any>;
+  textComponent?: React.ReactElement<any>;
 }
 
 interface ChartDonutTitleInterface {
   dy?: number;
   styles?: any;
-  textComponent?: React.ReactElement<any>;
   titles?: string | string[];
 }
 

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
@@ -394,6 +394,16 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
   /**
    * The label component to render the chart subTitle.
    *
+   * When overriding the subTitleComponent prop, title and subTitle will be centered independently. You may choose to
+   * use the x and y props of ChartLabel to adjust the center position. For example:
+   *
+   * <pre>
+   * subTitle="Pets"
+   * subTitleComponent={<ChartLabel y={130} />}
+   * title={100}
+   * titleComponent={<ChartLabel y={107} />}
+   * </pre>
+   *
    * Note: Default label properties may be applied
    */
   subTitleComponent?: React.ReactElement<any>;
@@ -429,6 +439,42 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    * The title for the donut chart label
    */
   title?: string;
+  /**
+   * The label component to render the donut chart title.
+   *
+   * When centering both title and subTitle props, it's possible to override both styles via an array provided to
+   * ChartLabel. The first item in the array is associated with title styles, while the second item in the array is
+   * associated with subtitle styles.
+   *
+   * <pre>
+   * subTitle="Pets"
+   * title={100}
+   * titleComponent={
+   *   <ChartLabel style={[{
+   *       fill: 'red', // title color
+   *       fontSize: 24
+   *     }, {
+   *       fill: 'blue', // subtitle color
+   *       fontSize: 14
+   *     }]}
+   *   />
+   * }
+   * </pre>
+   *
+   * In this case, both title and subTitle will be centered together. However, should you also override the
+   * subTitleComponent prop, title and subTitle will be centered independently. You may choose to
+   * use the x and y props of ChartLabel to adjust the center position. For example:
+   *
+   * <pre>
+   * subTitle="Pets"
+   * subTitleComponent={<ChartLabel y={130} />}
+   * title={100}
+   * titleComponent={<ChartLabel y={107} />}
+   * </pre>
+   *
+   * Note: Default label properties may be applied
+   */
+  titleComponent?: React.ReactElement<any>;
   /**
    * The dynamic portion of the chart will change colors when data reaches the given threshold. Colors may be
    * overridden, but defaults shall be provided.

--- a/packages/react-charts/src/components/ChartUtils/chart-origin.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-origin.ts
@@ -6,7 +6,7 @@ interface ChartPieOriginInterface {
   width: number; // Chart width
 }
 
-// Returns te origin for pie based charts. For example, something with a radius such as pie, donut, donut utilization,
+// Returns the origin for pie based charts. For example, something with a radius such as pie, donut, donut utilization,
 // and donut threshold.
 export const getPieOrigin = ({ height, padding, width }: ChartPieOriginInterface) => {
   const { top, bottom, left, right } = Helpers.getPadding({ padding });


### PR DESCRIPTION
Adding documentation to describe how to override `title` and `subTitle` styles via `titleComponent`. Also ensured that the `subTitleComponent` prop of `ChartDonut` is not ignored when `title` and `subTitle` are both used.

https://github.com/patternfly/patternfly-react/issues/4172