### PR TITLE
fix(package.json) Removed call for yarn clean:pf3

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "build:docs": "yarn workspace @patternfly/react-docs build:docs",
     "build:umd": "yarn workspace @patternfly/react-core build:umd",
     "build:generate": "lerna run generate --parallel --stream",
-    "clean": "yarn clean:build && yarn clean:pf3 && lerna run clean --parallel",
+    "clean": "yarn clean:build && lerna run clean --parallel",
     "clean:build": "rimraf .cache .eslintcache coverage",
     "commit": "git-cz",
     "generate": "yarn plop",


### PR DESCRIPTION
Fix for `yarn clean`:
```
$ yarn clean:build && yarn clean:pf3 && lerna run clean --parallel
$ rimraf .cache .eslintcache coverage
error Command "clean:pf3" not found.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
```
It was left there after pf3 removal...