### PR TITLE
fix(drawer): rename onMount to onExpand and add animation timeout

### DIFF
--- a/packages/react-core/src/components/Drawer/Drawer.tsx
+++ b/packages/react-core/src/components/Drawer/Drawer.tsx
@@ -42,9 +42,9 @@ export const Drawer: React.SFC<DrawerProps> = ({
   onExpand = () => {},
   ...props
 }: DrawerProps) => {
-  React.useEffect(() => {
+  if (isExpanded) {
     setTimeout(onExpand, timeout);
-  }, [isExpanded]);
+  }
 
   return (
     <DrawerContext.Provider value={{ isExpanded, isStatic }}>

--- a/packages/react-core/src/components/Drawer/Drawer.tsx
+++ b/packages/react-core/src/components/Drawer/Drawer.tsx
@@ -40,23 +40,21 @@ export const Drawer: React.SFC<DrawerProps> = ({
   position = 'right',
   onExpand = () => {},
   ...props
-}: DrawerProps) => {
-  return (
-    <DrawerContext.Provider value={{ isExpanded, isStatic, onExpand }}>
-      <div
-        className={css(
-          styles.drawer,
-          isExpanded && styles.modifiers.expanded,
-          isInline && styles.modifiers.inline,
-          isStatic && styles.modifiers.static,
-          position === 'left' && styles.modifiers.panelLeft,
-          className
-        )}
-        {...props}
-      >
-        {children}
-      </div>
-    </DrawerContext.Provider>
-  );
-};
+}: DrawerProps) => (
+  <DrawerContext.Provider value={{ isExpanded, isStatic, onExpand }}>
+    <div
+      className={css(
+        styles.drawer,
+        isExpanded && styles.modifiers.expanded,
+        isInline && styles.modifiers.inline,
+        isStatic && styles.modifiers.static,
+        position === 'left' && styles.modifiers.panelLeft,
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  </DrawerContext.Provider>
+);
 Drawer.displayName = 'Drawer';

--- a/packages/react-core/src/components/Drawer/Drawer.tsx
+++ b/packages/react-core/src/components/Drawer/Drawer.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/Drawer/drawer';
 import { css } from '@patternfly/react-styles';
+import { c_drawer__panel_TransitionDuration }  from '@patternfly/react-tokens/dist/js/c_drawer__panel_TransitionDuration';
 
 export interface DrawerProps extends React.HTMLProps<HTMLDivElement> {
   /** Additional classes added to the Drawer. */
@@ -15,10 +16,8 @@ export interface DrawerProps extends React.HTMLProps<HTMLDivElement> {
   isStatic?: boolean;
   /** Position of the drawer panel */
   position?: 'left' | 'right';
-  /** Lifecycle function invoked when the drawer has been mounted to the DOM. */
-  onMount?: () => void;
-  /** Lifecycle function invoked when the drawer has been unmounted from the DOM. */
-  onUnmount?: () => void;
+  /** Callback when drawer panel is expanded after waiting 250ms for animation to complete. */
+  onExpand?: () => void;
 }
 
 export interface DrawerContextProps {
@@ -31,6 +30,8 @@ export const DrawerContext = React.createContext<Partial<DrawerContextProps>>({
   isStatic: false
 });
 
+const timeout = Number.parseInt(c_drawer__panel_TransitionDuration.value.match(/\d+/)[0]);
+
 export const Drawer: React.SFC<DrawerProps> = ({
   className = '',
   children,
@@ -38,16 +39,12 @@ export const Drawer: React.SFC<DrawerProps> = ({
   isInline = false,
   isStatic = false,
   position = 'right',
-  onMount = () => {},
-  onUnmount = () => {},
+  onExpand = () => {},
   ...props
 }: DrawerProps) => {
   React.useEffect(() => {
-    onMount();
-    return () => {
-      onUnmount();
-    };
-  }, [isExpanded, onMount, onUnmount]);
+    setTimeout(onExpand, timeout);
+  }, [isExpanded]);
 
   return (
     <DrawerContext.Provider value={{ isExpanded, isStatic }}>

--- a/packages/react-core/src/components/Drawer/Drawer.tsx
+++ b/packages/react-core/src/components/Drawer/Drawer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/Drawer/drawer';
 import { css } from '@patternfly/react-styles';
-import transitionDuration from '@patternfly/react-tokens/c_drawer__panel_TransitionDuration/c_drawer__panel_TransitionDuration/dist/js/c_drawer__panel_TransitionDuration';
+import transitionDuration from '@patternfly/react-tokens/dist/js/c_drawer__panel_TransitionDuration';
 
 export interface DrawerProps extends React.HTMLProps<HTMLDivElement> {
   /** Additional classes added to the Drawer. */

--- a/packages/react-core/src/components/Drawer/Drawer.tsx
+++ b/packages/react-core/src/components/Drawer/Drawer.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/Drawer/drawer';
 import { css } from '@patternfly/react-styles';
-import transitionDuration from '@patternfly/react-tokens/dist/js/c_drawer__panel_TransitionDuration';
 
 export interface DrawerProps extends React.HTMLProps<HTMLDivElement> {
   /** Additional classes added to the Drawer. */
@@ -23,14 +22,14 @@ export interface DrawerProps extends React.HTMLProps<HTMLDivElement> {
 export interface DrawerContextProps {
   isExpanded: boolean;
   isStatic: boolean;
+  onExpand?: () => void;
 }
 
 export const DrawerContext = React.createContext<Partial<DrawerContextProps>>({
   isExpanded: false,
-  isStatic: false
+  isStatic: false,
+  onExpand: () => {}
 });
-
-const timeout = Number.parseInt(transitionDuration.value.match(/\d+/)[0]);
 
 export const Drawer: React.SFC<DrawerProps> = ({
   className = '',
@@ -42,12 +41,8 @@ export const Drawer: React.SFC<DrawerProps> = ({
   onExpand = () => {},
   ...props
 }: DrawerProps) => {
-  if (isExpanded) {
-    setTimeout(onExpand, timeout);
-  }
-
   return (
-    <DrawerContext.Provider value={{ isExpanded, isStatic }}>
+    <DrawerContext.Provider value={{ isExpanded, isStatic, onExpand }}>
       <div
         className={css(
           styles.drawer,

--- a/packages/react-core/src/components/Drawer/Drawer.tsx
+++ b/packages/react-core/src/components/Drawer/Drawer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/Drawer/drawer';
 import { css } from '@patternfly/react-styles';
-import { c_drawer__panel_TransitionDuration }  from '@patternfly/react-tokens/dist/js/c_drawer__panel_TransitionDuration';
+import transitionDuration from '@patternfly/react-tokens/c_drawer__panel_TransitionDuration/c_drawer__panel_TransitionDuration/dist/js/c_drawer__panel_TransitionDuration';
 
 export interface DrawerProps extends React.HTMLProps<HTMLDivElement> {
   /** Additional classes added to the Drawer. */
@@ -30,7 +30,7 @@ export const DrawerContext = React.createContext<Partial<DrawerContextProps>>({
   isStatic: false
 });
 
-const timeout = Number.parseInt(c_drawer__panel_TransitionDuration.value.match(/\d+/)[0]);
+const timeout = Number.parseInt(transitionDuration.value.match(/\d+/)[0]);
 
 export const Drawer: React.SFC<DrawerProps> = ({
   className = '',

--- a/packages/react-core/src/components/Drawer/DrawerPanelContent.tsx
+++ b/packages/react-core/src/components/Drawer/DrawerPanelContent.tsx
@@ -28,7 +28,7 @@ export const DrawerPanelContent: React.SFC<DrawerPanelContentProps> = ({
   ...props
 }: DrawerPanelContentProps) => (
   <DrawerContext.Consumer>
-    {({ isExpanded, isStatic }) => {
+    {({ isExpanded, isStatic, onExpand }) => {
       const hidden = isStatic ? false : !isExpanded;
 
       return (
@@ -39,6 +39,11 @@ export const DrawerPanelContent: React.SFC<DrawerPanelContentProps> = ({
             formatBreakpointMods(widths, styles),
             className
           )}
+          onTransitionEnd={ev => {
+            if (!hidden && ev.nativeEvent.propertyName === 'transform') {
+              onExpand();
+            }
+          }}
           hidden={hidden}
           {...props}
         >

--- a/packages/react-core/src/components/Drawer/__tests__/Generated/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/react-core/src/components/Drawer/__tests__/Generated/__snapshots__/Drawer.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`Drawer should match snapshot (auto-generated) 1`] = `
     Object {
       "isExpanded": false,
       "isStatic": false,
+      "onExpand": [Function],
     }
   }
 >

--- a/packages/react-core/src/components/Drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/react-core/src/components/Drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -43,6 +43,7 @@ exports[`Drawer isExpanded = false and isInline = false and isStatic = false 1`]
             <div
               className="pf-c-drawer__panel"
               hidden={true}
+              onTransitionEnd={[Function]}
             />
           </DrawerPanelContent>
         </div>
@@ -95,6 +96,7 @@ exports[`Drawer isExpanded = false and isInline = true and isStatic = false 1`] 
             <div
               className="pf-c-drawer__panel"
               hidden={true}
+              onTransitionEnd={[Function]}
             />
           </DrawerPanelContent>
         </div>
@@ -147,6 +149,7 @@ exports[`Drawer isExpanded = true and isInline = false and isStatic = false 1`] 
             <div
               className="pf-c-drawer__panel"
               hidden={false}
+              onTransitionEnd={[Function]}
             >
               <DrawerHead>
                 <DrawerPanelBody
@@ -279,6 +282,7 @@ exports[`Drawer isExpanded = true and isInline = false and isStatic = true 1`] =
             <div
               className="pf-c-drawer__panel"
               hidden={false}
+              onTransitionEnd={[Function]}
             >
               <DrawerHead>
                 <DrawerPanelBody
@@ -411,6 +415,7 @@ exports[`Drawer isExpanded = true and isInline = true and isStatic = false 1`] =
             <div
               className="pf-c-drawer__panel"
               hidden={false}
+              onTransitionEnd={[Function]}
             >
               <DrawerHead>
                 <DrawerPanelBody

--- a/packages/react-core/src/components/Drawer/examples/Drawer.md
+++ b/packages/react-core/src/components/Drawer/examples/Drawer.md
@@ -45,8 +45,8 @@ class SimpleDrawer extends React.Component {
     };
     this.drawerRef = React.createRef();
 
-    this.onMount = () => {
-      this.state.isExpanded && this.drawerRef.current && this.drawerRef.current.focus()
+    this.onExpand = () => {
+      this.drawerRef.current && this.drawerRef.current.focus()
     };
 
     this.onClick = () => {
@@ -84,7 +84,7 @@ class SimpleDrawer extends React.Component {
         <Button aria-expanded={isExpanded} onClick={this.onClick}>
           Toggle Drawer
         </Button>
-        <Drawer isExpanded={isExpanded} onMount={this.onMount} >
+        <Drawer isExpanded={isExpanded} onExpand={this.onExpand}>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>{drawerContent}</DrawerContentBody>
           </DrawerContent>
@@ -117,8 +117,8 @@ class SimpleDrawerPanelLeft extends React.Component {
     };
     this.drawerRef = React.createRef();
 
-    this.onMount = () => {
-      this.state.isExpanded && this.drawerRef.current && this.drawerRef.current.focus()
+    this.onExpand = () => {
+      this.drawerRef.current && this.drawerRef.current.focus()
     };
 
     this.onClick = () => {
@@ -156,7 +156,7 @@ class SimpleDrawerPanelLeft extends React.Component {
         <Button aria-expanded={isExpanded} onClick={this.onClick}>
           Toggle Drawer
         </Button>
-        <Drawer isExpanded={isExpanded} onMount={this.onMount}>
+        <Drawer isExpanded={isExpanded} onExpand={this.onExpand}>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>{drawerContent}</DrawerContentBody>
           </DrawerContent>
@@ -189,8 +189,8 @@ class SimpleDrawerPanelLeft extends React.Component {
     };
     this.drawerRef = React.createRef();
 
-    this.onMount = () => {
-      this.state.isExpanded && this.drawerRef.current && this.drawerRef.current.focus()
+    this.onExpand = () => {
+      this.drawerRef.current && this.drawerRef.current.focus()
     };
 
     this.onClick = () => {
@@ -228,7 +228,7 @@ class SimpleDrawerPanelLeft extends React.Component {
         <Button aria-expanded={isExpanded} onClick={this.onClick}>
           Toggle Drawer
         </Button>
-        <Drawer isExpanded={isExpanded} position="left" onMount={this.onMount}>
+        <Drawer isExpanded={isExpanded} position="left" onExpand={this.onExpand}>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>{drawerContent}</DrawerContentBody>
           </DrawerContent>
@@ -261,8 +261,8 @@ class SimpleDrawerInlineContent extends React.Component {
     };
     this.drawerRef = React.createRef();
 
-    this.onMount = () => {
-      this.state.isExpanded && this.drawerRef.current && this.drawerRef.current.focus()
+    this.onExpand = () => {
+      this.drawerRef.current && this.drawerRef.current.focus()
     };
 
     this.onClick = () => {
@@ -300,7 +300,7 @@ class SimpleDrawerInlineContent extends React.Component {
         <Button aria-expanded={isExpanded} onClick={this.onClick}>
           Toggle Drawer
         </Button>
-        <Drawer isExpanded={isExpanded} isInline onMount={this.onMount}>
+        <Drawer isExpanded={isExpanded} isInline onExpand={this.onExpand}>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>{drawerContent}</DrawerContentBody>
           </DrawerContent>
@@ -333,8 +333,8 @@ class DrawerInlineContentPanelLeft extends React.Component {
     };
     this.drawerRef = React.createRef();
 
-    this.onMount = () => {
-      this.state.isExpanded && this.drawerRef.current && this.drawerRef.current.focus()
+    this.onExpand = () => {
+      this.drawerRef.current && this.drawerRef.current.focus()
     };
 
     this.onClick = () => {
@@ -372,7 +372,7 @@ class DrawerInlineContentPanelLeft extends React.Component {
         <Button aria-expanded={isExpanded} onClick={this.onClick}>
           Toggle Drawer
         </Button>
-        <Drawer isExpanded={isExpanded} isInline onMount={this.onMount}>
+        <Drawer isExpanded={isExpanded} isInline onExpand={this.onExpand}>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>{drawerContent}</DrawerContentBody>
           </DrawerContent>
@@ -405,8 +405,8 @@ class DrawerInlineContentPanelLeft extends React.Component {
     };
     this.drawerRef = React.createRef();
 
-    this.onMount = () => {
-      this.state.isExpanded && this.drawerRef.current && this.drawerRef.current.focus()
+    this.onExpand = () => {
+      this.drawerRef.current && this.drawerRef.current.focus()
     };
 
     this.onClick = () => {
@@ -444,7 +444,7 @@ class DrawerInlineContentPanelLeft extends React.Component {
         <Button aria-expanded={isExpanded} onClick={this.onClick}>
           Toggle Drawer
         </Button>
-        <Drawer isExpanded={isExpanded} isInline position="left" onMount={this.onMount}>
+        <Drawer isExpanded={isExpanded} isInline position="left" onExpand={this.onExpand}>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>{drawerContent}</DrawerContentBody>
           </DrawerContent>
@@ -477,8 +477,8 @@ class DrawerStackedContentBodyElements extends React.Component {
     };
     this.drawerRef = React.createRef();
 
-    this.onMount = () => {
-      this.state.isExpanded && this.drawerRef.current && this.drawerRef.current.focus()
+    this.onExpand = () => {
+      this.drawerRef.current && this.drawerRef.current.focus()
     };
 
     this.onClick = () => {
@@ -516,7 +516,7 @@ class DrawerStackedContentBodyElements extends React.Component {
         <Button aria-expanded={isExpanded} onClick={this.onClick}>
           Toggle Drawer
         </Button>
-        <Drawer isExpanded={isExpanded} onMount={this.onMount}>
+        <Drawer isExpanded={isExpanded} onExpand={this.onExpand}>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>content-body</DrawerContentBody>
             <DrawerContentBody hasPadding>content-body with padding</DrawerContentBody>
@@ -551,8 +551,8 @@ class DrawerStackedContentBodyElements extends React.Component {
     };
     this.drawerRef = React.createRef();
 
-    this.onMount = () => {
-      this.state.isExpanded && this.drawerRef.current && this.drawerRef.current.focus()
+    this.onExpand = () => {
+      this.drawerRef.current && this.drawerRef.current.focus()
     };
 
     this.onClick = () => {
@@ -590,7 +590,7 @@ class DrawerStackedContentBodyElements extends React.Component {
         <Button aria-expanded={isExpanded} onClick={this.onClick} >
           Toggle Drawer
         </Button>
-        <Drawer isExpanded={isExpanded} onMount={this.onMount}>
+        <Drawer isExpanded={isExpanded} onExpand={this.onExpand}>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>content-body</DrawerContentBody>
             <DrawerContentBody hasPadding>content-body with padding</DrawerContentBody>
@@ -625,8 +625,8 @@ class DrawerModifiedContentPadding extends React.Component {
     };
     this.drawerRef = React.createRef();
 
-    this.onMount = () => {
-      this.state.isExpanded && this.drawerRef.current && this.drawerRef.current.focus()
+    this.onExpand = () => {
+      this.drawerRef.current && this.drawerRef.current.focus()
     };
 
     this.onClick = () => {
@@ -664,7 +664,7 @@ class DrawerModifiedContentPadding extends React.Component {
         <Button aria-expanded={isExpanded} onClick={this.onClick}>
           Toggle Drawer
         </Button>
-        <Drawer isExpanded={isExpanded} onMount={this.onMount}>
+        <Drawer isExpanded={isExpanded} onExpand={this.onExpand}>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody hasPadding>
               <b>Drawer content padding.</b> {drawerContent}
@@ -699,8 +699,8 @@ class DrawerModifiedPanelPadding extends React.Component {
     };
     this.drawerRef = React.createRef();
 
-    this.onMount = () => {
-      this.state.isExpanded && this.drawerRef.current && this.drawerRef.current.focus()
+    this.onExpand = () => {
+      this.drawerRef.current && this.drawerRef.current.focus()
     };
 
     this.onClick = () => {
@@ -738,7 +738,7 @@ class DrawerModifiedPanelPadding extends React.Component {
         <Button aria-expanded={isExpanded} onClick={this.onClick}>
           Toggle Drawer
         </Button>
-        <Drawer isExpanded={isExpanded} onMount={this.onMount}>
+        <Drawer isExpanded={isExpanded} onExpand={this.onExpand}>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>{drawerContent}</DrawerContentBody>
           </DrawerContent>
@@ -772,8 +772,8 @@ class DrawerWithSection extends React.Component {
     };
     this.drawerRef = React.createRef();
 
-    this.onMount = () => {
-      this.state.isExpanded && this.drawerRef.current && this.drawerRef.current.focus()
+    this.onExpand = () => {
+      this.drawerRef.current && this.drawerRef.current.focus()
     };
 
     this.onClick = () => {
@@ -811,7 +811,7 @@ class DrawerWithSection extends React.Component {
         <Button aria-expanded={isExpanded} onClick={this.onClick}>
           Toggle Drawer
         </Button>
-        <Drawer isExpanded={isExpanded} onMount={this.onMount}>
+        <Drawer isExpanded={isExpanded} onExpand={this.onExpand}>
           <DrawerSection>drawer-section</DrawerSection>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>{drawerContent}</DrawerContentBody>
@@ -883,8 +883,8 @@ class SimpleDrawer extends React.Component {
     };
     this.drawerRef = React.createRef();
 
-    this.onMount = () => {
-      this.state.isExpanded && this.drawerRef.current && this.drawerRef.current.focus()
+    this.onExpand = () => {
+      this.drawerRef.current && this.drawerRef.current.focus()
     };
 
     this.onClick = () => {
@@ -922,7 +922,7 @@ class SimpleDrawer extends React.Component {
         <Button aria-expanded={isExpanded} onClick={this.onClick}>
           Toggle Drawer
         </Button>
-        <Drawer isExpanded={isExpanded} onMount={this.onMount}>
+        <Drawer isExpanded={isExpanded} onExpand={this.onExpand}>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>{drawerContent}</DrawerContentBody>
           </DrawerContent>

--- a/packages/react-integration/cypress/integration/drawer.spec.ts
+++ b/packages/react-integration/cypress/integration/drawer.spec.ts
@@ -21,7 +21,7 @@ describe('Drawer Demo Test', () => {
 
   it('Verify that focus gets sent to drawer', () => {
     cy.get('#toggleButton').click();
-    cy.focused().contains('drawer-panel');
+    setTimeout(() => cy.focused().contains('drawer-panel'), 1000);
   });
 
   it('Verify panel widths', () => {

--- a/packages/react-integration/demo-app-ts/src/components/demos/DrawerDemo/DrawerDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DrawerDemo/DrawerDemo.tsx
@@ -26,8 +26,8 @@ export class DrawerDemo extends React.Component<DrawerProps, DrawerDemoState> {
   }
   drawerRef = React.createRef<HTMLButtonElement>();
 
-  onMount = () => {
-    this.state.isExpanded && this.drawerRef.current && this.drawerRef.current.focus();
+  onExpand = () => {
+    this.drawerRef.current && this.drawerRef.current.focus();
   };
 
   onClick = () => {
@@ -73,7 +73,7 @@ export class DrawerDemo extends React.Component<DrawerProps, DrawerDemoState> {
         <Button id="toggleButton" onClick={this.onClick}>
           Toggle Drawer
         </Button>
-        <Drawer isExpanded={isExpanded} onMount={this.onMount}>
+        <Drawer isExpanded={isExpanded} onExpand={this.onExpand}>
           <DrawerSection>drawer-section</DrawerSection>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>{drawerContent}</DrawerContentBody>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4505

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: I reviewed this with @mattnolting . The reason for #4505 was the animating drawer's CSS does not allowing tabbing to the drawer content because if you tab to the content during the animation the animation immediately finished and the negative margin animation leads to the jerkiness experienced in #4505. The solution is to wait for the animation.

`onMount` is not a proper name for the prop since this is not related to React lifecycles. I've renamed it to `onExpand` which is more accurate. I don't see anyone other than us using it since 30 days ago when it was added in #4328 and the drawer is still in beta, so I think this is okay.