### PR TITLE
fix: Do not handle modified clicks on VerticalNav links

### DIFF
--- a/packages/patternfly-react/src/components/VerticalNav/VerticalNav.js
+++ b/packages/patternfly-react/src/components/VerticalNav/VerticalNav.js
@@ -272,6 +272,7 @@ class BaseVerticalNav extends React.Component {
                 dataID={secondaryItem.dataID}
                 isDivider={secondaryItem.isDivider}
                 preventHref={secondaryItem.preventHref}
+                preventUpdate={secondaryItem.preventUpdate}
                 item={secondaryItem}
                 key={`secondary_${secondaryItem.title}`}
               >

--- a/packages/patternfly-react/src/components/VerticalNav/VerticalNavItemHelper.js
+++ b/packages/patternfly-react/src/components/VerticalNav/VerticalNavItemHelper.js
@@ -82,8 +82,12 @@ class BaseVerticalNavItemHelper extends React.Component {
 
   onItemClick = event => {
     const { primary, secondary, tertiary } = this.getContextNavItems();
-    const { isMobile, preventHref, updateNavOnItemClick, idPath } = this.props;
+    const { isMobile, preventHref, updateNavOnItemClick, idPath, preventUpdate } = this.props;
     const { onClick } = this.navItem();
+
+    if (preventUpdate(event)) {
+      return;
+    }
 
     if (preventHref && !!onClick) {
       event.preventDefault();
@@ -331,7 +335,8 @@ BaseVerticalNavItemHelper.propTypes = {
   /** anchor id */
   id: PropTypes.string,
   /** anchor data-id */
-  dataID: PropTypes.string
+  dataID: PropTypes.string,
+  preventUpdate: PropTypes.func
 };
 
 BaseVerticalNavItemHelper.defaultProps = {
@@ -341,7 +346,8 @@ BaseVerticalNavItemHelper.defaultProps = {
   isDivider: false,
   preventHref: true,
   id: null,
-  dataID: null
+  dataID: null,
+  preventUpdate: (event) => false
 };
 
 const VerticalNavItemHelper = getContext(navContextTypes)(BaseVerticalNavItemHelper);


### PR DESCRIPTION
**What:** Closes #4783

VerticalNav should not prevent default and call onClick handler
when user wishes to open a link from vertical navigation in another tab
and uses ctrl+click.


<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: https://projects.theforeman.org/issues/29020
