### PR TITLE
fix(Table): update imports to direct imports for react table

### DIFF
--- a/packages/react-table/src/components/Table/EditColumn.tsx
+++ b/packages/react-table/src/components/Table/EditColumn.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
-import { Button } from '@patternfly/react-core';
-import { PencilAltIcon, CheckIcon, TimesIcon } from '@patternfly/react-icons';
+import { Button } from '@patternfly/react-core/dist/js/components/Button';
+import PencilAltIcon from '@patternfly/react-icons/dist/js/icons/pencil-alt-icon';
+import CheckIcon from '@patternfly/react-icons/dist/js/icons/check-icon';
+import TimesIcon from '@patternfly/react-icons/dist/js/icons/times-icon';
 import { OnRowEdit } from './Table';
 import inlineStyles from '@patternfly/react-styles/css/components/InlineEdit/inline-edit';
 import classNames from 'classnames';

--- a/packages/react-table/src/components/Table/EditableTextCell.tsx
+++ b/packages/react-table/src/components/Table/EditableTextCell.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { TextInput } from '@patternfly/react-core';
+import { TextInput } from '@patternfly/react-core/dist/js/components/TextInput';
 import inlineStyles from '@patternfly/react-styles/css/components/InlineEdit/inline-edit';
 import formStyles from '@patternfly/react-styles/css/components/Form/form';
 import classNames from 'classnames';


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**:

Fixes bloating build when using any react-table component. For some reason this file was forgotten when imports were changed to direct imports in react-table. When we used any component/util that used anything from Table component (for instance `sortable`) the build suddenly contained every icon and component. This PR fixes such issue, I've tried running build and publishing custom package that I later used. The build size went from 12 MB to 6 MB (might need a bit more investigation why it's still relatively that big).