### PR TITLE
feat(Drawer): enable users to define actions when they click outside the drawer panel

### DIFF
--- a/packages/react-core/src/components/Drawer/DrawerPanelContent.tsx
+++ b/packages/react-core/src/components/Drawer/DrawerPanelContent.tsx
@@ -18,13 +18,16 @@ export interface DrawerPanelContentProps extends React.HTMLProps<HTMLDivElement>
     xl?: 'width_25' | 'width_33' | 'width_50' | 'width_66' | 'width_75' | 'width_100';
     '2xl'?: 'width_25' | 'width_33' | 'width_50' | 'width_66' | 'width_75' | 'width_100';
   };
+  /** Forward the ref outside the component */
+  innerRef?: React.Ref<HTMLDivElement>;
 }
 
-export const DrawerPanelContent: React.SFC<DrawerPanelContentProps> = ({
+const DrawerPanelContentWithRef: React.SFC<DrawerPanelContentProps> = ({
   className = '',
   children,
   hasNoBorder = false,
   widths,
+  innerRef,
   ...props
 }: DrawerPanelContentProps) => (
   <DrawerContext.Consumer>
@@ -44,6 +47,7 @@ export const DrawerPanelContent: React.SFC<DrawerPanelContentProps> = ({
               onExpand();
             }
           }}
+          ref={innerRef}
           hidden={hidden}
           {...props}
         >
@@ -53,4 +57,10 @@ export const DrawerPanelContent: React.SFC<DrawerPanelContentProps> = ({
     }}
   </DrawerContext.Consumer>
 );
-DrawerPanelContent.displayName = 'DrawerPanelContent';
+DrawerPanelContentWithRef.displayName = 'DrawerPanelContent';
+
+export const DrawerPanelContent = React.forwardRef((props: DrawerPanelContentProps, ref: React.Ref<HTMLDivElement>) => (
+  <DrawerPanelContentWithRef innerRef={ref} {...props}>
+    {props.children}
+  </DrawerPanelContentWithRef>
+));

--- a/packages/react-core/src/components/Drawer/__tests__/Generated/__snapshots__/DrawerPanelContent.test.tsx.snap
+++ b/packages/react-core/src/components/Drawer/__tests__/Generated/__snapshots__/DrawerPanelContent.test.tsx.snap
@@ -1,7 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DrawerPanelContent should match snapshot (auto-generated) 1`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<DrawerPanelContent
+  className="''"
+  hasNoPadding={false}
+  innerRef={null}
+>
+  <div>
+    ReactNode
+  </div>
+</DrawerPanelContent>
 `;

--- a/packages/react-core/src/components/Drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/react-core/src/components/Drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`Drawer isExpanded = false and isInline = false and isStatic = false 1`]
   >
     <DrawerContent
       panelContent={
-        <DrawerPanelContent>
+        <ForwardRef>
           <DrawerHead>
             <span>
               drawer-panel
@@ -21,7 +21,7 @@ exports[`Drawer isExpanded = false and isInline = false and isStatic = false 1`]
           <DrawerPanelBody>
             drawer-panel
           </DrawerPanelBody>
-        </DrawerPanelContent>
+        </ForwardRef>
       }
     >
       <DrawerMain>
@@ -39,13 +39,17 @@ exports[`Drawer isExpanded = false and isInline = false and isStatic = false 1`]
               </div>
             </DrawerContentBody>
           </div>
-          <DrawerPanelContent>
-            <div
-              className="pf-c-drawer__panel"
-              hidden={true}
-              onTransitionEnd={[Function]}
-            />
-          </DrawerPanelContent>
+          <ForwardRef>
+            <DrawerPanelContent
+              innerRef={null}
+            >
+              <div
+                className="pf-c-drawer__panel"
+                hidden={true}
+                onTransitionEnd={[Function]}
+              />
+            </DrawerPanelContent>
+          </ForwardRef>
         </div>
       </DrawerMain>
     </DrawerContent>
