### PR TITLE
fix(table): update property name to avoid error

### DIFF
--- a/packages/react-table/src/components/Table/utils/decorators/selectable.tsx
+++ b/packages/react-table/src/components/Table/utils/decorators/selectable.tsx
@@ -48,7 +48,7 @@ export const selectable: ITransform = (
     ...(rowData &&
       rowData.disableCheckbox && {
         disabled: true,
-        class: checkStyles.checkInput
+        className: checkStyles.checkInput
       })
   };
 


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: A follow up from recent change to selectable transform for Table. Fixed the below error

<img width="470" alt="Screen Shot 2020-06-02 at 9 54 02 AM" src="https://user-images.githubusercontent.com/5942899/83561067-36ad1400-a4e5-11ea-8ee2-9aec08933791.png">

The DOM was getting the correct attribute anyway, just that now we don't get the console error.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: https://github.com/patternfly/patternfly-react/pull/4231
