### PR TITLE
fix(select): revert to single "selections" prop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,7 @@ jobs:
         name: Breaking Change Lint
         # https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
         command: |
-            if git log origin/${CIRCLE_BRANCH}..HEAD --format="%b" | grep -i "breaking change";
+            if git log origin/v4..HEAD --format="%b" | grep -i "breaking change";
             then
                 echo "Breaking change above detected"
                 exit 1

--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -376,7 +376,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
     const { openedOnEnter, typeaheadInputValue, typeaheadActiveChild, typeaheadFilteredChildren } = this.state;
     const selectToggleId = toggleId || `pf-toggle-id-${currentId++}`;
     const selections = Array.isArray(selectionsProp) ? selectionsProp : [selectionsProp];
-    const hasAnySelections = selections && selections.length > 0 && selectionsProp !== '';
+    const hasAnySelections = Boolean(selections[0] && selections[0] !== '');
     let childPlaceholderText = null;
     if (!customContent) {
       if (!hasAnySelections && !placeholderText) {

--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -40,10 +40,8 @@ export interface SelectProps
   placeholderText?: string | React.ReactNode;
   /** Text to display in typeahead select when no results are found */
   noResultsFoundText?: string;
-  /** Selected item for single select variants. */
-  selection?: string | SelectOptionObject;
   /** Array of selected items for multi select variants. */
-  selections?: string[] | SelectOptionObject[];
+  selections?: string | SelectOptionObject | (string | SelectOptionObject)[];
   /** Flag indicating if selection badge should be hidden for checkbox variant,default false */
   isCheckboxSelectionBadgeHidden?: boolean;
   /** Id for select toggle element */
@@ -118,7 +116,6 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
     clearSelectionsAriaLabel: 'Clear all',
     toggleAriaLabel: 'Options menu',
     removeSelectionAriaLabel: 'Remove',
-    selection: '',
     selections: [],
     createText: 'Create',
     placeholderText: '',
@@ -157,9 +154,9 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
       });
     }
 
-    if (prevProps.selection !== this.props.selection && this.props.variant === SelectVariant.typeahead) {
+    if (prevProps.selections !== this.props.selections && this.props.variant === SelectVariant.typeahead) {
       this.setState({
-        typeaheadInputValue: this.props.selection.toString()
+        typeaheadInputValue: this.props.selections.toString()
       });
     }
   };
