### PR TITLE
feat(Select): Added support for Divider in Select

### DIFF
--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -352,8 +352,8 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
         if (group.type === SelectGroup) {
           return React.cloneElement(group, {
             titleId: group.props.label && group.props.label.replace(/\W/g, '-'),
-            children: React.Children.map(group.props.children, (child: React.ReactElement) => {
-              return child.type === Divider
+            children: React.Children.map(group.props.children, (child: React.ReactElement) =>
+              child.type === Divider
                 ? child
                 : React.cloneElement(child as React.ReactElement, {
                     isFocused:
@@ -362,8 +362,8 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
                         (this.props.isCreatable &&
                           typeaheadActiveChild.innerText ===
                             `{createText} "${(child as React.ReactElement).props.value}"`))
-                  });
-            })
+                  })
+            )
           });
         } else {
           return React.cloneElement(group, {

--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -366,13 +366,15 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
             )
           });
         } else {
-          return React.cloneElement(group, {
-            isFocused:
-              typeaheadActiveChild &&
-              (typeaheadActiveChild.id === (group as React.ReactElement).props.id ||
-                (this.props.isCreatable &&
-                  typeaheadActiveChild.innerText === `{createText} "${(group as React.ReactElement).props.value}"`))
-          });
+          return group.type === Divider
+            ? group
+            : React.cloneElement(group, {
+                isFocused:
+                  typeaheadActiveChild &&
+                  (typeaheadActiveChild.id === (group as React.ReactElement).props.id ||
+                    (this.props.isCreatable &&
+                      typeaheadActiveChild.innerText === `{createText} "${(group as React.ReactElement).props.value}"`))
+              });
         }
       });
     }

--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -353,7 +353,6 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
     this.optionContainerRefCollection = [];
     if (isGrouped) {
       return React.Children.map(typeaheadChildren as React.ReactElement[], (group: React.ReactElement) => {
-        debugger;
         if (group.type === Divider) {
           return group;
         } else if (group.type === SelectGroup && onFavorite) {
@@ -768,7 +767,6 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
           };
           variantChildren = onFavorite ? renderableItems : this.extendTypeaheadChildren(typeaheadCurrIndex);
           if (variantChildren.length === 0) {
-            debugger;
             variantChildren.push(<SelectOption isDisabled key={0} value={noResultsFoundText} isNoResultsOption />);
           }
           break;

--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -353,6 +353,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
     this.optionContainerRefCollection = [];
     if (isGrouped) {
       return React.Children.map(typeaheadChildren as React.ReactElement[], (group: React.ReactElement) => {
+        debugger;
         if (group.type === Divider) {
           return group;
         } else if (group.type === SelectGroup && onFavorite) {
@@ -386,6 +387,14 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
                             `{createText} "${(child as React.ReactElement).props.value}"`))
                   })
             )
+          });
+        } else {
+          // group has been filtered down to SelectOption
+          return React.cloneElement(group as React.ReactElement, {
+            isFocused:
+              typeaheadActiveChild &&
+              (typeaheadActiveChild.innerText === group.props.value.toString() ||
+                (this.props.isCreatable && typeaheadActiveChild.innerText === `{createText} "${group.props.value}"`))
           });
         }
       });
@@ -759,6 +768,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
           };
           variantChildren = onFavorite ? renderableItems : this.extendTypeaheadChildren(typeaheadCurrIndex);
           if (variantChildren.length === 0) {
+            debugger;
             variantChildren.push(<SelectOption isDisabled key={0} value={noResultsFoundText} isNoResultsOption />);
           }
           break;