@@ -62,7 +66,7 @@ exports[`Drawer isExpanded = false and isInline = true and isStatic = false 1`] 
   >
     <DrawerContent
       panelContent={
-        <DrawerPanelContent>
+        <ForwardRef>
           <DrawerHead>
             <span>
               drawer-panel
@@ -74,7 +78,7 @@ exports[`Drawer isExpanded = false and isInline = true and isStatic = false 1`] 
           <DrawerPanelBody>
             drawer-panel
           </DrawerPanelBody>
-        </DrawerPanelContent>
+        </ForwardRef>
       }
     >
       <DrawerMain>
@@ -92,13 +96,17 @@ exports[`Drawer isExpanded = false and isInline = true and isStatic = false 1`] 
               </div>
             </DrawerContentBody>
           </div>
-          <DrawerPanelContent>
-            <div
-              className="pf-c-drawer__panel"
-              hidden={true}
-              onTransitionEnd={[Function]}
-            />
-          </DrawerPanelContent>
+          <ForwardRef>
+            <DrawerPanelContent
+              innerRef={null}
+            >
+              <div
+                className="pf-c-drawer__panel"
+                hidden={true}
+                onTransitionEnd={[Function]}
+              />
+            </DrawerPanelContent>
+          </ForwardRef>
         </div>
       </DrawerMain>
     </DrawerContent>
@@ -115,7 +123,7 @@ exports[`Drawer isExpanded = true and isInline = false and isStatic = false 1`] 
   >
     <DrawerContent
       panelContent={
-        <DrawerPanelContent>
+        <ForwardRef>
           <DrawerHead>
             <span>
               drawer-panel
@@ -127,7 +135,7 @@ exports[`Drawer isExpanded = true and isInline = false and isStatic = false 1`] 
           <DrawerPanelBody>
             drawer-panel
           </DrawerPanelBody>
-        </DrawerPanelContent>
+        </ForwardRef>
       }
     >
       <DrawerMain>
@@ -145,93 +153,97 @@ exports[`Drawer isExpanded = true and isInline = false and isStatic = false 1`] 
               </div>
             </DrawerContentBody>
           </div>
-          <DrawerPanelContent>
-            <div
-              className="pf-c-drawer__panel"
-              hidden={false}
-              onTransitionEnd={[Function]}
+          <ForwardRef>
+            <DrawerPanelContent
+              innerRef={null}
             >
-              <DrawerHead>
-                <DrawerPanelBody
-                  hasNoPadding={false}
-                >
+              <div
+                className="pf-c-drawer__panel"
+                hidden={false}
+                onTransitionEnd={[Function]}
+              >
+                <DrawerHead>
+                  <DrawerPanelBody
+                    hasNoPadding={false}
+                  >
+                    <div
+                      className="pf-c-drawer__body"
+                    >
+                      <div
+                        className="pf-c-drawer__head"
+                      >
+                        <span>
+                          drawer-panel
+                        </span>
+                        <DrawerActions>
+                          <div
+                            className="pf-c-drawer__actions"
+                          >
+                            <DrawerCloseButton>
+                              <div
+                                className="pf-c-drawer__close"
+                              >
+                                <Button
+                                  aria-label="Close drawer panel"
+                                  onClick={[Function]}
+                                  variant="plain"
+                                >
+                                  <button
+                                    aria-disabled={false}
+                                    aria-label="Close drawer panel"
+                                    className="pf-c-button pf-m-plain"
+                                    data-ouia-component-id={0}
+                                    data-ouia-component-type="PF4/Button"
+                                    data-ouia-safe={true}
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    type="button"
+                                  >
+                                    <TimesIcon
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      size="sm"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        aria-labelledby={null}
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        style={
+                                          Object {
+                                            "verticalAlign": "-0.125em",
+                                          }
+                                        }
+                                        viewBox="0 0 352 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                          transform=""
+                                        />
+                                      </svg>
+                                    </TimesIcon>
+                                  </button>
+                                </Button>
+                              </div>
+                            </DrawerCloseButton>
+                          </div>
+                        </DrawerActions>
+                      </div>
+                    </div>
+                  </DrawerPanelBody>
+                </DrawerHead>
+                <DrawerPanelBody>
                   <div
                     className="pf-c-drawer__body"
                   >
