### PR TITLE
fix(topology): create connector drag spec configuration

### DIFF
--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/Selection.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/Selection.tsx
@@ -151,7 +151,7 @@ export const Performance: React.FC = withTopologySetup(() => {
       const widget = defaultComponentFactory(kind, type);
       if (kind === ModelKind.node || kind === ModelKind.graph) {
         // TODO fix any type
-        return withSelection({ multiSelect: true, controlled: false })(widget as any);
+        return withSelection({ multiSelect: true, controlled: false, raiseOnSelect: false })(widget as any);
       }
       return widget;
     }, [])

--- a/packages/react-topology/src/behavior/useSelection.tsx
+++ b/packages/react-topology/src/behavior/useSelection.tsx
@@ -21,7 +21,7 @@ interface Options {
   raiseOnSelect?: boolean;
 }
 
-export const useSelection = ({ multiSelect, controlled, raiseOnSelect }: Options = {}): [boolean, OnSelect] => {
+export const useSelection = ({ multiSelect, controlled, raiseOnSelect = true }: Options = {}): [boolean, OnSelect] => {
   const element = React.useContext(ElementContext);
   const elementRef = React.useRef(element);
   elementRef.current = element;

--- a/packages/react-topology/src/behavior/withCreateConnector.tsx
+++ b/packages/react-topology/src/behavior/withCreateConnector.tsx
@@ -26,6 +26,8 @@ export interface ConnectorChoice {
 export interface CreateConnectorOptions {
   handleAngle?: number;
   handleLength?: number;
+  dragItem?: DragObjectWithType;
+  dragOperation?: DragOperationWithType;
 }
 
 interface ConnectorComponentProps {
@@ -80,7 +82,9 @@ const CreateConnectorWidget: React.FC<CreateConnectorWidgetProps> = observer(pro
     ConnectorComponent,
     handleAngle = DEFAULT_HANDLE_ANGLE,
     handleLength = DEFAULT_HANDLE_LENGTH,
-    contextMenuClass
+    contextMenuClass,
+    dragItem,
+    dragOperation
   } = props;
   const [prompt, setPrompt] = React.useState<PromptData | null>(null);
   const [active, setActive] = React.useState(false);
@@ -94,8 +98,8 @@ const CreateConnectorWidget: React.FC<CreateConnectorWidgetProps> = observer(pro
       CollectProps,
       CreateConnectorWidgetProps
     > = {
-      item: { type: CREATE_CONNECTOR_DROP_TYPE },
-      operation: { type: CREATE_CONNECTOR_OPERATION },
+      item: dragItem || { type: CREATE_CONNECTOR_DROP_TYPE },
+      operation: dragOperation || { type: CREATE_CONNECTOR_OPERATION },
       begin: (monitor: DragSourceMonitor, dragProps: any) => {
         setActive(true);
         return dragProps.element;
@@ -122,7 +126,7 @@ const CreateConnectorWidget: React.FC<CreateConnectorWidgetProps> = observer(pro
       })
     };
     return dragSourceSpec;
-  }, [setActive]);
+  }, [setActive, dragItem, dragOperation]);
   const [{ dragging, event, hints }, dragRef] = useDndDrag(spec, props);
 
   if (!active && dragging && !event) {

--- a/packages/react-topology/src/components/VisualizationSurface.tsx
+++ b/packages/react-topology/src/components/VisualizationSurface.tsx
@@ -16,7 +16,6 @@ import useVisualizationController from '../hooks/useVisualizationController';
 import '@patternfly/react-styles/css/components/Topology/topology-components.css';
 
 interface VisualizationSurfaceProps {
-  visualization?: Controller;
   state?: State;
   children?: React.ReactNode;
 }


### PR DESCRIPTION
This change addresses some missing functionality in the topology migration along with fixing types and default values.

- Add options to `withCreateConnector` to allow configuration of the drag item and operation.
- Removed unused prop from `VisualizationSurfaceProps` which was part of the old API.
- Fixed `raiseOnSelect` to default to `true` which was the old default before the selection API changes.

cc @jeff-phillips-18 