### PR TITLE
Ensure PagerHeaderToolsGroup visibility mods are optional

### DIFF
--- a/packages/react-core/src/components/Page/PageHeaderToolsGroup.tsx
+++ b/packages/react-core/src/components/Page/PageHeaderToolsGroup.tsx
@@ -10,7 +10,7 @@ export interface PageHeaderToolsGroupProps extends React.HTMLProps<HTMLDivElemen
   className?: string;
   /** Visibility at various breakpoints. */
   visibility?: {
-    default: 'hidden' | 'visible';
+    default?: 'hidden' | 'visible';
     sm?: 'hidden' | 'visible';
     md?: 'hidden' | 'visible';
     lg?: 'hidden' | 'visible';

--- a/packages/react-core/src/components/Page/PageHeaderToolsGroup.tsx
+++ b/packages/react-core/src/components/Page/PageHeaderToolsGroup.tsx
@@ -11,11 +11,11 @@ export interface PageHeaderToolsGroupProps extends React.HTMLProps<HTMLDivElemen
   /** Visibility at various breakpoints. */
   visibility?: {
     default: 'hidden' | 'visible';
-    sm: 'hidden' | 'visible';
-    md: 'hidden' | 'visible';
-    lg: 'hidden' | 'visible';
-    xl: 'hidden' | 'visible';
-    '2xl': 'hidden' | 'visible';
+    sm?: 'hidden' | 'visible';
+    md?: 'hidden' | 'visible';
+    lg?: 'hidden' | 'visible';
+    xl?: 'hidden' | 'visible';
+    '2xl'?: 'hidden' | 'visible';
   };
 }
 


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: 

In the official demos here:
https://www.patternfly.org/v4/documentation/react/demos/pagelayout

You can see from the horizontal nav example that only the default and lg
props are specified.

This is legal in JS and I assume is how it is expected to work. Set a
default and add exceptions for other sizes you'd like for other
properties.

In ts, there is a hard requirement on setting each of the properties
because it is typechecked unlike JS which is super tedious (especially
if you just want something to always be visible).

This brings the convenience of the JS examples to TS as well.

I don't think there are any issues for this.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:

No