### PR TITLE
feat(Table actions): allow custom properties for actions

### DIFF
--- a/packages/react-table/src/components/Table/ActionsColumn.tsx
+++ b/packages/react-table/src/components/Table/ActionsColumn.tsx
@@ -67,7 +67,7 @@ export class ActionsColumn extends React.Component<ActionsColumnProps, ActionsCo
 
   render() {
     const { isOpen } = this.state;
-    const { items, children, dropdownPosition, dropdownDirection, isDisabled } = this.props;
+    const { items, children, dropdownPosition, dropdownDirection, isDisabled, rowData } = this.props;
     return (
       <React.Fragment>
         <Dropdown
@@ -91,6 +91,7 @@ export class ActionsColumn extends React.Component<ActionsColumnProps, ActionsCo
             )
           )}
           isPlain
+          {...(rowData && rowData.actionProps)}
         />
         {children}
       </React.Fragment>

--- a/packages/react-table/src/components/Table/examples/Table.md
+++ b/packages/react-table/src/components/Table/examples/Table.md
@@ -551,10 +551,17 @@ class ActionsTable extends React.Component {
       rows: [
         {
           cells: ['one', 'two', 'a', 'four', 'five'],
-          type: 'green'
+          type: 'green',
+          actionProps: {
+            dropdownPosition: 'right',
+            dropdownDirection: 'up'
+          }
         },
         {
-          cells: ['a', 'two', 'k', 'four', 'five']
+          cells: ['a', 'two', 'k', 'four', 'five'],
+          actionProps: {
+            'data-specific-attr': 'some-value'
+          }
         },
         {
           cells: ['p', 'two', 'b', 'four', 'five'],


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
If consumers would want to add custom className or specific attribute to actions dropdown they would be out of luck, this PR adds option to override any dropdown property in actions column. Meaning even dropdown direction and position, or custom classes, additional props and even ifthere is need to change the toggle or other properties they can do that.

<!-- Are there any upstream issues or separate issues you need to reference? -->
Fixes: https://github.com/patternfly/patternfly-react/issues/4561
