### PR TITLE
fix(Topology): Re-parent nodes with invalid parents to graph

### DIFF
--- a/packages/react-topology/src/Visualization.ts
+++ b/packages/react-topology/src/Visualization.ts
@@ -103,7 +103,7 @@ export class Visualization extends Stateful implements Controller {
     }
 
     if (this.graph) {
-      this.parentOrphansToGraph(this.graph);
+      this.parentOrphansToGraph(this.graph, validIds);
     }
   }
 
@@ -269,9 +269,9 @@ export class Visualization extends Stateful implements Controller {
     this.addElement(element);
   }
 
-  private parentOrphansToGraph(graph: Graph): void {
+  private parentOrphansToGraph(graph: Graph, validIds: string[]): void {
     this.getElements().forEach((element: GraphElement) => {
-      if (element !== this.graph && !element.hasParent()) {
+      if (element !== this.graph && (!element.hasParent() || !validIds.includes(element.getParent().getId()))) {
         graph.appendChild(element);
       }
     });


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: 
Fixes an issue where a node is not shown if it is no longer a child of a valid group (when it previously was)

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
None

Need this fix for OpenShift Console 4.6