### PR TITLE
fix(Drawer): opening drawer can send focus to the drawer

### DIFF
--- a/packages/react-core/src/components/Drawer/Drawer.tsx
+++ b/packages/react-core/src/components/Drawer/Drawer.tsx
@@ -46,8 +46,8 @@ export const Drawer: React.SFC<DrawerProps> = ({
     onMount && onMount();
     return () => {
       onUnMount && onUnMount();
-    }
-  }, [isExpanded, onMount, onUnMount])
+    };
+  }, [isExpanded, onMount, onUnMount]);
 
   return (
     <DrawerContext.Provider value={{ isExpanded, isStatic }}>
@@ -58,12 +58,12 @@ export const Drawer: React.SFC<DrawerProps> = ({
           isInline && styles.modifiers.inline,
           isStatic && styles.modifiers.static,
           position === 'left' && styles.modifiers.panelLeft,
-          className,
+          className
         )}
         {...props}
       >
         {children}
       </div>
     </DrawerContext.Provider>
-  )
+  );
 };

--- a/packages/react-core/src/components/Drawer/Drawer.tsx
+++ b/packages/react-core/src/components/Drawer/Drawer.tsx
@@ -15,6 +15,10 @@ export interface DrawerProps extends React.HTMLProps<HTMLDivElement> {
   isStatic?: boolean;
   /** Position of the drawer panel */
   position?: 'left' | 'right';
+  /** Lifecycle function invoked when the drawer has been mounted to the DOM. */
+  onMount?: () => void;
+  /** Lifecycle function invoked when the drawer has been unmounted from the DOM. */
+  onUnMount?: () => void;
 }
 
 export interface DrawerContextProps {
@@ -34,21 +38,32 @@ export const Drawer: React.SFC<DrawerProps> = ({
   isInline = false,
   isStatic = false,
   position = 'right',
+  onMount,
+  onUnMount,
   ...props
-}: DrawerProps) => (
-  <DrawerContext.Provider value={{ isExpanded, isStatic }}>
-    <div
-      className={css(
-        styles.drawer,
-        isExpanded && styles.modifiers.expanded,
-        isInline && styles.modifiers.inline,
-        isStatic && styles.modifiers.static,
-        position === 'left' && styles.modifiers.panelLeft,
-        className
-      )}
-      {...props}
-    >
-      {children}
-    </div>
-  </DrawerContext.Provider>
-);
+}: DrawerProps) => {
+  React.useEffect(() => {
+    onMount && onMount();
+    return () => {
+      onUnMount && onUnMount();
+    }
+  }, [isExpanded, onMount, onUnMount])
+
+  return (
+    <DrawerContext.Provider value={{ isExpanded, isStatic }}>
+      <div
+        className={css(
+          styles.drawer,
+          isExpanded && styles.modifiers.expanded,
+          isInline && styles.modifiers.inline,
+          isStatic && styles.modifiers.static,
+          position === 'left' && styles.modifiers.panelLeft,
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    </DrawerContext.Provider>
+  )
+};

--- a/packages/react-core/src/components/Drawer/Drawer.tsx
+++ b/packages/react-core/src/components/Drawer/Drawer.tsx
@@ -18,7 +18,7 @@ export interface DrawerProps extends React.HTMLProps<HTMLDivElement> {
   /** Lifecycle function invoked when the drawer has been mounted to the DOM. */
   onMount?: () => void;
   /** Lifecycle function invoked when the drawer has been unmounted from the DOM. */
-  onUnMount?: () => void;
+  onUnmount?: () => void;
 }
 
 export interface DrawerContextProps {
@@ -38,16 +38,16 @@ export const Drawer: React.SFC<DrawerProps> = ({
   isInline = false,
   isStatic = false,
   position = 'right',
-  onMount,
-  onUnMount,
+  onMount = () => {},
+  onUnmount = () => {},
   ...props
 }: DrawerProps) => {
   React.useEffect(() => {
-    onMount && onMount();
+    onMount();
     return () => {
-      onUnMount && onUnMount();
+      onUnmount();
     };
-  }, [isExpanded, onMount, onUnMount]);
+  }, [isExpanded, onMount, onUnmount]);
 
   return (
     <DrawerContext.Provider value={{ isExpanded, isStatic }}>

--- a/packages/react-core/src/components/Drawer/examples/Drawer.md
+++ b/packages/react-core/src/components/Drawer/examples/Drawer.md
@@ -42,6 +42,11 @@ class SimpleDrawer extends React.Component {
     this.state = {
       isExpanded: false
     };
+    this.drawerRef = React.createRef();
+
+    this.onMount = () => {
+      this.state.isExpanded && this.drawerRef.current && this.drawerRef.current.focus()
+    }
 
     this.onClick = () => {
       const isExpanded = !this.state.isExpanded;
@@ -62,7 +67,7 @@ class SimpleDrawer extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
-          <span>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -78,7 +83,7 @@ class SimpleDrawer extends React.Component {
         <Button aria-expanded={isExpanded} onClick={this.onClick}>
           Toggle Drawer
         </Button>
-        <Drawer isExpanded={isExpanded}>
+        <Drawer isExpanded={isExpanded} onMount={this.onMount} >
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>{drawerContent}</DrawerContentBody>
           </DrawerContent>

--- a/packages/react-core/src/components/Drawer/examples/Drawer.md
+++ b/packages/react-core/src/components/Drawer/examples/Drawer.md
@@ -12,7 +12,7 @@ propComponents:
     DrawerSection,
     DrawerHead,
     DrawerActions,
-    DrawerCloseButton,
+    DrawerCloseButton
   ]
 section: 'components'
 beta: true
@@ -33,7 +33,8 @@ import {
   DrawerHead,
   DrawerActions,
   DrawerCloseButton,
-  Button
+  Button,
+  Title
 } from '@patternfly/react-core';
 
 class SimpleDrawer extends React.Component {
@@ -46,7 +47,7 @@ class SimpleDrawer extends React.Component {
 
     this.onMount = () => {
       this.state.isExpanded && this.drawerRef.current && this.drawerRef.current.focus()
-    }
+    };
 
     this.onClick = () => {
       const isExpanded = !this.state.isExpanded;
@@ -114,6 +115,11 @@ class SimpleDrawerPanelLeft extends React.Component {
     this.state = {
       isExpanded: false
     };
+    this.drawerRef = React.createRef();
+
+    this.onMount = () => {
+      this.state.isExpanded && this.drawerRef.current && this.drawerRef.current.focus()
+    };
 
     this.onClick = () => {
       const isExpanded = !this.state.isExpanded;
@@ -134,7 +140,7 @@ class SimpleDrawerPanelLeft extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
-          <span>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -150,7 +156,7 @@ class SimpleDrawerPanelLeft extends React.Component {
         <Button aria-expanded={isExpanded} onClick={this.onClick}>
           Toggle Drawer
         </Button>
-        <Drawer isExpanded={isExpanded}>
+        <Drawer isExpanded={isExpanded} onMount={this.onMount}>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>{drawerContent}</DrawerContentBody>
           </DrawerContent>
@@ -181,6 +187,11 @@ class SimpleDrawerPanelLeft extends React.Component {
     this.state = {
       isExpanded: false
     };
+    this.drawerRef = React.createRef();
+
+    this.onMount = () => {
+      this.state.isExpanded && this.drawerRef.current && this.drawerRef.current.focus()
+    };
 
     this.onClick = () => {
       const isExpanded = !this.state.isExpanded;
@@ -201,7 +212,7 @@ class SimpleDrawerPanelLeft extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
-          <span>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -217,7 +228,7 @@ class SimpleDrawerPanelLeft extends React.Component {
         <Button aria-expanded={isExpanded} onClick={this.onClick}>
           Toggle Drawer
         </Button>
-        <Drawer isExpanded={isExpanded} position="left">
+        <Drawer isExpanded={isExpanded} position="left" onMount={this.onMount}>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>{drawerContent}</DrawerContentBody>
           </DrawerContent>
@@ -248,6 +259,11 @@ class SimpleDrawerInlineContent extends React.Component {
     this.state = {
       isExpanded: false
     };
+    this.drawerRef = React.createRef();
+
+    this.onMount = () => {
+      this.state.isExpanded && this.drawerRef.current && this.drawerRef.current.focus()
+    };
 
     this.onClick = () => {
       const isExpanded = !this.state.isExpanded;
@@ -268,7 +284,7 @@ class SimpleDrawerInlineContent extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
-          <span>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -284,7 +300,7 @@ class SimpleDrawerInlineContent extends React.Component {
         <Button aria-expanded={isExpanded} onClick={this.onClick}>
           Toggle Drawer
         </Button>
-        <Drawer isExpanded={isExpanded} isInline>
+        <Drawer isExpanded={isExpanded} isInline onMount={this.onMount}>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>{drawerContent}</DrawerContentBody>
           </DrawerContent>
@@ -315,6 +331,11 @@ class DrawerInlineContentPanelLeft extends React.Component {
     this.state = {
       isExpanded: false
     };
+    this.drawerRef = React.createRef();
+
+    this.onMount = () => {
+      this.state.isExpanded && this.drawerRef.current && this.drawerRef.current.focus()
+    };
 
     this.onClick = () => {
       const isExpanded = !this.state.isExpanded;
@@ -335,7 +356,7 @@ class DrawerInlineContentPanelLeft extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
-          <span>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -351,7 +372,7 @@ class DrawerInlineContentPanelLeft extends React.Component {
         <Button aria-expanded={isExpanded} onClick={this.onClick}>
           Toggle Drawer
         </Button>
-        <Drawer isExpanded={isExpanded} isInline>
+        <Drawer isExpanded={isExpanded} isInline onMount={this.onMount}>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>{drawerContent}</DrawerContentBody>
           </DrawerContent>
@@ -382,6 +403,11 @@ class DrawerInlineContentPanelLeft extends React.Component {
     this.state = {
       isExpanded: false
     };
+    this.drawerRef = React.createRef();
+
+    this.onMount = () => {
+      this.state.isExpanded && this.drawerRef.current && this.drawerRef.current.focus()
+    };
 
     this.onClick = () => {
       const isExpanded = !this.state.isExpanded;
@@ -402,7 +428,7 @@ class DrawerInlineContentPanelLeft extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
-          <span>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -418,7 +444,7 @@ class DrawerInlineContentPanelLeft extends React.Component {
         <Button aria-expanded={isExpanded} onClick={this.onClick}>
           Toggle Drawer
         </Button>
-        <Drawer isExpanded={isExpanded} isInline position="left">
+        <Drawer isExpanded={isExpanded} isInline position="left" onMount={this.onMount}>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>{drawerContent}</DrawerContentBody>
           </DrawerContent>
@@ -440,7 +466,8 @@ import {
   DrawerHead,
   DrawerActions,
   DrawerCloseButton,
-  Button
+  Button,
+  Title
 } from '@patternfly/react-core';
 
 class DrawerStackedContentBodyElements extends React.Component {
@@ -448,6 +475,11 @@ class DrawerStackedContentBodyElements extends React.Component {
     super(props);
     this.state = {
       isExpanded: false
+    };
+    this.drawerRef = React.createRef();
+
+    this.onMount = () => {
+      this.state.isExpanded && this.drawerRef.current && this.drawerRef.current.focus()
     };
 
     this.onClick = () => {
@@ -469,6 +501,7 @@ class DrawerStackedContentBodyElements extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
+          <h3 className= "pf-c-title pf-m-2xl" tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer title </h3>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -484,7 +517,7 @@ class DrawerStackedContentBodyElements extends React.Component {
         <Button aria-expanded={isExpanded} onClick={this.onClick}>
           Toggle Drawer
         </Button>
-        <Drawer isExpanded={isExpanded}>
+        <Drawer isExpanded={isExpanded} onMount={this.onMount}>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>content-body</DrawerContentBody>
             <DrawerContentBody hasPadding>content-body with padding</DrawerContentBody>
@@ -508,7 +541,8 @@ import {
   DrawerHead,
   DrawerActions,
   DrawerCloseButton,
-  Button
+  Button,
+  Title
 } from '@patternfly/react-core';
 
 class DrawerStackedContentBodyElements extends React.Component {
@@ -516,6 +550,11 @@ class DrawerStackedContentBodyElements extends React.Component {
     super(props);
     this.state = {
       isExpanded: false
+    };
+    this.drawerRef = React.createRef();
+
+    this.onMount = () => {
+      this.state.isExpanded && this.drawerRef.current && this.drawerRef.current.focus()
     };
 
     this.onClick = () => {
@@ -537,6 +576,7 @@ class DrawerStackedContentBodyElements extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
+          <h3 className= "pf-c-title pf-m-2xl" tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer title </h3>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -549,10 +589,10 @@ class DrawerStackedContentBodyElements extends React.Component {
 
     return (
       <React.Fragment>
-        <Button aria-expanded={isExpanded} onClick={this.onClick}>
+        <Button aria-expanded={isExpanded} onClick={this.onClick} >
           Toggle Drawer
         </Button>
-        <Drawer isExpanded={isExpanded}>
+        <Drawer isExpanded={isExpanded} onMount={this.onMount}>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>content-body</DrawerContentBody>
             <DrawerContentBody hasPadding>content-body with padding</DrawerContentBody>
@@ -585,6 +625,11 @@ class DrawerModifiedContentPadding extends React.Component {
     this.state = {
       isExpanded: false
     };
+    this.drawerRef = React.createRef();
+
+    this.onMount = () => {
+      this.state.isExpanded && this.drawerRef.current && this.drawerRef.current.focus()
+    };
 
     this.onClick = () => {
       const isExpanded = !this.state.isExpanded;
@@ -605,7 +650,7 @@ class DrawerModifiedContentPadding extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
-          <span>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -621,7 +666,7 @@ class DrawerModifiedContentPadding extends React.Component {
         <Button aria-expanded={isExpanded} onClick={this.onClick}>
           Toggle Drawer
         </Button>
-        <Drawer isExpanded={isExpanded}>
+        <Drawer isExpanded={isExpanded} onMount={this.onMount}>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody hasPadding>
               <b>Drawer content padding.</b> {drawerContent}
@@ -654,6 +699,11 @@ class DrawerModifiedPanelPadding extends React.Component {
     this.state = {
       isExpanded: false
     };
+    this.drawerRef = React.createRef();
+
+    this.onMount = () => {
+      this.state.isExpanded && this.drawerRef.current && this.drawerRef.current.focus()
+    };
 
     this.onClick = () => {
       const isExpanded = !this.state.isExpanded;
@@ -674,7 +724,7 @@ class DrawerModifiedPanelPadding extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead hasNoPadding>
-          <span>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -690,7 +740,7 @@ class DrawerModifiedPanelPadding extends React.Component {
         <Button aria-expanded={isExpanded} onClick={this.onClick}>
           Toggle Drawer
         </Button>
-        <Drawer isExpanded={isExpanded}>
+        <Drawer isExpanded={isExpanded} onMount={this.onMount}>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>{drawerContent}</DrawerContentBody>
           </DrawerContent>
@@ -722,6 +772,11 @@ class DrawerWithSection extends React.Component {
     this.state = {
       isExpanded: false
     };
+    this.drawerRef = React.createRef();
+
+    this.onMount = () => {
+      this.state.isExpanded && this.drawerRef.current && this.drawerRef.current.focus()
+    };
 
     this.onClick = () => {
       const isExpanded = !this.state.isExpanded;
@@ -742,7 +797,7 @@ class DrawerWithSection extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
-          <span>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -758,7 +813,7 @@ class DrawerWithSection extends React.Component {
         <Button aria-expanded={isExpanded} onClick={this.onClick}>
           Toggle Drawer
         </Button>
-        <Drawer isExpanded={isExpanded}>
+        <Drawer isExpanded={isExpanded} onMount={this.onMount}>
           <DrawerSection>drawer-section</DrawerSection>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>{drawerContent}</DrawerContentBody>
@@ -828,6 +883,11 @@ class SimpleDrawer extends React.Component {
     this.state = {
       isExpanded: false
     };
+    this.drawerRef = React.createRef();
+
+    this.onMount = () => {
+      this.state.isExpanded && this.drawerRef.current && this.drawerRef.current.focus()
+    };
 
     this.onClick = () => {
       const isExpanded = !this.state.isExpanded;
@@ -848,7 +908,7 @@ class SimpleDrawer extends React.Component {
     const panelContent = (
       <DrawerPanelContent widths={{ default: 'width_33' }}>
         <DrawerHead>
-          <span>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -864,7 +924,7 @@ class SimpleDrawer extends React.Component {
         <Button aria-expanded={isExpanded} onClick={this.onClick}>
           Toggle Drawer
         </Button>
-        <Drawer isExpanded={isExpanded}>
+        <Drawer isExpanded={isExpanded} onMount={this.onMount}>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>{drawerContent}</DrawerContentBody>
           </DrawerContent>

--- a/packages/react-core/src/components/Drawer/examples/Drawer.md
+++ b/packages/react-core/src/components/Drawer/examples/Drawer.md
@@ -466,8 +466,7 @@ import {
   DrawerHead,
   DrawerActions,
   DrawerCloseButton,
-  Button,
-  Title
+  Button
 } from '@patternfly/react-core';
 
 class DrawerStackedContentBodyElements extends React.Component {
@@ -541,8 +540,7 @@ import {
   DrawerHead,
   DrawerActions,
   DrawerCloseButton,
-  Button,
-  Title
+  Button
 } from '@patternfly/react-core';
 
 class DrawerStackedContentBodyElements extends React.Component {

--- a/packages/react-integration/cypress/integration/drawer.spec.ts
+++ b/packages/react-integration/cypress/integration/drawer.spec.ts
@@ -16,7 +16,13 @@ describe('Drawer Demo Test', () => {
     cy.get('.pf-c-drawer').should('not.have.class', 'pf-m-expanded');
     cy.get('#toggleButton').click();
     cy.get('.pf-c-drawer').should('have.class', 'pf-m-expanded');
+    cy.get('#toggleButton').click();
   });
+
+  it('Verify that focus gets sent to drawer', () => {
+    cy.get('#toggleButton').click();
+    cy.focused().contains('drawer-panel');
+  })
 
   it('Verify panel widths', () => {
     // Large viewport

--- a/packages/react-integration/cypress/integration/drawer.spec.ts
+++ b/packages/react-integration/cypress/integration/drawer.spec.ts
@@ -22,7 +22,7 @@ describe('Drawer Demo Test', () => {
   it('Verify that focus gets sent to drawer', () => {
     cy.get('#toggleButton').click();
     cy.focused().contains('drawer-panel');
-  })
+  });
 
   it('Verify panel widths', () => {
     // Large viewport

--- a/packages/react-integration/demo-app-ts/src/components/demos/DrawerDemo/DrawerDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DrawerDemo/DrawerDemo.tsx
@@ -23,11 +23,11 @@ export class DrawerDemo extends React.Component<DrawerProps, DrawerDemoState> {
       isExpanded: false
     };
   }
-  drawerRef = React.createRef<HTMLButtonElement>();;
+  drawerRef = React.createRef<HTMLButtonElement>();
 
   onMount = () => {
-    this.state.isExpanded && this.drawerRef.current && this.drawerRef.current.focus()
-  }
+    this.state.isExpanded && this.drawerRef.current && this.drawerRef.current.focus();
+  };
 
   onClick = () => {
     const isExpanded = !this.state.isExpanded;
@@ -54,7 +54,9 @@ export class DrawerDemo extends React.Component<DrawerProps, DrawerDemoState> {
         }}
       >
         <DrawerHead>
-          <span ref={this.drawerRef} tabIndex={isExpanded ? 0 : -1}>drawer-panel</span>
+          <span ref={this.drawerRef} tabIndex={isExpanded ? 0 : -1}>
+            drawer-panel
+          </span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>

--- a/packages/react-integration/demo-app-ts/src/components/demos/DrawerDemo/DrawerDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DrawerDemo/DrawerDemo.tsx
@@ -23,6 +23,11 @@ export class DrawerDemo extends React.Component<DrawerProps, DrawerDemoState> {
       isExpanded: false
     };
   }
+  drawerRef = React.createRef<HTMLButtonElement>();;
+
+  onMount = () => {
+    this.state.isExpanded && this.drawerRef.current && this.drawerRef.current.focus()
+  }
 
   onClick = () => {
     const isExpanded = !this.state.isExpanded;
@@ -49,7 +54,7 @@ export class DrawerDemo extends React.Component<DrawerProps, DrawerDemoState> {
         }}
       >
         <DrawerHead>
-          <span>drawer-panel</span>
+          <span ref={this.drawerRef} tabIndex={isExpanded ? 0 : -1}>drawer-panel</span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -65,7 +70,7 @@ export class DrawerDemo extends React.Component<DrawerProps, DrawerDemoState> {
         <Button id="toggleButton" onClick={this.onClick}>
           Toggle Drawer
         </Button>
-        <Drawer isExpanded={isExpanded}>
+        <Drawer isExpanded={isExpanded} onMount={this.onMount}>
           <DrawerSection>drawer-section</DrawerSection>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>{drawerContent}</DrawerContentBody>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4309

This PR allows consumers to pass a function to the onMount or onUnMount prop and add their own functionality. This way allows for flexibility so, depending on the way the consumer is rendering the drawer content, they can specify where in the drawer to send focus with a ref.

An alternative way would be to manage this focus for them, but I was defaulting to flexibility first in case consumers end up using a more complex way of putting data into the drawer that I'm not considering.