-                    <div
-                      className="pf-c-drawer__head"
-                    >
-                      <span>
-                        drawer-panel
-                      </span>
-                      <DrawerActions>
-                        <div
-                          className="pf-c-drawer__actions"
-                        >
-                          <DrawerCloseButton>
-                            <div
-                              className="pf-c-drawer__close"
-                            >
-                              <Button
-                                aria-label="Close drawer panel"
-                                onClick={[Function]}
-                                variant="plain"
-                              >
-                                <button
-                                  aria-disabled={false}
-                                  aria-label="Close drawer panel"
-                                  className="pf-c-button pf-m-plain"
-                                  data-ouia-component-id={0}
-                                  data-ouia-component-type="PF4/Button"
-                                  data-ouia-safe={true}
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <TimesIcon
-                                    color="currentColor"
-                                    noVerticalAlign={false}
-                                    size="sm"
-                                  >
-                                    <svg
-                                      aria-hidden={true}
-                                      aria-labelledby={null}
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      style={
-                                        Object {
-                                          "verticalAlign": "-0.125em",
-                                        }
-                                      }
-                                      viewBox="0 0 352 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                        transform=""
-                                      />
-                                    </svg>
-                                  </TimesIcon>
-                                </button>
-                              </Button>
-                            </div>
-                          </DrawerCloseButton>
-                        </div>
-                      </DrawerActions>
-                    </div>
+                    drawer-panel
                   </div>
                 </DrawerPanelBody>
-              </DrawerHead>
-              <DrawerPanelBody>
-                <div
-                  className="pf-c-drawer__body"
-                >
-                  drawer-panel
-                </div>
-              </DrawerPanelBody>
-            </div>
-          </DrawerPanelContent>
+              </div>
+            </DrawerPanelContent>
+          </ForwardRef>
         </div>
       </DrawerMain>
     </DrawerContent>
@@ -248,7 +260,7 @@ exports[`Drawer isExpanded = true and isInline = false and isStatic = true 1`] =
   >
     <DrawerContent
       panelContent={
-        <DrawerPanelContent>
+        <ForwardRef>
           <DrawerHead>
             <span>
               drawer-panel
@@ -260,7 +272,7 @@ exports[`Drawer isExpanded = true and isInline = false and isStatic = true 1`] =
           <DrawerPanelBody>
             drawer-panel
           </DrawerPanelBody>
-        </DrawerPanelContent>
+        </ForwardRef>
       }
     >
       <DrawerMain>
@@ -278,93 +290,97 @@ exports[`Drawer isExpanded = true and isInline = false and isStatic = true 1`] =
               </div>
             </DrawerContentBody>
           </div>
-          <DrawerPanelContent>
-            <div
-              className="pf-c-drawer__panel"
-              hidden={false}
-              onTransitionEnd={[Function]}
+          <ForwardRef>
+            <DrawerPanelContent
+              innerRef={null}
             >
-              <DrawerHead>
-                <DrawerPanelBody
-                  hasNoPadding={false}
-                >
+              <div
+                className="pf-c-drawer__panel"
+                hidden={false}
+                onTransitionEnd={[Function]}
+              >
+                <DrawerHead>
+                  <DrawerPanelBody
+                    hasNoPadding={false}
+                  >
+                    <div
+                      className="pf-c-drawer__body"
+                    >
+                      <div
+                        className="pf-c-drawer__head"
+                      >
+                        <span>
+                          drawer-panel
+                        </span>
+                        <DrawerActions>
+                          <div
+                            className="pf-c-drawer__actions"
+                          >
+                            <DrawerCloseButton>
+                              <div
+                                className="pf-c-drawer__close"
+                              >
+                                <Button
+                                  aria-label="Close drawer panel"
+                                  onClick={[Function]}
+                                  variant="plain"
+                                >
+                                  <button
+                                    aria-disabled={false}
+                                    aria-label="Close drawer panel"
+                                    className="pf-c-button pf-m-plain"
+                                    data-ouia-component-id={2}
+                                    data-ouia-component-type="PF4/Button"
+                                    data-ouia-safe={true}
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    type="button"
+                                  >
+                                    <TimesIcon
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      size="sm"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        aria-labelledby={null}
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        style={
+                                          Object {
+                                            "verticalAlign": "-0.125em",
+                                          }
+                                        }
+                                        viewBox="0 0 352 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                          transform=""
+                                        />
+                                      </svg>
+                                    </TimesIcon>
+                                  </button>
+                                </Button>
+                              </div>
+                            </DrawerCloseButton>
+                          </div>
+                        </DrawerActions>
+                      </div>
+                    </div>
+                  </DrawerPanelBody>
+                </DrawerHead>
+                <DrawerPanelBody>
                   <div
                     className="pf-c-drawer__body"
                   >
