### PR TITLE
Chart: Vertical cursor tooltip example

### DIFF
--- a/packages/react-charts/package.json
+++ b/packages/react-charts/package.json
@@ -41,6 +41,7 @@
     "victory-bar": "^34.3.8",
     "victory-chart": "^34.3.8",
     "victory-core": "^34.3.8",
+    "victory-create-container": "^34.3.8",
     "victory-group": "^34.3.8",
     "victory-legend": "^34.3.8",
     "victory-line": "^34.3.8",

--- a/packages/react-charts/src/components/ChartArea/examples/ChartArea.md
+++ b/packages/react-charts/src/components/ChartArea/examples/ChartArea.md
@@ -13,7 +13,7 @@ propComponents: [
 hideDarkMode: true
 ---
 
-import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThreshold, ChartThemeColor, ChartThemeVariant, ChartVoronoiContainer } from '@patternfly/react-charts';
+import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThreshold, ChartThemeColor, ChartThemeVariant, ChartVoronoiContainer, createContainer } from '@patternfly/react-charts';
 import '@patternfly/patternfly/patternfly-charts.css';
 
 ## Introduction
@@ -90,64 +90,83 @@ BasicRightAlignedLegend = (
 
 ```js title=Cyan-with-bottom-aligned-legend-and-axis-label
 import React from 'react';
-import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor, ChartVoronoiContainer } from '@patternfly/react-charts';
+import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor, ChartVoronoiContainer, createContainer } from '@patternfly/react-charts';
 // import '@patternfly/patternfly/patternfly-charts.css'; // Required for mix-blend-mode CSS property
 
-BottomAlignedLegend = (
-  <div style={{ height: '250px', width: '650px' }}>
-    <Chart
-      ariaDesc="Average number of pets"
-      ariaTitle="Area chart example"
-      containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
-      legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }]}
-      legendPosition="bottom"
-      height={250}
-      padding={{
-        bottom: 100, // Adjusted to accommodate legend
-        left: 50,
-        right: 50,
-        top: 50,
-      }}
-      maxDomain={{y: 9}}
-      themeColor={ChartThemeColor.cyan}
-      width={650}
-    >
-      <ChartAxis label="Years"/>
-      <ChartAxis dependentAxis showGrid/>
-      <ChartGroup>
-        <ChartArea
-          data={[
-            { name: 'Cats', x: '2015', y: 3 },
-            { name: 'Cats', x: '2016', y: 4 },
-            { name: 'Cats', x: '2017', y: 8 },
-            { name: 'Cats', x: '2018', y: 6 }
-          ]}
-          interpolation="monotoneX"
-        />
-        <ChartArea
-          data={[
-            { name: 'Dogs', x: '2015', y: 2 },
-            { name: 'Dogs', x: '2016', y: 3 },
-            { name: 'Dogs', x: '2017', y: 4 },
-            { name: 'Dogs', x: '2018', y: 5 },
-            { name: 'Dogs', x: '2019', y: 6 }
-          ]}
-          interpolation="monotoneX"
-        />
-        <ChartArea
-          data={[
-            { name: 'Birds', x: '2015', y: 1 },
-            { name: 'Birds', x: '2016', y: 2 },
-            { name: 'Birds', x: '2017', y: 3 },
-            { name: 'Birds', x: '2018', y: 2 },
-            { name: 'Birds', x: '2019', y: 4 }
-          ]}
-          interpolation="monotoneX"
-        />
-      </ChartGroup>
-    </Chart>
-  </div>
-)
+class BottomAlignedLegend extends React.Component {
+  render() {
+    // Note: Container order is important
+    const CursorVoronoiContainer = createContainer("cursor", "voronoi");
+
+    return (
+      <div>
+        <p>This demonstrates how to combine cursor and voronoi containers to display tooltips along with a cursor</p>
+        <div style={{ height: '250px', width: '650px' }}>
+          <Chart
+            ariaDesc="Average number of pets"
+            ariaTitle="Area chart example"
+            containerComponent={
+              <CursorVoronoiContainer
+                constrainToVisibleArea
+                cursorDimension="x"
+                labels={({ datum }) => `${datum.name}: ${datum.y}`}
+                mouseFollowTooltips
+                voronoiDimension="x"
+                voronoiPadding={50}
+              />
+            }
+            legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }]}
+            legendPosition="bottom"
+            height={250}
+            padding={{
+              bottom: 100, // Adjusted to accommodate legend
+              left: 50,
+              right: 50,
+              top: 50,
+            }}
+            maxDomain={{y: 9}}
+            themeColor={ChartThemeColor.cyan}
+            width={650}
+          >
+            <ChartAxis label="Years"/>
+            <ChartAxis dependentAxis showGrid/>
+            <ChartGroup>
+              <ChartArea
+                data={[
+                  { name: 'Cats', x: '2015', y: 3 },
+                  { name: 'Cats', x: '2016', y: 4 },
+                  { name: 'Cats', x: '2017', y: 8 },
+                  { name: 'Cats', x: '2018', y: 6 }
+                ]}
+                interpolation="monotoneX"
+              />
+              <ChartArea
+                data={[
+                  { name: 'Dogs', x: '2015', y: 2 },
+                  { name: 'Dogs', x: '2016', y: 3 },
+                  { name: 'Dogs', x: '2017', y: 4 },
+                  { name: 'Dogs', x: '2018', y: 5 },
+                  { name: 'Dogs', x: '2019', y: 6 }
+                ]}
+                interpolation="monotoneX"
+              />
+              <ChartArea
+                data={[
+                  { name: 'Birds', x: '2015', y: 1 },
+                  { name: 'Birds', x: '2016', y: 2 },
+                  { name: 'Birds', x: '2017', y: 3 },
+                  { name: 'Birds', x: '2018', y: 2 },
+                  { name: 'Birds', x: '2019', y: 4 }
+                ]}
+                interpolation="monotoneX"
+              />
+            </ChartGroup>
+          </Chart>
+        </div>
+      </div>
+    );
+  }
+}
 ```
 
 ```js title=Multi--color-(unordered)-bottom--left-aligned-legend-and-responsive-container

--- a/packages/react-charts/src/components/ChartLine/examples/ChartLine.md
+++ b/packages/react-charts/src/components/ChartLine/examples/ChartLine.md
@@ -12,7 +12,7 @@ propComponents: [
 hideDarkMode: true
 ---
 
-import { Chart, ChartAxis, ChartGroup, ChartLine, ChartThemeColor, ChartThemeVariant, ChartVoronoiContainer } from '@patternfly/react-charts';
+import { Chart, ChartAxis, ChartGroup, ChartLine, ChartThemeColor, ChartThemeVariant, ChartVoronoiContainer, createContainer } from '@patternfly/react-charts';
 import { VictoryZoomContainer } from 'victory';
 
 ## Introduction
@@ -95,74 +95,93 @@ BasicRightAligned = (
 )
 ```
 
-```js title=Green-with-right-aligned-legend
+```js title=Green-with-bottom-aligned-legend
 import React from 'react';
-import { Chart, ChartAxis, ChartGroup, ChartLine, ChartThemeColor, ChartVoronoiContainer } from '@patternfly/react-charts';
+import { Chart, ChartAxis, ChartGroup, ChartLine, ChartThemeColor, ChartVoronoiContainer, createContainer } from '@patternfly/react-charts';
 
-Green = (
-  <div style={{ height: '275px', width: '450px' }}>
-    <Chart
-      ariaDesc="Average number of pets"
-      ariaTitle="Line chart example"
-      containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
-      legendData={[{ name: 'Cats' }, { name: 'Dogs', symbol: { type: 'dash' } }, { name: 'Birds' }, { name: 'Mice' }]}
-      legendPosition="bottom"
-      height={275}
-      maxDomain={{y: 10}}
-      minDomain={{y: 0}}
-      padding={{
-        bottom: 75, // Adjusted to accommodate legend
-        left: 50,
-        right: 50,
-        top: 50
-      }}
-      themeColor={ChartThemeColor.green}
-      width={450}
-    >
-      <ChartAxis tickValues={[2, 3, 4]} />
-      <ChartAxis dependentAxis showGrid tickValues={[2, 5, 8]} />
-      <ChartGroup>
-        <ChartLine
-          data={[
-            { name: 'Cats', x: '2015', y: 1 },
-            { name: 'Cats', x: '2016', y: 2 },
-            { name: 'Cats', x: '2017', y: 5 },
-            { name: 'Cats', x: '2018', y: 3 }
-          ]}
-        />
-        <ChartLine
-          data={[
-            { name: 'Dogs', x: '2015', y: 2 },
-            { name: 'Dogs', x: '2016', y: 1 },
-            { name: 'Dogs', x: '2017', y: 7 },
-            { name: 'Dogs', x: '2018', y: 4 }
-          ]}
-          style={{
-            data: {
-              strokeDasharray: '3,3'
+class BottomAlignedLegend extends React.Component {
+  render() {
+    // Note: Container order is important
+    const CursorVoronoiContainer = createContainer("cursor", "voronoi");
+
+    return (
+      <div>
+        <p>This demonstrates how to combine cursor and voronoi containers to display tooltips along with a cursor</p>
+        <div style={{ height: '275px', width: '450px' }}>
+          <Chart
+            ariaDesc="Average number of pets"
+            ariaTitle="Line chart example"
+            containerComponent={
+              <CursorVoronoiContainer
+                constrainToVisibleArea
+                cursorDimension="x"
+                labels={({ datum }) => `${datum.name}: ${datum.y}`}
+                mouseFollowTooltips
+                voronoiDimension="x"
+                voronoiPadding={50}
+              />
             }
-          }}
-        />
-        <ChartLine
-          data={[
-            { name: 'Birds', x: '2015', y: 3 },
-            { name: 'Birds', x: '2016', y: 4 },
-            { name: 'Birds', x: '2017', y: 9 },
-            { name: 'Birds', x: '2018', y: 5 }
-          ]}
-        />
-        <ChartLine
-          data={[
-            { name: 'Mice', x: '2015', y: 3 },
-            { name: 'Mice', x: '2016', y: 3 },
-            { name: 'Mice', x: '2017', y: 8 },
-            { name: 'Mice', x: '2018', y: 7 }
-          ]}
-        />
-      </ChartGroup>
-    </Chart>
-  </div>
-)
+            legendData={[{ name: 'Cats' }, { name: 'Dogs', symbol: { type: 'dash' } }, { name: 'Birds' }, { name: 'Mice' }]}
+            legendPosition="bottom"
+            height={275}
+            maxDomain={{y: 10}}
+            minDomain={{y: 0}}
+            padding={{
+              bottom: 75, // Adjusted to accommodate legend
+              left: 50,
+              right: 50,
+              top: 50
+            }}
+            themeColor={ChartThemeColor.green}
+            width={450}
+          >
+            <ChartAxis tickValues={[2, 3, 4]} />
+            <ChartAxis dependentAxis showGrid tickValues={[2, 5, 8]} />
+            <ChartGroup>
+              <ChartLine
+                data={[
+                  { name: 'Cats', x: '2015', y: 1 },
+                  { name: 'Cats', x: '2016', y: 2 },
+                  { name: 'Cats', x: '2017', y: 5 },
+                  { name: 'Cats', x: '2018', y: 3 }
+                ]}
+              />
+              <ChartLine
+                data={[
+                  { name: 'Dogs', x: '2015', y: 2 },
+                  { name: 'Dogs', x: '2016', y: 1 },
+                  { name: 'Dogs', x: '2017', y: 7 },
+                  { name: 'Dogs', x: '2018', y: 4 }
+                ]}
+                style={{
+                  data: {
+                    strokeDasharray: '3,3'
+                  }
+                }}
+              />
+              <ChartLine
+                data={[
+                  { name: 'Birds', x: '2015', y: 3 },
+                  { name: 'Birds', x: '2016', y: 4 },
+                  { name: 'Birds', x: '2017', y: 9 },
+                  { name: 'Birds', x: '2018', y: 5 }
+                ]}
+              />
+              <ChartLine
+                data={[
+                  { name: 'Mice', x: '2015', y: 3 },
+                  { name: 'Mice', x: '2016', y: 3 },
+                  { name: 'Mice', x: '2017', y: 8 },
+                  { name: 'Mice', x: '2018', y: 7 }
+                ]}
+              />
+            </ChartGroup>
+          </Chart>
+        </div>
+      </div>
+    );
+  }
+}
 ```
 
 ```js title=Multi--color-(unordered)-with-responsive-container

--- a/packages/react-charts/src/components/ChartTooltip/ChartTooltip.tsx
+++ b/packages/react-charts/src/components/ChartTooltip/ChartTooltip.tsx
@@ -4,10 +4,12 @@ import {
   NumberOrCallback,
   OrientationTypes,
   StringOrNumberOrCallback,
+  TextAnchorType,
   VictoryNumberCallback,
   VictoryStyleObject
 } from 'victory-core';
 import { VictoryTooltip, VictoryTooltipProps } from 'victory-tooltip';
+import { ChartLabel } from '../ChartLabel';
 import { ChartThemeDefinition } from '../ChartTheme';
 import { getTheme } from '../ChartUtils';
 
@@ -141,6 +143,11 @@ export interface ChartTooltipProps extends VictoryTooltipProps {
    */
   labelComponent?: React.ReactElement<any>;
   /**
+   * Defines how the labelComponent text is horizontally positioned relative to its `x` and `y` coordinates. Valid
+   * values are 'start', 'middle', 'end', and 'inherit'.
+   */
+  labelTextAnchor?: TextAnchorType | (() => TextAnchorType);
+  /**
    * The orientation prop determines which side of the (x, y) coordinate the tooltip should be rendered on.
    * This prop can be given as “top”, “bottom”, “left”, “right”, or as a function of datum that returns one of these
    * values. If this prop is not provided it will be determined from the sign of the datum, and the value of the
@@ -211,13 +218,29 @@ export interface ChartTooltipProps extends VictoryTooltipProps {
 
 export const ChartTooltip: React.FunctionComponent<ChartTooltipProps> = ({
   constrainToVisibleArea = false,
+  labelComponent = <ChartLabel />,
+  labelTextAnchor,
   themeColor,
   themeVariant,
 
   // destructure last
   theme = getTheme(themeColor, themeVariant),
   ...rest
-}: ChartTooltipProps) => <VictoryTooltip constrainToVisibleArea={constrainToVisibleArea} theme={theme} {...rest} />;
+}: ChartTooltipProps) => {
+  const chartLabelComponent = React.cloneElement(labelComponent, {
+    textAnchor: labelTextAnchor,
+    ...labelComponent.props
+  });
+
+  return (
+    <VictoryTooltip
+      constrainToVisibleArea={constrainToVisibleArea}
+      labelComponent={chartLabelComponent}
+      theme={theme}
+      {...rest}
+    />
+  );
+};
 
 // Note: VictoryTooltip.defaultEvents must be hoisted
 hoistNonReactStatics(ChartTooltip, VictoryTooltip);

--- a/packages/react-charts/src/components/ChartTooltip/__snapshots__/ChartTooltip.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartTooltip/__snapshots__/ChartTooltip.test.tsx.snap
@@ -12,15 +12,7 @@ exports[`ChartTooltip 1`] = `
     />
   }
   groupComponent={<g />}
-  labelComponent={
-    <VictoryLabel
-      capHeight={0.71}
-      direction="inherit"
-      lineHeight={1}
-      textComponent={<Text />}
-      tspanComponent={<TSpan />}
-    />
-  }
+  labelComponent={<ChartLabel />}
   renderInPortal={true}
   text="This is a tooltip"
   theme={
@@ -487,15 +479,7 @@ exports[`ChartTooltip 2`] = `
     />
   }
   groupComponent={<g />}
-  labelComponent={
-    <VictoryLabel
-      capHeight={0.71}
-      direction="inherit"
-      lineHeight={1}
-      textComponent={<Text />}
-      tspanComponent={<TSpan />}
-    />
-  }
+  labelComponent={<ChartLabel />}
   renderInPortal={true}
   text="This is a tooltip"
   theme={

--- a/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
+++ b/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
@@ -6,7 +6,7 @@ propComponents: ['ChartTooltip']
 hideDarkMode: true
 ---
 
-import { Chart, ChartArea, ChartAxis, ChartBar, ChartDonut, ChartGroup, ChartLabel, ChartLine, ChartStack, ChartThemeColor, ChartTooltip, getCustomTheme } from '@patternfly/react-charts';
+import { Chart, ChartArea, ChartAxis, ChartBar, ChartDonut, ChartGroup, ChartLabel, ChartLine, ChartStack, ChartThemeColor, ChartTooltip, createContainer, getCustomTheme } from '@patternfly/react-charts';
 import { Button, Tooltip } from '@patternfly/react-core';
 import './chart-tooltip.css';
 
@@ -79,6 +79,95 @@ VononoiContainer = (
     </div>
   </div>
 )
+```
+
+```js title=Combined-cursor-and-voronoi-containers
+import React from 'react';
+import { Chart, ChartAxis, ChartGroup, ChartLine, ChartThemeColor, ChartTooltip, ChartVoronoiContainer, createContainer } from '@patternfly/react-charts';
+
+class CombinedCursorVoronoiContainer extends React.Component {
+  render() {
+    // Note: Container order is important
+    const CursorVoronoiContainer = createContainer("cursor", "voronoi");
+
+    return (
+      <div>
+        <p>This demonstrates how to combine cursor and voronoi containers to display tooltips along with a cursor</p>
+        <div style={{ height: '275px', width: '450px' }}>
+          <Chart
+            ariaDesc="Average number of pets"
+            ariaTitle="Line chart example"
+            containerComponent={
+              <CursorVoronoiContainer
+                constrainToVisibleArea
+                cursorDimension="x"
+                labels={({ datum }) => `${datum.name}: ${datum.y}`}
+                mouseFollowTooltips
+                voronoiDimension="x"
+                voronoiPadding={50}
+              />
+            }
+            legendData={[{ name: 'Cats' }, { name: 'Dogs', symbol: { type: 'dash' } }, { name: 'Birds' }, { name: 'Mice' }]}
+            legendPosition="bottom"
+            height={275}
+            maxDomain={{y: 10}}
+            minDomain={{y: 0}}
+            padding={{
+              bottom: 75, // Adjusted to accommodate legend
+              left: 50,
+              right: 50,
+              top: 50
+            }}
+            themeColor={ChartThemeColor.green}
+            width={450}
+          >
+            <ChartAxis tickValues={[2, 3, 4]} />
+            <ChartAxis dependentAxis showGrid tickValues={[2, 5, 8]} />
+            <ChartGroup>
+              <ChartLine
+                data={[
+                  { name: 'Cats', x: '2015', y: 1 },
+                  { name: 'Cats', x: '2016', y: 2 },
+                  { name: 'Cats', x: '2017', y: 5 },
+                  { name: 'Cats', x: '2018', y: 3 }
+                ]}
+              />
+              <ChartLine
+                data={[
+                  { name: 'Dogs', x: '2015', y: 2 },
+                  { name: 'Dogs', x: '2016', y: 1 },
+                  { name: 'Dogs', x: '2017', y: 7 },
+                  { name: 'Dogs', x: '2018', y: 4 }
+                ]}
+                style={{
+                  data: {
+                    strokeDasharray: '3,3'
+                  }
+                }}
+              />
+              <ChartLine
+                data={[
+                  { name: 'Birds', x: '2015', y: 3 },
+                  { name: 'Birds', x: '2016', y: 4 },
+                  { name: 'Birds', x: '2017', y: 9 },
+                  { name: 'Birds', x: '2018', y: 5 }
+                ]}
+              />
+              <ChartLine
+                data={[
+                  { name: 'Mice', x: '2015', y: 3 },
+                  { name: 'Mice', x: '2016', y: 3 },
+                  { name: 'Mice', x: '2017', y: 8 },
+                  { name: 'Mice', x: '2018', y: 7 }
+                ]}
+              />
+            </ChartGroup>
+          </Chart>
+        </div>
+      </div>
+    );
+  }
+}
 ```
 
 ```js title=Data-label

--- a/packages/react-charts/src/components/ChartUtils/chart-container.tsx
+++ b/packages/react-charts/src/components/ChartUtils/chart-container.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { ContainerType, createContainer as victoryCreateContainer } from 'victory-create-container';
+import { ChartLabel } from '../ChartLabel';
+import { ChartTooltip } from '../ChartTooltip';
+import { getTooltipCenterOffset } from './chart-tooltip';
+
+/**
+ * Makes a container component with multiple behaviors. It allows you to effectively combine any two
+ * containers of type 'brush', 'cursor', 'selection', 'voronoi', or 'zoom'. Default container props are applied to
+ * support the PatternFly theme.
+ *
+ * Each behavior must be one of the following strings: 'brush', 'cursor', 'selection', 'voronoi', and 'zoom'. The
+ * resulting container uses the events from both behaviors. For example, if both behaviors use the click event (like
+ * zoom and selection) the combined container will trigger both behaviors' events on each click.
+ *
+ * Note: Order of the behaviors matters in a few cases. It is recommended to use 'zoom' before any other behaviors: for
+ * example, createContainer('zoom', 'voronoi') instead of createContainer('voronoi', 'zoom').
+ *
+ * See https://formidable.com/open-source/victory/docs/create-container
+ *
+ * @param {string} behaviorA 'brush', 'cursor', 'selection', 'voronoi', or 'zoom'
+ * @param {string} behaviorB 'brush', 'cursor', 'selection', 'voronoi', or 'zoom'
+ */
+export const createContainer = (behaviorA: ContainerType, behaviorB: ContainerType) => {
+  const container: any = victoryCreateContainer(behaviorA, behaviorB);
+  const isCursor = behaviorA === 'cursor' || behaviorB === 'cursor';
+  const isVoronoi = behaviorA === 'voronoi' || behaviorB === 'voronoi';
+
+  if (isCursor) {
+    container.defaultProps.cursorLabelComponent = <ChartLabel />;
+  }
+  if (isVoronoi) {
+    const labelTextAnchor = isCursor ? 'start' : undefined; // Left align tooltip text
+    const centerOffset = isCursor ? getTooltipCenterOffset(true) : undefined;
+
+    container.defaultProps.labelComponent = (
+      <ChartTooltip labelTextAnchor={labelTextAnchor} centerOffset={centerOffset} />
+    );
+  }
+  return container;
+};

--- a/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
@@ -1,0 +1,16 @@
+/**
+ * When using a cursor container, the tooltip can be offset from the cursor point. If true, the tooltip
+ * will appear to the right of the vertical cursor.
+ *
+ * @param {boolean} offsetCursorDimensionX If true, the tooltip will appear to the right of the vertical cursor
+ * @param {boolean} offsetCursorDimensionY If true, the tooltip will appear above the horizontal cursor
+ */
+export const getTooltipCenterOffset = (offsetCursorDimensionX = false, offsetCursorDimensionY = false) => {
+  const offsetX = (props: any) => props.flyoutWidth / 2 + 5;
+  const offsetY = (props: any) => -(props.flyoutHeight / 2 + 5);
+
+  return {
+    x: offsetCursorDimensionX ? offsetX : 0,
+    y: offsetCursorDimensionY ? offsetY : 0
+  };
+};

--- a/packages/react-charts/src/components/ChartUtils/index.ts
+++ b/packages/react-charts/src/components/ChartUtils/index.ts
@@ -1,3 +1,4 @@
+export * from './chart-container';
 export * from './chart-domain';
 export * from './chart-helpers';
 export * from './chart-interactive-legend';
@@ -6,3 +7,4 @@ export * from './chart-legend';
 export * from './chart-origin';
 export * from './chart-padding';
 export * from './chart-theme';
+export * from './chart-tooltip';

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -20,7 +20,7 @@
     "clean:mdx": "rimraf .cache/caches/gatsby-mdx",
     "develop": "gatsby develop",
     "serve": "gatsby serve",
-    "test:a11y": "patternfly-a11y --file .cache/fullscreenPages.json --prefix http://localhost:9000 --aggregate --noIncomplete --ignore color-contrast,focusable-content,scrollable-region-focusable --skip \"charts/chartbullet|virtualizedtable/selectable|charts/chartarea\""
+    "test:a11y": "patternfly-a11y --file .cache/fullscreenPages.json --prefix http://localhost:9000 --aggregate --noIncomplete --ignore color-contrast,focusable-content,scrollable-region-focusable --skip \"charts|virtualizedtable/selectable\""
   },
   "dependencies": {
     "@mdx-js/mdx": "^1.1.5",


### PR DESCRIPTION
This adds examples showing how to use tooltips with a vertical cursor. This work is a prequel to adding custom legends to tooltips -- see #3219.

Insights Subscription Watch and Cost Management have already implemented this Victory feature, but wanted to add a couple utils to help make things easier.

For example, I've created a util to wrap Victory functionality when combining `cursor` and `voronoi` containers. This ensures that our theme will be applied to the default `ChartLabel` and `ChartTooltip` components.

Reviewed with @nlcwong.

Fixes https://github.com/patternfly/patternfly-react/issues/3151

![chrome-capture (4)](https://user-images.githubusercontent.com/17481322/83185582-3681d280-a0f9-11ea-810a-e490c600ecd6.gif)
