### PR TITLE
Chart: Tooltip legend updates

### DIFF
--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipContent.test.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipContent.test.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import { ChartLegendTooltipLegend } from './ChartLegendTooltipLegend';
+import { ChartLegendTooltipContent } from './ChartLegendTooltipContent';
 
 Object.values([true, false]).forEach(() => {
-  test('ChartLegendTooltipLegend', () => {
-    const view = shallow(<ChartLegendTooltipLegend />);
+  test('ChartLegendTooltipContent', () => {
+    const view = shallow(<ChartLegendTooltipContent />);
     expect(view).toMatchSnapshot();
   });
 });
@@ -16,6 +16,6 @@ test('renders component text', () => {
     { name: 'Birds' },
     { name: 'Mice' }
   ];
-  const view = shallow(<ChartLegendTooltipLegend data={legendData} text={['1, 2, 3, 4']} />);
+  const view = shallow(<ChartLegendTooltipContent data={legendData} text={['1, 2, 3, 4']} />);
   expect(view).toMatchSnapshot();
 });

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipContent.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipContent.tsx
@@ -28,7 +28,7 @@ import { getLegendTooltipSize, getTheme } from '../ChartUtils';
 // Overriding title prop
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
-export interface ChartLegendTooltipLegendProps extends ChartLegendProps {
+export interface ChartLegendTooltipContentProps extends ChartLegendProps {
   /**
    * The borderComponent prop takes a component instance which will be responsible
    * for rendering a border around the legend. The new element created from the passed
@@ -326,7 +326,7 @@ export const defaultLegendProps = {
   }
 };
 
-export const ChartLegendTooltipLegend: React.FunctionComponent<ChartLegendTooltipLegendProps> = ({
+export const ChartLegendTooltipContent: React.FunctionComponent<ChartLegendTooltipContentProps> = ({
   borderPadding = defaultLegendProps.borderPadding,
   data,
   datum,
@@ -350,11 +350,11 @@ export const ChartLegendTooltipLegend: React.FunctionComponent<ChartLegendToolti
   // destructure last
   theme = getTheme(themeColor, themeVariant),
   ...rest
-}: ChartLegendTooltipLegendProps) => {
+}: ChartLegendTooltipContentProps) => {
   const offsetY = 10 * (Array.isArray(text) ? text.length : 1);
 
   // Component offsets
-  const legendOffsetX = -50;
+  const legendOffsetX = -50; // Todo: base this on the flyout edge
   const legendOffsetY = -offsetY + 5 + (title ? 0 : -10);
   const titleOffsetX = -40;
   const titleOffsetY = -offsetY;
@@ -435,4 +435,4 @@ export const ChartLegendTooltipLegend: React.FunctionComponent<ChartLegendToolti
 };
 
 // Note: VictoryLegend.role must be hoisted, but getBaseProps causes error with ChartVoronoiContainer
-hoistNonReactStatics(ChartLegendTooltipLegend, VictoryLegend, { getBaseProps: true });
+hoistNonReactStatics(ChartLegendTooltipContent, VictoryLegend, { getBaseProps: true });

--- a/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltip.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltip.test.tsx.snap
@@ -1,923 +1,927 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ChartLegendTooltip 1`] = `
-<Fragment>
-  <ChartCursorTooltip
-    flyoutHeight={[Function]}
-    flyoutWidth={[Function]}
-    labelComponent={<ChartLegendTooltipLegend />}
-    text="This is a tooltip"
-    theme={
-      Object {
-        "area": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "data": Object {
-              "fill": "#06c",
-              "fillOpacity": 0.3,
-              "strokeWidth": 2,
-            },
-            "labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-              "textAnchor": "middle",
-            },
+<ChartCursorTooltip
+  flyoutHeight={[Function]}
+  flyoutWidth={[Function]}
+  labelComponent={
+    <ChartLegendTooltipContent
+      isCursorTooltip={true}
+    />
+  }
+  text="This is a tooltip"
+  theme={
+    Object {
+      "area": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "#06c",
+            "fillOpacity": 0.3,
+            "strokeWidth": 2,
           },
-          "width": 450,
-        },
-        "axis": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "axis": Object {
-              "fill": "transparent",
-              "stroke": "#d2d2d2",
-              "strokeLinecap": "round",
-              "strokeLinejoin": "round",
-              "strokeWidth": 1,
-            },
-            "axisLabel": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 40,
-              "stroke": "transparent",
-              "textAnchor": "middle",
-            },
-            "grid": Object {
-              "fill": "none",
-              "pointerEvents": "painted",
-              "stroke": "none",
-              "strokeLinecap": "round",
-              "strokeLinejoin": "round",
-            },
-            "tickLabels": Object {
-              "fill": "#4f5255",
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-            },
-            "ticks": Object {
-              "fill": "transparent",
-              "size": 5,
-              "stroke": "#d2d2d2",
-              "strokeLinecap": "round",
-              "strokeLinejoin": "round",
-              "strokeWidth": 1,
-            },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+            "textAnchor": "middle",
           },
-          "width": 450,
         },
-        "bar": Object {
-          "barWidth": 10,
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "data": Object {
-              "fill": "#06c",
-              "padding": 8,
-              "stroke": "none",
-              "strokeWidth": 0,
-            },
-            "labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-            },
+        "width": 450,
+      },
+      "axis": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "axis": Object {
+            "fill": "transparent",
+            "stroke": "#d2d2d2",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
-          "width": 450,
-        },
-        "boxplot": Object {
-          "boxWidth": 20,
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "max": Object {
-              "padding": 8,
-              "stroke": "#151515",
-              "strokeWidth": 1,
-            },
-            "maxLabels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-            },
-            "median": Object {
-              "padding": 8,
-              "stroke": "#151515",
-              "strokeWidth": 1,
-            },
-            "medianLabels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-            },
-            "min": Object {
-              "padding": 8,
-              "stroke": "#151515",
-              "strokeWidth": 1,
-            },
-            "minLabels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-            },
-            "q1": Object {
-              "fill": "#8a8d90",
-              "padding": 8,
-            },
-            "q1Labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-            },
-            "q3": Object {
-              "fill": "#8a8d90",
-              "padding": 8,
-            },
-            "q3Labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-            },
+          "axisLabel": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 40,
+            "stroke": "transparent",
+            "textAnchor": "middle",
           },
-          "width": 450,
-        },
-        "candlestick": Object {
-          "candleColors": Object {
-            "negative": "#151515",
-            "positive": "#fff",
+          "grid": Object {
+            "fill": "none",
+            "pointerEvents": "painted",
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "data": Object {
-              "stroke": "#151515",
-              "strokeWidth": 1,
-            },
-            "labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-              "textAnchor": "middle",
-            },
+          "tickLabels": Object {
+            "fill": "#4f5255",
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
           },
-          "width": 450,
-        },
-        "chart": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "width": 450,
-        },
-        "errorbar": Object {
-          "borderWidth": 8,
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "data": Object {
-              "fill": "transparent",
-              "opacity": 1,
-              "stroke": "#151515",
-              "strokeWidth": 2,
-            },
-            "labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-              "textAnchor": "middle",
-            },
+          "ticks": Object {
+            "fill": "transparent",
+            "size": 5,
+            "stroke": "#d2d2d2",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
-          "width": 450,
         },
-        "group": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "width": 450,
-        },
-        "legend": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "gutter": 20,
-          "orientation": "horizontal",
-          "style": Object {
-            "data": Object {
-              "type": "square",
-            },
-            "labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-            },
-            "title": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 2,
-              "stroke": "transparent",
-            },
+        "width": 450,
+      },
+      "bar": Object {
+        "barWidth": 10,
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "#06c",
+            "padding": 8,
+            "stroke": "none",
+            "strokeWidth": 0,
           },
-          "titleOrientation": "top",
-        },
-        "line": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "data": Object {
-              "fill": "transparent",
-              "opacity": 1,
-              "stroke": "#06c",
-              "strokeWidth": 2,
-            },
-            "labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-              "textAnchor": "middle",
-            },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
           },
-          "width": 450,
         },
-        "pie": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 230,
-          "padding": 20,
-          "style": Object {
-            "data": Object {
-              "padding": 8,
-              "stroke": "transparent",
-              "strokeWidth": 1,
-            },
-            "labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 8,
-              "stroke": "transparent",
-            },
+        "width": 450,
+      },
+      "boxplot": Object {
+        "boxWidth": 20,
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "max": Object {
+            "padding": 8,
+            "stroke": "#151515",
+            "strokeWidth": 1,
           },
-          "width": 230,
-        },
-        "scatter": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "data": Object {
-              "fill": "#151515",
-              "opacity": 1,
-              "stroke": "transparent",
-              "strokeWidth": 0,
-            },
-            "labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-              "textAnchor": "middle",
-            },
+          "maxLabels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
           },
-          "width": 450,
-        },
-        "stack": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "data": Object {
-              "strokeWidth": 1,
-            },
+          "median": Object {
+            "padding": 8,
+            "stroke": "#151515",
+            "strokeWidth": 1,
           },
-          "width": 450,
+          "medianLabels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+          "min": Object {
+            "padding": 8,
+            "stroke": "#151515",
+            "strokeWidth": 1,
+          },
+          "minLabels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+          "q1": Object {
+            "fill": "#8a8d90",
+            "padding": 8,
+          },
+          "q1Labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+          "q3": Object {
+            "fill": "#8a8d90",
+            "padding": 8,
+          },
+          "q3Labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
         },
-        "tooltip": Object {
+        "width": 450,
+      },
+      "candlestick": Object {
+        "candleColors": Object {
+          "negative": "#151515",
+          "positive": "#fff",
+        },
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "stroke": "#151515",
+            "strokeWidth": 1,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+            "textAnchor": "middle",
+          },
+        },
+        "width": 450,
+      },
+      "chart": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "width": 450,
+      },
+      "errorbar": Object {
+        "borderWidth": 8,
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "transparent",
+            "opacity": 1,
+            "stroke": "#151515",
+            "strokeWidth": 2,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+            "textAnchor": "middle",
+          },
+        },
+        "width": 450,
+      },
+      "group": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "width": 450,
+      },
+      "legend": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "gutter": 20,
+        "orientation": "horizontal",
+        "style": Object {
+          "data": Object {
+            "type": "square",
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+          "title": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 2,
+            "stroke": "transparent",
+          },
+        },
+        "titleOrientation": "top",
+      },
+      "line": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "transparent",
+            "opacity": 1,
+            "stroke": "#06c",
+            "strokeWidth": 2,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+            "textAnchor": "middle",
+          },
+        },
+        "width": 450,
+      },
+      "pie": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 230,
+        "padding": 20,
+        "style": Object {
+          "data": Object {
+            "padding": 8,
+            "stroke": "transparent",
+            "strokeWidth": 1,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 8,
+            "stroke": "transparent",
+          },
+        },
+        "width": 230,
+      },
+      "scatter": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "#151515",
+            "opacity": 1,
+            "stroke": "transparent",
+            "strokeWidth": 0,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+            "textAnchor": "middle",
+          },
+        },
+        "width": 450,
+      },
+      "stack": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "strokeWidth": 1,
+          },
+        },
+        "width": 450,
+      },
+      "tooltip": Object {
+        "cornerRadius": 0,
+        "flyoutStyle": Object {
           "cornerRadius": 0,
-          "flyoutStyle": Object {
-            "cornerRadius": 0,
+          "fill": "#151515",
+          "pointerEvents": "none",
+          "stroke": "#151515",
+          "strokeWidth": 0,
+        },
+        "pointerLength": 10,
+        "pointerWidth": 20,
+        "style": Object {
+          "fill": "#f0f0f0",
+          "padding": 16,
+          "pointerEvents": "none",
+        },
+      },
+      "voronoi": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "transparent",
+            "stroke": "transparent",
+            "strokeWidth": 0,
+          },
+          "flyout": Object {
             "fill": "#151515",
             "pointerEvents": "none",
             "stroke": "#151515",
-            "strokeWidth": 0,
+            "strokeWidth": 1,
           },
-          "pointerLength": 10,
-          "pointerWidth": 20,
-          "style": Object {
+          "labels": Object {
             "fill": "#f0f0f0",
-            "padding": 16,
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 8,
             "pointerEvents": "none",
+            "stroke": "transparent",
+            "textAnchor": "middle",
           },
         },
-        "voronoi": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "data": Object {
-              "fill": "transparent",
-              "stroke": "transparent",
-              "strokeWidth": 0,
-            },
-            "flyout": Object {
-              "fill": "#151515",
-              "pointerEvents": "none",
-              "stroke": "#151515",
-              "strokeWidth": 1,
-            },
-            "labels": Object {
-              "fill": "#f0f0f0",
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 8,
-              "pointerEvents": "none",
-              "stroke": "transparent",
-              "textAnchor": "middle",
-            },
-          },
-          "width": 450,
-        },
-      }
+        "width": 450,
+      },
     }
-  />
-</Fragment>
+  }
+/>
 `;
 
 exports[`ChartLegendTooltip 2`] = `
-<Fragment>
-  <ChartCursorTooltip
-    flyoutHeight={[Function]}
-    flyoutWidth={[Function]}
-    labelComponent={<ChartLegendTooltipLegend />}
-    text="This is a tooltip"
-    theme={
-      Object {
-        "area": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "data": Object {
-              "fill": "#06c",
-              "fillOpacity": 0.3,
-              "strokeWidth": 2,
-            },
-            "labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-              "textAnchor": "middle",
-            },
+<ChartCursorTooltip
+  flyoutHeight={[Function]}
+  flyoutWidth={[Function]}
+  labelComponent={
+    <ChartLegendTooltipContent
+      isCursorTooltip={true}
+    />
+  }
+  text="This is a tooltip"
+  theme={
+    Object {
+      "area": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "#06c",
+            "fillOpacity": 0.3,
+            "strokeWidth": 2,
           },
-          "width": 450,
-        },
-        "axis": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "axis": Object {
-              "fill": "transparent",
-              "stroke": "#d2d2d2",
-              "strokeLinecap": "round",
-              "strokeLinejoin": "round",
-              "strokeWidth": 1,
-            },
-            "axisLabel": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 40,
-              "stroke": "transparent",
-              "textAnchor": "middle",
-            },
-            "grid": Object {
-              "fill": "none",
-              "pointerEvents": "painted",
-              "stroke": "none",
-              "strokeLinecap": "round",
-              "strokeLinejoin": "round",
-            },
-            "tickLabels": Object {
-              "fill": "#4f5255",
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-            },
-            "ticks": Object {
-              "fill": "transparent",
-              "size": 5,
-              "stroke": "#d2d2d2",
-              "strokeLinecap": "round",
-              "strokeLinejoin": "round",
-              "strokeWidth": 1,
-            },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+            "textAnchor": "middle",
           },
-          "width": 450,
         },
-        "bar": Object {
-          "barWidth": 10,
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "data": Object {
-              "fill": "#06c",
-              "padding": 8,
-              "stroke": "none",
-              "strokeWidth": 0,
-            },
-            "labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-            },
+        "width": 450,
+      },
+      "axis": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "axis": Object {
+            "fill": "transparent",
+            "stroke": "#d2d2d2",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
-          "width": 450,
-        },
-        "boxplot": Object {
-          "boxWidth": 20,
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "max": Object {
-              "padding": 8,
-              "stroke": "#151515",
-              "strokeWidth": 1,
-            },
-            "maxLabels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-            },
-            "median": Object {
-              "padding": 8,
-              "stroke": "#151515",
-              "strokeWidth": 1,
-            },
-            "medianLabels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-            },
-            "min": Object {
-              "padding": 8,
-              "stroke": "#151515",
-              "strokeWidth": 1,
-            },
-            "minLabels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-            },
-            "q1": Object {
-              "fill": "#8a8d90",
-              "padding": 8,
-            },
-            "q1Labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-            },
-            "q3": Object {
-              "fill": "#8a8d90",
-              "padding": 8,
-            },
-            "q3Labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-            },
+          "axisLabel": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 40,
+            "stroke": "transparent",
+            "textAnchor": "middle",
           },
-          "width": 450,
-        },
-        "candlestick": Object {
-          "candleColors": Object {
-            "negative": "#151515",
-            "positive": "#fff",
+          "grid": Object {
+            "fill": "none",
+            "pointerEvents": "painted",
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "data": Object {
-              "stroke": "#151515",
-              "strokeWidth": 1,
-            },
-            "labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-              "textAnchor": "middle",
-            },
+          "tickLabels": Object {
+            "fill": "#4f5255",
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
           },
-          "width": 450,
-        },
-        "chart": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "width": 450,
-        },
-        "errorbar": Object {
-          "borderWidth": 8,
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "data": Object {
-              "fill": "transparent",
-              "opacity": 1,
-              "stroke": "#151515",
-              "strokeWidth": 2,
-            },
-            "labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-              "textAnchor": "middle",
-            },
+          "ticks": Object {
+            "fill": "transparent",
+            "size": 5,
+            "stroke": "#d2d2d2",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
-          "width": 450,
         },
-        "group": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "width": 450,
-        },
-        "legend": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "gutter": 20,
-          "orientation": "horizontal",
-          "style": Object {
-            "data": Object {
-              "type": "square",
-            },
-            "labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-            },
-            "title": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 2,
-              "stroke": "transparent",
-            },
+        "width": 450,
+      },
+      "bar": Object {
+        "barWidth": 10,
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "#06c",
+            "padding": 8,
+            "stroke": "none",
+            "strokeWidth": 0,
           },
-          "titleOrientation": "top",
-        },
-        "line": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "data": Object {
-              "fill": "transparent",
-              "opacity": 1,
-              "stroke": "#06c",
-              "strokeWidth": 2,
-            },
-            "labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-              "textAnchor": "middle",
-            },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
           },
-          "width": 450,
         },
-        "pie": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 230,
-          "padding": 20,
-          "style": Object {
-            "data": Object {
-              "padding": 8,
-              "stroke": "transparent",
-              "strokeWidth": 1,
-            },
-            "labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 8,
-              "stroke": "transparent",
-            },
+        "width": 450,
+      },
+      "boxplot": Object {
+        "boxWidth": 20,
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "max": Object {
+            "padding": 8,
+            "stroke": "#151515",
+            "strokeWidth": 1,
           },
-          "width": 230,
-        },
-        "scatter": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "data": Object {
-              "fill": "#151515",
-              "opacity": 1,
-              "stroke": "transparent",
-              "strokeWidth": 0,
-            },
-            "labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-              "textAnchor": "middle",
-            },
+          "maxLabels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
           },
-          "width": 450,
-        },
-        "stack": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "data": Object {
-              "strokeWidth": 1,
-            },
+          "median": Object {
+            "padding": 8,
+            "stroke": "#151515",
+            "strokeWidth": 1,
           },
-          "width": 450,
+          "medianLabels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+          "min": Object {
+            "padding": 8,
+            "stroke": "#151515",
+            "strokeWidth": 1,
+          },
+          "minLabels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+          "q1": Object {
+            "fill": "#8a8d90",
+            "padding": 8,
+          },
+          "q1Labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+          "q3": Object {
+            "fill": "#8a8d90",
+            "padding": 8,
+          },
+          "q3Labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
         },
-        "tooltip": Object {
+        "width": 450,
+      },
+      "candlestick": Object {
+        "candleColors": Object {
+          "negative": "#151515",
+          "positive": "#fff",
+        },
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "stroke": "#151515",
+            "strokeWidth": 1,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+            "textAnchor": "middle",
+          },
+        },
+        "width": 450,
+      },
+      "chart": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "width": 450,
+      },
+      "errorbar": Object {
+        "borderWidth": 8,
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "transparent",
+            "opacity": 1,
+            "stroke": "#151515",
+            "strokeWidth": 2,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+            "textAnchor": "middle",
+          },
+        },
+        "width": 450,
+      },
+      "group": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "width": 450,
+      },
+      "legend": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "gutter": 20,
+        "orientation": "horizontal",
+        "style": Object {
+          "data": Object {
+            "type": "square",
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+          "title": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 2,
+            "stroke": "transparent",
+          },
+        },
+        "titleOrientation": "top",
+      },
+      "line": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "transparent",
+            "opacity": 1,
+            "stroke": "#06c",
+            "strokeWidth": 2,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+            "textAnchor": "middle",
+          },
+        },
+        "width": 450,
+      },
+      "pie": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 230,
+        "padding": 20,
+        "style": Object {
+          "data": Object {
+            "padding": 8,
+            "stroke": "transparent",
+            "strokeWidth": 1,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 8,
+            "stroke": "transparent",
+          },
+        },
+        "width": 230,
+      },
+      "scatter": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "#151515",
+            "opacity": 1,
+            "stroke": "transparent",
+            "strokeWidth": 0,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+            "textAnchor": "middle",
+          },
+        },
+        "width": 450,
+      },
+      "stack": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "strokeWidth": 1,
+          },
+        },
+        "width": 450,
+      },
+      "tooltip": Object {
+        "cornerRadius": 0,
+        "flyoutStyle": Object {
           "cornerRadius": 0,
-          "flyoutStyle": Object {
-            "cornerRadius": 0,
+          "fill": "#151515",
+          "pointerEvents": "none",
+          "stroke": "#151515",
+          "strokeWidth": 0,
+        },
+        "pointerLength": 10,
+        "pointerWidth": 20,
+        "style": Object {
+          "fill": "#f0f0f0",
+          "padding": 16,
+          "pointerEvents": "none",
+        },
+      },
+      "voronoi": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "transparent",
+            "stroke": "transparent",
+            "strokeWidth": 0,
+          },
+          "flyout": Object {
             "fill": "#151515",
             "pointerEvents": "none",
             "stroke": "#151515",
-            "strokeWidth": 0,
+            "strokeWidth": 1,
           },
-          "pointerLength": 10,
-          "pointerWidth": 20,
-          "style": Object {
+          "labels": Object {
             "fill": "#f0f0f0",
-            "padding": 16,
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 8,
             "pointerEvents": "none",
+            "stroke": "transparent",
+            "textAnchor": "middle",
           },
         },
-        "voronoi": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "data": Object {
-              "fill": "transparent",
-              "stroke": "transparent",
-              "strokeWidth": 0,
-            },
-            "flyout": Object {
-              "fill": "#151515",
-              "pointerEvents": "none",
-              "stroke": "#151515",
-              "strokeWidth": 1,
-            },
-            "labels": Object {
-              "fill": "#f0f0f0",
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 8,
-              "pointerEvents": "none",
-              "stroke": "transparent",
-              "textAnchor": "middle",
-            },
-          },
-          "width": 450,
-        },
-      }
+        "width": 450,
+      },
     }
-  />
-</Fragment>
+  }
+/>
 `;
 
 exports[`allows tooltip via container component 1`] = `

--- a/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltipContent.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltipContent.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ChartLegendTooltipLegend 1`] = `
+exports[`ChartLegendTooltipContent 1`] = `
 <Fragment>
   <ChartLabel
     style={
@@ -500,7 +500,7 @@ exports[`ChartLegendTooltipLegend 1`] = `
 </Fragment>
 `;
 
-exports[`ChartLegendTooltipLegend 2`] = `
+exports[`ChartLegendTooltipContent 2`] = `
 <Fragment>
   <ChartLabel
     style={

--- a/packages/react-charts/src/components/ChartLegendTooltip/index.ts
+++ b/packages/react-charts/src/components/ChartLegendTooltip/index.ts
@@ -1,3 +1,3 @@
 export * from './ChartLegendTooltip';
+export * from './ChartLegendTooltipContent';
 export * from './ChartLegendTooltipLabel';
-export * from './ChartLegendTooltipLegend';

--- a/packages/react-charts/src/components/ChartStack/examples/ChartStack.md
+++ b/packages/react-charts/src/components/ChartStack/examples/ChartStack.md
@@ -12,7 +12,7 @@ propComponents: [
 hideDarkMode: true
 ---
 
-import { Chart, ChartArea, ChartBar, ChartStack, ChartThemeColor, ChartTooltip } from '@patternfly/react-charts';
+import { Chart, ChartArea, ChartBar, ChartStack, ChartLegendTooltip, ChartThemeColor, ChartTooltip, createContainer } from '@patternfly/react-charts';
 
 ## Introduction
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
@@ -284,7 +284,7 @@ class MonthlyResponsiveStack extends React.Component {
 
 ```js title=Multi--color-(unordered)-responsive-container
 import React from 'react';
-import { Chart, ChartArea, ChartAxis, ChartStack, ChartThemeColor, ChartVoronoiContainer } from '@patternfly/react-charts';
+import { Chart, ChartArea, ChartAxis, ChartStack, ChartLegendTooltip, ChartThemeColor, ChartVoronoiContainer, createContainer } from '@patternfly/react-charts';
 
 class MultiColorChart extends React.Component {
   constructor(props) {
@@ -312,14 +312,27 @@ class MultiColorChart extends React.Component {
   render() {
     const { width } = this.state;
     
+    // Note: Container order is important
+    const CursorVoronoiContainer = createContainer("cursor", "voronoi");
+    const legendData = [{ name: 'Cats' }, { name: 'Dogs', symbol: { type: 'dash' } }, { name: 'Birds' }];
+
     return (
       <div ref={this.containerRef}>
         <div style={{ height: '225px' }}>
           <Chart
             ariaDesc="Average number of pets"
             ariaTitle="Area chart example"
-            containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
-            legendData={[{ name: 'Cats' }, { name: 'Birds' }, { name: 'Dogs' }]}
+            containerComponent={
+              <CursorVoronoiContainer
+                cursorDimension="x"
+                labels={({ datum }) => `${datum.y !== null ? datum.y : 'no data'}`}
+                labelComponent={<ChartLegendTooltip legendData={legendData} title={(datum) => datum.x}/>}
+                mouseFollowTooltips
+                voronoiDimension="x"
+                voronoiPadding={50}
+              />
+            }
+            legendData={legendData}
             legendPosition="bottom-left"
             height={225}
             padding={{

--- a/packages/react-charts/src/components/ChartTooltip/ChartCursorTooltip.tsx
+++ b/packages/react-charts/src/components/ChartTooltip/ChartCursorTooltip.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import {
+  Helpers,
   NumberOrCallback,
   OrientationTypes,
   StringOrNumberOrCallback,
@@ -223,6 +224,7 @@ export interface ChartCursorTooltipProps extends ChartTooltipProps {
 
 export const ChartCursorTooltip: React.FunctionComponent<ChartCursorTooltipProps> = ({
   constrainToVisibleArea = true,
+  flyoutComponent = <ChartCursorFlyout />,
   labelComponent = <ChartLabel />,
   labelTextAnchor = 'start',
   style,
@@ -244,16 +246,20 @@ export const ChartCursorTooltip: React.FunctionComponent<ChartCursorTooltipProps
   });
   const newStyle: any = Array.isArray(style) ? style.map(applyDefaultStyle) : applyDefaultStyle(style);
 
+  const getFlyoutComponent = () => {
+    const _pointerLength = Helpers.evaluateProp(pointerLength);
+    return React.cloneElement(flyoutComponent, {
+      pointerLength: _pointerLength > 0 ? _pointerLength : theme.tooltip.pointerLength,
+      pointerWidth,
+      ...flyoutComponent.props
+    });
+  };
+
   return (
     <ChartTooltip
       centerOffset={centerOffset}
       constrainToVisibleArea={constrainToVisibleArea}
-      flyoutComponent={
-        <ChartCursorFlyout
-          pointerLength={pointerLength > 0 ? pointerLength : theme.tooltip.pointerLength}
-          pointerWidth={pointerWidth}
-        />
-      }
+      flyoutComponent={getFlyoutComponent()}
       labelComponent={labelComponent}
       labelTextAnchor={labelTextAnchor}
       pointerOrientation={pointerOrientation}

--- a/packages/react-charts/src/components/ChartTooltip/__snapshots__/ChartCursorFlyout.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartTooltip/__snapshots__/ChartCursorFlyout.test.tsx.snap
@@ -12,6 +12,8 @@ exports[`ChartTooltip 1`] = `
   flyoutComponent={
     <ChartCursorFlyout
       pathComponent={<Path />}
+      pointerLength={10}
+      pointerWidth={20}
       role="presentation"
       shapeRendering="auto"
     />
@@ -489,6 +491,8 @@ exports[`ChartTooltip 2`] = `
   flyoutComponent={
     <ChartCursorFlyout
       pathComponent={<Path />}
+      pointerLength={10}
+      pointerWidth={20}
       role="presentation"
       shapeRendering="auto"
     />


### PR DESCRIPTION
A couple updates for the chart tooltip legend. 

- Updated the stacked area example to use a legend
- Renamed `ChartLegendTooltipLegend` (sounds weird) as `ChartLegendTooltipContent`
- Tooltip flyout should  be overridable
- Added `isCursorTooltip` prop so `ChartTooltip` can be used instead of `ChartCursorTooltip`
