### PR TITLE
fix(OptionsMenu): fix accessibility bug in plain with text disabled part

### DIFF
--- a/packages/react-core/src/components/OptionsMenu/OptionsMenuToggleWithText.tsx
+++ b/packages/react-core/src/components/OptionsMenu/OptionsMenuToggleWithText.tsx
@@ -119,6 +119,7 @@ export const OptionsMenuToggleWithText: React.FunctionComponent<OptionsMenuToggl
         aria-label={ariaLabel}
         aria-expanded={isOpen}
         ref={buttonRef}
+        disabled={isDisabled}
         onClick={() => onToggle(!isOpen)}
         onKeyDown={onKeyDown}
       >

--- a/packages/react-core/src/components/OptionsMenu/__tests__/Generated/__snapshots__/OptionsMenuToggleWithText.test.tsx.snap
+++ b/packages/react-core/src/components/OptionsMenu/__tests__/Generated/__snapshots__/OptionsMenuToggleWithText.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`OptionsMenuToggleWithText should match snapshot (auto-generated) 1`] = 
     aria-haspopup="listbox"
     aria-label="'Options menu'"
     className="pf-c-options-menu__toggle-button ''"
+    disabled={false}
     id="''-toggle"
     onClick={[Function]}
     onKeyDown={[Function]}

--- a/packages/react-core/src/components/OptionsMenu/__tests__/__snapshots__/OptionsMenu.test.tsx.snap
+++ b/packages/react-core/src/components/OptionsMenu/__tests__/__snapshots__/OptionsMenu.test.tsx.snap
@@ -3066,6 +3066,7 @@ exports[`optionsMenu text 1`] = `
             aria-haspopup="listbox"
             aria-label="Options menu"
             className="pf-c-options-menu__toggle-button"
+            disabled={false}
             id="-toggle"
             onClick={[Function]}
             onKeyDown={[Function]}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: I pass the `isDisabled` value to the dropdown button so that it cannot be focused when it is disabled.
Closes #4423 

