### PR TITLE
Chart legend tooltip label size

### DIFF
--- a/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltipContent.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltipContent.test.tsx.snap
@@ -25,12 +25,13 @@ exports[`ChartLegendTooltipContent 1`] = `
     }
     orientation="vertical"
     padding={0}
-    rowGutter={-12}
+    rowGutter={0}
     standalone={false}
     style={
       Object {
         "labels": Object {
           "fill": "#f0f0f0",
+          "lineHeight": 0.275,
           "padding": 0,
         },
         "title": Object {
@@ -519,12 +520,13 @@ exports[`ChartLegendTooltipContent 2`] = `
     }
     orientation="vertical"
     padding={0}
-    rowGutter={-12}
+    rowGutter={0}
     standalone={false}
     style={
       Object {
         "labels": Object {
           "fill": "#f0f0f0",
+          "lineHeight": 0.275,
           "padding": 0,
         },
         "title": Object {
@@ -1013,12 +1015,13 @@ exports[`renders component text 1`] = `
     }
     orientation="vertical"
     padding={0}
-    rowGutter={-12}
+    rowGutter={0}
     standalone={false}
     style={
       Object {
         "labels": Object {
           "fill": "#f0f0f0",
+          "lineHeight": 0.275,
           "padding": 0,
         },
         "title": Object {

--- a/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
@@ -87,10 +87,11 @@ export const getLegendTooltipDataProps = (defaultProps: ChartLegendProps) => ({
   gutter: 0,
   orientation: 'vertical',
   padding: 0,
-  rowGutter: -12,
+  rowGutter: 0,
   style: {
     labels: {
       fill: ChartLegendTooltipStyles.label.fill,
+      lineHeight: 0.275,
       padding: 0
     },
     title: {
@@ -162,8 +163,16 @@ export const getLegendTooltipSize = ({
     };
   });
 
-  const legendDimensions = getLegendDimensions({
+  // This should include both legend data and text
+  const widthDimensions = getLegendDimensions({
     legendData: data,
+    legendOrientation,
+    legendProps,
+    theme
+  });
+  // This should only use text. The row gutter changes when displaying all "no data" messages
+  const heightDimensions = getLegendDimensions({
+    legendData: _text.map((name: string) => ({ name })),
     legendOrientation,
     legendProps,
     theme
@@ -174,8 +183,8 @@ export const getLegendTooltipSize = ({
     theme
   });
   return {
-    height: legendDimensions.height,
-    width: legendDimensions.width - textSizeWorkAround > 0 ? legendDimensions.width - textSizeWorkAround : 0
+    height: heightDimensions.height,
+    width: widthDimensions.width - textSizeWorkAround > 0 ? widthDimensions.width - textSizeWorkAround : 0
   };
 };
 


### PR DESCRIPTION
This adds a fixed line height for the labels shown in with the chart's tooltip legend. 

In Cost Management, we occasionally show a "no data" message in place of the numeric value. The line height adjusts vertically to accommodate the smaller text, but prefer the legend remain the same height.

See #3219

**Before**
![chrome-capture](https://user-images.githubusercontent.com/17481322/85152583-2f933f00-b223-11ea-8cc4-a82989e0d2d5.gif)

**After**
![chrome-capture (1)](https://user-images.githubusercontent.com/17481322/85152606-3752e380-b223-11ea-9a71-d08be8f05852.gif)
