### PR TITLE
fix(examples): make the interactions in the demo more life-like

### DIFF
--- a/packages/react-core/src/components/Dropdown/examples/Dropdown.md
+++ b/packages/react-core/src/components/Dropdown/examples/Dropdown.md
@@ -970,10 +970,10 @@ class SplitButtonActionDropdown extends React.Component {
       });
     };
     this.onActionClick = event => {
-      console.log('Action clicked!');
+      window.alert('You selected an action button!');
     };
     this.onCogClick = event => {
-      console.log('Cog clicked!');
+      window.alert('You selected the Cog!');
     };
     this.onActionSelect = event => {
       this.setState({
@@ -990,24 +990,24 @@ class SplitButtonActionDropdown extends React.Component {
   render() {
     const { isActionOpen, isCogOpen } = this.state;
     const dropdownItems = [
-      <DropdownItem key="action" component="button">
+      <DropdownItem key="action" component="button" onClick={this.onActionClick}>
         Action
       </DropdownItem>,
-      <DropdownItem key="disabled link" component="button" isDisabled>
+      <DropdownItem key="disabled link" component="button" isDisabled onClick={this.onActionClick}>
         Disabled action
       </DropdownItem>,
-      <DropdownItem key="other action" component="button">
+      <DropdownItem key="other action" component="button" onClick={this.onActionClick}>
         Other action
       </DropdownItem>
     ];
     const dropdownIconItems = [
-      <DropdownItem key="action" component="button" icon={<CogIcon />}>
+      <DropdownItem key="action" component="button" icon={<CogIcon />} onClick={this.onActionClick}>
         Action
       </DropdownItem>,
-      <DropdownItem key="disabled link" component="button" icon={<BellIcon />} isDisabled>
+      <DropdownItem key="disabled link" component="button" icon={<BellIcon />} isDisabled onClick={this.onActionClick}>
         Disabled action
       </DropdownItem>,
-      <DropdownItem key="other action" component="button" icon={<CubesIcon />}>
+      <DropdownItem key="other action" component="button" icon={<CubesIcon />} onClick={this.onActionClick}>
         Other action
       </DropdownItem>
     ];
@@ -1215,9 +1215,9 @@ class ImageTextDropdown extends React.Component {
       <Dropdown
         onSelect={this.onSelect}
         toggle={
-          <DropdownToggle 
-            id="toggle-id-9" 
-            onToggle={this.onToggle} 
+          <DropdownToggle
+            id="toggle-id-9"
+            onToggle={this.onToggle}
             toggleIndicator={CaretDownIcon}
             icon={<UserIcon />}
           >


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes https://github.com/patternfly/patternfly-react/issues/3337

This PR updates the example for "Split button action" of the Dropdown component, making the interactions trigger alerts instead of console logs so that users who are not developers can see the impacts of interacting with elements of the Dropdowns. I think it was already working as desired, just that it wasn't as obvious with the way the example was wired up.

We should probably swap all similar types of console logs in the docs to alerts for the same reason. I can do that in a separate PR if it's helpful.

<img width="420" alt="Screen Shot 2020-07-07 at 4 00 55 PM" src="https://user-images.githubusercontent.com/5942899/86836172-1daafc00-c06b-11ea-8269-3da2fb1cbf80.png">