-                    <div
-                      className="pf-c-drawer__head"
-                    >
-                      <span>
-                        drawer-panel
-                      </span>
-                      <DrawerActions>
-                        <div
-                          className="pf-c-drawer__actions"
-                        >
-                          <DrawerCloseButton>
-                            <div
-                              className="pf-c-drawer__close"
-                            >
-                              <Button
-                                aria-label="Close drawer panel"
-                                onClick={[Function]}
-                                variant="plain"
-                              >
-                                <button
-                                  aria-disabled={false}
-                                  aria-label="Close drawer panel"
-                                  className="pf-c-button pf-m-plain"
-                                  data-ouia-component-id={2}
-                                  data-ouia-component-type="PF4/Button"
-                                  data-ouia-safe={true}
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <TimesIcon
-                                    color="currentColor"
-                                    noVerticalAlign={false}
-                                    size="sm"
-                                  >
-                                    <svg
-                                      aria-hidden={true}
-                                      aria-labelledby={null}
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      style={
-                                        Object {
-                                          "verticalAlign": "-0.125em",
-                                        }
-                                      }
-                                      viewBox="0 0 352 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                        transform=""
-                                      />
-                                    </svg>
-                                  </TimesIcon>
-                                </button>
-                              </Button>
-                            </div>
-                          </DrawerCloseButton>
-                        </div>
-                      </DrawerActions>
-                    </div>
+                    drawer-panel
                   </div>
                 </DrawerPanelBody>
-              </DrawerHead>
-              <DrawerPanelBody>
-                <div
-                  className="pf-c-drawer__body"
-                >
-                  drawer-panel
-                </div>
-              </DrawerPanelBody>
-            </div>
-          </DrawerPanelContent>
+              </div>
+            </DrawerPanelContent>
+          </ForwardRef>
         </div>
       </DrawerMain>
     </DrawerContent>
@@ -381,7 +397,7 @@ exports[`Drawer isExpanded = true and isInline = true and isStatic = false 1`] =
   >
     <DrawerContent
       panelContent={
-        <DrawerPanelContent>
+        <ForwardRef>
           <DrawerHead>
             <span>
               drawer-panel
@@ -393,7 +409,7 @@ exports[`Drawer isExpanded = true and isInline = true and isStatic = false 1`] =
           <DrawerPanelBody>
             drawer-panel
           </DrawerPanelBody>
-        </DrawerPanelContent>
+        </ForwardRef>
       }
     >
       <DrawerMain>
@@ -411,93 +427,97 @@ exports[`Drawer isExpanded = true and isInline = true and isStatic = false 1`] =
               </div>
             </DrawerContentBody>
           </div>
-          <DrawerPanelContent>
-            <div
-              className="pf-c-drawer__panel"
-              hidden={false}
-              onTransitionEnd={[Function]}
+          <ForwardRef>
+            <DrawerPanelContent
+              innerRef={null}
             >
-              <DrawerHead>
-                <DrawerPanelBody
-                  hasNoPadding={false}
-                >
+              <div
+                className="pf-c-drawer__panel"
+                hidden={false}
+                onTransitionEnd={[Function]}
+              >
+                <DrawerHead>
+                  <DrawerPanelBody
+                    hasNoPadding={false}
+                  >
+                    <div
+                      className="pf-c-drawer__body"
+                    >
+                      <div
+                        className="pf-c-drawer__head"
+                      >
+                        <span>
+                          drawer-panel
+                        </span>
+                        <DrawerActions>
+                          <div
+                            className="pf-c-drawer__actions"
+                          >
+                            <DrawerCloseButton>
+                              <div
+                                className="pf-c-drawer__close"
+                              >
+                                <Button
+                                  aria-label="Close drawer panel"
+                                  onClick={[Function]}
+                                  variant="plain"
+                                >
+                                  <button
+                                    aria-disabled={false}
+                                    aria-label="Close drawer panel"
+                                    className="pf-c-button pf-m-plain"
+                                    data-ouia-component-id={1}
+                                    data-ouia-component-type="PF4/Button"
+                                    data-ouia-safe={true}
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    type="button"
+                                  >
+                                    <TimesIcon
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      size="sm"
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        aria-labelledby={null}
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        style={
+                                          Object {
+                                            "verticalAlign": "-0.125em",
+                                          }
+                                        }
+                                        viewBox="0 0 352 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                          transform=""
+                                        />
+                                      </svg>
+                                    </TimesIcon>
+                                  </button>
+                                </Button>
+                              </div>
+                            </DrawerCloseButton>
+                          </div>
+                        </DrawerActions>
+                      </div>
+                    </div>
+                  </DrawerPanelBody>
+                </DrawerHead>
+                <DrawerPanelBody>
                   <div
                     className="pf-c-drawer__body"
                   >
