### PR TITLE
fix(react-docs): add missing imports

### DIFF
--- a/packages/react-core/src/components/Dropdown/examples/Dropdown.md
+++ b/packages/react-core/src/components/Dropdown/examples/Dropdown.md
@@ -9,6 +9,7 @@ ouia: true
 
 import { ThIcon, CaretDownIcon, CogIcon, BellIcon, CubesIcon, UserIcon } from '@patternfly/react-icons';
 import { Link } from '@reach/router';
+import avatarImg from '../../Avatar/examples/avatarImg.svg';
 
 ## Examples
 

--- a/packages/react-core/src/components/EmptyState/examples/EmptyState.md
+++ b/packages/react-core/src/components/EmptyState/examples/EmptyState.md
@@ -14,7 +14,7 @@ import {
   EmptyStateSecondaryActions,
   EmptyStatePrimary
 } from '@patternfly/react-core';
-import { CubesIcon } from '@patternfly/react-icons';
+import { CubesIcon, SearchIcon } from '@patternfly/react-icons';
 
 ## Examples
 ### Small


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: For the patternfly.org refactor I've added proper MDX scope handling, so each file MUST import components it uses that aren't in react-core or react-table.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