@@ -339,7 +336,6 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
   };
 
   render() {
-    /* eslint-disable @typescript-eslint/no-unused-vars */
     const {
       children,
       className,
@@ -357,8 +353,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
       isPlain,
       isDisabled,
       isCreatable,
-      selection,
-      selections,
+      selections: selectionsProp,
       typeAheadAriaLabel,
       clearSelectionsAriaLabel,
       toggleAriaLabel,
@@ -376,12 +371,14 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
       isCheckboxSelectionBadgeHidden,
       ...props
     } = this.props;
+    /* eslint-disable @typescript-eslint/no-unused-vars */
     /* eslint-enable @typescript-eslint/no-unused-vars */
+    const selections = !Array.isArray(selectionsProp) ? [selectionsProp] : selectionsProp;
     const { openedOnEnter, typeaheadInputValue, typeaheadActiveChild, typeaheadFilteredChildren } = this.state;
     const selectToggleId = toggleId || `pf-toggle-id-${currentId++}`;
     let childPlaceholderText = null;
     if (!customContent) {
-      if (!selection && !placeholderText) {
+      if (!selections && !placeholderText) {
         const childPlaceholder = React.Children.toArray(children).filter(
           (child: React.ReactNode) => (child as React.ReactElement).props.isPlaceholder === true
         );
@@ -392,7 +389,6 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
     }
 
     const hasOnClear = onClear !== Select.defaultProps.onClear;
-    const hasAnySelections = (selections && selections.length > 0) || (selection && selection !== '');
     const clearBtn = (
       <button
         className={css(buttonStyles.button, buttonStyles.modifiers.plain, styles.selectToggleClear)}
@@ -465,7 +461,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
       switch (variant) {
         case 'single':
           variantProps = {
-            selected: selection,
+            selected: selections[0],
             openedOnEnter
           };
           variantChildren = children;
@@ -480,7 +476,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
           break;
         case 'typeahead':
           variantProps = {
-            selected: selection,
+            selected: selections[0],
             openedOnEnter
           };
           variantChildren = this.extendTypeaheadChildren(typeaheadActiveChild);
@@ -534,10 +530,10 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
                 <div className={css(styles.selectToggleWrapper)}>
                   {toggleIcon && <span className={css(styles.selectToggleIcon)}>{toggleIcon}</span>}
                   <span className={css(styles.selectToggleText)}>
-                    {this.getDisplay(selection as string, 'node') || placeholderText || childPlaceholderText}
+                    {this.getDisplay(selections[0] as string, 'node') || placeholderText || childPlaceholderText}
                   </span>
                 </div>
-                {hasOnClear && hasAnySelections && clearBtn}
+                {hasOnClear && selections && clearBtn}
               </React.Fragment>
             )}
             {variant === SelectVariant.checkbox && !customContent && (
@@ -553,7 +549,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
                       </div>
                     )}
                 </div>
-                {hasOnClear && hasAnySelections && clearBtn}
+                {hasOnClear && selections && clearBtn}
               </React.Fragment>
             )}
             {variant === SelectVariant.typeahead && !customContent && (
@@ -569,7 +565,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
                     value={
                       typeaheadInputValue !== null
                         ? typeaheadInputValue
-                        : this.getDisplay(selection as string, 'text') || ''
+                        : this.getDisplay(selections[0] as string, 'text') || ''
                     }
                     type="text"
                     onClick={this.onClick}
@@ -579,7 +575,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
                     disabled={isDisabled}
                   />
                 </div>
-                {(selection || typeaheadInputValue) && clearBtn}
+                {(selections || typeaheadInputValue) && clearBtn}
               </React.Fragment>
             )}
             {variant === SelectVariant.typeaheadMulti && !customContent && (

--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -345,14 +345,11 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
       onToggle,
       onSelect,
       onClear,
-      onFilter,
-      onCreateOption,
       toggleId,
       isOpen,
       isGrouped,
       isPlain,
       isDisabled,
-      isCreatable,
       selections: selectionsProp,
       typeAheadAriaLabel,
       clearSelectionsAriaLabel,
@@ -365,17 +362,20 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
       maxHeight,
       toggleIcon,
       ouiaId,
-      createText,
-      noResultsFoundText,
       hasInlineFilter,
       isCheckboxSelectionBadgeHidden,
+      /* eslint-disable @typescript-eslint/no-unused-vars */
+      onFilter,
+      onCreateOption,
+      isCreatable,
+      createText,
+      noResultsFoundText,
+      /* eslint-enable @typescript-eslint/no-unused-vars */
       ...props
     } = this.props;
-    /* eslint-disable @typescript-eslint/no-unused-vars */
-    /* eslint-enable @typescript-eslint/no-unused-vars */
-    const selections = !Array.isArray(selectionsProp) ? [selectionsProp] : selectionsProp;
     const { openedOnEnter, typeaheadInputValue, typeaheadActiveChild, typeaheadFilteredChildren } = this.state;
     const selectToggleId = toggleId || `pf-toggle-id-${currentId++}`;
+    const selections = !Array.isArray(selectionsProp) ? [selectionsProp] : selectionsProp;
     let childPlaceholderText = null;
     if (!customContent) {
       if (!selections && !placeholderText) {
@@ -389,6 +389,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
     }
 
     const hasOnClear = onClear !== Select.defaultProps.onClear;
+    const hasAnySelections = selections && selections.length > 0;
     const clearBtn = (
       <button
         className={css(buttonStyles.button, buttonStyles.modifiers.plain, styles.selectToggleClear)}
@@ -533,7 +534,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
                     {this.getDisplay(selections[0] as string, 'node') || placeholderText || childPlaceholderText}
                   </span>
                 </div>
-                {hasOnClear && selections && clearBtn}
+                {hasOnClear && hasAnySelections && clearBtn}
               </React.Fragment>
             )}
             {variant === SelectVariant.checkbox && !customContent && (
@@ -549,7 +550,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
                       </div>
                     )}
                 </div>
-                {hasOnClear && selections && clearBtn}
+                {hasOnClear && hasAnySelections && clearBtn}
               </React.Fragment>
             )}
             {variant === SelectVariant.typeahead && !customContent && (

--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -156,7 +156,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
 
     if (prevProps.selections !== this.props.selections && this.props.variant === SelectVariant.typeahead) {
       this.setState({
-        typeaheadInputValue: this.props.selections.toString()
+        typeaheadInputValue: this.props.selections as string
       });
     }
   };
@@ -376,7 +376,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
     const { openedOnEnter, typeaheadInputValue, typeaheadActiveChild, typeaheadFilteredChildren } = this.state;
     const selectToggleId = toggleId || `pf-toggle-id-${currentId++}`;
     const selections = Array.isArray(selectionsProp) ? selectionsProp : [selectionsProp];
-    const hasAnySelections = selections && selections.length > 0;
+    const hasAnySelections = selections && selections.length > 0 && selectionsProp !== '';
     let childPlaceholderText = null;
     if (!customContent) {
       if (!hasAnySelections && !placeholderText) {

--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -375,10 +375,11 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
     } = this.props;
     const { openedOnEnter, typeaheadInputValue, typeaheadActiveChild, typeaheadFilteredChildren } = this.state;
     const selectToggleId = toggleId || `pf-toggle-id-${currentId++}`;
-    const selections = !Array.isArray(selectionsProp) ? [selectionsProp] : selectionsProp;
+    const selections = Array.isArray(selectionsProp) ? selectionsProp : [selectionsProp];
+    const hasAnySelections = selections && selections.length > 0;
     let childPlaceholderText = null;
     if (!customContent) {
-      if (!selections && !placeholderText) {
+      if (!hasAnySelections && !placeholderText) {
         const childPlaceholder = React.Children.toArray(children).filter(
           (child: React.ReactNode) => (child as React.ReactElement).props.isPlaceholder === true
         );
@@ -389,7 +390,6 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
     }
 
     const hasOnClear = onClear !== Select.defaultProps.onClear;
-    const hasAnySelections = selections && selections.length > 0;
     const clearBtn = (
       <button
         className={css(buttonStyles.button, buttonStyles.modifiers.plain, styles.selectToggleClear)}
@@ -576,7 +576,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
                     disabled={isDisabled}
                   />
                 </div>
-                {(selections || typeaheadInputValue) && clearBtn}
+                {(selections[0] || typeaheadInputValue) && clearBtn}
               </React.Fragment>
             )}
             {variant === SelectVariant.typeaheadMulti && !customContent && (

--- a/packages/react-core/src/components/Select/__tests__/Generated/__snapshots__/Select.test.tsx.snap
+++ b/packages/react-core/src/components/Select/__tests__/Generated/__snapshots__/Select.test.tsx.snap
@@ -50,20 +50,6 @@ exports[`Select should match snapshot (auto-generated) 1`] = `
           className="pf-c-select__toggle-text"
         />
       </div>
-      <button
-        aria-label="'Clear all'"
-        className="pf-c-button pf-m-plain pf-c-select__toggle-clear"
-        disabled={false}
-        onClick={[Function]}
-        type="button"
-      >
-        <TimesCircleIcon
-          aria-hidden={true}
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
-        />
-      </button>
     </SelectToggle>
   </ContextProvider>
 </div>

--- a/packages/react-core/src/components/Select/__tests__/Generated/__snapshots__/Select.test.tsx.snap
+++ b/packages/react-core/src/components/Select/__tests__/Generated/__snapshots__/Select.test.tsx.snap
@@ -50,6 +50,20 @@ exports[`Select should match snapshot (auto-generated) 1`] = `
           className="pf-c-select__toggle-text"
         />
       </div>
+      <button
+        aria-label="'Clear all'"
+        className="pf-c-button pf-m-plain pf-c-select__toggle-clear"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        <TimesCircleIcon
+          aria-hidden={true}
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
+        />
+      </button>
     </SelectToggle>
   </ContextProvider>
 </div>

--- a/packages/react-core/src/components/Select/__tests__/Select.test.tsx
+++ b/packages/react-core/src/components/Select/__tests__/Select.test.tsx
@@ -239,7 +239,7 @@ describe('typeahead select', () => {
 
   test('renders selected successfully', () => {
     const view = mount(
-      <Select variant={SelectVariant.typeahead} selection="Mr" onSelect={jest.fn()} onToggle={jest.fn()} isOpen>
+      <Select variant={SelectVariant.typeahead} selections="Mr" onSelect={jest.fn()} onToggle={jest.fn()} isOpen>
         {selectOptions}
       </Select>
     );

--- a/packages/react-core/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/packages/react-core/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
@@ -7391,8 +7391,7 @@ exports[`typeahead select renders selected successfully 1`] = `
   onToggle={[MockFunction]}
   placeholderText=""
   removeSelectionAriaLabel="Remove"
-  selection="Mr"
-  selections={Array []}
+  selections="Mr"
   toggleAriaLabel="Options menu"
   toggleIcon={null}
   toggleId={null}
@@ -7446,9 +7445,29 @@ exports[`typeahead select renders selected successfully 1`] = `
                   id="pf-toggle-id-8-select-typeahead"
                   placeholder=""
                   type="text"
-                  value=""
+                  value="Mr"
                 />
               </div>
+              <button
+                aria-label="Clear all"
+                class="pf-c-button pf-m-plain pf-c-select__toggle-clear"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+                    transform=""
+                  />
+                </svg>
+              </button>
               <button
                 aria-expanded="true"
                 aria-haspopup="listbox"
@@ -7478,18 +7497,36 @@ exports[`typeahead select renders selected successfully 1`] = `
             <ul
               class="pf-c-select__menu"
               role="listbox"
-              selection="Mr"
             >
               <li
                 role="presentation"
               >
                 <button
-                  class="pf-c-select__menu-item"
+                  aria-selected="true"
+                  class="pf-c-select__menu-item pf-m-selected"
                   id="Mr-0"
                   role="option"
                   type="button"
                 >
                   Mr
+                  <span
+                    class="pf-c-select__menu-item-icon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 512 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
+                        transform=""
+                      />
+                    </svg>
+                  </span>
                 </button>
               </li>
               <li
@@ -7555,9 +7592,43 @@ exports[`typeahead select renders selected successfully 1`] = `
             onFocus={[Function]}
             placeholder=""
             type="text"
-            value=""
+            value="Mr"
           />
         </div>
+        <button
+          aria-label="Clear all"
+          className="pf-c-button pf-m-plain pf-c-select__toggle-clear"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          <TimesCircleIcon
+            aria-hidden={true}
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
+          >
+            <svg
+              aria-hidden={true}
+              aria-labelledby={null}
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+                transform=""
+              />
+            </svg>
+          </TimesCircleIcon>
+        </button>
         <button
           aria-expanded={true}
           aria-haspopup="listbox"
@@ -7610,14 +7681,12 @@ exports[`typeahead select renders selected successfully 1`] = `
       keyHandler={[Function]}
       maxHeight=""
       openedOnEnter={false}
-      selected=""
-      selection="Mr"
+      selected="Mr"
       sendRef={[Function]}
     >
       <ul
         className="pf-c-select__menu"
         role="listbox"
-        selection="Mr"
       >
         <SelectOption
           className=""
@@ -7629,7 +7698,7 @@ exports[`typeahead select renders selected successfully 1`] = `
           isFocused={null}
           isNoResultsOption={false}
           isPlaceholder={false}
-          isSelected={false}
+          isSelected={true}
           key=".$.$00"
           keyHandler={[Function]}
           onClick={[Function]}
@@ -7640,8 +7709,8 @@ exports[`typeahead select renders selected successfully 1`] = `
             role="presentation"
           >
             <button
-              aria-selected={null}
-              className="pf-c-select__menu-item"
+              aria-selected={true}
+              className="pf-c-select__menu-item pf-m-selected"
               id="Mr-0"
               isFocused={null}
               onClick={[Function]}
@@ -7650,6 +7719,36 @@ exports[`typeahead select renders selected successfully 1`] = `
               type="button"
             >
               Mr
+              <span
+                className="pf-c-select__menu-item-icon"
+              >
+                <CheckIcon
+                  aria-hidden={true}
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
+                >
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
+                      transform=""
+                    />
+                  </svg>
+                </CheckIcon>
+              </span>
             </button>
           </li>
         </SelectOption>

--- a/packages/react-core/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/packages/react-core/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
@@ -23,7 +23,6 @@ exports[`checkbox select renders checkbox select groups successfully 1`] = `
   onToggle={[MockFunction]}
   placeholderText=""
   removeSelectionAriaLabel="Remove"
-  selection=""
   selections={Array []}
   toggleAriaLabel="Options menu"
   toggleIcon={null}
@@ -688,7 +687,6 @@ exports[`checkbox select renders checkbox select selections properly 1`] = `
   onToggle={[MockFunction]}
   placeholderText=""
   removeSelectionAriaLabel="Remove"
-  selection=""
   selections={
     Array [
       <SelectOption
@@ -880,7 +878,6 @@ exports[`checkbox select renders checkbox select selections properly when isChec
   onToggle={[MockFunction]}
   placeholderText=""
   removeSelectionAriaLabel="Remove"
-  selection=""
   selections={
     Array [
       <SelectOption
@@ -1054,7 +1051,6 @@ exports[`checkbox select renders closed successfully 1`] = `
   onToggle={[MockFunction]}
   placeholderText=""
   removeSelectionAriaLabel="Remove"
-  selection=""
   selections={Array []}
   toggleAriaLabel="Options menu"
   toggleIcon={null}
@@ -1211,7 +1207,6 @@ exports[`checkbox select renders expanded successfully 1`] = `
   onToggle={[MockFunction]}
   placeholderText=""
   removeSelectionAriaLabel="Remove"
-  selection=""
   selections={Array []}
   toggleAriaLabel="Options menu"
   toggleIcon={null}
@@ -1609,7 +1604,6 @@ exports[`checkbox select renders expanded successfully with custom objects 1`] =
   onToggle={[MockFunction]}
   placeholderText=""
   removeSelectionAriaLabel="Remove"
-  selection=""
   selections={Array []}
   toggleAriaLabel="Options menu"
   toggleIcon={null}
@@ -1983,7 +1977,6 @@ exports[`checkbox select renders expanded with filtering successfully 1`] = `
   onToggle={[MockFunction]}
   placeholderText=""
   removeSelectionAriaLabel="Remove"
-  selection=""
   selections={Array []}
   toggleAriaLabel="Options menu"
   toggleIcon={null}
@@ -2035,7 +2028,6 @@ exports[`checkbox select renders expanded with filtering successfully 1`] = `
                   class="pf-c-select__toggle-text"
                 />
               </div>
-              
               <button
                 aria-expanded="true"
                 aria-label="Options menu"
@@ -2421,7 +2413,6 @@ exports[`checkbox select renders expanded with filtering successfully 2`] = `
   onToggle={[MockFunction]}
   placeholderText=""
   removeSelectionAriaLabel="Remove"
-  selection=""
   selections={Array []}
   toggleAriaLabel="Options menu"
   toggleIcon={null}
@@ -2473,7 +2464,6 @@ exports[`checkbox select renders expanded with filtering successfully 2`] = `
                   class="pf-c-select__toggle-text"
                 />
               </div>
-              
               <button
                 aria-expanded="false"
                 aria-label="Options menu"
@@ -2585,7 +2575,6 @@ exports[`select custom select filter filters properly 1`] = `
   onToggle={[MockFunction]}
   placeholderText=""
   removeSelectionAriaLabel="Remove"
-  selection=""
   selections={Array []}
   toggleAriaLabel="Options menu"
   toggleIcon={null}
@@ -2983,7 +2972,6 @@ exports[`select renders select groups successfully 1`] = `
   onToggle={[MockFunction]}
   placeholderText=""
   removeSelectionAriaLabel="Remove"
-  selection=""
   selections={Array []}
   toggleAriaLabel="Options menu"
   toggleIcon={null}
@@ -3572,7 +3560,6 @@ exports[`select renders up direction successfully 1`] = `
   onToggle={[MockFunction]}
   placeholderText=""
   removeSelectionAriaLabel="Remove"
-  selection=""
   selections={Array []}
   toggleAriaLabel="Options menu"
   toggleIcon={null}
@@ -3627,9 +3614,7 @@ exports[`select renders up direction successfully 1`] = `
               >
                 <span
                   class="pf-c-select__toggle-text"
-                >
-                  Mr
-                </span>
+                />
               </div>
               <span
                 class="pf-c-select__toggle-arrow"
@@ -3672,9 +3657,7 @@ exports[`select renders up direction successfully 1`] = `
         >
           <span
             className="pf-c-select__toggle-text"
-          >
-            Mr
-          </span>
+          />
         </div>
         <span
           className="pf-c-select__toggle-arrow"
@@ -3734,7 +3717,6 @@ exports[`select single select renders closed successfully 1`] = `
   onToggle={[MockFunction]}
   placeholderText=""
   removeSelectionAriaLabel="Remove"
-  selection=""
   selections={Array []}
   toggleAriaLabel="Options menu"
   toggleIcon={null}
@@ -3789,9 +3771,7 @@ exports[`select single select renders closed successfully 1`] = `
               >
                 <span
                   class="pf-c-select__toggle-text"
-                >
-                  Mr
-                </span>
+                />
               </div>
               <span
                 class="pf-c-select__toggle-arrow"
@@ -3834,9 +3814,7 @@ exports[`select single select renders closed successfully 1`] = `
         >
           <span
             className="pf-c-select__toggle-text"
-          >
-            Mr
-          </span>
+          />
         </div>
         <span
           className="pf-c-select__toggle-arrow"
@@ -3896,7 +3874,6 @@ exports[`select single select renders disabled successfully 1`] = `
   onToggle={[MockFunction]}
   placeholderText=""
   removeSelectionAriaLabel="Remove"
-  selection=""
   selections={Array []}
   toggleAriaLabel="Options menu"
   toggleIcon={null}
@@ -3952,9 +3929,7 @@ exports[`select single select renders disabled successfully 1`] = `
               >
                 <span
                   class="pf-c-select__toggle-text"
-                >
-                  Mr
-                </span>
+                />
               </div>
               <span
                 class="pf-c-select__toggle-arrow"
@@ -3997,9 +3972,7 @@ exports[`select single select renders disabled successfully 1`] = `
         >
           <span
             className="pf-c-select__toggle-text"
-          >
-            Mr
-          </span>
+          />
         </div>
         <span
           className="pf-c-select__toggle-arrow"
@@ -4059,7 +4032,6 @@ exports[`select single select renders expanded successfully 1`] = `
   onToggle={[MockFunction]}
   placeholderText=""
   removeSelectionAriaLabel="Remove"
-  selection=""
   selections={Array []}
   toggleAriaLabel="Options menu"
   toggleIcon={null}
@@ -4114,9 +4086,7 @@ exports[`select single select renders expanded successfully 1`] = `
               >
                 <span
                   class="pf-c-select__toggle-text"
-                >
-                  Mr
-                </span>
+                />
               </div>
               <span
                 class="pf-c-select__toggle-arrow"
@@ -4212,9 +4182,7 @@ exports[`select single select renders expanded successfully 1`] = `
         >
           <span
             className="pf-c-select__toggle-text"
-          >
-            Mr
-          </span>
+          />
         </div>
         <span
           className="pf-c-select__toggle-arrow"
@@ -4422,7 +4390,6 @@ exports[`select single select renders expanded successfully with custom objects 
   onToggle={[MockFunction]}
   placeholderText=""
   removeSelectionAriaLabel="Remove"
-  selection=""
   selections={Array []}
   toggleAriaLabel="Options menu"
   toggleIcon={null}
@@ -4477,9 +4444,7 @@ exports[`select single select renders expanded successfully with custom objects 
               >
                 <span
                   class="pf-c-select__toggle-text"
-                >
-                  Mr: User One
-                </span>
+                />
               </div>
               <span
                 class="pf-c-select__toggle-arrow"
@@ -4563,9 +4528,7 @@ exports[`select single select renders expanded successfully with custom objects 
         >
           <span
             className="pf-c-select__toggle-text"
-          >
-            Mr: User One
-          </span>
+          />
         </div>
         <span
           className="pf-c-select__toggle-arrow"
@@ -4764,7 +4727,6 @@ exports[`select with custom content renders closed successfully 1`] = `
   onToggle={[MockFunction]}
   placeholderText=""
   removeSelectionAriaLabel="Remove"
-  selection=""
   selections={Array []}
   toggleAriaLabel="Options menu"
   toggleIcon={null}
@@ -4921,7 +4883,6 @@ exports[`select with custom content renders expanded successfully 1`] = `
   onToggle={[MockFunction]}
   placeholderText=""
   removeSelectionAriaLabel="Remove"
-  selection=""
   selections={Array []}
   toggleAriaLabel="Options menu"
   toggleIcon={null}
@@ -5144,7 +5105,6 @@ exports[`typeahead multi select renders closed successfully 1`] = `
   onToggle={[MockFunction]}
   placeholderText=""
   removeSelectionAriaLabel="Remove"
-  selection=""
   selections={Array []}
   toggleAriaLabel="Options menu"
   toggleIcon={null}
@@ -5325,7 +5285,6 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
   onToggle={[MockFunction]}
   placeholderText=""
   removeSelectionAriaLabel="Remove"
-  selection=""
   selections={Array []}
   toggleAriaLabel="Options menu"
   toggleIcon={null}
@@ -5715,7 +5674,6 @@ exports[`typeahead multi select renders selected successfully 1`] = `
   onToggle={[MockFunction]}
   placeholderText=""
   removeSelectionAriaLabel="Remove"
-  selection=""
   selections={
     Array [
       "Mr",
@@ -6539,7 +6497,6 @@ exports[`typeahead multi select test onChange 1`] = `
   onToggle={[MockFunction]}
   placeholderText=""
   removeSelectionAriaLabel="Remove"
-  selection=""
   selections={Array []}
   toggleAriaLabel="Options menu"
   toggleIcon={null}
@@ -6845,7 +6802,6 @@ exports[`typeahead select renders closed successfully 1`] = `
   onToggle={[MockFunction]}
   placeholderText=""
   removeSelectionAriaLabel="Remove"
-  selection=""
   selections={Array []}
   toggleAriaLabel="Options menu"
   toggleIcon={null}
@@ -6904,6 +6860,26 @@ exports[`typeahead select renders closed successfully 1`] = `
                 />
               </div>
               <button
+                aria-label="Clear all"
+                class="pf-c-button pf-m-plain pf-c-select__toggle-clear"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+                    transform=""
+                  />
+                </svg>
+              </button>
+              <button
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
@@ -6958,6 +6934,40 @@ exports[`typeahead select renders closed successfully 1`] = `
             value=""
           />
         </div>
+        <button
+          aria-label="Clear all"
+          className="pf-c-button pf-m-plain pf-c-select__toggle-clear"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          <TimesCircleIcon
+            aria-hidden={true}
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
+          >
+            <svg
+              aria-hidden={true}
+              aria-labelledby={null}
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+                transform=""
+              />
+            </svg>
+          </TimesCircleIcon>
+        </button>
         <button
           aria-expanded={false}
           aria-haspopup="listbox"
@@ -7026,7 +7036,6 @@ exports[`typeahead select renders expanded successfully 1`] = `
   onToggle={[MockFunction]}
   placeholderText=""
   removeSelectionAriaLabel="Remove"
-  selection=""
   selections={Array []}
   toggleAriaLabel="Options menu"
   toggleIcon={null}
@@ -7084,6 +7093,26 @@ exports[`typeahead select renders expanded successfully 1`] = `
                   value=""
                 />
               </div>
+              <button
+                aria-label="Clear all"
+                class="pf-c-button pf-m-plain pf-c-select__toggle-clear"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+                    transform=""
+                  />
+                </svg>
+              </button>
               <button
                 aria-expanded="true"
                 aria-haspopup="listbox"
@@ -7192,6 +7221,40 @@ exports[`typeahead select renders expanded successfully 1`] = `
             value=""
           />
         </div>
+        <button
+          aria-label="Clear all"
+          className="pf-c-button pf-m-plain pf-c-select__toggle-clear"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          <TimesCircleIcon
+            aria-hidden={true}
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
+          >
+            <svg
+              aria-hidden={true}
+              aria-labelledby={null}
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+                transform=""
+              />
+            </svg>
+          </TimesCircleIcon>
+        </button>
         <button
           aria-expanded={true}
           aria-haspopup="listbox"
@@ -7471,7 +7534,7 @@ exports[`typeahead select renders selected successfully 1`] = `
                   id="pf-toggle-id-8-select-typeahead"
                   placeholder=""
                   type="text"
-                  value="Mr"
+                  value=""
                 />
               </div>
               <button
@@ -7523,36 +7586,18 @@ exports[`typeahead select renders selected successfully 1`] = `
             <ul
               class="pf-c-select__menu"
               role="listbox"
+              selection="Mr"
             >
               <li
                 role="presentation"
               >
                 <button
-                  aria-selected="true"
-                  class="pf-c-select__menu-item pf-m-selected"
+                  class="pf-c-select__menu-item"
                   id="Mr-0"
                   role="option"
                   type="button"
                 >
                   Mr
-                  <span
-                    class="pf-c-select__menu-item-icon"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      fill="currentColor"
-                      height="1em"
-                      role="img"
-                      style="vertical-align: -0.125em;"
-                      viewBox="0 0 512 512"
-                      width="1em"
-                    >
-                      <path
-                        d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
-                        transform=""
-                      />
-                    </svg>
-                  </span>
                 </button>
               </li>
               <li
@@ -7618,7 +7663,7 @@ exports[`typeahead select renders selected successfully 1`] = `
             onFocus={[Function]}
             placeholder=""
             type="text"
-            value="Mr"
+            value=""
           />
         </div>
         <button
@@ -7707,12 +7752,14 @@ exports[`typeahead select renders selected successfully 1`] = `
       keyHandler={[Function]}
       maxHeight=""
       openedOnEnter={false}
-      selected="Mr"
+      selected=""
+      selection="Mr"
       sendRef={[Function]}
     >
       <ul
         className="pf-c-select__menu"
         role="listbox"
+        selection="Mr"
       >
         <SelectOption
           className=""
@@ -7724,7 +7771,7 @@ exports[`typeahead select renders selected successfully 1`] = `
           isFocused={null}
           isNoResultsOption={false}
           isPlaceholder={false}
-          isSelected={true}
+          isSelected={false}
           key=".$.$00"
           keyHandler={[Function]}
           onClick={[Function]}
@@ -7735,8 +7782,8 @@ exports[`typeahead select renders selected successfully 1`] = `
             role="presentation"
           >
             <button
-              aria-selected={true}
-              className="pf-c-select__menu-item pf-m-selected"
+              aria-selected={null}
+              className="pf-c-select__menu-item"
               id="Mr-0"
               isFocused={null}
               onClick={[Function]}
@@ -7745,36 +7792,6 @@ exports[`typeahead select renders selected successfully 1`] = `
               type="button"
             >
               Mr
-              <span
-                className="pf-c-select__menu-item-icon"
-              >
-                <CheckIcon
-                  aria-hidden={true}
-                  color="currentColor"
-                  noVerticalAlign={false}
-                  size="sm"
-                >
-                  <svg
-                    aria-hidden={true}
-                    aria-labelledby={null}
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style={
-                      Object {
-                        "verticalAlign": "-0.125em",
-                      }
-                    }
-                    viewBox="0 0 512 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
-                      transform=""
-                    />
-                  </svg>
-                </CheckIcon>
-              </span>
             </button>
           </li>
         </SelectOption>
@@ -7908,7 +7925,6 @@ exports[`typeahead select test creatable option 1`] = `
   onToggle={[MockFunction]}
   placeholderText=""
   removeSelectionAriaLabel="Remove"
-  selection=""
   selections={Array []}
   toggleAriaLabel="Options menu"
   toggleIcon={null}
@@ -8220,7 +8236,6 @@ exports[`typeahead select test onChange 1`] = `
   onToggle={[MockFunction]}
   placeholderText=""
   removeSelectionAriaLabel="Remove"
-  selection=""
   selections={Array []}
   toggleAriaLabel="Options menu"
   toggleIcon={null}

--- a/packages/react-core/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/packages/react-core/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
@@ -3614,7 +3614,9 @@ exports[`select renders up direction successfully 1`] = `
               >
                 <span
                   class="pf-c-select__toggle-text"
-                />
+                >
+                  Mr
+                </span>
               </div>
               <span
                 class="pf-c-select__toggle-arrow"
@@ -3657,7 +3659,9 @@ exports[`select renders up direction successfully 1`] = `
         >
           <span
             className="pf-c-select__toggle-text"
-          />
+          >
+            Mr
+          </span>
         </div>
         <span
           className="pf-c-select__toggle-arrow"
@@ -3771,7 +3775,9 @@ exports[`select single select renders closed successfully 1`] = `
               >
                 <span
                   class="pf-c-select__toggle-text"
-                />
+                >
+                  Mr
+                </span>
               </div>
               <span
                 class="pf-c-select__toggle-arrow"
@@ -3814,7 +3820,9 @@ exports[`select single select renders closed successfully 1`] = `
         >
           <span
             className="pf-c-select__toggle-text"
-          />
+          >
+            Mr
+          </span>
         </div>
         <span
           className="pf-c-select__toggle-arrow"
@@ -3929,7 +3937,9 @@ exports[`select single select renders disabled successfully 1`] = `
               >
                 <span
                   class="pf-c-select__toggle-text"
-                />
+                >
+                  Mr
+                </span>
               </div>
               <span
                 class="pf-c-select__toggle-arrow"
@@ -3972,7 +3982,9 @@ exports[`select single select renders disabled successfully 1`] = `
         >
           <span
             className="pf-c-select__toggle-text"
-          />
+          >
+            Mr
+          </span>
         </div>
         <span
           className="pf-c-select__toggle-arrow"
@@ -4086,7 +4098,9 @@ exports[`select single select renders expanded successfully 1`] = `
               >
                 <span
                   class="pf-c-select__toggle-text"
-                />
+                >
+                  Mr
+                </span>
               </div>
               <span
                 class="pf-c-select__toggle-arrow"
@@ -4182,7 +4196,9 @@ exports[`select single select renders expanded successfully 1`] = `
         >
           <span
             className="pf-c-select__toggle-text"
-          />
+          >
+            Mr
+          </span>
         </div>
         <span
           className="pf-c-select__toggle-arrow"
@@ -4444,7 +4460,9 @@ exports[`select single select renders expanded successfully with custom objects 
               >
                 <span
                   class="pf-c-select__toggle-text"
-                />
+                >
+                  Mr: User One
+                </span>
               </div>
               <span
                 class="pf-c-select__toggle-arrow"
@@ -4528,7 +4546,9 @@ exports[`select single select renders expanded successfully with custom objects 
         >
           <span
             className="pf-c-select__toggle-text"
-          />
+          >
+            Mr: User One
+          </span>
         </div>
         <span
           className="pf-c-select__toggle-arrow"
@@ -6860,26 +6880,6 @@ exports[`typeahead select renders closed successfully 1`] = `
                 />
               </div>
               <button
-                aria-label="Clear all"
-                class="pf-c-button pf-m-plain pf-c-select__toggle-clear"
-                type="button"
-              >
-                <svg
-                  aria-hidden="true"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 512 512"
-                  width="1em"
-                >
-                  <path
-                    d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
-                    transform=""
-                  />
-                </svg>
-              </button>
-              <button
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
@@ -6934,40 +6934,6 @@ exports[`typeahead select renders closed successfully 1`] = `
             value=""
           />
         </div>
-        <button
-          aria-label="Clear all"
-          className="pf-c-button pf-m-plain pf-c-select__toggle-clear"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-        >
-          <TimesCircleIcon
-            aria-hidden={true}
-            color="currentColor"
-            noVerticalAlign={false}
-            size="sm"
-          >
-            <svg
-              aria-hidden={true}
-              aria-labelledby={null}
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style={
-                Object {
-                  "verticalAlign": "-0.125em",
-                }
-              }
-              viewBox="0 0 512 512"
-              width="1em"
-            >
-              <path
-                d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
-                transform=""
-              />
-            </svg>
-          </TimesCircleIcon>
-        </button>
         <button
           aria-expanded={false}
           aria-haspopup="listbox"
@@ -7094,26 +7060,6 @@ exports[`typeahead select renders expanded successfully 1`] = `
                 />
               </div>
               <button
-                aria-label="Clear all"
-                class="pf-c-button pf-m-plain pf-c-select__toggle-clear"
-                type="button"
-              >
-                <svg
-                  aria-hidden="true"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 512 512"
-                  width="1em"
-                >
-                  <path
-                    d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
-                    transform=""
-                  />
-                </svg>
-              </button>
-              <button
                 aria-expanded="true"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
@@ -7221,40 +7167,6 @@ exports[`typeahead select renders expanded successfully 1`] = `
             value=""
           />
         </div>
-        <button
-          aria-label="Clear all"
-          className="pf-c-button pf-m-plain pf-c-select__toggle-clear"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-        >
-          <TimesCircleIcon
-            aria-hidden={true}
-            color="currentColor"
-            noVerticalAlign={false}
-            size="sm"
-          >
-            <svg
-              aria-hidden={true}
-              aria-labelledby={null}
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style={
-                Object {
-                  "verticalAlign": "-0.125em",
-                }
-              }
-              viewBox="0 0 512 512"
-              width="1em"
-            >
-              <path
-                d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
-                transform=""
-              />
-            </svg>
-          </TimesCircleIcon>
-        </button>
         <button
           aria-expanded={true}
           aria-haspopup="listbox"
@@ -7538,26 +7450,6 @@ exports[`typeahead select renders selected successfully 1`] = `
                 />
               </div>
               <button
-                aria-label="Clear all"
-                class="pf-c-button pf-m-plain pf-c-select__toggle-clear"
-                type="button"
-              >
-                <svg
-                  aria-hidden="true"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 512 512"
-                  width="1em"
-                >
-                  <path
-                    d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
-                    transform=""
-                  />
-                </svg>
-              </button>
-              <button
                 aria-expanded="true"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
@@ -7666,40 +7558,6 @@ exports[`typeahead select renders selected successfully 1`] = `
             value=""
           />
         </div>
-        <button
-          aria-label="Clear all"
-          className="pf-c-button pf-m-plain pf-c-select__toggle-clear"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-        >
-          <TimesCircleIcon
-            aria-hidden={true}
-            color="currentColor"
-            noVerticalAlign={false}
-            size="sm"
-          >
-            <svg
-              aria-hidden={true}
-              aria-labelledby={null}
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style={
-                Object {
-                  "verticalAlign": "-0.125em",
-                }
-              }
-              viewBox="0 0 512 512"
-              width="1em"
-            >
-              <path
-                d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
-                transform=""
-              />
-            </svg>
-          </TimesCircleIcon>
-        </button>
         <button
           aria-expanded={true}
           aria-haspopup="listbox"

--- a/packages/react-core/src/components/Select/examples/Select.md
+++ b/packages/react-core/src/components/Select/examples/Select.md
@@ -152,20 +152,20 @@ class GroupedSingleSelectInput extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      isExpanded: false,
+      isOpen: false,
       selected: null
     };
 
-    this.onToggle = isExpanded => {
+    this.onToggle = isOpen => {
       this.setState({
-        isExpanded
+        isOpen
       });
     };
 
     this.onSelect = (event, selection) => {
       this.setState({
         selected: selection,
-        isExpanded: false
+        isOpen: false
       })
     };
 
@@ -192,7 +192,7 @@ class GroupedSingleSelectInput extends React.Component {
   }
 
   render() {
-    const { isExpanded, selected } = this.state;
+    const { isOpen, selected } = this.state;
     const titleId = 'grouped-single-select-id';
     return (
       <div>
@@ -204,7 +204,7 @@ class GroupedSingleSelectInput extends React.Component {
           onToggle={this.onToggle}
           onSelect={this.onSelect}
           selections={selected}
-          isExpanded={isExpanded}
+          isOpen={isOpen}
           placeholderText="Filter by status/vendor"
           ariaLabelledBy={titleId}
           isGrouped
@@ -301,13 +301,13 @@ class CheckboxSelectInputNoBadge extends React.Component {
     super(props);
 
     this.state = {
-      isExpanded: false,
+      isOpen: false,
       selected: []
     };
 
-    this.onToggle = isExpanded => {
+    this.onToggle = isOpen => {
       this.setState({
-        isExpanded
+        isOpen
       });
     };
 
@@ -341,7 +341,7 @@ class CheckboxSelectInputNoBadge extends React.Component {
   }
 
   render() {
-    const { isExpanded, selected } = this.state;
+    const { isOpen, selected } = this.state;
     const titleId = 'checkbox-select-id';
     return (
       <div>
@@ -355,7 +355,7 @@ class CheckboxSelectInputNoBadge extends React.Component {
           onSelect={this.onSelect}
           selections={selected}
           isCheckboxSelectionBadgeHidden
-          isExpanded={isExpanded}
+          isOpen={isOpen}
           placeholderText="Filter by status"
           ariaLabelledBy={titleId}
         >
@@ -376,13 +376,13 @@ class CheckboxSelectInputNoBadge extends React.Component {
     super(props);
 
     this.state = {
-      isExpanded: false,
+      isOpen: false,
       selected: []
     };
 
-    this.onToggle = isExpanded => {
+    this.onToggle = isOpen => {
       this.setState({
-        isExpanded
+        isOpen
       });
     };
 
@@ -416,7 +416,7 @@ class CheckboxSelectInputNoBadge extends React.Component {
   }
 
   render() {
-    const { isExpanded, selected } = this.state;
+    const { isOpen, selected } = this.state;
     const titleId = 'checkbox-select-id';
     return (
       <div>
@@ -430,7 +430,7 @@ class CheckboxSelectInputNoBadge extends React.Component {
           onSelect={this.onSelect}
           selections={selected}
           isCheckboxSelectionBadgeHidden
-          isExpanded={isExpanded}
+          isOpen={isOpen}
           placeholderText="Filter by status"
           ariaLabelledBy={titleId}
         >
@@ -451,13 +451,13 @@ class CheckboxSelectInputNoBadge extends React.Component {
     super(props);
 
     this.state = {
-      isExpanded: false,
+      isOpen: false,
       selected: []
     };
 
-    this.onToggle = isExpanded => {
+    this.onToggle = isOpen => {
       this.setState({
-        isExpanded
+        isOpen
       });
     };
 
@@ -491,7 +491,7 @@ class CheckboxSelectInputNoBadge extends React.Component {
   }
 
   render() {
-    const { isExpanded, selected } = this.state;
+    const { isOpen, selected } = this.state;
     const titleId = 'checkbox-select-id';
     return (
       <div>
@@ -505,7 +505,7 @@ class CheckboxSelectInputNoBadge extends React.Component {
           onSelect={this.onSelect}
           selections={selected}
           isCheckboxSelectionBadgeHidden
-          isExpanded={isExpanded}
+          isOpen={isOpen}
           placeholderText="Filter by status"
           ariaLabelledBy={titleId}
         >
@@ -711,7 +711,7 @@ class FilteringCheckboxSelectInput extends React.Component {
     super(props);
 
     this.state = {
-      isExpanded: false,
+      isOpen: false,
       selected: []
     };
 
@@ -730,9 +730,9 @@ class FilteringCheckboxSelectInput extends React.Component {
       </SelectGroup>
     ];
 
-    this.onToggle = isExpanded => {
+    this.onToggle = isOpen => {
       this.setState({
-        isExpanded
+        isOpen
       });
     };
 
@@ -778,7 +778,7 @@ class FilteringCheckboxSelectInput extends React.Component {
   }
 
   render() {
-    const { isExpanded, selected, filteredOptions } = this.state;
+    const { isOpen, selected, filteredOptions } = this.state;
     const titleId = 'checkbox-filtering-select-id';
     return (
       <div>
@@ -790,7 +790,7 @@ class FilteringCheckboxSelectInput extends React.Component {
           onToggle={this.onToggle}
           onSelect={this.onSelect}
           selections={selected}
-          isExpanded={isExpanded}
+          isOpen={isOpen}
           placeholderText="Filter by status"
           ariaLabelledBy={titleId}
           onFilter={this.onFilter}
@@ -815,7 +815,7 @@ class FilteringCheckboxSelectInput extends React.Component {
     super(props);
 
     this.state = {
-      isExpanded: false,
+      isOpen: false,
       selected: []
     };
 
@@ -834,9 +834,9 @@ class FilteringCheckboxSelectInput extends React.Component {
       </SelectGroup>
     ];
 
-    this.onToggle = isExpanded => {
+    this.onToggle = isOpen => {
       this.setState({
-        isExpanded
+        isOpen
       });
     };
 
@@ -882,7 +882,7 @@ class FilteringCheckboxSelectInput extends React.Component {
   }
 
   render() {
-    const { isExpanded, selected, filteredOptions } = this.state;
+    const { isOpen, selected, filteredOptions } = this.state;
     const titleId = 'checkbox-filtering-select-id';
     return (
       <div>
@@ -894,7 +894,7 @@ class FilteringCheckboxSelectInput extends React.Component {
           onToggle={this.onToggle}
           onSelect={this.onSelect}
           selections={selected}
-          isExpanded={isExpanded}
+          isOpen={isOpen}
           placeholderText="Filter by status"
           ariaLabelledBy={titleId}
           onFilter={this.onFilter}
@@ -919,7 +919,7 @@ class FilteringCheckboxSelectInput extends React.Component {
     super(props);
 
     this.state = {
-      isExpanded: false,
+      isOpen: false,
       selected: []
     };
 
@@ -938,9 +938,9 @@ class FilteringCheckboxSelectInput extends React.Component {
       </SelectGroup>
     ];
 
-    this.onToggle = isExpanded => {
+    this.onToggle = isOpen => {
       this.setState({
-        isExpanded
+        isOpen
       });
     };
 
@@ -986,7 +986,7 @@ class FilteringCheckboxSelectInput extends React.Component {
   }
 
   render() {
-    const { isExpanded, selected, filteredOptions } = this.state;
+    const { isOpen, selected, filteredOptions } = this.state;
     const titleId = 'checkbox-filtering-select-id';
     return (
       <div>
@@ -998,7 +998,7 @@ class FilteringCheckboxSelectInput extends React.Component {
           onToggle={this.onToggle}
           onSelect={this.onSelect}
           selections={selected}
-          isExpanded={isExpanded}
+          isOpen={isOpen}
           placeholderText="Filter by status"
           ariaLabelledBy={titleId}
           onFilter={this.onFilter}

--- a/packages/react-core/src/components/Select/examples/Select.md
+++ b/packages/react-core/src/components/Select/examples/Select.md
@@ -99,7 +99,7 @@ class SingleSelectInput extends React.Component {
           aria-label="Select Input"
           onToggle={this.onToggle}
           onSelect={this.onSelect}
-          selection={selected}
+          selections={selected}
           isOpen={isOpen}
           aria-labelledby={titleId}
           isDisabled={isDisabled}
@@ -1101,7 +1101,7 @@ class TypeaheadSelectInput extends React.Component {
           onToggle={this.onToggle}
           onSelect={this.onSelect}
           onClear={this.clearSelection}
-          selection={selected}
+          selections={selected}
           isOpen={isOpen}
           aria-labelledby={titleId}
           placeholderText="Select a state"
@@ -1211,7 +1211,7 @@ class TypeaheadSelectInput extends React.Component {
           onSelect={this.onSelect}
           onClear={this.clearSelection}
           onFilter={this.customFilter}
-          selection={selected}
+          selections={selected}
           isOpen={isOpen}
           aria-labelledby={titleId}
           placeholderText="Select a state"

--- a/packages/react-integration/demo-app-ts/src/components/demos/SelectDemo/SelectDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/SelectDemo/SelectDemo.tsx
@@ -438,7 +438,7 @@ export class SelectDemo extends Component<SelectDemoState> {
             aria-label="Select Input"
             onToggle={this.singleOnToggle}
             onSelect={this.singleOnSelect}
-            selection={singleSelected}
+            selections={singleSelected}
             isOpen={singleisOpen}
             aria-labelledby={titleId}
             direction={this.state.direction}
@@ -484,7 +484,7 @@ export class SelectDemo extends Component<SelectDemoState> {
             aria-label="Select Input"
             onToggle={this.disabledSingleOnToggle}
             onSelect={this.disabledSingleOnSelect}
-            selection={disabledSingleSelected}
+            selections={disabledSingleSelected}
             isOpen={disabledSingleisOpen}
             aria-labelledby={titleId}
             isDisabled
@@ -521,7 +521,7 @@ export class SelectDemo extends Component<SelectDemoState> {
             aria-label="CustomSelect Input"
             onToggle={this.customSingleOnToggle}
             onSelect={this.customSingleOnSelect}
-            selection={customSingleSelected}
+            selections={customSingleSelected}
             isOpen={customSingleisOpen}
             aria-labelledby={titleId}
           >
@@ -645,7 +645,7 @@ export class SelectDemo extends Component<SelectDemoState> {
             onToggle={this.typeaheadOnToggle}
             onSelect={this.typeaheadOnSelect}
             onClear={this.clearSelection}
-            selection={typeaheadSelected}
+            selections={typeaheadSelected}
             isOpen={typeaheadisOpen}
             aria-labelledby={titleId}
             placeholderText="Select a state"
@@ -879,7 +879,7 @@ export class SelectDemo extends Component<SelectDemoState> {
             onToggle={() => null}
             onSelect={() => null}
             onClear={() => null}
-            selection=""
+            selections=""
             isOpen={false}
             aria-labelledby={titleId}
             placeholderText="Select a state"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4151, followup to #3945

Also properly fix the CI linter for PRs and update the examples to use `isOpen` rather than `isExpanded`

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
