### PR TITLE
fix(charts): tooltip legend to use Victory's activePoints

### DIFF
--- a/packages/react-charts/src/components/ChartArea/examples/ChartArea.md
+++ b/packages/react-charts/src/components/ChartArea/examples/ChartArea.md
@@ -97,7 +97,7 @@ class BottomAlignedLegend extends React.Component {
   render() {
     // Note: Container order is important
     const CursorVoronoiContainer = createContainer("cursor", "voronoi");
-    const legendData = [{ name: 'Cats' }, { name: 'Dogs', symbol: { type: 'dash' } }, { name: 'Birds' }];
+    const legendData = [{ childName: 'cats', name: 'Cats' }, { childName: 'dogs', name: 'Dogs' }, { childName: 'birds', name: 'Birds' }];
 
     return (
       <div>
@@ -134,32 +134,35 @@ class BottomAlignedLegend extends React.Component {
             <ChartGroup>
               <ChartArea
                 data={[
-                  { name: 'Cats', x: '2015', y: 3 },
-                  { name: 'Cats', x: '2016', y: 4 },
-                  { name: 'Cats', x: '2017', y: 8 },
-                  { name: 'Cats', x: '2018', y: 6 }
+                  { x: '2015', y: 3 },
+                  { x: '2016', y: 4 },
+                  { x: '2017', y: 8 },
+                  { x: '2018', y: 6 }
                 ]}
                 interpolation="monotoneX"
+                name="cats"
               />
               <ChartArea
                 data={[
-                  { name: 'Dogs', x: '2015', y: 2 },
-                  { name: 'Dogs', x: '2016', y: 3 },
-                  { name: 'Dogs', x: '2017', y: 4 },
-                  { name: 'Dogs', x: '2018', y: 5 },
-                  { name: 'Dogs', x: '2019', y: 6 }
+                  { x: '2015', y: 2 },
+                  { x: '2016', y: 3 },
+                  { x: '2017', y: 4 },
+                  { x: '2018', y: 5 },
+                  { x: '2019', y: 6 }
                 ]}
                 interpolation="monotoneX"
+                name="dogs"
               />
               <ChartArea
                 data={[
-                  { name: 'Birds', x: '2015', y: 1 },
-                  { name: 'Birds', x: '2016', y: 2 },
-                  { name: 'Birds', x: '2017', y: 3 },
-                  { name: 'Birds', x: '2018', y: 2 },
-                  { name: 'Birds', x: '2019', y: 4 }
+                  { x: '2015', y: 1 },
+                  { x: '2016', y: 2 },
+                  { x: '2017', y: 3 },
+                  { x: '2018', y: 2 },
+                  { x: '2019', y: 4 }
                 ]}
                 interpolation="monotoneX"
+                name="birds"
               />
             </ChartGroup>
           </Chart>

--- a/packages/react-charts/src/components/ChartCursorTooltip/ChartCursorFlyout.tsx
+++ b/packages/react-charts/src/components/ChartCursorTooltip/ChartCursorFlyout.tsx
@@ -6,7 +6,7 @@ import { isPlainObject, assign } from 'lodash';
 const getVerticalPath = (props: any) => {
   const { pointerWidth, cornerRadius, orientation, width, height, center } = props;
   const sign = orientation === 'bottom' ? 1 : -1;
-  const x = props.x + (props.dx || 0);
+  // const x = props.x + (props.dx || 0);
   // const y = props.y + (props.dy || 0);
   const centerX = isPlainObject(center) && center.x;
   const centerY = isPlainObject(center) && center.y;
@@ -16,6 +16,7 @@ const getVerticalPath = (props: any) => {
   const leftEdge = centerX - width / 2;
 
   // This has been overridden so the pointer does not stick to data points -- want pointerLength to take precedence
+  const x = center.x + (props.dx || 0);
   const y =
     orientation === 'bottom'
       ? pointerEdge + props.pointerLength + (props.dy || 0)
@@ -42,7 +43,7 @@ const getHorizontalPath = (props: any) => {
   const { pointerWidth, cornerRadius, orientation, width, height, center } = props;
   const sign = orientation === 'left' ? 1 : -1;
   // const x = props.x + (props.dx || 0);
-  const y = props.y + (props.dy || 0);
+  // const y = props.y + (props.dy || 0);
   const centerX = isPlainObject(center) && center.x;
   const centerY = isPlainObject(center) && center.y;
   const pointerEdge = centerX - sign * (width / 2);
@@ -55,6 +56,7 @@ const getHorizontalPath = (props: any) => {
     orientation === 'left'
       ? pointerEdge - props.pointerLength + (props.dx || 0)
       : pointerEdge + props.pointerLength + (props.dx || 0);
+  const y = center.y + (props.dy || 0);
 
   const pointerLength = sign * (x - pointerEdge) > 0 ? 0 : props.pointerLength;
   const direction = orientation === 'left' ? '0 0 0' : '0 0 1';

--- a/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
+++ b/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
@@ -267,28 +267,28 @@ class InteractiveLegendChart extends React.Component {
     };
     this.series = [{
       datapoints: [
-        { name: 'Cats', x: '2015', y: 3 },
-        { name: 'Cats', x: '2016', y: 4 },
-        { name: 'Cats', x: '2017', y: 8 },
-        { name: 'Cats', x: '2018', y: 6 }
+        { x: '2015', y: 3 },
+        { x: '2016', y: 4 },
+        { x: '2017', y: 8 },
+        { x: '2018', y: 6 }
       ],
       legendItem: { name: 'Cats' }
     }, {
       datapoints: [
-        { name: 'Dogs', x: '2015', y: 2 },
-        { name: 'Dogs', x: '2016', y: 3 },
-        { name: 'Dogs', x: '2017', y: 4 },
-        { name: 'Dogs', x: '2018', y: 5 },
-        { name: 'Dogs', x: '2019', y: 6 }
+        { x: '2015', y: 2 },
+        { x: '2016', y: 3 },
+        { x: '2017', y: 4 },
+        { x: '2018', y: 5 },
+        { x: '2019', y: 6 }
       ],
       legendItem: { name: 'Dogs' }
     }, {
       datapoints: [
-        { name: 'Birds', x: '2015', y: 1 },
-        { name: 'Birds', x: '2016', y: 2 },
-        { name: 'Birds', x: '2017', y: 3 },
-        { name: 'Birds', x: '2018', y: 2 },
-        { name: 'Birds', x: '2019', y: 4 }
+        { x: '2015', y: 1 },
+        { x: '2016', y: 2 },
+        { x: '2017', y: 3 },
+        { x: '2018', y: 2 },
+        { x: '2019', y: 4 }
       ],
       legendItem: { name: 'Birds' }
     }];
@@ -316,6 +316,7 @@ class InteractiveLegendChart extends React.Component {
       const { hiddenSeries } = this.state;
       return this.series.map((s, index) => {
         return {
+          childName: `area-${index}`, // Sync tooltip legend with the series associated with given chart name
           ...s.legendItem, // name property
           ...getInteractiveLegendItemStyles(hiddenSeries.has(index)) // hidden styles
         };
@@ -364,7 +365,7 @@ class InteractiveLegendChart extends React.Component {
   render() {
     const { hiddenSeries, width } = this.state;
     const allHidden = hiddenSeries.length === this.series.length;
-    const tootlip = ({ datum }) => datum.childName.includes('area-') && datum.y !== null ? `${datum.y}` : null;
+    const tooltip = ({ datum }) => datum.childName.includes('area-') && datum.y !== null ? `${datum.y}` : null;
 
     return (
       <div ref={this.containerRef}>
@@ -376,7 +377,7 @@ class InteractiveLegendChart extends React.Component {
             containerComponent={
               <this.CursorVoronoiContainer
                 cursorDimension="x"
-                labels={!allHidden ? tootlip : undefined}
+                labels={!allHidden ? tooltip : undefined}
                 labelComponent={<ChartLegendTooltip legendData={this.getLegendData()} title={(datum) => datum.x}/>}
                 mouseFollowTooltips
                 voronoiDimension="x"

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
@@ -38,6 +38,12 @@ export interface ChartLegendTooltipProps extends ChartCursorTooltipProps {
    */
   activateData?: boolean;
   /**
+   * The activePoints prop specifies the active data
+   *
+   * **This prop should not be set manually.**
+   */
+  activePoints?: any[];
+  /**
    * The angle prop specifies the angle to rotate the tooltip around its origin point.
    */
   angle?: string | number;
@@ -165,14 +171,20 @@ export interface ChartLegendTooltipProps extends ChartCursorTooltipProps {
    */
   labelTextAnchor?: TextAnchorType | (() => TextAnchorType);
   /**
-   * Specify data via the data prop. ChartLegend expects data as an
-   * array of objects with name (required), symbol, and labels properties.
+   * Specify data via the data prop. ChartLegend expects data as an array of objects with name (required), symbol, and
+   * labels properties. The childName is used to sync the data series associated with the given chart child name.
+   *
    * The data prop must be given as an array.
    *
    * @example legendData={[{ name: `GBps capacity - 45%` }, { name: 'Unused' }]}
+   * @example legendData={[{ childName: `cats`, name: `Total cats` }, { childName: `dogs`, name: 'Total dogs' }]}
    */
   legendData?: {
+    childName?: string;
     name?: string;
+    labels?: {
+      fill?: string;
+    };
     symbol?: {
       fill?: string;
       type?: string;
@@ -263,6 +275,7 @@ export interface ChartLegendTooltipProps extends ChartCursorTooltipProps {
 }
 
 export const ChartLegendTooltip: React.FunctionComponent<ChartLegendTooltipProps> = ({
+  activePoints,
   datum,
   center = { x: 0, y: 0 },
   flyoutHeight,
@@ -288,7 +301,7 @@ export const ChartLegendTooltip: React.FunctionComponent<ChartLegendTooltipProps
     const getKeyValue = (key: string) =>
       labelComponent.props[key] ? labelComponent.props[key] : (defaultLegendProps as any)[key];
     return {
-      legendData: getLegendTooltipVisibleData({ legendData, text, theme }),
+      legendData: getLegendTooltipVisibleData({ activePoints, legendData, text, theme }),
       legendProps: {
         borderPadding: getKeyValue('borderPadding'),
         gutter: getKeyValue('gutter'),
@@ -297,7 +310,7 @@ export const ChartLegendTooltip: React.FunctionComponent<ChartLegendTooltipProps
         rowGutter: getKeyValue('rowGutter'),
         style: getKeyValue('style')
       },
-      text: getLegendTooltipVisibleText({ legendData, text }),
+      text: getLegendTooltipVisibleText({ activePoints, legendData, text }),
       theme
     };
   };
@@ -329,6 +342,7 @@ export const ChartLegendTooltip: React.FunctionComponent<ChartLegendTooltipProps
     const _flyoutWidth = getFlyoutWidth();
     const tooltipComponent = isCursorTooltip ? <ChartCursorTooltip /> : <ChartTooltip />;
     return React.cloneElement(tooltipComponent, {
+      activePoints,
       center,
       datum,
       flyoutHeight: flyoutHeight || getFlyoutHeight(),

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import {
-  Helpers,
   NumberOrCallback,
   OrientationTypes,
   StringOrNumberOrCallback,
@@ -11,10 +10,11 @@ import {
 } from 'victory-core';
 import { VictoryTooltip } from 'victory-tooltip';
 import { ChartCursorTooltip, ChartCursorTooltipProps } from '../ChartCursorTooltip';
-import { ChartLegendTooltipContent, defaultLegendProps } from './ChartLegendTooltipContent';
+import { ChartLegendTooltipContent } from './ChartLegendTooltipContent';
 import { ChartLegendTooltipStyles, ChartThemeDefinition } from '../ChartTheme';
 import { ChartTooltip } from '../ChartTooltip';
 import {
+  getLegendTooltipDataProps,
   getLegendTooltipSize,
   getLegendTooltipVisibleData,
   getLegendTooltipVisibleText,
@@ -295,43 +295,30 @@ export const ChartLegendTooltip: React.FunctionComponent<ChartLegendTooltipProps
   ...rest
 }: ChartLegendTooltipProps) => {
   const pointerLength = theme && theme.tooltip ? theme.tooltip.pointerLength : 10;
-
-  // Returns legend props
-  const getLegendProps = () => {
-    const getKeyValue = (key: string) =>
-      labelComponent.props[key] ? labelComponent.props[key] : (defaultLegendProps as any)[key];
-    return {
-      legendData: getLegendTooltipVisibleData({ activePoints, legendData, text, theme }),
-      legendProps: {
-        borderPadding: getKeyValue('borderPadding'),
-        gutter: getKeyValue('gutter'),
-        orientation: getKeyValue('orientation'),
-        padding: getKeyValue('padding'),
-        rowGutter: getKeyValue('rowGutter'),
-        style: getKeyValue('style')
-      },
-      text: getLegendTooltipVisibleText({ activePoints, legendData, text }),
-      theme
-    };
+  const legendTooltipProps = {
+    legendData: getLegendTooltipVisibleData({ activePoints, legendData, text, theme }),
+    legendProps: getLegendTooltipDataProps(labelComponent.props.legendComponent),
+    text: getLegendTooltipVisibleText({ activePoints, legendData, text }),
+    theme
   };
 
   // Returns flyout height based on legend size
   const getFlyoutHeight = () => {
-    const _flyoutHeight = getLegendTooltipSize(getLegendProps()).height + ChartLegendTooltipStyles.flyout.padding;
+    const _flyoutHeight = getLegendTooltipSize(legendTooltipProps).height + ChartLegendTooltipStyles.flyout.padding;
     return title ? _flyoutHeight : _flyoutHeight - 10;
   };
 
   // Returns flyout width based on legend size
-  const getFlyoutWidth = () => getLegendTooltipSize(getLegendProps()).width + ChartLegendTooltipStyles.flyout.padding;
+  const getFlyoutWidth = () => getLegendTooltipSize(legendTooltipProps).width + ChartLegendTooltipStyles.flyout.padding;
 
   // Returns the tooltip content component
   const getTooltipContentComponent = () =>
     React.cloneElement(labelComponent, {
       center,
-      data: legendData,
       flyoutHeight: flyoutHeight || getFlyoutHeight(),
       flyoutWidth: flyoutWidth || getFlyoutWidth(),
       height,
+      legendData,
       title,
       width,
       ...labelComponent.props

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipContent.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipContent.tsx
@@ -35,6 +35,12 @@ import {
 // @ts-ignore
 export interface ChartLegendTooltipContentProps extends ChartLegendProps {
   /**
+   * The activePoints prop specifies the active data
+   *
+   * **This prop should not be set manually.**
+   */
+  activePoints?: any[];
+  /**
    * The borderComponent prop takes a component instance which will be responsible
    * for rendering a border around the legend. The new element created from the passed
    * borderComponent will be provided with the following properties calculated by
@@ -99,7 +105,17 @@ export interface ChartLegendTooltipContentProps extends ChartLegendProps {
    * array of objects with name (required), symbol, and labels properties.
    * The data prop must be given as an array.
    */
+  /**
+   * Specify data via the data prop. ChartLegend expects data as an array of objects with name (required), symbol, and
+   * labels properties. The childName is used to sync the data series associated with the given chart child name.
+   *
+   * The data prop must be given as an array.
+   *
+   * @example legendData={[{ name: `GBps capacity - 45%` }, { name: 'Unused' }]}
+   * @example legendData={[{ childName: `cats`, name: `Total cats` }, { childName: `dogs`, name: 'Total dogs' }]}
+   */
   data?: {
+    childName?: string;
     name?: string;
     labels?: {
       fill?: string;
@@ -353,6 +369,7 @@ export const defaultLegendProps = {
 };
 
 export const ChartLegendTooltipContent: React.FunctionComponent<ChartLegendTooltipContentProps> = ({
+  activePoints,
   borderPadding = defaultLegendProps.borderPadding,
   center,
   colorScale,
@@ -398,12 +415,10 @@ export const ChartLegendTooltipContent: React.FunctionComponent<ChartLegendToolt
     const _flyoutWidth = Helpers.evaluateProp(flyoutWidth);
     if (width > center.x + _flyoutWidth + pointerLength) {
       return center.x + ChartLegendTooltipStyles.flyout.padding / 2;
+    } else if (center.x < _flyoutWidth + pointerLength) {
+      return ChartLegendTooltipStyles.flyout.padding / 2 - pointerLength;
     } else {
-      if (center.x < _flyoutWidth + pointerLength) {
-        return ChartLegendTooltipStyles.flyout.padding / 2 - pointerLength;
-      } else {
-        return center.x - _flyoutWidth;
-      }
+      return center.x - _flyoutWidth;
     }
   };
 
@@ -432,9 +447,9 @@ export const ChartLegendTooltipContent: React.FunctionComponent<ChartLegendToolt
     style: Array.isArray(style) ? defaultLegendProps.style : style
   };
   const maxLegendDimensions = getLegendTooltipSize({
-    legendData: getLegendTooltipVisibleData({ colorScale, legendData: data, text, theme }),
+    legendData: getLegendTooltipVisibleData({ activePoints, colorScale, legendData: data, text, theme }),
     legendProps,
-    text: getLegendTooltipVisibleText({ legendData: data, text }),
+    text: getLegendTooltipVisibleText({ activePoints, legendData: data, text }),
     theme
   });
   const minLegendDimensions = getLegendTooltipSize({
@@ -447,7 +462,7 @@ export const ChartLegendTooltipContent: React.FunctionComponent<ChartLegendToolt
   const getLabelComponent = () =>
     React.cloneElement(labelComponent, {
       dx: maxLegendDimensions.width - minLegendDimensions.width,
-      legendData: getLegendTooltipVisibleData({ colorScale, legendData: data, text, theme }),
+      legendData: getLegendTooltipVisibleData({ activePoints, colorScale, legendData: data, text, theme }),
       ...labelComponent.props
     });
 
@@ -473,7 +488,14 @@ export const ChartLegendTooltipContent: React.FunctionComponent<ChartLegendToolt
       {getTitleComponent()}
       <ChartLegend
         colorScale={colorScale}
-        data={getLegendTooltipVisibleData({ colorScale, legendData: data, text, textAsLegendData: true, theme })}
+        data={getLegendTooltipVisibleData({
+          activePoints,
+          colorScale,
+          legendData: data,
+          text,
+          textAsLegendData: true,
+          theme
+        })}
         labelComponent={getLabelComponent()}
         standalone={false}
         theme={theme}

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipContent.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipContent.tsx
@@ -1,25 +1,13 @@
 import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import {
-  BlockProps,
-  ColorScalePropType,
-  EventCallbackInterface,
-  EventPropTypeInterface,
-  Helpers,
-  NumberOrCallback,
-  OrientationTypes,
-  PaddingProps,
-  StringOrNumberOrCallback,
-  StringOrNumberOrList,
-  VictoryStyleInterface,
-  VictoryStyleObject
-} from 'victory-core';
-import { VictoryLegend, VictoryLegendOrientationType, VictoryLegendTTargetType } from 'victory-legend';
+import { Helpers, NumberOrCallback, StringOrNumberOrCallback } from 'victory-core';
+import { VictoryLegend } from 'victory-legend';
 import { ChartLabel } from '../ChartLabel';
-import { ChartLegend, ChartLegendProps } from '../ChartLegend';
+import { ChartLegend } from '../ChartLegend';
 import { ChartLegendTooltipLabel } from './ChartLegendTooltipLabel';
 import { ChartLegendTooltipStyles, ChartThemeDefinition } from '../ChartTheme';
 import {
+  getLegendTooltipDataProps,
   getLegendTooltipSize,
   getLegendTooltipVisibleData,
   getLegendTooltipVisibleText,
@@ -30,37 +18,13 @@ import {
  * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
  * and https://github.com/FormidableLabs/victory/blob/master/packages/victory-legend/src/index.d.ts
  */
-// Overriding title prop
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
-export interface ChartLegendTooltipContentProps extends ChartLegendProps {
+export interface ChartLegendTooltipContentProps {
   /**
    * The activePoints prop specifies the active data
    *
    * **This prop should not be set manually.**
    */
   activePoints?: any[];
-  /**
-   * The borderComponent prop takes a component instance which will be responsible
-   * for rendering a border around the legend. The new element created from the passed
-   * borderComponent will be provided with the following properties calculated by
-   * ChartLegend: x, y, width, height, and style. Any of these props may be
-   * overridden by passing in props to the supplied component, or modified or ignored
-   * within the custom component itself. If a borderComponent
-   * is not provided, ChartLegend will use its default Border component.
-   * Please note that the default width and height calculated
-   * for the border component is based on approximated
-   * text measurements, and may need to be adjusted.
-   */
-  borderComponent?: React.ReactElement<any>;
-  /**
-   * The borderPadding specifies the amount of padding that should
-   * be added between the legend items and the border. This prop may be given as
-   * a number, or asanobject with values specified for top, bottom, left, and right.
-   * Please note that the default width and height calculated for the border
-   * component is based on approximated text measurements, so padding may need to be adjusted.
-   */
-  borderPadding?: PaddingProps;
   /**
    * The center prop determines the position of the center of the tooltip flyout. This prop should be given as an object
    * that describes the desired x and y svg coordinates of the center of the tooltip. This prop is useful for
@@ -69,74 +33,6 @@ export interface ChartLegendTooltipContentProps extends ChartLegendProps {
    * non-zero pointerLength values will no longer be respected.
    */
   center?: { x: number; y: number };
-  /**
-   * The centerTitle boolean prop specifies whether a legend title should be centered.
-   */
-  centerTitle?: boolean;
-  /**
-   * The colorScale prop defines a color scale to be applied to each data
-   * symbol in ChartLegend. This prop should be given as an array of CSS
-   * colors, or as a string corresponding to one of the built in color
-   * scales: "grayscale", "qualitative", "heatmap", "warm", "cool", "red",
-   * "green", "blue". ChartLegend will assign a color to each symbol by
-   * index, unless they are explicitly specified in the data object.
-   * Colors will repeat when there are more symbols than colors in the
-   * provided colorScale.
-   */
-  colorScale?: ColorScalePropType;
-  /**
-   * The containerComponent prop takes an entire component which will be used to
-   * create a container element for standalone charts.
-   * The new element created from the passed containerComponent wil be provided with
-   * these props from ChartLegend: height, width, children
-   * (the chart itself) and style. Props that are not provided by the
-   * child chart component include title and desc, both of which
-   * are intended to add accessibility to Victory components. The more descriptive these props
-   * are, the more accessible your data will be for people using screen readers.
-   * Any of these props may be overridden by passing in props to the supplied component,
-   * or modified or ignored within the custom component itself. If a dataComponent is
-   * not provided, ChartLegend will use the default ChartContainer component.
-   *
-   * @example <ChartContainer title="Chart of Dog Breeds" desc="This chart shows ..." />
-   */
-  containerComponent?: React.ReactElement<any>;
-  /**
-   * Specify data via the data prop. ChartLegend expects data as an
-   * array of objects with name (required), symbol, and labels properties.
-   * The data prop must be given as an array.
-   */
-  /**
-   * Specify data via the data prop. ChartLegend expects data as an array of objects with name (required), symbol, and
-   * labels properties. The childName is used to sync the data series associated with the given chart child name.
-   *
-   * The data prop must be given as an array.
-   *
-   * @example legendData={[{ name: `GBps capacity - 45%` }, { name: 'Unused' }]}
-   * @example legendData={[{ childName: `cats`, name: `Total cats` }, { childName: `dogs`, name: 'Total dogs' }]}
-   */
-  data?: {
-    childName?: string;
-    name?: string;
-    labels?: {
-      fill?: string;
-    };
-    symbol?: {
-      fill?: string;
-      type?: string;
-    };
-  }[];
-  /**
-   * The dataComponent prop takes a component instance which will be
-   * responsible for rendering a data element used to associate a symbol
-   * or color with each data series. The new element created from the
-   * passed dataComponent will be provided with the following properties
-   * calculated by ChartLegend: x, y, size, style, and symbol. Any of
-   * these props may be overridden by passing in props to the supplied
-   * component, or modified or ignored within the custom component itself.
-   * If a dataComponent is not provided, ChartLegend will use its
-   * default Point component.
-   */
-  dataComponent?: React.ReactElement<any>;
   /**
    * Victory components can pass a datum prop to their label component. This can be used to calculate functional styles,
    * and determine child text
@@ -151,19 +47,6 @@ export interface ChartLegendTooltipContentProps extends ChartLegendProps {
    */
   dy?: NumberOrCallback;
   /**
-   * ChartLegend uses the standard eventKey prop to specify how event targets
-   * are addressed. This prop is not commonly used.
-   */
-  eventKey?: StringOrNumberOrCallback | string[];
-  /**
-   * ChartLegend uses the standard events prop.
-   */
-  events?: EventPropTypeInterface<VictoryLegendTTargetType, StringOrNumberOrCallback>[];
-  /**
-   * ChartLegend uses the standard externalEventMutations prop.
-   */
-  externalEventMutations?: EventCallbackInterface<string | string[], StringOrNumberOrList>[];
-  /**
    * The flyoutHeight prop defines the height of the tooltip flyout. This prop may be given as a positive number or a function
    * of datum. If this prop is not set, height will be determined based on an approximate text size calculated from the
    * text and style props provided to ChartTooltip.
@@ -176,19 +59,6 @@ export interface ChartLegendTooltipContentProps extends ChartLegendProps {
    */
   flyoutWidth?: NumberOrCallback;
   /**
-   * The groupComponent prop takes an entire component which will be used to
-   * create group elements for use within container elements. This prop defaults
-   * to a <g> tag on web, and a react-native-svg <G> tag on mobile
-   */
-  groupComponent?: React.ReactElement<any>;
-  /**
-   * The gutter prop defines the number of pixels between legend rows or
-   * columns, depending on orientation. When orientation is horizontal,
-   * gutters are between columns. When orientation is vertical, gutters
-   * are the space between rows.
-   */
-  gutter?: number | { left: number; right: number };
-  /**
    * Specifies the height the svg viewBox of the chart container. This value should be given as a
    * number of pixels.
    *
@@ -197,13 +67,6 @@ export interface ChartLegendTooltipContentProps extends ChartLegendProps {
    * pixels will depend on the size of the container the chart is rendered into.
    */
   height?: number;
-  /**
-   * The itemsPerRow prop determines how many items to render in each row
-   * of a horizontal legend, or in each column of a vertical legend. This
-   * prop should be given as an integer. When this prop is not given,
-   * legend items will be rendered in a single row or column.
-   */
-  itemsPerRow?: number;
   /**
    * The labelComponent prop takes a component instance which will be used
    * to render each legend label. The new element created from the passed
@@ -215,59 +78,32 @@ export interface ChartLegendTooltipContentProps extends ChartLegendProps {
    */
   labelComponent?: React.ReactElement<any>;
   /**
-   * The orientation prop takes a string that defines whether legend data
-   * are displayed in a row or column. When orientation is "horizontal",
-   * legend items will be displayed in a single row. When orientation is
-   * "vertical", legend items will be displayed in a single column. Line
-   * and text-wrapping is not currently supported, so "vertical"
-   * orientation is both the default setting and recommended for
-   * displaying many series of data.
-   */
-  orientation?: VictoryLegendOrientationType;
-  /**
-   * The padding props specifies the amount of padding in number of pixels between
-   * the edge of the chart and any rendered child components. This prop can be given
-   * as a number or as an object with padding specified for top, bottom, left
-   * and right.
-   */
-  padding?: PaddingProps;
-  /**
-   * The responsive prop specifies whether the rendered container should be a responsive container with a viewBox
-   * attribute, or a static container with absolute width and height.
+   * The legend component to render with chart.
    *
-   * Useful when legend is located inside a chart -- default is false.
-   *
-   * Note: Not compatible with containerComponent prop
+   * Note: Use legendData so the legend width can be calculated and positioned properly.
+   * Default legend properties may be applied
    */
-  responsive?: boolean;
+  legendComponent?: React.ReactElement<any>;
   /**
-   * The rowGutter prop defines the number of pixels between legend rows.
-   * This prop may be given as a number, or as an object with values
-   * specified for “top” and “bottom” gutters. To set spacing between columns,
-   * use the gutter prop.
-   */
-  rowGutter?: number | Omit<BlockProps, 'left' | 'right'>;
-  /**
-   * The sharedEvents prop is used internally to coordinate events between components.
+   * Specify data via the data prop. ChartLegend expects data as an array of objects with name (required), symbol, and
+   * labels properties. The childName is used to sync the data series associated with the given chart child name.
    *
-   * **This prop should not be set manually.**
-   */
-  sharedEvents?: { events: any[]; getEventState: Function };
-  /**
-   * The style prop specifies styles for your pie. ChartLegend relies on Radium,
-   * so valid Radium style objects should work for this prop. Height, width, and
-   * padding should be specified via the height, width, and padding props.
+   * The data prop must be given as an array.
    *
-   * Note: this may be overridden when ChartLegendTooltip is used as a label component.
-   *
-   * @example {data: {stroke: "black"}, label: {fontSize: 10}}
+   * @example legendData={[{ name: `GBps capacity - 45%` }, { name: 'Unused' }]}
+   * @example legendData={[{ childName: `cats`, name: `Total cats` }, { childName: `dogs`, name: 'Total dogs' }]}
    */
-  style?: VictoryStyleInterface & { title?: VictoryStyleObject };
-  /**
-   * The symbolSpacer prop defines the number of pixels between data
-   * components and label components.
-   */
-  symbolSpacer?: number;
+  legendData?: {
+    childName?: string;
+    name?: string;
+    labels?: {
+      fill?: string;
+    };
+    symbol?: {
+      fill?: string;
+      type?: string;
+    };
+  }[];
   /**
    * The text prop defines the text ChartTooltip will render. The text prop may be given as a string, number, or
    * function of datum. When ChartLabel is used as the labelComponent, strings may include newline characters, which
@@ -318,12 +154,6 @@ export interface ChartLegendTooltipContentProps extends ChartLegendProps {
    */
   titleComponent?: React.ReactElement<any>;
   /**
-   * The titleOrientation prop specifies where the a title should be rendered
-   * in relation to the rest of the legend. Possible values
-   * for this prop are “top”, “bottom”, “left”, and “right”.
-   */
-  titleOrientation?: OrientationTypes;
-  /**
    * Specifies the width of the svg viewBox of the chart container. This value should be given as a
    * number of pixels.
    *
@@ -332,74 +162,40 @@ export interface ChartLegendTooltipContentProps extends ChartLegendProps {
    * pixels will depend on the size of the container the chart is rendered into.
    */
   width?: number;
-  /**
-   * The x and y props define the base position of the legend element.
-   *
-   * Note: When the center, flyoutWidth, and width props are provided, the x prop will be overridden.
-   *
-   * **This prop should not be set manually.**
-   */
-  x?: number;
-  /**
-   * The x and y props define the base position of the legend element.
-   *
-   * Note: When the center, flyoutWidth, and height props are provided, the y prop will be overridden.
-   *
-   * **This prop should not be set manually.**
-   */
-  y?: number;
 }
-
-export const defaultLegendProps = {
-  borderPadding: 0,
-  gutter: 0,
-  orientation: 'vertical' as any,
-  padding: 0,
-  rowGutter: -12,
-  style: {
-    labels: {
-      fill: ChartLegendTooltipStyles.label.fill,
-      padding: 0
-    },
-    title: {
-      fill: ChartLegendTooltipStyles.label.fill,
-      padding: 0
-    }
-  }
-};
 
 export const ChartLegendTooltipContent: React.FunctionComponent<ChartLegendTooltipContentProps> = ({
   activePoints,
-  borderPadding = defaultLegendProps.borderPadding,
   center,
-  colorScale,
-  data,
   datum,
   dx = 0,
   dy = 0,
   flyoutHeight,
   flyoutWidth,
   height,
-  gutter = defaultLegendProps.gutter,
   labelComponent = <ChartLegendTooltipLabel />,
-  orientation = defaultLegendProps.orientation,
-  padding = defaultLegendProps.padding,
-  rowGutter = defaultLegendProps.rowGutter,
-  style = defaultLegendProps.style,
+  legendComponent = <ChartLegend />,
+  legendData,
   text,
   themeColor,
   themeVariant,
   title,
   titleComponent = <ChartLabel />,
   width,
-  x,
-  y,
 
   // destructure last
   theme = getTheme(themeColor, themeVariant),
   ...rest
 }: ChartLegendTooltipContentProps) => {
   const pointerLength = theme && theme.tooltip ? theme.tooltip.pointerLength : 10;
+  const legendProps = getLegendTooltipDataProps(legendComponent.props);
+  const visibleLegendData = getLegendTooltipVisibleData({
+    activePoints,
+    colorScale: legendProps.colorScale,
+    legendData,
+    text,
+    theme
+  });
 
   // Component offsets
   const legendOffsetX = 0;
@@ -409,8 +205,9 @@ export const ChartLegendTooltipContent: React.FunctionComponent<ChartLegendToolt
 
   // Returns x position of flyout
   const getX = () => {
-    if (!(center && flyoutWidth && width)) {
-      return x;
+    if (!(center || flyoutWidth || width)) {
+      const x = (rest as any).x;
+      return x ? x : undefined;
     }
     const _flyoutWidth = Helpers.evaluateProp(flyoutWidth);
     if (width > center.x + _flyoutWidth + pointerLength) {
@@ -424,8 +221,9 @@ export const ChartLegendTooltipContent: React.FunctionComponent<ChartLegendToolt
 
   // Returns y position
   const getY = () => {
-    if (!(center && flyoutHeight && height)) {
-      return y;
+    if (!(center || flyoutHeight || height)) {
+      const y = (rest as any).y;
+      return y ? y : undefined;
     }
     const _flyoutHeight = Helpers.evaluateProp(flyoutHeight);
     if (center.y < _flyoutHeight / 2) {
@@ -438,18 +236,10 @@ export const ChartLegendTooltipContent: React.FunctionComponent<ChartLegendToolt
   };
 
   // Min & max dimensions do not include flyout padding
-  const legendProps = {
-    borderPadding,
-    gutter,
-    orientation,
-    padding,
-    rowGutter,
-    style: Array.isArray(style) ? defaultLegendProps.style : style
-  };
   const maxLegendDimensions = getLegendTooltipSize({
-    legendData: getLegendTooltipVisibleData({ activePoints, colorScale, legendData: data, text, theme }),
+    legendData: visibleLegendData,
     legendProps,
-    text: getLegendTooltipVisibleText({ activePoints, legendData: data, text }),
+    text: getLegendTooltipVisibleText({ activePoints, legendData, text }),
     theme
   });
   const minLegendDimensions = getLegendTooltipSize({
@@ -462,7 +252,7 @@ export const ChartLegendTooltipContent: React.FunctionComponent<ChartLegendToolt
   const getLabelComponent = () =>
     React.cloneElement(labelComponent, {
       dx: maxLegendDimensions.width - minLegendDimensions.width,
-      legendData: getLegendTooltipVisibleData({ activePoints, colorScale, legendData: data, text, theme }),
+      legendData: visibleLegendData,
       ...labelComponent.props
     });
 
@@ -483,27 +273,29 @@ export const ChartLegendTooltipContent: React.FunctionComponent<ChartLegendToolt
     });
   };
 
+  // Returns the legebd component
+  const getLegendComponent = () =>
+    React.cloneElement(legendComponent, {
+      data: getLegendTooltipVisibleData({
+        activePoints,
+        colorScale: legendProps.colorScale,
+        legendData,
+        text,
+        textAsLegendData: true,
+        theme
+      }),
+      labelComponent: getLabelComponent(),
+      standalone: false,
+      theme,
+      x: getX() + legendOffsetX + Helpers.evaluateProp(dx),
+      y: getY() + legendOffsetY + Helpers.evaluateProp(dy),
+      ...legendProps
+    });
+
   return (
     <React.Fragment>
       {getTitleComponent()}
-      <ChartLegend
-        colorScale={colorScale}
-        data={getLegendTooltipVisibleData({
-          activePoints,
-          colorScale,
-          legendData: data,
-          text,
-          textAsLegendData: true,
-          theme
-        })}
-        labelComponent={getLabelComponent()}
-        standalone={false}
-        theme={theme}
-        x={getX() + legendOffsetX + Helpers.evaluateProp(dx)}
-        y={getY() + legendOffsetY + Helpers.evaluateProp(dy)}
-        {...legendProps}
-        {...rest}
-      />
+      {getLegendComponent()}
     </React.Fragment>
   );
 };

--- a/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltipContent.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltipContent.test.tsx.snap
@@ -1003,30 +1003,12 @@ exports[`renders component text 1`] = `
   />
   <ChartLegend
     borderPadding={0}
-    data={
-      Array [
-        Object {
-          "name": "1, 2, 3, 4",
-          "symbol": Object {
-            "fill": "#06c",
-          },
-        },
-      ]
-    }
+    data={Array []}
     gutter={0}
     labelComponent={
       <ChartLegendTooltipLabel
-        dx={121.73913043478262}
-        legendData={
-          Array [
-            Object {
-              "name": "Cats",
-              "symbol": Object {
-                "fill": "#06c",
-              },
-            },
-          ]
-        }
+        dx={-19.6}
+        legendData={Array []}
       />
     }
     orientation="vertical"

--- a/packages/react-charts/src/components/ChartLine/examples/ChartLine.md
+++ b/packages/react-charts/src/components/ChartLine/examples/ChartLine.md
@@ -103,7 +103,7 @@ class BottomAlignedLegend extends React.Component {
   render() {
     // Note: Container order is important
     const CursorVoronoiContainer = createContainer("cursor", "voronoi");
-    const legendData = [{ name: 'Cats' }, { name: 'Dogs', symbol: { type: 'dash' } }, { name: 'Birds' }, { name: 'Mice' }];
+    const legendData = [{ childName: 'cats', name: 'Cats' }, { childName: 'dogs', name: 'Dogs', symbol: { type: 'dash' }}, { childName: 'birds', name: 'Birds' }, { childName: 'mice', name: 'Mice' }];
 
     return (
       <div>
@@ -141,19 +141,21 @@ class BottomAlignedLegend extends React.Component {
             <ChartGroup>
               <ChartLine
                 data={[
-                  { name: 'Cats', x: '2015', y: 1 },
-                  { name: 'Cats', x: '2016', y: 2 },
-                  { name: 'Cats', x: '2017', y: 5 },
-                  { name: 'Cats', x: '2018', y: 3 }
+                  { x: '2015', y: 1 },
+                  { x: '2016', y: 2 },
+                  { x: '2017', y: 5 },
+                  { x: '2018', y: 3 }
                 ]}
+                name="cats"
               />
               <ChartLine
                 data={[
-                  { name: 'Dogs', x: '2015', y: 2 },
-                  { name: 'Dogs', x: '2016', y: 1 },
-                  { name: 'Dogs', x: '2017', y: 7 },
-                  { name: 'Dogs', x: '2018', y: 4 }
+                  { x: '2015', y: 2 },
+                  { x: '2016', y: 1 },
+                  { x: '2017', y: 7 },
+                  { x: '2018', y: 4 }
                 ]}
+                name="dogs"
                 style={{
                   data: {
                     strokeDasharray: '3,3'
@@ -162,19 +164,21 @@ class BottomAlignedLegend extends React.Component {
               />
               <ChartLine
                 data={[
-                  { name: 'Birds', x: '2015', y: 3 },
-                  { name: 'Birds', x: '2016', y: 4 },
-                  { name: 'Birds', x: '2017', y: 9 },
-                  { name: 'Birds', x: '2018', y: 5 }
+                  { x: '2015', y: 3 },
+                  { x: '2016', y: 4 },
+                  { x: '2017', y: 9 },
+                  { x: '2018', y: 5 }
                 ]}
+                name="birds"
               />
               <ChartLine
                 data={[
-                  { name: 'Mice', x: '2015', y: 3 },
-                  { name: 'Mice', x: '2016', y: 3 },
-                  { name: 'Mice', x: '2017', y: 8 },
-                  { name: 'Mice', x: '2018', y: 7 }
+                  { x: '2015', y: 3 },
+                  { x: '2016', y: 3 },
+                  { x: '2017', y: 8 },
+                  { x: '2018', y: 7 }
                 ]}
+                name="mice"
               />
             </ChartGroup>
           </Chart>

--- a/packages/react-charts/src/components/ChartStack/examples/ChartStack.md
+++ b/packages/react-charts/src/components/ChartStack/examples/ChartStack.md
@@ -314,8 +314,8 @@ class MultiColorChart extends React.Component {
     
     // Note: Container order is important
     const CursorVoronoiContainer = createContainer("cursor", "voronoi");
-    const legendData = [{ name: 'Cats' }, { name: 'Dogs', symbol: { type: 'dash' } }, { name: 'Birds' }];
-
+    const legendData = [{ childName: 'cats', name: 'Cats' }, { childName: 'dogs', name: 'Dogs' }, { childName: 'birds', name: 'Birds' }];
+    
     return (
       <div ref={this.containerRef}>
         <div style={{ height: '225px' }}>
@@ -350,39 +350,42 @@ class MultiColorChart extends React.Component {
             <ChartStack>
               <ChartArea
                 data={[
-                  { name: 'Cats', x: 'Sunday', y: 6 },
-                  { name: 'Cats', x: 'Monday', y: 2 },
-                  { name: 'Cats', x: 'Tuesday', y: 8 },
-                  { name: 'Cats', x: 'Wednesday', y: 15 },
-                  { name: 'Cats', x: 'Thursday', y: 6 },
-                  { name: 'Cats', x: 'Friday', y: 2 },
-                  { name: 'Cats', x: 'Saturday', y: 0 }
+                  { x: 'Sunday', y: 6 },
+                  { x: 'Monday', y: 2 },
+                  { x: 'Tuesday', y: 8 },
+                  { x: 'Wednesday', y: 15 },
+                  { x: 'Thursday', y: 6 },
+                  { x: 'Friday', y: 2 },
+                  { x: 'Saturday', y: 0 }
                 ]}
                 interpolation="monotoneX"
+                name="cats"
               />
              <ChartArea
                data={[
-                  { name: 'Birds', x: 'Sunday', y: 4 },
-                  { name: 'Birds', x: 'Monday', y: 5 },
-                  { name: 'Birds', x: 'Tuesday', y: 7 },
-                  { name: 'Birds', x: 'Wednesday', y: 6 },
-                  { name: 'Birds', x: 'Thursday', y: 10 },
-                  { name: 'Birds', x: 'Friday', y: 3 },
-                  { name: 'Birds', x: 'Saturday', y: 5 }
+                  { x: 'Sunday', y: 4 },
+                  { x: 'Monday', y: 5 },
+                  { x: 'Tuesday', y: 7 },
+                  { x: 'Wednesday', y: 6 },
+                  { x: 'Thursday', y: 10 },
+                  { x: 'Friday', y: 3 },
+                  { x: 'Saturday', y: 5 }
                 ]}
                 interpolation="monotoneX"
+                name="dogs"
               />
               <ChartArea
                 data={[
-                  { name: 'Dogs', x: 'Sunday', y: 8 },
-                  { name: 'Dogs', x: 'Monday', y: 18 },
-                  { name: 'Dogs', x: 'Tuesday', y: 14 },
-                  { name: 'Dogs', x: 'Wednesday', y: 8 },
-                  { name: 'Dogs', x: 'Thursday', y: 6 },
-                  { name: 'Dogs', x: 'Friday', y: 8 },
-                  { name: 'Dogs', x: 'Saturday', y: 12 }
+                  { x: 'Sunday', y: 8 },
+                  { x: 'Monday', y: 18 },
+                  { x: 'Tuesday', y: 14 },
+                  { x: 'Wednesday', y: 8 },
+                  { x: 'Thursday', y: 6 },
+                  { x: 'Friday', y: 8 },
+                  { x: 'Saturday', y: 12 }
                 ]}
                 interpolation="monotoneX"
+                name="birds"
               />
             </ChartStack>
           </Chart>

--- a/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
+++ b/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
@@ -180,8 +180,8 @@ class EmbeddedLegend extends React.Component {
   render() {
     // Note: Container order is important
     const CursorVoronoiContainer = createContainer("cursor", "voronoi");
-    const legendData = [{ name: 'Cats' }, { name: 'Dogs', symbol: { type: 'dash' } }, { name: 'Birds' }, { name: 'Mice' }];
-
+    const legendData = [{ childName: 'cats', name: 'Cats' }, { childName: 'dogs', name: 'Dogs', symbol: { type: 'dash' }}, { childName: 'birds', name: 'Birds' }, { childName: 'mice', name: 'Mice' }];
+    
     return (
       <div>
         <p>This demonstrates how to embed a legend within a tooltip. Combining cursor and voronoi containers is required to display tooltips with a vertical cursor.</p>
@@ -222,6 +222,7 @@ class EmbeddedLegend extends React.Component {
                   { name: 'Cats', x: '2017', y: 5 },
                   { name: 'Cats', x: '2018', y: 3 }
                 ]}
+                name="cats"
               />
               <ChartLine
                 data={[
@@ -230,6 +231,7 @@ class EmbeddedLegend extends React.Component {
                   { name: 'Dogs', x: '2017', y: 7 },
                   { name: 'Dogs', x: '2018', y: 4 }
                 ]}
+                name="dogs"
                 style={{
                   data: {
                     strokeDasharray: '3,3'
@@ -243,6 +245,7 @@ class EmbeddedLegend extends React.Component {
                   { name: 'Birds', x: '2017', y: 9 },
                   { name: 'Birds', x: '2018', y: 5 }
                 ]}
+                name="birds"
               />
               <ChartLine
                 data={[
@@ -251,6 +254,7 @@ class EmbeddedLegend extends React.Component {
                   { name: 'Mice', x: '2017', y: 8 },
                   { name: 'Mice', x: '2018', y: 7 }
                 ]}
+                name="mice"
               />
             </ChartGroup>
           </Chart>

--- a/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
@@ -24,6 +24,7 @@ interface ChartLegendTooltipFlyoutInterface {
 }
 
 interface ChartLegendTooltipVisibleDataInterface {
+  activePoints?: any[];
   colorScale?: ColorScalePropType;
   legendData: any;
   text?: StringOrNumberOrCallback | string[] | number[];
@@ -32,6 +33,7 @@ interface ChartLegendTooltipVisibleDataInterface {
 }
 
 interface ChartLegendTooltipVisibleTextInterface {
+  activePoints?: any[];
   legendData: any;
   text: StringOrNumberOrCallback | string[] | number[];
 }
@@ -107,7 +109,7 @@ export const getLegendTooltipSize = ({
   });
 
   let maxLength = maxDataLength + maxTextLength;
-  maxLength += maxLength > 20 ? 1 : maxLength > 15 ? 2 : 4;
+  maxLength += maxDataLength > 10 ? 2 : 4;
 
   // Adds spacing to help align legend labels and text values
   const getSpacer = (legendLabel: string, textLabel: string) => {
@@ -159,6 +161,7 @@ export const getLegendTooltipSize = ({
 // Returns visible legend data, while syncing color scale. If textAsLegendData is true, the text prop is used as
 // legend data so y values can be passed individually to the label component
 export const getLegendTooltipVisibleData = ({
+  activePoints,
   colorScale,
   legendData,
   text,
@@ -174,7 +177,11 @@ export const getLegendTooltipVisibleData = ({
     let index = -1;
     for (let i = 0; i < legendData.length; i++) {
       const data = legendData[i];
-      if (data.symbol && data.symbol.type === 'eyeSlash' && data.symbol.fill === chart_color_black_500.value) {
+      const activePoint = activePoints ? activePoints.find(item => item.childName === data.childName) : '';
+      if (
+        !activePoint ||
+        (data.symbol && data.symbol.type === 'eyeSlash' && data.symbol.fill === chart_color_black_500.value)
+      ) {
         continue; // Skip hidden data
       }
       if (index++ < _text.length - 1) {
@@ -196,14 +203,22 @@ export const getLegendTooltipVisibleData = ({
 };
 
 // Returns visible text for interactive legends
-export const getLegendTooltipVisibleText = ({ legendData, text }: ChartLegendTooltipVisibleTextInterface) => {
+export const getLegendTooltipVisibleText = ({
+  activePoints,
+  legendData,
+  text
+}: ChartLegendTooltipVisibleTextInterface) => {
   const textEvaluated = Helpers.evaluateProp(text);
   const _text = Array.isArray(textEvaluated) ? textEvaluated : [textEvaluated];
   const result = [];
   if (legendData) {
     let index = -1;
     for (const data of legendData) {
-      if (data.symbol && data.symbol.type === 'eyeSlash' && data.symbol.fill === chart_color_black_500.value) {
+      const activePoint = activePoints ? activePoints.find(item => item.childName === data.childName) : '';
+      if (
+        !activePoint ||
+        (data.symbol && data.symbol.type === 'eyeSlash' && data.symbol.fill === chart_color_black_500.value)
+      ) {
         continue; // Skip hidden data
       }
       if (index++ < _text.length - 1) {

--- a/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
@@ -1,7 +1,8 @@
 /* eslint-disable camelcase */
 import chart_color_black_500 from '@patternfly/react-tokens/dist/js/chart_color_black_500';
 import { ColorScalePropType, Helpers, OrientationTypes, StringOrNumberOrCallback } from 'victory-core';
-import { ChartThemeDefinition } from '../ChartTheme';
+import { ChartLegendProps } from '../ChartLegend';
+import { ChartLegendTooltipStyles, ChartThemeDefinition } from '../ChartTheme';
 import { getLegendDimensions, getTextSizeWorkAround } from './chart-legend';
 
 interface ChartCursorTooltipCenterOffsetInterface {
@@ -79,6 +80,26 @@ export const getCursorTooltipPoniterOrientation = ({
     height > center.y + flyoutHeight + pointerLength ? 'top' : 'bottom';
   return horizontal ? orientationX : orientationY;
 };
+
+// Returns props associated with legend data
+export const getLegendTooltipDataProps = (defaultProps: ChartLegendProps) => ({
+  borderPadding: 0,
+  gutter: 0,
+  orientation: 'vertical',
+  padding: 0,
+  rowGutter: -12,
+  style: {
+    labels: {
+      fill: ChartLegendTooltipStyles.label.fill,
+      padding: 0
+    },
+    title: {
+      fill: ChartLegendTooltipStyles.label.fill,
+      padding: 0
+    }
+  },
+  ...defaultProps
+});
 
 // Returns the legend height and width
 export const getLegendTooltipSize = ({


### PR DESCRIPTION
This syncs the tooltip legend (yet to be published) with the items from Victory's `activePoints` array. This is a more reliable way to hide / show interactive legends because `activePoints` only includes visible items when data points are missing / not available.

In addition, I cleaned up `ChartLegendTooltipContent`. That evolved to more than just a legend component, so I've replaced `ChartLegendProps` with a `legendComponent` prop for customization -- which eliminated unused props like `standalone`, `x`, `y`, etc.

See #3219