### PR TITLE
feat(topology): Enable saving current topology graph model

### DIFF
--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/TopologyPackage.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/TopologyPackage.tsx
@@ -12,6 +12,7 @@ import {
   Model,
   ModelKind,
   NodeModel,
+  Controller,
   Visualization,
   withPanZoom,
   GraphComponent,
@@ -24,15 +25,15 @@ import {
   useEventListener
 } from '@patternfly/react-topology';
 import {
-  Toolbar,
-  ToolbarGroup,
   ToolbarItem,
   Split,
   SplitItem,
   Dropdown,
   DropdownItem,
   DropdownToggle,
-  DropdownPosition
+  DropdownPosition,
+  Button,
+  Tooltip
 } from '@patternfly/react-core';
 import defaultLayoutFactory from './layouts/defaultLayoutFactory';
 import data from './data/reasonable';
@@ -43,6 +44,9 @@ import defaultComponentFactory from './components/defaultComponentFactory';
 
 import '@patternfly/patternfly/patternfly.css';
 import '@patternfly/patternfly/patternfly-addons.css';
+
+const GRAPH_LAYOUT_OPTIONS = ['x', 'y', 'visible', 'style', 'layout', 'scale', 'scaleExtent', 'layers'];
+const NODE_LAYOUT_OPTIONS = ['x', 'y', 'visible', 'style', 'collapsed', 'width', 'height', 'shape'];
 
 const getModel = (layout: string): Model => {
   // create nodes from data
@@ -55,8 +59,6 @@ const getModel = (layout: string): Model => {
       type: 'node',
       width,
       height,
-      x: 0,
-      y: 0,
       data: d
     };
   });
@@ -126,7 +128,7 @@ const getVisualization = (model: Model): Visualization => {
 };
 
 interface TopologyViewComponentProps {
-  vis: Visualization;
+  vis: Controller;
   useSidebar: boolean;
 }
 
