### PR TITLE
fix(table): Specify button type to avoid unwanted form submits

### DIFF
--- a/packages/react-table/src/components/Table/SortColumn.tsx
+++ b/packages/react-table/src/components/Table/SortColumn.tsx
@@ -7,7 +7,7 @@ import styles from '@patternfly/react-styles/css/components/Table/table';
 import { SortByDirection } from './Table';
 import { TableText } from './TableText';
 
-export interface SortColumnProps extends React.HTMLAttributes<HTMLButtonElement> {
+export interface SortColumnProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   children?: React.ReactNode;
   className?: string;
   isSortedBy?: boolean;
@@ -21,6 +21,7 @@ export const SortColumn: React.FunctionComponent<SortColumnProps> = ({
   isSortedBy = false,
   onSort = null,
   sortDirection = '',
+  type = 'button',
   ...props
 }: SortColumnProps) => {
   let SortedByIcon;
@@ -30,7 +31,12 @@ export const SortColumn: React.FunctionComponent<SortColumnProps> = ({
     SortedByIcon = ArrowsAltVIcon;
   }
   return (
-    <button {...props} className={css(className, styles.tableButton)} onClick={event => onSort && onSort(event)}>
+    <button
+      {...props}
+      type={type}
+      className={css(className, styles.tableButton)}
+      onClick={event => onSort && onSort(event)}
+    >
       <div className={css(className, styles.tableButtonContent)}>
         <TableText>{children}</TableText>
         <span className={css(styles.tableSortIndicator)}>

--- a/packages/react-virtualized-extension/src/components/Virtualized/__snapshots__/VirtualizedTable.test.tsx.snap
+++ b/packages/react-virtualized-extension/src/components/Virtualized/__snapshots__/VirtualizedTable.test.tsx.snap
@@ -1008,6 +1008,7 @@ exports[`Actions virtualized table 1`] = `
                           <button
                             className="pf-c-table__button"
                             onClick={[Function]}
+                            type="button"
                           >
                             <div
                               className="pf-c-table__button-content"
@@ -2182,6 +2183,7 @@ exports[`Selectable virtualized table 1`] = `
                           <button
                             className="pf-c-table__button"
                             onClick={[Function]}
+                            type="button"
                           >
                             <div
                               className="pf-c-table__button-content"
@@ -3684,6 +3686,7 @@ exports[`Simple Actions table 1`] = `
                           <button
                             className="pf-c-table__button"
                             onClick={[Function]}
+                            type="button"
                           >
                             <div
                               className="pf-c-table__button-content"
@@ -6562,6 +6565,7 @@ exports[`Sortable Virtualized Table 1`] = `
                           <button
                             className="pf-c-table__button"
                             onClick={[Function]}
+                            type="button"
                           >
                             <div
                               className="pf-c-table__button-content"


### PR DESCRIPTION
Buttons without specified type attribute are treated as 'submit' buttons by browsers. This causes issues when a table with sortable columns is used inside a form as the form is submitted by clicking the sort buttons.

This change sets the button type to 'button' which establishes correct behaviour.

<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4251
