### PR TITLE
chore(deps): bump lodash to 4.17.19

### DIFF
--- a/packages/react-charts/package.json
+++ b/packages/react-charts/package.json
@@ -33,7 +33,7 @@
     "@patternfly/react-styles": "^4.5.0",
     "@patternfly/react-tokens": "^4.6.0",
     "hoist-non-react-statics": "^3.3.0",
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.19",
     "tslib": "^1.11.1",
     "victory": "^34.3.12",
     "victory-area": "^34.3.12",
@@ -60,7 +60,7 @@
     "clean": "rimraf dist"
   },
   "devDependencies": {
-    "@types/lodash": "^4.14.138",
+    "@types/lodash": "^4.14.157",
     "css": "^2.2.3",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",

--- a/packages/react-table/package.json
+++ b/packages/react-table/package.json
@@ -37,7 +37,7 @@
     "@patternfly/react-tokens": "^4.6.0",
     "@types/classnames": "^2.2.9",
     "classnames": "^2.2.5",
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.19",
     "tslib": "^1.11.1"
   },
   "peerDependencies": {

--- a/packages/react-topology/package.json
+++ b/packages/react-topology/package.json
@@ -33,7 +33,7 @@
     "@patternfly/react-styles": "^4.5.0",
     "d3": "^5.16.0",
     "dagre": "0.8.2",
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.19",
     "mobx": "^5.15.4",
     "mobx-react": "^6.2.0",
     "point-in-svg-path": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3677,9 +3677,10 @@
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
 
-"@types/lodash@^4.14.138":
-  version "4.14.144"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.144.tgz#12e57fc99064bce45e5ab3c8bc4783feb75eab8e"
+"@types/lodash@^4.14.157":
+  version "4.14.157"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.157.tgz#fdac1c52448861dfde1a2e1515dbc46e54926dc8"
+  integrity sha512-Ft5BNFmv2pHDgxV5JDsndOWTRJ+56zte0ZpYLowp03tW+K+t8u8YMOzAnpuqPgzX6WO1XpDIUm7u04M8vdDiVQ==
 
 "@types/lodash@^4.14.92":
   version "4.14.149"
@@ -15464,6 +15465,11 @@ lodash@4.17.14:
 lodash@4.17.15, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.11.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.1, lodash@~4.17.10:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+
+lodash@^4.17.19:
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 log-symbols@2.2.0, log-symbols@^2.1.0, log-symbols@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes security vulnerability

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
