### PR TITLE
docs(Dropdown.md): update dropdown with image example to use an Avatar

### DIFF
--- a/packages/react-core/src/components/Dropdown/examples/Dropdown.md
+++ b/packages/react-core/src/components/Dropdown/examples/Dropdown.md
@@ -1164,13 +1164,14 @@ class RouterDropdown extends React.Component {
 ```js title=Dropdown-with-image-and-text
 import React from 'react';
 import {
+  Avatar,
   Dropdown,
   DropdownGroup,
   DropdownToggle,
   DropdownItem,
   DropdownSeparator
 } from '@patternfly/react-core';
-import { UserIcon } from '@patternfly/react-icons';
+import avatarImg from '../../Avatar/examples/avatarImg.svg';
 
 class ImageTextDropdown extends React.Component {
   constructor(props) {
@@ -1219,7 +1220,7 @@ class ImageTextDropdown extends React.Component {
             id="toggle-id-9"
             onToggle={this.onToggle}
             toggleIndicator={CaretDownIcon}
-            icon={<UserIcon />}
+            icon={<Avatar src={avatarImg} alt="avatar"></Avatar>}
           >
             Ned Username
           </DropdownToggle>


### PR DESCRIPTION
- update the dropdown with image example to use an Avatar instead of a UserIcon

re #4551
