### PR TITLE
chore(charts): align legend tooltip with flyout edge

### DIFF
--- a/packages/react-charts/src/components/ChartCursorTooltip/ChartCursorTooltip.tsx
+++ b/packages/react-charts/src/components/ChartCursorTooltip/ChartCursorTooltip.tsx
@@ -122,9 +122,9 @@ export interface ChartCursorTooltipProps extends ChartTooltipProps {
    */
   groupComponent?: React.ReactElement<any>;
   /**
-   * This prop refers to the height of the svg that VictoryLabel is rendered within. This prop is passed from parents
-   * of VictoryLabel, and should not be set manually. In versions before ^33.0.0 this prop referred to the height of the
-   * tooltip flyout. Please use flyoutHeight instead
+   * This prop refers to the height of the svg that ChartCursorTooltip is rendered within. This prop is passed from
+   * parents of ChartCursorTooltip, and should not be set manually. In versions before ^33.0.0 this prop referred to
+   * the height of the tooltip flyout. Please use flyoutHeight instead
    *
    * **This prop should not be set manually.**
    */
@@ -182,6 +182,11 @@ export interface ChartCursorTooltipProps extends ChartTooltipProps {
    */
   renderInPortal?: boolean;
   /**
+   * Flag to force flyout pointer to be shown. Victory provides pointerLength=0 when using a voronoi container with
+   * voronoiDimension="x"
+   */
+  showPointer?: boolean;
+  /**
    * The style prop applies CSS properties to the rendered `<text>` element.
    */
   style?: React.CSSProperties | React.CSSProperties[];
@@ -213,6 +218,14 @@ export interface ChartCursorTooltipProps extends ChartTooltipProps {
    */
   themeVariant?: string;
   /**
+   * This prop refers to the width of the svg that ChartCursorTooltip is rendered within. This prop is passed from
+   * parents of ChartCursorTooltip, and should not be set manually. In versions before ^33.0.0 this prop referred to the
+   * width of the tooltip flyout. Please use flyoutWidth instead
+   *
+   * **This prop should not be set manually.**
+   */
+  width?: number;
+  /**
    * The x prop defines the x coordinate to use as a basis for horizontal positioning.
    */
   x?: number;
@@ -227,6 +240,7 @@ export const ChartCursorTooltip: React.FunctionComponent<ChartCursorTooltipProps
   flyoutComponent = <ChartCursorFlyout />,
   labelComponent = <ChartLabel />,
   labelTextAnchor = 'start',
+  showPointer = true,
   style,
   themeColor,
   themeVariant,
@@ -235,7 +249,7 @@ export const ChartCursorTooltip: React.FunctionComponent<ChartCursorTooltipProps
   theme = getTheme(themeColor, themeVariant),
   centerOffset = getCursorTooltipCenterOffset({ offsetCursorDimensionX: true, theme }),
   pointerOrientation = getCursorTooltipPoniterOrientation({ horizontal: true, theme }),
-  pointerLength = theme.tooltip.pointerLength,
+  pointerLength = showPointer ? theme.tooltip.pointerLength : 0,
   pointerWidth = (theme.tooltip as any).pointerWidth,
   ...rest
 }: ChartCursorTooltipProps) => {
@@ -247,9 +261,12 @@ export const ChartCursorTooltip: React.FunctionComponent<ChartCursorTooltipProps
   const newStyle: any = Array.isArray(style) ? style.map(applyDefaultStyle) : applyDefaultStyle(style);
 
   const getFlyoutComponent = () => {
-    const _pointerLength = Helpers.evaluateProp(pointerLength);
+    let _pointerLength = Helpers.evaluateProp(pointerLength);
+    if (showPointer && _pointerLength === 0) {
+      _pointerLength = theme.tooltip.pointerLength;
+    }
     return React.cloneElement(flyoutComponent, {
-      pointerLength: _pointerLength > 0 ? _pointerLength : theme.tooltip.pointerLength,
+      pointerLength: _pointerLength,
       pointerWidth,
       ...flyoutComponent.props
     });

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipContent.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipContent.tsx
@@ -135,6 +135,18 @@ export interface ChartLegendTooltipContentProps extends ChartLegendProps {
    */
   externalEventMutations?: EventCallbackInterface<string | string[], StringOrNumberOrList>[];
   /**
+   * The flyoutX and flyoutX props define the base position of the flyout.
+   *
+   * *This prop should not be set manually.**
+   */
+  flyoutX?: number;
+  /**
+   * The flyoutX and flyoutX props define the base position of the flyout.
+   *
+   * *This prop should not be set manually.**
+   */
+  flyoutY?: number;
+  /**
    * The groupComponent prop takes an entire component which will be used to
    * create group elements for use within container elements. This prop defaults
    * to a <g> tag on web, and a react-native-svg <G> tag on mobile
@@ -312,7 +324,7 @@ export const defaultLegendProps = {
   gutter: 0,
   orientation: 'vertical' as any,
   padding: 0,
-  rowGutter: -10,
+  rowGutter: -12,
   standalone: false,
   style: {
     labels: {
@@ -349,15 +361,15 @@ export const ChartLegendTooltipContent: React.FunctionComponent<ChartLegendToolt
 
   // destructure last
   theme = getTheme(themeColor, themeVariant),
+  flyoutX = x,
+  flyoutY = y,
   ...rest
 }: ChartLegendTooltipContentProps) => {
-  const offsetY = 10 * (Array.isArray(text) ? text.length : 1);
-
   // Component offsets
-  const legendOffsetX = -50; // Todo: base this on the flyout edge
-  const legendOffsetY = -offsetY + 5 + (title ? 0 : -10);
-  const titleOffsetX = -40;
-  const titleOffsetY = -offsetY;
+  const legendOffsetX = 0;
+  const legendOffsetY = title ? 5 : -10;
+  const titleOffsetX = 10;
+  const titleOffsetY = 0;
 
   // Legend properties
   const legendProps = {
@@ -378,11 +390,6 @@ export const ChartLegendTooltipContent: React.FunctionComponent<ChartLegendToolt
     legendData: data,
     legendProps,
     text,
-    theme
-  });
-  const minLegendDimensions = getLegendTooltipSize({
-    legendData: data,
-    legendProps,
     theme
   });
 
@@ -412,8 +419,8 @@ export const ChartLegendTooltipContent: React.FunctionComponent<ChartLegendToolt
       },
       text: _title,
       textAnchor: 'start',
-      x: x + titleOffsetX + Helpers.evaluateProp(dx),
-      y: y + titleOffsetY + Helpers.evaluateProp(dy),
+      x: flyoutX + titleOffsetX + Helpers.evaluateProp(dx),
+      y: flyoutY + titleOffsetY + Helpers.evaluateProp(dy),
       ...titleComponent.props
     });
   };
@@ -425,8 +432,8 @@ export const ChartLegendTooltipContent: React.FunctionComponent<ChartLegendToolt
         data={getLegendData()}
         labelComponent={getLabelComponent()}
         theme={theme}
-        x={x + legendOffsetX + Helpers.evaluateProp(dx)}
-        y={y + legendOffsetY + Helpers.evaluateProp(dy)}
+        x={flyoutX + legendOffsetX + Helpers.evaluateProp(dx)}
+        y={flyoutY + legendOffsetY + Helpers.evaluateProp(dy)}
         {...legendProps}
         {...rest}
       />

--- a/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltip.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltip.test.tsx.snap
@@ -2,13 +2,21 @@
 
 exports[`ChartLegendTooltip 1`] = `
 <ChartCursorTooltip
+  center={
+    Object {
+      "x": 0,
+      "y": 0,
+    }
+  }
   flyoutHeight={[Function]}
   flyoutWidth={[Function]}
   labelComponent={
     <ChartLegendTooltipContent
-      isCursorTooltip={true}
+      flyoutX={10}
+      flyoutY={-4.452500000000001}
     />
   }
+  showPointer={false}
   text="This is a tooltip"
   theme={
     Object {
@@ -464,13 +472,21 @@ exports[`ChartLegendTooltip 1`] = `
 
 exports[`ChartLegendTooltip 2`] = `
 <ChartCursorTooltip
+  center={
+    Object {
+      "x": 0,
+      "y": 0,
+    }
+  }
   flyoutHeight={[Function]}
   flyoutWidth={[Function]}
   labelComponent={
     <ChartLegendTooltipContent
-      isCursorTooltip={true}
+      flyoutX={10}
+      flyoutY={-4.452500000000001}
     />
   }
+  showPointer={false}
   text="This is a tooltip"
   theme={
     Object {

--- a/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltipContent.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltipContent.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`ChartLegendTooltipContent 1`] = `
     }
     orientation="vertical"
     padding={0}
-    rowGutter={-10}
+    rowGutter={-12}
     standalone={false}
     style={
       Object {
@@ -531,7 +531,7 @@ exports[`ChartLegendTooltipContent 2`] = `
     }
     orientation="vertical"
     padding={0}
-    rowGutter={-10}
+    rowGutter={-12}
     standalone={false}
     style={
       Object {
@@ -1026,7 +1026,7 @@ exports[`renders component text 1`] = `
     gutter={0}
     labelComponent={
       <ChartLegendTooltipLabel
-        dx={137.2549019607843}
+        dx={128.5024154589372}
         legendData={
           Array [
             Object {
@@ -1050,7 +1050,7 @@ exports[`renders component text 1`] = `
     }
     orientation="vertical"
     padding={0}
-    rowGutter={-10}
+    rowGutter={-12}
     standalone={false}
     style={
       Object {

--- a/packages/react-charts/src/components/ChartTooltip/ChartTooltip.tsx
+++ b/packages/react-charts/src/components/ChartTooltip/ChartTooltip.tsx
@@ -117,8 +117,8 @@ export interface ChartTooltipProps extends VictoryTooltipProps {
    */
   groupComponent?: React.ReactElement<any>;
   /**
-   * This prop refers to the height of the svg that VictoryLabel is rendered within. This prop is passed from parents
-   * of VictoryLabel, and should not be set manually. In versions before ^33.0.0 this prop referred to the height of the
+   * This prop refers to the height of the svg that ChartTooltip is rendered within. This prop is passed from parents
+   * of ChartTooltip, and should not be set manually. In versions before ^33.0.0 this prop referred to the height of the
    * tooltip flyout. Please use flyoutHeight instead
    *
    * **This prop should not be set manually.**
@@ -207,6 +207,14 @@ export interface ChartTooltipProps extends VictoryTooltipProps {
    * @example themeVariant={ChartThemeVariant.light}
    */
   themeVariant?: string;
+  /**
+   * This prop refers to the width of the svg that ChartTooltip is rendered within. This prop is passed from parents
+   * of ChartTooltip, and should not be set manually. In versions before ^33.0.0 this prop referred to the width of the
+   * tooltip flyout. Please use flyoutWidth instead
+   *
+   * **This prop should not be set manually.**
+   */
+  width?: number;
   /**
    * The x prop defines the x coordinate to use as a basis for horizontal positioning.
    */

--- a/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
+++ b/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
@@ -324,7 +324,7 @@ class EmbeddedHtml extends React.Component {
                 labels={({ datum }) => `${datum.y}`}
                 labelComponent={
                   <ChartCursorTooltip
-                    centerOffset={{x: ({ flyoutWidth, width, x, offset = flyoutWidth / 2 + 10 }) => width > offset + x ? offset : -offset}}
+                    centerOffset={{x: ({ center, flyoutWidth, width, offset = flyoutWidth / 2 + 10 }) => width > center.x + flyoutWidth + 10 ? offset : -offset}}
                     flyout={<ChartCursorFlyout />}
                     flyoutHeight={110}
                     flyoutWidth={125}

--- a/packages/react-charts/src/components/ChartUtils/chart-legend.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-legend.ts
@@ -456,7 +456,7 @@ export const getMaxLegendTextSize = ({ legendData, theme }: ChartLegendTextMaxSi
 // Returns an approximation of over-sized text width due to growing character count
 //
 // See https://github.com/FormidableLabs/victory/issues/864
-const getTextSizeWorkAround = ({ legendData, legendOrientation, theme }: ChartLegendTextSizeInterface) => {
+export const getTextSizeWorkAround = ({ legendData, legendOrientation, theme }: ChartLegendTextSizeInterface) => {
   const style: any = theme && theme.legend && theme.legend.style ? theme.legend.style.labels : undefined;
   if (!(legendData && legendData.length)) {
     return 0;


### PR DESCRIPTION
While testing Cost Management with the new legend tooltip feature (yet to be promoted), I noticed that the alignment is off with very long labels.

This change better aligns legend components with the tooltip flyout edge. 

**Before:**
<img width="767" alt="Screen Shot 2020-06-15 at 12 21 56 PM" src="https://user-images.githubusercontent.com/17481322/84735262-14010d80-af71-11ea-8008-557eed63328c.png">

**After:**
![chrome-capture](https://user-images.githubusercontent.com/17481322/84735349-4e6aaa80-af71-11ea-8f6c-da8531a131fc.gif)

Related to #3219