-                    <div
-                      className="pf-c-drawer__head"
-                    >
-                      <span>
-                        drawer-panel
-                      </span>
-                      <DrawerActions>
-                        <div
-                          className="pf-c-drawer__actions"
-                        >
-                          <DrawerCloseButton>
-                            <div
-                              className="pf-c-drawer__close"
-                            >
-                              <Button
-                                aria-label="Close drawer panel"
-                                onClick={[Function]}
-                                variant="plain"
-                              >
-                                <button
-                                  aria-disabled={false}
-                                  aria-label="Close drawer panel"
-                                  className="pf-c-button pf-m-plain"
-                                  data-ouia-component-id={1}
-                                  data-ouia-component-type="PF4/Button"
-                                  data-ouia-safe={true}
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  <TimesIcon
-                                    color="currentColor"
-                                    noVerticalAlign={false}
-                                    size="sm"
-                                  >
-                                    <svg
-                                      aria-hidden={true}
-                                      aria-labelledby={null}
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      style={
-                                        Object {
-                                          "verticalAlign": "-0.125em",
-                                        }
-                                      }
-                                      viewBox="0 0 352 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                        transform=""
-                                      />
-                                    </svg>
-                                  </TimesIcon>
-                                </button>
-                              </Button>
-                            </div>
-                          </DrawerCloseButton>
-                        </div>
-                      </DrawerActions>
-                    </div>
+                    drawer-panel
                   </div>
                 </DrawerPanelBody>
-              </DrawerHead>
-              <DrawerPanelBody>
-                <div
-                  className="pf-c-drawer__body"
-                >
-                  drawer-panel
-                </div>
-              </DrawerPanelBody>
-            </div>
-          </DrawerPanelContent>
+              </div>
+            </DrawerPanelContent>
+          </ForwardRef>
         </div>
       </DrawerMain>
     </DrawerContent>

--- a/packages/react-core/src/components/Drawer/examples/Drawer.md
+++ b/packages/react-core/src/components/Drawer/examples/Drawer.md
@@ -11,7 +11,7 @@ propComponents:
     DrawerSection,
     DrawerHead,
     DrawerActions,
-    DrawerCloseButton
+    DrawerCloseButton,
   ]
 section: components
 beta: true
@@ -20,6 +20,7 @@ beta: true
 ## Examples
 
 ### Basic
+
 ```js
 import React from 'react';
 import {
@@ -42,12 +43,18 @@ class SimpleDrawer extends React.Component {
       isExpanded: false
     };
     this.drawerRef = React.createRef();
+    this.panelRef = React.createRef();
 
     this.onExpand = () => {
-      this.drawerRef.current && this.drawerRef.current.focus()
+      this.drawerRef.current && this.drawerRef.current.focus();
     };
 
     this.onClick = () => {
+      if (!this.state.isExpanded) {
+        document.addEventListener('click', this.onClickOutside);
+      } else {
+        document.removeEventListener('click', this.onClickOutside);
+      }
       const isExpanded = !this.state.isExpanded;
       this.setState({
         isExpanded
@@ -55,18 +62,28 @@ class SimpleDrawer extends React.Component {
     };
 
     this.onCloseClick = () => {
+      document.removeEventListener('click', this.onClickOutside);
       this.setState({
         isExpanded: false
       });
+    };
+
+    this.onClickOutside = event => {
+      if (this.panelRef.current.contains(event.target)) {
+        return;
+      }
+      this.onClick();
     };
   }
 
   render() {
     const { isExpanded } = this.state;
     const panelContent = (
-      <DrawerPanelContent>
+      <DrawerPanelContent ref={this.panelRef}>
         <DrawerHead>
-          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer-panel
+          </span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -94,6 +111,7 @@ class SimpleDrawer extends React.Component {
 ```
 
 ### Panel on right
