### PR TITLE
updated gatsby-transformer-react-docgen-typescript version

### DIFF
--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -38,7 +38,7 @@
     "@patternfly/react-virtualized-extension": "^4.2.34",
     "gatsby": "2.21.0",
     "gatsby-theme-patternfly-org": "^4.0.6",
-    "gatsby-transformer-react-docgen-typescript": "^4.0.1",
+    "gatsby-transformer-react-docgen-typescript": "^4.0.2",
     "null-loader": "^3.0.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11334,12 +11334,12 @@ gatsby-transformer-json@^2.3.0:
     "@babel/runtime" "^7.8.7"
     bluebird "^3.7.2"
 
-gatsby-transformer-react-docgen-typescript@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/gatsby-transformer-react-docgen-typescript/-/gatsby-transformer-react-docgen-typescript-4.0.1.tgz#38ad498890855ea492066e866a4355941842c16e"
-  integrity sha512-7Zq0WmQ5bv7b46UC16OzpYBNs2ipej3tcecExAMzNMKxXlc1IBJQ3jJHO8pw0AJglcMZHaDh2wBftmlydI4p7A==
+gatsby-transformer-react-docgen-typescript@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/gatsby-transformer-react-docgen-typescript/-/gatsby-transformer-react-docgen-typescript-4.0.2.tgz#2abd0ef0250ccd2ba3e01732bdd5b7d1afcc79af"
+  integrity sha512-9MLVkk5RBgp8UCOTXonvcd7lbl+F5uNyZV5y7EkZVwRFppfvotD0TOJ4ll02Iw4/wrxIlJ+7TWN20n6KZkJGEw==
   dependencies:
-    react-docgen "^5.1.0"
+    react-docgen "^5.3.0"
 
 gatsby@2.21.0:
   version "2.21.0"
@@ -19680,6 +19680,20 @@ react-docgen@^5.1.0:
     async "^2.1.4"
     commander "^2.19.0"
     doctrine "^3.0.0"
+    node-dir "^0.1.10"
+    strip-indent "^3.0.0"
+
+react-docgen@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-5.3.0.tgz#9aabde5e69f1993c8ba839fd9a86696504654589"
+  integrity sha512-hUrv69k6nxazOuOmdGeOpC/ldiKy7Qj/UFpxaQi0eDMrUFUTIPGtY5HJu7BggSmiyAMfREaESbtBL9UzdQ+hyg==
+  dependencies:
+    "@babel/core" "^7.7.5"
+    "@babel/runtime" "^7.7.6"
+    ast-types "^0.13.2"
+    commander "^2.19.0"
+    doctrine "^3.0.0"
+    neo-async "^2.6.1"
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 


### PR DESCRIPTION
Closes: #4197 

With the updates in gatsby-transformer-react-docgen-typescript we are now seeing properties

## Example:
![Screen Shot 2020-05-13 at 2 33 49 PM](https://user-images.githubusercontent.com/57504257/81857169-dbb07e80-952f-11ea-953e-dda6d52f64d0.png)

![Screen Shot 2020-05-13 at 2 34 57 PM](https://user-images.githubusercontent.com/57504257/81857179-de12d880-952f-11ea-934f-e72314d8449b.png)
