### PR TITLE
fix(ToolbarToggleGroup): revert show to breakpoint

### DIFF
--- a/packages/react-core/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/packages/react-core/src/components/OverflowMenu/OverflowMenu.tsx
@@ -8,6 +8,13 @@ import xlBreakpoint from '@patternfly/react-tokens/dist/js/global_breakpoint_xl'
 import xl2Breakpoint from '@patternfly/react-tokens/dist/js/global_breakpoint_2xl';
 import { debounce } from '../../helpers/util';
 
+const breakpoints = {
+  md: mdBreakpoint,
+  lg: lgBreakpoint,
+  xl: xlBreakpoint,
+  '2xl': xl2Breakpoint
+};
+
 export interface OverflowMenuProps extends React.HTMLProps<HTMLDivElement> {
   /** Any elements that can be rendered in the menu */
   children?: any;
@@ -39,22 +46,21 @@ export class OverflowMenu extends React.Component<OverflowMenuProps, OverflowMen
   }
 
   handleResize = () => {
-    const breakpoints: { [index: string]: { value: string } } = {
-      md: mdBreakpoint,
-      lg: lgBreakpoint,
-      xl: xlBreakpoint,
-      '2xl': xl2Breakpoint
-    };
-    const { breakpoint } = this.props;
-    let breakpointWidth: string | number = breakpoints[breakpoint].value;
-    breakpointWidth = Number(breakpointWidth.split('px')[0]);
+    const breakpointPx = breakpoints[this.props.breakpoint];
+    if (!breakpointPx) {
+      // eslint-disable-next-line no-console
+      console.error('OverflowMenu will not be visible without a valid breakpoint.');
+      return;
+    }
+    const breakpointWidth = Number(breakpointPx.value.replace('px', ''));
     const isBelowBreakpoint = window.innerWidth < breakpointWidth;
-    this.state.isBelowBreakpoint !== isBelowBreakpoint && this.setState({ isBelowBreakpoint });
+    this.setState({ isBelowBreakpoint });
   };
 
   render() {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { className, breakpoint, children, ...props } = this.props;
+
     return (
       <div {...props} className={css(styles.overflowMenu, className)}>
         <OverflowMenuContext.Provider value={{ isBelowBreakpoint: this.state.isBelowBreakpoint }}>

--- a/packages/react-core/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/packages/react-core/src/components/OverflowMenu/OverflowMenu.tsx
@@ -2,11 +2,10 @@ import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/OverflowMenu/overflow-menu';
 import { css } from '@patternfly/react-styles';
 import { OverflowMenuContext } from './OverflowMenuContext';
-/* eslint-disable camelcase */
-import global_breakpoint_md from '@patternfly/react-tokens/dist/js/global_breakpoint_md';
-import global_breakpoint_lg from '@patternfly/react-tokens/dist/js/global_breakpoint_lg';
-import global_breakpoint_xl from '@patternfly/react-tokens/dist/js/global_breakpoint_xl';
-/* eslint-enable camelcase */
+import mdBreakpoint from '@patternfly/react-tokens/dist/js/global_breakpoint_md';
+import lgBreakpoint from '@patternfly/react-tokens/dist/js/global_breakpoint_lg';
+import xlBreakpoint from '@patternfly/react-tokens/dist/js/global_breakpoint_xl';
+import xl2Breakpoint from '@patternfly/react-tokens/dist/js/global_breakpoint_2xl';
 import { debounce } from '../../helpers/util';
 
 export interface OverflowMenuProps extends React.HTMLProps<HTMLDivElement> {
@@ -15,7 +14,7 @@ export interface OverflowMenuProps extends React.HTMLProps<HTMLDivElement> {
   /** Additional classes added to the OverflowMenu. */
   className?: string;
   /** Indicates breakpoint at which to switch between horizontal menu and vertical dropdown */
-  breakpoint: 'md' | 'lg' | 'xl';
+  breakpoint: 'md' | 'lg' | 'xl' | '2xl';
 }
 
 export interface OverflowMenuState extends React.HTMLProps<HTMLDivElement> {
@@ -41,11 +40,10 @@ export class OverflowMenu extends React.Component<OverflowMenuProps, OverflowMen
 
   handleResize = () => {
     const breakpoints: { [index: string]: { value: string } } = {
-      /* eslint-disable camelcase */
-      md: global_breakpoint_md,
-      lg: global_breakpoint_lg,
-      xl: global_breakpoint_xl
-      /* eslint-enable camelcase */
+      md: mdBreakpoint,
+      lg: lgBreakpoint,
+      xl: xlBreakpoint,
+      '2xl': xl2Breakpoint
     };
     const { breakpoint } = this.props;
     let breakpointWidth: string | number = breakpoints[breakpoint].value;

--- a/packages/react-core/src/components/OverflowMenu/__tests__/OverflowMenu.test.tsx
+++ b/packages/react-core/src/components/OverflowMenu/__tests__/OverflowMenu.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, mount } from 'enzyme';
+import { render, shallow, mount } from 'enzyme';
 import styles from '@patternfly/react-styles/css/components/OverflowMenu/overflow-menu';
 import { OverflowMenu } from '../OverflowMenu';
 
@@ -27,5 +27,16 @@ describe('OverflowMenu', () => {
       </OverflowMenu>
     );
     expect(view).toMatchSnapshot();
+  });
+
+  test('should warn on bad props', () => {
+    const myMock = jest.fn() as any;
+    global.console = { error: myMock } as any;
+    shallow(
+      <OverflowMenu breakpoint={undefined as "md"}>
+        <div>BASIC</div>
+      </OverflowMenu>
+    );
+    expect(myMock).toBeCalled();
   });
 });

--- a/packages/react-core/src/components/Toolbar/ToolbarToggleGroup.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarToggleGroup.tsx
@@ -7,11 +7,13 @@ import { ToolbarContext, ToolbarContentContext } from './ToolbarUtils';
 import { Button } from '../Button';
 import globalBreakpointLg from '@patternfly/react-tokens/dist/js/global_breakpoint_lg';
 
-import { formatBreakpointMods, toCamel } from '../../helpers/util';
+import { formatBreakpointMods, toCamel, capitalize } from '../../helpers/util';
 
 export interface ToolbarToggleGroupProps extends ToolbarGroupProps {
   /** An icon to be rendered when the toggle group has collapsed down */
   toggleIcon: React.ReactNode;
+  /** Controls when filters are shown and when the toggle button is hidden. */
+  breakpoint: 'md' | 'lg' | 'xl' | '2xl';
   /** Visibility at various breakpoints. */
   visiblity?: {
     default?: 'hidden' | 'visible';
@@ -19,14 +21,6 @@ export interface ToolbarToggleGroupProps extends ToolbarGroupProps {
     lg?: 'hidden' | 'visible';
     xl?: 'hidden' | 'visible';
     '2xl'?: 'hidden' | 'visible';
-  };
-  /** Controls when filters are shown and when the toggle button is hidden. */
-  show?: {
-    default?: 'show';
-    md?: 'show';
-    lg?: 'show';
-    xl?: 'show';
-    '2xl'?: 'show';
   };
   /** Alignment at various breakpoints. */
   alignment?: {
@@ -66,7 +60,7 @@ export class ToolbarToggleGroup extends React.Component<ToolbarToggleGroupProps>
       toggleIcon,
       variant,
       visiblity,
-      show,
+      breakpoint,
       alignment,
       spacer,
       spaceItems,
@@ -87,18 +81,19 @@ export class ToolbarToggleGroup extends React.Component<ToolbarToggleGroupProps>
                   expandableContentRef.current.classList.remove(styles.modifiers.expanded);
                 }
               }
+              console.log('breakpoint', breakpoint, capitalize(breakpoint))
 
               return (
                 <div
                   className={css(
                     styles.toolbarGroup,
+                    styles.modifiers.toggleGroup,
                     variant && styles.modifiers[toCamel(variant) as 'filterGroup' | 'iconButtonGroup' | 'buttonGroup'],
+                    breakpoint && styles.modifiers[`showOn${capitalize(breakpoint.replace('2xl', '_2xl'))}` as 'showOnMd' | 'showOnLg' | 'showOnXl' | 'showOn_2xl'],
                     formatBreakpointMods(visiblity, styles),
-                    formatBreakpointMods(show, styles),
                     formatBreakpointMods(alignment, styles),
                     formatBreakpointMods(spacer, styles),
                     formatBreakpointMods(spaceItems, styles),
-                    styles.modifiers.toggleGroup,
                     className
                   )}
                   {...props}

--- a/packages/react-core/src/components/Toolbar/ToolbarToggleGroup.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarToggleGroup.tsx
@@ -69,6 +69,11 @@ export class ToolbarToggleGroup extends React.Component<ToolbarToggleGroupProps>
       ...props
     } = this.props;
 
+    if (!breakpoint && !toggleIcon) {
+      // eslint-disable-next-line no-console
+      console.error('ToolbarToggleGroup will not be visible without a breakpoint or toggleIcon.');
+    }
+
     return (
       <ToolbarContext.Consumer>
         {({ isExpanded, toggleIsExpanded }) => (
@@ -81,7 +86,6 @@ export class ToolbarToggleGroup extends React.Component<ToolbarToggleGroupProps>
                   expandableContentRef.current.classList.remove(styles.modifiers.expanded);
                 }
               }
-              console.log('breakpoint', breakpoint, capitalize(breakpoint))
 
               return (
                 <div
@@ -89,7 +93,14 @@ export class ToolbarToggleGroup extends React.Component<ToolbarToggleGroupProps>
                     styles.toolbarGroup,
                     styles.modifiers.toggleGroup,
                     variant && styles.modifiers[toCamel(variant) as 'filterGroup' | 'iconButtonGroup' | 'buttonGroup'],
-                    breakpoint && styles.modifiers[`showOn${capitalize(breakpoint.replace('2xl', '_2xl'))}` as 'showOnMd' | 'showOnLg' | 'showOnXl' | 'showOn_2xl'],
+                    breakpoint &&
+                      styles.modifiers[
+                        `showOn${capitalize(breakpoint.replace('2xl', '_2xl'))}` as
+                          | 'showOnMd'
+                          | 'showOnLg'
+                          | 'showOnXl'
+                          | 'showOn_2xl'
+                      ],
                     formatBreakpointMods(visiblity, styles),
                     formatBreakpointMods(alignment, styles),
                     formatBreakpointMods(spacer, styles),

--- a/packages/react-core/src/components/Toolbar/__tests__/Generated/ToolbarToggleGroup.test.tsx
+++ b/packages/react-core/src/components/Toolbar/__tests__/Generated/ToolbarToggleGroup.test.tsx
@@ -8,6 +8,6 @@ import { ToolbarToggleGroup } from '../../ToolbarToggleGroup';
 import {} from '../..';
 
 it('ToolbarToggleGroup should match snapshot (auto-generated)', () => {
-  const view = shallow(<ToolbarToggleGroup toggleIcon={<div>ReactNode</div>} />);
+  const view = shallow(<ToolbarToggleGroup breakpoint="xl" toggleIcon={<div>ReactNode</div>} />);
   expect(view).toMatchSnapshot();
 });

--- a/packages/react-core/src/components/Toolbar/__tests__/ToolbarToggleGroup.test.tsx
+++ b/packages/react-core/src/components/Toolbar/__tests__/ToolbarToggleGroup.test.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { ToolbarToggleGroup } from '../ToolbarToggleGroup';
+
+describe('ToolbarToggleGroup', () => {
+  it('should warn on bad props', () => {
+    const myMock = jest.fn() as any;
+    global.console = { error: myMock } as any;
+    shallow(<ToolbarToggleGroup breakpoint={undefined as 'xl'} toggleIcon={null} />);
+    expect(myMock).toBeCalled();
+  });
+});

--- a/packages/react-core/src/components/Toolbar/examples/Toolbar.md
+++ b/packages/react-core/src/components/Toolbar/examples/Toolbar.md
@@ -402,7 +402,7 @@ class ToolbarComponentMangedToggleGroup extends React.Component {
        </ToolbarGroup>
     </React.Fragment>;
 
-    const items =  <ToolbarToggleGroup toggleIcon={<FilterIcon />} show={{ xl: 'show' }}>{toggleGroupItems}</ToolbarToggleGroup>;
+    const items =  <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl">{toggleGroupItems}</ToolbarToggleGroup>;
 
     return <Toolbar id="toolbar-component-managed-toggle-groups" className='pf-m-toggle-group-container'>
       <ToolbarContent>
@@ -556,7 +556,7 @@ class ToolbarConsumerMangedToggleGroup extends React.Component {
       </ToolbarGroup>
     </React.Fragment>;
 
-    const items =  <ToolbarToggleGroup toggleIcon={<FilterIcon />} show={{ xl: 'show' }}>{toggleGroupItems}</ToolbarToggleGroup>;
+    const items =  <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl">{toggleGroupItems}</ToolbarToggleGroup>;
 
     return (
       <Toolbar id="toolbar-consumer-managed-toggle-groups"
@@ -787,8 +787,7 @@ class ToolbarWithFilterExample extends React.Component {
     ];
 
     const toolbarItems = <React.Fragment>
-      <ToolbarToggleGroup toggleIcon={<FilterIcon />}
-        show={{ xl: 'show' }}>
+      <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl">
         {toggleGroupItems}
       </ToolbarToggleGroup>
       <ToolbarGroup variant="icon-button-group">
@@ -1016,7 +1015,7 @@ class ToolbarStacked extends React.Component {
 
 
     const firstRowItems = <React.Fragment>
-      <ToolbarToggleGroup toggleIcon={<FilterIcon />} show={{ xl: 'show' }}>{toggleGroupItems}</ToolbarToggleGroup>
+      <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl">{toggleGroupItems}</ToolbarToggleGroup>
       <ToolbarGroup variant="icon-button-group">{iconButtonGroupItems}</ToolbarGroup>
       <ToolbarItem variant="overflow-menu">Overflow Menu</ToolbarItem>
     </React.Fragment>;

--- a/packages/react-core/src/demos/FilterTableDemo.md
+++ b/packages/react-core/src/demos/FilterTableDemo.md
@@ -320,7 +320,7 @@ class FilterTableDemo extends React.Component {
         collapseListedFiltersBreakpoint="xl"
       >
         <ToolbarContent>
-          <ToolbarToggleGroup toggleIcon={<FilterIcon />} show={{ xl: 'show' }}>
+          <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl">
             <ToolbarGroup variant="filter-group">
               {this.buildCategoryDropdown()}
               {this.buildFilterDropdown()}

--- a/packages/react-core/src/demos/MasterDetailDemo.md
+++ b/packages/react-core/src/demos/MasterDetailDemo.md
@@ -407,7 +407,7 @@ class MasterDetailFullPage extends React.Component {
        </ToolbarGroup>
     </React.Fragment>;
 
-    const ToolbarItems =  <ToolbarToggleGroup toggleIcon={<FilterIcon />} show={{ xl: 'show' }}>{toggleGroupItems}</ToolbarToggleGroup>;
+    const ToolbarItems =  <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl">{toggleGroupItems}</ToolbarToggleGroup>;
     
     const panelContent = (
       <DrawerPanelContent>
@@ -935,7 +935,7 @@ class MasterDetailContentPadding extends React.Component {
       </ToolbarGroup>
     </React.Fragment>;
 
-    const ToolbarItems =  <ToolbarToggleGroup toggleIcon={<FilterIcon />} show={{ xl: 'show' }}>{toggleGroupItems}</ToolbarToggleGroup>;
+    const ToolbarItems =  <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl">{toggleGroupItems}</ToolbarToggleGroup>;
     
     const panelContent = (
       <DrawerPanelContent>
@@ -2447,7 +2447,7 @@ class MasterDetailInlineModifier extends React.Component {
        </ToolbarGroup>
     </React.Fragment>;
 
-    const ToolbarItems =  <ToolbarToggleGroup toggleIcon={<FilterIcon />} show={{ xl: 'show' }}>{toggleGroupItems}</ToolbarToggleGroup>;
+    const ToolbarItems =  <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl">{toggleGroupItems}</ToolbarToggleGroup>;
     
     const panelContent = (
       <DrawerPanelContent>

--- a/packages/react-integration/demo-app-ts/src/Demos.ts
+++ b/packages/react-integration/demo-app-ts/src/Demos.ts
@@ -166,11 +166,6 @@ export const Demos: DemoInterface[] = [
     componentType: Examples.DataListCompactDemo
   },
   {
-    id: 'toolbar-demo',
-    name: 'Toolbar Demo',
-    componentType: Examples.ToolbarDemo
-  },
-  {
     id: 'divider-demo',
     name: 'Divider Demo',
     componentType: Examples.DividerDemo

--- a/packages/react-integration/demo-app-ts/src/components/demos/ToolbarDemo/ToolbarDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/ToolbarDemo/ToolbarDemo.tsx
@@ -247,7 +247,7 @@ export class ToolbarDemo extends React.Component<ToolbarProps, ToolbarState> {
 
     const toolbarItems = (
       <React.Fragment>
-        <ToolbarToggleGroup toggleIcon={<FilterIcon />} show={{ xl: 'show' }} id="demo-toggle-group">
+        <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl" id="demo-toggle-group">
           {toggleGroupItems}
         </ToolbarToggleGroup>
         <ToolbarGroup variant="icon-button-group">


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Revert `show` to single required `breakpoint` prop. Add warning message when prop values are such that the component would be invisible. Closes #4341

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: Allow OverflowMenu to support 2xl.
