### PR TITLE
fix(Pagination): Fix imports of tokens in pagination to direct imports

### DIFF
--- a/packages/react-core/src/components/Pagination/Pagination.tsx
+++ b/packages/react-core/src/components/Pagination/Pagination.tsx
@@ -6,7 +6,7 @@ import { css } from '@patternfly/react-styles';
 import { Navigation } from './Navigation';
 import { PaginationOptionsMenu } from './PaginationOptionsMenu';
 import { InjectedOuiaProps, withOuiaContext } from '../withOuia';
-import { c_pagination__nav_page_select_c_form_control_width_chars as widthChars } from '@patternfly/react-tokens';
+import widthChars from '@patternfly/react-tokens/dist/js/c_pagination__nav_page_select_c_form_control_width_chars';
 import { PickOptional } from '../../helpers';
 
 export enum PaginationVariant {


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**:
Similiar to https://github.com/patternfly/patternfly-react/pull/4286. I've updaed the versions of PF packages to latest v3 and saw the drop of build chunks from ~11MB to 4MB. That is awesome! I've checked the BundleAnalyzePlugin and saw additional 800KB to be pulled from `react-tokens` which felt ood. I've then searched for direct imports for this package and found out that paginations is still using the old way of importing files. Hopefully this should shave off significant part of this dependency.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
