### PR TITLE
chore(packages): bump core to 2.71.6

### DIFF
--- a/packages/react-catalog-view-extension/package.json
+++ b/packages/react-catalog-view-extension/package.json
@@ -40,7 +40,7 @@
     "develop": "yarn build:babel:esm --skip-initial-build --watch --verbose --source-maps"
   },
   "dependencies": {
-    "@patternfly/patternfly": "2.71.5",
+    "@patternfly/patternfly": "2.71.6",
     "@patternfly/react-core": "^3.158.0",
     "@patternfly/react-styles": "^3.7.13",
     "classnames": "^2.2.5",

--- a/packages/react-charts/package.json
+++ b/packages/react-charts/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/patternfly/patternfly-react#readme",
   "dependencies": {
-    "@patternfly/patternfly": "2.71.5",
+    "@patternfly/patternfly": "2.71.6",
     "@patternfly/react-styles": "^3.7.13",
     "@patternfly/react-tokens": "^2.8.13",
     "hoist-non-react-statics": "^3.3.0",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -57,7 +57,7 @@
     "@babel/plugin-transform-typescript": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
-    "@patternfly/patternfly": "2.71.5",
+    "@patternfly/patternfly": "2.71.6",
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",
     "@rollup/plugin-replace": "^2.3.1",

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@mdx-js/mdx": "^1.1.5",
     "@mdx-js/react": "^1.1.5",
-    "@patternfly/patternfly": "2.71.5",
+    "@patternfly/patternfly": "2.71.6",
     "@patternfly/react-catalog-view-extension": "^1.4.65",
     "@patternfly/react-charts": "^5.3.20",
     "@patternfly/react-core": "^3.158.0",

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -42,7 +42,7 @@
     "@babel/preset-react": "^7.0.0",
     "@fortawesome/free-regular-svg-icons": "^5.7.2",
     "@fortawesome/free-solid-svg-icons": "^5.7.2",
-    "@patternfly/patternfly": "2.71.5",
+    "@patternfly/patternfly": "2.71.6",
     "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
     "babel-plugin-typescript-to-proptypes": "^0.17.1",
     "fs-extra": "^6.0.1",

--- a/packages/react-inline-edit-extension/package.json
+++ b/packages/react-inline-edit-extension/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/patternfly/patternfly-react/tree/master/packages/patternfly-4/",
   "dependencies": {
-    "@patternfly/patternfly": "2.71.5",
+    "@patternfly/patternfly": "2.71.6",
     "@patternfly/react-core": "^3.158.0",
     "@patternfly/react-icons": "^3.15.16",
     "@patternfly/react-styles": "^3.7.13",

--- a/packages/react-styles/package.json
+++ b/packages/react-styles/package.json
@@ -42,7 +42,7 @@
     "@babel/plugin-transform-typescript": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
-    "@patternfly/patternfly": "2.71.5",
+    "@patternfly/patternfly": "2.71.6",
     "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
     "babel-plugin-typescript-to-proptypes": "^0.17.1",
     "fbjs-scripts": "^0.8.3",

--- a/packages/react-table/package.json
+++ b/packages/react-table/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/patternfly/patternfly-react/tree/master/packages/react-table#readme",
   "dependencies": {
-    "@patternfly/patternfly": "2.71.5",
+    "@patternfly/patternfly": "2.71.6",
     "@patternfly/react-core": "^3.158.0",
     "@patternfly/react-icons": "^3.15.16",
     "@patternfly/react-styles": "^3.7.13",

--- a/packages/react-tokens/package.json
+++ b/packages/react-tokens/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
-    "@patternfly/patternfly": "2.71.5",
+    "@patternfly/patternfly": "2.71.6",
     "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
     "css": "^2.2.3",
     "fs-extra": "^6.0.1",

--- a/packages/react-topology/package.json
+++ b/packages/react-topology/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/patternfly/patternfly-react/tree/master/packages/react-topology#readme",
   "dependencies": {
-    "@patternfly/patternfly": "2.71.5",
+    "@patternfly/patternfly": "2.71.6",
     "@patternfly/react-core": "^3.158.0",
     "@patternfly/react-icons": "^3.15.16",
     "@patternfly/react-styles": "^3.7.13"

--- a/packages/react-virtualized-extension/package.json
+++ b/packages/react-virtualized-extension/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/patternfly/patternfly-react/tree/master/packages/react-virtualized-extension/",
   "dependencies": {
-    "@patternfly/patternfly": "2.71.5",
+    "@patternfly/patternfly": "2.71.6",
     "@patternfly/react-core": "^3.158.0",
     "@patternfly/react-icons": "^3.15.16",
     "@patternfly/react-styles": "^3.7.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3647,10 +3647,10 @@
     xmldoc "^1.1.2"
     yargs "^15.0.2"
 
-"@patternfly/patternfly@2.71.5":
-  version "2.71.5"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-2.71.5.tgz#db096c07cf3478a3c05f9020e3cd16be9c098be2"
-  integrity sha512-kkPVr+B9UKDeko8F31RzO7g1ecMbp4rVVQhg6X95rrzPd9mqBC8TGuwhyXnnHCbSAyNyqsp+ldGhDMsN5yMPiw==
+"@patternfly/patternfly@2.71.6":
+  version "2.71.6"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-2.71.6.tgz#6385cbd5aaca2f59bf65496e0189c541a7f00a82"
+  integrity sha512-mqqtuCVa+/FbyyK8hSAcfEIwNX73+zbnzHpmC4NrW0kyMzSszPtBqev/ZO79ZxGqZUpLOyUBTVaH7oKn8cL35Q==
 
 "@pieh/friendly-errors-webpack-plugin@1.7.0-chalk-2":
   version "1.7.0-chalk-2"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Version bump only for 2020.06 master release. Core has no changes for this release.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
