### PR TITLE
docs(Notification Drawer): Add streamlined notification drawer example to docs

### DIFF
--- a/packages/react-core/src/components/NotificationDrawer/examples/NotificationDrawer.md
+++ b/packages/react-core/src/components/NotificationDrawer/examples/NotificationDrawer.md
@@ -390,7 +390,7 @@ render() {
               There are currently no critical alerts firing. There may be firing alerts of other severities or silenced critical alerts however.
             </EmptyStateBody>
             <EmptyStatePrimary>
-              <Button variant="link">View all alerts</Button>
+              <Button variant="link">Action</Button>
             </EmptyStatePrimary>
            </EmptyState>
          </NotificationDrawerList>
@@ -400,5 +400,205 @@ render() {
 </NotificationDrawer>
 )
 }
+}
+```
+
+```js title=Lightweight
+import React from 'react';
+import {
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStatePrimary,
+  EmptyStateVariant,
+  NotificationDrawer,
+  NotificationDrawerBody,
+  NotificationDrawerHeader,
+  NotificationDrawerGroup,
+  NotificationDrawerGroupList,
+  NotificationDrawerList,
+  NotificationDrawerListItem,
+  NotificationDrawerListItemBody,
+  NotificationDrawerListItemHeader,
+  Title
+} from '@patternfly/react-core';
+import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon';
+
+class LightweightNotificationDrawerDemo extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      firstGroupExpanded: false,
+      secondGroupExpanded: true,
+      thirdGroupExpanded: false
+    };
+
+      this.onFocus = (id) => {
+        if (id) {
+          const element = document.getElementById(id);
+          element.focus();
+        }
+      };
+    
+      this.toggleFirstDrawer = (event, value) => {
+        this.setState({
+          firstGroupExpanded: value
+        });
+      };
+    
+      this.toggleSecondDrawer = (event, value) => {
+        this.setState({
+          secondGroupExpanded: value
+        });
+      };
+    
+      this.toggleThirdDrawer = (event, value) => {
+        this.setState({
+          thirdGroupExpanded: value
+        });
+      };
+  }
+
+  render() {
+    const { firstGroupExpanded, secondGroupExpanded, thirdGroupExpanded } = this.state;
+
+    return (
+      <NotificationDrawer>
+        <NotificationDrawerHeader />
+        <NotificationDrawerBody>
+          <NotificationDrawerGroupList>
+            <NotificationDrawerGroup
+              title="First notification group"
+              isExpanded={firstGroupExpanded}
+              count={4}
+              isRead
+              onExpand={this.toggleFirstDrawer}
+            >
+              <NotificationDrawerList isHidden={!firstGroupExpanded}>
+                <NotificationDrawerListItem variant="info">
+                  <NotificationDrawerListItemHeader
+                    variant="info"
+                    title="Info notification title"
+                    srTitle="Info notification:"
+                  />
+                  <NotificationDrawerListItemBody timestamp="5 minutes ago">
+                    This is an info notification description.
+                  </NotificationDrawerListItemBody>
+                </NotificationDrawerListItem>
+                <NotificationDrawerListItem variant="danger">
+                  <NotificationDrawerListItemHeader
+                    variant="danger"
+                    title="Danger notification title. This is a long title to show how the title will wrap if it is long and wraps to multiple lines."
+                    srTitle="Danger notification:"
+                  />
+                  <NotificationDrawerListItemBody timestamp="10 minutes ago">
+                    This is a danger notification description. This is a long description to show how the title will
+                    wrap if it is long and wraps to multiple lines.
+                  </NotificationDrawerListItemBody>
+                </NotificationDrawerListItem>
+                <NotificationDrawerListItem variant="warning">
+                  <NotificationDrawerListItemHeader
+                    variant="warning"
+                    title="Warning notification title"
+                    srTitle="Warning notification:"
+                  />
+                  <NotificationDrawerListItemBody timestamp="20 minutes ago">
+                    This is a warning notification description.
+                  </NotificationDrawerListItemBody>
+                </NotificationDrawerListItem>
+                <NotificationDrawerListItem variant="success">
+                  <NotificationDrawerListItemHeader
+                    variant="success"
+                    title="Success notification title"
+                    srTitle="Success notification:"
+                  />
+                  <NotificationDrawerListItemBody timestamp="30 minutes ago">
+                    This is a success notification description.
+                  </NotificationDrawerListItemBody>
+                </NotificationDrawerListItem>
+              </NotificationDrawerList>
+            </NotificationDrawerGroup>
+            <NotificationDrawerGroup
+              title="Second notification group"
+              isExpanded={secondGroupExpanded}
+              count={4}
+              isRead
+              onExpand={this.toggleSecondDrawer}
+            >
+              <NotificationDrawerList isHidden={!secondGroupExpanded}>
+                <NotificationDrawerListItem variant="info">
+                  <NotificationDrawerListItemHeader
+                    variant="info"
+                    title="Info notification title w/action"
+                    srTitle="Info notification:"
+                  >
+                    <Button variant="link">Action</Button>
+                  </NotificationDrawerListItemHeader>
+                  <NotificationDrawerListItemBody timestamp="5 minutes ago">
+                    This is an info notification description.
+                  </NotificationDrawerListItemBody>
+                </NotificationDrawerListItem>
+                <NotificationDrawerListItem variant="danger">
+                  <NotificationDrawerListItemHeader
+                    variant="danger"
+                    title="Danger notification title. This is a long title to show how the title will wrap if it is long and wraps to multiple lines."
+                    srTitle="Danger notification:"
+                  />
+                  <NotificationDrawerListItemBody timestamp="10 minutes ago">
+                    This is a danger notification description. This is a long description to show how the title will
+                    wrap if it is long and wraps to multiple lines.
+                  </NotificationDrawerListItemBody>
+                </NotificationDrawerListItem>
+                <NotificationDrawerListItem variant="warning">
+                  <NotificationDrawerListItemHeader
+                    variant="warning"
+                    title="Warning notification title"
+                    srTitle="Warning notification:"
+                  />
+                  <NotificationDrawerListItemBody timestamp="20 minutes ago">
+                    This is a warning notification description.
+                  </NotificationDrawerListItemBody>
+                </NotificationDrawerListItem>
+                <NotificationDrawerListItem variant="success">
+                  <NotificationDrawerListItemHeader
+                    variant="success"
+                    title="Success notification title"
+                    srTitle="Success notification:"
+                  />
+                  <NotificationDrawerListItemBody timestamp="30 minutes ago">
+                    This is a success notification description.
+                  </NotificationDrawerListItemBody>
+                </NotificationDrawerListItem>
+              </NotificationDrawerList>
+            </NotificationDrawerGroup>
+            <NotificationDrawerGroup
+              title="Third notification group"
+              isExpanded={thirdGroupExpanded}
+              count={0}
+              isRead
+              onExpand={this.toggleThirdDrawer}
+            >
+              <NotificationDrawerList isHidden={!thirdGroupExpanded}>
+                <EmptyState variant={EmptyStateVariant.full}>
+                  <EmptyStateIcon icon={SearchIcon} />
+                  <Title headingLevel="h2" size="lg">
+                    No alerts found
+                  </Title>
+                  <EmptyStateBody>
+                    There are currently no critical alerts firing. There may be firing alerts of other severities or
+                    silenced critical alerts however.
+                  </EmptyStateBody>
+                  <EmptyStatePrimary>
+                    <Button variant="link">Action</Button>
+                  </EmptyStatePrimary>
+                </EmptyState>
+              </NotificationDrawerList>
+            </NotificationDrawerGroup>
+          </NotificationDrawerGroupList>
+        </NotificationDrawerBody>
+      </NotificationDrawer>
+    );
+  }
 }
 ```

--- a/packages/react-integration/cypress/integration/notificationdrawerlightweight.spec.ts
+++ b/packages/react-integration/cypress/integration/notificationdrawerlightweight.spec.ts
@@ -1,0 +1,110 @@
+describe('Drawer Lightweight Demo Test', () => {
+  it('Navigate to the drawer lightweight demo', () => {
+    cy.visit('http://localhost:3000/');
+    cy.get('#notification-drawer-lightweight-demo-nav-item-link').click();
+    cy.url().should('eq', 'http://localhost:3000/notification-drawer-lightweight-demo-nav-link');
+  });
+
+  it('Verify text in header title', () => {
+    cy.get('.pf-c-notification-drawer__header-title').contains('Notifications');
+  });
+
+  it('Verify text in header status', () => {
+    cy.get('.pf-c-notification-drawer__header-status').should('not.exist');
+  });
+
+  it('Verify 3 groups exist', () => {
+    cy.get('.pf-c-notification-drawer__group').then(groups => expect(groups.length).to.equal(3));
+  });
+
+  it('Verify first and last list items are hidden', () => {
+    cy.get('.pf-c-notification-drawer__list')
+      .first()
+      .should('have.attr', 'hidden');
+    cy.get('.pf-c-notification-drawer__list')
+      .eq(1)
+      .should('not.have.attr', 'hidden', false);
+    cy.get('.pf-c-notification-drawer__list')
+      .last()
+      .should('have.attr', 'hidden');
+  });
+
+  it('Verify first item is expanded after click', () => {
+    cy.get('.pf-c-notification-drawer__group')
+      .first()
+      .click();
+    cy.get('.pf-c-notification-drawer__list').should('not.have.attr', 'hidden');
+  });
+
+  it('Verify list items in lightweight drawer are all in unread state', () => {
+    cy.get('.pf-c-notification-drawer__list-item')
+      .first()
+      .should('not.have.class', 'pf-m-read');
+    cy.get('.pf-c-notification-drawer__list-item')
+      .eq(1)
+      .should('not.have.class', 'pf-m-read');
+    cy.get('.pf-c-notification-drawer__list-item')
+      .eq(2)
+      .should('not.have.class', 'pf-m-read');
+    cy.get('.pf-c-notification-drawer__list-item')
+      .last()
+      .should('not.have.class', 'pf-m-read');
+  });
+
+  it('Verify list items are hoverable', () => {
+    cy.get('.pf-c-notification-drawer__list-item')
+      .first()
+      .should('have.class', 'pf-m-hoverable');
+    cy.get('.pf-c-notification-drawer__list-item')
+      .eq(1)
+      .should('have.class', 'pf-m-hoverable');
+    cy.get('.pf-c-notification-drawer__list-item')
+      .eq(2)
+      .should('have.class', 'pf-m-hoverable');
+    cy.get('.pf-c-notification-drawer__list-item')
+      .last()
+      .should('have.class', 'pf-m-hoverable');
+  });
+
+  it('Verify list items severities', () => {
+    cy.get('.pf-c-notification-drawer__list-item')
+      .first()
+      .should('have.class', 'pf-m-info');
+    cy.get('.pf-c-notification-drawer__list-item')
+      .eq(1)
+      .should('have.class', 'pf-m-danger');
+    cy.get('.pf-c-notification-drawer__list-item')
+      .eq(2)
+      .should('have.class', 'pf-m-warning');
+    cy.get('.pf-c-notification-drawer__list-item')
+      .last()
+      .should('have.class', 'pf-m-success');
+  });
+
+  it('Verify timestamp in list items', () => {
+    cy.get('.pf-c-notification-drawer__list-item-timestamp')
+      .first()
+      .contains('5 minutes ago');
+    cy.get('.pf-c-notification-drawer__list-item-timestamp')
+      .eq(1)
+      .contains('10 minutes ago');
+    cy.get('.pf-c-notification-drawer__list-item-timestamp')
+      .eq(2)
+      .contains('20 minutes ago');
+    cy.get('.pf-c-notification-drawer__list-item-timestamp')
+      .last()
+      .contains('30 minutes ago');
+  });
+
+  it('Verify all badges are marked unread', () => {
+    cy.get('.pf-c-notification-drawer__group-toggle-count')
+      .first()
+      .should('not.have.attr', 'pf-m-unread');
+    cy.get('.pf-c-notification-drawer__group-toggle-count')
+      .eq(1)
+      .should('not.have.attr', 'pf-m-unread');
+    cy.get('.pf-c-notification-drawer__group-toggle-count')
+      .last()
+      .should('not.have.attr', 'pf-m-unread');
+  });
+});

--- a/packages/react-integration/demo-app-ts/src/Demos.ts
+++ b/packages/react-integration/demo-app-ts/src/Demos.ts
@@ -382,6 +382,11 @@ export const Demos: DemoInterface[] = [
     componentType: Examples.NotificationBadgeDemo
   },
   {
+    id: 'notification-drawer-lightweight-demo',
+    name: 'Notification Drawer Lightweight Demo',
+    componentType: Examples.LightweightNotificationDrawerDemo
+  },
+  {
     id: 'notification-drawer-basic-demo',
     name: 'Notification Drawer Basic Demo',
     componentType: Examples.BasicNotificationDrawerDemo

--- a/packages/react-integration/demo-app-ts/src/components/demos/NotificationDrawerDemo/NotificationDrawerLightweightDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/NotificationDrawerDemo/NotificationDrawerLightweightDemo.tsx
@@ -1,17 +1,11 @@
 import React from 'react';
 import {
   Button,
-  Dropdown,
-  DropdownItem,
-  DropdownDirection,
-  DropdownPosition,
-  DropdownSeparator,
   EmptyState,
   EmptyStateBody,
   EmptyStateIcon,
   EmptyStatePrimary,
   EmptyStateVariant,
-  KebabToggle,
   NotificationDrawer,
   NotificationDrawerProps,
   NotificationDrawerBody,
@@ -27,48 +21,23 @@ import {
 import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon';
 
 interface GroupsNotificationDrawerDemoState {
-  isOpen: boolean;
-  isActive: string;
   firstGroupIsOpen: boolean;
   secondGroupIsOpen: boolean;
   thirdGroupIsOpen: boolean;
 }
 
-export class GroupsNotificationDrawerDemo extends React.Component<
+export class LightweightNotificationDrawerDemo extends React.Component<
   NotificationDrawerProps,
   GroupsNotificationDrawerDemoState
 > {
   constructor(props: NotificationDrawerProps) {
     super(props);
     this.state = {
-      isOpen: false,
-      isActive: '',
       firstGroupIsOpen: false,
       secondGroupIsOpen: true,
       thirdGroupIsOpen: false
     };
   }
-
-  onToggle = (isOpen: boolean) => {
-    this.setState({
-      isOpen
-    });
-  };
-
-  onSelect = (event: any) => {
-    this.setState({
-      isOpen: !this.state.isOpen,
-      isActive: ''
-    });
-    this.onFocus(event.target.id);
-  };
-
-  onClick = (event: any) => {
-    this.setState({
-      isActive: event.target.id
-    });
-    this.onFocus(event.target.id);
-  };
 
   onFocus = (id: string) => {
     if (id) {
@@ -97,63 +66,30 @@ export class GroupsNotificationDrawerDemo extends React.Component<
 
   render() {
     const {
-      isOpen,
-      isActive,
       firstGroupIsOpen: firstGroupExpanded,
       secondGroupIsOpen: secondGroupExpanded,
       thirdGroupIsOpen: thirdGroupExpanded
     } = this.state;
-    const dropdownItems = [
-      <DropdownItem key="link">Link</DropdownItem>,
-      <DropdownItem key="action" component="button">
-        Action
-      </DropdownItem>,
-      <DropdownSeparator key="separator" />,
-      <DropdownItem key="disabled link" isDisabled>
-        Disabled Link
-      </DropdownItem>
-    ];
 
     return (
       <NotificationDrawer>
-        <NotificationDrawerHeader count={4}>
-          <Dropdown
-            onClick={this.onClick}
-            onSelect={this.onSelect}
-            toggle={<KebabToggle onToggle={this.onToggle} id="toggle-id-0" />}
-            isOpen={isOpen && isActive === 'toggle-id-0'}
-            isPlain
-            dropdownItems={dropdownItems}
-            id="notification-0"
-            position={DropdownPosition.right}
-          />
-        </NotificationDrawerHeader>
+        <NotificationDrawerHeader />
         <NotificationDrawerBody>
           <NotificationDrawerGroupList>
             <NotificationDrawerGroup
               title="First notification group"
               isExpanded={firstGroupExpanded}
-              count={2}
+              count={4}
+              isRead
               onExpand={this.toggleFirstDrawer}
             >
               <NotificationDrawerList isHidden={!firstGroupExpanded}>
                 <NotificationDrawerListItem variant="info">
                   <NotificationDrawerListItemHeader
                     variant="info"
-                    title="Unread info notification title"
+                    title="Info notification title"
                     srTitle="Info notification:"
-                  >
-                    <Dropdown
-                      position={DropdownPosition.right}
-                      onClick={this.onClick}
-                      onSelect={this.onSelect}
-                      toggle={<KebabToggle onToggle={this.onToggle} id="toggle-id-5" />}
-                      isOpen={isOpen && isActive === 'toggle-id-5'}
-                      isPlain
-                      dropdownItems={dropdownItems}
-                      id="notification-5"
-                    />
-                  </NotificationDrawerListItemHeader>
+                  />
                   <NotificationDrawerListItemBody timestamp="5 minutes ago">
                     This is an info notification description.
                   </NotificationDrawerListItemBody>
@@ -161,64 +97,30 @@ export class GroupsNotificationDrawerDemo extends React.Component<
                 <NotificationDrawerListItem variant="danger">
                   <NotificationDrawerListItemHeader
                     variant="danger"
-                    title="Unread danger notification title. This is a long title to show how the title will wrap if it is long and wraps to multiple lines."
+                    title="Danger notification title. This is a long title to show how the title will wrap if it is long and wraps to multiple lines."
                     srTitle="Danger notification:"
-                  >
-                    <Dropdown
-                      position={DropdownPosition.right}
-                      onClick={this.onClick}
-                      onSelect={this.onSelect}
-                      toggle={<KebabToggle onToggle={this.onToggle} id="toggle-id-6" />}
-                      isOpen={isOpen && isActive === 'toggle-id-6'}
-                      isPlain
-                      dropdownItems={dropdownItems}
-                      id="notification-6"
-                    />
-                  </NotificationDrawerListItemHeader>
+                  />
                   <NotificationDrawerListItemBody timestamp="10 minutes ago">
                     This is a danger notification description. This is a long description to show how the title will
                     wrap if it is long and wraps to multiple lines.
                   </NotificationDrawerListItemBody>
                 </NotificationDrawerListItem>
-                <NotificationDrawerListItem variant="warning" isRead>
+                <NotificationDrawerListItem variant="warning">
                   <NotificationDrawerListItemHeader
                     variant="warning"
-                    title="Read warning notification title"
+                    title="Warning notification title"
                     srTitle="Warning notification:"
-                  >
-                    <Dropdown
-                      position={DropdownPosition.right}
-                      onClick={this.onClick}
-                      onSelect={this.onSelect}
-                      toggle={<KebabToggle onToggle={this.onToggle} id="toggle-id-7" />}
-                      isOpen={isOpen && isActive === 'toggle-id-7'}
-                      isPlain
-                      dropdownItems={dropdownItems}
-                      id="notification-7"
-                    />
-                  </NotificationDrawerListItemHeader>
+                  />
                   <NotificationDrawerListItemBody timestamp="20 minutes ago">
                     This is a warning notification description.
                   </NotificationDrawerListItemBody>
                 </NotificationDrawerListItem>
-                <NotificationDrawerListItem variant="success" isRead>
+                <NotificationDrawerListItem variant="success">
                   <NotificationDrawerListItemHeader
                     variant="success"
-                    title="Read success notification title"
+                    title="Success notification title"
                     srTitle="Success notification:"
-                  >
-                    <Dropdown
-                      position={DropdownPosition.right}
-                      direction={DropdownDirection.up}
-                      onClick={this.onClick}
-                      onSelect={this.onSelect}
-                      toggle={<KebabToggle onToggle={this.onToggle} id="toggle-id-8" />}
-                      isOpen={isOpen && isActive === 'toggle-id-8'}
-                      isPlain
-                      dropdownItems={dropdownItems}
-                      id="notification-8"
-                    />
-                  </NotificationDrawerListItemHeader>
+                  />
                   <NotificationDrawerListItemBody timestamp="30 minutes ago">
                     This is a success notification description.
                   </NotificationDrawerListItemBody>
@@ -228,26 +130,18 @@ export class GroupsNotificationDrawerDemo extends React.Component<
             <NotificationDrawerGroup
               title="Second notification group"
               isExpanded={secondGroupExpanded}
-              count={2}
+              count={4}
+              isRead
               onExpand={this.toggleSecondDrawer}
             >
               <NotificationDrawerList isHidden={!secondGroupExpanded}>
                 <NotificationDrawerListItem variant="info">
                   <NotificationDrawerListItemHeader
                     variant="info"
-                    title="Unread info notification title"
+                    title="Info notification title w/action"
                     srTitle="Info notification:"
                   >
-                    <Dropdown
-                      position={DropdownPosition.right}
-                      onClick={this.onClick}
-                      onSelect={this.onSelect}
-                      toggle={<KebabToggle onToggle={this.onToggle} id="toggle-id-9" />}
-                      isOpen={isOpen && isActive === 'toggle-id-9'}
-                      isPlain
-                      dropdownItems={dropdownItems}
-                      id="notification-9"
-                    />
+                    <Button variant="link">Action</Button>
                   </NotificationDrawerListItemHeader>
                   <NotificationDrawerListItemBody timestamp="5 minutes ago">
                     This is an info notification description.
@@ -256,64 +150,30 @@ export class GroupsNotificationDrawerDemo extends React.Component<
                 <NotificationDrawerListItem variant="danger">
                   <NotificationDrawerListItemHeader
                     variant="danger"
-                    title="Unread danger notification title. This is a long title to show how the title will wrap if it is long and wraps to multiple lines."
+                    title="Danger notification title. This is a long title to show how the title will wrap if it is long and wraps to multiple lines."
                     srTitle="Danger notification:"
-                  >
-                    <Dropdown
-                      position={DropdownPosition.right}
-                      onClick={this.onClick}
-                      onSelect={this.onSelect}
-                      toggle={<KebabToggle onToggle={this.onToggle} id="toggle-id-10" />}
-                      isOpen={isOpen && isActive === 'toggle-id-10'}
-                      isPlain
-                      dropdownItems={dropdownItems}
-                      id="notification-10"
-                    />
-                  </NotificationDrawerListItemHeader>
+                  />
                   <NotificationDrawerListItemBody timestamp="10 minutes ago">
                     This is a danger notification description. This is a long description to show how the title will
                     wrap if it is long and wraps to multiple lines.
                   </NotificationDrawerListItemBody>
                 </NotificationDrawerListItem>
-                <NotificationDrawerListItem variant="warning" isRead>
+                <NotificationDrawerListItem variant="warning">
                   <NotificationDrawerListItemHeader
                     variant="warning"
-                    title="Read warning notification title"
+                    title="Warning notification title"
                     srTitle="Warning notification:"
-                  >
-                    <Dropdown
-                      position={DropdownPosition.right}
-                      onClick={this.onClick}
-                      onSelect={this.onSelect}
-                      toggle={<KebabToggle onToggle={this.onToggle} id="toggle-id-11" />}
-                      isOpen={isOpen && isActive === 'toggle-id-11'}
-                      isPlain
-                      dropdownItems={dropdownItems}
-                      id="notification-11"
-                    />
-                  </NotificationDrawerListItemHeader>
+                  />
                   <NotificationDrawerListItemBody timestamp="20 minutes ago">
                     This is a warning notification description.
                   </NotificationDrawerListItemBody>
                 </NotificationDrawerListItem>
-                <NotificationDrawerListItem variant="success" isRead>
+                <NotificationDrawerListItem variant="success">
                   <NotificationDrawerListItemHeader
                     variant="success"
-                    title="Read success notification title"
+                    title="Success notification title"
                     srTitle="Success notification:"
-                  >
-                    <Dropdown
-                      position={DropdownPosition.right}
-                      direction={DropdownDirection.up}
-                      onClick={this.onClick}
-                      onSelect={this.onSelect}
-                      toggle={<KebabToggle onToggle={this.onToggle} id="toggle-id-12" />}
-                      isOpen={isOpen && isActive === 'toggle-id-12'}
-                      isPlain
-                      dropdownItems={dropdownItems}
-                      id="notification-12"
-                    />
-                  </NotificationDrawerListItemHeader>
+                  />
                   <NotificationDrawerListItemBody timestamp="30 minutes ago">
                     This is a success notification description.
                   </NotificationDrawerListItemBody>
@@ -324,6 +184,7 @@ export class GroupsNotificationDrawerDemo extends React.Component<
               title="Third notification group"
               isExpanded={thirdGroupExpanded}
               count={0}
+              isRead
               onExpand={this.toggleThirdDrawer}
             >
               <NotificationDrawerList isHidden={!thirdGroupExpanded}>

--- a/packages/react-integration/demo-app-ts/src/components/demos/index.ts
+++ b/packages/react-integration/demo-app-ts/src/components/demos/index.ts
@@ -74,6 +74,7 @@ export * from './NavDemo/NavDemo';
 export * from './NotificationBadgeDemo/NotificationBadgeDemo';
 export * from './NotificationDrawerDemo/NotificationDrawerBasicDemo';
 export * from './NotificationDrawerDemo/NotificationDrawerGroupsDemo';
+export * from './NotificationDrawerDemo/NotificationDrawerLightweightDemo';
 export * from './OptionsMenuDemo/OptionsMenuDemo';
 export * from './OuiaDemo/OuiaDemo';
 export * from './OverflowMenuDemo/OverflowMenuDemo';


### PR DESCRIPTION
Add streamlined notification drawer example to docs (examples, integration app, and integration tests).

Provide the streamlined notification drawer to patternfly that we use in openshift. IE we don't use
the read/unread notifications so all notifications in the drawer are styled unread, all category
counts are read. Also removed kebabs in all components in this new example.

fix #4160
cc: @mcarrano 

@mcoker when moving all notifications in a category to unread, I get a vertical scrollbar. Would you mind taking a look please? See image below:

![Screen Shot 2020-05-31 at 2 15 02 PM](https://user-images.githubusercontent.com/35978579/83359589-2b24e600-a349-11ea-9c06-a5d77f64545a.png)



