### PR TITLE
fix(wiz): add missing label for wiz-in-modal

### DIFF
--- a/packages/react-core/src/components/Wizard/Wizard.tsx
+++ b/packages/react-core/src/components/Wizard/Wizard.tsx
@@ -453,7 +453,14 @@ export class Wizard extends React.Component<WizardProps, WizardState> {
 
     if (isOpen !== undefined) {
       return (
-        <Modal isOpen={isOpen} variant={ModalVariant.large} showClose={false} hasNoBodyWrapper>
+        <Modal
+          isOpen={isOpen}
+          variant={ModalVariant.large}
+          aria-labelledby={this.titleId}
+          aria-describedby={this.descriptionId}
+          showClose={false}
+          hasNoBodyWrapper
+        >
           {wizard}
         </Modal>
       );

--- a/packages/react-core/src/components/Wizard/__tests__/Generated/__snapshots__/Wizard.test.tsx.snap
+++ b/packages/react-core/src/components/Wizard/__tests__/Generated/__snapshots__/Wizard.test.tsx.snap
@@ -4,9 +4,9 @@ exports[`Wizard should match snapshot (auto-generated) 1`] = `
 <Modal
   actions={Array []}
   appendTo={<body />}
-  aria-describedby=""
+  aria-describedby="string"
   aria-label=""
-  aria-labelledby=""
+  aria-labelledby="string"
   className=""
   hasNoBodyWrapper={true}
   isOpen={true}

--- a/packages/react-integration/demo-app-ts/src/components/demos/DropdownDemo/DropdownDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DropdownDemo/DropdownDemo.tsx
@@ -99,11 +99,6 @@ export class DropdownDemo extends React.Component<{}, DropdownState> {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     this.onCogClick = _event => {
       // eslint-disable-next-line no-console
-      console.log('Action clicked!');
-    };
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    this.onCogClick = _event => {
-      // eslint-disable-next-line no-console
       console.log('Cog clicked!');
     };
     this.onCogFocus = () => {


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: This PR adds label and description for the case where a user is launching wizard in modal with isOpen. Currently, the modal example for Wizard throws an expected error about this.

Also, I see there's a `width` prop documented for Wizard, but setting it doesn't seem to have an impact. Seems like Wiz should just occupy the space of its container like most other things.. Should we remove the width prop?
