### PR TITLE
feat(Form): added icon to form helper text

### DIFF
--- a/packages/react-core/src/components/Form/FormGroup.tsx
+++ b/packages/react-core/src/components/Form/FormGroup.tsx
@@ -3,7 +3,6 @@ import styles from '@patternfly/react-styles/css/components/Form/form';
 import { ASTERISK } from '../../helpers/htmlConstants';
 import { css } from '@patternfly/react-styles';
 import { ValidatedOptions } from '../../helpers/constants';
-import { FormHelperText } from './FormHelperText';
 
 export interface FormGroupProps extends Omit<React.HTMLProps<HTMLDivElement>, 'label'> {
   /** Anything that can be rendered as FormGroup content. */
@@ -51,7 +50,7 @@ export const FormGroup: React.FunctionComponent<FormGroupProps> = ({
   ...props
 }: FormGroupProps) => {
   const validHelperText =
-    React.isValidElement(helperText) && (helperText as React.ReactElement).type === FormHelperText ? (
+    typeof helperText !== 'string' ? (
       helperText
     ) : (
       <div
@@ -65,7 +64,7 @@ export const FormGroup: React.FunctionComponent<FormGroupProps> = ({
     );
 
   const inValidHelperText =
-    React.isValidElement(helperTextInvalid) && (helperTextInvalid as React.ReactElement).type === FormHelperText ? (
+    typeof helperTextInvalid !== 'string' ? (
       helperTextInvalid
     ) : (
       <div className={css(styles.formHelperText, styles.modifiers.error)} id={`${fieldId}-helper`} aria-live="polite">

--- a/packages/react-core/src/components/Form/FormGroup.tsx
+++ b/packages/react-core/src/components/Form/FormGroup.tsx
@@ -3,6 +3,7 @@ import styles from '@patternfly/react-styles/css/components/Form/form';
 import { ASTERISK } from '../../helpers/htmlConstants';
 import { css } from '@patternfly/react-styles';
 import { ValidatedOptions } from '../../helpers/constants';
+import { FormHelperText } from './FormHelperText';
 
 export interface FormGroupProps extends Omit<React.HTMLProps<HTMLDivElement>, 'label'> {
   /** Anything that can be rendered as FormGroup content. */
@@ -26,6 +27,10 @@ export interface FormGroupProps extends Omit<React.HTMLProps<HTMLDivElement>, 'l
   helperText?: React.ReactNode;
   /** Helper text after the field when the field is invalid. It can be a simple text or an object. */
   helperTextInvalid?: React.ReactNode;
+  /** Icon displayed to the left of the helper text. */
+  helperTextIcon?: React.ReactNode;
+  /** Icon displayed to the left of the helper text when the field is invalid. */
+  helperTextInvalidIcon?: React.ReactNode;
   /** ID of the included field. It has to be the same for proper working. */
   fieldId: string;
 }
@@ -40,24 +45,34 @@ export const FormGroup: React.FunctionComponent<FormGroupProps> = ({
   hasNoPaddingTop = false,
   helperText,
   helperTextInvalid,
+  helperTextIcon,
+  helperTextInvalidIcon,
   fieldId,
   ...props
 }: FormGroupProps) => {
-  const validHelperText = (
-    <div
-      className={css(styles.formHelperText, validated === ValidatedOptions.success && styles.modifiers.success)}
-      id={`${fieldId}-helper`}
-      aria-live="polite"
-    >
-      {helperText}
-    </div>
-  );
+  const validHelperText =
+    helperText && (helperText as React.ReactElement).type === FormHelperText ? (
+      helperText
+    ) : (
+      <div
+        className={css(styles.formHelperText, validated === ValidatedOptions.success && styles.modifiers.success)}
+        id={`${fieldId}-helper`}
+        aria-live="polite"
+      >
+        {helperTextIcon && <span className={css(styles.formHelperTextIcon)}>{helperTextIcon}</span>}
+        {helperText}
+      </div>
+    );
 
-  const inValidHelperText = (
-    <div className={css(styles.formHelperText, styles.modifiers.error)} id={`${fieldId}-helper`} aria-live="polite">
-      {helperTextInvalid}
-    </div>
-  );
+  const inValidHelperText =
+    helperTextInvalid && (helperTextInvalid as React.ReactElement).type === FormHelperText ? (
+      helperTextInvalid
+    ) : (
+      <div className={css(styles.formHelperText, styles.modifiers.error)} id={`${fieldId}-helper`} aria-live="polite">
+        {helperTextInvalidIcon && <span className={css(styles.formHelperTextIcon)}>{helperTextInvalidIcon}</span>}
+        {helperTextInvalid}
+      </div>
+    );
 
   return (
     <div {...props} className={css(styles.formGroup, isInline ? styles.modifiers.inline : className)}>

--- a/packages/react-core/src/components/Form/FormGroup.tsx
+++ b/packages/react-core/src/components/Form/FormGroup.tsx
@@ -51,7 +51,7 @@ export const FormGroup: React.FunctionComponent<FormGroupProps> = ({
   ...props
 }: FormGroupProps) => {
   const validHelperText =
-    helperText && (helperText as React.ReactElement).type === FormHelperText ? (
+    React.isValidElement(helperText) && (helperText as React.ReactElement).type === FormHelperText ? (
       helperText
     ) : (
       <div
@@ -65,7 +65,7 @@ export const FormGroup: React.FunctionComponent<FormGroupProps> = ({
     );
 
   const inValidHelperText =
-    helperTextInvalid && (helperTextInvalid as React.ReactElement).type === FormHelperText ? (
+    React.isValidElement(helperTextInvalid) && (helperTextInvalid as React.ReactElement).type === FormHelperText ? (
       helperTextInvalid
     ) : (
       <div className={css(styles.formHelperText, styles.modifiers.error)} id={`${fieldId}-helper`} aria-live="polite">

--- a/packages/react-core/src/components/Form/FormHelperText.tsx
+++ b/packages/react-core/src/components/Form/FormHelperText.tsx
@@ -11,6 +11,8 @@ export interface FormHelperTextProps extends React.HTMLProps<HTMLDivElement> {
   isHidden?: boolean;
   /** Additional classes added to the Helper Text Item  */
   className?: string;
+  /** Icon displayed to the left of the helper text. */
+  icon?: React.ReactNode;
 }
 
 export const FormHelperText: React.FunctionComponent<FormHelperTextProps> = ({
@@ -18,6 +20,7 @@ export const FormHelperText: React.FunctionComponent<FormHelperTextProps> = ({
   isError = false,
   isHidden = true,
   className = '',
+  icon = null,
   ...props
 }: FormHelperTextProps) => (
   <p
@@ -29,6 +32,7 @@ export const FormHelperText: React.FunctionComponent<FormHelperTextProps> = ({
     )}
     {...props}
   >
+    {icon && <span className={css(styles.formHelperTextIcon)}>{icon}</span>}
     {children}
   </p>
 );

--- a/packages/react-core/src/components/Form/__tests__/FormHelperText.test.tsx
+++ b/packages/react-core/src/components/Form/__tests__/FormHelperText.test.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
 import { FormHelperText } from '../FormHelperText';
 import { shallow } from 'enzyme';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 test('renders with PatternFly Core styles', () => {
   const view = shallow(<FormHelperText isError isHidden={false} />);
+  expect(view).toMatchSnapshot();
+});
+
+test('renders with icon', () => {
+  const view = shallow(<FormHelperText isError isHidden={false} icon={<ExclamationCircleIcon />} />);
   expect(view).toMatchSnapshot();
 });
 

--- a/packages/react-core/src/components/Form/__tests__/Generated/__snapshots__/FormGroup.test.tsx.snap
+++ b/packages/react-core/src/components/Form/__tests__/Generated/__snapshots__/FormGroup.test.tsx.snap
@@ -18,14 +18,8 @@ exports[`FormGroup should match snapshot (auto-generated) 1`] = `
     </span>
   </label>
   ReactNode
-  <div
-    aria-live="polite"
-    className="pf-c-form__helper-text"
-    id="string-helper"
-  >
-    <div>
-      ReactNode
-    </div>
+  <div>
+    ReactNode
   </div>
 </div>
 `;

--- a/packages/react-core/src/components/Form/__tests__/__snapshots__/FormGroup.test.tsx.snap
+++ b/packages/react-core/src/components/Form/__tests__/__snapshots__/FormGroup.test.tsx.snap
@@ -221,14 +221,8 @@ exports[`FormGroup component should render form group variant with function help
     <input
       id="label-id"
     />
-    <div
-      aria-live="polite"
-      className="pf-c-form__helper-text"
-      id="label-id-helper"
-    >
-      <div>
-        label
-      </div>
+    <div>
+      label
     </div>
   </div>
 </FormGroup>
@@ -291,15 +285,9 @@ exports[`FormGroup component should render form group variant with node helperTe
     <input
       id="label-id"
     />
-    <div
-      aria-live="polite"
-      className="pf-c-form__helper-text"
-      id="label-id-helper"
-    >
-      <h1>
-        Header
-      </h1>
-    </div>
+    <h1>
+      Header
+    </h1>
   </div>
 </FormGroup>
 `;

--- a/packages/react-core/src/components/Form/__tests__/__snapshots__/FormHelperText.test.tsx.snap
+++ b/packages/react-core/src/components/Form/__tests__/__snapshots__/FormHelperText.test.tsx.snap
@@ -15,3 +15,19 @@ exports[`renders with PatternFly Core styles 1`] = `
   className="pf-c-form__helper-text pf-m-error"
 />
 `;
+
+exports[`renders with icon 1`] = `
+<p
+  className="pf-c-form__helper-text pf-m-error"
+>
+  <span
+    className="pf-c-form__helper-text-icon"
+  >
+    <ExclamationCircleIcon
+      color="currentColor"
+      noVerticalAlign={false}
+      size="sm"
+    />
+  </span>
+</p>
+`;

--- a/packages/react-core/src/components/Form/examples/Form.md
+++ b/packages/react-core/src/components/Form/examples/Form.md
@@ -5,19 +5,23 @@ cssPrefix: 'pf-c-form'
 typescript: true
 propComponents: ['ActionGroup', 'Form', 'FormGroup', 'FormHelperText']
 ---
+
 import {
-  Form,
-  FormGroup,
-  TextInput,
-  TextArea,
-  FormSelect,
-  Checkbox,
-  ActionGroup,
-  Button,
-  Radio
+Form,
+FormGroup,
+TextInput,
+TextArea,
+FormSelect,
+FormHelperText,
+Checkbox,
+ActionGroup,
+Button,
+Radio
 } from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 ## Examples
+
 ```js title=Basic
 import React from 'react';
 import {
@@ -56,12 +60,7 @@ class SimpleForm extends React.Component {
 
     return (
       <Form>
-        <FormGroup
-          label="Name"
-          isRequired
-          fieldId="simple-form-name"
-          helperText="Please provide your full name"
-        >
+        <FormGroup label="Name" isRequired fieldId="simple-form-name" helperText="Please provide your full name">
           <TextInput
             isRequired
             type="text"
@@ -96,7 +95,7 @@ class SimpleForm extends React.Component {
         <FormGroup isInline label="How can we contact you?" isRequired>
           <Checkbox label="Email" aria-label="Email" id="inlinecheck1" />
           <Checkbox label="Phone" aria-label="Phone" id="inlinecheck2" />
-          <Checkbox label="Please don't contact me" aria-label="Please don't contact me" id="inlinecheck3"/>
+          <Checkbox label="Please don't contact me" aria-label="Please don't contact me" id="inlinecheck3" />
         </FormGroup>
         <FormGroup label="Additional Note:" fieldId="simple-form-note">
           <TextInput isDisabled type="text" id="simple-form-note" name="simple-form-number" value="disabled" />
@@ -166,12 +165,7 @@ class HorizontalForm extends React.Component {
 
     return (
       <Form isHorizontal>
-        <FormGroup
-          label="Name"
-          isRequired
-          fieldId="horizontal-form-name"
-          helperText="Please provide your full name"
-        >
+        <FormGroup label="Name" isRequired fieldId="horizontal-form-name" helperText="Please provide your full name">
           <TextInput
             value={value1}
             isRequired
@@ -237,11 +231,13 @@ import {
   TextInput,
   TextArea,
   FormSelect,
+  FormHelperText,
   Checkbox,
   ActionGroup,
   Button,
   Radio
 } from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 class InvalidForm extends React.Component {
   constructor(props) {
@@ -251,7 +247,7 @@ class InvalidForm extends React.Component {
       validated: 'error'
     };
     this.handleTextInputChange = value => {
-      this.setState({ value, validated: /^\d+$/.test(value) ? 'success' : 'error' });
+      this.setState({ value, validated: value === '' ? 'noval' : /^\d+$/.test(value) ? 'success' : 'error' });
     };
   }
 
@@ -263,8 +259,13 @@ class InvalidForm extends React.Component {
         <FormGroup
           label="Age:"
           type="number"
-          helperText="Please enter your age"
+          helperText={
+            <FormHelperText icon={<ExclamationCircleIcon />} isHidden={validated !== 'noval'}>
+              Please enter your age
+            </FormHelperText>
+          }
           helperTextInvalid="Age has to be a number"
+          helperTextInvalidIcon={<ExclamationCircleIcon />}
           fieldId="age-1"
           validated={validated}
         >
@@ -308,22 +309,23 @@ class InvalidForm extends React.Component {
 
     this.simulateNetworkCall = callback => {
       setTimeout(callback, 2000);
-    }
+    };
 
     this.handleTextInputChange = value => {
-      this.setState({ value, validated: 'default', helperText: 'Validating...' },
+      this.setState(
+        { value, validated: 'default', helperText: 'Validating...' },
         this.simulateNetworkCall(() => {
           if (/^\d+$/.test(value)) {
             if (parseInt(value, 10) >= 21) {
-              this.setState({validated: 'success', helperText: 'Enjoy your stay'});
+              this.setState({ validated: 'success', helperText: 'Enjoy your stay' });
             } else {
-              this.setState({validated: 'error', invalidText: 'You must be at least 21 to continue'});
+              this.setState({ validated: 'error', invalidText: 'You must be at least 21 to continue' });
             }
+          } else {
+            this.setState({ validated: 'error', invalidText: 'Age has to be a number' });
           }
-          else {
-            this.setState({validated: 'error', invalidText: 'Age has to be a number'});
-          }
-        }));
+        })
+      );
     };
   }
 
@@ -337,6 +339,7 @@ class InvalidForm extends React.Component {
           type="number"
           helperText={helperText}
           helperTextInvalid={invalidText}
+          helperTextInvalidIcon={<ExclamationCircleIcon />}
           fieldId="age-2"
           validated={validated}
         >
@@ -356,25 +359,15 @@ class InvalidForm extends React.Component {
 
 ```js title=Horizontal-no-padding-top
 import React from 'react';
-import {
-  Form,
-  FormGroup,
-  Checkbox,
-  Radio
-} from '@patternfly/react-core';
+import { Form, FormGroup, Checkbox, Radio } from '@patternfly/react-core';
 
 class HorizontalForm extends React.Component {
   render() {
-
     return (
       <Form isHorizontal>
-        <FormGroup
-          label="Label"
-          hasNoPaddingTop
-          fieldId="options"
-        >
-        <Checkbox label="option 1" id="option-1" />
-        <Checkbox label="option 2" id="option-2" />
+        <FormGroup label="Label" hasNoPaddingTop fieldId="options">
+          <Checkbox label="option 1" id="option-1" />
+          <Checkbox label="option 2" id="option-2" />
         </FormGroup>
       </Form>
     );

--- a/packages/react-core/src/components/Form/examples/Form.md
+++ b/packages/react-core/src/components/Form/examples/Form.md
@@ -296,6 +296,7 @@ import {
   Button,
   Radio
 } from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 class InvalidForm extends React.Component {
   constructor(props) {

--- a/packages/react-core/src/components/LoginPage/LoginForm.tsx
+++ b/packages/react-core/src/components/LoginPage/LoginForm.tsx
@@ -14,6 +14,8 @@ export interface LoginFormProps extends React.HTMLProps<HTMLFormElement> {
   showHelperText?: boolean;
   /** Content displayed in the Helper Text component * */
   helperText?: React.ReactNode;
+  /** Icon displayed to the left in the Helper Text */
+  helperTextIcon?: React.ReactNode;
   /** Label for the Username Input Field */
   usernameLabel?: string;
   /** Value for the Username */
@@ -49,6 +51,7 @@ export const LoginForm: React.FunctionComponent<LoginFormProps> = ({
   className = '',
   showHelperText = false,
   helperText = null,
+  helperTextIcon = null,
   usernameLabel = 'Username',
   usernameValue = '',
   onChangeUsername = () => undefined as any,
@@ -66,7 +69,7 @@ export const LoginForm: React.FunctionComponent<LoginFormProps> = ({
   ...props
 }: LoginFormProps) => (
   <Form className={className} {...props}>
-    <FormHelperText isError={!isValidUsername || !isValidPassword} isHidden={!showHelperText}>
+    <FormHelperText isError={!isValidUsername || !isValidPassword} isHidden={!showHelperText} icon={helperTextIcon}>
       {helperText}
     </FormHelperText>
     <FormGroup

--- a/packages/react-core/src/components/LoginPage/__tests__/Generated/__snapshots__/LoginForm.test.tsx.snap
+++ b/packages/react-core/src/components/LoginPage/__tests__/Generated/__snapshots__/LoginForm.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`LoginForm should match snapshot (auto-generated) 1`] = `
   className="''"
 >
   <FormHelperText
+    icon={null}
     isError={false}
     isHidden={true}
   />

--- a/packages/react-core/src/components/LoginPage/__tests__/__snapshots__/LoginForm.test.tsx.snap
+++ b/packages/react-core/src/components/LoginPage/__tests__/__snapshots__/LoginForm.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`LoginForm with rememberMeLabel 1`] = `
   className=""
 >
   <FormHelperText
+    icon={null}
     isError={false}
     isHidden={true}
   />
@@ -73,6 +74,7 @@ exports[`should render Login form 1`] = `
   className=""
 >
   <FormHelperText
+    icon={null}
     isError={false}
     isHidden={true}
   />

--- a/packages/react-core/src/components/LoginPage/examples/LoginPage.md
+++ b/packages/react-core/src/components/LoginPage/examples/LoginPage.md
@@ -79,7 +79,7 @@ class SimpleLoginPage extends React.Component {
   }
 
   render() {
-    const helperText = <React.Fragment>&nbsp;Invalid login credentials.</React.Fragment>;
+    const helperText = 'Invalid login credentials.';
 
     const socialMediaLoginContent = (
       <React.Fragment>

--- a/packages/react-core/src/components/LoginPage/examples/LoginPage.md
+++ b/packages/react-core/src/components/LoginPage/examples/LoginPage.md
@@ -3,21 +3,35 @@ title: 'Login page'
 section: components
 cssPrefix: 'pf-c-login'
 typescript: true
-propComponents: ['LoginPage', 'Login', 'LoginForm', 'LoginMainBody', 'LoginMainHeader', 'LoginHeader', 'LoginFooter', 'LoginMainFooter', 'LoginFooterItem', 'LoginMainFooterBandItem', 'LoginMainFooterLinksItem']
+propComponents:
+  [
+    'LoginPage',
+    'Login',
+    'LoginForm',
+    'LoginMainBody',
+    'LoginMainHeader',
+    'LoginHeader',
+    'LoginFooter',
+    'LoginMainFooter',
+    'LoginFooterItem',
+    'LoginMainFooterBandItem',
+    'LoginMainFooterLinksItem',
+  ]
 ---
 
 import brandImg from './brandImgColor.svg';
 import {
-  LoginFooterItem,
-  LoginForm,
-  LoginMainFooterBandItem,
-  LoginMainFooterLinksItem,
-  LoginPage,
-  ListItem
+LoginFooterItem,
+LoginForm,
+LoginMainFooterBandItem,
+LoginMainFooterLinksItem,
+LoginPage,
+ListItem
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 ## Examples
+
 ```js title=Basic isFullscreen
 import React from 'react';
 import brandImg from './brandImgColor.svg';
@@ -65,12 +79,7 @@ class SimpleLoginPage extends React.Component {
   }
 
   render() {
-    const helperText = (
-      <React.Fragment>
-        <ExclamationCircleIcon />
-        &nbsp;Invalid login credentials.
-      </React.Fragment>
-    );
+    const helperText = <React.Fragment>&nbsp;Invalid login credentials.</React.Fragment>;
 
     const socialMediaLoginContent = (
       <React.Fragment>
@@ -131,6 +140,7 @@ class SimpleLoginPage extends React.Component {
       <LoginForm
         showHelperText={this.state.showHelperText}
         helperText={helperText}
+        helperTextIcon={<ExclamationCircleIcon />}
         usernameLabel="Username"
         usernameValue={this.state.usernameValue}
         onChangeUsername={this.handleUsernameChange}
@@ -147,11 +157,11 @@ class SimpleLoginPage extends React.Component {
     );
 
     const images = {
-      'lg': '/assets/images/pfbg_1200.jpg',
-      'sm': '/assets/images/pfbg_768.jpg',
-      'sm2x': '/assets/images/pfbg_768@2x.jpg',
-      'xs': '/assets/images/pfbg_576.jpg',
-      'xs2x': '/assets/images/pfbg_576@2x.jpg',
+      lg: '/assets/images/pfbg_1200.jpg',
+      sm: '/assets/images/pfbg_768.jpg',
+      sm2x: '/assets/images/pfbg_768@2x.jpg',
+      xs: '/assets/images/pfbg_576.jpg',
+      xs2x: '/assets/images/pfbg_576@2x.jpg'
     };
 
     return (

--- a/packages/react-integration/demo-app-ts/src/components/demos/FormDemo/FormDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/FormDemo/FormDemo.tsx
@@ -11,6 +11,7 @@ import {
   SelectVariant,
   ValidatedOptions
 } from '@patternfly/react-core';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
 
 export interface FormState {
   value: string;
@@ -92,6 +93,7 @@ export class FormDemo extends Component<FormProps, FormState> {
             type="number"
             helperText="Please write your age"
             helperTextInvalid="Age has to be a number"
+            helperTextInvalidIcon={<ExclamationCircleIcon />}
             fieldId="age"
             validated={isValid ? ValidatedOptions.default : ValidatedOptions.error}
           >


### PR DESCRIPTION
and added icon props to login and formgroup

<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4070

Note:
Allows icon via FormHelperText component or via additional props in FormGroup and LoginForm, which wrap FormHelperText internally. For FormGroup, helper text with icons can be implemented by passing FormHelperText components, or using the current helperText props combined with the new helperTextIcon props.


1. **LoginForm**: added `helperTextIcon` property. The example's helper text was updated to use this new property. 
2. **FormHelperText**: added `icon` property.
3. **FormGroup**: added `helperTextIcon` and `helperTextInvalidIcon` properties. `FormHelperText` components may now be passed into the `helperText` and `helperTextInvalid` properties directly.