### PR TITLE
fix(ClipboardCopy): maintain line breaks & spaces when copying text

### DIFF
--- a/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
+++ b/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
@@ -10,12 +10,14 @@ import { ClipboardCopyButton } from './ClipboardCopyButton';
 import { ClipboardCopyToggle } from './ClipboardCopyToggle';
 import { ClipboardCopyExpanded } from './ClipboardCopyExpanded';
 
-export const clipboardCopyFunc = (event: React.ClipboardEvent<HTMLDivElement>) => {
-  const inpt = event.currentTarget.previousSibling;
-  const r = document.createRange();
-  r.selectNode(inpt);
-  window.getSelection().addRange(r);
+export const clipboardCopyFunc = (event: React.ClipboardEvent<HTMLDivElement>, text?: React.ReactNode) => {
+  const clipboard = event.currentTarget.parentElement;
+  const el = document.createElement('textarea');
+  el.value = text.toString();
+  clipboard.appendChild(el);
+  el.select();
   document.execCommand('copy');
+  clipboard.removeChild(el);
 };
 
 export enum ClipboardCopyVariant {

--- a/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
+++ b/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
@@ -10,14 +10,12 @@ import { ClipboardCopyButton } from './ClipboardCopyButton';
 import { ClipboardCopyToggle } from './ClipboardCopyToggle';
 import { ClipboardCopyExpanded } from './ClipboardCopyExpanded';
 
-export const clipboardCopyFunc = (event: React.ClipboardEvent<HTMLDivElement>, text?: React.ReactNode) => {
-  const clipboard = event.currentTarget.parentElement;
-  const el = document.createElement('input');
-  el.value = text.toString();
-  clipboard.appendChild(el);
-  el.select();
+export const clipboardCopyFunc = (event: React.ClipboardEvent<HTMLDivElement>) => {
+  const inpt = event.currentTarget.previousSibling;
+  const r = document.createRange();
+  r.selectNode(inpt);
+  window.getSelection().addRange(r);
   document.execCommand('copy');
-  clipboard.removeChild(el);
 };
 
 export enum ClipboardCopyVariant {


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4618

This PR allows copying to keep the line breaks/spaces in the text