--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -268,7 +268,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
       const childrenArray = React.Children.toArray(children) as React.ReactElement<SelectGroupProps>[];
       if (isGrouped) {
         const childFilter = (child: React.ReactElement<SelectGroupProps>) =>
-          this.getDisplay(child.props.value.toString(), 'text').search(input) === 0;
+          child.props.value && this.getDisplay(child.props.value.toString(), 'text').search(input) === 0;
         typeaheadFilteredChildren =
           e.target.value.toString() !== ''
             ? React.Children.map(children, group => {
@@ -504,7 +504,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
         this.moveFocus(nextIndex);
       } else {
         const nextIndex = this.refCollection.findIndex(
-          ref => ref[0] === document.activeElement || ref[1] === document.activeElement
+          ref => ref !== undefined && (ref[0] === document.activeElement || ref[1] === document.activeElement)
         );
         this.moveFocus(nextIndex);
       }

--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -225,7 +225,8 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
         ? [
             <SelectGroup key="favorites" label={this.props.favoritesLabel}>
               {renderableFavorites}
-            </SelectGroup>
+            </SelectGroup>,
+            <Divider key="favorites-group-divider" />
           ]
         : [];
       this.setState({ favoritesGroup });

--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -371,7 +371,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
                   })
             )
           });
-        } else {
+        } else if (group.type === SelectGroup) {
           return React.cloneElement(group, {
             titleId: group.props.label && group.props.label.replace(/\W/g, '-'),
             children: React.Children.map(group.props.children, (child: React.ReactElement) =>

--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -352,15 +352,18 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
         if (group.type === SelectGroup) {
           return React.cloneElement(group, {
             titleId: group.props.label && group.props.label.replace(/\W/g, '-'),
-            children: React.Children.map(group.props.children, (child: React.ReactElement) =>
-              React.cloneElement(child as React.ReactElement, {
-                isFocused:
-                  activeElement &&
-                  (activeElement.id === (child as React.ReactElement).props.id ||
-                    (this.props.isCreatable &&
-                      typeaheadActiveChild.innerText === `{createText} "${(child as React.ReactElement).props.value}"`))
-              })
-            )
+            children: React.Children.map(group.props.children, (child: React.ReactElement) => {
+              return child.type === Divider
+                ? child
+                : React.cloneElement(child as React.ReactElement, {
+                    isFocused:
+                      activeElement &&
+                      (activeElement.id === (child as React.ReactElement).props.id ||
+                        (this.props.isCreatable &&
+                          typeaheadActiveChild.innerText ===
+                            `{createText} "${(child as React.ReactElement).props.value}"`))
+                  });
+            })
           });
         } else {
           return React.cloneElement(group, {
@@ -374,15 +377,18 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
       });
     }
 
-    return typeaheadChildren.map((child: React.ReactNode) =>
-      React.cloneElement(child as React.ReactElement, {
-        isFocused:
-          typeaheadActiveChild &&
-          (typeaheadActiveChild.innerText === (child as React.ReactElement).props.value.toString() ||
-            (this.props.isCreatable &&
-              typeaheadActiveChild.innerText === `{createText} "${(child as React.ReactElement).props.value}"`))
-      })
-    );
+    return typeaheadChildren.map((child: React.ReactNode) => {
+      const childElement = child as any;
+      return childElement.type.displayName === 'Divider'
+        ? child
+        : React.cloneElement(child as React.ReactElement, {
+            isFocused:
+              typeaheadActiveChild &&
+              (typeaheadActiveChild.innerText === (child as React.ReactElement).props.value.toString() ||
+                (this.props.isCreatable &&
+                  typeaheadActiveChild.innerText === `{createText} "${(child as React.ReactElement).props.value}"`))
+          });
+    });
   }
 
   sendRef = (

--- a/packages/react-core/src/components/Select/SelectMenu.tsx
+++ b/packages/react-core/src/components/Select/SelectMenu.tsx
@@ -129,7 +129,7 @@ class SelectMenuWithRef extends React.Component<SelectMenuProps> {
     let index = hasInlineFilter ? 1 : 0;
     if (isGrouped) {
       return React.Children.map(children, (group: React.ReactElement) => {
-        if (group.type === SelectOption) {
+        if (group.type === SelectOption || group.type === Divider) {
           return group;
         }
         return React.cloneElement(group, {
@@ -140,12 +140,14 @@ class SelectMenuWithRef extends React.Component<SelectMenuProps> {
               className={css(styles.selectMenuFieldset)}
             >
               {React.Children.map(group.props.children, (option: React.ReactElement) =>
-                React.cloneElement(option, {
-                  isChecked: this.checkForValue(option.props.value, checked),
-                  sendRef,
-                  keyHandler,
-                  index: index++
-                })
+                option.type === Divider
+                  ? option
+                  : React.cloneElement(option, {
+                      isChecked: this.checkForValue(option.props.value, checked),
+                      sendRef,
+                      keyHandler,
+                      index: index++
+                    })
               )}
             </fieldset>
           )
@@ -153,12 +155,14 @@ class SelectMenuWithRef extends React.Component<SelectMenuProps> {
       });
     }
     return React.Children.map(children, (child: React.ReactElement) =>
-      React.cloneElement(child, {
-        isChecked: this.checkForValue(child.props.value, checked),
-        sendRef,
-        keyHandler,
-        index: index++
-      })
+      child.type === Divider
+        ? child
+        : React.cloneElement(child, {
+            isChecked: this.checkForValue(child.props.value, checked),
+            sendRef,
+            keyHandler,
+            index: index++
+          })
     );
   }
 

--- a/packages/react-core/src/components/Select/SelectMenu.tsx
+++ b/packages/react-core/src/components/Select/SelectMenu.tsx
@@ -8,6 +8,7 @@ import { PickOptional } from '../../helpers/typeUtils';
 
 import { FocusTrap } from '../../helpers';
 import { SelectGroup } from './SelectGroup';
+import { Divider } from '../Divider/Divider';
 
 export interface SelectMenuProps extends Omit<React.HTMLProps<HTMLElement>, 'checked' | 'selected' | 'ref'> {
   /** Content rendered inside the SelectMenu */
@@ -82,6 +83,9 @@ class SelectMenuWithRef extends React.Component<SelectMenuProps> {
   cloneOption(child: React.ReactElement, index: number, randomId: string) {
     const { selected, sendRef, keyHandler } = this.props;
     const isSelected = this.checkForValue(child.props.value, selected);
+    if (child.type === Divider) {
+      return child;
+    }
     return React.cloneElement(child, {
       inputId: `${randomId}-${index}`,
       isSelected,

--- a/packages/react-core/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/packages/react-core/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
@@ -8749,11 +8749,11 @@ exports[`select with custom content renders expanded successfully 1`] = `
     >
       <SelectToggle
         aria-label="Options menu"
-        aria-labelledby=" pf-select-toggle-id-18"
+        aria-labelledby=" pf-select-toggle-id-16"
         className=""
         handleTypeaheadKeys={[Function]}
         hasClearButton={false}
-        id="pf-select-toggle-id-18"
+        id="pf-select-toggle-id-16"
         isActive={false}
         isDisabled={false}
         isOpen={true}
@@ -8782,9 +8782,9 @@ exports[`select with custom content renders expanded successfully 1`] = `
               <button
                 aria-expanded="true"
                 aria-haspopup="listbox"
-                aria-labelledby=" pf-select-toggle-id-18"
+                aria-labelledby=" pf-select-toggle-id-16"
                 class="pf-c-select__toggle"
-                id="pf-select-toggle-id-18"
+                id="pf-select-toggle-id-16"
                 type="button"
               >
                 <div
@@ -8826,10 +8826,10 @@ exports[`select with custom content renders expanded successfully 1`] = `
         <button
           aria-expanded={true}
           aria-haspopup="listbox"
-          aria-labelledby=" pf-select-toggle-id-18"
+          aria-labelledby=" pf-select-toggle-id-16"
           className="pf-c-select__toggle"
           disabled={false}
-          id="pf-select-toggle-id-18"
+          id="pf-select-toggle-id-16"
           onClick={[Function]}
           onKeyDown={[Function]}
           type="button"
@@ -9196,11 +9196,11 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
     >
       <SelectToggle
         aria-label="Options menu"
-        aria-labelledby=" pf-select-toggle-id-13"
+        aria-labelledby=" pf-select-toggle-id-12"
         className=""
         handleTypeaheadKeys={[Function]}
         hasClearButton={false}
-        id="pf-select-toggle-id-13"
+        id="pf-select-toggle-id-12"
         isActive={false}
         isDisabled={false}
         isOpen={true}
@@ -9288,7 +9288,7 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
                     aria-label=""
                     autocomplete="off"
                     class="pf-c-form-control pf-c-select__toggle-typeahead"
-                    id="pf-select-toggle-id-13-select-multi-typeahead-typeahead"
+                    id="pf-select-toggle-id-12-select-multi-typeahead-typeahead"
                     placeholder=""
                     type="text"
                     value=""
@@ -9298,9 +9298,9 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
                   aria-expanded="true"
                   aria-haspopup="listbox"
                   aria-label="Options menu"
-                  aria-labelledby=" pf-select-toggle-id-13"
+                  aria-labelledby=" pf-select-toggle-id-12"
                   class="pf-c-button pf-c-select__toggle-button pf-m-plain"
-                  id="pf-select-toggle-id-13"
+                  id="pf-select-toggle-id-12"
                   tabindex="-1"
                   type="button"
                 >
@@ -9397,7 +9397,7 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
               autoComplete="off"
               className="pf-c-form-control pf-c-select__toggle-typeahead"
               disabled={false}
-              id="pf-select-toggle-id-13-select-multi-typeahead-typeahead"
+              id="pf-select-toggle-id-12-select-multi-typeahead-typeahead"
               onChange={[Function]}
               onClick={[Function]}
               placeholder=""
@@ -9409,10 +9409,10 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
             aria-expanded={true}
             aria-haspopup="listbox"
             aria-label="Options menu"
-            aria-labelledby=" pf-select-toggle-id-13"
+            aria-labelledby=" pf-select-toggle-id-12"
             className="pf-c-button pf-c-select__toggle-button pf-m-plain"
             disabled={false}
-            id="pf-select-toggle-id-13"
+            id="pf-select-toggle-id-12"
             onClick={[Function]}
             tabIndex={-1}
             type="button"
@@ -13299,11 +13299,11 @@ exports[`typeahead select test select existing option on a non-creatable select 
     >
       <SelectToggle
         aria-label="Options menu"
-        aria-labelledby=" pf-select-toggle-id-12"
+        aria-labelledby=" pf-select-toggle-id-11"
         className=""
         handleTypeaheadKeys={[Function]}
         hasClearButton={false}
-        id="pf-select-toggle-id-12"
+        id="pf-select-toggle-id-11"
         isActive={false}
         isDisabled={false}
         isOpen={true}
@@ -13352,7 +13352,7 @@ exports[`typeahead select test select existing option on a non-creatable select 
                     aria-label=""
                     autocomplete="off"
                     class="pf-c-form-control pf-c-select__toggle-typeahead"
-                    id="pf-select-toggle-id-12-select-typeahead"
+                    id="pf-select-toggle-id-11-select-typeahead"
                     placeholder=""
                     type="text"
                     value="Oth"
@@ -13381,9 +13381,9 @@ exports[`typeahead select test select existing option on a non-creatable select 
                   aria-expanded="true"
                   aria-haspopup="listbox"
                   aria-label="Options menu"
-                  aria-labelledby=" pf-select-toggle-id-12"
+                  aria-labelledby=" pf-select-toggle-id-11"
                   class="pf-c-button pf-c-select__toggle-button pf-m-plain"
-                  id="pf-select-toggle-id-12"
+                  id="pf-select-toggle-id-11"
                   tabindex="-1"
                   type="button"
                 >
@@ -13441,7 +13441,7 @@ exports[`typeahead select test select existing option on a non-creatable select 
               autoComplete="off"
               className="pf-c-form-control pf-c-select__toggle-typeahead"
               disabled={false}
-              id="pf-select-toggle-id-12-select-typeahead"
+              id="pf-select-toggle-id-11-select-typeahead"
               onChange={[Function]}
               onClick={[Function]}
               placeholder=""
@@ -13487,10 +13487,10 @@ exports[`typeahead select test select existing option on a non-creatable select 
             aria-expanded={true}
             aria-haspopup="listbox"
             aria-label="Options menu"
-            aria-labelledby=" pf-select-toggle-id-12"
+            aria-labelledby=" pf-select-toggle-id-11"
             className="pf-c-button pf-c-select__toggle-button pf-m-plain"
             disabled={false}
-            id="pf-select-toggle-id-12"
+            id="pf-select-toggle-id-11"
             onClick={[Function]}
             tabIndex={-1}
             type="button"

--- a/packages/react-core/src/components/Select/examples/Select.md
+++ b/packages/react-core/src/components/Select/examples/Select.md
@@ -234,7 +234,7 @@ class SingleSelectDescription extends React.Component {
 
 ```js
 import React from 'react';
-import { Select, SelectOption, SelectVariant, SelectGroup } from '@patternfly/react-core';
+import { Select, SelectOption, SelectVariant, SelectGroup, Divider } from '@patternfly/react-core';
 
 class GroupedSingleSelectInput extends React.Component {
   constructor(props) {
@@ -271,6 +271,7 @@ class GroupedSingleSelectInput extends React.Component {
         <SelectOption key={3} value="Degraded" />
         <SelectOption key={4} value="Needs Maintenence" />
       </SelectGroup>,
+      <Divider/>,
       <SelectGroup label="Vendor Names" key="group2">
         <SelectOption key={5} value="Dell" />
         <SelectOption key={6} value="Samsung" isDisabled />

--- a/packages/react-core/src/components/Select/examples/Select.md
+++ b/packages/react-core/src/components/Select/examples/Select.md
@@ -981,6 +981,8 @@ class TypeaheadSelectInput extends React.Component {
               {...(option.description && { description: option.description })}
             />
           ))}
+          <Divider key="testdivider" />
+          <SelectOption key="test" value="testing" />
         </Select>
         <Checkbox
           label="isDisabled"

--- a/packages/react-core/src/components/Select/examples/Select.md
+++ b/packages/react-core/src/components/Select/examples/Select.md
@@ -1442,7 +1442,7 @@ class MultiTypeaheadSelectInputWithChipGroupProps extends React.Component {
 
 ```js
 import React from 'react';
-import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
+import { Select, SelectOption, SelectVariant, Divider } from '@patternfly/react-core';
 
 class MultiTypeaheadSelectInputCustomObjects extends React.Component {
   constructor(props) {

--- a/packages/react-core/src/components/Select/examples/Select.md
+++ b/packages/react-core/src/components/Select/examples/Select.md
@@ -352,8 +352,9 @@ class CheckboxSelectInput extends React.Component {
       <SelectOption key={0} value="Active" description="This is a description" />,
       <SelectOption key={1} value="Cancelled" />,
       <SelectOption key={2} value="Paused" />,
-      <SelectOption key={3} value="Warning" />,
-      <SelectOption key={4} value="Restarted" />
+      <Divider key={3} />,
+      <SelectOption key={4} value="Warning" />,
+      <SelectOption key={5} value="Restarted" />
     ];
   }
 

--- a/packages/react-core/src/components/Select/examples/Select.md
+++ b/packages/react-core/src/components/Select/examples/Select.md
@@ -981,8 +981,6 @@ class TypeaheadSelectInput extends React.Component {
               {...(option.description && { description: option.description })}
             />
           ))}
-          <Divider key="testdivider" />
-          <SelectOption key="test" value="testing" />
         </Select>
         <Checkbox
           label="isDisabled"

--- a/packages/react-core/src/components/Select/examples/Select.md
+++ b/packages/react-core/src/components/Select/examples/Select.md
@@ -15,19 +15,20 @@ import CubeIcon from '@patternfly/react-icons/dist/js/icons/cube-icon';
 ```js
 import React from 'react';
 import CubeIcon from '@patternfly/react-icons/dist/js/icons/cube-icon';
-import { Select, SelectOption, SelectVariant, SelectDirection, Checkbox } from '@patternfly/react-core';
+import { Select, SelectOption, SelectVariant, SelectDirection, Checkbox , Divider } from '@patternfly/react-core';
 
 class SingleSelectInput extends React.Component {
   constructor(props) {
     super(props);
     this.options = [
-      { value: 'Choose...', disabled: false, isPlaceholder: true },
-      { value: 'Mr', disabled: false },
-      { value: 'Miss', disabled: false },
-      { value: 'Mrs', disabled: false },
-      { value: 'Ms', disabled: false },
-      { value: 'Dr', disabled: false },
-      { value: 'Other', disabled: false }
+       <SelectOption key={0} value="Choose..." isPlaceholder/>,
+        <SelectOption key={1} value="Mr" />,
+        <SelectOption key={2} value="Miss" />,
+        <SelectOption key={3} value="Mrs" />,
+        <SelectOption key={4} value="Ms" />,
+        <Divider component="li" key={5} />,
+        <SelectOption key={6} value="Dr" />,
+        <SelectOption key={7} value="Other" />
     ];
 
     this.state = {
@@ -107,14 +108,7 @@ class SingleSelectInput extends React.Component {
           isDisabled={isDisabled}
           direction={direction}
         >
-          {this.options.map((option, index) => (
-            <SelectOption
-              isDisabled={option.disabled}
-              key={index}
-              value={option.value}
-              isPlaceholder={option.isPlaceholder}
-            />
-          ))}
+          {this.options}
         </Select>
         <Checkbox
           label="isDisabled"
@@ -271,7 +265,7 @@ class GroupedSingleSelectInput extends React.Component {
         <SelectOption key={3} value="Degraded" />
         <SelectOption key={4} value="Needs Maintenence" />
       </SelectGroup>,
-      <Divider/>,
+      <Divider key="divider" />,
       <SelectGroup label="Vendor Names" key="group2">
         <SelectOption key={5} value="Dell" />
         <SelectOption key={6} value="Samsung" isDisabled />
@@ -310,7 +304,7 @@ class GroupedSingleSelectInput extends React.Component {
 
 ```js
 import React from 'react';
-import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
+import { Select, SelectOption, SelectVarian, Divider } from '@patternfly/react-core';
 
 class CheckboxSelectInput extends React.Component {
   constructor(props) {
@@ -1022,7 +1016,7 @@ class TypeaheadSelectInput extends React.Component {
 
 ```js
 import React from 'react';
-import { Checkbox, Select, SelectGroup, SelectOption, SelectVariant } from '@patternfly/react-core';
+import { Checkbox, Select, SelectGroup, SelectOption, SelectVariant, Divider } from '@patternfly/react-core';
 
 class GroupedTypeaheadSelectInput extends React.Component {
   constructor(props) {
@@ -1037,6 +1031,7 @@ class GroupedTypeaheadSelectInput extends React.Component {
           <SelectOption key={3} value="Degraded" />
           <SelectOption key={4} value="Needs Maintenence" />
         </SelectGroup>,
+        <Divider key="divider"/>,
         <SelectGroup label="Vendor Names" key="group2">
           <SelectOption key={5} value="Dell" />
           <SelectOption key={6} value="Samsung" isDisabled />
@@ -1470,6 +1465,7 @@ class MultiTypeaheadSelectInputCustomObjects extends React.Component {
     };
     this.options = [
       <SelectOption key={0} value={this.createState('Alabama', 'AL', 'Montgomery', 1846)} />,
+      <Divider component="li" key={111} />,
       <SelectOption key={1} value={this.createState('Florida', 'FL', 'Tailahassee', 1845)} />,
       <SelectOption key={2} value={this.createState('New Jersey', 'NJ', 'Trenton', 1787)} />,
       <SelectOption key={3} value={this.createState('New Mexico', 'NM', 'Santa Fe', 1912)} />,

--- a/packages/react-core/src/helpers/util.ts
+++ b/packages/react-core/src/helpers/util.ts
@@ -2,6 +2,7 @@ import * as ReactDOM from 'react-dom';
 import { SIDE } from './constants';
 import * as React from 'react';
 import { ApplicationLauncherSeparator } from '../components/ApplicationLauncher/ApplicationLauncherSeparator';
+import { Divider } from '../components/Divider/Divider';
 
 /**
  * @param {string} input - String to capitalize first letter
@@ -335,7 +336,7 @@ export const extendItemsWithFavorite = (items: object, isGrouped: boolean, favor
     return (items as React.ReactElement[]).map(group =>
       React.cloneElement(group, {
         children: React.Children.map(group.props.children as React.ReactElement[], item => {
-          if (item.type === ApplicationLauncherSeparator) {
+          if (item.type === ApplicationLauncherSeparator || item.type === Divider) {
             return item;
           }
           return React.cloneElement(item, {

--- a/packages/react-core/src/helpers/util.ts
+++ b/packages/react-core/src/helpers/util.ts
@@ -213,7 +213,7 @@ export function getNextIndex(index: number, position: string, collection: any[])
   } else {
     nextIndex = index + 1;
   }
-  if (collection[nextIndex][0] === null) {
+  if (collection[nextIndex] === undefined || collection[nextIndex][0] === null) {
     return getNextIndex(nextIndex, position, collection);
   } else {
     return nextIndex;

--- a/packages/react-integration/cypress/integration/select.spec.ts
+++ b/packages/react-integration/cypress/integration/select.spec.ts
@@ -160,6 +160,7 @@ describe('Select Test', () => {
 
   it('Verify Checkbox Select', () => {
     cy.get('#check-select').click();
+    cy.get('.pf-c-divider').should('exist');
     cy.get('input#Cancelled').click();
     cy.get('#check-select')
       .contains('1')

--- a/packages/react-integration/cypress/integration/selectfavorites.spec.ts
+++ b/packages/react-integration/cypress/integration/selectfavorites.spec.ts
@@ -27,7 +27,7 @@ describe('Select Test', () => {
     cy.get('#option-grouped-1 > .pf-m-action').click();
     cy.get('#My-Favorites').should('exist');
     cy.get('#option-grouped-1 > .pf-m-action').should('have.attr', 'aria-label', 'starred');
-    cy.get(':nth-child(2) > #option-grouped-1 > .pf-m-action')
+    cy.get('#option-grouped-1 > .pf-m-action')
       .first()
       .click();
     cy.get('#My-Favorites').should('not.exist');

--- a/packages/react-integration/demo-app-ts/src/components/demos/SelectDemo/SelectDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/SelectDemo/SelectDemo.tsx
@@ -8,7 +8,8 @@ import {
   SelectOptionObject,
   Checkbox,
   SelectDirection,
-  Form
+  Form,
+  Divider
 } from '@patternfly/react-core';
 import React, { Component } from 'react';
 import CartArrowDownIcon from '@patternfly/react-icons/dist/js/icons/cart-arrow-down-icon';
@@ -112,6 +113,7 @@ export class SelectDemo extends Component<SelectDemoState> {
       id="Cancelled"
     />,
     <SelectOption key={2} value="Paused" inputId="Paused" id="Paused" />,
+    <Divider/>,
     <SelectOption key={3} value="Warning" inputId="Warning" id="Warning" />,
     <SelectOption key={4} value="Restarted" inputId="Restarted" id="Restarted" />
   ];

--- a/packages/react-integration/demo-app-ts/src/components/demos/SelectDemo/SelectDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/SelectDemo/SelectDemo.tsx
@@ -113,9 +113,9 @@ export class SelectDemo extends Component<SelectDemoState> {
       id="Cancelled"
     />,
     <SelectOption key={2} value="Paused" inputId="Paused" id="Paused" />,
-    <Divider/>,
-    <SelectOption key={3} value="Warning" inputId="Warning" id="Warning" />,
-    <SelectOption key={4} value="Restarted" inputId="Restarted" id="Restarted" />
+    <Divider key={3} />,
+    <SelectOption key={4} value="Warning" inputId="Warning" id="Warning" />,
+    <SelectOption key={5} value="Restarted" inputId="Restarted" id="Restarted" />
   ];
 
   customTypeaheadOptions = [


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4641 , #4890

See the "Single",  "Grouped single" and "Checkbox input" , "  and "Grouped typeahead"  to see the divider preview.

A check was also added to `componentDidUpdate` so that createRenderableFavorites is only called if onFavorite is provided.
