### PR TITLE
fix(react-docs): title syntax

### DIFF
--- a/packages/react-core/src/components/Wizard/examples/Wizard.md
+++ b/packages/react-core/src/components/Wizard/examples/Wizard.md
@@ -42,7 +42,8 @@ class SimpleWizard extends React.Component {
 }
 ```
 
-```js title=Anchors-for-nav-items
+### Anchors for nav items
+```js
 import React from 'react';
 import { Button, Wizard } from '@patternfly/react-core';
 import { ExternalLinkAltIcon, SlackHashIcon } from '@patternfly/react-icons';


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Followup to #4627. For the patternfly.org refactor we need to use the `### Example title` syntax.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
