### PR TITLE
Import TitleSizes in Title demo

### DIFF
--- a/packages/react-core/src/components/Title/examples/Title.md
+++ b/packages/react-core/src/components/Title/examples/Title.md
@@ -11,7 +11,7 @@ import { Title, TitleSizes } from '@patternfly/react-core';
 ## Examples
 ```js title=Sizes
 import React from 'react';
-import { Title } from '@patternfly/react-core';
+import { Title, TitleSizes } from '@patternfly/react-core';
 
 <React.Fragment>
   <Title headingLevel="h1" size={TitleSizes['4xl']}>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Include missing import in Title docs.

No issue for this that I know of.

Side Q - has there been any thought to having CI compile doc code? Sometimes it doesn't compile and there are warnings for it like extra imports that could be removed. I've been a little spoiled by [rust docs that do it automatically](https://doc.rust-lang.org/rustdoc/documentation-tests.html). 

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:

No