+
 ```js
 import React from 'react';
 import {
@@ -117,7 +135,7 @@ class SimpleDrawerPanelRight extends React.Component {
     this.drawerRef = React.createRef();
 
     this.onExpand = () => {
-      this.drawerRef.current && this.drawerRef.current.focus()
+      this.drawerRef.current && this.drawerRef.current.focus();
     };
 
     this.onClick = () => {
@@ -139,7 +157,9 @@ class SimpleDrawerPanelRight extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
-          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer-panel
+          </span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -167,6 +187,7 @@ class SimpleDrawerPanelRight extends React.Component {
 ```
 
 ### Panel on left
+
 ```js
 import React from 'react';
 import {
@@ -190,7 +211,7 @@ class SimpleDrawerPanelLeft extends React.Component {
     this.drawerRef = React.createRef();
 
     this.onExpand = () => {
-      this.drawerRef.current && this.drawerRef.current.focus()
+      this.drawerRef.current && this.drawerRef.current.focus();
     };
 
     this.onClick = () => {
@@ -212,7 +233,9 @@ class SimpleDrawerPanelLeft extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
-          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer-panel
+          </span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -240,6 +263,7 @@ class SimpleDrawerPanelLeft extends React.Component {
 ```
 
 ### Basic inline
+
 ```js
 import React from 'react';
 import {
@@ -263,7 +287,7 @@ class SimpleDrawerInlineContent extends React.Component {
     this.drawerRef = React.createRef();
 
     this.onExpand = () => {
-      this.drawerRef.current && this.drawerRef.current.focus()
+      this.drawerRef.current && this.drawerRef.current.focus();
     };
 
     this.onClick = () => {
@@ -285,7 +309,9 @@ class SimpleDrawerInlineContent extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
-          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer-panel
+          </span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -313,6 +339,7 @@ class SimpleDrawerInlineContent extends React.Component {
 ```
 
 ### Inline panel on right
+
 ```js
 import React from 'react';
 import {
@@ -336,7 +363,7 @@ class DrawerInlineContentPanelRight extends React.Component {
     this.drawerRef = React.createRef();
 
     this.onExpand = () => {
-      this.drawerRef.current && this.drawerRef.current.focus()
+      this.drawerRef.current && this.drawerRef.current.focus();
     };
 
     this.onClick = () => {
@@ -358,7 +385,9 @@ class DrawerInlineContentPanelRight extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
-          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer-panel
+          </span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -386,6 +415,7 @@ class DrawerInlineContentPanelRight extends React.Component {
 ```
 
 ### Inline panel on left
+
 ```js
 import React from 'react';
 import {
@@ -409,7 +439,7 @@ class DrawerInlineContentPanelLeft extends React.Component {
     this.drawerRef = React.createRef();
 
     this.onExpand = () => {
-      this.drawerRef.current && this.drawerRef.current.focus()
+      this.drawerRef.current && this.drawerRef.current.focus();
     };
 
     this.onClick = () => {
@@ -431,7 +461,9 @@ class DrawerInlineContentPanelLeft extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
-          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer-panel
+          </span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -459,6 +491,7 @@ class DrawerInlineContentPanelLeft extends React.Component {
 ```
 
 ### Stacked content body elements
+
 ```js
 import React from 'react';
 import {
@@ -482,7 +515,7 @@ class DrawerStackedContentBodyElements extends React.Component {
     this.drawerRef = React.createRef();
 
     this.onExpand = () => {
-      this.drawerRef.current && this.drawerRef.current.focus()
+      this.drawerRef.current && this.drawerRef.current.focus();
     };
 
     this.onClick = () => {
@@ -504,7 +537,9 @@ class DrawerStackedContentBodyElements extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
-          <h3 className= "pf-c-title pf-m-2xl" tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer title </h3>
+          <h3 className="pf-c-title pf-m-2xl" tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer title{' '}
+          </h3>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -534,6 +569,7 @@ class DrawerStackedContentBodyElements extends React.Component {
 ```
 
 ### Stacked content body elements
