### PR TITLE
Fix Maximum call stack size exceeded in a read-only typeahead Select field when pressing enter

### DIFF
--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -161,7 +161,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
       this.refCollection[0] = this.filterRef.current;
     }
 
-    if (!prevState.openedOnEnter && this.state.openedOnEnter && !this.props.customContent) {
+    if (!prevState.openedOnEnter && this.state.openedOnEnter && !this.props.customContent && this.refCollection[0]) {
       this.refCollection[0].focus();
     }
 

--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -289,15 +289,17 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
     const { isOpen, isCreatable, createText } = this.props;
     const { typeaheadActiveChild, typeaheadCurrIndex } = this.state;
     if (isOpen) {
-      if (position === 'enter' && (typeaheadActiveChild || this.refCollection[0])) {
-        this.setState({
-          typeaheadInputValue:
-            (typeaheadActiveChild && typeaheadActiveChild.innerText) || this.refCollection[0].innerText
-        });
-        if (typeaheadActiveChild) {
-          typeaheadActiveChild.click();
-        } else {
-          this.refCollection[0].click();
+      if (position === 'enter') {
+        if (typeaheadActiveChild || this.refCollection[0]) {
+          this.setState({
+            typeaheadInputValue:
+              (typeaheadActiveChild && typeaheadActiveChild.innerText) || this.refCollection[0].innerText
+          });
+          if (typeaheadActiveChild) {
+            typeaheadActiveChild.click();
+          } else {
+            this.refCollection[0].click();
+          }
         }
       } else {
         let nextIndex;

--- a/packages/react-core/src/components/Select/SelectToggle.tsx
+++ b/packages/react-core/src/components/Select/SelectToggle.tsx
@@ -137,9 +137,7 @@ export class SelectToggle extends React.Component<SelectToggleProps> {
     if (
       (event.key === KeyTypes.Tab && variant === SelectVariant.checkbox) ||
       (event.key === KeyTypes.Tab && !isOpen) ||
-      (event.key !== KeyTypes.Enter && event.key !== KeyTypes.Space) ||
-      ((event.key === KeyTypes.Space || event.key === KeyTypes.Enter) &&
-        (variant === SelectVariant.typeahead || variant === SelectVariant.typeaheadMulti))
+      (event.key !== KeyTypes.Enter && event.key !== KeyTypes.Space)
     ) {
       return;
     }

--- a/packages/react-core/src/components/Select/__tests__/Select.test.tsx
+++ b/packages/react-core/src/components/Select/__tests__/Select.test.tsx
@@ -259,6 +259,34 @@ describe('typeahead select', () => {
     expect(view).toMatchSnapshot();
   });
 
+  test('test select existing option on a non-creatable select', () => {
+    const mockEvent = { target: { value: 'Oth' } } as React.ChangeEvent<HTMLInputElement>;
+    const view = mount(
+      <Select variant={SelectVariant.typeahead} onToggle={jest.fn()} isOpen>
+        {selectOptions}
+      </Select>
+    );
+    const inst = view.find('Select').instance() as any;
+    inst.onChange(mockEvent);
+    inst.handleTypeaheadKeys('enter');
+    view.update();
+    expect(view).toMatchSnapshot();
+  });
+
+  test('test select non-existing option on a non-creatable select', () => {
+    const mockEvent = { target: { value: 'NonExistingOption' } } as React.ChangeEvent<HTMLInputElement>;
+    const view = mount(
+      <Select variant={SelectVariant.typeahead} onToggle={jest.fn()} isOpen>
+        {selectOptions}
+      </Select>
+    );
+    const inst = view.find('Select').instance() as any;
+    inst.onChange(mockEvent);
+    inst.handleTypeaheadKeys('enter');
+    view.update();
+    expect(view).toMatchSnapshot();
+  });
+
   test('test creatable option', () => {
     const mockEvent = { target: { value: 'test' } } as React.ChangeEvent<HTMLInputElement>;
     const view = mount(

--- a/packages/react-core/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/packages/react-core/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
@@ -6704,7 +6704,7 @@ exports[`select with custom content renders closed successfully 1`] = `
   >
     <div
       className="pf-c-select"
-      data-ouia-component-id={43}
+      data-ouia-component-id={47}
       data-ouia-component-type="PF4/Select"
       data-ouia-safe={true}
     >
@@ -6731,7 +6731,7 @@ exports[`select with custom content renders closed successfully 1`] = `
           Object {
             "current": <div
               class="pf-c-select"
-              data-ouia-component-id="43"
+              data-ouia-component-id="47"
               data-ouia-component-type="PF4/Select"
               data-ouia-safe="true"
             >
@@ -6869,17 +6869,17 @@ exports[`select with custom content renders expanded successfully 1`] = `
   >
     <div
       className="pf-c-select pf-m-expanded"
-      data-ouia-component-id={44}
+      data-ouia-component-id={48}
       data-ouia-component-type="PF4/Select"
       data-ouia-safe={true}
     >
       <SelectToggle
         aria-label="Options menu"
-        aria-labelledby=" pf-select-toggle-id-19"
+        aria-labelledby=" pf-select-toggle-id-23"
         className=""
         handleTypeaheadKeys={[Function]}
         hasClearButton={false}
-        id="pf-select-toggle-id-19"
+        id="pf-select-toggle-id-23"
         isActive={false}
         isDisabled={false}
         isOpen={true}
@@ -6900,16 +6900,16 @@ exports[`select with custom content renders expanded successfully 1`] = `
           Object {
             "current": <div
               class="pf-c-select pf-m-expanded"
-              data-ouia-component-id="44"
+              data-ouia-component-id="48"
               data-ouia-component-type="PF4/Select"
               data-ouia-safe="true"
             >
               <button
                 aria-expanded="true"
                 aria-haspopup="listbox"
-                aria-labelledby=" pf-select-toggle-id-19"
+                aria-labelledby=" pf-select-toggle-id-23"
                 class="pf-c-select__toggle"
-                id="pf-select-toggle-id-19"
+                id="pf-select-toggle-id-23"
                 type="button"
               >
                 <div
@@ -6952,10 +6952,10 @@ exports[`select with custom content renders expanded successfully 1`] = `
         <button
           aria-expanded={true}
           aria-haspopup="listbox"
-          aria-labelledby=" pf-select-toggle-id-19"
+          aria-labelledby=" pf-select-toggle-id-23"
           className="pf-c-select__toggle"
           disabled={false}
-          id="pf-select-toggle-id-19"
+          id="pf-select-toggle-id-23"
           onClick={[Function]}
           onKeyDown={[Function]}
           type="button"
@@ -7124,7 +7124,7 @@ exports[`typeahead multi select renders closed successfully 1`] = `
   >
     <div
       className="pf-c-select"
-      data-ouia-component-id={23}
+      data-ouia-component-id={27}
       data-ouia-component-type="PF4/Select"
       data-ouia-safe={true}
     >
@@ -7151,7 +7151,7 @@ exports[`typeahead multi select renders closed successfully 1`] = `
           Object {
             "current": <div
               class="pf-c-select"
-              data-ouia-component-id="23"
+              data-ouia-component-id="27"
               data-ouia-component-type="PF4/Select"
               data-ouia-safe="true"
             >
@@ -7315,17 +7315,17 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
   >
     <div
       className="pf-c-select pf-m-expanded"
-      data-ouia-component-id={24}
+      data-ouia-component-id={28}
       data-ouia-component-type="PF4/Select"
       data-ouia-safe={true}
     >
       <SelectToggle
         aria-label="Options menu"
-        aria-labelledby=" pf-select-toggle-id-13"
+        aria-labelledby=" pf-select-toggle-id-17"
         className=""
         handleTypeaheadKeys={[Function]}
         hasClearButton={false}
-        id="pf-select-toggle-id-13"
+        id="pf-select-toggle-id-17"
         isActive={false}
         isDisabled={false}
         isOpen={true}
@@ -7341,7 +7341,7 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
               >
                 <button
                   class="pf-c-select__menu-item"
-                  id="pf-random-id-21-0"
+                  id="pf-random-id-23-0"
                   role="option"
                   type="button"
                 >
@@ -7353,7 +7353,7 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
               >
                 <button
                   class="pf-c-select__menu-item"
-                  id="pf-random-id-21-1"
+                  id="pf-random-id-23-1"
                   role="option"
                   type="button"
                 >
@@ -7365,7 +7365,7 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
               >
                 <button
                   class="pf-c-select__menu-item"
-                  id="pf-random-id-21-2"
+                  id="pf-random-id-23-2"
                   role="option"
                   type="button"
                 >
@@ -7377,7 +7377,7 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
               >
                 <button
                   class="pf-c-select__menu-item"
-                  id="pf-random-id-21-3"
+                  id="pf-random-id-23-3"
                   role="option"
                   type="button"
                 >
@@ -7394,7 +7394,7 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
           Object {
             "current": <div
               class="pf-c-select pf-m-expanded"
-              data-ouia-component-id="24"
+              data-ouia-component-id="28"
               data-ouia-component-type="PF4/Select"
               data-ouia-safe="true"
             >
@@ -7408,7 +7408,7 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
                     aria-label=""
                     autocomplete="off"
                     class="pf-c-form-control pf-c-select__toggle-typeahead"
-                    id="pf-select-toggle-id-13-select-multi-typeahead-typeahead"
+                    id="pf-select-toggle-id-17-select-multi-typeahead-typeahead"
                     placeholder=""
                     type="text"
                     value=""
@@ -7418,9 +7418,9 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
                   aria-expanded="true"
                   aria-haspopup="listbox"
                   aria-label="Options menu"
-                  aria-labelledby=" pf-select-toggle-id-13"
+                  aria-labelledby=" pf-select-toggle-id-17"
                   class="pf-c-button pf-c-select__toggle-button pf-m-plain"
-                  id="pf-select-toggle-id-13"
+                  id="pf-select-toggle-id-17"
                   tabindex="-1"
                   type="button"
                 >
@@ -7450,7 +7450,7 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
                 >
                   <button
                     class="pf-c-select__menu-item"
-                    id="pf-random-id-21-0"
+                    id="pf-random-id-23-0"
                     role="option"
                     type="button"
                   >
@@ -7462,7 +7462,7 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
                 >
                   <button
                     class="pf-c-select__menu-item"
-                    id="pf-random-id-21-1"
+                    id="pf-random-id-23-1"
                     role="option"
                     type="button"
                   >
@@ -7474,7 +7474,7 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
                 >
                   <button
                     class="pf-c-select__menu-item"
-                    id="pf-random-id-21-2"
+                    id="pf-random-id-23-2"
                     role="option"
                     type="button"
                   >
@@ -7486,7 +7486,7 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
                 >
                   <button
                     class="pf-c-select__menu-item"
-                    id="pf-random-id-21-3"
+                    id="pf-random-id-23-3"
                     role="option"
                     type="button"
                   >
@@ -7514,7 +7514,7 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
               autoComplete="off"
               className="pf-c-form-control pf-c-select__toggle-typeahead"
               disabled={false}
-              id="pf-select-toggle-id-13-select-multi-typeahead-typeahead"
+              id="pf-select-toggle-id-17-select-multi-typeahead-typeahead"
               onChange={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -7527,10 +7527,10 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
             aria-expanded={true}
             aria-haspopup="listbox"
             aria-label="Options menu"
-            aria-labelledby=" pf-select-toggle-id-13"
+            aria-labelledby=" pf-select-toggle-id-17"
             className="pf-c-button pf-c-select__toggle-button pf-m-plain"
             disabled={false}
-            id="pf-select-toggle-id-13"
+            id="pf-select-toggle-id-17"
             onClick={[Function]}
             tabIndex={-1}
             type="button"
@@ -7590,7 +7590,7 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
                 >
                   <button
                     class="pf-c-select__menu-item"
-                    id="pf-random-id-21-0"
+                    id="pf-random-id-23-0"
                     role="option"
                     type="button"
                   >
@@ -7602,7 +7602,7 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
                 >
                   <button
                     class="pf-c-select__menu-item"
-                    id="pf-random-id-21-1"
+                    id="pf-random-id-23-1"
                     role="option"
                     type="button"
                   >
@@ -7614,7 +7614,7 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
                 >
                   <button
                     class="pf-c-select__menu-item"
-                    id="pf-random-id-21-2"
+                    id="pf-random-id-23-2"
                     role="option"
                     type="button"
                   >
@@ -7626,7 +7626,7 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
                 >
                   <button
                     class="pf-c-select__menu-item"
-                    id="pf-random-id-21-3"
+                    id="pf-random-id-23-3"
                     role="option"
                     type="button"
                   >
@@ -7652,9 +7652,9 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
             <SelectOption
               className=""
               component="button"
-              id="pf-random-id-21-0"
+              id="pf-random-id-23-0"
               index={0}
-              inputId="pf-random-id-21-0"
+              inputId="pf-random-id-23-0"
               isChecked={false}
               isDisabled={false}
               isFocused={null}
@@ -7673,7 +7673,7 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
                 <button
                   aria-selected={null}
                   className="pf-c-select__menu-item"
-                  id="pf-random-id-21-0"
+                  id="pf-random-id-23-0"
                   onClick={[Function]}
                   onKeyDown={[Function]}
                   role="option"
@@ -7686,9 +7686,9 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
             <SelectOption
               className=""
               component="button"
-              id="pf-random-id-21-1"
+              id="pf-random-id-23-1"
               index={1}
-              inputId="pf-random-id-21-1"
+              inputId="pf-random-id-23-1"
               isChecked={false}
               isDisabled={false}
               isFocused={null}
@@ -7707,7 +7707,7 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
                 <button
                   aria-selected={null}
                   className="pf-c-select__menu-item"
-                  id="pf-random-id-21-1"
+                  id="pf-random-id-23-1"
                   onClick={[Function]}
                   onKeyDown={[Function]}
                   role="option"
@@ -7720,9 +7720,9 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
             <SelectOption
               className=""
               component="button"
-              id="pf-random-id-21-2"
+              id="pf-random-id-23-2"
               index={2}
-              inputId="pf-random-id-21-2"
+              inputId="pf-random-id-23-2"
               isChecked={false}
               isDisabled={false}
               isFocused={null}
@@ -7741,7 +7741,7 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
                 <button
                   aria-selected={null}
                   className="pf-c-select__menu-item"
-                  id="pf-random-id-21-2"
+                  id="pf-random-id-23-2"
                   onClick={[Function]}
                   onKeyDown={[Function]}
                   role="option"
@@ -7754,9 +7754,9 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
             <SelectOption
               className=""
               component="button"
-              id="pf-random-id-21-3"
+              id="pf-random-id-23-3"
               index={3}
-              inputId="pf-random-id-21-3"
+              inputId="pf-random-id-23-3"
               isChecked={false}
               isDisabled={false}
               isFocused={null}
@@ -7775,7 +7775,7 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
                 <button
                   aria-selected={null}
                   className="pf-c-select__menu-item"
-                  id="pf-random-id-21-3"
+                  id="pf-random-id-23-3"
                   onClick={[Function]}
                   onKeyDown={[Function]}
                   role="option"
@@ -7839,7 +7839,7 @@ exports[`typeahead multi select renders selected successfully 1`] = `
   >
     <div
       className="pf-c-select pf-m-expanded"
-      data-ouia-component-id={25}
+      data-ouia-component-id={29}
       data-ouia-component-type="PF4/Select"
       data-ouia-safe={true}
     >
@@ -7866,7 +7866,7 @@ exports[`typeahead multi select renders selected successfully 1`] = `
                 <button
                   aria-selected="true"
                   class="pf-c-select__menu-item pf-m-selected"
-                  id="pf-random-id-22-0"
+                  id="pf-random-id-24-0"
                   role="option"
                   type="button"
                 >
@@ -7897,7 +7897,7 @@ exports[`typeahead multi select renders selected successfully 1`] = `
                 <button
                   aria-selected="true"
                   class="pf-c-select__menu-item pf-m-selected"
-                  id="pf-random-id-22-1"
+                  id="pf-random-id-24-1"
                   role="option"
                   type="button"
                 >
@@ -7927,7 +7927,7 @@ exports[`typeahead multi select renders selected successfully 1`] = `
               >
                 <button
                   class="pf-c-select__menu-item"
-                  id="pf-random-id-22-2"
+                  id="pf-random-id-24-2"
                   role="option"
                   type="button"
                 >
@@ -7939,7 +7939,7 @@ exports[`typeahead multi select renders selected successfully 1`] = `
               >
                 <button
                   class="pf-c-select__menu-item"
-                  id="pf-random-id-22-3"
+                  id="pf-random-id-24-3"
                   role="option"
                   type="button"
                 >
@@ -7956,7 +7956,7 @@ exports[`typeahead multi select renders selected successfully 1`] = `
           Object {
             "current": <div
               class="pf-c-select pf-m-expanded"
-              data-ouia-component-id="25"
+              data-ouia-component-id="29"
               data-ouia-component-type="PF4/Select"
               data-ouia-safe="true"
             >
@@ -7980,25 +7980,25 @@ exports[`typeahead multi select renders selected successfully 1`] = `
                       >
                         <div
                           class="pf-c-chip"
-                          data-ouia-component-id="30"
+                          data-ouia-component-id="34"
                           data-ouia-component-type="PF4/Chip"
                           data-ouia-safe="true"
                         >
                           <span
                             class="pf-c-chip__text"
-                            id="pf-random-id-24"
+                            id="pf-random-id-26"
                           >
                             Mr
                           </span>
                           <button
                             aria-disabled="false"
                             aria-label="Remove"
-                            aria-labelledby="remove_pf-random-id-24 pf-random-id-24"
+                            aria-labelledby="remove_pf-random-id-26 pf-random-id-26"
                             class="pf-c-button pf-m-plain"
-                            data-ouia-component-id="31"
+                            data-ouia-component-id="35"
                             data-ouia-component-type="PF4/Button"
                             data-ouia-safe="true"
-                            id="remove_pf-random-id-24"
+                            id="remove_pf-random-id-26"
                             type="button"
                           >
                             <svg
@@ -8023,25 +8023,25 @@ exports[`typeahead multi select renders selected successfully 1`] = `
                       >
                         <div
                           class="pf-c-chip"
-                          data-ouia-component-id="32"
+                          data-ouia-component-id="36"
                           data-ouia-component-type="PF4/Chip"
                           data-ouia-safe="true"
                         >
                           <span
                             class="pf-c-chip__text"
-                            id="pf-random-id-25"
+                            id="pf-random-id-27"
                           >
                             Mrs
                           </span>
                           <button
                             aria-disabled="false"
                             aria-label="Remove"
-                            aria-labelledby="remove_pf-random-id-25 pf-random-id-25"
+                            aria-labelledby="remove_pf-random-id-27 pf-random-id-27"
                             class="pf-c-button pf-m-plain"
-                            data-ouia-component-id="33"
+                            data-ouia-component-id="37"
                             data-ouia-component-type="PF4/Button"
                             data-ouia-safe="true"
-                            id="remove_pf-random-id-25"
+                            id="remove_pf-random-id-27"
                             type="button"
                           >
                             <svg
@@ -8130,7 +8130,7 @@ exports[`typeahead multi select renders selected successfully 1`] = `
                   <button
                     aria-selected="true"
                     class="pf-c-select__menu-item pf-m-selected"
-                    id="pf-random-id-22-0"
+                    id="pf-random-id-24-0"
                     role="option"
                     type="button"
                   >
@@ -8161,7 +8161,7 @@ exports[`typeahead multi select renders selected successfully 1`] = `
                   <button
                     aria-selected="true"
                     class="pf-c-select__menu-item pf-m-selected"
-                    id="pf-random-id-22-1"
+                    id="pf-random-id-24-1"
                     role="option"
                     type="button"
                   >
@@ -8191,7 +8191,7 @@ exports[`typeahead multi select renders selected successfully 1`] = `
                 >
                   <button
                     class="pf-c-select__menu-item"
-                    id="pf-random-id-22-2"
+                    id="pf-random-id-24-2"
                     role="option"
                     type="button"
                   >
@@ -8203,7 +8203,7 @@ exports[`typeahead multi select renders selected successfully 1`] = `
                 >
                   <button
                     class="pf-c-select__menu-item"
-                    id="pf-random-id-22-3"
+                    id="pf-random-id-24-3"
                     role="option"
                     type="button"
                   >
@@ -8267,33 +8267,33 @@ exports[`typeahead multi select renders selected successfully 1`] = `
                         >
                           <div
                             className="pf-c-chip"
-                            data-ouia-component-id={30}
+                            data-ouia-component-id={34}
                             data-ouia-component-type="PF4/Chip"
                             data-ouia-safe={true}
                           >
                             <span
                               className="pf-c-chip__text"
-                              id="pf-random-id-24"
+                              id="pf-random-id-26"
                             >
                               Mr
                             </span>
                             <Button
                               aria-label="Remove"
-                              aria-labelledby="remove_pf-random-id-24 pf-random-id-24"
-                              id="remove_pf-random-id-24"
+                              aria-labelledby="remove_pf-random-id-26 pf-random-id-26"
+                              id="remove_pf-random-id-26"
                               onClick={[Function]}
                               variant="plain"
                             >
                               <button
                                 aria-disabled={false}
                                 aria-label="Remove"
-                                aria-labelledby="remove_pf-random-id-24 pf-random-id-24"
+                                aria-labelledby="remove_pf-random-id-26 pf-random-id-26"
                                 className="pf-c-button pf-m-plain"
-                                data-ouia-component-id={31}
+                                data-ouia-component-id={35}
                                 data-ouia-component-type="PF4/Button"
                                 data-ouia-safe={true}
                                 disabled={false}
-                                id="remove_pf-random-id-24"
+                                id="remove_pf-random-id-26"
                                 onClick={[Function]}
                                 type="button"
                               >
@@ -8348,33 +8348,33 @@ exports[`typeahead multi select renders selected successfully 1`] = `
                         >
                           <div
                             className="pf-c-chip"
-                            data-ouia-component-id={32}
+                            data-ouia-component-id={36}
                             data-ouia-component-type="PF4/Chip"
                             data-ouia-safe={true}
                           >
                             <span
                               className="pf-c-chip__text"
-                              id="pf-random-id-25"
+                              id="pf-random-id-27"
                             >
                               Mrs
                             </span>
                             <Button
                               aria-label="Remove"
-                              aria-labelledby="remove_pf-random-id-25 pf-random-id-25"
-                              id="remove_pf-random-id-25"
+                              aria-labelledby="remove_pf-random-id-27 pf-random-id-27"
+                              id="remove_pf-random-id-27"
                               onClick={[Function]}
                               variant="plain"
                             >
                               <button
                                 aria-disabled={false}
                                 aria-label="Remove"
-                                aria-labelledby="remove_pf-random-id-25 pf-random-id-25"
+                                aria-labelledby="remove_pf-random-id-27 pf-random-id-27"
                                 className="pf-c-button pf-m-plain"
-                                data-ouia-component-id={33}
+                                data-ouia-component-id={37}
                                 data-ouia-component-type="PF4/Button"
                                 data-ouia-safe={true}
                                 disabled={false}
-                                id="remove_pf-random-id-25"
+                                id="remove_pf-random-id-27"
                                 onClick={[Function]}
                                 type="button"
                               >
@@ -8537,7 +8537,7 @@ exports[`typeahead multi select renders selected successfully 1`] = `
                   <button
                     aria-selected="true"
                     class="pf-c-select__menu-item pf-m-selected"
-                    id="pf-random-id-22-0"
+                    id="pf-random-id-24-0"
                     role="option"
                     type="button"
                   >
@@ -8568,7 +8568,7 @@ exports[`typeahead multi select renders selected successfully 1`] = `
                   <button
                     aria-selected="true"
                     class="pf-c-select__menu-item pf-m-selected"
-                    id="pf-random-id-22-1"
+                    id="pf-random-id-24-1"
                     role="option"
                     type="button"
                   >
@@ -8598,7 +8598,7 @@ exports[`typeahead multi select renders selected successfully 1`] = `
                 >
                   <button
                     class="pf-c-select__menu-item"
-                    id="pf-random-id-22-2"
+                    id="pf-random-id-24-2"
                     role="option"
                     type="button"
                   >
@@ -8610,7 +8610,7 @@ exports[`typeahead multi select renders selected successfully 1`] = `
                 >
                   <button
                     class="pf-c-select__menu-item"
-                    id="pf-random-id-22-3"
+                    id="pf-random-id-24-3"
                     role="option"
                     type="button"
                   >
@@ -8641,9 +8641,9 @@ exports[`typeahead multi select renders selected successfully 1`] = `
             <SelectOption
               className=""
               component="button"
-              id="pf-random-id-22-0"
+              id="pf-random-id-24-0"
               index={0}
-              inputId="pf-random-id-22-0"
+              inputId="pf-random-id-24-0"
               isChecked={false}
               isDisabled={false}
               isFocused={null}
@@ -8662,7 +8662,7 @@ exports[`typeahead multi select renders selected successfully 1`] = `
                 <button
                   aria-selected={true}
                   className="pf-c-select__menu-item pf-m-selected"
-                  id="pf-random-id-22-0"
+                  id="pf-random-id-24-0"
                   onClick={[Function]}
                   onKeyDown={[Function]}
                   role="option"
@@ -8705,9 +8705,9 @@ exports[`typeahead multi select renders selected successfully 1`] = `
             <SelectOption
               className=""
               component="button"
-              id="pf-random-id-22-1"
+              id="pf-random-id-24-1"
               index={1}
-              inputId="pf-random-id-22-1"
+              inputId="pf-random-id-24-1"
               isChecked={false}
               isDisabled={false}
               isFocused={null}
@@ -8726,7 +8726,7 @@ exports[`typeahead multi select renders selected successfully 1`] = `
                 <button
                   aria-selected={true}
                   className="pf-c-select__menu-item pf-m-selected"
-                  id="pf-random-id-22-1"
+                  id="pf-random-id-24-1"
                   onClick={[Function]}
                   onKeyDown={[Function]}
                   role="option"
@@ -8769,9 +8769,9 @@ exports[`typeahead multi select renders selected successfully 1`] = `
             <SelectOption
               className=""
               component="button"
-              id="pf-random-id-22-2"
+              id="pf-random-id-24-2"
               index={2}
-              inputId="pf-random-id-22-2"
+              inputId="pf-random-id-24-2"
               isChecked={false}
               isDisabled={false}
               isFocused={null}
@@ -8790,7 +8790,7 @@ exports[`typeahead multi select renders selected successfully 1`] = `
                 <button
                   aria-selected={null}
                   className="pf-c-select__menu-item"
-                  id="pf-random-id-22-2"
+                  id="pf-random-id-24-2"
                   onClick={[Function]}
                   onKeyDown={[Function]}
                   role="option"
@@ -8803,9 +8803,9 @@ exports[`typeahead multi select renders selected successfully 1`] = `
             <SelectOption
               className=""
               component="button"
-              id="pf-random-id-22-3"
+              id="pf-random-id-24-3"
               index={3}
-              inputId="pf-random-id-22-3"
+              inputId="pf-random-id-24-3"
               isChecked={false}
               isDisabled={false}
               isFocused={null}
@@ -8824,7 +8824,7 @@ exports[`typeahead multi select renders selected successfully 1`] = `
                 <button
                   aria-selected={null}
                   className="pf-c-select__menu-item"
-                  id="pf-random-id-22-3"
+                  id="pf-random-id-24-3"
                   onClick={[Function]}
                   onKeyDown={[Function]}
                   role="option"
@@ -8883,17 +8883,17 @@ exports[`typeahead multi select test onChange 1`] = `
   >
     <div
       className="pf-c-select pf-m-expanded"
-      data-ouia-component-id={35}
+      data-ouia-component-id={39}
       data-ouia-component-type="PF4/Select"
       data-ouia-safe={true}
     >
       <SelectToggle
         aria-label="Options menu"
-        aria-labelledby=" pf-select-toggle-id-15"
+        aria-labelledby=" pf-select-toggle-id-19"
         className=""
         handleTypeaheadKeys={[Function]}
         hasClearButton={true}
-        id="pf-select-toggle-id-15"
+        id="pf-select-toggle-id-19"
         isActive={false}
         isDisabled={false}
         isOpen={true}
@@ -8909,7 +8909,7 @@ exports[`typeahead multi select test onChange 1`] = `
               >
                 <button
                   class="pf-c-select__menu-item pf-m-disabled"
-                  id="pf-random-id-26-0"
+                  id="pf-random-id-28-0"
                   role="option"
                   type="button"
                 >
@@ -8926,7 +8926,7 @@ exports[`typeahead multi select test onChange 1`] = `
           Object {
             "current": <div
               class="pf-c-select pf-m-expanded"
-              data-ouia-component-id="35"
+              data-ouia-component-id="39"
               data-ouia-component-type="PF4/Select"
               data-ouia-safe="true"
             >
@@ -8940,7 +8940,7 @@ exports[`typeahead multi select test onChange 1`] = `
                     aria-label=""
                     autocomplete="off"
                     class="pf-c-form-control pf-c-select__toggle-typeahead"
-                    id="pf-select-toggle-id-15-select-typeahead"
+                    id="pf-select-toggle-id-19-select-typeahead"
                     placeholder=""
                     type="text"
                     value="test"
@@ -8970,9 +8970,9 @@ exports[`typeahead multi select test onChange 1`] = `
                   aria-expanded="true"
                   aria-haspopup="listbox"
                   aria-label="Options menu"
-                  aria-labelledby=" pf-select-toggle-id-15"
+                  aria-labelledby=" pf-select-toggle-id-19"
                   class="pf-c-button pf-c-select__toggle-button pf-m-plain"
-                  id="pf-select-toggle-id-15"
+                  id="pf-select-toggle-id-19"
                   tabindex="-1"
                   type="button"
                 >
@@ -9002,7 +9002,7 @@ exports[`typeahead multi select test onChange 1`] = `
                 >
                   <button
                     class="pf-c-select__menu-item pf-m-disabled"
-                    id="pf-random-id-26-0"
+                    id="pf-random-id-28-0"
                     role="option"
                     type="button"
                   >
@@ -9030,7 +9030,7 @@ exports[`typeahead multi select test onChange 1`] = `
               autoComplete="off"
               className="pf-c-form-control pf-c-select__toggle-typeahead"
               disabled={false}
-              id="pf-select-toggle-id-15-select-typeahead"
+              id="pf-select-toggle-id-19-select-typeahead"
               onChange={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -9078,10 +9078,10 @@ exports[`typeahead multi select test onChange 1`] = `
             aria-expanded={true}
             aria-haspopup="listbox"
             aria-label="Options menu"
-            aria-labelledby=" pf-select-toggle-id-15"
+            aria-labelledby=" pf-select-toggle-id-19"
             className="pf-c-button pf-c-select__toggle-button pf-m-plain"
             disabled={false}
-            id="pf-select-toggle-id-15"
+            id="pf-select-toggle-id-19"
             onClick={[Function]}
             tabIndex={-1}
             type="button"
@@ -9140,7 +9140,7 @@ exports[`typeahead multi select test onChange 1`] = `
                 >
                   <button
                     class="pf-c-select__menu-item pf-m-disabled"
-                    id="pf-random-id-26-0"
+                    id="pf-random-id-28-0"
                     role="option"
                     type="button"
                   >
@@ -9166,9 +9166,9 @@ exports[`typeahead multi select test onChange 1`] = `
             <SelectOption
               className=""
               component="button"
-              id="pf-random-id-26-0"
+              id="pf-random-id-28-0"
               index={0}
-              inputId="pf-random-id-26-0"
+              inputId="pf-random-id-28-0"
               isChecked={false}
               isDisabled={true}
               isFocused={null}
@@ -9187,7 +9187,7 @@ exports[`typeahead multi select test onChange 1`] = `
                 <button
                   aria-selected={null}
                   className="pf-c-select__menu-item pf-m-disabled"
-                  id="pf-random-id-26-0"
+                  id="pf-random-id-28-0"
                   onClick={[Function]}
                   onKeyDown={[Function]}
                   role="option"
@@ -10615,17 +10615,17 @@ exports[`typeahead select test creatable option 1`] = `
   >
     <div
       className="pf-c-select pf-m-expanded"
-      data-ouia-component-id={22}
+      data-ouia-component-id={26}
       data-ouia-component-type="PF4/Select"
       data-ouia-safe={true}
     >
       <SelectToggle
         aria-label="Options menu"
-        aria-labelledby=" pf-select-toggle-id-12"
+        aria-labelledby=" pf-select-toggle-id-16"
         className=""
         handleTypeaheadKeys={[Function]}
         hasClearButton={false}
-        id="pf-select-toggle-id-12"
+        id="pf-select-toggle-id-16"
         isActive={false}
         isDisabled={false}
         isOpen={true}
@@ -10641,7 +10641,7 @@ exports[`typeahead select test creatable option 1`] = `
               >
                 <button
                   class="pf-c-select__menu-item"
-                  id="pf-random-id-19-0"
+                  id="pf-random-id-21-0"
                   role="option"
                   type="button"
                 >
@@ -10661,7 +10661,7 @@ exports[`typeahead select test creatable option 1`] = `
           Object {
             "current": <div
               class="pf-c-select pf-m-expanded"
-              data-ouia-component-id="22"
+              data-ouia-component-id="26"
               data-ouia-component-type="PF4/Select"
               data-ouia-safe="true"
             >
@@ -10675,7 +10675,7 @@ exports[`typeahead select test creatable option 1`] = `
                     aria-label=""
                     autocomplete="off"
                     class="pf-c-form-control pf-c-select__toggle-typeahead"
-                    id="pf-select-toggle-id-12-select-typeahead"
+                    id="pf-select-toggle-id-16-select-typeahead"
                     placeholder=""
                     type="text"
                     value="test"
@@ -10705,9 +10705,9 @@ exports[`typeahead select test creatable option 1`] = `
                   aria-expanded="true"
                   aria-haspopup="listbox"
                   aria-label="Options menu"
-                  aria-labelledby=" pf-select-toggle-id-12"
+                  aria-labelledby=" pf-select-toggle-id-16"
                   class="pf-c-button pf-c-select__toggle-button pf-m-plain"
-                  id="pf-select-toggle-id-12"
+                  id="pf-select-toggle-id-16"
                   tabindex="-1"
                   type="button"
                 >
@@ -10737,7 +10737,7 @@ exports[`typeahead select test creatable option 1`] = `
                 >
                   <button
                     class="pf-c-select__menu-item"
-                    id="pf-random-id-19-0"
+                    id="pf-random-id-21-0"
                     role="option"
                     type="button"
                   >
@@ -10768,7 +10768,7 @@ exports[`typeahead select test creatable option 1`] = `
               autoComplete="off"
               className="pf-c-form-control pf-c-select__toggle-typeahead"
               disabled={false}
-              id="pf-select-toggle-id-12-select-typeahead"
+              id="pf-select-toggle-id-16-select-typeahead"
               onChange={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -10816,10 +10816,10 @@ exports[`typeahead select test creatable option 1`] = `
             aria-expanded={true}
             aria-haspopup="listbox"
             aria-label="Options menu"
-            aria-labelledby=" pf-select-toggle-id-12"
+            aria-labelledby=" pf-select-toggle-id-16"
             className="pf-c-button pf-c-select__toggle-button pf-m-plain"
             disabled={false}
-            id="pf-select-toggle-id-12"
+            id="pf-select-toggle-id-16"
             onClick={[Function]}
             tabIndex={-1}
             type="button"
@@ -10878,7 +10878,7 @@ exports[`typeahead select test creatable option 1`] = `
                 >
                   <button
                     class="pf-c-select__menu-item"
-                    id="pf-random-id-19-0"
+                    id="pf-random-id-21-0"
                     role="option"
                     type="button"
                   >
@@ -10907,9 +10907,9 @@ exports[`typeahead select test creatable option 1`] = `
             <SelectOption
               className=""
               component="button"
-              id="pf-random-id-19-0"
+              id="pf-random-id-21-0"
               index={0}
-              inputId="pf-random-id-19-0"
+              inputId="pf-random-id-21-0"
               isChecked={false}
               isDisabled={false}
               isFocused={null}
@@ -10928,7 +10928,7 @@ exports[`typeahead select test creatable option 1`] = `
                 <button
                   aria-selected={null}
                   className="pf-c-select__menu-item"
-                  id="pf-random-id-19-0"
+                  id="pf-random-id-21-0"
                   onClick={[Function]}
                   onKeyDown={[Function]}
                   role="option"
@@ -11295,6 +11295,730 @@ exports[`typeahead select test onChange 1`] = `
                   aria-selected={null}
                   className="pf-c-select__menu-item pf-m-disabled"
                   id="pf-random-id-18-0"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="option"
+                  type="button"
+                >
+                  No results found
+                </button>
+              </li>
+            </SelectOption>
+          </ul>
+        </SelectMenu>
+      </ForwardRef>
+    </div>
+  </GenerateId>
+</Select>
+`;
+
+exports[`typeahead select test select existing option on a non-creatable select 1`] = `
+<Select
+  aria-label=""
+  aria-labelledby=""
+  className=""
+  clearSelectionsAriaLabel="Clear all"
+  createText="Create"
+  customBadgeText={null}
+  customContent={null}
+  direction="down"
+  hasInlineFilter={false}
+  inlineFilterPlaceholderText={null}
+  inputIdPrefix=""
+  isCreatable={false}
+  isDisabled={false}
+  isGrouped={false}
+  isOpen={true}
+  isPlain={false}
+  menuAppendTo="inline"
+  noResultsFoundText="No results found"
+  onClear={[Function]}
+  onCreateOption={[Function]}
+  onFilter={null}
+  onToggle={[MockFunction]}
+  ouiaSafe={true}
+  placeholderText=""
+  removeSelectionAriaLabel="Remove"
+  selections={Array []}
+  toggleAriaLabel="Options menu"
+  toggleIcon={null}
+  toggleId={null}
+  typeAheadAriaLabel=""
+  variant="typeahead"
+  width=""
+>
+  <GenerateId
+    prefix="pf-random-id-"
+  >
+    <div
+      className="pf-c-select pf-m-expanded"
+      data-ouia-component-id={22}
+      data-ouia-component-type="PF4/Select"
+      data-ouia-safe={true}
+    >
+      <SelectToggle
+        aria-label="Options menu"
+        aria-labelledby=" pf-select-toggle-id-12"
+        className=""
+        handleTypeaheadKeys={[Function]}
+        hasClearButton={false}
+        id="pf-select-toggle-id-12"
+        isActive={false}
+        isDisabled={false}
+        isOpen={true}
+        isPlain={false}
+        menuRef={
+          Object {
+            "current": <ul
+              class="pf-c-select__menu"
+              role="listbox"
+            >
+              <li
+                role="presentation"
+              >
+                <button
+                  class="pf-c-select__menu-item"
+                  id="pf-random-id-19-0"
+                  role="option"
+                  type="button"
+                >
+                  Other
+                </button>
+              </li>
+            </ul>,
+          }
+        }
+        onClose={[Function]}
+        onEnter={[Function]}
+        onToggle={[MockFunction]}
+        parentRef={
+          Object {
+            "current": <div
+              class="pf-c-select pf-m-expanded"
+              data-ouia-component-id="22"
+              data-ouia-component-type="PF4/Select"
+              data-ouia-safe="true"
+            >
+              <div
+                class="pf-c-select__toggle pf-m-typeahead"
+              >
+                <div
+                  class="pf-c-select__toggle-wrapper"
+                >
+                  <input
+                    aria-label=""
+                    autocomplete="off"
+                    class="pf-c-form-control pf-c-select__toggle-typeahead"
+                    id="pf-select-toggle-id-12-select-typeahead"
+                    placeholder=""
+                    type="text"
+                    value="Oth"
+                  />
+                </div>
+                <button
+                  aria-label="Clear all"
+                  class="pf-c-button pf-m-plain pf-c-select__toggle-clear"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+                      transform=""
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-expanded="true"
+                  aria-haspopup="listbox"
+                  aria-label="Options menu"
+                  aria-labelledby=" pf-select-toggle-id-12"
+                  class="pf-c-button pf-c-select__toggle-button pf-m-plain"
+                  id="pf-select-toggle-id-12"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-c-select__toggle-arrow"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                      transform=""
+                    />
+                  </svg>
+                </button>
+              </div>
+              <ul
+                class="pf-c-select__menu"
+                role="listbox"
+              >
+                <li
+                  role="presentation"
+                >
+                  <button
+                    class="pf-c-select__menu-item"
+                    id="pf-random-id-19-0"
+                    role="option"
+                    type="button"
+                  >
+                    Other
+                  </button>
+                </li>
+              </ul>
+            </div>,
+          }
+        }
+        type="button"
+        variant="typeahead"
+      >
+        <div
+          className="pf-c-select__toggle pf-m-typeahead"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          <div
+            className="pf-c-select__toggle-wrapper"
+          >
+            <input
+              aria-activedescendant={null}
+              aria-label=""
+              autoComplete="off"
+              className="pf-c-form-control pf-c-select__toggle-typeahead"
+              disabled={false}
+              id="pf-select-toggle-id-12-select-typeahead"
+              onChange={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              placeholder=""
+              type="text"
+              value="Oth"
+            />
+          </div>
+          <button
+            aria-label="Clear all"
+            className="pf-c-button pf-m-plain pf-c-select__toggle-clear"
+            disabled={false}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            type="button"
+          >
+            <TimesCircleIcon
+              aria-hidden={true}
+              color="currentColor"
+              noVerticalAlign={false}
+              size="sm"
+            >
+              <svg
+                aria-hidden={true}
+                aria-labelledby={null}
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style={
+                  Object {
+                    "verticalAlign": "-0.125em",
+                  }
+                }
+                viewBox="0 0 512 512"
+                width="1em"
+              >
+                <path
+                  d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+                  transform=""
+                />
+              </svg>
+            </TimesCircleIcon>
+          </button>
+          <button
+            aria-expanded={true}
+            aria-haspopup="listbox"
+            aria-label="Options menu"
+            aria-labelledby=" pf-select-toggle-id-12"
+            className="pf-c-button pf-c-select__toggle-button pf-m-plain"
+            disabled={false}
+            id="pf-select-toggle-id-12"
+            onClick={[Function]}
+            tabIndex={-1}
+            type="button"
+          >
+            <CaretDownIcon
+              className="pf-c-select__toggle-arrow"
+              color="currentColor"
+              noVerticalAlign={false}
+              size="sm"
+            >
+              <svg
+                aria-hidden={true}
+                aria-labelledby={null}
+                className="pf-c-select__toggle-arrow"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style={
+                  Object {
+                    "verticalAlign": "-0.125em",
+                  }
+                }
+                viewBox="0 0 320 512"
+                width="1em"
+              >
+                <path
+                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                  transform=""
+                />
+              </svg>
+            </CaretDownIcon>
+          </button>
+        </div>
+      </SelectToggle>
+      <ForwardRef
+        aria-label=""
+        aria-labelledby=""
+        isGrouped={false}
+        keyHandler={[Function]}
+        openedOnEnter={false}
+        sendRef={[Function]}
+      >
+        <SelectMenu
+          aria-label=""
+          aria-labelledby=""
+          className=""
+          hasInlineFilter={false}
+          innerRef={
+            Object {
+              "current": <ul
+                class="pf-c-select__menu"
+                role="listbox"
+              >
+                <li
+                  role="presentation"
+                >
+                  <button
+                    class="pf-c-select__menu-item"
+                    id="pf-random-id-19-0"
+                    role="option"
+                    type="button"
+                  >
+                    Other
+                  </button>
+                </li>
+              </ul>,
+            }
+          }
+          isCustomContent={false}
+          isExpanded={false}
+          isGrouped={false}
+          keyHandler={[Function]}
+          maxHeight=""
+          openedOnEnter={false}
+          selected=""
+          sendRef={[Function]}
+        >
+          <ul
+            className="pf-c-select__menu"
+            role="listbox"
+          >
+            <SelectOption
+              className=""
+              component="button"
+              id="pf-random-id-19-0"
+              index={0}
+              inputId="pf-random-id-19-0"
+              isChecked={false}
+              isDisabled={false}
+              isFocused={null}
+              isNoResultsOption={false}
+              isPlaceholder={false}
+              isSelected={false}
+              key=".$.$03"
+              keyHandler={[Function]}
+              onClick={[Function]}
+              sendRef={[Function]}
+              value="Other"
+            >
+              <li
+                role="presentation"
+              >
+                <button
+                  aria-selected={null}
+                  className="pf-c-select__menu-item"
+                  id="pf-random-id-19-0"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="option"
+                  type="button"
+                >
+                  Other
+                </button>
+              </li>
+            </SelectOption>
+          </ul>
+        </SelectMenu>
+      </ForwardRef>
+    </div>
+  </GenerateId>
+</Select>
+`;
+
+exports[`typeahead select test select non-existing option on a non-creatable select 1`] = `
+<Select
+  aria-label=""
+  aria-labelledby=""
+  className=""
+  clearSelectionsAriaLabel="Clear all"
+  createText="Create"
+  customBadgeText={null}
+  customContent={null}
+  direction="down"
+  hasInlineFilter={false}
+  inlineFilterPlaceholderText={null}
+  inputIdPrefix=""
+  isCreatable={false}
+  isDisabled={false}
+  isGrouped={false}
+  isOpen={true}
+  isPlain={false}
+  menuAppendTo="inline"
+  noResultsFoundText="No results found"
+  onClear={[Function]}
+  onCreateOption={[Function]}
+  onFilter={null}
+  onToggle={[MockFunction]}
+  ouiaSafe={true}
+  placeholderText=""
+  removeSelectionAriaLabel="Remove"
+  selections={Array []}
+  toggleAriaLabel="Options menu"
+  toggleIcon={null}
+  toggleId={null}
+  typeAheadAriaLabel=""
+  variant="typeahead"
+  width=""
+>
+  <GenerateId
+    prefix="pf-random-id-"
+  >
+    <div
+      className="pf-c-select pf-m-expanded"
+      data-ouia-component-id={24}
+      data-ouia-component-type="PF4/Select"
+      data-ouia-safe={true}
+    >
+      <SelectToggle
+        aria-label="Options menu"
+        aria-labelledby=" pf-select-toggle-id-14"
+        className=""
+        handleTypeaheadKeys={[Function]}
+        hasClearButton={false}
+        id="pf-select-toggle-id-14"
+        isActive={false}
+        isDisabled={false}
+        isOpen={true}
+        isPlain={false}
+        menuRef={
+          Object {
+            "current": <ul
+              class="pf-c-select__menu"
+              role="listbox"
+            >
+              <li
+                role="presentation"
+              >
+                <button
+                  class="pf-c-select__menu-item pf-m-disabled"
+                  id="pf-random-id-20-0"
+                  role="option"
+                  type="button"
+                >
+                  No results found
+                </button>
+              </li>
+            </ul>,
+          }
+        }
+        onClose={[Function]}
+        onEnter={[Function]}
+        onToggle={[MockFunction]}
+        parentRef={
+          Object {
+            "current": <div
+              class="pf-c-select pf-m-expanded"
+              data-ouia-component-id="24"
+              data-ouia-component-type="PF4/Select"
+              data-ouia-safe="true"
+            >
+              <div
+                class="pf-c-select__toggle pf-m-typeahead"
+              >
+                <div
+                  class="pf-c-select__toggle-wrapper"
+                >
+                  <input
+                    aria-label=""
+                    autocomplete="off"
+                    class="pf-c-form-control pf-c-select__toggle-typeahead"
+                    id="pf-select-toggle-id-14-select-typeahead"
+                    placeholder=""
+                    type="text"
+                    value="NonExistingOption"
+                  />
+                </div>
+                <button
+                  aria-label="Clear all"
+                  class="pf-c-button pf-m-plain pf-c-select__toggle-clear"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+                      transform=""
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-expanded="true"
+                  aria-haspopup="listbox"
+                  aria-label="Options menu"
+                  aria-labelledby=" pf-select-toggle-id-14"
+                  class="pf-c-button pf-c-select__toggle-button pf-m-plain"
+                  id="pf-select-toggle-id-14"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-c-select__toggle-arrow"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                      transform=""
+                    />
+                  </svg>
+                </button>
+              </div>
+              <ul
+                class="pf-c-select__menu"
+                role="listbox"
+              >
+                <li
+                  role="presentation"
+                >
+                  <button
+                    class="pf-c-select__menu-item pf-m-disabled"
+                    id="pf-random-id-20-0"
+                    role="option"
+                    type="button"
+                  >
+                    No results found
+                  </button>
+                </li>
+              </ul>
+            </div>,
+          }
+        }
+        type="button"
+        variant="typeahead"
+      >
+        <div
+          className="pf-c-select__toggle pf-m-typeahead"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+        >
+          <div
+            className="pf-c-select__toggle-wrapper"
+          >
+            <input
+              aria-activedescendant={null}
+              aria-label=""
+              autoComplete="off"
+              className="pf-c-form-control pf-c-select__toggle-typeahead"
+              disabled={false}
+              id="pf-select-toggle-id-14-select-typeahead"
+              onChange={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              placeholder=""
+              type="text"
+              value="NonExistingOption"
+            />
+          </div>
+          <button
+            aria-label="Clear all"
+            className="pf-c-button pf-m-plain pf-c-select__toggle-clear"
+            disabled={false}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            type="button"
+          >
+            <TimesCircleIcon
+              aria-hidden={true}
+              color="currentColor"
+              noVerticalAlign={false}
+              size="sm"
+            >
+              <svg
+                aria-hidden={true}
+                aria-labelledby={null}
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style={
+                  Object {
+                    "verticalAlign": "-0.125em",
+                  }
+                }
+                viewBox="0 0 512 512"
+                width="1em"
+              >
+                <path
+                  d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+                  transform=""
+                />
+              </svg>
+            </TimesCircleIcon>
+          </button>
+          <button
+            aria-expanded={true}
+            aria-haspopup="listbox"
+            aria-label="Options menu"
+            aria-labelledby=" pf-select-toggle-id-14"
+            className="pf-c-button pf-c-select__toggle-button pf-m-plain"
+            disabled={false}
+            id="pf-select-toggle-id-14"
+            onClick={[Function]}
+            tabIndex={-1}
+            type="button"
+          >
+            <CaretDownIcon
+              className="pf-c-select__toggle-arrow"
+              color="currentColor"
+              noVerticalAlign={false}
+              size="sm"
+            >
+              <svg
+                aria-hidden={true}
+                aria-labelledby={null}
+                className="pf-c-select__toggle-arrow"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style={
+                  Object {
+                    "verticalAlign": "-0.125em",
+                  }
+                }
+                viewBox="0 0 320 512"
+                width="1em"
+              >
+                <path
+                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                  transform=""
+                />
+              </svg>
+            </CaretDownIcon>
+          </button>
+        </div>
+      </SelectToggle>
+      <ForwardRef
+        aria-label=""
+        aria-labelledby=""
+        isGrouped={false}
+        keyHandler={[Function]}
+        openedOnEnter={false}
+        sendRef={[Function]}
+      >
+        <SelectMenu
+          aria-label=""
+          aria-labelledby=""
+          className=""
+          hasInlineFilter={false}
+          innerRef={
+            Object {
+              "current": <ul
+                class="pf-c-select__menu"
+                role="listbox"
+              >
+                <li
+                  role="presentation"
+                >
+                  <button
+                    class="pf-c-select__menu-item pf-m-disabled"
+                    id="pf-random-id-20-0"
+                    role="option"
+                    type="button"
+                  >
+                    No results found
+                  </button>
+                </li>
+              </ul>,
+            }
+          }
+          isCustomContent={false}
+          isExpanded={false}
+          isGrouped={false}
+          keyHandler={[Function]}
+          maxHeight=""
+          openedOnEnter={false}
+          selected=""
+          sendRef={[Function]}
+        >
+          <ul
+            className="pf-c-select__menu"
+            role="listbox"
+          >
+            <SelectOption
+              className=""
+              component="button"
+              id="pf-random-id-20-0"
+              index={0}
+              inputId="pf-random-id-20-0"
+              isChecked={false}
+              isDisabled={true}
+              isFocused={null}
+              isNoResultsOption={true}
+              isPlaceholder={false}
+              isSelected={false}
+              key=".$0"
+              keyHandler={[Function]}
+              onClick={[Function]}
+              sendRef={[Function]}
+              value="No results found"
+            >
+              <li
+                role="presentation"
+              >
+                <button
+                  aria-selected={null}
+                  className="pf-c-select__menu-item pf-m-disabled"
+                  id="pf-random-id-20-0"
                   onClick={[Function]}
                   onKeyDown={[Function]}
                   role="option"

--- a/packages/react-integration/cypress/integration/select.spec.ts
+++ b/packages/react-integration/cypress/integration/select.spec.ts
@@ -33,12 +33,47 @@ describe('Select Test', () => {
       .should('exist');
   });
 
-  xit('Verify Typeahead Select', () => {
-    cy.get('#typeahead-select').click();
-    cy.get('#Florida-2').click();
-    cy.get('#select-typeahead').should('have.value', 'Florida');
-    cy.get('button.pf-c-select__toggle-clear').click();
-    cy.get('#select-typeahead').should('have.value', '');
+  it('Verify Typeahead Select', () => {
+    const find = (selector: string) =>
+      cy
+        .get('#typeahead-select-id')
+        .parent()
+        .find(selector);
+    find('button.pf-c-select__toggle-button').click();
+    find('li:nth-child(3) button').click();
+    find('#typeahead-select-select-typeahead').should('have.value', 'Florida');
+    find('button.pf-c-select__toggle-clear:first').click();
+    find('#typeahead-select-select-typeahead').should('have.value', '');
+  });
+
+  it('Verify Non-Creatable Typeahead selection', () => {
+    const find = (selector: string) =>
+      cy
+        .get('#typeahead-select-id')
+        .parent()
+        .find(selector);
+    find('#typeahead-select').click();
+    find('#typeahead-select-select-typeahead').should('have.value', '');
+    find('input:nth-child(1)').type('Flo');
+    find('#typeahead-select-select-typeahead').should('have.value', 'Flo');
+    find('input:nth-child(1)').trigger('keydown', { keyCode: 13 });
+    find('#typeahead-select-select-typeahead').should('have.value', 'Florida');
+    find('button.pf-c-select__toggle-clear:first').click();
+    find('#typeahead-select-select-typeahead').should('have.value', '');
+  });
+
+  it('Verify Non-Creatable Typeahead selection which does not exist', () => {
+    const find = (selector: string) =>
+      cy
+        .get('#typeahead-select-id')
+        .parent()
+        .find(selector);
+    find('#typeahead-select').click();
+    find('#typeahead-select-select-typeahead').should('have.value', '');
+    find('input:nth-child(1)').type('Unknown');
+    find('#typeahead-select-select-typeahead').should('have.value', 'Unknown');
+    find('input:nth-child(1)').trigger('keydown', { keyCode: 13 });
+    find('#typeahead-select-select-typeahead').should('have.value', '');
   });
 
   xit('Verify Creatable Typeahead Select', () => {


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes https://github.com/patternfly/patternfly-react/issues/4615

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:

The first commit fixes the issue https://github.com/patternfly/patternfly-react/issues/4615 which is reproducible on CodeSandbox: https://codesandbox.io/s/elegant-hofstadter-omfke?file=/index.js

After fixing this I noticed that the preventDefault method was not called for an "enter" key event. Which results in the issue that the Form was automatically submitted. When the Select is open and the user presses enter this should close the select field instead of submitting the form. I added a second commit for this.

I'm not sure if this is your desired way to solve this issue. I'm open for your feedback on this fix.