### PR TITLE
fix(DrawerPanelContent): don't render children when hidden

### DIFF
--- a/packages/react-core/src/components/Drawer/DrawerPanelContent.tsx
+++ b/packages/react-core/src/components/Drawer/DrawerPanelContent.tsx
@@ -28,20 +28,24 @@ export const DrawerPanelContent: React.SFC<DrawerPanelContentProps> = ({
   ...props
 }: DrawerPanelContentProps) => (
   <DrawerContext.Consumer>
-    {({ isExpanded, isStatic }) => (
-      <div
-        className={css(
-          styles.drawerPanel,
-          hasNoBorder && styles.modifiers.noBorder,
-          formatBreakpointMods(widths, styles),
-          className
-        )}
-        hidden={isStatic ? false : !isExpanded}
-        {...props}
-      >
-        {children}
-      </div>
-    )}
+    {({ isExpanded, isStatic }) => {
+      const hidden = isStatic ? false : !isExpanded;
+
+      return (
+        <div
+          className={css(
+            styles.drawerPanel,
+            hasNoBorder && styles.modifiers.noBorder,
+            formatBreakpointMods(widths, styles),
+            className
+          )}
+          hidden={hidden}
+          {...props}
+        >
+          {!hidden && children}
+        </div>
+      );
+    }}
   </DrawerContext.Consumer>
 );
 DrawerPanelContent.displayName = 'DrawerPanelContent';

--- a/packages/react-core/src/components/Drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/react-core/src/components/Drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -43,87 +43,7 @@ exports[`Drawer isExpanded = false and isInline = false and isStatic = false 1`]
             <div
               className="pf-c-drawer__panel"
               hidden={true}
-            >
-              <DrawerHead>
-                <DrawerPanelBody
-                  hasNoPadding={false}
-                >
-                  <div
-                    className="pf-c-drawer__body"
-                  >
-                    <div
-                      className="pf-c-drawer__head"
-                    >
-                      <span>
-                        drawer-panel
-                      </span>
-                      <DrawerActions>
-                        <div
-                          className="pf-c-drawer__actions"
-                        >
-                          <DrawerCloseButton>
-                            <div
-                              className="pf-c-drawer__close"
-                            >
-                              <Button
-                                aria-label="Close drawer panel"
-                                onClick={[Function]}
-                                variant="plain"
-                              >
-                                <button
-                                  aria-disabled={false}
-                                  aria-label="Close drawer panel"
-                                  className="pf-c-button pf-m-plain"
-                                  data-ouia-component-id={1}
-                                  data-ouia-component-type="PF4/Button"
-                                  data-ouia-safe={true}
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <TimesIcon
-                                    color="currentColor"
-                                    noVerticalAlign={false}
-                                    size="sm"
-                                  >
-                                    <svg
-                                      aria-hidden={true}
-                                      aria-labelledby={null}
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      style={
-                                        Object {
-                                          "verticalAlign": "-0.125em",
-                                        }
-                                      }
-                                      viewBox="0 0 352 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                        transform=""
-                                      />
-                                    </svg>
-                                  </TimesIcon>
-                                </button>
-                              </Button>
-                            </div>
-                          </DrawerCloseButton>
-                        </div>
-                      </DrawerActions>
-                    </div>
-                  </div>
-                </DrawerPanelBody>
-              </DrawerHead>
-              <DrawerPanelBody>
-                <div
-                  className="pf-c-drawer__body"
-                >
-                  drawer-panel
-                </div>
-              </DrawerPanelBody>
-            </div>
+            />
           </DrawerPanelContent>
         </div>
       </DrawerMain>
@@ -175,87 +95,7 @@ exports[`Drawer isExpanded = false and isInline = true and isStatic = false 1`] 
             <div
               className="pf-c-drawer__panel"
               hidden={true}
-            >
-              <DrawerHead>
-                <DrawerPanelBody
-                  hasNoPadding={false}
-                >
-                  <div
-                    className="pf-c-drawer__body"
-                  >
-                    <div
-                      className="pf-c-drawer__head"
-                    >
-                      <span>
-                        drawer-panel
-                      </span>
-                      <DrawerActions>
-                        <div
-                          className="pf-c-drawer__actions"
-                        >
-                          <DrawerCloseButton>
-                            <div
-                              className="pf-c-drawer__close"
-                            >
-                              <Button
-                                aria-label="Close drawer panel"
-                                onClick={[Function]}
-                                variant="plain"
-                              >
-                                <button
-                                  aria-disabled={false}
-                                  aria-label="Close drawer panel"
-                                  className="pf-c-button pf-m-plain"
-                                  data-ouia-component-id={3}
-                                  data-ouia-component-type="PF4/Button"
-                                  data-ouia-safe={true}
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <TimesIcon
-                                    color="currentColor"
-                                    noVerticalAlign={false}
-                                    size="sm"
-                                  >
-                                    <svg
-                                      aria-hidden={true}
-                                      aria-labelledby={null}
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      style={
-                                        Object {
-                                          "verticalAlign": "-0.125em",
-                                        }
-                                      }
-                                      viewBox="0 0 352 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                        transform=""
-                                      />
-                                    </svg>
-                                  </TimesIcon>
-                                </button>
-                              </Button>
-                            </div>
-                          </DrawerCloseButton>
-                        </div>
-                      </DrawerActions>
-                    </div>
-                  </div>
-                </DrawerPanelBody>
-              </DrawerHead>
-              <DrawerPanelBody>
-                <div
-                  className="pf-c-drawer__body"
-                >
-                  drawer-panel
-                </div>
-              </DrawerPanelBody>
-            </div>
+            />
           </DrawerPanelContent>
         </div>
       </DrawerMain>
@@ -470,7 +310,7 @@ exports[`Drawer isExpanded = true and isInline = false and isStatic = true 1`] =
                                   aria-disabled={false}
                                   aria-label="Close drawer panel"
                                   className="pf-c-button pf-m-plain"
-                                  data-ouia-component-id={4}
+                                  data-ouia-component-id={2}
                                   data-ouia-component-type="PF4/Button"
                                   data-ouia-safe={true}
                                   disabled={false}
@@ -602,7 +442,7 @@ exports[`Drawer isExpanded = true and isInline = true and isStatic = false 1`] =
                                   aria-disabled={false}
                                   aria-label="Close drawer panel"
                                   className="pf-c-button pf-m-plain"
-                                  data-ouia-component-id={2}
+                                  data-ouia-component-id={1}
                                   data-ouia-component-type="PF4/Button"
                                   data-ouia-safe={true}
                                   disabled={false}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4498

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: The animation still works since `<div className="pf-c-drawer-panel">` is always rendered.