### PR TITLE
fix(virtualized-props): fix required and extended props

### DIFF
--- a/.circleci/upload-preview.js
+++ b/.circleci/upload-preview.js
@@ -17,7 +17,9 @@ if (!uploadFolder) {
 }
 
 const uploadFolderName = path.basename(uploadFolder);
-let uploadURL = `${repo}-${prnum ? `pr-${prnum}` : prbranch}`.replace(/[\/|\.]/g, '-');
+let uploadURL = `${repo}-${prnum ? `pr-${prnum}` : prbranch}`
+  .replace(/[\/|\.]/g, '-')
+  .replace('-master', '');
 
 if (uploadFolderName === 'coverage') {
   fs.copyFileSync(

--- a/packages/react-virtualized-extension/package.json
+++ b/packages/react-virtualized-extension/package.json
@@ -33,10 +33,7 @@
     "@patternfly/react-core": "^4.15.0",
     "@patternfly/react-icons": "^4.3.0",
     "@patternfly/react-styles": "^4.3.0",
-    "clsx": "^1.0.1",
-    "dom-helpers": "^2.4.0 || ^3.0.0",
     "linear-layout-vector": "0.0.1",
-    "react-lifecycles-compat": "^3.0.4",
     "react-virtualized": "^9.21.1",
     "tslib": "^1.11.1"
   },
@@ -46,11 +43,8 @@
   },
   "devDependencies": {
     "@types/dom-helpers": "^3.4.1",
-    "@types/react-lifecycles-compat": "^3.0.1",
     "@types/react-virtualized": "^9.21.5",
-    "lodash": "^4.17.15",
     "rimraf": "^2.6.2",
-    "typescript": "^3.8.3",
-    "uuid": "^3.3.2"
+    "typescript": "^3.8.3"
   }
 }

--- a/packages/react-virtualized-extension/src/components/Virtualized/VirtualTableBody.tsx
+++ b/packages/react-virtualized-extension/src/components/Virtualized/VirtualTableBody.tsx
@@ -14,8 +14,8 @@ import {
 } from './types';
 
 import accessibilityOverscanIndicesGetter from './accessibilityOverscanIndicesGetter';
-import { VirtualGrid } from './VirtualGrid';
-import clsx from 'clsx';
+import { VirtualGrid, VirtualGridProps } from './VirtualGrid';
+import { css } from '@patternfly/react-styles';
 
 /**
  * It is inefficient to create and manage a large list of DOM elements within a scrolling container
@@ -26,14 +26,34 @@ import clsx from 'clsx';
  * This component renders a virtualized list of elements with either fixed or dynamic heights.
  */
 
