### PR TITLE
fix(EmptyStateIcon): Add back color prop

### DIFF
--- a/packages/react-core/src/components/EmptyState/EmptyStateIcon.tsx
+++ b/packages/react-core/src/components/EmptyState/EmptyStateIcon.tsx
@@ -2,7 +2,11 @@ import * as React from 'react';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/EmptyState/empty-state';
 
-export interface EmptyStateIconProps {
+export interface IconProps extends Omit<React.HTMLProps<SVGElement>, 'size'> {
+  /** Changes the color of the icon.  */
+  color?: string;
+}
+export interface EmptyStateIconProps extends IconProps {
   /** Additional classes added to the EmptyState */
   className?: string;
   /** Icon component to be rendered inside the EmptyState on icon variant


### PR DESCRIPTION


<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4166

Color was marked deprecated and removed (#4065) but it is a prop that is in use.  This PR reverts that change.

