### PR TITLE
fix(Toolbar*): change spelling of visiblity prop

### DIFF
--- a/packages/react-core/src/components/Toolbar/ToolbarContent.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarContent.tsx
@@ -9,6 +9,14 @@ export interface ToolbarContentProps extends React.HTMLProps<HTMLDivElement> {
   /** Classes applied to root element of the data toolbar content row */
   className?: string;
   /** Visibility at various breakpoints. */
+  visibility?: {
+    default?: 'hidden' | 'visible';
+    md?: 'hidden' | 'visible';
+    lg?: 'hidden' | 'visible';
+    xl?: 'hidden' | 'visible';
+    '2xl'?: 'hidden' | 'visible';
+  };
+  /** Deprecated: prop misspelled */
   visiblity?: {
     default?: 'hidden' | 'visible';
     md?: 'hidden' | 'visible';
@@ -55,6 +63,7 @@ export class ToolbarContent extends React.Component<ToolbarContentProps> {
       children,
       isExpanded,
       toolbarId,
+      visibility,
       visiblity,
       alignment,
       clearAllFilters,
@@ -63,11 +72,19 @@ export class ToolbarContent extends React.Component<ToolbarContentProps> {
       ...props
     } = this.props;
 
+    if (visiblity !== undefined) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'The ToolbarContent visiblity prop has been deprecated. ' +
+          'Please use the correctly spelled visibility prop instead.'
+      );
+    }
+
     return (
       <div
         className={css(
           styles.toolbarContent,
-          formatBreakpointMods(visiblity, styles),
+          formatBreakpointMods(visibility || visiblity, styles),
           formatBreakpointMods(alignment, styles),
           className
         )}

--- a/packages/react-core/src/components/Toolbar/ToolbarGroup.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarGroup.tsx
@@ -15,6 +15,14 @@ export interface ToolbarGroupProps extends Omit<React.HTMLProps<HTMLDivElement>,
   /** A type modifier which modifies spacing specifically depending on the type of group */
   variant?: ToolbarGroupVariant | 'filter-group' | 'icon-button-group' | 'button-group';
   /** Visibility at various breakpoints. */
+  visibility?: {
+    default?: 'hidden' | 'visible';
+    md?: 'hidden' | 'visible';
+    lg?: 'hidden' | 'visible';
+    xl?: 'hidden' | 'visible';
+    '2xl'?: 'hidden' | 'visible';
+  };
+  /** Deprecated: prop misspelled */
   visiblity?: {
     default?: 'hidden' | 'visible';
     md?: 'hidden' | 'visible';
@@ -54,13 +62,33 @@ export interface ToolbarGroupProps extends Omit<React.HTMLProps<HTMLDivElement>,
 
 class ToolbarGroupWithRef extends React.Component<ToolbarGroupProps> {
   render() {
-    const { visiblity, alignment, spacer, spaceItems, className, variant, children, innerRef, ...props } = this.props;
+    const {
+      visibility,
+      visiblity,
+      alignment,
+      spacer,
+      spaceItems,
+      className,
+      variant,
+      children,
+      innerRef,
+      ...props
+    } = this.props;
+
+    if (visiblity !== undefined) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'The ToolbarGroup visiblity prop has been deprecated. ' +
+          'Please use the correctly spelled visibility prop instead.'
+      );
+    }
+
     return (
       <div
         className={css(
           styles.toolbarGroup,
           variant && styles.modifiers[toCamel(variant) as 'filterGroup' | 'iconButtonGroup' | 'buttonGroup'],
-          formatBreakpointMods(visiblity, styles),
+          formatBreakpointMods(visibility || visiblity, styles),
           formatBreakpointMods(alignment, styles),
           formatBreakpointMods(spacer, styles),
           formatBreakpointMods(spaceItems, styles),

--- a/packages/react-core/src/components/Toolbar/ToolbarItem.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarItem.tsx
@@ -29,6 +29,14 @@ export interface ToolbarItemProps extends React.HTMLProps<HTMLDivElement> {
     | 'chip-group'
     | 'separator';
   /** Visibility at various breakpoints. */
+  visibility?: {
+    default?: 'hidden' | 'visible';
+    md?: 'hidden' | 'visible';
+    lg?: 'hidden' | 'visible';
+    xl?: 'hidden' | 'visible';
+    '2xl'?: 'hidden' | 'visible';
+  };
+  /** Deprecated: prop misspelled */
   visiblity?: {
     default?: 'hidden' | 'visible';
     md?: 'hidden' | 'visible';
@@ -61,6 +69,7 @@ export interface ToolbarItemProps extends React.HTMLProps<HTMLDivElement> {
 export const ToolbarItem: React.FunctionComponent<ToolbarItemProps> = ({
   className,
   variant,
+  visibility,
   visiblity,
   alignment,
   spacer,
@@ -72,6 +81,14 @@ export const ToolbarItem: React.FunctionComponent<ToolbarItemProps> = ({
     return <Divider className={css(styles.modifiers.vertical, className)} {...props} />;
   }
 
+  if (visiblity !== undefined) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'The ToolbarItem visiblity prop has been deprecated. ' +
+        'Please use the correctly spelled visibility prop instead.'
+    );
+  }
+
   return (
     <div
       className={css(
@@ -80,7 +97,7 @@ export const ToolbarItem: React.FunctionComponent<ToolbarItemProps> = ({
           styles.modifiers[
             toCamel(variant) as 'bulkSelect' | 'overflowMenu' | 'pagination' | 'searchFilter' | 'label' | 'chipGroup'
           ],
-        formatBreakpointMods(visiblity, styles),
+        formatBreakpointMods(visibility || visiblity, styles),
         formatBreakpointMods(alignment, styles),
         formatBreakpointMods(spacer, styles),
         className

--- a/packages/react-core/src/components/Toolbar/ToolbarToggleGroup.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarToggleGroup.tsx
@@ -15,6 +15,14 @@ export interface ToolbarToggleGroupProps extends ToolbarGroupProps {
   /** Controls when filters are shown and when the toggle button is hidden. */
   breakpoint: 'md' | 'lg' | 'xl' | '2xl';
   /** Visibility at various breakpoints. */
+  visibility?: {
+    default?: 'hidden' | 'visible';
+    md?: 'hidden' | 'visible';
+    lg?: 'hidden' | 'visible';
+    xl?: 'hidden' | 'visible';
+    '2xl'?: 'hidden' | 'visible';
+  };
+  /** Deprecated: prop misspelled */
   visiblity?: {
     default?: 'hidden' | 'visible';
     md?: 'hidden' | 'visible';
@@ -60,6 +68,7 @@ export class ToolbarToggleGroup extends React.Component<ToolbarToggleGroupProps>
     const {
       toggleIcon,
       variant,
+      visibility,
       visiblity,
       breakpoint,
       alignment,
@@ -73,6 +82,14 @@ export class ToolbarToggleGroup extends React.Component<ToolbarToggleGroupProps>
     if (!breakpoint && !toggleIcon) {
       // eslint-disable-next-line no-console
       console.error('ToolbarToggleGroup will not be visible without a breakpoint or toggleIcon.');
+    }
+
+    if (visiblity !== undefined) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'The ToolbarToggleGroup visiblity prop has been deprecated. ' +
+          'Please use the correctly spelled visibility prop instead.'
+      );
     }
 
     return (
@@ -102,7 +119,7 @@ export class ToolbarToggleGroup extends React.Component<ToolbarToggleGroupProps>
                           | 'showOnXl'
                           | 'showOn_2xl'
                       ],
-                    formatBreakpointMods(visiblity, styles),
+                    formatBreakpointMods(visibility || visiblity, styles),
                     formatBreakpointMods(alignment, styles),
                     formatBreakpointMods(spacer, styles),
                     formatBreakpointMods(spaceItems, styles),

--- a/packages/react-integration/demo-app-ts/src/Demos.ts
+++ b/packages/react-integration/demo-app-ts/src/Demos.ts
@@ -667,6 +667,16 @@ export const Demos: DemoInterface[] = [
     componentType: Examples.ToolbarDemo
   },
   {
+    id: 'toolbar-visibility-demo',
+    name: 'Toolbar Visibility Demo',
+    componentType: Examples.ToolbarVisibilityDemo
+  },
+  {
+    id: 'toolbar-visiblity-demo',
+    name: 'Toolbar Visiblity Demo (Deprecated)',
+    componentType: Examples.ToolbarVisiblityDemo
+  },
+  {
     id: 'tooltip-demo',
     name: 'Tooltip Demo',
     componentType: Examples.TooltipDemo

--- a/packages/react-integration/demo-app-ts/src/components/demos/ToolbarDemo/ToolbarVisibilityDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/ToolbarDemo/ToolbarVisibilityDemo.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { Toolbar, ToolbarContent, ToolbarGroup, ToolbarItem, ToolbarToggleGroup } from '@patternfly/react-core';
+import FilterIcon from '@patternfly/react-icons/dist/js/icons/filter-icon';
+
+export class ToolbarVisibilityDemo extends React.Component {
+  static displayName = 'ToolbarVisibilityDemo';
+
+  render() {
+    const toolbarContents = (
+      <React.Fragment>
+        <ToolbarContent visibility={{ default: 'visible', md: 'hidden' }}>ToolbarContent visibility sm</ToolbarContent>
+        <ToolbarContent visibility={{ default: 'hidden', md: 'visible', lg: 'hidden' }}>
+          ToolbarContent visibility md
+        </ToolbarContent>
+        <ToolbarContent visibility={{ default: 'hidden', lg: 'visible', xl: 'hidden' }}>
+          ToolbarContent visibility lg
+        </ToolbarContent>
+        <ToolbarContent visibility={{ default: 'hidden', xl: 'visible', '2xl': 'hidden' }}>
+          ToolbarContent visibility xl
+        </ToolbarContent>
+        <ToolbarContent visibility={{ default: 'hidden', '2xl': 'visible' }}>
+          ToolbarContent visibility 2xl
+        </ToolbarContent>
+      </React.Fragment>
+    );
+
+    const toolbarGroups = (
+      <React.Fragment>
+        <ToolbarGroup visibility={{ default: 'visible', md: 'hidden' }}>ToolbarGroup visibility sm</ToolbarGroup>
+        <ToolbarGroup visibility={{ default: 'hidden', md: 'visible', lg: 'hidden' }}>
+          ToolbarGroup visibility md
+        </ToolbarGroup>
+        <ToolbarGroup visibility={{ default: 'hidden', lg: 'visible', xl: 'hidden' }}>
+          ToolbarGroup visibility lg
+        </ToolbarGroup>
+        <ToolbarGroup visibility={{ default: 'hidden', xl: 'visible', '2xl': 'hidden' }}>
+          ToolbarGroup visibility xl
+        </ToolbarGroup>
+        <ToolbarGroup visibility={{ default: 'hidden', '2xl': 'visible' }}>ToolbarGroup visibility 2xl</ToolbarGroup>
+      </React.Fragment>
+    );
+
+    const toolbarItems = (
+      <React.Fragment>
+        <ToolbarItem visibility={{ default: 'visible', md: 'hidden' }}>ToolbarItem visibility sm</ToolbarItem>
+        <ToolbarItem visibility={{ default: 'hidden', md: 'visible', lg: 'hidden' }}>
+          ToolbarItem visibility md
+        </ToolbarItem>
+        <ToolbarItem visibility={{ default: 'hidden', lg: 'visible', xl: 'hidden' }}>
+          ToolbarItem visibility lg
+        </ToolbarItem>
+        <ToolbarItem visibility={{ default: 'hidden', xl: 'visible', '2xl': 'hidden' }}>
+          ToolbarItem visibility xl
+        </ToolbarItem>
+        <ToolbarItem visibility={{ default: 'hidden', '2xl': 'visible' }}>ToolbarItem visibility 2xl</ToolbarItem>
+      </React.Fragment>
+    );
+
+    const toolbarToggleGroups = (
+      <React.Fragment>
+        <Toolbar>
+          <ToolbarContent>
+            <ToolbarToggleGroup
+              toggleIcon={<FilterIcon />}
+              breakpoint="md"
+              visibility={{ default: 'visible', md: 'hidden' }}
+            >
+              ToolbarToggleGroup visibility sm
+            </ToolbarToggleGroup>
+          </ToolbarContent>
+        </Toolbar>
+        <Toolbar>
+          <ToolbarContent>
+            <ToolbarToggleGroup
+              toggleIcon={<FilterIcon />}
+              breakpoint="lg"
+              visibility={{ default: 'hidden', md: 'visible', lg: 'hidden' }}
+            >
+              ToolbarToggleGroup visibility md
+            </ToolbarToggleGroup>
+          </ToolbarContent>
+        </Toolbar>
+        <Toolbar>
+          <ToolbarContent>
+            <ToolbarToggleGroup
+              toggleIcon={<FilterIcon />}
+              breakpoint="xl"
+              visibility={{ default: 'hidden', lg: 'visible', xl: 'hidden' }}
+            >
+              ToolbarToggleGroup visibility lg
+            </ToolbarToggleGroup>
+          </ToolbarContent>
+        </Toolbar>
+        <Toolbar>
+          <ToolbarContent>
+            <ToolbarToggleGroup
+              toggleIcon={<FilterIcon />}
+              breakpoint="2xl"
+              visibility={{ default: 'hidden', xl: 'visible', '2xl': 'hidden' }}
+            >
+              ToolbarToggleGroup visibility xl
+            </ToolbarToggleGroup>
+          </ToolbarContent>
+        </Toolbar>
+        <Toolbar>
+          <ToolbarContent>
+            <ToolbarToggleGroup
+              toggleIcon={<FilterIcon />}
+              breakpoint="md"
+              visibility={{ default: 'hidden', '2xl': 'visible' }}
+            >
+              ToolbarToggleGroup visibility 2xl
+            </ToolbarToggleGroup>
+          </ToolbarContent>
+        </Toolbar>
+      </React.Fragment>
+    );
+
+    return (
+      <div id="toolbar-visibility-demo">
+        <Toolbar>{toolbarContents}</Toolbar>
+        <Toolbar>
+          <ToolbarContent>{toolbarGroups}</ToolbarContent>
+        </Toolbar>
+        <Toolbar>
+          <ToolbarContent>{toolbarItems}</ToolbarContent>
+        </Toolbar>
+        {toolbarToggleGroups}
+      </div>
+    );
+  }
+}

--- a/packages/react-integration/demo-app-ts/src/components/demos/ToolbarDemo/ToolbarVisiblityDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/ToolbarDemo/ToolbarVisiblityDemo.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { Toolbar, ToolbarContent, ToolbarGroup, ToolbarItem, ToolbarToggleGroup } from '@patternfly/react-core';
+import FilterIcon from '@patternfly/react-icons/dist/js/icons/filter-icon';
+
+export class ToolbarVisiblityDemo extends React.Component {
+  static displayName = 'ToolbarVisibilityDemo';
+
+  render() {
+    const toolbarContents = (
+      <React.Fragment>
+        <ToolbarContent visiblity={{ default: 'visible', md: 'hidden' }}>ToolbarContent visiblity sm</ToolbarContent>
+        <ToolbarContent visiblity={{ default: 'hidden', md: 'visible', lg: 'hidden' }}>
+          ToolbarContent visiblity md
+        </ToolbarContent>
+        <ToolbarContent visiblity={{ default: 'hidden', lg: 'visible', xl: 'hidden' }}>
+          ToolbarContent visiblity lg
+        </ToolbarContent>
+        <ToolbarContent visiblity={{ default: 'hidden', xl: 'visible', '2xl': 'hidden' }}>
+          ToolbarContent visiblity xl
+        </ToolbarContent>
+        <ToolbarContent visiblity={{ default: 'hidden', '2xl': 'visible' }}>
+          ToolbarContent visiblity 2xl
+        </ToolbarContent>
+      </React.Fragment>
+    );
+
+    const toolbarGroups = (
+      <React.Fragment>
+        <ToolbarGroup visiblity={{ default: 'visible', md: 'hidden' }}>ToolbarGroup visiblity sm</ToolbarGroup>
+        <ToolbarGroup visiblity={{ default: 'hidden', md: 'visible', lg: 'hidden' }}>
+          ToolbarGroup visiblity md
+        </ToolbarGroup>
+        <ToolbarGroup visiblity={{ default: 'hidden', lg: 'visible', xl: 'hidden' }}>
+          ToolbarGroup visiblity lg
+        </ToolbarGroup>
+        <ToolbarGroup visiblity={{ default: 'hidden', xl: 'visible', '2xl': 'hidden' }}>
+          ToolbarGroup visiblity xl
+        </ToolbarGroup>
+        <ToolbarGroup visiblity={{ default: 'hidden', '2xl': 'visible' }}>ToolbarGroup visiblity 2xl</ToolbarGroup>
+      </React.Fragment>
+    );
+
+    const toolbarItems = (
+      <React.Fragment>
+        <ToolbarItem visiblity={{ default: 'visible', md: 'hidden' }}>ToolbarItem visiblity sm</ToolbarItem>
+        <ToolbarItem visiblity={{ default: 'hidden', md: 'visible', lg: 'hidden' }}>
+          ToolbarItem visiblity md
+        </ToolbarItem>
+        <ToolbarItem visiblity={{ default: 'hidden', lg: 'visible', xl: 'hidden' }}>
+          ToolbarItem visiblity lg
+        </ToolbarItem>
+        <ToolbarItem visiblity={{ default: 'hidden', xl: 'visible', '2xl': 'hidden' }}>
+          ToolbarItem visiblity xl
+        </ToolbarItem>
+        <ToolbarItem visiblity={{ default: 'hidden', '2xl': 'visible' }}>ToolbarItem visiblity 2xl</ToolbarItem>
+      </React.Fragment>
+    );
+
+    const toolbarToggleGroups = (
+      <React.Fragment>
+        <Toolbar>
+          <ToolbarContent>
+            <ToolbarToggleGroup
+              toggleIcon={<FilterIcon />}
+              breakpoint="md"
+              visiblity={{ default: 'visible', md: 'hidden' }}
+            >
+              ToolbarToggleGroup visiblity sm
+            </ToolbarToggleGroup>
+          </ToolbarContent>
+        </Toolbar>
+        <Toolbar>
+          <ToolbarContent>
+            <ToolbarToggleGroup
+              toggleIcon={<FilterIcon />}
+              breakpoint="lg"
+              visiblity={{ default: 'hidden', md: 'visible', lg: 'hidden' }}
+            >
+              ToolbarToggleGroup visiblity md
+            </ToolbarToggleGroup>
+          </ToolbarContent>
+        </Toolbar>
+        <Toolbar>
+          <ToolbarContent>
+            <ToolbarToggleGroup
+              toggleIcon={<FilterIcon />}
+              breakpoint="xl"
+              visiblity={{ default: 'hidden', lg: 'visible', xl: 'hidden' }}
+            >
+              ToolbarToggleGroup visiblity lg
+            </ToolbarToggleGroup>
+          </ToolbarContent>
+        </Toolbar>
+        <Toolbar>
+          <ToolbarContent>
+            <ToolbarToggleGroup
+              toggleIcon={<FilterIcon />}
+              breakpoint="2xl"
+              visiblity={{ default: 'hidden', xl: 'visible', '2xl': 'hidden' }}
+            >
+              ToolbarToggleGroup visiblity xl
+            </ToolbarToggleGroup>
+          </ToolbarContent>
+        </Toolbar>
+        <Toolbar>
+          <ToolbarContent>
+            <ToolbarToggleGroup
+              toggleIcon={<FilterIcon />}
+              breakpoint="md"
+              visiblity={{ default: 'hidden', '2xl': 'visible' }}
+            >
+              ToolbarToggleGroup visiblity 2xl
+            </ToolbarToggleGroup>
+          </ToolbarContent>
+        </Toolbar>
+      </React.Fragment>
+    );
+
+    return (
+      <div id="toolbar-visiblity-demo">
+        <Toolbar>{toolbarContents}</Toolbar>
+        <Toolbar>
+          <ToolbarContent>{toolbarGroups}</ToolbarContent>
+        </Toolbar>
+        <Toolbar>
+          <ToolbarContent>{toolbarItems}</ToolbarContent>
+        </Toolbar>
+        {toolbarToggleGroups}
+      </div>
+    );
+  }
+}

--- a/packages/react-integration/demo-app-ts/src/components/demos/index.ts
+++ b/packages/react-integration/demo-app-ts/src/components/demos/index.ts
@@ -33,6 +33,8 @@ export * from './ClipboardCopyDemo/ClipboardCopyExpandedDemo';
 export * from './DataListDemo/DataListDemo';
 export * from './DataListDemo/DataListCompactDemo';
 export * from './ToolbarDemo/ToolbarDemo';
+export * from './ToolbarDemo/ToolbarVisibilityDemo';
+export * from './ToolbarDemo/ToolbarVisiblityDemo';
 export * from './DividerDemo/DividerDemo';
 export * from './DividerDemo/DividerInsetDemo';
 export * from './DonutChartDemo/DonutBottomAlignedLegendDemo';


### PR DESCRIPTION
- deprecate visiblity prop in ToolbarItem, ToolbarContent, ToolbarGroup, and ToolbarToggleGroup
- add visibility prop in ToolbarItem, ToolbarContent, ToolbarGroup, and ToolbarToggleGroup

fix #4501 