### PR TITLE
fix(charts): Donut chart unique key warning

### DIFF
--- a/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -546,10 +546,10 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
       });
     }
     return (
-      <>
+      <React.Fragment key="pf-chart-donut-titles">
         {getTitle({ titles: title, dy: centerSubTitle ? -8 : 0 })}
         {getSubTitle({ textComponent: subTitleComponent, dy: centerSubTitle ? 15 : 0 })}
-      </>
+      </React.Fragment>
     );
   };
 


### PR DESCRIPTION
Resolves the unique key warning generated by the donut chart.

Fixes https://github.com/patternfly/patternfly-react/issues/4302
