### PR TITLE
feat(ContextSelector): Add ability to render content before searchbar

### DIFF
--- a/packages/react-core/src/components/ContextSelector/ContextSelector.tsx
+++ b/packages/react-core/src/components/ContextSelector/ContextSelector.tsx
@@ -43,6 +43,8 @@ export interface ContextSelectorProps extends ToggleMenuBaseProps, OUIAProps {
   searchInputPlaceholder?: string;
   /** Function callback for when Search Button is clicked */
   onSearchButtonClick?: (event?: React.SyntheticEvent<HTMLButtonElement>) => void;
+  /** content that is inserted before the search bar filter */
+  menuHeader?: React.ReactNode;
 }
 
 export class ContextSelector extends React.Component<ContextSelectorProps> {
@@ -61,7 +63,8 @@ export class ContextSelector extends React.Component<ContextSelectorProps> {
     searchInputPlaceholder: 'Search',
     onSearchButtonClick: () => undefined as any,
     menuAppendTo: 'inline',
-    ouiaSafe: true
+    ouiaSafe: true,
+    menuHeader: null as React.ReactNode
   };
 
   parentRef: React.RefObject<HTMLDivElement> = React.createRef();
@@ -92,12 +95,15 @@ export class ContextSelector extends React.Component<ContextSelectorProps> {
       menuAppendTo,
       ouiaId,
       ouiaSafe,
+      menuHeader,
       ...props
     } = this.props;
+
     const menuContainer = (
       <div className={css(styles.contextSelectorMenu)}>
         {isOpen && (
           <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }}>
+            {menuHeader && <ContextSelectorMenuList isOpen={isOpen}>{menuHeader}</ContextSelectorMenuList>}
             <div className={css(styles.contextSelectorMenuSearch)}>
               <InputGroup>
                 <TextInput

--- a/packages/react-core/src/components/ContextSelector/__tests__/ContextSelector.test.tsx
+++ b/packages/react-core/src/components/ContextSelector/__tests__/ContextSelector.test.tsx
@@ -11,13 +11,25 @@ const items = [
   <ContextSelectorItem key="4">Azure</ContextSelectorItem>
 ];
 
+const menuHeader = (
+  <React.Fragment>
+    Projects:
+    <ContextSelectorItem onClick={e => this.onSelect(e, 'All projects')}>
+      All projects
+    </ContextSelectorItem>
+  </React.Fragment>
+);
 test('Renders ContextSelector', () => {
   const view = shallow(<ContextSelector> {items} </ContextSelector>);
   expect(view).toMatchSnapshot();
 });
 
 test('Renders ContextSelector open', () => {
-  const view = shallow(<ContextSelector isOpen> {items} </ContextSelector>);
+  const view = shallow(
+    <ContextSelector isOpen menuHeader={menuHeader}>
+      {items}
+    </ContextSelector>
+  );
   expect(view).toMatchSnapshot();
 });
 

--- a/packages/react-core/src/components/ContextSelector/__tests__/__snapshots__/ContextSelector.test.tsx.snap
+++ b/packages/react-core/src/components/ContextSelector/__tests__/__snapshots__/ContextSelector.test.tsx.snap
@@ -51,6 +51,20 @@ exports[`Renders ContextSelector open 1`] = `
       }
       paused={false}
     >
+      <ContextSelectorMenuList
+        className=""
+        isOpen={true}
+      >
+        Projects:
+        <ContextSelectorItem
+          className=""
+          isDisabled={false}
+          onClick={[Function]}
+          sendRef={[Function]}
+        >
+          All projects
+        </ContextSelectorItem>
+      </ContextSelectorMenuList>
       <div
         className="pf-c-context-selector__menu-search"
       >
@@ -89,7 +103,6 @@ exports[`Renders ContextSelector open 1`] = `
           className=""
           isOpen={true}
         >
-           
           <ContextSelectorItem
             className=""
             isDisabled={false}
@@ -135,7 +148,6 @@ exports[`Renders ContextSelector open 1`] = `
           >
             Azure
           </ContextSelectorItem>
-           
         </ContextSelectorMenuList>
       </ContextProvider>
     </FocusTrap>

--- a/packages/react-core/src/components/ContextSelector/examples/ContextSelector.md
+++ b/packages/react-core/src/components/ContextSelector/examples/ContextSelector.md
@@ -6,7 +6,9 @@ ouia: true
 ---
 
 ## Examples
+
 ### Basic
+
 ```js
 import React from 'react';
 import { ContextSelector, ContextSelectorItem } from '@patternfly/react-core';
@@ -76,6 +78,95 @@ class SimpleContextSelector extends React.Component {
       >
         {filteredItems.map((item, index) => (
           <ContextSelectorItem key={index}>{item}</ContextSelectorItem>
+        ))}
+      </ContextSelector>
+    );
+  }
+}
+```
+
+### With menu header
+
+```js
+import React from 'react';
+import { ContextSelector, ContextSelectorItem, Title } from '@patternfly/react-core';
+
+class ContextSelectorWithBeforeSearch extends React.Component {
+  constructor(props) {
+    super(props);
+    this.items = [
+      'My Project',
+      'OpenShift Cluster',
+      'Production Ansible',
+      'AWS',
+      'Azure',
+      'My Project 2',
+      'OpenShift Cluster ',
+      'Production Ansible 2 ',
+      'AWS 2',
+      'Azure 2'
+    ];
+
+    this.state = {
+      isOpen: false,
+      selected: this.items[0],
+      searchValue: '',
+      filteredItems: this.items
+    };
+
+    this.onToggle = (event, isOpen) => {
+      this.setState({
+        isOpen
+      });
+    };
+
+    this.onSelect = (event, value) => {
+      this.setState({
+        selected: value,
+        isOpen: !this.state.isOpen
+      });
+    };
+
+    this.onSearchInputChange = value => {
+      this.setState({ searchValue: value });
+    };
+
+    this.onSearchButtonClick = event => {
+      const filtered =
+        this.state.searchValue === ''
+          ? this.items
+          : this.items.filter(str => str.toLowerCase().indexOf(this.state.searchValue.toLowerCase()) !== -1);
+
+      this.setState({ filteredItems: filtered || [] });
+    };
+  }
+
+  render() {
+    const { isOpen, selected, searchValue, filteredItems } = this.state;
+    const menuHeader = (
+      <React.Fragment>
+        <Title headingLevel="h6" size="md" style={{ paddingLeft: '5px' }}>
+          Projects:
+        </Title>
+        <ContextSelectorItem onClick={e => this.onSelect(e, 'All projects')} key={0}>
+          All projects
+        </ContextSelectorItem>
+      </React.Fragment>
+    );
+    return (
+      <ContextSelector
+        toggleText={selected}
+        onSearchInputChange={this.onSearchInputChange}
+        isOpen={isOpen}
+        searchInputValue={searchValue}
+        onToggle={this.onToggle}
+        onSelect={this.onSelect}
+        onSearchButtonClick={this.onSearchButtonClick}
+        screenReaderLabel="Selected Project:"
+        menuHeader={menuHeader}
+      >
+        {filteredItems.map((item, index) => (
+          <ContextSelectorItem key={index + 1}>{item}</ContextSelectorItem>
         ))}
       </ContextSelector>
     );


### PR DESCRIPTION
Adds the ability to render custom content before the search bar - good for titling the context selector, adding non filterable items, adding 'add project' buttons and more.
Added a storybook item as an example for title + non filterable item