### PR TITLE
fix(lint): fixed linting errors related to icon imports in Tile and TreeView

### DIFF
--- a/packages/react-core/src/components/Tile/examples/Tile.md
+++ b/packages/react-core/src/components/Tile/examples/Tile.md
@@ -50,7 +50,7 @@ SubtextTile = () => (
 ```js
 import React from 'react';
 import { Tile } from '@patternfly/react-core';
-import { PlusIcon } from '@patternfly/react-icons';
+import PlusIcon from '@patternfly/react-icons/dist/js/icons/plus-icon';
 
 IconTile = () => (
   <React.Fragment>
@@ -72,7 +72,7 @@ IconTile = () => (
 ```js
 import React from 'react';
 import { Tile } from '@patternfly/react-core';
-import { BellIcon } from '@patternfly/react-icons';
+import BellIcon from '@patternfly/react-icons/dist/js/icons/bell-icon';
 
 StackedTile = () => (
   <React.Fragment>
@@ -94,7 +94,7 @@ StackedTile = () => (
 ```js
 import React from 'react';
 import { Tile } from '@patternfly/react-core';
-import { BellIcon } from '@patternfly/react-icons';
+import BellIcon from '@patternfly/react-icons/dist/js/icons/bell-icon';
 
 LargeStackedTile = () => (
   <React.Fragment>
@@ -116,7 +116,7 @@ LargeStackedTile = () => (
 ```js
 import React from 'react';
 import { Tile, Flex } from '@patternfly/react-core';
-import { BellIcon } from '@patternfly/react-icons';
+import BellIcon from '@patternfly/react-icons/dist/js/icons/bell-icon';
 
 ExtraContentTile = () => (
   <Flex>

--- a/packages/react-core/src/components/TreeView/examples/TreeView.md
+++ b/packages/react-core/src/components/TreeView/examples/TreeView.md
@@ -423,7 +423,8 @@ class CheckboxTreeView extends React.Component {
 ```js
 import React from 'react';
 import { TreeView, TreeViewDataItem } from '@patternfly/react-core';
-import { FolderIcon, FolderOpenIcon } from '@patternfly/react-icons';
+import FolderIcon from '@patternfly/react-icons/dist/js/icons/folder-icon';
+import FolderOpenIcon from '@patternfly/react-icons/dist/js/icons/folder-open-icon';
 
 class IconTreeView extends React.Component {
   constructor(props) {
@@ -586,7 +587,9 @@ class BadgesTreeView extends React.Component {
 ```js
 import React from 'react';
 import { TreeView, TreeViewDataItem, Button } from '@patternfly/react-core';
-import { EllipsisVIcon, ClipboardIcon, HamburgerIcon } from '@patternfly/react-icons';
+import EllipsisVIcon from '@patternfly/react-icons/dist/js/icons/ellipsis-v-icon';
+import ClipboardIcon from '@patternfly/react-icons/dist/js/icons/clipboard-icon';
+import HamburgerIcon from '@patternfly/react-icons/dist/js/icons/hamburger-icon';
 
 class IconTreeView extends React.Component {
   constructor(props) {


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4727 

This PR updates icon imports in Tile and Tree view examples from barrel file to dist/js file.
