### PR TITLE
feat(Select): allow typeahead groups, fix few bugs around groups

### DIFF
--- a/packages/react-core/src/components/Select/SelectMenu.tsx
+++ b/packages/react-core/src/components/Select/SelectMenu.tsx
@@ -7,6 +7,7 @@ import { SelectConsumer, SelectVariant } from './selectConstants';
 import { PickOptional } from '../../helpers/typeUtils';
 
 import { FocusTrap } from '../../helpers';
+import { SelectGroup } from './SelectGroup';
 
 export interface SelectMenuProps extends Omit<React.HTMLProps<HTMLElement>, 'checked' | 'selected' | 'ref'> {
   /** Content rendered inside the SelectMenu */
@@ -59,14 +60,19 @@ class SelectMenuWithRef extends React.Component<SelectMenuProps> {
     const { children, isGrouped } = this.props;
     const childrenArray: React.ReactElement[] = children as React.ReactElement[];
     if (isGrouped) {
-      return React.Children.map(childrenArray, (group: React.ReactElement, index: number) =>
-        React.cloneElement(group, {
-          titleId: group.props.label && group.props.label.replace(/\W/g, '-'),
-          children: group.props.children.map((option: React.ReactElement) =>
-            this.cloneOption(option, index++, randomId)
-          )
-        })
-      );
+      let index = 0;
+      return React.Children.map(childrenArray, (group: React.ReactElement) => {
+        if (group.type === SelectGroup) {
+          return React.cloneElement(group, {
+            titleId: group.props.label && group.props.label.replace(/\W/g, '-'),
+            children: React.Children.map(group.props.children, (option: React.ReactElement) =>
+              this.cloneOption(option, index++, randomId)
+            )
+          });
+        } else {
+          return this.cloneOption(group, index++, randomId);
+        }
+      });
     }
     return React.Children.map(childrenArray, (child: React.ReactElement, index: number) =>
       this.cloneOption(child, index, randomId)

--- a/packages/react-core/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/packages/react-core/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
@@ -4483,7 +4483,7 @@ exports[`select renders select groups successfully 1`] = `
                 >
                   <button
                     class="pf-c-select__menu-item"
-                    id="pf-random-id-6-1"
+                    id="pf-random-id-6-4"
                     role="option"
                     type="button"
                   >
@@ -4495,7 +4495,7 @@ exports[`select renders select groups successfully 1`] = `
                 >
                   <button
                     class="pf-c-select__menu-item"
-                    id="pf-random-id-6-2"
+                    id="pf-random-id-6-5"
                     role="option"
                     type="button"
                   >
@@ -4507,7 +4507,7 @@ exports[`select renders select groups successfully 1`] = `
                 >
                   <button
                     class="pf-c-select__menu-item"
-                    id="pf-random-id-6-3"
+                    id="pf-random-id-6-6"
                     role="option"
                     type="button"
                   >
@@ -4519,7 +4519,7 @@ exports[`select renders select groups successfully 1`] = `
                 >
                   <button
                     class="pf-c-select__menu-item"
-                    id="pf-random-id-6-4"
+                    id="pf-random-id-6-7"
                     role="option"
                     type="button"
                   >
@@ -4653,7 +4653,7 @@ exports[`select renders select groups successfully 1`] = `
                   >
                     <button
                       class="pf-c-select__menu-item"
-                      id="pf-random-id-6-1"
+                      id="pf-random-id-6-4"
                       role="option"
                       type="button"
                     >
@@ -4665,7 +4665,7 @@ exports[`select renders select groups successfully 1`] = `
                   >
                     <button
                       class="pf-c-select__menu-item"
-                      id="pf-random-id-6-2"
+                      id="pf-random-id-6-5"
                       role="option"
                       type="button"
                     >
@@ -4677,7 +4677,7 @@ exports[`select renders select groups successfully 1`] = `
                   >
                     <button
                       class="pf-c-select__menu-item"
-                      id="pf-random-id-6-3"
+                      id="pf-random-id-6-6"
                       role="option"
                       type="button"
                     >
@@ -4689,7 +4689,7 @@ exports[`select renders select groups successfully 1`] = `
                   >
                     <button
                       class="pf-c-select__menu-item"
-                      id="pf-random-id-6-4"
+                      id="pf-random-id-6-7"
                       role="option"
                       type="button"
                     >
@@ -4846,7 +4846,7 @@ exports[`select renders select groups successfully 1`] = `
                   >
                     <button
                       class="pf-c-select__menu-item"
-                      id="pf-random-id-6-1"
+                      id="pf-random-id-6-4"
                       role="option"
                       type="button"
                     >
@@ -4858,7 +4858,7 @@ exports[`select renders select groups successfully 1`] = `
                   >
                     <button
                       class="pf-c-select__menu-item"
-                      id="pf-random-id-6-2"
+                      id="pf-random-id-6-5"
                       role="option"
                       type="button"
                     >
@@ -4870,7 +4870,7 @@ exports[`select renders select groups successfully 1`] = `
                   >
                     <button
                       class="pf-c-select__menu-item"
-                      id="pf-random-id-6-3"
+                      id="pf-random-id-6-6"
                       role="option"
                       type="button"
                     >
@@ -4882,7 +4882,7 @@ exports[`select renders select groups successfully 1`] = `
                   >
                     <button
                       class="pf-c-select__menu-item"
-                      id="pf-random-id-6-4"
+                      id="pf-random-id-6-7"
                       role="option"
                       type="button"
                     >
@@ -4932,7 +4932,7 @@ exports[`select renders select groups successfully 1`] = `
                   isNoResultsOption={false}
                   isPlaceholder={false}
                   isSelected={false}
-                  key="00"
+                  key=".$00"
                   keyHandler={[Function]}
                   onClick={[Function]}
                   sendRef={[Function]}
@@ -4965,7 +4965,7 @@ exports[`select renders select groups successfully 1`] = `
                   isNoResultsOption={false}
                   isPlaceholder={false}
                   isSelected={false}
-                  key="01"
+                  key=".$01"
                   keyHandler={[Function]}
                   onClick={[Function]}
                   sendRef={[Function]}
@@ -4998,7 +4998,7 @@ exports[`select renders select groups successfully 1`] = `
                   isNoResultsOption={false}
                   isPlaceholder={false}
                   isSelected={false}
-                  key="02"
+                  key=".$02"
                   keyHandler={[Function]}
                   onClick={[Function]}
                   sendRef={[Function]}
@@ -5031,7 +5031,7 @@ exports[`select renders select groups successfully 1`] = `
                   isNoResultsOption={false}
                   isPlaceholder={false}
                   isSelected={false}
-                  key="03"
+                  key=".$03"
                   keyHandler={[Function]}
                   onClick={[Function]}
                   sendRef={[Function]}
@@ -5073,15 +5073,15 @@ exports[`select renders select groups successfully 1`] = `
                 <SelectOption
                   className=""
                   component="button"
-                  id="pf-random-id-6-1"
-                  index={1}
-                  inputId="pf-random-id-6-1"
+                  id="pf-random-id-6-4"
+                  index={4}
+                  inputId="pf-random-id-6-4"
                   isChecked={false}
                   isDisabled={false}
                   isNoResultsOption={false}
                   isPlaceholder={false}
                   isSelected={false}
-                  key="00"
+                  key=".$00"
                   keyHandler={[Function]}
                   onClick={[Function]}
                   sendRef={[Function]}
@@ -5093,7 +5093,7 @@ exports[`select renders select groups successfully 1`] = `
                     <button
                       aria-selected={null}
                       className="pf-c-select__menu-item"
-                      id="pf-random-id-6-1"
+                      id="pf-random-id-6-4"
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
@@ -5106,15 +5106,15 @@ exports[`select renders select groups successfully 1`] = `
                 <SelectOption
                   className=""
                   component="button"
-                  id="pf-random-id-6-2"
-                  index={2}
-                  inputId="pf-random-id-6-2"
+                  id="pf-random-id-6-5"
+                  index={5}
+                  inputId="pf-random-id-6-5"
                   isChecked={false}
                   isDisabled={false}
                   isNoResultsOption={false}
                   isPlaceholder={false}
                   isSelected={false}
-                  key="01"
+                  key=".$01"
                   keyHandler={[Function]}
                   onClick={[Function]}
                   sendRef={[Function]}
@@ -5126,7 +5126,7 @@ exports[`select renders select groups successfully 1`] = `
                     <button
                       aria-selected={null}
                       className="pf-c-select__menu-item"
-                      id="pf-random-id-6-2"
+                      id="pf-random-id-6-5"
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
@@ -5139,15 +5139,15 @@ exports[`select renders select groups successfully 1`] = `
                 <SelectOption
                   className=""
                   component="button"
-                  id="pf-random-id-6-3"
-                  index={3}
-                  inputId="pf-random-id-6-3"
+                  id="pf-random-id-6-6"
+                  index={6}
+                  inputId="pf-random-id-6-6"
                   isChecked={false}
                   isDisabled={false}
                   isNoResultsOption={false}
                   isPlaceholder={false}
                   isSelected={false}
-                  key="02"
+                  key=".$02"
                   keyHandler={[Function]}
                   onClick={[Function]}
                   sendRef={[Function]}
@@ -5159,7 +5159,7 @@ exports[`select renders select groups successfully 1`] = `
                     <button
                       aria-selected={null}
                       className="pf-c-select__menu-item"
-                      id="pf-random-id-6-3"
+                      id="pf-random-id-6-6"
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
@@ -5172,15 +5172,15 @@ exports[`select renders select groups successfully 1`] = `
                 <SelectOption
                   className=""
                   component="button"
-                  id="pf-random-id-6-4"
-                  index={4}
-                  inputId="pf-random-id-6-4"
+                  id="pf-random-id-6-7"
+                  index={7}
+                  inputId="pf-random-id-6-7"
                   isChecked={false}
                   isDisabled={false}
                   isNoResultsOption={false}
                   isPlaceholder={false}
                   isSelected={false}
-                  key="03"
+                  key=".$03"
                   keyHandler={[Function]}
                   onClick={[Function]}
                   sendRef={[Function]}
@@ -5192,7 +5192,7 @@ exports[`select renders select groups successfully 1`] = `
                     <button
                       aria-selected={null}
                       className="pf-c-select__menu-item"
-                      id="pf-random-id-6-4"
+                      id="pf-random-id-6-7"
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"

--- a/packages/react-core/src/components/Select/examples/Select.md
+++ b/packages/react-core/src/components/Select/examples/Select.md
@@ -9,6 +9,7 @@ ouia: true
 ## Examples
 
 ### Single
+
 ```js
 import React from 'react';
 import { CubeIcon } from '@patternfly/react-icons';
@@ -144,6 +145,7 @@ class SingleSelectInput extends React.Component {
 ```
 
 ### Single with description
+
 ```js
 import React from 'react';
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
@@ -227,6 +229,7 @@ class SingleSelectDescription extends React.Component {
 ```
 
 ### Grouped single
+
 ```js
 import React from 'react';
 import { Select, SelectOption, SelectVariant, SelectGroup } from '@patternfly/react-core';
@@ -301,6 +304,7 @@ class GroupedSingleSelectInput extends React.Component {
 ```
 
 ### Checkbox input
+
 ```js
 import React from 'react';
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
@@ -377,6 +381,7 @@ class CheckboxSelectInput extends React.Component {
 ```
 
 ### Checkbox input no badge
+
 ```js
 import React from 'react';
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
@@ -453,6 +458,7 @@ class CheckboxSelectInputNoBadge extends React.Component {
 ```
 
 ### Grouped checkbox input
+
 ```js
 import React from 'react';
 import { Select, SelectOption, SelectVariant, SelectGroup } from '@patternfly/react-core';
@@ -535,6 +541,7 @@ class GroupedCheckboxSelectInput extends React.Component {
 ```
 
 ### Grouped checkbox input with filtering
+
 ```js
 import React from 'react';
 import { Select, SelectOption, SelectGroup, SelectVariant } from '@patternfly/react-core';
@@ -640,6 +647,7 @@ class FilteringCheckboxSelectInput extends React.Component {
 ```
 
 ### Grouped checkbox input with filtering and placeholder text
+
 ```js
 import React from 'react';
 import { Select, SelectOption, SelectGroup, SelectVariant } from '@patternfly/react-core';
@@ -746,6 +754,7 @@ class FilteringCheckboxSelectInputWithPlaceholder extends React.Component {
 ```
 
 ### Grouped checkbox input with filtering and custom badging
+
 ```js
 import React from 'react';
 import { Select, SelectOption, SelectGroup, SelectVariant } from '@patternfly/react-core';
@@ -870,6 +879,7 @@ class FilteringCheckboxSelectInputWithBadging extends React.Component {
 ```
 
 ### Typeahead
+
 ```js
 import React from 'react';
 import { Checkbox, Select, SelectOption, SelectVariant } from '@patternfly/react-core';
@@ -1004,7 +1014,137 @@ class TypeaheadSelectInput extends React.Component {
 }
 ```
 
+### Grouped typeahead
+
+```js
+import React from 'react';
+import { Checkbox, Select, SelectGroup, SelectOption, SelectVariant } from '@patternfly/react-core';
+
+class GroupedTypeaheadSelectInput extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      options: [
+        <SelectGroup label="Status" key="group1">
+          <SelectOption key={0} value="Running" />
+          <SelectOption key={1} value="Stopped" />
+          <SelectOption key={2} value="Down" />
+          <SelectOption key={3} value="Degraded" />
+          <SelectOption key={4} value="Needs Maintenence" />
+        </SelectGroup>,
+        <SelectGroup label="Vendor Names" key="group2">
+          <SelectOption key={5} value="Dell" />
+          <SelectOption key={6} value="Samsung" isDisabled />
+          <SelectOption key={7} value="Hewlett-Packard" />
+        </SelectGroup>
+      ],
+      newOptions: [],
+      isOpen: false,
+      selected: null,
+      isCreatable: false,
+      hasOnCreateOption: false
+    };
+
+    this.onToggle = isOpen => {
+      this.setState({
+        isOpen
+      });
+    };
+
+    this.onSelect = (event, selection, isPlaceholder) => {
+      if (isPlaceholder) this.clearSelection();
+      else {
+        this.setState({
+          selected: selection,
+          isOpen: false
+        });
+        console.log('selected:', selection);
+      }
+    };
+
+    this.onCreateOption = newValue => {
+      this.setState({
+        newOptions: [...this.state.newOptions, <SelectOption key={newValue} value={newValue} />]
+      });
+    };
+
+    this.clearSelection = () => {
+      this.setState({
+        selected: null,
+        isOpen: false
+      });
+    };
+
+    this.toggleCreatable = checked => {
+      this.setState({
+        isCreatable: checked
+      });
+    };
+
+    this.toggleCreateNew = checked => {
+      this.setState({
+        hasOnCreateOption: checked
+      });
+    };
+  }
+
+  render() {
+    const { isOpen, selected, isDisabled, isCreatable, hasOnCreateOption, options, newOptions } = this.state;
+    const titleId = 'grouped-typeahead-select-id';
+    const allOptions =
+      newOptions.length > 0
+        ? options.concat(
+            <SelectGroup label="Created" key="create-group">
+              {newOptions}
+            </SelectGroup>
+          )
+        : options;
+    return (
+      <div>
+        <span id={titleId} hidden>
+          Select a state
+        </span>
+        <Select
+          variant={SelectVariant.typeahead}
+          typeAheadAriaLabel="Select a state"
+          onToggle={this.onToggle}
+          onSelect={this.onSelect}
+          onClear={this.clearSelection}
+          selections={selected}
+          isOpen={isOpen}
+          aria-labelledby={titleId}
+          placeholderText="Select a state"
+          isGrouped
+          isCreatable={isCreatable}
+          onCreateOption={(hasOnCreateOption && this.onCreateOption) || undefined}
+        >
+          {allOptions}
+        </Select>
+        <Checkbox
+          label="isCreatable"
+          isChecked={this.state.isCreatable}
+          onChange={this.toggleCreatable}
+          aria-label="toggle creatable checkbox"
+          id="toggle-creatable-typeahead"
+          name="toggle-creatable-typeahead"
+        />
+        <Checkbox
+          label="onCreateOption"
+          isChecked={this.state.hasOnCreateOption}
+          onChange={this.toggleCreateNew}
+          aria-label="toggle new checkbox"
+          id="toggle-new-typeahead"
+          name="toggle-new-typeahead"
+        />
+      </div>
+    );
+  }
+}
+```
+
 ### Custom filtering
+
 ```js
 import React from 'react';
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
@@ -1087,6 +1227,7 @@ class TypeaheadSelectInput extends React.Component {
 ```
 
 ### Multiple
+
 ```js
 import React from 'react';
 import { Checkbox, Select, SelectOption, SelectVariant } from '@patternfly/react-core';
@@ -1211,6 +1352,7 @@ class MultiTypeaheadSelectInput extends React.Component {
 ```
 
 ### Multiple with custom objects
+
 ```js
 import React from 'react';
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
@@ -1315,6 +1457,7 @@ class MultiTypeaheadSelectInputCustomObjects extends React.Component {
 ```
 
 ### Plain multiple typeahead
+
 ```js
 import React from 'react';
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
@@ -1398,6 +1541,7 @@ class PlainSelectInput extends React.Component {
 ```
 
 ### Panel
+
 ```js
 import React from 'react';
 import { CubeIcon } from '@patternfly/react-icons';
@@ -1479,6 +1623,7 @@ class SingleSelectInput extends React.Component {
 ```
 
 ### select menu document body
+
 ```js
 import React from 'react';
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';

--- a/packages/react-core/src/helpers/util.ts
+++ b/packages/react-core/src/helpers/util.ts
@@ -196,7 +196,7 @@ export function keyHandler(
  * @param {string} position The orientation of the dropdown
  * @param {string[]} collection Array of refs to the items in the dropdown
  */
-export function getNextIndex(index: number, position: string, collection: any[]) {
+export function getNextIndex(index: number, position: string, collection: any[]): number {
   let nextIndex;
   if (position === 'up') {
     if (index === 0) {
@@ -212,7 +212,7 @@ export function getNextIndex(index: number, position: string, collection: any[])
     nextIndex = index + 1;
   }
   if (collection[nextIndex] === null) {
-    getNextIndex(nextIndex, position, collection);
+    return getNextIndex(nextIndex, position, collection);
   } else {
     return nextIndex;
   }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4590, #4592 + a couple related bugs found while addressing the tickets

In summary:
- Allows typeahead variants to properly use `isGrouped` and `SelectGroup`. (#4590)
- Allows mixed grouped and ungrouped SelectOptions when using `isGrouped`, as typeahead variants may add ungrouped options (such as no results, and createable options).
- Fixes bug in keyboard navigation of grouped options, where the ref collection wasn't indexed properly.
- Fixes bug in keyboard navigation of typeahead options, where disabled options weren't skipped properly.
- Fixes bug where an error occurred when a SelectGroup had only one SelectOption and wasn't defined as an array. (#4592)
- Adds handling of an edge case in typeahead keyboard navigation, where a typeahead select's options could solely be a disabled option (in the case of no results).
- Adds an example of a grouped typeahead select.