+
 ```js
 import React from 'react';
 import {
@@ -557,7 +593,7 @@ class DrawerStackedContentBodyElements extends React.Component {
     this.drawerRef = React.createRef();
 
     this.onExpand = () => {
-      this.drawerRef.current && this.drawerRef.current.focus()
+      this.drawerRef.current && this.drawerRef.current.focus();
     };
 
     this.onClick = () => {
@@ -579,7 +615,9 @@ class DrawerStackedContentBodyElements extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
-          <h3 className= "pf-c-title pf-m-2xl" tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer title </h3>
+          <h3 className="pf-c-title pf-m-2xl" tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer title{' '}
+          </h3>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -592,7 +630,7 @@ class DrawerStackedContentBodyElements extends React.Component {
 
     return (
       <React.Fragment>
-        <Button aria-expanded={isExpanded} onClick={this.onClick} >
+        <Button aria-expanded={isExpanded} onClick={this.onClick}>
           Toggle Drawer
         </Button>
         <Drawer isExpanded={isExpanded} onExpand={this.onExpand}>
@@ -609,6 +647,7 @@ class DrawerStackedContentBodyElements extends React.Component {
 ```
 
 ### Modified content padding
+
 ```js
 import React from 'react';
 import {
@@ -632,7 +671,7 @@ class DrawerModifiedContentPadding extends React.Component {
     this.drawerRef = React.createRef();
 
     this.onExpand = () => {
-      this.drawerRef.current && this.drawerRef.current.focus()
+      this.drawerRef.current && this.drawerRef.current.focus();
     };
 
     this.onClick = () => {
@@ -654,7 +693,9 @@ class DrawerModifiedContentPadding extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
-          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer-panel
+          </span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -684,6 +725,7 @@ class DrawerModifiedContentPadding extends React.Component {
 ```
 
 ### Modified panel padding
+
 ```js
 import React from 'react';
 import {
@@ -707,7 +749,7 @@ class DrawerModifiedPanelPadding extends React.Component {
     this.drawerRef = React.createRef();
 
     this.onExpand = () => {
-      this.drawerRef.current && this.drawerRef.current.focus()
+      this.drawerRef.current && this.drawerRef.current.focus();
     };
 
     this.onClick = () => {
@@ -729,7 +771,9 @@ class DrawerModifiedPanelPadding extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead hasNoPadding>
-          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer-panel
+          </span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -757,6 +801,7 @@ class DrawerModifiedPanelPadding extends React.Component {
 ```
 
 ### Additional section above drawer content
+
 ```js
 import React from 'react';
 import {
@@ -781,7 +826,7 @@ class DrawerWithSection extends React.Component {
     this.drawerRef = React.createRef();
 
     this.onExpand = () => {
-      this.drawerRef.current && this.drawerRef.current.focus()
+      this.drawerRef.current && this.drawerRef.current.focus();
     };
 
     this.onClick = () => {
@@ -803,7 +848,9 @@ class DrawerWithSection extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
-          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer-panel
+          </span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -832,6 +879,7 @@ class DrawerWithSection extends React.Component {
 ```
 
 ### Static drawer
+
 ```js
 import React from 'react';
 import {
@@ -871,6 +919,7 @@ StaticDrawer = () => {
 ```
 
 ### Breakpoint