@@ -134,6 +136,9 @@ const TopologyViewComponent: React.FC<TopologyViewComponentProps> = ({ vis, useS
   const [selectedIds, setSelectedIds] = React.useState<string[]>();
   const [layoutDropdownOpen, setLayoutDropdownOpen] = React.useState(false);
   const [layout, setLayout] = React.useState('Force');
+  const [savedModel, setSavedModel] = React.useState<Model>();
+  const [modelSaved, setModelSaved] = React.useState<boolean>(false);
+  const newNodeCount = React.useRef(0);
 
   useEventListener<SelectionEventListener>(SELECTION_EVENT, ids => {
     setSelectedIds(ids);
@@ -149,6 +154,7 @@ const TopologyViewComponent: React.FC<TopologyViewComponentProps> = ({ vis, useS
     // FIXME reset followed by layout causes a flash of the reset prior to the layout
     vis.getGraph().reset();
     vis.getGraph().setLayout(newLayout);
+    vis.getGraph().layout();
     setLayout(newLayout);
     setLayoutDropdownOpen(false);
   };
@@ -178,12 +184,107 @@ const TopologyViewComponent: React.FC<TopologyViewComponentProps> = ({ vis, useS
       </SplitItem>
     </Split>
   );
+
+  const saveModel = () => {
+    setSavedModel(vis.toModel());
+    setModelSaved(true);
+    window.setTimeout(() => {
+      setModelSaved(false);
+    }, 2000);
+  };
+
+  const restoreLayout = () => {
+    if (savedModel) {
+      const currentModel = vis.toModel();
+      currentModel.graph = {
+        ...currentModel.graph,
+        ..._.pick(savedModel.graph, GRAPH_LAYOUT_OPTIONS)
+      };
+      currentModel.nodes = currentModel.nodes.map(n => {
+        const savedNode = savedModel.nodes.find(sn => sn.id === n.id);
+        if (!savedNode) {
+          return n;
+        }
+        return {
+          ...n,
+          ..._.pick(savedNode, NODE_LAYOUT_OPTIONS)
+        };
+      });
+      vis.fromModel(currentModel, false);
+
+      if (savedModel.graph.layout !== layout) {
+        setLayout(savedModel.graph.layout);
+      }
+    }
+  };
+
+  const addNode = () => {
+    const newNode = {
+      id: `new-node-${newNodeCount.current++}`,
+      type: 'node',
+      width: 100,
+      height: 100,
+      data: {}
+    };
+    const currentModel = vis.toModel();
+    currentModel.nodes.push(newNode);
+    vis.fromModel(currentModel);
+  };
+
+  const removeSelectedNode = () => {
+    const currentModel = vis.toModel();
+    const selectedIndex = currentModel.nodes.findIndex(n => n.id === selectedIds[0]);
+    currentModel.nodes = [
+      ...currentModel.nodes.slice(0, selectedIndex),
+      ...currentModel.nodes.slice(selectedIndex + 1)
+    ];
+    const effectedEdges = currentModel.edges.filter(e => e.source === selectedIds[0] || e.target === selectedIds[0]);
+    effectedEdges.forEach(e => {
+      const effectedIndex = currentModel.edges.findIndex(edge => edge.id === e.id);
+      currentModel.edges = [
+        ...currentModel.edges.slice(0, effectedIndex),
+        ...currentModel.edges.slice(effectedIndex + 1)
+      ];
+    });
+    currentModel.nodes
+      .filter(n => n.group)
+      .forEach(g => {
+        const childIndex = g.children.findIndex(c => c === selectedIds[0]);
+        if (childIndex) {
+          g.children = [...g.children.slice(0, childIndex), ...g.children.slice(childIndex + 1)];
+        }
+      });
+
+    vis.fromModel(currentModel);
+    setSelectedIds([]);
+  };
+
   const viewToolbar = (
-    <Toolbar className="pf-u-mx-md pf-u-my-md">
-      <ToolbarGroup>
-        <ToolbarItem>{layoutDropdown}</ToolbarItem>
-      </ToolbarGroup>
-    </Toolbar>
+    <>
+      <ToolbarItem>{layoutDropdown}</ToolbarItem>
+      <ToolbarItem>
+        <Tooltip content="Layout info saved" trigger="manual" isVisible={modelSaved}>
+          <Button variant="secondary" onClick={saveModel}>
+            Save Layout Info
+          </Button>
+        </Tooltip>
+      </ToolbarItem>
+      <ToolbarItem>
+        <Button variant="secondary" onClick={restoreLayout}>
+          Restore Layout Info
+        </Button>
+      </ToolbarItem>
+      <ToolbarItem>
+        <Button variant="secondary" onClick={addNode}>
+          Add Node
+        </Button>
+      </ToolbarItem>
+      <ToolbarItem>
+        <Button variant="secondary" onClick={removeSelectedNode} isDisabled={!selectedIds || selectedIds.length === 0}>
+          Remove Node
+        </Button>
+      </ToolbarItem>
+    </>
   );
 
   return (

--- a/packages/react-topology/src/components/GraphComponent.tsx
+++ b/packages/react-topology/src/components/GraphComponent.tsx
@@ -46,13 +46,6 @@ const GraphComponent: React.FC<GraphComponentProps> = ({
   onSelect,
   onContextMenu
 }) => {
-  const layout = element.getLayout();
-  React.useEffect(() => {
-    element.layout();
-    // Only re-run if the layout changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [layout]);
-
   const { x, y, width, height } = element.getBounds();
   return (
     <>

--- a/packages/react-topology/src/elements/BaseEdge.ts
+++ b/packages/react-topology/src/elements/BaseEdge.ts
@@ -160,4 +160,13 @@ export default class BaseEdge<E extends EdgeModel = EdgeModel, D = any> extends 
       this.bendpoints = model.bendpoints ? model.bendpoints.map(b => new Point(b[0], b[1])) : [];
     }
   }
+
+  toModel(): EdgeModel {
+    return {
+      ...super.toModel(),
+      source: this.getSource() ? this.getSource().getId() : undefined,
+      target: this.getTarget() ? this.getTarget().getId() : undefined,
+      bendpoints: this.getBendpoints().map(bp => [bp.x, bp.y])
+    };
+  }
 }

--- a/packages/react-topology/src/elements/BaseElement.ts
+++ b/packages/react-topology/src/elements/BaseElement.ts
@@ -250,6 +250,18 @@ export default abstract class BaseElement<E extends ElementModel = ElementModel,
     }
   }
 
+  toModel(): ElementModel {
+    return {
+      id: this.getId(),
+      type: this.getType(),
+      label: this.getLabel(),
+      visible: this.isVisible(),
+      children: this.getChildren().map(c => c.getId()),
+      data: this.getData(),
+      style: this.getStyle()
+    };
+  }
+
   raise(): void {
     const { parent } = this;
     if (parent) {

--- a/packages/react-topology/src/elements/BaseGraph.ts
+++ b/packages/react-topology/src/elements/BaseGraph.ts
@@ -133,6 +133,9 @@ export default class BaseGraph<E extends GraphModel = GraphModel, D = any> exten
   }
 
   reset(): void {
+    if (this.currentLayout) {
+      this.currentLayout.stop();
+    }
     this.scale = 1;
     this.position = new Point(0, 0);
   }
@@ -268,6 +271,18 @@ export default class BaseGraph<E extends GraphModel = GraphModel, D = any> exten
     if (p) {
       this.setPosition(p);
     }
+  }
+
+  toModel(): GraphModel {
+    return {
+      ...super.toModel(),
+      layout: this.getLayout(),
+      x: this.getPosition().x,
+      y: this.getPosition().y,
+      scale: this.getScale(),
+      scaleExtent: this.getScaleExtent(),
+      layers: this.getLayers()
+    };
   }
 
   translateToAbsolute(): void {

--- a/packages/react-topology/src/elements/__tests__/BaseGraph.spec.ts
+++ b/packages/react-topology/src/elements/__tests__/BaseGraph.spec.ts
@@ -8,7 +8,7 @@ import { Visualization } from '../../Visualization';
 
 class TestLayout implements Layout {
   layout = jest.fn();
-
+  stop = jest.fn();
   destroy = jest.fn();
 }
 

--- a/packages/react-topology/src/layouts/ColaNode.ts
+++ b/packages/react-topology/src/layouts/ColaNode.ts
@@ -13,4 +13,8 @@ export class ColaNode extends LayoutNode implements webcola.Node {
     this.nodeWidth = maxDimension;
     this.nodeHeight = maxDimension;
   }
+  setFixed(fixed: boolean): void {
+    super.setFixed(fixed);
+    this.fixed = fixed ? 1 : 0;
+  }
 }

--- a/packages/react-topology/src/layouts/ForceLayout.ts
+++ b/packages/react-topology/src/layouts/ForceLayout.ts
@@ -9,7 +9,10 @@ export default class ForceLayout extends BaseLayout implements Layout {
   constructor(graph: Graph, options?: Partial<LayoutOptions>) {
     super(graph, {
       ...options,
-      layoutOnDrag: true
+      layoutOnDrag: true,
+      onSimulationEnd: () => {
+        this.nodes.forEach(n => n.setFixed(false));
+      }
     });
   }
 

--- a/packages/react-topology/src/layouts/ForceSimulation.ts
+++ b/packages/react-topology/src/layouts/ForceSimulation.ts
@@ -11,6 +11,7 @@ interface ForceSimulationOptions {
   collideDistance: number;
   simulationSpeed: number;
   chargeStrength: number;
+  onSimulationEnd?: () => void;
 }
 
 class ForceSimulation {
@@ -53,6 +54,9 @@ class ForceSimulation {
         this.simulation.nodes().forEach((d: ForceSimulationNode) => !this.destroyed && d.update());
       })
     );
+    if (options.onSimulationEnd) {
+      this.simulation.on('end', this.options.onSimulationEnd);
+    }
   }
 
   public destroy(): void {

--- a/packages/react-topology/src/layouts/LayoutNode.ts
+++ b/packages/react-topology/src/layouts/LayoutNode.ts
@@ -1,7 +1,9 @@
+import * as d3 from 'd3';
 import { Node, NodeStyle } from '../types';
 import { Rect } from '../geom';
 import { LayoutGroup } from './LayoutGroup';
-export class LayoutNode {
+
+export class LayoutNode implements d3.SimulationNodeDatum {
   protected readonly node: Node;
   protected xx?: number;
   protected yy?: number;
@@ -58,6 +60,9 @@ export class LayoutNode {
         .clone()
         .setCenter(x, y)
     );
+  }
+  setFixed(fixed: boolean): void {
+    this.isFixed = fixed;
   }
   get nodeBounds(): Rect {
     const { padding } = this.node.getStyle<NodeStyle>();

--- a/packages/react-topology/src/layouts/LayoutOptions.ts
+++ b/packages/react-topology/src/layouts/LayoutOptions.ts
@@ -7,4 +7,5 @@ export interface LayoutOptions {
   chargeStrength: number;
   allowDrag: boolean;
   layoutOnDrag: boolean;
+  onSimulationEnd?: () => void;
 }

--- a/packages/react-topology/src/types.ts
+++ b/packages/react-topology/src/types.ts
@@ -9,6 +9,7 @@ export type PointTuple = [number, number];
 
 export interface Layout {
   layout(): void;
+  stop(): void;
   destroy(): void;
 }
 
@@ -74,7 +75,6 @@ export interface GraphModel extends ElementModel {
   y?: number;
   scale?: number;
   scaleExtent?: ScaleExtent;
-  maxScale?: number;
   layers?: string[];
 }
 
@@ -109,6 +109,7 @@ export interface GraphElement<E extends ElementModel = ElementModel, D = any> ex
   removeChild(child: GraphElement): void;
   remove(): void;
   setModel(model: E): void;
+  toModel(): ElementModel;
   raise(): void;
   getStyle<T extends {}>(): T;
   translateToAbsolute(t: Translatable): void;
@@ -137,6 +138,7 @@ export interface Node<E extends NodeModel = NodeModel, D = any> extends GraphEle
   getSourceEdges(): Edge[];
   getTargetEdges(): Edge[];
   isDimensionsInitialized(): boolean;
+  isPositioned(): boolean;
 }
 
 export interface Edge<E extends EdgeModel = EdgeModel, D = any> extends GraphElement<E, D> {
@@ -206,7 +208,8 @@ export type ElementFactory = (kind: ModelKind, type: string) => GraphElement | u
 
 export interface Controller extends WithState {
   getStore<S extends {} = {}>(): S;
-  fromModel(model: Model): void;
+  fromModel(model: Model, merge?: boolean): void;
+  toModel(): Model;
   hasGraph(): boolean;
   getGraph(): Graph;
   setGraph(graph: Graph): void;
@@ -242,4 +245,5 @@ export const ADD_CHILD_EVENT = 'element-add-child';
 export const ELEMENT_VISIBILITY_CHANGE_EVENT = 'element-visibility-change';
 export const REMOVE_CHILD_EVENT = 'element-remove-child';
 export const NODE_COLLAPSE_CHANGE_EVENT = 'node-collapse-change';
+export const NODE_POSITIONED_EVENT = 'node-positioned';
 export const GRAPH_LAYOUT_END_EVENT = 'graph-layout-end';


### PR DESCRIPTION
**What**: 
This PR is aimed at allowing adopters to track the current layout of nodes so that it can be saved and restored.

Provides API for `toModel` for the current Controller/GraphElements.
Keeps track of nodes that have had their position set, do not reset positions on layout.
Adds events on individual node moves, and overall event for all node moves (debouncing individual node moves)

/cc @christianvogt 