### PR TITLE
feat(NotificationDrawer): add formatHeaderText prop to support customize notification drawer header text

### DIFF
--- a/packages/react-core/src/components/NotificationDrawer/NotificationDrawerHeader.tsx
+++ b/packages/react-core/src/components/NotificationDrawer/NotificationDrawerHeader.tsx
@@ -14,8 +14,8 @@ export interface NotificationDrawerHeaderProps extends React.HTMLProps<HTMLDivEl
   count?: number;
   /**  Notification drawer heading title */
   title?: string;
-  /**  Notification drawer heading unread custom text */
-  unreadText?: string;
+  /**  Notification drawer heading custom text */
+  formatHeaderText?: string;
 }
 
 export const NotificationDrawerHeader: React.FunctionComponent<NotificationDrawerHeaderProps> = ({
@@ -23,15 +23,17 @@ export const NotificationDrawerHeader: React.FunctionComponent<NotificationDrawe
   className = '',
   count,
   title = 'Notifications',
-  unreadText = 'unread',
+  formatHeaderText,
   ...props
 }: NotificationDrawerHeaderProps) => (
   <div {...props} className={css(styles.notificationDrawerHeader, className)}>
     <Text component={TextVariants.h1} className={css(styles.notificationDrawerHeaderTitle)}>
       {title}
     </Text>
-    {count !== undefined && (
-      <span className={css(styles.notificationDrawerHeaderStatus)}>{`${count} ${unreadText}`}</span>
+    {formatHeaderText === undefined ? (
+      count !== undefined && <span className={css(styles.notificationDrawerHeaderStatus)}>{`${count} unread`}</span>
+    ) : (
+      <span className={css(styles.notificationDrawerHeaderStatus)}>{formatHeaderText}</span>
     )}
     {children && <div className={css(styles.notificationDrawerHeaderAction)}>{children}</div>}
   </div>

--- a/packages/react-core/src/components/NotificationDrawer/__tests__/NotificationDrawerHeader.test.tsx
+++ b/packages/react-core/src/components/NotificationDrawer/__tests__/NotificationDrawerHeader.test.tsx
@@ -29,6 +29,6 @@ test('drawer header with title applied', () => {
 });
 
 test('drawer header with custom unread text applied', () => {
-  const view = shallow(<NotificationDrawerHeader unreadText="unread alerts" />);
+  const view = shallow(<NotificationDrawerHeader formatHeaderText="2 unread alerts" />);
   expect(view).toMatchSnapshot();
 });

--- a/packages/react-core/src/components/NotificationDrawer/__tests__/__snapshots__/NotificationDrawerHeader.test.tsx.snap
+++ b/packages/react-core/src/components/NotificationDrawer/__tests__/__snapshots__/NotificationDrawerHeader.test.tsx.snap
@@ -30,6 +30,11 @@ exports[`drawer header with custom unread text applied 1`] = `
   >
     Notifications
   </Text>
+  <span
+    className="pf-c-notification-drawer__header-status"
+  >
+    2 unread alerts
+  </span>
 </div>
 `;
 

--- a/packages/react-core/src/components/NotificationDrawer/examples/NotificationDrawer.md
+++ b/packages/react-core/src/components/NotificationDrawer/examples/NotificationDrawer.md
@@ -2,14 +2,27 @@
 id: Notification drawer
 section: components
 cssPrefix: pf-c-notification-drawer
-propComponents: ['NotificationDrawer', 'NotificationDrawerBody', 'NotificationDrawerHeader', 'NotificationDrawerGroup', 'NotificationDrawerGroupList', 'NotificationDrawerList', 'NotificationDrawerListItem', 'NotificationDrawerListItemBody', 'NotificationDrawerListItemHeader']
+propComponents:
+  [
+    'NotificationDrawer',
+    'NotificationDrawerBody',
+    'NotificationDrawerHeader',
+    'NotificationDrawerGroup',
+    'NotificationDrawerGroupList',
+    'NotificationDrawerList',
+    'NotificationDrawerListItem',
+    'NotificationDrawerListItemBody',
+    'NotificationDrawerListItemHeader',
+  ]
 beta: true
 ---
 
 import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon';
 
 ## Examples
+
 ### Basic
+
 ```js
 import React from 'react';
 import {
@@ -193,6 +206,7 @@ class BasicNotificationDrawer extends React.Component {
 ```
 
 ### Groups
+
 ```js
 import React from 'react';
 import {
@@ -511,6 +525,7 @@ class GroupNotificationDrawer extends React.Component {
 ```
 
 ### Lightweight
+
 ```js
 import React from 'react';
 import {
@@ -573,7 +588,7 @@ class LightweightNotificationDrawerDemo extends React.Component {
 
     return (
       <NotificationDrawer>
-        <NotificationDrawerHeader />
+        <NotificationDrawerHeader formatHeaderText="2 unread alerts" />
         <NotificationDrawerBody>
           <NotificationDrawerGroupList>
             <NotificationDrawerGroup

--- a/packages/react-integration/cypress/integration/notificationdrawerlightweight.spec.ts
+++ b/packages/react-integration/cypress/integration/notificationdrawerlightweight.spec.ts
@@ -10,7 +10,7 @@ describe('Notification Drawer Lightweight Demo Test', () => {
   });
 
   it('Verify text in header status', () => {
-    cy.get('.pf-c-notification-drawer__header-status').should('not.exist');
+    cy.get('.pf-c-notification-drawer__header-status').contains('2 unread alerts');
   });
 
   it('Verify 3 groups exist', () => {

--- a/packages/react-integration/demo-app-ts/src/components/demos/NotificationDrawerDemo/NotificationDrawerLightweightDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/NotificationDrawerDemo/NotificationDrawerLightweightDemo.tsx
@@ -74,7 +74,7 @@ export class LightweightNotificationDrawerDemo extends React.Component<
 
     return (
       <NotificationDrawer>
-        <NotificationDrawerHeader />
+        <NotificationDrawerHeader formatHeaderText="2 unread alerts" />
         <NotificationDrawerBody>
           <NotificationDrawerGroupList>
             <NotificationDrawerGroup


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4651 .
The header status of notification drawer is not flexible as the issue mentioned. To fix this problem, I add a prop named `formatHeaderText` and remove the prop `unreadText`. Then here are 3 situations how our users use it:

1. If they define `formatHeaderText`, it will show this string on the header status.
2. If they don't define `formatHeaderText` but define `count`, it will show `${count} unread` on the header status.
3. If they don't define both `formatHeaderText` and `count`, it will show nothing on the header status.

This is a good way for users to make the header status more flexible but not only show `${count} ${unreadText}` like before.
Also I update the text cases and add this usage into the lightweight notification drawer example and demo app.