+
 ```js
 import React from 'react';
 import {
@@ -894,7 +943,7 @@ class SimpleDrawer extends React.Component {
     this.drawerRef = React.createRef();
 
     this.onExpand = () => {
-      this.drawerRef.current && this.drawerRef.current.focus()
+      this.drawerRef.current && this.drawerRef.current.focus();
     };
 
     this.onClick = () => {
@@ -916,7 +965,9 @@ class SimpleDrawer extends React.Component {
     const panelContent = (
       <DrawerPanelContent widths={{ default: 'width_33' }}>
         <DrawerHead>
-          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer-panel
+          </span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>

--- a/packages/react-core/src/components/Drawer/examples/Drawer.md
+++ b/packages/react-core/src/components/Drawer/examples/Drawer.md
@@ -43,18 +43,12 @@ class SimpleDrawer extends React.Component {
       isExpanded: false
     };
     this.drawerRef = React.createRef();
-    this.panelRef = React.createRef();
 
     this.onExpand = () => {
       this.drawerRef.current && this.drawerRef.current.focus();
     };
 
     this.onClick = () => {
-      if (!this.state.isExpanded) {
-        document.addEventListener('click', this.onClickOutside);
-      } else {
-        document.removeEventListener('click', this.onClickOutside);
-      }
       const isExpanded = !this.state.isExpanded;
       this.setState({
         isExpanded
@@ -62,24 +56,16 @@ class SimpleDrawer extends React.Component {
     };
 
     this.onCloseClick = () => {
-      document.removeEventListener('click', this.onClickOutside);
       this.setState({
         isExpanded: false
       });
-    };
-
-    this.onClickOutside = event => {
-      if (this.panelRef.current.contains(event.target)) {
-        return;
-      }
-      this.onClick();
     };
   }
 
   render() {
     const { isExpanded } = this.state;
     const panelContent = (
-      <DrawerPanelContent ref={this.panelRef}>
+      <DrawerPanelContent>
         <DrawerHead>
           <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
             drawer-panel
@@ -964,6 +950,97 @@ class SimpleDrawer extends React.Component {
     const { isExpanded } = this.state;
     const panelContent = (
       <DrawerPanelContent widths={{ default: 'width_33' }}>
+        <DrawerHead>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer-panel
+          </span>
+          <DrawerActions>
+            <DrawerCloseButton onClick={this.onCloseClick} />
+          </DrawerActions>
+        </DrawerHead>
+      </DrawerPanelContent>
+    );
+
+    const drawerContent =
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.';
+
+    return (
+      <React.Fragment>
+        <Button aria-expanded={isExpanded} onClick={this.onClick}>
+          Toggle Drawer
+        </Button>
+        <Drawer isExpanded={isExpanded} onExpand={this.onExpand}>
+          <DrawerContent panelContent={panelContent}>
+            <DrawerContentBody>{drawerContent}</DrawerContentBody>
+          </DrawerContent>
+        </Drawer>
+      </React.Fragment>
+    );
+  }
+}
+```
+
+### Click outside to close
+
+```js
+import React from 'react';
+import {
+  Drawer,
+  DrawerPanelContent,
+  DrawerContent,
+  DrawerContentBody,
+  DrawerPanelBody,
+  DrawerHead,
+  DrawerActions,
+  DrawerCloseButton,
+  Button,
+  Title
+} from '@patternfly/react-core';
+
+class SimpleDrawer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isExpanded: false
+    };
+    this.drawerRef = React.createRef();
+    this.panelRef = React.createRef();
+
+    this.onExpand = () => {
+      this.drawerRef.current && this.drawerRef.current.focus();
+    };
+
+    this.onClick = () => {
+      if (!this.state.isExpanded) {
+        document.addEventListener('click', this.onClickOutside);
+      } else {
+        document.removeEventListener('click', this.onClickOutside);
+      }
+      const isExpanded = !this.state.isExpanded;
+      this.setState({
+        isExpanded
+      });
+    };
+
+    this.onCloseClick = () => {
+      document.removeEventListener('click', this.onClickOutside);
+      this.setState({
+        isExpanded: false
+      });
+    };
+
+    this.onClickOutside = event => {
+      if (this.panelRef.current.contains(event.target)) {
+        return;
+      }
+      this.onClick();
+    };
+  }
+
+  render() {
+    const { isExpanded } = this.state;
+    const panelContent = (
+      <DrawerPanelContent ref={this.panelRef}>
         <DrawerHead>
           <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
             drawer-panel


### PR DESCRIPTION

<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4574 
To solve this problem, I forward the ref of `div` node in DrawerPanelContent for user to use. User then could use the ref to create some event listeners to detect whether they click outside the drawer panel or not and customize the actions as well.
Thus, I change the usage of the first example Basic Drawer in the docs. When user click outside of the drawer panel, the drawer will close automatically.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: Now it's a little bit too complex for users to use the ref and create the auto-close event. Is there a better way to solve this problem? Can we change the code inside the component so that users could easily use it by passing a function like `onClickOutside` as a prop and don't need to create those event listeners by themselves?
