### PR TITLE
Set sideEffects to true

### DIFF
--- a/packages/patternfly-react/package.json
+++ b/packages/patternfly-react/package.json
@@ -5,7 +5,7 @@
   "description": "This library provides a set of common React components for use with the PatternFly reference implementation.",
   "main": "dist/js/index.js",
   "module": "dist/esm/index.js",
-  "sideEffects": false,
+  "sideEffects": true,
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
NotificationDrawer has sideEffects and with sideEffects set to
false webpack does the wrong thing, triggering modules to be
not found when compiled in production mode (similar to this
PR: https://github.com/webpack/webpack/issues/7499)

Setting sideEffects to true fixes issues with apps using
patternfly-react v3 with an updated webpack.

<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