-interface Props {
+interface VirtualTableBodyProps extends Omit<
+  VirtualGridProps,
+  | 'style'
+  | 'containerStyle'
+  | 'aria-label'
+  | 'aria-readonly'
+  | 'tabIndex'
+  | 'role'
+  | 'autoContainerWidth'
+  | 'cellRenderer'
+  | 'className'
+  | 'columnWidth'
+  | 'columnCount'
+  | 'noContentRenderer'
+  | 'onScroll'
+  | 'onSectionRendered'
+  | 'ref'
+  | 'scrollToRow'
+  | 'scrollContainerComponent'
+  | 'innerScrollContainerComponent'
+> {
   'aria-label'?: string;
 
   /**
    * Removes fixed height from the scrollingContainer so that the total height
    * of rows can stretch the window. Intended for use with WindowScroller
    */
-  autoHeight: boolean;
+  autoHeight?: boolean;
 
   /** Optional CSS class name */
   className?: string;
@@ -42,32 +62,32 @@ interface Props {
    * Used to estimate the total height of a List before all of its rows have actually been measured.
    * The estimated total height is adjusted as rows are rendered.
    */
-  estimatedRowSize: number;
+  estimatedRowSize?: number;
 
   /** Height constraint for list (determines how many actual rows are rendered) */
   height: number;
 
   /** Optional renderer to be used in place of rows when rowCount is 0 */
-  noRowsRenderer: NoContentRenderer;
+  noRowsRenderer?: NoContentRenderer;
 
   /** Callback invoked with information about the slice of rows that were just rendered.  */
 
-  onRowsRendered: (params: any) => void;
+  onRowsRendered?: (params: any) => void;
 
   /**
    * Callback invoked whenever the scroll offset changes within the inner scrollable region.
    * This callback can be used to sync scrolling between lists, tables, or grids.
    */
-  onScroll: (params: Scroll) => void;
+  onScroll?: (params: Scroll) => void;
 
   /** See VirtualGrid#overscanIndicesGetter */
-  overscanIndicesGetter: OverscanIndicesGetter;
+  overscanIndicesGetter?: OverscanIndicesGetter;
 
   /**
    * Number of rows to render above/below the visible bounds of the list.
    * These rows can help for smoother scrolling on touch devices.
    */
-  overscanRowCount: number;
+  overscanRowCount?: number;
 
   /** Either a fixed row height (number) or a function that returns the height of a row given its index.  */
   rowHeight: CellSize;
@@ -79,16 +99,15 @@ interface Props {
   rowCount: number;
 
   /** See VirtualGrid#scrollToAlignment */
-  scrollToAlignment: Alignment;
+  scrollToAlignment?: Alignment;
 
   /** Row index to ensure visible (by forcefully scrolling if necessary) */
-  scrollToIndex: number;
+  scrollToIndex?: number;
 
   /** Vertical offset. */
   scrollTop?: number;
 
-  /** Optional inline style */
-  style: Object;
+  style?: Object;
 
   /** Tab index for focus */
   tabIndex?: number;
@@ -103,7 +122,7 @@ interface Props {
   rows: any[];
 }
 
-export class VirtualTableBody extends React.PureComponent<Props> {
+export class VirtualTableBody extends React.Component<VirtualTableBodyProps> {
   static defaultProps = {
     autoHeight: false,
     estimatedRowSize: 30,
@@ -196,14 +215,13 @@ export class VirtualTableBody extends React.PureComponent<Props> {
   render() {
     const { className, noRowsRenderer, scrollToIndex, width, columns, columnCount, rows, tabIndex, style } = this.props;
 
-    const classNames = clsx('ReactVirtualized__List', className);
+    const classNames = css('ReactVirtualized__List', className);
 
-    const VirtualGridAny = VirtualGrid as any;
     return (
       // note: these aria props if rendered will break a11y for role="presentation"
       // this approach attempts to fix non standard table grids
       // see: https://www.html5accessibility.com/tests/aria-table-fix.html
-      <VirtualGridAny
+      <VirtualGrid
         {...this.props}
         style={{
           tableLayout: 'fixed',
@@ -227,8 +245,6 @@ export class VirtualTableBody extends React.PureComponent<Props> {
         onSectionRendered={this._onSectionRendered}
         ref={this._setRef}
         scrollToRow={scrollToIndex}
-        columns={columns}
-        rows={rows}
         scrollContainerComponent="table"
         innerScrollContainerComponent="tbody"
       />

--- a/packages/react-virtualized-extension/src/components/Virtualized/VirtualTableBody.tsx
+++ b/packages/react-virtualized-extension/src/components/Virtualized/VirtualTableBody.tsx
@@ -213,7 +213,7 @@ export class VirtualTableBody extends React.Component<VirtualTableBodyProps> {
   }
 
   render() {
-    const { className, noRowsRenderer, scrollToIndex, width, columns, columnCount, rows, tabIndex, style } = this.props;
+    const { className, noRowsRenderer, scrollToIndex, width, columns, columnCount, style } = this.props;
 
     const classNames = css('ReactVirtualized__List', className);
 

--- a/packages/react-virtualized-extension/src/components/Virtualized/VirtualizedTable.md
+++ b/packages/react-virtualized-extension/src/components/Virtualized/VirtualizedTable.md
@@ -9,23 +9,18 @@ This package is currently an extension. Extension components do not undergo the 
 <br />
 <br />
 
-import clsx from 'clsx';
-import PropTypes from 'prop-types';
 import * as React from 'react';
-import { debounce } from 'lodash';
+import { debounce } from '@patternfly/react-core';
 import { ActionsColumn, Table, TableHeader, TableGridBreakpoint, headerCol, sortable, SortByDirection } from '@patternfly/react-table';
 import { CellMeasurerCache, CellMeasurer} from 'react-virtualized';
 import { AutoSizer, VirtualTableBody } from '@patternfly/react-virtualized-extension';
-import UUID from 'uuid/v1';
 import virtualGridStyles from './VirtualGrid.example.css';
 
 
 ## Examples
 ```js title=Basic
-import clsx from 'clsx';
-import PropTypes from 'prop-types';
 import * as React from 'react';
-import { debounce } from 'lodash';
+import { debounce } from '@patternfly/react-core';
 import { Table, TableHeader, TableGridBreakpoint } from '@patternfly/react-table';
 import { CellMeasurerCache, CellMeasurer} from 'react-virtualized';
 import { AutoSizer, VirtualTableBody } from '@patternfly/react-virtualized-extension';
@@ -37,7 +32,7 @@ class VirtualizedExample extends React.Component {
    const rows = [];
     for (let i = 0; i < 100; i++) {
       rows.push({
-        id: UUID(),
+        id: `basic-row-${i}`,
         cells: [`one-${i}`, `two-${i}`, `three-${i}`, `four-${i}`, `five-${i}`]
       });
     }
@@ -77,13 +72,9 @@ class VirtualizedExample extends React.Component {
       keyMapper: rowIndex => rowIndex
     });
 
-    const rowRenderer = ({index, isScrolling, isVisible, key, style, parent}) => {
+    const rowRenderer = ({index, isScrolling, key, style, parent}) => {
       const {rows, columns} = this.state;
       const text = rows[index].cells[0];
-
-      const className = clsx({
-        isVisible: isVisible
-      });
 
       return <CellMeasurer
         cache={measurementCache}
@@ -91,7 +82,7 @@ class VirtualizedExample extends React.Component {
         key={key}
         parent={parent}
         rowIndex={index}>
-        <tr style={style} className={className} role="row">
+        <tr style={style} role="row">
           <td className={columns[0].props.className} role="gridcell">{text}</td>
           <td className={columns[1].props.className} role="gridcell">{text}</td>
           <td className={columns[2].props.className} role="gridcell">{text}</td>
@@ -119,8 +110,7 @@ class VirtualizedExample extends React.Component {
         <AutoSizer disableHeight>
           {({width}) => (
             <VirtualTableBody
-              className={'pf-c-table pf-c-virtualized pf-c-window-scroller'}
-              deferredMeasurementCache={measurementCache}
+              className="pf-c-table pf-c-virtualized pf-c-window-scroller"
               rowHeight={measurementCache.rowHeight}
               height={400}
               overscanRowCount={2}
@@ -136,13 +126,9 @@ class VirtualizedExample extends React.Component {
     );
   }
 }
-
-export default VirtualizedExample;
 ```
 
 ```js title=Sortable
-import clsx from 'clsx';
-import PropTypes from 'prop-types';
 import * as React from 'react';
 import { debounce } from 'lodash';
 import { Table, TableHeader, sortable, SortByDirection, TableGridBreakpoint } from '@patternfly/react-table';
@@ -156,7 +142,7 @@ class SortableExample extends React.Component {
    const rows = [];
     for (let i = 0; i < 100; i++) {
       rows.push({
-        id: UUID(),
+        id: `sortable-row-${i}`,
         cells: [`one-${i}`, `two-${i}`, `three-${i}`, `four-${i}`, `five-${i}`]
       });
     }
@@ -216,20 +202,17 @@ class SortableExample extends React.Component {
       keyMapper: rowIndex => rowIndex
     });
 
-    const rowRenderer = ({index, isScrolling, isVisible, key, style, parent}) => {
+    const rowRenderer = ({index, isScrolling, key, style, parent}) => {
       const {rows, columns} = this.state;
       const text = rows[index].cells[0];
 
-      const className = clsx({
-        isVisible: isVisible
-      });
       return <CellMeasurer
         cache={measurementCache}
         columnIndex={0}
         key={key}
         parent={parent}
         rowIndex={index}>
-        <tr style={style} className={className} role="row">
+        <tr style={style} role="row">
           <td className={columns[0].props.className} role="gridcell">{text}</td>
           <td className={columns[1].props.className} role="gridcell">{text}</td>
           <td className={columns[2].props.className} role="gridcell">{text}</td>
@@ -260,8 +243,7 @@ class SortableExample extends React.Component {
           {({width}) => (
             <VirtualTableBody
               ref={ref => this.sortableVirtualBody = ref}
-              className={'pf-c-table pf-c-virtualized pf-c-window-scroller'}
-              deferredMeasurementCache={measurementCache}
+              className="pf-c-table pf-c-virtualized pf-c-window-scroller"
               rowHeight={measurementCache.rowHeight}
               height={400}
               overscanRowCount={2}
@@ -277,13 +259,9 @@ class SortableExample extends React.Component {
     );
   }
 }
-
-export default SortableExample;
 ```
 
 ```js title=Selectable
-import clsx from 'clsx';
-import PropTypes from 'prop-types';
 import * as React from 'react';
 import { debounce } from 'lodash';
 import { Table, TableHeader, headerCol, TableGridBreakpoint } from '@patternfly/react-table';
@@ -298,7 +276,7 @@ class SelectableExample extends React.Component {
     for (let i = 0; i < 100; i++) {
       rows.push({
         selected: false,
-        id: UUID(),
+        id: `selectable-row-${i}`,
         cells: [`one-${i}`, `two-${i}`, `three-${i}`, `four-${i}`, `five-${i}`]
       });
     }
@@ -360,13 +338,9 @@ class SelectableExample extends React.Component {
       keyMapper: rowIndex => rowIndex
     });
 
-    const rowRenderer = ({index, isScrolling, isVisible, key, style, parent}) => {
+    const rowRenderer = ({index, isScrolling, key, style, parent}) => {
       const {rows, columns} = this.state;
       const text = rows[index].cells[0];
-
-      const className = clsx({
-        isVisible: isVisible
-      });
 
       return <CellMeasurer
         cache={measurementCache}
@@ -374,7 +348,7 @@ class SelectableExample extends React.Component {
         key={key}
         parent={parent}
         rowIndex={index}>
-        <tr data-id={index} style={style} className={className} role="row">
+        <tr data-id={index} style={style} role="row">
           <td data-key="0" className="pf-c-table__check" role="gridcell">
             <input type="checkbox" checked={rows[index].selected} 
               onChange={(e) => 
@@ -410,8 +384,7 @@ class SelectableExample extends React.Component {
           {({width}) => (
             <VirtualTableBody
               ref={ref => this.selectableVirtualBody = ref}
-              className={'pf-c-table pf-c-virtualized pf-c-window-scroller'}
-              deferredMeasurementCache={measurementCache}
+              className="pf-c-table pf-c-virtualized pf-c-window-scroller"
               rowHeight={measurementCache.rowHeight}
               height={400}
               overscanRowCount={2}
@@ -427,13 +400,9 @@ class SelectableExample extends React.Component {
     );
   }
 }
-
-export default SelectableExample;
 ```
 
 ```js title=Actions
-import clsx from 'clsx';
-import PropTypes from 'prop-types';
 import * as React from 'react';
 import { debounce } from 'lodash';
 import { ActionsColumn, Table, TableHeader, TableGridBreakpoint } from '@patternfly/react-table';
@@ -448,7 +417,7 @@ class ActionsExample extends React.Component {
     for (let i = 0; i < 100; i++) {
       rows.push({
         disableActions: i % 3 === 2,
-        id: UUID(),
+        id: `actions-row-${i}`,
         cells: [`one-${i}`, `two-${i}`, `three-${i}`, `four-${i}`, `five-${i}`]
       });
     }
@@ -509,13 +478,9 @@ class ActionsExample extends React.Component {
       keyMapper: rowIndex => rowIndex
     });
 
-    const rowRenderer = ({index, isScrolling, isVisible, key, style, parent}) => {
+    const rowRenderer = ({index, isScrolling, key, style, parent}) => {
       const {rows, columns, actions} = this.state;
       const text = rows[index].cells[0];
-
-      const className = clsx({
-        isVisible: isVisible
-      });
 
       return <CellMeasurer
         cache={measurementCache}
@@ -523,7 +488,7 @@ class ActionsExample extends React.Component {
         key={key}
         parent={parent}
         rowIndex={index}>
-        <tr data-id={index} style={style} className={className} role="row">
+        <tr data-id={index} style={style} role="row">
           <td className={columns[0].props.className} role="gridcell">{text}</td>
           <td className={columns[1].props.className} role="gridcell">{text}</td>
           <td className={columns[2].props.className} role="gridcell">{text}</td>
@@ -559,8 +524,7 @@ class ActionsExample extends React.Component {
           {({width}) => (
             <VirtualTableBody
               ref={ref => this.actionsVirtualBody = ref}
-              className={'pf-c-table pf-c-virtualized pf-c-window-scroller'}
-              deferredMeasurementCache={measurementCache}
+              className="pf-c-table pf-c-virtualized pf-c-window-scroller"
               rowHeight={measurementCache.rowHeight}
               height={400}
               overscanRowCount={2}
@@ -576,6 +540,4 @@ class ActionsExample extends React.Component {
     );
   }
 }
-
-export default ActionsExample;
 ```

--- a/packages/react-virtualized-extension/src/components/Virtualized/VirtualizedTable.md
+++ b/packages/react-virtualized-extension/src/components/Virtualized/VirtualizedTable.md
@@ -111,7 +111,7 @@ class VirtualizedExample extends React.Component {
           {({width}) => (
             <VirtualTableBody
               className="pf-c-table pf-c-virtualized pf-c-window-scroller"
-              deferredMeasurementCache={deferredMeasurementCache}
+              deferredMeasurementCache={measurementCache}
               rowHeight={measurementCache.rowHeight}
               height={400}
               overscanRowCount={2}
@@ -245,7 +245,7 @@ class SortableExample extends React.Component {
             <VirtualTableBody
               ref={ref => this.sortableVirtualBody = ref}
               className="pf-c-table pf-c-virtualized pf-c-window-scroller"
-              deferredMeasurementCache={deferredMeasurementCache}
+              deferredMeasurementCache={measurementCache}
               rowHeight={measurementCache.rowHeight}
               height={400}
               overscanRowCount={2}
@@ -387,7 +387,7 @@ class SelectableExample extends React.Component {
             <VirtualTableBody
               ref={ref => this.selectableVirtualBody = ref}
               className="pf-c-table pf-c-virtualized pf-c-window-scroller"
-              deferredMeasurementCache={deferredMeasurementCache}
+              deferredMeasurementCache={measurementCache}
               rowHeight={measurementCache.rowHeight}
               height={400}
               overscanRowCount={2}
@@ -528,7 +528,7 @@ class ActionsExample extends React.Component {
             <VirtualTableBody
               ref={ref => this.actionsVirtualBody = ref}
               className="pf-c-table pf-c-virtualized pf-c-window-scroller"
-              deferredMeasurementCache={deferredMeasurementCache}
+              deferredMeasurementCache={measurementCache}
               rowHeight={measurementCache.rowHeight}
               height={400}
               overscanRowCount={2}

--- a/packages/react-virtualized-extension/src/components/Virtualized/VirtualizedTable.md
+++ b/packages/react-virtualized-extension/src/components/Virtualized/VirtualizedTable.md
@@ -111,6 +111,7 @@ class VirtualizedExample extends React.Component {
           {({width}) => (
             <VirtualTableBody
               className="pf-c-table pf-c-virtualized pf-c-window-scroller"
+              deferredMeasurementCache={deferredMeasurementCache}
               rowHeight={measurementCache.rowHeight}
               height={400}
               overscanRowCount={2}
@@ -244,6 +245,7 @@ class SortableExample extends React.Component {
             <VirtualTableBody
               ref={ref => this.sortableVirtualBody = ref}
               className="pf-c-table pf-c-virtualized pf-c-window-scroller"
+              deferredMeasurementCache={deferredMeasurementCache}
               rowHeight={measurementCache.rowHeight}
               height={400}
               overscanRowCount={2}
@@ -385,6 +387,7 @@ class SelectableExample extends React.Component {
             <VirtualTableBody
               ref={ref => this.selectableVirtualBody = ref}
               className="pf-c-table pf-c-virtualized pf-c-window-scroller"
+              deferredMeasurementCache={deferredMeasurementCache}
               rowHeight={measurementCache.rowHeight}
               height={400}
               overscanRowCount={2}
@@ -525,6 +528,7 @@ class ActionsExample extends React.Component {
             <VirtualTableBody
               ref={ref => this.actionsVirtualBody = ref}
               className="pf-c-table pf-c-virtualized pf-c-window-scroller"
+              deferredMeasurementCache={deferredMeasurementCache}
               rowHeight={measurementCache.rowHeight}
               height={400}
               overscanRowCount={2}

--- a/packages/react-virtualized-extension/src/components/Virtualized/VirtualizedTable.test.tsx
+++ b/packages/react-virtualized-extension/src/components/Virtualized/VirtualizedTable.test.tsx
@@ -22,6 +22,7 @@ describe('Simple virtualized table', () => {
         {({ width }: { width: number }) => (
           <VirtualTableBody
             className="pf-c-table pf-c-virtualized pf-c-window-scroller"
+            deferredMeasurementCache={measurementCache}
             height={400}
             rowCount={rows.length}
             rowHeight={measurementCache.rowHeight}

--- a/packages/react-virtualized-extension/src/components/Virtualized/VirtualizedTable.test.tsx
+++ b/packages/react-virtualized-extension/src/components/Virtualized/VirtualizedTable.test.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as React from 'react';
-import clsx from 'clsx';
 import { mount } from 'enzyme';
 import { Table, TableHeader, sortable } from '@patternfly/react-table';
 import { VirtualTableBody } from './index';
@@ -14,13 +13,7 @@ const measurementCache = new CellMeasurerCache({
 });
 
 describe('Simple virtualized table', () => {
-  const rowRenderer = (index: number, isVisible: boolean) => {
-    const text = rows[index].cells[0];
-
-    const className = clsx({
-      isVisible
-    });
-  };
+  const rowRenderer = () => {};
 
   test('className', () => {
     const view = mount(
@@ -64,13 +57,7 @@ describe('Simple virtualized table', () => {
 });
 
 test('Sortable Virtualized Table', () => {
-  const rowRenderer = (index: number, isVisible: boolean) => {
-    const text = rows[index].cells[0];
-
-    const className = clsx({
-      isVisible
-    });
-  };
+  const rowRenderer = () => {};
 
   const onSortCall = () => undefined as any;
   columns[0] = { ...(columns[0] as object), transforms: [sortable] };
@@ -93,13 +80,7 @@ test('Sortable Virtualized Table', () => {
 });
 
 test('Simple Actions table', () => {
-  const rowRenderer = (index: number, isVisible: boolean) => {
-    const text = rows[index].cells[0];
-
-    const className = clsx({
-      isVisible
-    });
-  };
+  const rowRenderer = () => {};
 
   const rowsWithDisabledAction = [
     ...rows,
@@ -130,13 +111,7 @@ test('Simple Actions table', () => {
 });
 
 test('Actions virtualized table', () => {
-  const rowRenderer = (index: number, isVisible: boolean) => {
-    const text = rows[index].cells[0];
-
-    const className = clsx({
-      isVisible
-    });
-  };
+  const rowRenderer = () => {};
 
   const view = mount(
     <Table
@@ -165,13 +140,7 @@ test('Actions virtualized table', () => {
 });
 
 test('Selectable virtualized table', () => {
-  const rowRenderer = (index: number, isVisible: boolean) => {
-    const text = rows[index].cells[0];
-
-    const className = clsx({
-      isVisible
-    });
-  };
+  const rowRenderer = () => {};
 
   const onSelect = () => undefined as any;
   const view = mount(

--- a/packages/react-virtualized-extension/src/components/Virtualized/WindowScroller.md
+++ b/packages/react-virtualized-extension/src/components/Virtualized/WindowScroller.md
@@ -9,23 +9,18 @@ This package is currently an extension. Extension components do not undergo the 
 <br />
 <br />
 
-import clsx from 'clsx';
-import PropTypes from 'prop-types';
 import * as React from 'react';
-import { debounce } from 'lodash';
+import { debounce } from '@patternfly/react-core';
 import { Table, TableHeader, TableGridBreakpoint } from '@patternfly/react-table';
 import { CellMeasurerCache, CellMeasurer } from 'react-virtualized';
 import { AutoSizer, VirtualTableBody, WindowScroller } from '@patternfly/react-virtualized-extension';
-import UUID from 'uuid/v1';
 import virtualGridStyles from './VirtualGrid.example.css';
 import windowScrollerStyles from './WindowScroller.example.css';
 
 ## Examples
 ```js title=Window-scroller
-import clsx from 'clsx';
-import PropTypes from 'prop-types';
 import * as React from 'react';
-import { debounce } from 'lodash';
+import { debounce } from '@patternfly/react-core';
 import { Table, TableHeader, TableGridBreakpoint } from '@patternfly/react-table';
 import { CellMeasurerCache, CellMeasurer } from 'react-virtualized';
 import { AutoSizer, VirtualTableBody, WindowScroller } from '@patternfly/react-virtualized-extension';
@@ -44,7 +39,7 @@ class WindowScrollerExample extends React.Component {
         cells.push(cellValue);
       }
       rows.push({
-        id: UUID(),
+        id: `window-scroller-row-${i}`,
         cells
       });
 
@@ -103,13 +98,9 @@ class WindowScrollerExample extends React.Component {
   render() {
     const {scrollToIndex, columns, rows, scollableElement} = this.state;
 
-    const rowRenderer = ({index, isScrolling, isVisible, key, style, parent}) => {
+    const rowRenderer = ({index, isScrolling, key, style, parent}) => {
       const {rows, columns} = this.state;
       const text = rows[index].cells[0];
-
-      const className = clsx({
-        isVisible: isVisible
-      });
 
       return <CellMeasurer
         cache={this._cellMeasurementCache}
@@ -117,7 +108,7 @@ class WindowScrollerExample extends React.Component {
         key={key}
         parent={parent}
         rowIndex={index}>
-        <tr style={style} className={className} role="row">
+        <tr style={style} role="row">
           <td className={columns[0].props.className} role="gridcell">{text}</td>
           <td className={columns[1].props.className} role="gridcell">{text}</td>
           <td className={columns[2].props.className} role="gridcell">{text}</td>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3825,12 +3825,6 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-lifecycles-compat@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/@types/react-lifecycles-compat/-/react-lifecycles-compat-3.0.1.tgz#a0b1fe18cfb9435bd52737829a69cbe93faf32e2"
-  dependencies:
-    "@types/react" "*"
-
 "@types/react-router-dom@^4.3.1":
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-4.3.5.tgz#72f229967690c890d00f96e6b85e9ee5780db31f"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4261 and also cleans up a lot of code since my internet went out.

- Makes `VirtualGrid` and `VirtualTableBody`'s props that already have defaults optional
- Make `VirtualTableBodyProps` correctly extend `VirtualGridProps` since it does `<VirtualGrid {...this.props}`
- Remove `clsx`, `lodash`, `uuid`, `dom-helpers`, and `react-lifecycles-compat` since these all add to bundle size and have readily available alternatives
  - clsx -> css from @patternfly/react-styles
  - lodash's debounce -> debounce from @patternfly/react-core
  - dom-helpers -> copy single `scrollbar` function (and it works properly now for the `actions` example!)
  - uuid -> use string template + for loop's index
  - react-lifecycles-compat -> add when react@17 comes out and also update the rest of our component code in other packages

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: Make the preview on master upload to https://patternfly-react.surge.sh rather than https://patternfly-react-master.surge.sh like it is now.
