### PR TITLE
fix(pageheader): use the correct type for the page context

### DIFF
--- a/packages/react-core/src/components/Page/Page.tsx
+++ b/packages/react-core/src/components/Page/Page.tsx
@@ -9,7 +9,18 @@ export enum PageLayouts {
   horizontal = 'horizontal'
 }
 
-const PageContext = React.createContext({});
+export interface PageContextProps {
+  isManagedSidebar: boolean;
+  onNavToggle: () => void;
+  isNavOpen: boolean;
+}
+
+const PageContext = React.createContext<PageContextProps>({
+  isManagedSidebar: false,
+  isNavOpen: false,
+  onNavToggle: () => null
+});
+
 export const PageContextProvider = PageContext.Provider;
 export const PageContextConsumer = PageContext.Consumer;
 

--- a/packages/react-core/src/components/Page/PageHeader.tsx
+++ b/packages/react-core/src/components/Page/PageHeader.tsx
@@ -1,9 +1,10 @@
+/* eslint-disable no-console */
 import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/Page/page';
 import { css } from '@patternfly/react-styles';
 import BarsIcon from '@patternfly/react-icons/dist/js/icons/bars-icon';
 import { Button, ButtonVariant } from '../../components/Button';
-import { PageContextConsumer } from './Page';
+import { PageContextConsumer, PageContextProps } from './Page';
 
 export interface PageHeaderProps extends React.HTMLProps<HTMLDivElement> {
   /** Additional classes added to the page header */
@@ -22,10 +23,7 @@ export interface PageHeaderProps extends React.HTMLProps<HTMLDivElement> {
   showNavToggle?: boolean;
   /** True if the side nav is shown  */
   isNavOpen?: boolean;
-  /**
-   * If true, manages the sidebar open/close state and there is no need to pass the isNavOpen boolean into
-   * the sidebar component or add a callback onNavToggle function into the PageHeader component
-   */
+  /** This prop is no longer managed through PageHeader but in the Page component. */
   isManagedSidebar?: boolean;
   /** Sets the value for role on the <main> element */
   role?: string;
@@ -43,6 +41,7 @@ export const PageHeader: React.FunctionComponent<PageHeaderProps> = ({
   headerTools = null as React.ReactNode,
   topNav = null as React.ReactNode,
   isNavOpen = true,
+  isManagedSidebar: deprecatedIsManagedSidebar = undefined,
   role = undefined as string,
   showNavToggle = false,
   onNavToggle = () => undefined as any,
@@ -50,9 +49,14 @@ export const PageHeader: React.FunctionComponent<PageHeaderProps> = ({
   ...props
 }: PageHeaderProps) => {
   const LogoComponent = logoComponent as any;
+  if ([false, true].includes(deprecatedIsManagedSidebar)) {
+    console.warn(
+      'isManagedSidebar is deprecated in the PageHeader component. To make the sidebar toggle uncontrolled, pass this prop in the Page component'
+    );
+  }
   return (
     <PageContextConsumer>
-      {({ isManagedSidebar, onNavToggle: managedOnNavToggle, isNavOpen: managedIsNavOpen }: PageHeaderProps) => {
+      {({ isManagedSidebar, onNavToggle: managedOnNavToggle, isNavOpen: managedIsNavOpen }: PageContextProps) => {
         const navToggle = isManagedSidebar ? managedOnNavToggle : onNavToggle;
         const navOpen = isManagedSidebar ? managedIsNavOpen : isNavOpen;
 

--- a/packages/react-core/src/components/Page/examples/Page.md
+++ b/packages/react-core/src/components/Page/examples/Page.md
@@ -224,3 +224,42 @@ class FillPage extends React.Component {
   }
 }
 ```
+### Uncontrolled nav
+```js
+import React from 'react';
+import {
+  Page,
+  PageHeader,
+  PageHeaderTools,
+  PageSidebar,
+  PageSection,
+  PageSectionVariants
+} from '@patternfly/react-core';
+
+class UncontrolledNavPage extends React.Component {
+  render() {
+    const logoProps = {
+      href: 'https://patternfly.org',
+      onClick: () => console.log('clicked logo'),
+      target: '_blank'
+    };
+    const Header = (
+      <PageHeader
+        logo="Logo"
+        logoProps={logoProps}
+        headerTools={<PageHeaderTools>header-tools</PageHeaderTools>}
+        showNavToggle
+      />
+    );
+    const Sidebar = <PageSidebar nav="Navigation" />;
+
+    return (
+      <Page isManagedSidebar header={Header} sidebar={Sidebar}>
+        <PageSection variant={PageSectionVariants.darker}>Section with darker background</PageSection>
+        <PageSection variant={PageSectionVariants.dark}>Section with dark background</PageSection>
+        <PageSection variant={PageSectionVariants.light}>Section with light background</PageSection>
+      </Page>
+    );
+  }
+}
+```


### PR DESCRIPTION
**What**: Closes #4549 

`PageContext.Consumer` returns a children that is a function. And that function's argument is the values set in the `PageContext`.
However, in `PageHeader` there was a mistake that assumed the function's argument is `PageHeaderProps`. Which made the `PageHeaderProps` to have `isManagedSidebar` even though it's not used and caused a confusion.

This patch fixes that mistake.

This also solves the warning that were mentioned in #4549.

//cc @dtaylor113 @redallen 