### PR TITLE
chore(Modal): add tooltip to truncated Modal titles

### DIFF
--- a/packages/react-core/src/components/Modal/ModalBoxTitle.tsx
+++ b/packages/react-core/src/components/Modal/ModalBoxTitle.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import modalStyles from '@patternfly/react-styles/css/components/ModalBox/modal-box';
+import { css } from '@patternfly/react-styles';
+
+import { Tooltip } from '../Tooltip';
+
+export interface ModalBoxTitleProps {
+  /** Content rendered inside the modal box header title. */
+  title: React.ReactNode;
+  /** Additional classes added to the modal box header title. */
+  className?: string;
+  /** id of the modal box header title. */
+  id: string;
+}
+
+export const ModalBoxTitle: React.FunctionComponent<ModalBoxTitleProps> = ({
+  className = '',
+  id,
+  title,
+  ...props
+}: ModalBoxTitleProps) => {
+  const [isTooltipVisible, setIsTooltipVisible] = React.useState(false);
+  const h1 = React.useRef<HTMLHeadingElement>();
+
+  React.useLayoutEffect(() => {
+    setIsTooltipVisible(h1.current && h1.current.offsetWidth < h1.current.scrollWidth);
+  }, []);
+
+  return isTooltipVisible ? (
+    <Tooltip content={title}>
+      <h1 id={id} ref={h1} className={css(modalStyles.modalBoxTitle, className)} {...props}>
+        {title}
+      </h1>
+    </Tooltip>
+  ) : (
+    <h1 id={id} ref={h1} className={css(modalStyles.modalBoxTitle, className)} {...props}>
+      {title}
+    </h1>
+  );
+};

--- a/packages/react-core/src/components/Modal/ModalContent.tsx
+++ b/packages/react-core/src/components/Modal/ModalContent.tsx
@@ -11,6 +11,7 @@ import { ModalBox } from './ModalBox';
 import { ModalBoxFooter } from './ModalBoxFooter';
 import { ModalBoxDescription } from './ModalBoxDescription';
 import { ModalBoxHeader } from './ModalBoxHeader';
+import { ModalBoxTitle } from './ModalBoxTitle';
 
 export interface ModalContentProps {
   /** Content rendered inside the Modal. */
@@ -87,11 +88,7 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
   ) : (
     title && (
       <ModalBoxHeader>
-        {
-          <h1 id={labelId} className={css(modalStyles.modalBoxTitle)}>
-            {title}
-          </h1>
-        }
+        <ModalBoxTitle title={title} id={labelId} className={css(modalStyles.modalBoxTitle)} />
         {description && <ModalBoxDescription id={descriptorId}>{description}</ModalBoxDescription>}
       </ModalBoxHeader>
     )

--- a/packages/react-core/src/components/Modal/__tests__/__snapshots__/ModalContent.test.tsx.snap
+++ b/packages/react-core/src/components/Modal/__tests__/__snapshots__/ModalContent.test.tsx.snap
@@ -23,11 +23,10 @@ exports[`Modal Content Test description 1`] = `
         onClose={[Function]}
       />
       <ModalBoxHeader>
-        <h1
+        <ModalBoxTitle
           className="pf-c-modal-box__title"
-        >
-          Test Modal Content title
-        </h1>
+          title="Test Modal Content title"
+        />
         <ModalBoxDescription>
           This is a test description.
         </ModalBoxDescription>
@@ -65,11 +64,10 @@ exports[`Modal Content Test isOpen 1`] = `
         onClose={[Function]}
       />
       <ModalBoxHeader>
-        <h1
+        <ModalBoxTitle
           className="pf-c-modal-box__title"
-        >
-          Test Modal Content title
-        </h1>
+          title="Test Modal Content title"
+        />
       </ModalBoxHeader>
       <ModalBoxBody>
         This is a ModalBox header
@@ -102,11 +100,10 @@ exports[`Modal Content Test only body 1`] = `
         onClose={[Function]}
       />
       <ModalBoxHeader>
-        <h1
+        <ModalBoxTitle
           className="pf-c-modal-box__title"
-        >
-          Test Modal Content title
-        </h1>
+          title="Test Modal Content title"
+        />
       </ModalBoxHeader>
       <ModalBoxBody>
         This is a ModalBox header
@@ -139,11 +136,10 @@ exports[`Modal Content Test with footer 1`] = `
         onClose={[Function]}
       />
       <ModalBoxHeader>
-        <h1
+        <ModalBoxTitle
           className="pf-c-modal-box__title"
-        >
-          Test Modal Content title
-        </h1>
+          title="Test Modal Content title"
+        />
       </ModalBoxHeader>
       <ModalBoxBody>
         This is a ModalBox header
@@ -179,11 +175,10 @@ exports[`Modal Content Test with onclose 1`] = `
         onClose={[Function]}
       />
       <ModalBoxHeader>
-        <h1
+        <ModalBoxTitle
           className="pf-c-modal-box__title"
-        >
-          Test Modal Content title
-        </h1>
+          title="Test Modal Content title"
+        />
       </ModalBoxHeader>
       <ModalBoxBody
         isLarge={true}
@@ -221,11 +216,10 @@ exports[`Modal Content test without footer 1`] = `
         onClose={[Function]}
       />
       <ModalBoxHeader>
-        <h1
+        <ModalBoxTitle
           className="pf-c-modal-box__title"
-        >
-          Test Modal Content title
-        </h1>
+          title="Test Modal Content title"
+        />
       </ModalBoxHeader>
       <ModalBoxBody>
         This is a ModalBox header
@@ -258,11 +252,10 @@ exports[`Modal Test with custom footer 1`] = `
         onClose={[Function]}
       />
       <ModalBoxHeader>
-        <h1
+        <ModalBoxTitle
           className="pf-c-modal-box__title"
-        >
-          Test Modal Custom Footer
-        </h1>
+          title="Test Modal Custom Footer"
+        />
       </ModalBoxHeader>
       <ModalBoxBody
         isLarge={true}


### PR DESCRIPTION
**What**: Closes #3503 

Does this need to be demonstrated in an example if it happens automatically? I have not added an example at this point.