### PR TITLE
fix(nav): fix expanding on new span icon

### DIFF
--- a/packages/react-core/src/components/Nav/NavExpandable.tsx
+++ b/packages/react-core/src/components/Nav/NavExpandable.tsx
@@ -79,7 +79,6 @@ export class NavExpandable extends React.Component<NavExpandableProps, NavExpand
   ) => {
     // Item events can bubble up, ignore those
     if (!this.expandableRef.current || !this.expandableRef.current.contains(e.target as Node)) {
-      console.log('true');
       return;
     }
 

--- a/packages/react-core/src/components/Nav/NavExpandable.tsx
+++ b/packages/react-core/src/components/Nav/NavExpandable.tsx
@@ -44,6 +44,7 @@ export class NavExpandable extends React.Component<NavExpandableProps, NavExpand
     id: ''
   };
 
+  expandableRef = React.createRef<HTMLAnchorElement>();
   id = this.props.id || getUniqueId();
 
   state = {
@@ -77,7 +78,8 @@ export class NavExpandable extends React.Component<NavExpandableProps, NavExpand
     ) => void
   ) => {
     // Item events can bubble up, ignore those
-    if ((e.target as any).getAttribute('data-component') !== 'pf-nav-expandable') {
+    if (!this.expandableRef.current || !this.expandableRef.current.contains(e.target as Node)) {
+      console.log('true');
       return;
     }
 
@@ -106,8 +108,8 @@ export class NavExpandable extends React.Component<NavExpandableProps, NavExpand
             {...props}
           >
             <a
-              data-component="pf-nav-expandable"
-              className={css(styles.navLink)}
+              ref={this.expandableRef}
+              className={styles.navLink}
               id={srText ? null : this.id}
               href="#"
               onClick={e => e.preventDefault()}

--- a/packages/react-core/src/components/Nav/__tests__/__snapshots__/Nav.test.tsx.snap
+++ b/packages/react-core/src/components/Nav/__tests__/__snapshots__/Nav.test.tsx.snap
@@ -334,7 +334,6 @@ exports[`Expandable Nav List - Trigger toggle 1`] = `
             <a
               aria-expanded={true}
               className="pf-c-nav__link"
-              data-component="pf-nav-expandable"
               href="#"
               id="grp-1"
               onClick={[Function]}
@@ -499,7 +498,6 @@ exports[`Expandable Nav List 1`] = `
             <a
               aria-expanded={false}
               className="pf-c-nav__link"
-              data-component="pf-nav-expandable"
               href="#"
               id="grp-1"
               onClick={[Function]}
@@ -665,7 +663,6 @@ exports[`Expandable Nav List with aria label 1`] = `
             <a
               aria-expanded={false}
               className="pf-c-nav__link"
-              data-component="pf-nav-expandable"
               href="#"
               id={null}
               onClick={[Function]}

--- a/packages/react-integration/cypress/integration/nav.spec.ts
+++ b/packages/react-integration/cypress/integration/nav.spec.ts
@@ -34,7 +34,7 @@ describe('Nav Test', () => {
 
   it('Verify Expandable Nav', () => {
     // All groups start open
-    cy.get('#nav-primary-expandable .pf-c-nav__link[data-component="pf-nav-expandable"]').each(
+    cy.get('#nav-primary-expandable .pf-c-nav__link[id="grp-1"]').each(
       (expandableGroup: JQuery<HTMLAnchorElement>) => {
         expect(expandableGroup.attr('aria-expanded')).to.be.equal('true');
       }

--- a/packages/react-integration/cypress/integration/nav.spec.ts
+++ b/packages/react-integration/cypress/integration/nav.spec.ts
@@ -34,11 +34,9 @@ describe('Nav Test', () => {
 
   it('Verify Expandable Nav', () => {
     // All groups start open
-    cy.get('#nav-primary-expandable .pf-c-nav__link[id="grp-1"]').each(
-      (expandableGroup: JQuery<HTMLAnchorElement>) => {
-        expect(expandableGroup.attr('aria-expanded')).to.be.equal('true');
-      }
-    );
+    cy.get('#nav-primary-expandable .pf-c-nav__link[id="grp-1"]').each((expandableGroup: JQuery<HTMLAnchorElement>) => {
+      expect(expandableGroup.attr('aria-expanded')).to.be.equal('true');
+    });
 
     // Verify close and open of group 1
     cy.get('#grp-1').then((group1Link: JQuery<HTMLAnchorElement>) => {


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Fixes Slack reported issue. Clicking on the icon should expand the nav like in v3.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
