### PR TITLE
fix(charts): Use Victory's createContainer instead of allowZoom prop

### DIFF
--- a/packages/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/react-charts/src/components/Chart/Chart.tsx
@@ -13,7 +13,6 @@ import {
   VictoryStyleInterface
 } from 'victory-core';
 import { VictoryChart, VictoryChartProps } from 'victory-chart';
-import { VictoryZoomContainer } from 'victory-zoom-container';
 import { ChartContainer } from '../ChartContainer';
 import { ChartLegend, ChartLegendOrientation, ChartLegendPosition } from '../ChartLegend';
 import { ChartCommonStyles, ChartThemeDefinition } from '../ChartTheme';
@@ -23,14 +22,6 @@ import { getClassName, getComputedLegend, getLabelTextSize, getPaddingForSide, g
  * See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/victory/index.d.ts
  */
 export interface ChartProps extends VictoryChartProps {
-  /**
-   * Specifies the zoom capability of the container component. A value of true allows the chart to
-   * zoom in and out. Zoom events are controlled by scrolling. When zoomed in, panning events are
-   * controlled by dragging. By default this value is set to false.
-   *
-   * Note: Only compatible with charts that display an x, y axis
-   */
-  allowZoom?: boolean;
   /**
    * The animate prop specifies props for VictoryAnimation to use.
    * The animate prop should also be used to specify enter and exit
@@ -364,7 +355,6 @@ export interface ChartProps extends VictoryChartProps {
 }
 
 export const Chart: React.FunctionComponent<ChartProps> = ({
-  allowZoom = false,
   ariaDesc,
   ariaTitle,
   children,
@@ -378,7 +368,7 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
 
   // destructure last
   theme = getTheme(themeColor, themeVariant),
-  containerComponent = allowZoom ? <VictoryZoomContainer /> : <ChartContainer />,
+  containerComponent = <ChartContainer />,
   legendOrientation = theme.legend.orientation as ChartLegendOrientation,
   height = theme.chart.height,
   width = theme.chart.width,

--- a/packages/react-charts/src/components/ChartBar/examples/ChartBar.md
+++ b/packages/react-charts/src/components/ChartBar/examples/ChartBar.md
@@ -13,6 +13,7 @@ hideDarkMode: true
 ---
 
 import { Chart, ChartAxis, ChartBar, ChartGroup, ChartThemeColor, ChartVoronoiContainer } from '@patternfly/react-charts';
+import { VictoryZoomContainer } from 'victory-zoom-container';
 
 ## Introduction
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
@@ -100,15 +101,16 @@ PurpleBottomLegend = (
 ```js title=Multi--color-(ordered)-with-bottom--left-aligned-legend
 import React from 'react';
 import { Chart, ChartAxis, ChartBar, ChartGroup, ChartThemeColor } from '@patternfly/react-charts';
+import { VictoryZoomContainer } from 'victory-zoom-container';
 
 BottomLeftLegend = (
   <div>
     This demonstrates zoom for both the x and y axis
     <div style={{ height: '400px', width: '450px' }}>
       <Chart
-        allowZoom
         ariaDesc="Average number of pets"
         ariaTitle="Bar chart example"
+        containerComponent={<VictoryZoomContainer />}
         domainPadding={{ x: [30, 25] }}
         legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
         legendPosition="bottom-left"

--- a/packages/react-charts/src/components/ChartGroup/ChartGroup.tsx
+++ b/packages/react-charts/src/components/ChartGroup/ChartGroup.tsx
@@ -15,7 +15,6 @@ import {
   VictoryStyleInterface
 } from 'victory-core';
 import { VictoryGroup, VictoryGroupProps } from 'victory-group';
-import { VictoryZoomContainer } from 'victory-zoom-container';
 import { ChartContainer } from '../ChartContainer';
 import { ChartThemeDefinition } from '../ChartTheme';
 import { getClassName, getTheme } from '../ChartUtils';
@@ -29,14 +28,6 @@ export enum ChartGroupSortOrder {
  * See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/victory/index.d.ts
  */
 export interface ChartGroupProps extends VictoryGroupProps {
-  /**
-   * Specifies the zoom capability of the container component. A value of true allows the chart to
-   * zoom in and out. Zoom events are controlled by scrolling. When zoomed in, panning events are
-   * controlled by dragging. By default this value is set to false.
-   *
-   * Note: Only compatible with charts that display an x, y axis
-   */
-  allowZoom?: boolean;
   /**
    * The animate prop specifies props for VictoryAnimation to use.
    * The animate prop should also be used to specify enter and exit
@@ -415,16 +406,16 @@ export interface ChartGroupProps extends VictoryGroupProps {
 }
 
 export const ChartGroup: React.FunctionComponent<ChartGroupProps> = ({
-  allowZoom = false,
   ariaDesc,
   ariaTitle,
   children,
-  containerComponent = allowZoom ? <VictoryZoomContainer /> : <ChartContainer />,
+  containerComponent = <ChartContainer />,
   themeColor,
   themeVariant,
 
   // destructure last
   theme = getTheme(themeColor, themeVariant),
+
   ...rest
 }: ChartGroupProps) => {
   // Clone so users can override container props

--- a/packages/react-integration/demo-app-ts/src/components/demos/BarChartDemo/ColorBarZoomDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/BarChartDemo/ColorBarZoomDemo.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Chart, ChartBar, ChartGroup, ChartThemeColor, ChartAxis } from '@patternfly/react-charts';
+import { VictoryZoomContainer } from 'victory-zoom-container';
 
 export class ColorBarZoomDemo extends React.Component {
   componentDidMount() {
@@ -11,7 +12,7 @@ export class ColorBarZoomDemo extends React.Component {
       <div>
         <div style={{ height: '400px', width: '450px', paddingLeft: '50px' }}>
           <Chart
-            allowZoom
+            containerComponent={<VictoryZoomContainer />}
             domainPadding={{ x: [30, 25] }}
             legendData={[{ name: 'Cats' }, { name: 'Birds' }, { name: 'Dogs' }, { name: 'Mice' }]}
             legendPosition="bottom"
@@ -27,7 +28,7 @@ export class ColorBarZoomDemo extends React.Component {
           >
             <ChartAxis />
             <ChartAxis dependentAxis showGrid />
-            <ChartGroup allowZoom offset={11} horizontal>
+            <ChartGroup offset={11} horizontal>
               <ChartBar
                 data={[
                   { name: 'Cats', x: '2015', y: 1 },


### PR DESCRIPTION
This change uses the `VictoryZoomContainer` instead of our `allowZoom` prop. 

Ultimately, this will allow us to to combine Victory container features. For example, if a user wants both a cursor and zoom feature, they must combine containers using Victory's `createContainer` function.

Fixes https://github.com/patternfly/patternfly-react/issues/4277

## Breaking change
Use `containerComponent` instead of `allowZoom`, for example:

```
import { VictoryZoomContainer } from 'victory-zoom-container';
<Chart containerComponent={<VictoryZoomContainer />} />
```