### PR TITLE
chore(dependabot): add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    # Should pickup monorepo in root
+    directory: "/"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,8 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: "daily"
+    allow:
+      # Just bump core for now
+      - dependency-name: "@patternfly/patternfly"
+    labels:
+      - "infrastructure"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Our bot to bump core in React broke some time ago. This could possibly work instead.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: Dependabot claims to [support monorepos](https://dependabot.com/javascript/) and the [config is valid.](https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#configuration-options-for-dependabotyml)
