### PR TITLE
fix(Spinner): className prop not getting applied properly

### DIFF
--- a/packages/react-core/src/components/Spinner/Spinner.tsx
+++ b/packages/react-core/src/components/Spinner/Spinner.tsx
@@ -26,7 +26,7 @@ export const Spinner: React.FunctionComponent<SpinnerProps> = ({
   ...props
 }: SpinnerProps) => (
   <span
-    className={css(styles.spinner, styles.modifiers[size])}
+    className={css(styles.spinner, styles.modifiers[size], className)}
     role="progressbar"
     aria-valuetext={ariaValueText}
     {...props}

--- a/packages/react-core/src/components/Spinner/__tests__/Generated/Spinner.test.tsx
+++ b/packages/react-core/src/components/Spinner/__tests__/Generated/Spinner.test.tsx
@@ -8,6 +8,6 @@ import { Spinner } from '../../Spinner';
 import {} from '../..';
 
 it('Spinner should match snapshot (auto-generated)', () => {
-  const view = shallow(<Spinner className={"''"} size={'xl'} aria-valuetext={"'Loading...'"} />);
+  const view = shallow(<Spinner className={"test"} size={'xl'} aria-valuetext={"'Loading...'"} />);
   expect(view).toMatchSnapshot();
 });

--- a/packages/react-core/src/components/Spinner/__tests__/Generated/__snapshots__/Spinner.test.tsx.snap
+++ b/packages/react-core/src/components/Spinner/__tests__/Generated/__snapshots__/Spinner.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Spinner should match snapshot (auto-generated) 1`] = `
 <span
   aria-valuetext="'Loading...'"
-  className="pf-c-spinner pf-m-xl"
+  className="pf-c-spinner pf-m-xl test"
   role="progressbar"
 >
   <span


### PR DESCRIPTION
Closes #4373

### Problem
If we pass the className prop to the spinner, it was not getting rendered correctly: 
```tsx
import { Spinner } from '@patternfly/react-core';
SpinnerWithClass = () => (<Spinner className="apple"/>);
```
Will result in:
```
<span class="pf-c-spinner pf-m-xl" role="progressbar" aria-valuetext="Loading...">
    <span class="pf-c-spinner__clipper"></span>
    <span class="pf-c-spinner__lead-ball"></span>
    <span class="pf-c-spinner__tail-ball"></span>
</span>
```

### Solution
Fixed the issue by adding className to the class list now it will behave like this:
```tsx
<span class="pf-c-spinner pf-m-xl apple" role="progressbar" aria-valuetext="Loading...">
    <span class="pf-c-spinner__clipper"></span>
    <span class="pf-c-spinner__lead-ball"></span>
    <span class="pf-c-spinner__tail-ball"></span>
</span>
```

