### PR TITLE
fix(search-input): use title case id

### DIFF
--- a/packages/react-core/src/components/SearchInput/examples/SearchInput.md
+++ b/packages/react-core/src/components/SearchInput/examples/SearchInput.md
@@ -1,5 +1,5 @@
 ---
-id: 'Search Input'
+id: 'Search input'
 section: components
 cssPrefix: 'pf-c-search-input'
 propComponents: ['SearchInput']


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Titles should use camel case.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
