### PR TITLE
Set modal size in docs -> variant

### DIFF
--- a/packages/react-core/src/components/Modal/examples/Modal.md
+++ b/packages/react-core/src/components/Modal/examples/Modal.md
@@ -201,7 +201,7 @@ class LargeModal extends React.Component {
           Show Large Modal
         </Button>
         <Modal
-          size={ModalVariant.large}
+          variant={ModalVariant.large}
           title="Large modal header"
           isOpen={isModalOpen}
           onClose={this.handleModalToggle}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Modal doesn't use size anymore 🚮

I don't think there are any issues for this.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:

No