### PR TITLE
improvement(react-topology): make APIs more react friendly with hooks

### DIFF
--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/Basics.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/Basics.tsx
@@ -1,215 +1,344 @@
 import * as React from 'react';
-import { Visualization, VisualizationSurface, Model, ModelKind, withDragNode } from '@patternfly/react-topology';
+import {
+  action,
+  observer,
+  Model,
+  ModelKind,
+  withDragNode,
+  useComponentFactory,
+  useModel,
+  useAnchor,
+  RectAnchor,
+  EllipseAnchor,
+  Node,
+  ComponentFactory
+} from '@patternfly/react-topology';
 import defaultComponentFactory from './components/defaultComponentFactory';
-import Node from './components/DefaultNode';
+import DefaultNode from './components/DefaultNode';
+import withTopologySetup from './utils/withTopologySetup';
+import Dimensions from '@patternfly/react-topology/dist/js/geom/Dimensions';
 
-export const SingleNode = () => {
-  const vis = new Visualization();
-  const model: Model = {
-    graph: {
-      id: 'g1',
-      type: 'graph'
-    },
-    nodes: [
-      {
-        id: 'n1',
-        type: 'node',
-        x: 50,
-        y: 50,
-        width: 20,
-        height: 20
+export const SingleNode = withTopologySetup(() => {
+  useComponentFactory(defaultComponentFactory);
+  useModel(
+    React.useMemo(
+      (): Model => ({
+        graph: {
+          id: 'g1',
+          type: 'graph'
+        },
+        nodes: [
+          {
+            id: 'n1',
+            type: 'node',
+            x: 50,
+            y: 50,
+            width: 20,
+            height: 20
+          }
+        ]
+      }),
+      []
+    )
+  );
+  return null;
+});
+
+export const SingleEdge = withTopologySetup(() => {
+  useComponentFactory(defaultComponentFactory);
+  useModel(
+    React.useMemo(
+      (): Model => ({
+        graph: {
+          id: 'g1',
+          type: 'graph'
+        },
+        nodes: [
+          {
+            id: 'n1',
+            type: 'node',
+            x: 20,
+            y: 20,
+            width: 20,
+            height: 20
+          },
+          {
+            id: 'n2',
+            type: 'node',
+            x: 200,
+            y: 50,
+            width: 100,
+            height: 30
+          }
+        ],
+        edges: [
+          {
+            id: 'e1',
+            type: 'edge',
+            source: 'n1',
+            target: 'n2',
+            bendpoints: [[80, 30], [110, 10]]
+          }
+        ]
+      }),
+      []
+    )
+  );
+  return null;
+});
+
+export const MultiEdge = withTopologySetup(() => {
+  useComponentFactory(defaultComponentFactory);
+  useComponentFactory(
+    React.useCallback<ComponentFactory>(kind => {
+      if (kind === ModelKind.node) {
+        return withDragNode()(DefaultNode);
       }
-    ]
-  };
-  vis.fromModel(model);
-  vis.registerComponentFactory(defaultComponentFactory);
-  return <VisualizationSurface visualization={vis} />;
+      return undefined;
+    }, [])
+  );
+  useModel(
+    React.useMemo(
+      (): Model => ({
+        graph: {
+          id: 'g1',
+          type: 'graph'
+        },
+        nodes: [
+          {
+            id: 'n1',
+            type: 'node',
+            x: 50,
+            y: 50,
+            width: 100,
+            height: 100
+          },
+          {
+            id: 'n2',
+            type: 'node',
+            x: 400,
+            y: 50,
+            width: 100,
+            height: 100
+          },
+          {
+            id: 'n3',
+            type: 'node',
+            x: 50,
+            y: 200,
+            width: 100,
+            height: 100
+          },
+          {
+            id: 'n4',
+            type: 'node',
+            x: 400,
+            y: 200,
+            width: 100,
+            height: 100
+          }
+        ],
+        edges: [
+          {
+            id: 'e1',
+            type: 'multi-edge',
+            source: 'n1',
+            target: 'n2'
+          },
+          {
+            id: 'e2',
+            type: 'multi-edge',
+            source: 'n1',
+            target: 'n2'
+          },
+          {
+            id: 'e3',
+            type: 'multi-edge',
+            source: 'n3',
+            target: 'n4'
+          },
+          {
+            id: 'e4',
+            type: 'multi-edge',
+            source: 'n3',
+            target: 'n4'
+          },
+          {
+            id: 'e5',
+            type: 'multi-edge',
+            source: 'n3',
+            target: 'n4'
+          },
+          {
+            id: 'e6',
+            type: 'multi-edge',
+            source: 'n3',
+            target: 'n4'
+          },
+          {
+            id: 'e7',
+            type: 'multi-edge',
+            source: 'n3',
+            target: 'n4'
+          }
+        ]
+      }),
+      []
+    )
+  );
+  return null;
+});
+
+const groupStory = (groupType: string): React.FC => () => {
+  useComponentFactory(defaultComponentFactory);
+  useModel(
+    React.useMemo(
+      (): Model => ({
+        graph: {
+          id: 'g1',
+          type: 'graph'
+        },
+        nodes: [
+          {
+            id: 'gr1',
+            type: groupType,
+            group: true,
+            children: ['n1', 'n2', 'n3'],
+            style: {
+              padding: 10
+            }
+          },
+          {
+            id: 'n1',
+            type: 'node',
+            x: 50,
+            y: 50,
+            width: 30,
+            height: 30
+          },
+          {
+            id: 'n2',
+            type: 'node',
+            x: 200,
+            y: 20,
+            width: 10,
+            height: 10
+          },
+          {
+            id: 'n3',
+            type: 'node',
+            x: 150,
+            y: 100,
+            width: 20,
+            height: 20
+          }
+        ]
+      }),
+      []
+    )
+  );
+  return null;
 };
 
-export const SingleEdge = () => {
-  const vis = new Visualization();
-  const model: Model = {
-    graph: {
-      id: 'g1',
-      type: 'graph'
-    },
-    nodes: [
-      {
-        id: 'n1',
-        type: 'node',
-        x: 20,
-        y: 20,
-        width: 20,
-        height: 20
-      },
-      {
-        id: 'n2',
-        type: 'node',
-        x: 200,
-        y: 50,
-        width: 100,
-        height: 30
-      }
-    ],
-    edges: [
-      {
-        id: 'e1',
-        type: 'edge',
-        source: 'n1',
-        target: 'n2',
-        bendpoints: [[80, 30], [110, 10]]
-      }
-    ]
-  };
-  vis.fromModel(model);
-  vis.registerComponentFactory(defaultComponentFactory);
-  return <VisualizationSurface visualization={vis} />;
-};
+export const Group = withTopologySetup(groupStory('group'));
+export const GroupHull = withTopologySetup(groupStory('group-hull'));
 
-export const MultiEdge = () => {
-  const vis = new Visualization();
-  const model: Model = {
-    graph: {
-      id: 'g1',
-      type: 'graph'
-    },
-    nodes: [
-      {
-        id: 'n1',
-        type: 'node',
-        x: 50,
-        y: 50,
-        width: 100,
-        height: 100
-      },
-      {
-        id: 'n2',
-        type: 'node',
-        x: 400,
-        y: 50,
-        width: 100,
-        height: 100
-      },
-      {
-        id: 'n3',
-        type: 'node',
-        x: 50,
-        y: 200,
-        width: 100,
-        height: 100
-      },
-      {
-        id: 'n4',
-        type: 'node',
-        x: 400,
-        y: 200,
-        width: 100,
-        height: 100
-      }
-    ],
-    edges: [
-      {
-        id: 'e1',
-        type: 'multi-edge',
-        source: 'n1',
-        target: 'n2'
-      },
-      {
-        id: 'e2',
-        type: 'multi-edge',
-        source: 'n1',
-        target: 'n2'
-      },
-      {
-        id: 'e3',
-        type: 'multi-edge',
-        source: 'n3',
-        target: 'n4'
-      },
-      {
-        id: 'e4',
-        type: 'multi-edge',
-        source: 'n3',
-        target: 'n4'
-      },
-      {
-        id: 'e5',
-        type: 'multi-edge',
-        source: 'n3',
-        target: 'n4'
-      },
-      {
-        id: 'e6',
-        type: 'multi-edge',
-        source: 'n3',
-        target: 'n4'
-      },
-      {
-        id: 'e7',
-        type: 'multi-edge',
-        source: 'n3',
-        target: 'n4'
-      }
-    ]
-  };
-  vis.fromModel(model);
-  vis.registerComponentFactory(defaultComponentFactory);
-  vis.registerComponentFactory(kind => {
-    if (kind === ModelKind.node) {
-      return withDragNode()(Node);
-    }
-    return undefined;
-  });
-  return <VisualizationSurface visualization={vis} />;
-};
+const CustomCircle: React.FC<{ element: Node }> = observer(({ element }) => {
+  useAnchor(EllipseAnchor);
+  React.useEffect(() => {
+    // init height
+    action(() => element.setDimensions(new Dimensions(40, 40)))();
+  }, [element]);
+  const r = element.getDimensions().width / 2;
+  return (
+    <circle
+      cx={r}
+      cy={r}
+      r={r}
+      fill="grey"
+      strokeWidth={1}
+      stroke="#333333"
+      onClick={() => {
+        const size = element.getDimensions().width === 40 ? 80 : 40;
+        action(() => element.setDimensions(new Dimensions(size, size)))();
+      }}
+    />
+  );
+});
 
-const GroupStory = (groupType: string) => {
-  const vis = new Visualization();
-  const model: Model = {
-    graph: {
-      id: 'g1',
-      type: 'graph'
-    },
-    nodes: [
-      {
-        id: 'gr1',
-        type: groupType,
-        group: true,
-        children: ['n1', 'n2', 'n3'],
-        style: {
-          padding: 10
-        }
-      },
-      {
-        id: 'n1',
-        type: 'node',
-        x: 50,
-        y: 50,
-        width: 30,
-        height: 30
-      },
-      {
-        id: 'n2',
-        type: 'node',
-        x: 200,
-        y: 20,
-        width: 10,
-        height: 10
-      },
-      {
-        id: 'n3',
-        type: 'node',
-        x: 150,
-        y: 100,
-        width: 20,
-        height: 20
-      }
-    ]
-  };
-  vis.fromModel(model);
-  vis.registerComponentFactory(defaultComponentFactory);
-  return <VisualizationSurface visualization={vis} />;
-};
+const CustomRect: React.FC = observer(() => {
+  useAnchor(RectAnchor);
+  return <rect x={0} y={0} width={100} height={20} fill="grey" strokeWidth={1} stroke="#333333" />;
+});
 
-export const Group = () => GroupStory('group');
-export const GroupHull = () => GroupStory('group-hull');
+export const AutoSizeNode = withTopologySetup(() => {
+  useComponentFactory(defaultComponentFactory);
+  useComponentFactory(
+    React.useCallback<ComponentFactory>((kind, type) => {
+      if (type === 'autoSize-circle') {
+        return CustomCircle;
+      }
+      if (type === 'autoSize-rect') {
+        return CustomRect;
+      }
+      return undefined;
+    }, [])
+  );
+  useModel(
+    React.useMemo(
+      (): Model => ({
+        graph: {
+          id: 'g1',
+          type: 'graph'
+        },
+        nodes: [
+          {
+            id: 'n1',
+            type: 'autoSize-rect',
+            x: 50,
+            y: 50
+          },
+
+          {
+            id: 'n2',
+            type: 'autoSize-circle',
+            x: 250,
+            y: 200
+          },
+
+          {
+            id: 'n3',
+            type: 'autoSize-rect',
+            x: 300,
+            y: 70
+          },
+          {
+            id: 'gr1',
+            type: 'group',
+            group: true,
+            children: ['n1', 'n3'],
+            style: {
+              padding: 10
+            }
+          }
+        ],
+        edges: [
+          {
+            id: 'e1',
+            type: 'edge',
+            source: 'n1',
+            target: 'n2'
+          },
+          {
+            id: 'e2',
+            type: 'edge',
+            source: 'gr1',
+            target: 'n2'
+          }
+        ]
+      }),
+      []
+    )
+  );
+  return null;
+});

--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/CollapsibleGroups.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/CollapsibleGroups.tsx
@@ -18,9 +18,11 @@ import {
   SELECTION_EVENT,
   SelectionEventListener,
   withSelection,
-  createAggregateEdges
+  createAggregateEdges,
+  VisualizationProvider,
+  useEventListener
 } from '@patternfly/react-topology';
-import { Toolbar, ToolbarGroup, ToolbarItem, Checkbox } from '@patternfly/react-core';
+import { ToolbarGroup, ToolbarItem, Checkbox } from '@patternfly/react-core';
 import defaultLayoutFactory from './layouts/defaultLayoutFactory';
 import data from './data/group-types';
 import GroupHull from './components/GroupHull';
@@ -128,7 +130,7 @@ const TopologyViewComponent: React.FC<TopologyViewComponentProps> = ({ vis }) =>
   const [collapseOrange, setCollapseOrange] = React.useState<boolean>(false);
   const [collapsePink, setCollapsePink] = React.useState<boolean>(false);
 
-  vis.addEventListener<SelectionEventListener>(SELECTION_EVENT, ids => {
+  useEventListener<SelectionEventListener>(SELECTION_EVENT, ids => {
     setSelectedIds(ids);
   });
 
@@ -235,7 +237,7 @@ const TopologyViewComponent: React.FC<TopologyViewComponentProps> = ({ vis }) =>
       }
       viewToolbar={viewToolbar}
     >
-      <VisualizationSurface visualization={vis} state={{ selectedIds }} />
+      <VisualizationSurface state={{ selectedIds }} />
     </TopologyView>
   );
 };
@@ -243,5 +245,9 @@ const TopologyViewComponent: React.FC<TopologyViewComponentProps> = ({ vis }) =>
 export const CollapsibleGroups = () => {
   const vis: Visualization = getVisualization(getModel());
 
-  return <TopologyViewComponent vis={vis} />;
+  return (
+    <VisualizationProvider controller={vis}>
+      <TopologyViewComponent vis={vis} />
+    </VisualizationProvider>
+  );
 };

--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/Connectors.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/Connectors.tsx
@@ -22,12 +22,17 @@ import {
   WithDragNodeProps,
   Layer,
   Graph,
-  isGraph
+  isGraph,
+  useModel,
+  useComponentFactory,
+  ComponentFactory,
+  useVisualizationController
 } from '@patternfly/react-topology';
 import defaultComponentFactory from './components/defaultComponentFactory';
 import DefaultEdge from './components/DefaultEdge';
 import DefaultNode from './components/DefaultNode';
 import NodeRect from './components/NodeRect';
+import withTopologySetup from './utils/withTopologySetup';
 
 interface NodeProps {
   element: Node;
@@ -37,291 +42,308 @@ interface EdgeProps {
   element: Edge;
 }
 
-export const Reconnect = () => {
-  const vis = new Visualization();
-  vis.registerComponentFactory(defaultComponentFactory);
-  vis.registerComponentFactory(kind => {
-    if (kind === ModelKind.graph) {
-      return withPanZoom()(GraphComponent);
-    }
-    if (kind === ModelKind.node) {
-      return withDndDrop<Edge, any, { droppable?: boolean; hover?: boolean; canDrop?: boolean }, NodeProps>({
-        accept: 'test',
-        canDrop: (item, monitor, props) =>
-          !props || (item.getSource() !== props.element && item.getTarget() !== props.element),
-        collect: monitor => ({
-          droppable: monitor.isDragging(),
-          hover: monitor.isOver(),
-          canDrop: monitor.canDrop()
-        })
-      })(DefaultNode);
-    }
-    if (kind === ModelKind.edge) {
-      return withSourceDrag<DragObjectWithType, Node, any, EdgeProps>({
-        item: { type: 'test' },
-        begin: (monitor, props) => {
-          props.element.raise();
-          return props.element;
-        },
-        drag: (event, monitor, props) => {
-          props.element.setStartPoint(event.x, event.y);
-        },
-        end: (dropResult, monitor, props) => {
-          if (monitor.didDrop() && dropResult && props) {
-            props.element.setSource(dropResult);
-          }
-          props.element.setStartPoint();
-        }
-      })(
-        withTargetDrag<DragObjectWithType, Node, { dragging?: boolean }, EdgeProps>({
+export const Reconnect = withTopologySetup(() => {
+  useComponentFactory(defaultComponentFactory);
+  useComponentFactory(
+    React.useCallback<ComponentFactory>(kind => {
+      if (kind === ModelKind.graph) {
+        return withPanZoom()(GraphComponent);
+      }
+      if (kind === ModelKind.node) {
+        return withDndDrop<Edge, any, { droppable?: boolean; hover?: boolean; canDrop?: boolean }, NodeProps>({
+          accept: 'test',
+          canDrop: (item, monitor, props) =>
+            !props || (item.getSource() !== props.element && item.getTarget() !== props.element),
+          collect: monitor => ({
+            droppable: monitor.isDragging(),
+            hover: monitor.isOver(),
+            canDrop: monitor.canDrop()
+          })
+        })(DefaultNode);
+      }
+      if (kind === ModelKind.edge) {
+        return withSourceDrag<DragObjectWithType, Node, any, EdgeProps>({
           item: { type: 'test' },
           begin: (monitor, props) => {
             props.element.raise();
             return props.element;
           },
           drag: (event, monitor, props) => {
-            props.element.setEndPoint(event.x, event.y);
+            props.element.setStartPoint(event.x, event.y);
           },
           end: (dropResult, monitor, props) => {
             if (monitor.didDrop() && dropResult && props) {
-              props.element.setTarget(dropResult);
+              props.element.setSource(dropResult);
             }
-            props.element.setEndPoint();
+            props.element.setStartPoint();
+          }
+        })(
+          withTargetDrag<DragObjectWithType, Node, { dragging?: boolean }, EdgeProps>({
+            item: { type: 'test' },
+            begin: (monitor, props) => {
+              props.element.raise();
+              return props.element;
+            },
+            drag: (event, monitor, props) => {
+              props.element.setEndPoint(event.x, event.y);
+            },
+            end: (dropResult, monitor, props) => {
+              if (monitor.didDrop() && dropResult && props) {
+                props.element.setTarget(dropResult);
+              }
+              props.element.setEndPoint();
+            },
+            collect: monitor => ({
+              dragging: monitor.isDragging()
+            })
+          })(DefaultEdge)
+        );
+      }
+      return undefined;
+    }, [])
+  );
+  useModel(
+    React.useMemo(
+      (): Model => ({
+        graph: {
+          id: 'g1',
+          type: 'graph'
+        },
+        nodes: [
+          {
+            id: 'n1',
+            type: 'node',
+            x: 20,
+            y: 150,
+            width: 20,
+            height: 20
           },
-          collect: monitor => ({
-            dragging: monitor.isDragging()
-          })
-        })(DefaultEdge)
-      );
-    }
-    return undefined;
-  });
-  const model: Model = {
-    graph: {
-      id: 'g1',
-      type: 'graph'
-    },
-    nodes: [
-      {
-        id: 'n1',
-        type: 'node',
-        x: 20,
-        y: 150,
-        width: 20,
-        height: 20
-      },
-      {
-        id: 'n2',
-        type: 'node',
-        x: 200,
-        y: 50,
-        width: 100,
-        height: 30
-      },
-      {
-        id: 'n3',
-        type: 'node',
-        x: 200,
-        y: 300,
-        width: 30,
-        height: 30
-      }
-    ],
-    edges: [
-      {
-        id: 'e1',
-        type: 'edge',
-        source: 'n1',
-        target: 'n2',
-        bendpoints: [[50, 30], [110, 10]]
-      },
-      {
-        id: 'e2',
-        type: 'edge',
-        source: 'n1',
-        target: 'n3'
-      }
-    ]
-  };
-  vis.fromModel(model);
-  return <VisualizationSurface visualization={vis} />;
-};
+          {
+            id: 'n2',
+            type: 'node',
+            x: 200,
+            y: 50,
+            width: 100,
+            height: 30
+          },
+          {
+            id: 'n3',
+            type: 'node',
+            x: 200,
+            y: 300,
+            width: 30,
+            height: 30
+          }
+        ],
+        edges: [
+          {
+            id: 'e1',
+            type: 'edge',
+            source: 'n1',
+            target: 'n2',
+            bendpoints: [[50, 30], [110, 10]]
+          },
+          {
+            id: 'e2',
+            type: 'edge',
+            source: 'n1',
+            target: 'n3'
+          }
+        ]
+      }),
+      []
+    )
+  );
+  return null;
+});
 
 type ColorChoice = ConnectorChoice & {
   color: string;
 };
 
-export const CreateConnector = () => {
-  const model: Model = {
-    graph: {
-      id: 'g1',
-      type: 'graph'
-    },
-    nodes: [
-      {
-        id: 'n1',
-        type: 'node',
-        x: 20,
-        y: 150,
-        width: 104,
-        height: 104
+export const CreateConnector = withTopologySetup(() => {
+  const model = React.useMemo(
+    (): Model => ({
+      graph: {
+        id: 'g1',
+        type: 'graph'
       },
-      {
-        id: 'n2',
-        type: 'node',
-        x: 200,
-        y: 50,
-        width: 100,
-        height: 30
-      },
-      {
-        id: 'n3',
-        type: 'node',
-        x: 200,
-        y: 300,
-        width: 30,
-        height: 30
-      }
-    ]
-  };
-
-  const vis = new Visualization();
-  vis.registerComponentFactory(defaultComponentFactory);
-  vis.registerComponentFactory(kind => {
-    if (kind === ModelKind.graph) {
-      return withDndDrop({
-        accept: CREATE_CONNECTOR_DROP_TYPE,
-        dropHint: 'create'
-      })(withPanZoom()(GraphComponent));
-    }
-    if (kind === ModelKind.node) {
-      return withCreateConnector(
-        (source: Node, target: Node | Graph, event: DragEvent, choice: ColorChoice | undefined): any[] | null => {
-          if (!choice) {
-            return [{ label: 'Create Annotation', color: 'red' }, { label: 'Create Binding', color: 'green' }];
-          }
-
-          let targetId;
-          if (isGraph(target)) {
-            if (!model.nodes) {
-              model.nodes = [];
-            }
-            targetId = `n${vis.getGraph().getNodes().length + 1}`;
-            model.nodes.push({
-              id: targetId,
-              type: 'node',
-              x: event.x - 15,
-              y: event.y - 15,
-              height: 30,
-              width: 30
-            });
-          } else {
-            targetId = target.getId();
-          }
-          const id = `e${vis.getGraph().getEdges().length + 1}`;
-          if (!model.edges) {
-            model.edges = [];
-          }
-          model.edges.push({
-            id,
-            type: 'edge',
-            source: source.getId(),
-            target: targetId,
-            data: {
-              color: choice.color
-            }
-          });
-          vis.fromModel(model);
-          return null;
+      nodes: [
+        {
+          id: 'n1',
+          type: 'node',
+          x: 20,
+          y: 150,
+          width: 104,
+          height: 104
+        },
+        {
+          id: 'n2',
+          type: 'node',
+          x: 200,
+          y: 50,
+          width: 100,
+          height: 30
+        },
+        {
+          id: 'n3',
+          type: 'node',
+          x: 200,
+          y: 300,
+          width: 30,
+          height: 30
         }
-      )(
-        withDndDrop<Node, any, { droppable?: boolean; hover?: boolean; canDrop?: boolean }, NodeProps>({
-          accept: CREATE_CONNECTOR_DROP_TYPE,
-          canDrop: (item, monitor, props) => !props || item !== props.element,
-          collect: monitor => ({
-            droppable: monitor.isDragging(),
-            hover: monitor.isOver(),
-            canDrop: monitor.canDrop()
-          })
-        })(DefaultNode)
-      );
-    }
-    return undefined;
-  });
-  vis.fromModel(model);
-  return <VisualizationSurface visualization={vis} />;
+      ]
+    }),
+    []
+  );
+  const controller = useVisualizationController();
+  useComponentFactory(defaultComponentFactory);
+  useComponentFactory(
+    React.useCallback<ComponentFactory>(
+      kind => {
+        if (kind === ModelKind.graph) {
+          return withDndDrop({
+            accept: CREATE_CONNECTOR_DROP_TYPE,
+            dropHint: 'create'
+          })(withPanZoom()(GraphComponent));
+        }
+        if (kind === ModelKind.node) {
+          return withCreateConnector(
+            (source: Node, target: Node | Graph, event: DragEvent, choice: ColorChoice | undefined): any[] | null => {
+              if (!choice) {
+                return [{ label: 'Create Annotation', color: 'red' }, { label: 'Create Binding', color: 'green' }];
+              }
+
+              let targetId;
+              if (isGraph(target)) {
+                if (!model.nodes) {
+                  model.nodes = [];
+                }
+                targetId = `n${controller.getGraph().getNodes().length + 1}`;
+                model.nodes.push({
+                  id: targetId,
+                  type: 'node',
+                  x: event.x - 15,
+                  y: event.y - 15,
+                  height: 30,
+                  width: 30
+                });
+              } else {
+                targetId = target.getId();
+              }
+              const id = `e${controller.getGraph().getEdges().length + 1}`;
+              if (!model.edges) {
+                model.edges = [];
+              }
+              model.edges.push({
+                id,
+                type: 'edge',
+                source: source.getId(),
+                target: targetId,
+                data: {
+                  color: choice.color
+                }
+              });
+              controller.fromModel(model);
+              return null;
+            }
+          )(
+            withDndDrop<Node, any, { droppable?: boolean; hover?: boolean; canDrop?: boolean }, NodeProps>({
+              accept: CREATE_CONNECTOR_DROP_TYPE,
+              canDrop: (item, monitor, props) => !props || item !== props.element,
+              collect: monitor => ({
+                droppable: monitor.isDragging(),
+                hover: monitor.isOver(),
+                canDrop: monitor.canDrop()
+              })
+            })(DefaultNode)
+          );
+        }
+        return undefined;
+      },
+      [model, controller]
+    )
+  );
+  useModel(model);
+  return null;
+});
+
+const NodeWithPointAnchor: React.FC<{ element: Node } & WithDragNodeProps> = props => {
+  const nodeRef = useSvgAnchor();
+  const targetRef = useSvgAnchor(AnchorEnd.target, 'edge-point');
+  const { width, height } = props.element.getDimensions();
+  return (
+    <>
+      <Layer id="bottom">
+        <NodeRect {...(props as any)} />
+      </Layer>
+      <circle ref={nodeRef} fill="lightgreen" r="5" cx={width * 0.25} cy={height * 0.25} />
+      <circle ref={targetRef} fill="red" r="5" cx={width * 0.75} cy={height * 0.75} />
+    </>
+  );
 };
 
-export const Anchors = () => {
-  const NodeWithPointAnchor: React.FC<{ element: Node } & WithDragNodeProps> = props => {
-    const nodeRef = useSvgAnchor();
-    const targetRef = useSvgAnchor(AnchorEnd.target, 'edge-point');
-    const { width, height } = props.element.getDimensions();
-    return (
-      <>
-        <Layer id="bottom">
-          <NodeRect {...(props as any)} />
-        </Layer>
-        <circle ref={nodeRef} fill="lightgreen" r="5" cx={width * 0.25} cy={height * 0.25} />
-        <circle ref={targetRef} fill="red" r="5" cx={width * 0.75} cy={height * 0.75} />
-      </>
-    );
-  };
-  const model: Model = {
-    graph: {
-      id: 'g1',
-      type: 'graph'
-    },
-    nodes: [
-      {
-        id: 'n1',
-        type: 'node',
-        x: 150,
-        y: 10,
-        width: 100,
-        height: 100
-      },
-      {
-        id: 'n2',
-        type: 'node',
-        x: 25,
-        y: 250,
-        width: 50,
-        height: 50
-      },
-      {
-        id: 'n3',
-        type: 'node',
-        x: 225,
-        y: 250,
-        width: 50,
-        height: 50
+export const Anchors = withTopologySetup(() => {
+  useComponentFactory(defaultComponentFactory);
+  useComponentFactory(
+    React.useCallback<ComponentFactory>(kind => {
+      if (kind === ModelKind.node) {
+        return withDragNode()(NodeWithPointAnchor);
       }
-    ],
-    edges: [
-      {
-        id: 'e1',
-        type: 'edge-point',
-        source: 'n1',
-        target: 'n3'
-      },
-      {
-        id: 'e2',
-        type: 'edge-point',
-        source: 'n2',
-        target: 'n1'
-      }
-    ]
-  };
-
-  const vis = new Visualization();
-  vis.registerComponentFactory(defaultComponentFactory);
-  vis.registerComponentFactory(kind => {
-    if (kind === ModelKind.node) {
-      return withDragNode()(NodeWithPointAnchor);
-    }
-    return undefined;
-  });
-  vis.fromModel(model);
-  return <VisualizationSurface visualization={vis} />;
-};
+      return undefined;
+    }, [])
+  );
+  useModel(
+    React.useMemo(
+      (): Model => ({
+        graph: {
+          id: 'g1',
+          type: 'graph'
+        },
+        nodes: [
+          {
+            id: 'n1',
+            type: 'node',
+            x: 150,
+            y: 10,
+            width: 100,
+            height: 100
+          },
+          {
+            id: 'n2',
+            type: 'node',
+            x: 25,
+            y: 250,
+            width: 50,
+            height: 50
+          },
+          {
+            id: 'n3',
+            type: 'node',
+            x: 225,
+            y: 250,
+            width: 50,
+            height: 50
+          }
+        ],
+        edges: [
+          {
+            id: 'e1',
+            type: 'edge-point',
+            source: 'n1',
+            target: 'n3'
+          },
+          {
+            id: 'e2',
+            type: 'edge-point',
+            source: 'n2',
+            target: 'n1'
+          }
+        ]
+      }),
+      []
+    )
+  );
+  return null;
+});

--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/DragDrop.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/DragDrop.tsx
@@ -11,230 +11,244 @@ import {
   GraphComponent,
   withPanZoom,
   DragObjectWithType,
-  withDragNode
+  withDragNode,
+  useModel,
+  useComponentFactory,
+  ComponentFactory
 } from '@patternfly/react-topology';
 import defaultComponentFactory from './components/defaultComponentFactory';
 import DefaultNode from './components/DefaultNode';
 import GroupHull from './components/GroupHull';
+import withTopologySetup from './utils/withTopologySetup';
 
 interface ElementProps {
   element: Node;
 }
 
-export const Dnd = () => {
-  const vis = new Visualization();
-  const model: Model = {
-    graph: {
-      id: 'g1',
-      type: 'graph'
-    },
-    nodes: [
-      {
-        id: 'gr1',
-        type: 'group-drop',
-        group: true,
-        children: ['n2', 'n3'],
-        style: {
-          padding: 10
-        }
-      },
-      {
-        id: 'gr2',
-        type: 'group-drop',
-        group: true,
-        children: ['n4', 'n5'],
-        style: {
-          padding: 10
-        }
-      },
-      {
-        id: 'n1',
-        type: 'node-drag',
-        x: 50,
-        y: 50,
-        width: 30,
-        height: 30
-      },
-      {
-        id: 'n2',
-        type: 'node',
-        x: 200,
-        y: 20,
-        width: 10,
-        height: 10
-      },
-      {
-        id: 'n3',
-        type: 'node',
-        x: 150,
-        y: 100,
-        width: 20,
-        height: 20
-      },
-      {
-        id: 'n4',
-        type: 'node',
-        x: 300,
-        y: 250,
-        width: 30,
-        height: 30
-      },
-      {
-        id: 'n5',
-        type: 'node',
-        x: 350,
-        y: 370,
-        width: 15,
-        height: 15
-      }
-    ]
-  };
-  vis.fromModel(model);
-  vis.registerComponentFactory(defaultComponentFactory);
+export const Dnd = withTopologySetup(() => {
+  useComponentFactory(defaultComponentFactory);
   // support pan zoom and drag
-  vis.registerComponentFactory((kind, type) => {
-    if (kind === ModelKind.graph) {
-      return withPanZoom()(GraphComponent);
-    }
-    if (type === 'group-drop') {
-      return withDndDrop<Node, any, { droppable?: boolean; hover?: boolean; canDrop?: boolean }, ElementProps>({
-        accept: 'test',
-        canDrop: (item, monitor, props) => !!props && item.getParent() !== props.element,
-        collect: monitor => ({
-          droppable: monitor.isDragging(),
-          hover: monitor.isOver(),
-          canDrop: monitor.canDrop()
-        })
-      })(GroupHull);
-    }
-    if (type === 'node-drag') {
-      return withDndDrag<DragObjectWithType, Node, {}, ElementProps>({
-        item: { type: 'test' },
-        begin: (monitor, props) => {
-          props.element.raise();
-          return props.element;
-        },
-        drag: (event, monitor, props) => {
-          props.element.setPosition(
-            props.element
-              .getPosition()
-              .clone()
-              .translate(event.dx, event.dy)
-          );
-        },
-        end: (dropResult, monitor, props) => {
-          if (monitor.didDrop() && dropResult && props) {
-            dropResult.appendChild(props.element);
+  useComponentFactory(
+    React.useCallback<ComponentFactory>((kind, type) => {
+      if (kind === ModelKind.graph) {
+        return withPanZoom()(GraphComponent);
+      }
+      if (type === 'group-drop') {
+        return withDndDrop<Node, any, { droppable?: boolean; hover?: boolean; canDrop?: boolean }, ElementProps>({
+          accept: 'test',
+          canDrop: (item, monitor, props) => !!props && item.getParent() !== props.element,
+          collect: monitor => ({
+            droppable: monitor.isDragging(),
+            hover: monitor.isOver(),
+            canDrop: monitor.canDrop()
+          })
+        })(GroupHull);
+      }
+      if (type === 'node-drag') {
+        return withDndDrag<DragObjectWithType, Node, {}, ElementProps>({
+          item: { type: 'test' },
+          begin: (monitor, props) => {
+            props.element.raise();
+            return props.element;
+          },
+          drag: (event, monitor, props) => {
+            props.element.setPosition(
+              props.element
+                .getPosition()
+                .clone()
+                .translate(event.dx, event.dy)
+            );
+          },
+          end: (dropResult, monitor, props) => {
+            if (monitor.didDrop() && dropResult && props) {
+              dropResult.appendChild(props.element);
+            }
           }
-        }
-      })(DefaultNode);
-    }
-    return undefined;
-  });
-  return <VisualizationSurface visualization={vis} />;
-};
+        })(DefaultNode);
+      }
+      return undefined;
+    }, [])
+  );
+  useModel(
+    React.useMemo(
+      (): Model => ({
+        graph: {
+          id: 'g1',
+          type: 'graph'
+        },
+        nodes: [
+          {
+            id: 'gr1',
+            type: 'group-drop',
+            group: true,
+            children: ['n2', 'n3'],
+            style: {
+              padding: 10
+            }
+          },
+          {
+            id: 'gr2',
+            type: 'group-drop',
+            group: true,
+            children: ['n4', 'n5'],
+            style: {
+              padding: 10
+            }
+          },
+          {
+            id: 'n1',
+            type: 'node-drag',
+            x: 50,
+            y: 50,
+            width: 30,
+            height: 30
+          },
+          {
+            id: 'n2',
+            type: 'node',
+            x: 200,
+            y: 20,
+            width: 10,
+            height: 10
+          },
+          {
+            id: 'n3',
+            type: 'node',
+            x: 150,
+            y: 100,
+            width: 20,
+            height: 20
+          },
+          {
+            id: 'n4',
+            type: 'node',
+            x: 300,
+            y: 250,
+            width: 30,
+            height: 30
+          },
+          {
+            id: 'n5',
+            type: 'node',
+            x: 350,
+            y: 370,
+            width: 15,
+            height: 15
+          }
+        ]
+      }),
+      []
+    )
+  );
+  return null;
+});
 
-export const DndShiftRegroup = () => {
-  const vis = new Visualization();
-  const model: Model = {
-    graph: {
-      id: 'g1',
-      type: 'graph'
-    },
-    nodes: [
-      {
-        id: 'gr1',
-        type: 'group-drop',
-        group: true,
-        children: ['n2', 'n3'],
-        style: {
-          padding: 10
-        }
-      },
-      {
-        id: 'gr2',
-        type: 'group-drop',
-        group: true,
-        children: ['n4', 'n5'],
-        style: {
-          padding: 10
-        }
-      },
-      {
-        id: 'n1',
-        type: 'node-drag',
-        x: 50,
-        y: 50,
-        width: 30,
-        height: 30
-      },
-      {
-        id: 'n2',
-        type: 'node',
-        x: 200,
-        y: 20,
-        width: 10,
-        height: 10
-      },
-      {
-        id: 'n3',
-        type: 'node',
-        x: 150,
-        y: 100,
-        width: 20,
-        height: 20
-      },
-      {
-        id: 'n4',
-        type: 'node',
-        x: 300,
-        y: 250,
-        width: 30,
-        height: 30
-      },
-      {
-        id: 'n5',
-        type: 'node',
-        x: 350,
-        y: 370,
-        width: 15,
-        height: 15
-      }
-    ]
-  };
-  vis.fromModel(model);
-  vis.registerComponentFactory(defaultComponentFactory);
+export const DndShiftRegroup = withTopologySetup(() => {
+  useComponentFactory(defaultComponentFactory);
   // support pan zoom and drag
-  vis.registerComponentFactory((kind, type) => {
-    if (kind === ModelKind.graph) {
-      return withPanZoom()(GraphComponent);
-    }
-    if (type === 'group-drop') {
-      return withDndDrop<Node, any, { droppable?: boolean; hover?: boolean; canDrop?: boolean }, ElementProps>({
-        accept: 'test',
-        canDrop: (item, monitor, props) =>
-          item && monitor.getOperation().type === 'regroup' && !!props && item.getParent() !== props.element,
-        collect: monitor => ({
-          droppable: monitor.isDragging() && monitor.getOperation().type === 'regroup',
-          hover: monitor.isOver(),
-          canDrop: monitor.canDrop()
-        })
-      })(GroupHull);
-    }
-    if (type === 'node-drag') {
-      return withDragNode<DragObjectWithType, Node, {}, ElementProps>({
-        item: { type: 'test' },
-        operation: () => ({
-          [Modifiers.SHIFT]: { type: 'regroup' }
-        }),
-        end: (dropResult, monitor, props) => {
-          if (monitor.didDrop() && dropResult && props) {
-            dropResult.appendChild(props.element);
+  useComponentFactory(
+    React.useCallback<ComponentFactory>((kind, type) => {
+      if (kind === ModelKind.graph) {
+        return withPanZoom()(GraphComponent);
+      }
+      if (type === 'group-drop') {
+        return withDndDrop<Node, any, { droppable?: boolean; hover?: boolean; canDrop?: boolean }, ElementProps>({
+          accept: 'test',
+          canDrop: (item, monitor, props) =>
+            item && monitor.getOperation().type === 'regroup' && !!props && item.getParent() !== props.element,
+          collect: monitor => ({
+            droppable: monitor.isDragging() && monitor.getOperation().type === 'regroup',
+            hover: monitor.isOver(),
+            canDrop: monitor.canDrop()
+          })
+        })(GroupHull);
+      }
+      if (type === 'node-drag') {
+        return withDragNode<DragObjectWithType, Node, {}, ElementProps>({
+          item: { type: 'test' },
+          operation: () => ({
+            [Modifiers.SHIFT]: { type: 'regroup' }
+          }),
+          end: (dropResult, monitor, props) => {
+            if (monitor.didDrop() && dropResult && props) {
+              dropResult.appendChild(props.element);
+            }
           }
-        }
-      })(DefaultNode);
-    }
-    return undefined;
-  });
-  return <VisualizationSurface visualization={vis} />;
-};
+        })(DefaultNode);
+      }
+      return undefined;
+    }, [])
+  );
+  useModel(
+    React.useMemo(
+      (): Model => ({
+        graph: {
+          id: 'g1',
+          type: 'graph'
+        },
+        nodes: [
+          {
+            id: 'gr1',
+            type: 'group-drop',
+            group: true,
+            children: ['n2', 'n3'],
+            style: {
+              padding: 10
+            }
+          },
+          {
+            id: 'gr2',
+            type: 'group-drop',
+            group: true,
+            children: ['n4', 'n5'],
+            style: {
+              padding: 10
+            }
+          },
+          {
+            id: 'n1',
+            type: 'node-drag',
+            x: 50,
+            y: 50,
+            width: 30,
+            height: 30
+          },
+          {
+            id: 'n2',
+            type: 'node',
+            x: 200,
+            y: 20,
+            width: 10,
+            height: 10
+          },
+          {
+            id: 'n3',
+            type: 'node',
+            x: 150,
+            y: 100,
+            width: 20,
+            height: 20
+          },
+          {
+            id: 'n4',
+            type: 'node',
+            x: 300,
+            y: 250,
+            width: 30,
+            height: 30
+          },
+          {
+            id: 'n5',
+            type: 'node',
+            x: 350,
+            y: 370,
+            width: 15,
+            height: 15
+          }
+        ]
+      }),
+      []
+    )
+  );
+  return null;
+});

--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/Groups.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/Groups.tsx
@@ -1,20 +1,23 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
 import {
-  Visualization,
-  VisualizationSurface,
   Model,
   Node,
   AnchorEnd,
   NodeShape,
   useSvgAnchor,
   withDragNode,
-  WithDragNodeProps
+  WithDragNodeProps,
+  useModel,
+  useLayoutFactory,
+  useComponentFactory,
+  ComponentFactory
 } from '@patternfly/react-topology';
 import defaultComponentFactory from './components/defaultComponentFactory';
 import DefaultGroup from './components/DefaultGroup';
 import DefaultNode from './components/DefaultNode';
 import defaultLayoutFactory from './layouts/defaultLayoutFactory';
+import withTopologySetup from './utils/withTopologySetup';
 
 const GroupWithDecorator: React.FC<{ element: Node } & WithDragNodeProps> = observer(props => {
   const trafficSourceRef = useSvgAnchor(AnchorEnd.source, 'traffic');
@@ -34,105 +37,111 @@ const GroupWithDecorator: React.FC<{ element: Node } & WithDragNodeProps> = obse
   );
 });
 
-export const ComplexGroup = () => {
-  const vis = new Visualization();
-  const model: Model = {
-    graph: {
-      id: 'g1',
-      type: 'graph',
-      layout: 'Force'
-    },
-    nodes: [
-      {
-        id: 'gr1',
-        type: 'group-hull',
-        group: true,
-        children: ['n1', 'n2', 's1'],
-        style: {
-          padding: 50
-        }
-      },
+export const ComplexGroup = withTopologySetup(() => {
+  useLayoutFactory(defaultLayoutFactory);
+  useComponentFactory(defaultComponentFactory);
+  useComponentFactory(
+    React.useCallback<ComponentFactory>((kind, type) => {
+      if (type === 'service') {
+        return withDragNode()(GroupWithDecorator);
+      }
+      if (type === 'node') {
+        return withDragNode()(DefaultNode);
+      }
+      return undefined;
+    }, [])
+  );
 
-      {
-        id: 's1',
-        type: 'service',
-        group: true,
-        children: ['r1', 'r2'],
-        shape: NodeShape.rect,
-        style: {
-          padding: 25
-        }
-      },
-      {
-        id: 's2',
-        type: 'service',
-        group: true,
-        shape: NodeShape.rect,
-        width: 100,
-        height: 100,
-        style: {
-          padding: 25
-        }
-      },
-      {
-        id: 'n1',
-        type: 'node',
-        x: 100,
-        y: 150,
-        width: 100,
-        height: 100
-      },
-      {
-        id: 'n2',
-        type: 'node',
-        x: 450,
-        y: 100,
-        width: 100,
-        height: 100
-      },
-      {
-        id: 'r1',
-        type: 'node',
-        x: 250,
-        y: 300,
-        width: 100,
-        height: 100
-      },
-      {
-        id: 'r2',
-        type: 'node',
-        x: 370,
-        y: 320,
-        width: 100,
-        height: 100
-      }
-    ],
-    edges: [
-      {
-        id: 't1',
-        type: 'traffic',
-        source: 's1',
-        target: 'r1'
-      },
-      {
-        id: 't2',
-        type: 'traffic',
-        source: 's1',
-        target: 'r2'
-      }
-    ]
-  };
-  vis.registerLayoutFactory(defaultLayoutFactory);
-  vis.registerComponentFactory(defaultComponentFactory);
-  vis.registerComponentFactory((kind, type) => {
-    if (type === 'service') {
-      return withDragNode()(GroupWithDecorator);
-    }
-    if (type === 'node') {
-      return withDragNode()(DefaultNode);
-    }
-    return undefined;
-  });
-  vis.fromModel(model);
-  return <VisualizationSurface visualization={vis} />;
-};
+  useModel(
+    React.useMemo(
+      (): Model => ({
+        graph: {
+          id: 'g1',
+          type: 'graph',
+          layout: 'Force'
+        },
+        nodes: [
+          {
+            id: 'gr1',
+            type: 'group-hull',
+            group: true,
+            children: ['n1', 'n2', 's1'],
+            style: {
+              padding: 50
+            }
+          },
+
+          {
+            id: 's1',
+            type: 'service',
+            group: true,
+            children: ['r1', 'r2'],
+            shape: NodeShape.rect,
+            style: {
+              padding: 25
+            }
+          },
+          {
+            id: 's2',
+            type: 'service',
+            group: true,
+            shape: NodeShape.rect,
+            width: 100,
+            height: 100,
+            style: {
+              padding: 25
+            }
+          },
+          {
+            id: 'n1',
+            type: 'node',
+            x: 100,
+            y: 150,
+            width: 100,
+            height: 100
+          },
+          {
+            id: 'n2',
+            type: 'node',
+            x: 450,
+            y: 100,
+            width: 100,
+            height: 100
+          },
+          {
+            id: 'r1',
+            type: 'node',
+            x: 250,
+            y: 300,
+            width: 100,
+            height: 100
+          },
+          {
+            id: 'r2',
+            type: 'node',
+            x: 370,
+            y: 320,
+            width: 100,
+            height: 100
+          }
+        ],
+        edges: [
+          {
+            id: 't1',
+            type: 'traffic',
+            source: 's1',
+            target: 'r1'
+          },
+          {
+            id: 't2',
+            type: 'traffic',
+            source: 's1',
+            target: 'r2'
+          }
+        ]
+      }),
+      []
+    )
+  );
+  return null;
+});

--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/Selection.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/Selection.tsx
@@ -1,17 +1,22 @@
 import * as React from 'react';
 import {
-  Visualization,
-  VisualizationSurface,
   Model,
   ModelKind,
   NodeModel,
   withSelection,
   SELECTION_EVENT,
-  SelectionEventListener
+  SelectionEventListener,
+  useComponentFactory,
+  ComponentFactory,
+  useModel,
+  useEventListener,
+  useVisualizationState,
+  SELECTION_STATE
 } from '@patternfly/react-topology';
 import defaultComponentFactory from './components/defaultComponentFactory';
+import withTopologySetup from './utils/withTopologySetup';
 
-const create2NodeModel = (): Model => ({
+const twoNodeModel: Model = {
   graph: {
     id: 'g1',
     type: 'graph'
@@ -43,90 +48,111 @@ const create2NodeModel = (): Model => ({
       height: 20
     }
   ]
+};
+
+export const UncontrolledSelection: React.FC = withTopologySetup(() => {
+  useComponentFactory(
+    React.useCallback<ComponentFactory>((kind, type) => {
+      const widget = defaultComponentFactory(kind, type);
+      if (kind === ModelKind.node || kind === ModelKind.graph) {
+        // TODO fix any type
+        return withSelection({ multiSelect: false, controlled: false })(widget as any);
+      }
+      return widget;
+    }, [])
+  );
+  useEventListener(
+    SELECTION_EVENT,
+    React.useCallback<SelectionEventListener>(([id]) => {
+      // eslint-disable-next-line no-console
+      console.log(`Selection event`, id);
+    }, [])
+  );
+  useModel(twoNodeModel);
+  return null;
 });
 
-export const UncontrolledSelection: React.FC = () => {
-  const vis = new Visualization();
-  vis.registerComponentFactory((kind, type) => {
-    const widget = defaultComponentFactory(kind, type);
-    if (kind === ModelKind.node || kind === ModelKind.graph) {
-      // TODO fix any type
-      return withSelection(false, false)(widget as any);
-    }
-    return widget;
-  });
-  vis.fromModel(create2NodeModel());
-  return <VisualizationSurface visualization={vis} />;
-};
-
-export const ControlledSelection = () => {
-  const vis = new Visualization();
-  vis.registerComponentFactory((kind, type) => {
-    const widget = defaultComponentFactory(kind, type);
-    if (kind === ModelKind.node || kind === ModelKind.graph) {
-      // TODO fix any type
-      return withSelection(false, false)(widget as any);
-    }
-    return widget;
-  });
-  vis.fromModel(create2NodeModel());
-  const Component = () => {
-    const [selectedIds, setSelectedIds] = React.useState<string[]>();
-    React.useEffect(() => {
-      vis.addEventListener<SelectionEventListener>(SELECTION_EVENT, ids => {
+export const ControlledSelection = withTopologySetup(() => {
+  const [, setSelectedIds] = useVisualizationState(SELECTION_STATE);
+  useComponentFactory(
+    React.useCallback<ComponentFactory>((kind, type) => {
+      const widget = defaultComponentFactory(kind, type);
+      if (kind === ModelKind.node || kind === ModelKind.graph) {
+        // TODO fix any type
+        return withSelection({ multiSelect: false, controlled: true })(widget as any);
+      }
+      return widget;
+    }, [])
+  );
+  useEventListener(
+    SELECTION_EVENT,
+    React.useCallback<SelectionEventListener>(
+      ids => {
+        // eslint-disable-next-line no-console
+        console.log(`Selection event`, ids);
         setSelectedIds(ids);
-      });
-    }, []);
-    return <VisualizationSurface visualization={vis} state={{ selectedIds }} />;
-  };
-  return <Component />;
-};
+      },
+      [setSelectedIds]
+    )
+  );
+  useModel(twoNodeModel);
+  return null;
+});
 
-export const MultiSelect: React.FC = () => {
-  const vis = new Visualization();
-  vis.registerComponentFactory((kind, type) => {
-    const widget = defaultComponentFactory(kind, type);
-    if (kind === ModelKind.node || kind === ModelKind.graph) {
-      // TODO fix any type
-      return withSelection(true, false)(widget as any);
-    }
-    return widget;
-  });
-  vis.fromModel(create2NodeModel());
-  return <VisualizationSurface visualization={vis} />;
-};
+export const MultiSelect: React.FC = withTopologySetup(() => {
+  useModel(twoNodeModel);
+  useComponentFactory(
+    React.useCallback<ComponentFactory>((kind, type) => {
+      const widget = defaultComponentFactory(kind, type);
+      if (kind === ModelKind.node || kind === ModelKind.graph) {
+        // TODO fix any type
+        return withSelection({ multiSelect: true, controlled: false })(widget as any);
+      }
+      return widget;
+    }, [])
+  );
+  useEventListener(
+    SELECTION_EVENT,
+    React.useCallback<SelectionEventListener>(ids => {
+      // eslint-disable-next-line no-console
+      console.log(`Selection event`, ids);
+    }, [])
+  );
+  return null;
+});
 
-export const Performance = () => {
-  const vis = new Visualization();
-  vis.registerComponentFactory((kind, type) => {
-    const widget = defaultComponentFactory(kind, type);
-    if (kind === ModelKind.node || kind === ModelKind.graph) {
-      // TODO fix any type
-      return withSelection(true, false)(widget as any);
-    }
-    return widget;
-  });
-  const model: Model = {
-    graph: {
-      id: 'g1',
-      type: 'graph'
-    },
-    nodes: []
-  };
-  for (let i = 1; i <= 100; i++) {
-    for (let j = 1; j <= 100; j++) {
-      const node: NodeModel = {
-        id: `${i}-${j}`,
-        type: 'node',
-        x: j * 20,
-        y: i * 20,
-        width: 10,
-        height: 10
-      };
-      model.graph && model.graph.children && model.graph.children.push(node.id);
-      model.nodes && model.nodes.push(node);
-    }
+const perfModel: Model = {
+  graph: {
+    id: 'g1',
+    type: 'graph'
+  },
+  nodes: []
+};
+for (let i = 1; i <= 100; i++) {
+  for (let j = 1; j <= 100; j++) {
+    const node: NodeModel = {
+      id: `${i}-${j}`,
+      type: 'node',
+      x: j * 20,
+      y: i * 20,
+      width: 10,
+      height: 10
+    };
+    perfModel.nodes.push(node);
   }
-  vis.fromModel(model);
-  return <VisualizationSurface visualization={vis} />;
-};
+}
+
+export const Performance: React.FC = withTopologySetup(() => {
+  useModel(perfModel);
+  useComponentFactory(
+    React.useCallback<ComponentFactory>((kind, type) => {
+      const widget = defaultComponentFactory(kind, type);
+      if (kind === ModelKind.node || kind === ModelKind.graph) {
+        // TODO fix any type
+        return withSelection({ multiSelect: true, controlled: false })(widget as any);
+      }
+      return widget;
+    }, [])
+  );
+  return null;
+});

--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/Shapes.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/Shapes.tsx
@@ -7,137 +7,146 @@ import {
   ModelKind,
   withPanZoom,
   GraphComponent,
-  withDragNode
+  withDragNode,
+  useComponentFactory,
+  useModel,
+  ComponentFactory
 } from '@patternfly/react-topology';
 import '@patternfly/react-styles/css/components/Topology/topology-components.css';
 import defaultComponentFactory from './components/defaultComponentFactory';
 import shapesComponentFactory from './components/shapesComponentFactory';
 import Node from './components/DefaultNode';
+import withTopologySetup from './utils/withTopologySetup';
 
 export const SHAPE_TITLE = 'Shapes';
 
-export const Shapes = () => {
-  const vis = new Visualization();
-  const model: Model = {
-    graph: {
-      id: 'g1',
-      type: 'graph',
-      x: 25,
-      y: 25
-    },
-    nodes: [
-      {
-        id: 'gr1',
-        type: 'group-hull',
-        group: true,
-        children: ['n2', 'n3'],
-        style: {
-          padding: 10
-        }
-      },
-      {
-        id: 'gr2',
-        type: 'group-hull',
-        group: true,
-        children: ['n4', 'n5'],
-        style: {
-          padding: 10
-        }
-      },
-      {
-        id: 'n1',
-        type: 'node-drag',
-        x: 50,
-        y: 50,
-        width: 30,
-        height: 30
-      },
-      {
-        id: 'n2',
-        type: 'node-rect',
-        x: 200,
-        y: 20,
-        width: 30,
-        height: 50
-      },
-      {
-        id: 'n3',
-        type: 'node-ellipse',
-        x: 150,
-        y: 100,
-        width: 50,
-        height: 30
-      },
-      {
-        id: 'n4',
-        type: 'node-path',
-        x: 300,
-        y: 250,
-        width: 30,
-        height: 30
-      },
-      {
-        id: 'n5',
-        type: 'node-polygon',
-        x: 350,
-        y: 370,
-        width: 65,
-        height: 65
-      },
-      {
-        id: 'n6',
-        type: 'node-rect',
-        x: 300,
-        y: 200,
-        width: 60,
-        height: 20
-      }
-    ],
-    edges: [
-      {
-        id: 'e1',
-        type: 'edge',
-        source: 'n1',
-        target: 'n2'
-      },
-      {
-        id: 'e2',
-        type: 'edge',
-        source: 'n1',
-        target: 'n3'
-      },
-      {
-        id: 'e3',
-        type: 'edge',
-        source: 'n1',
-        target: 'n4'
-      },
-      {
-        id: 'e4',
-        type: 'edge',
-        source: 'n1',
-        target: 'n5'
-      },
-      {
-        id: 'e5',
-        type: 'edge',
-        source: 'n1',
-        target: 'n6'
-      }
-    ]
-  };
-  vis.fromModel(model);
-  vis.registerComponentFactory(defaultComponentFactory);
-  vis.registerComponentFactory(shapesComponentFactory);
+export const Shapes = withTopologySetup(() => {
+  useComponentFactory(defaultComponentFactory);
+  useComponentFactory(shapesComponentFactory);
   // support pan zoom and drag
-  vis.registerComponentFactory((kind, type) => {
-    if (kind === ModelKind.graph) {
-      return withPanZoom()(GraphComponent);
-    }
-    if (type === 'node-drag') {
-      return withDragNode()(Node);
-    }
-    return undefined;
-  });
-  return <VisualizationSurface visualization={vis} />;
-};
+  useComponentFactory(
+    React.useCallback<ComponentFactory>((kind, type) => {
+      if (kind === ModelKind.graph) {
+        return withPanZoom()(GraphComponent);
+      }
+      if (type === 'node-drag') {
+        return withDragNode()(Node);
+      }
+      return undefined;
+    }, [])
+  );
+  useModel(
+    React.useMemo(
+      (): Model => ({
+        graph: {
+          id: 'g1',
+          type: 'graph',
+          x: 25,
+          y: 25
+        },
+        nodes: [
+          {
+            id: 'gr1',
+            type: 'group-hull',
+            group: true,
+            children: ['n2', 'n3'],
+            style: {
+              padding: 10
+            }
+          },
+          {
+            id: 'gr2',
+            type: 'group-hull',
+            group: true,
+            children: ['n4', 'n5'],
+            style: {
+              padding: 10
+            }
+          },
+          {
+            id: 'n1',
+            type: 'node-drag',
+            x: 50,
+            y: 50,
+            width: 30,
+            height: 30
+          },
+          {
+            id: 'n2',
+            type: 'node-rect',
+            x: 200,
+            y: 20,
+            width: 30,
+            height: 50
+          },
+          {
+            id: 'n3',
+            type: 'node-ellipse',
+            x: 150,
+            y: 100,
+            width: 50,
+            height: 30
+          },
+          {
+            id: 'n4',
+            type: 'node-path',
+            x: 300,
+            y: 250,
+            width: 30,
+            height: 30
+          },
+          {
+            id: 'n5',
+            type: 'node-polygon',
+            x: 350,
+            y: 370,
+            width: 65,
+            height: 65
+          },
+          {
+            id: 'n6',
+            type: 'node-rect',
+            x: 300,
+            y: 200,
+            width: 60,
+            height: 20
+          }
+        ],
+        edges: [
+          {
+            id: 'e1',
+            type: 'edge',
+            source: 'n1',
+            target: 'n2'
+          },
+          {
+            id: 'e2',
+            type: 'edge',
+            source: 'n1',
+            target: 'n3'
+          },
+          {
+            id: 'e3',
+            type: 'edge',
+            source: 'n1',
+            target: 'n4'
+          },
+          {
+            id: 'e4',
+            type: 'edge',
+            source: 'n1',
+            target: 'n5'
+          },
+          {
+            id: 'e5',
+            type: 'edge',
+            source: 'n1',
+            target: 'n6'
+          }
+        ]
+      }),
+      []
+    )
+  );
+  return null;
+});

--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/TopologyDemo.css
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/TopologyDemo.css
@@ -1,10 +1,16 @@
 .pf-ri__topology-demo {
-    height: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
+
 .pf-ri__topology-demo .pf-c-tab-content {
-    height: 100%;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
 }
 
 .pf-ri__topology-demo .pf-c-tab-content:focus {
-    outline: none;
+  outline: none;
 }

--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/TopologyDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/TopologyDemo.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 import '@patternfly/react-styles/css/components/Topology/topology-components.css';
 import { Shapes } from './Shapes';
-import { SingleNode, SingleEdge, Group, GroupHull, MultiEdge } from './Basics';
+import { SingleNode, SingleEdge, Group, GroupHull, MultiEdge, AutoSizeNode } from './Basics';
 import { ControlledSelection, MultiSelect, Performance, UncontrolledSelection } from './Selection';
 import { PanZoom } from './PanZoom';
 import { Cola, Dagre, Force } from './Layouts';
@@ -47,6 +47,9 @@ export const TopologyDemo: React.FC = () => {
             </Tab>
             <Tab eventKey={4} title={<TabTitleText>Group Hull</TabTitleText>}>
               <GroupHull />
+            </Tab>
+            <Tab eventKey={5} title={<TabTitleText>Auto Size Node</TabTitleText>}>
+              <AutoSizeNode />
             </Tab>
           </Tabs>
         </Tab>

--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/TopologyPackage.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/TopologyPackage.tsx
@@ -19,7 +19,9 @@ import {
   VisualizationSurface,
   SELECTION_EVENT,
   SelectionEventListener,
-  withSelection
+  withSelection,
+  VisualizationProvider,
+  useEventListener
 } from '@patternfly/react-topology';
 import {
   Toolbar,
@@ -133,7 +135,7 @@ const TopologyViewComponent: React.FC<TopologyViewComponentProps> = ({ vis, useS
   const [layoutDropdownOpen, setLayoutDropdownOpen] = React.useState(false);
   const [layout, setLayout] = React.useState('Force');
 
-  vis.addEventListener<SelectionEventListener>(SELECTION_EVENT, ids => {
+  useEventListener<SelectionEventListener>(SELECTION_EVENT, ids => {
     setSelectedIds(ids);
   });
 
@@ -211,7 +213,7 @@ const TopologyViewComponent: React.FC<TopologyViewComponentProps> = ({ vis, useS
       sideBar={useSidebar && topologySideBar}
       sideBarOpen={useSidebar && _.size(selectedIds) > 0}
     >
-      <VisualizationSurface visualization={vis} state={{ selectedIds }} />
+      <VisualizationSurface state={{ selectedIds }} />
     </TopologyView>
   );
 };
@@ -219,10 +221,18 @@ const TopologyViewComponent: React.FC<TopologyViewComponentProps> = ({ vis, useS
 export const Topology = () => {
   const vis: Visualization = getVisualization(getModel('Force'));
 
-  return <TopologyViewComponent useSidebar={false} vis={vis} />;
+  return (
+    <VisualizationProvider controller={vis}>
+      <TopologyViewComponent useSidebar={false} vis={vis} />
+    </VisualizationProvider>
+  );
 };
 
 export const WithSideBar = () => {
   const vis: Visualization = getVisualization(getModel('Force'));
-  return <TopologyViewComponent useSidebar vis={vis} />;
+  return (
+    <VisualizationProvider controller={vis}>
+      <TopologyViewComponent useSidebar vis={vis} />
+    </VisualizationProvider>
+  );
 };

--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/utils/withTopologySetup.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/utils/withTopologySetup.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { VisualizationProvider, VisualizationSurface } from '@patternfly/react-topology';
+
+const withTopologySetup = (WrappedComponent: React.ComponentType) => () => (
+  <VisualizationProvider>
+    <WrappedComponent />
+    <VisualizationSurface />
+  </VisualizationProvider>
+);
+
+export default withTopologySetup;

--- a/packages/react-styles/src/css/components/Topology/topology-components.css
+++ b/packages/react-styles/src/css/components/Topology/topology-components.css
@@ -1,60 +1,55 @@
 :root {
-    --pf-topology-create-connector-color: var(--pf-global--active-color--400);
-    --pf-topology-create-connector-bg-color: var(--pf-global--BackgroundColor--light-100);
+  --pf-topology-create-connector-color: var(--pf-global--active-color--400);
+  --pf-topology-create-connector-bg-color: var(--pf-global--BackgroundColor--light-100);
 }
 
-
 .pf-topology-connector-arrow {
-    stroke-width: 1;
-    stroke: var(--create-connector-color);
-    fill: var(--create-connector-color);
+  stroke-width: 1;
+  stroke: var(--pf-global--BackgroundColor--dark-200);
 }
 
 .pf-topology-default-create-connector__line {
-    stroke: var(--create-connector-color);
-    stroke-width: 2px;
-    stroke-dasharray: 5px, 5px;
+  stroke: var(--pf-topology-create-connector-color);
+  stroke-width: 2px;
+  stroke-dasharray: 5px, 5px;
 }
 
 .pf-topology-default-create-connector__create__bg {
-    stroke: var(--create-connector-color);
-    fill: var(--create-connector-bg-color);
-    stroke-width: 2px;
+  stroke: var(--pf-topology-create-connector-color);
+  fill: var(--pf-topology-create-connector-bg-color);
+  stroke-width: 2px;
 }
 
 .pf-topology-default-create-connector__create__cursor {
-    fill: var(--create-connector-color);
+  fill: var(--pf-topology-create-connector-color);
 }
 
 .pf-topology-visualization-surface {
-    height: 100%;
-    flex-grow: 1;
-    flex-shrink: 1;
-    overflow: hidden;
-    position: relative;
+  height: 100%;
+  flex-grow: 1;
+  flex-shrink: 1;
+  overflow: hidden;
+  position: relative;
 }
 
 .pf-topology-visualization-surface__svg {
-    display: block;
-    width: 100%;
-    height: 100%;
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 
 .pf-topology-context-menu__c-dropdown__menu {
-      position: initial !important;
-    
+  position: initial !important;
 }
 
 .pf-topology-context-sub-menu {
-    position: relative;
-    padding-right: var(--pf-global--spacer--lg);    
+  position: relative;
+  padding-right: var(--pf-global--spacer--lg);
 }
 
 .pf-topology-context-sub-menu__arrow {
-    position: absolute;
-    right: var(--pf-global--spacer--xs);
-    top: 50%;
-    transform: translateY(-50%);
+  position: absolute;
+  right: var(--pf-global--spacer--xs);
+  top: 50%;
+  transform: translateY(-50%);
 }
-  
-  

--- a/packages/react-topology/src/Visualization.ts
+++ b/packages/react-topology/src/Visualization.ts
@@ -107,6 +107,10 @@ export class Visualization extends Stateful implements Controller {
     }
   }
 
+  hasGraph(): boolean {
+    return !!this.graph;
+  }
+
   getGraph(): Graph {
     if (!this.graph) {
       throw new Error('Graph has not been set.');

--- a/packages/react-topology/src/behavior/useDndManager.tsx
+++ b/packages/react-topology/src/behavior/useDndManager.tsx
@@ -1,6 +1,5 @@
-import * as React from 'react';
 import { computed, observable } from 'mobx';
-import ControllerContext from '../utils/ControllerContext';
+import useVisualizationController from '../hooks/useVisualizationController';
 import {
   DndManager,
   Identifier,
@@ -325,7 +324,7 @@ export class DndManagerImpl implements DndManager {
 }
 
 export const useDndManager = () => {
-  const controller = React.useContext(ControllerContext);
+  const controller = useVisualizationController();
   const store = controller.getStore<DndStore>();
   let { dndManager } = store;
   if (!dndManager) {

--- a/packages/react-topology/src/components/VisualizationProvider.tsx
+++ b/packages/react-topology/src/components/VisualizationProvider.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import ControllerContext from '../utils/ControllerContext';
+import { Controller } from '../types';
+import { Visualization } from '../Visualization';
+
+interface VisualizationSurfaceProps {
+  controller?: Controller;
+  children?: React.ReactNode;
+}
+
+const VisualizationProvider: React.FC<VisualizationSurfaceProps> = ({ controller, children }) => {
+  const controllerRef = React.useRef<Controller>();
+  if (controller && controllerRef.current !== controller) {
+    controllerRef.current = controller;
+  } else if (!controllerRef.current) {
+    controllerRef.current = new Visualization();
+  }
+
+  return <ControllerContext.Provider value={controllerRef.current}>{children}</ControllerContext.Provider>;
+};
+
+export default VisualizationProvider;

--- a/packages/react-topology/src/components/VisualizationSurface.tsx
+++ b/packages/react-topology/src/components/VisualizationSurface.tsx
@@ -7,17 +7,18 @@ import { observer } from 'mobx-react';
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore-next-line
 import ReactMeasure from 'react-measure';
-import ControllerContext from '../utils/ControllerContext';
-import { State } from '../types';
-import { Visualization } from '../Visualization';
+import { State, Controller } from '../types';
 import SVGDefsProvider from './defs/SVGDefsProvider';
 import ElementWrapper from './ElementWrapper';
 import Dimensions from '../geom/Dimensions';
+import useVisualizationController from '../hooks/useVisualizationController';
+
 import '@patternfly/react-styles/css/components/Topology/topology-components.css';
 
 interface VisualizationSurfaceProps {
-  visualization: Visualization;
+  visualization?: Controller;
   state?: State;
+  children?: React.ReactNode;
 }
 
 const stopEvent = (e: React.MouseEvent): void => {
@@ -25,43 +26,47 @@ const stopEvent = (e: React.MouseEvent): void => {
   e.stopPropagation();
 };
 
-const VisualizationSurface: React.FC<VisualizationSurfaceProps> = ({ visualization, state }) => {
+const VisualizationSurface: React.FC<VisualizationSurfaceProps> = ({ state }) => {
+  const controller = useVisualizationController();
+
   React.useEffect(() => {
-    state && visualization.setState(state);
-  }, [visualization, state]);
+    state && controller.setState(state);
+  }, [controller, state]);
 
   const onMeasure = React.useMemo(
     () =>
       _.debounce<any>(
         action((contentRect: { client: { width: number; height: number } }) => {
-          visualization.getGraph().setDimensions(new Dimensions(contentRect.client.width, contentRect.client.height));
+          controller.getGraph().setDimensions(new Dimensions(contentRect.client.width, contentRect.client.height));
         }),
         100,
         { leading: true, trailing: true }
       ),
-    [visualization]
+    [controller]
   );
 
   // dispose of onMeasure
   React.useEffect(() => () => onMeasure.cancel(), [onMeasure]);
 
-  const graph = visualization.getGraph();
+  if (!controller.hasGraph()) {
+    return null;
+  }
+
+  const graph = controller.getGraph();
 
   return (
-    <ControllerContext.Provider value={visualization}>
-      <ReactMeasure client onResize={onMeasure}>
-        {({ measureRef }: { measureRef: React.LegacyRef<any> }) => (
-          // render an outer div because react-measure doesn't seem to fire events properly on svg resize
-          <div data-test-id="topology" className="pf-topology-visualization-surface" ref={measureRef}>
-            <svg className="pf-topology-visualization-surface__svg" onContextMenu={stopEvent}>
-              <SVGDefsProvider>
-                <ElementWrapper element={graph} />
-              </SVGDefsProvider>
-            </svg>
-          </div>
-        )}
-      </ReactMeasure>
-    </ControllerContext.Provider>
+    <ReactMeasure client onResize={onMeasure}>
+      {({ measureRef }: { measureRef: React.LegacyRef<any> }) => (
+        // render an outer div because react-measure doesn't seem to fire events properly on svg resize
+        <div data-test-id="topology" className="pf-topology-visualization-surface" ref={measureRef}>
+          <svg className="pf-topology-visualization-surface__svg" onContextMenu={stopEvent}>
+            <SVGDefsProvider>
+              <ElementWrapper element={graph} />
+            </SVGDefsProvider>
+          </svg>
+        </div>
+      )}
+    </ReactMeasure>
   );
 };
 

--- a/packages/react-topology/src/components/factories/RegisterComponentFactory.tsx
+++ b/packages/react-topology/src/components/factories/RegisterComponentFactory.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import useComponentFactory from '../../hooks/useComponentFactory';
+import { ComponentFactory } from '../../types';
+
+interface Props {
+  factory: ComponentFactory;
+}
+
+const RegisterComponentFactory: React.FC<Props> = ({ factory }) => {
+  useComponentFactory(factory);
+  return null;
+};
+
+export default RegisterComponentFactory;

--- a/packages/react-topology/src/components/factories/RegisterElementFactory.tsx
+++ b/packages/react-topology/src/components/factories/RegisterElementFactory.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import useElementFactory from '../../hooks/useElementFactory';
+import { ElementFactory } from '../../types';
+
+interface Props {
+  factory: ElementFactory;
+}
+
+const RegisteElementFactory: React.FC<Props> = ({ factory }) => {
+  useElementFactory(factory);
+  return null;
+};
+
+export default RegisteElementFactory;

--- a/packages/react-topology/src/components/factories/RegisterLayoutFactory.tsx
+++ b/packages/react-topology/src/components/factories/RegisterLayoutFactory.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import useLayoutFactory from '../../hooks/useLayoutFactory';
+import { LayoutFactory } from '../../types';
+
+interface Props {
+  factory: LayoutFactory;
+}
+
+const RegisterLayoutFactory: React.FC<Props> = ({ factory }) => {
+  useLayoutFactory(factory);
+  return null;
+};
+
+export default RegisterLayoutFactory;

--- a/packages/react-topology/src/components/factories/index.ts
+++ b/packages/react-topology/src/components/factories/index.ts
@@ -1,0 +1,3 @@
+export { default as RegisterComponentFactory } from './RegisterComponentFactory';
+export { default as RegisterElementFactory } from './RegisterElementFactory';
+export { default as RegisterLayoutFactory } from './RegisterLayoutFactory';

--- a/packages/react-topology/src/components/index.ts
+++ b/packages/react-topology/src/components/index.ts
@@ -1,6 +1,7 @@
 export * from './TopologyView';
 export * from './TopologyControlBar';
 export * from './TopologySideBar';
+export { default as VisualizationProvider } from './VisualizationProvider';
 export { default as VisualizationSurface } from './VisualizationSurface';
 export { default as ConnectorArrow } from './ConnectorArrow';
 export { default as DefaultCreateConnector } from './DefaultCreateConnector';
@@ -10,5 +11,6 @@ export { default as GraphComponent } from './GraphComponent';
 export { default as SVGArrowMarker } from './SVGArrowMarker';
 export { default as ElementWrapper } from './ElementWrapper';
 export * from './contextmenu';
+export * from './factories';
 export * from './layers';
 export * from './defs';

--- a/packages/react-topology/src/hooks/index.ts
+++ b/packages/react-topology/src/hooks/index.ts
@@ -1,0 +1,7 @@
+export { default as useComponentFactory } from './useComponentFactory';
+export { default as useElementFactory } from './useElementFactory';
+export { default as useEventListener } from './useEventListener';
+export { default as useLayoutFactory } from './useLayoutFactory';
+export { default as useModel } from './useModel';
+export { default as useVisualizationController } from './useVisualizationController';
+export { default as useVisualizationState } from './useVisualizationState';

--- a/packages/react-topology/src/hooks/useComponentFactory.tsx
+++ b/packages/react-topology/src/hooks/useComponentFactory.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { ComponentFactory } from '../types';
+import useVisualizationController from './useVisualizationController';
+
+const useComponentFactory = (factory: ComponentFactory): void => {
+  const controller = useVisualizationController();
+  React.useEffect(() => {
+    controller.registerComponentFactory(factory);
+    // TODO support unregister?
+  }, [controller, factory]);
+};
+
+export default useComponentFactory;

--- a/packages/react-topology/src/hooks/useElementFactory.tsx
+++ b/packages/react-topology/src/hooks/useElementFactory.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { ElementFactory } from '../types';
+import useVisualizationController from './useVisualizationController';
+
+const useElementFactory = (factory: ElementFactory): void => {
+  const controller = useVisualizationController();
+  React.useEffect(() => {
+    controller.registerElementFactory(factory);
+    // TODO support unregister?
+  }, [controller, factory]);
+};
+
+export default useElementFactory;

--- a/packages/react-topology/src/hooks/useEventListener.tsx
+++ b/packages/react-topology/src/hooks/useEventListener.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import useVisualizationController from './useVisualizationController';
+import { EventListener } from '../types';
+
+const useEventListener = <L extends EventListener = EventListener>(type: string, listener: L): void => {
+  const controller = useVisualizationController();
+  React.useEffect(() => {
+    controller.addEventListener(type, listener);
+    return () => {
+      controller.removeEventListener(type, listener);
+    };
+  }, [controller, type, listener]);
+};
+
+export default useEventListener;

--- a/packages/react-topology/src/hooks/useLayoutFactory.tsx
+++ b/packages/react-topology/src/hooks/useLayoutFactory.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { LayoutFactory } from '../types';
+import useVisualizationController from './useVisualizationController';
+
+const useLayoutFactory = (factory: LayoutFactory): void => {
+  const controller = useVisualizationController();
+  React.useEffect(() => {
+    controller.registerLayoutFactory(factory);
+    // TODO support unregister?
+  }, [controller, factory]);
+};
+
+export default useLayoutFactory;

--- a/packages/react-topology/src/hooks/useModel.tsx
+++ b/packages/react-topology/src/hooks/useModel.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import useVisualizationController from './useVisualizationController';
+import { Model } from '../types';
+
+const useModel = (model: Model): void => {
+  const controller = useVisualizationController();
+
+  React.useEffect(() => {
+    controller.fromModel(model);
+  }, [controller, model]);
+};
+
+export default useModel;

--- a/packages/react-topology/src/hooks/useVisualizationController.tsx
+++ b/packages/react-topology/src/hooks/useVisualizationController.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+import { ControllerContext } from '../utils';
+import { Controller } from '../types';
+
+const useVisualizationController = (): Controller => React.useContext(ControllerContext);
+
+export default useVisualizationController;

--- a/packages/react-topology/src/hooks/useVisualizationState.tsx
+++ b/packages/react-topology/src/hooks/useVisualizationState.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { reaction } from 'mobx';
+import useVisualizationController from './useVisualizationController';
+
+const useVisualizationState = <S extends any>(key: string, initialState?: S): [S, (value: S) => void] => {
+  const keyRef = React.useRef(key);
+  if (keyRef.current !== key) {
+    throw new Error(`State key change disallowed: ${keyRef.current} => ${key}`);
+  }
+
+  const [state, setState] = React.useState<S>(initialState);
+  const controller = useVisualizationController();
+
+  const setControllerState = React.useCallback(
+    (value?: S): void => {
+      controller.setState({ [keyRef.current]: value });
+    },
+    [controller]
+  );
+
+  React.useEffect(() => {
+    // init the controller state
+    setControllerState(initialState);
+
+    // sync controller state and react state such that the component is re-rendered when controller state changes
+    return reaction(
+      () => controller.getState()[keyRef.current],
+      (value: S) => {
+        setState(value);
+      }
+    );
+
+    // we only want to set the initial state once
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [controller]);
+
+  return [state, setControllerState];
+};
+
+export default useVisualizationState;

--- a/packages/react-topology/src/index.ts
+++ b/packages/react-topology/src/index.ts
@@ -5,6 +5,7 @@ export * from './components';
 export * from './const';
 export * from './elements';
 export * from './geom';
+export * from './hooks';
 export * from './layouts';
 export * from './utils';
 export * from './mobx-exports';

--- a/packages/react-topology/src/mobx-exports.ts
+++ b/packages/react-topology/src/mobx-exports.ts
@@ -1,4 +1,5 @@
+import { action } from 'mobx';
 import { observer } from 'mobx-react';
 
-// re-exports observer for ease of use externally
-export { observer };
+// re-export for ease of use externally
+export { action, observer };

--- a/packages/react-topology/src/types.ts
+++ b/packages/react-topology/src/types.ts
@@ -207,6 +207,7 @@ export type ElementFactory = (kind: ModelKind, type: string) => GraphElement | u
 export interface Controller extends WithState {
   getStore<S extends {} = {}>(): S;
   fromModel(model: Model): void;
+  hasGraph(): boolean;
   getGraph(): Graph;
   setGraph(graph: Graph): void;
   getLayout(type: string | undefined): Layout | undefined;


### PR DESCRIPTION
Depends on commits from the following PRs:

- https://github.com/patternfly/patternfly-react/pull/4315
- https://github.com/patternfly/patternfly-react/pull/4317

Changes the topology APIs to be more react friendly by introducing a top level component `VisualizationProvider` which sets up the visualization controller into the react context as well as several new hooks making it easier to initialize the controller with factories and setting the model.

Updated the integration demo app to make use of these new APIs.