### PR TITLE
chore(charts): tooltip support for interactive legends

### DIFF
--- a/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
+++ b/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
@@ -14,11 +14,13 @@ import {
   ChartAxis, 
   ChartBullet, 
   ChartGroup, 
-  ChartLegend, 
+  ChartLegend,
+  ChartLegendTooltip,
   ChartLine, 
   ChartPie, 
   ChartScatter, 
   ChartThemeColor, 
+  createContainer,
   getInteractiveLegendEvents, 
   getInteractiveLegendItemStyles 
 } from '@patternfly/react-charts';
@@ -245,9 +247,11 @@ import {
   ChartAxis, 
   ChartGroup, 
   ChartLegend,
+  ChartLegendTooltip,
   ChartScatter, 
   ChartThemeColor,
-  ChartVoronoiContainer, 
+  ChartVoronoiContainer,
+  createContainer, 
   getInteractiveLegendEvents, 
   getInteractiveLegendItemStyles 
 } from '@patternfly/react-charts';
@@ -338,6 +342,9 @@ class InteractiveLegendChart extends React.Component {
       const { hiddenSeries } = this.state; // Skip if already hidden                
       return hiddenSeries.has(index);
     };
+
+    // Note: Container order is important
+    this.CursorVoronoiContainer = createContainer("cursor", "voronoi");
   };
 
   componentDidMount() {
@@ -357,7 +364,7 @@ class InteractiveLegendChart extends React.Component {
   render() {
     const { hiddenSeries, width } = this.state;
     const allHidden = hiddenSeries.length === this.series.length;
-    const tootlip = ({ datum }) => datum.childName.includes('area-') && datum.y !== null ? `${datum.name}: ${datum.y}` : null;
+    const tootlip = ({ datum }) => datum.childName.includes('area-') && datum.y !== null ? `${datum.y}` : null;
 
     return (
       <div ref={this.containerRef}>
@@ -367,9 +374,13 @@ class InteractiveLegendChart extends React.Component {
             ariaDesc="Average number of pets"
             ariaTitle="Area chart example"
             containerComponent={
-              <ChartVoronoiContainer
-                labels={!allHidden ? tootlip : undefined} 
-                constrainToVisibleArea 
+              <this.CursorVoronoiContainer
+                cursorDimension="x"
+                labels={!allHidden ? tootlip : undefined}
+                labelComponent={<ChartLegendTooltip legendData={this.getLegendData()} title={(datum) => datum.x}/>}
+                mouseFollowTooltips
+                voronoiDimension="x"
+                voronoiPadding={50}
               />
             }
             events={this.getEvents()}

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import {
+  Helpers,
   NumberOrCallback,
   OrientationTypes,
   StringOrNumberOrCallback,
@@ -13,7 +14,12 @@ import { ChartCursorTooltip, ChartCursorTooltipProps } from '../ChartCursorToolt
 import { ChartLegendTooltipContent, defaultLegendProps } from './ChartLegendTooltipContent';
 import { ChartLegendTooltipStyles, ChartThemeDefinition } from '../ChartTheme';
 import { ChartTooltip } from '../ChartTooltip';
-import { getLegendTooltipSize, getTheme } from '../ChartUtils';
+import {
+  getLegendTooltipSize,
+  getLegendTooltipVisibleData,
+  getLegendTooltipVisibleText,
+  getTheme
+} from '../ChartUtils';
 
 /**
  * The ChartLegendTooltip is based on ChartCursorTooltip, which is intended to be used with a voronoi cursor
@@ -277,25 +283,12 @@ export const ChartLegendTooltip: React.FunctionComponent<ChartLegendTooltipProps
 }: ChartLegendTooltipProps) => {
   const pointerLength = theme && theme.tooltip ? theme.tooltip.pointerLength : 10;
 
-  // Returns the tooltip content component
-  const getTooltipContentComponent = () =>
-    React.cloneElement(labelComponent, {
-      center,
-      data: legendData,
-      flyoutHeight: flyoutHeight || getFlyoutHeight(),
-      flyoutWidth: flyoutWidth || getFlyoutWidth(),
-      height,
-      title,
-      width,
-      ...labelComponent.props
-    });
-
   // Returns legend props
   const getLegendProps = () => {
     const getKeyValue = (key: string) =>
       labelComponent.props[key] ? labelComponent.props[key] : (defaultLegendProps as any)[key];
     return {
-      legendData,
+      legendData: getLegendTooltipVisibleData({ legendData, text, theme }),
       legendProps: {
         borderPadding: getKeyValue('borderPadding'),
         gutter: getKeyValue('gutter'),
@@ -304,7 +297,7 @@ export const ChartLegendTooltip: React.FunctionComponent<ChartLegendTooltipProps
         rowGutter: getKeyValue('rowGutter'),
         style: getKeyValue('style')
       },
-      text,
+      text: getLegendTooltipVisibleText({ legendData, text }),
       theme
     };
   };
@@ -317,6 +310,19 @@ export const ChartLegendTooltip: React.FunctionComponent<ChartLegendTooltipProps
 
   // Returns flyout width based on legend size
   const getFlyoutWidth = () => getLegendTooltipSize(getLegendProps()).width + ChartLegendTooltipStyles.flyout.padding;
+
+  // Returns the tooltip content component
+  const getTooltipContentComponent = () =>
+    React.cloneElement(labelComponent, {
+      center,
+      data: legendData,
+      flyoutHeight: flyoutHeight || getFlyoutHeight(),
+      flyoutWidth: flyoutWidth || getFlyoutWidth(),
+      height,
+      title,
+      width,
+      ...labelComponent.props
+    });
 
   // Returns the tooltip component
   const getTooltipComponent = () => {

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
@@ -259,6 +259,8 @@ export interface ChartLegendTooltipProps extends ChartCursorTooltipProps {
 export const ChartLegendTooltip: React.FunctionComponent<ChartLegendTooltipProps> = ({
   datum,
   center = { x: 0, y: 0 },
+  flyoutHeight,
+  flyoutWidth,
   height,
   isCursorTooltip = true,
   labelComponent = <ChartLegendTooltipContent />,
@@ -268,8 +270,6 @@ export const ChartLegendTooltip: React.FunctionComponent<ChartLegendTooltipProps
   themeVariant,
   title,
   width,
-  x,
-  y,
 
   // destructure last
   theme = getTheme(themeColor, themeVariant),
@@ -280,10 +280,13 @@ export const ChartLegendTooltip: React.FunctionComponent<ChartLegendTooltipProps
   // Returns the tooltip content component
   const getTooltipContentComponent = () =>
     React.cloneElement(labelComponent, {
+      center,
       data: legendData,
-      flyoutX: getFlyoutX(),
-      flyoutY: getFlyoutY(),
+      flyoutHeight: flyoutHeight || getFlyoutHeight(),
+      flyoutWidth: flyoutWidth || getFlyoutWidth(),
+      height,
       title,
+      width,
       ...labelComponent.props
     });
 
@@ -299,7 +302,6 @@ export const ChartLegendTooltip: React.FunctionComponent<ChartLegendTooltipProps
         orientation: getKeyValue('orientation'),
         padding: getKeyValue('padding'),
         rowGutter: getKeyValue('rowGutter'),
-        standalone: getKeyValue('standalone'),
         style: getKeyValue('style')
       },
       text,
@@ -309,50 +311,30 @@ export const ChartLegendTooltip: React.FunctionComponent<ChartLegendTooltipProps
 
   // Returns flyout height based on legend size
   const getFlyoutHeight = () => {
-    const flyoutHeight = getLegendTooltipSize(getLegendProps()).height + ChartLegendTooltipStyles.flyout.padding;
-    return title ? flyoutHeight : flyoutHeight - 10;
+    const _flyoutHeight = getLegendTooltipSize(getLegendProps()).height + ChartLegendTooltipStyles.flyout.padding;
+    return title ? _flyoutHeight : _flyoutHeight - 10;
   };
 
   // Returns flyout width based on legend size
   const getFlyoutWidth = () => getLegendTooltipSize(getLegendProps()).width + ChartLegendTooltipStyles.flyout.padding;
 
-  // Returns x position of flyout
-  const getFlyoutX = () => {
-    const flyoutWidth = getFlyoutWidth();
-    if (width > center.x + flyoutWidth + pointerLength) {
-      return center.x + ChartLegendTooltipStyles.flyout.padding / 2;
-    } else {
-      if (center.x < flyoutWidth + pointerLength) {
-        return ChartLegendTooltipStyles.flyout.padding / 2 - pointerLength;
-      } else {
-        return center.x - flyoutWidth;
-      }
-    }
-  };
-
-  // Returns y position of flyout
-  const getFlyoutY = () => {
-    const flyoutHeight = getFlyoutHeight();
-    return center.y - flyoutHeight / 2 + ChartLegendTooltipStyles.flyout.padding / 2;
-  };
-
   // Returns the tooltip component
   const getTooltipComponent = () => {
-    const flyoutWidth = getFlyoutWidth();
+    const _flyoutWidth = getFlyoutWidth();
     const tooltipComponent = isCursorTooltip ? <ChartCursorTooltip /> : <ChartTooltip />;
     return React.cloneElement(tooltipComponent, {
       center,
       datum,
-      flyoutHeight: getFlyoutHeight,
-      flyoutWidth: getFlyoutWidth,
+      flyoutHeight: flyoutHeight || getFlyoutHeight(),
+      flyoutWidth: flyoutWidth || getFlyoutWidth(),
       height,
       labelComponent: getTooltipContentComponent(),
-      showPointer: width > flyoutWidth + x || center.x > flyoutWidth + pointerLength,
+      ...(flyoutWidth === undefined && {
+        showPointer: width > _flyoutWidth + center.x + pointerLength || center.x > _flyoutWidth + pointerLength
+      }),
       text,
       theme,
       width,
-      x,
-      y,
       ...rest
     });
   };

--- a/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltip.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltip.test.tsx.snap
@@ -8,12 +8,18 @@ exports[`ChartLegendTooltip 1`] = `
       "y": 0,
     }
   }
-  flyoutHeight={[Function]}
-  flyoutWidth={[Function]}
+  flyoutHeight={48.905}
+  flyoutWidth={174.575845410628}
   labelComponent={
     <ChartLegendTooltipContent
-      flyoutX={10}
-      flyoutY={-4.452500000000001}
+      center={
+        Object {
+          "x": 0,
+          "y": 0,
+        }
+      }
+      flyoutHeight={48.905}
+      flyoutWidth={174.575845410628}
     />
   }
   showPointer={false}
@@ -478,12 +484,18 @@ exports[`ChartLegendTooltip 2`] = `
       "y": 0,
     }
   }
-  flyoutHeight={[Function]}
-  flyoutWidth={[Function]}
+  flyoutHeight={48.905}
+  flyoutWidth={174.575845410628}
   labelComponent={
     <ChartLegendTooltipContent
-      flyoutX={10}
-      flyoutY={-4.452500000000001}
+      center={
+        Object {
+          "x": 0,
+          "y": 0,
+        }
+      }
+      flyoutHeight={48.905}
+      flyoutWidth={174.575845410628}
     />
   }
   showPointer={false}

--- a/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltip.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltip.test.tsx.snap
@@ -8,8 +8,8 @@ exports[`ChartLegendTooltip 1`] = `
       "y": 0,
     }
   }
-  flyoutHeight={48.905}
-  flyoutWidth={174.575845410628}
+  flyoutHeight={30}
+  flyoutWidth={40}
   labelComponent={
     <ChartLegendTooltipContent
       center={
@@ -18,8 +18,8 @@ exports[`ChartLegendTooltip 1`] = `
           "y": 0,
         }
       }
-      flyoutHeight={48.905}
-      flyoutWidth={174.575845410628}
+      flyoutHeight={30}
+      flyoutWidth={40}
     />
   }
   showPointer={false}
@@ -484,8 +484,8 @@ exports[`ChartLegendTooltip 2`] = `
       "y": 0,
     }
   }
-  flyoutHeight={48.905}
-  flyoutWidth={174.575845410628}
+  flyoutHeight={30}
+  flyoutWidth={40}
   labelComponent={
     <ChartLegendTooltipContent
       center={
@@ -494,8 +494,8 @@ exports[`ChartLegendTooltip 2`] = `
           "y": 0,
         }
       }
-      flyoutHeight={48.905}
-      flyoutWidth={174.575845410628}
+      flyoutHeight={30}
+      flyoutWidth={40}
     />
   }
   showPointer={false}

--- a/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltipContent.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltipContent.test.tsx.snap
@@ -1026,7 +1026,7 @@ exports[`renders component text 1`] = `
     gutter={0}
     labelComponent={
       <ChartLegendTooltipLabel
-        dx={128.5024154589372}
+        dx={121.73913043478262}
         legendData={
           Array [
             Object {

--- a/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltipContent.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltipContent.test.tsx.snap
@@ -15,18 +15,12 @@ exports[`ChartLegendTooltipContent 1`] = `
   />
   <ChartLegend
     borderPadding={0}
-    data={
-      Array [
-        Object {
-          "name": undefined,
-          "symbol": undefined,
-        },
-      ]
-    }
+    data={Array []}
     gutter={0}
     labelComponent={
       <ChartLegendTooltipLabel
-        dx={0}
+        dx={-19.6}
+        legendData={Array []}
       />
     }
     orientation="vertical"
@@ -515,18 +509,12 @@ exports[`ChartLegendTooltipContent 2`] = `
   />
   <ChartLegend
     borderPadding={0}
-    data={
-      Array [
-        Object {
-          "name": undefined,
-          "symbol": undefined,
-        },
-      ]
-    }
+    data={Array []}
     gutter={0}
     labelComponent={
       <ChartLegendTooltipLabel
-        dx={0}
+        dx={-19.6}
+        legendData={Array []}
       />
     }
     orientation="vertical"
@@ -1019,7 +1007,9 @@ exports[`renders component text 1`] = `
       Array [
         Object {
           "name": "1, 2, 3, 4",
-          "symbol": undefined,
+          "symbol": Object {
+            "fill": "#06c",
+          },
         },
       ]
     }
@@ -1031,18 +1021,9 @@ exports[`renders component text 1`] = `
           Array [
             Object {
               "name": "Cats",
-            },
-            Object {
-              "name": "Dogs",
               "symbol": Object {
-                "type": "dash",
+                "fill": "#06c",
               },
-            },
-            Object {
-              "name": "Birds",
-            },
-            Object {
-              "name": "Mice",
             },
           ]
         }

--- a/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
+++ b/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
@@ -287,11 +287,13 @@ class EmbeddedHtml extends React.Component {
         <foreignObject height="100%" width="100%" x={x - 40} y={y - 45} >
           <table>
             <thead>
-              <th colSpan={2} style={{...this.baseStyles, fontWeight: 700}}>{title(datum)}</th>
+              <tr>
+                <th colSpan={2} style={{...this.baseStyles, fontWeight: 700}}>{title(datum)}</th>
+              </tr>
             </thead>
             <tbody>
               {text.map((val, index) => (
-                <tr style={this.baseStyles}>
+                <tr key={`tbody-tr-${index}`} style={this.baseStyles}>
                   <th width="20px">
                     <svg height="9.74" width="9.74" role="img">
                       {<ChartPoint x={0} y={0}

--- a/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
@@ -74,21 +74,20 @@ export const getLegendTooltipSize = ({
   const textEvaluated = Helpers.evaluateProp(text);
   const _text = Array.isArray(textEvaluated) ? textEvaluated : [textEvaluated];
 
-  // Find max data char length
+  // Find max char lengths
   let maxDataLength = 0;
-  if (legendData) {
-    legendData.map((data: any) => {
-      if (data.name && data.name.length > maxDataLength) {
-        maxDataLength = data.name.length;
-      }
-    });
-  }
-
-  // Find max text char length
   let maxTextLength = 0;
-  _text.map((name: string) => {
-    if (name && name.length > maxTextLength) {
-      maxTextLength = name.length;
+  _text.map((name: string, index: number) => {
+    if (name) {
+      if (name.length > maxTextLength) {
+        maxTextLength = name.length;
+      }
+      const hasData = legendData && legendData[index] && legendData[index].name;
+      if (hasData) {
+        if (legendData[index].name.length > maxDataLength) {
+          maxDataLength = legendData[index].name.length;
+        }
+      }
     }
   });
 
@@ -118,10 +117,10 @@ export const getLegendTooltipSize = ({
   // {name: "Birds        4"}
   // {name: "Mice         3"}
   const data = _text.map((label: string, index: number) => {
-    const hasLegendData = legendData && legendData[index] && legendData[index].name;
-    const spacer = hasLegendData ? getSpacer(legendData[index].name, label) : '';
+    const hasData = legendData && legendData[index] && legendData[index].name;
+    const spacer = hasData ? getSpacer(legendData[index].name, label) : '';
     return {
-      name: `${hasLegendData ? legendData[index].name : ''}${spacer}${label}`
+      name: `${hasData ? legendData[index].name : ''}${spacer}${label}`
     };
   });
 


### PR DESCRIPTION
This takes the new legend tooltip (yet to be deployed) a step further and adds support for interactive legends. This eliminates the tedious, manual syncing of themed color scales between the legend and tooltip when data is hidden / shown.

In addition, I've made the following updates after testing with Cost Management.

- Ensures that the flyout height & width can be overridden. 
- Ensures tooltip remains within given height and width boundary.
- Flyout width should be adjusted (smaller) when values are not available

See #3219


**Example**
![chrome-capture (1)](https://user-images.githubusercontent.com/17481322/84858771-cd2b1a80-b039-11ea-9bd4-57b5409760c8.gif)


**Cost Management**
![chrome-capture](https://user-images.githubusercontent.com/17481322/84867902-db813280-b049-11ea-8b89-46a301a5c709.gif)
