### PR TITLE
PagerHeaderToolsItem visibility props should be optional

### DIFF
--- a/packages/react-core/src/components/Page/PageHeaderToolsItem.tsx
+++ b/packages/react-core/src/components/Page/PageHeaderToolsItem.tsx
@@ -10,12 +10,12 @@ export interface PageHeaderToolsItemProps extends React.HTMLProps<HTMLDivElement
   className?: string;
   /** Visibility at various breakpoints. */
   visibility?: {
-    default: 'hidden' | 'visible';
-    sm: 'hidden' | 'visible';
-    md: 'hidden' | 'visible';
-    lg: 'hidden' | 'visible';
-    xl: 'hidden' | 'visible';
-    '2xl': 'hidden' | 'visible';
+    default?: 'hidden' | 'visible';
+    sm?: 'hidden' | 'visible';
+    md?: 'hidden' | 'visible';
+    lg?: 'hidden' | 'visible';
+    xl?: 'hidden' | 'visible';
+    '2xl?': 'hidden' | 'visible';
   };
   /** True to make an icon button appear selected */
   isSelected?: boolean;


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**:
As in `DataListAction` and `PageHeaderToolbarGroup`, prop **visibility** should be optional in `PagerHeaderToolsItem`.

From the official docs https://www.patternfly.org/v4/documentation/react/demos/pagelayout:
```jsx
            />
          </PageHeaderToolsItem>
          <PageHeaderToolsItem visibility={{ default: 'hidden', md: 'visible' }} />
            <Dropdown
              isPlain
```
 
Closes #4495

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
Nope.
