### PR TITLE
header cell information tooltip/popover

### DIFF
--- a/packages/react-core/src/components/Popover/index.ts
+++ b/packages/react-core/src/components/Popover/index.ts
@@ -1,1 +1,1 @@
-export { Popover, PopoverPosition } from './Popover';
+export { Popover, PopoverPosition, PopoverProps } from './Popover';

--- a/packages/react-core/src/components/Tooltip/index.ts
+++ b/packages/react-core/src/components/Tooltip/index.ts
@@ -1,1 +1,1 @@
-export { Tooltip, TooltipPosition } from './Tooltip';
+export { Tooltip, TooltipPosition, TooltipProps } from './Tooltip';

--- a/packages/react-integration/cypress/integration/tablesimple.spec.ts
+++ b/packages/react-integration/cypress/integration/tablesimple.spec.ts
@@ -20,4 +20,28 @@ describe('Table Simple Test', () => {
       .find('th')
       .should('have.length', 5);
   });
+
+  it('Verify tooltip info', () => {
+    // there should be two header cells with tooltip and popover info respectively
+    cy.get('.pf-c-table__column-help-action').should('have.length', 2);
+    // tooltip shouldn't exist yet
+    cy.get('.pf-c-tooltip').should('not.exist');
+    // trigger tooltip
+    cy.get('.pf-c-table__column-help-action')
+      .first()
+      .click();
+    cy.get('.pf-c-tooltip').should('exist');
+  });
+
+  it('Verify popover info', () => {
+    // there should be two header cells with tooltip and popover info respectively
+    cy.get('.pf-c-table__column-help-action').should('have.length', 2);
+    // popover shouldn't exist yet
+    cy.get('.pf-c-popover').should('not.exist');
+    // trigger popover
+    cy.get('.pf-c-table__column-help-action')
+      .eq(1)
+      .click();
+    cy.get('.pf-c-popover').should('exist');
+  });
 });

--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableSimpleDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableSimpleDemo.tsx
@@ -10,14 +10,39 @@ export class TableSimpleDemo extends React.Component<
     super(props);
     this.state = {
       columns: [
-        { title: 'Repositories' },
+        {
+          title: 'Repositories',
+          header: {
+            info: {
+              tooltip: 'More information about repositories',
+              className: 'repositories-info-tip',
+              tooltipProps: {
+                isContentLeftAligned: true
+              }
+            }
+          }
+        },
         'Branches',
         { title: 'Pull requests' },
         'Workspaces',
         {
           title: 'Last Commit',
           transforms: [textCenter],
-          cellTransforms: [textCenter]
+          cellTransforms: [textCenter],
+          header: {
+            info: {
+              popover: (
+                <div>
+                  More <strong>information</strong> on commits
+                </div>
+              ),
+              ariaLabel: 'More information on commits',
+              popoverProps: {
+                headerContent: 'Last Commit',
+                footerContent: <a href="">Click here for even more info</a>
+              }
+            }
+          }
         }
       ],
       rows: [

--- a/packages/react-table/src/components/Table/HeaderCellInfoWrapper.tsx
+++ b/packages/react-table/src/components/Table/HeaderCellInfoWrapper.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import HelpIcon from '@patternfly/react-icons/dist/js/icons/help-icon';
+import { css } from '@patternfly/react-styles';
+import styles from '@patternfly/react-styles/css/components/Table/table';
+import { Button, Tooltip, Popover, TooltipProps, PopoverProps } from '@patternfly/react-core';
+
+export interface ColumnHelpWrapperProps {
+  /**
+   * The header cell that is wrapped
+   */
+  children: React.ReactNode;
+  /**
+   * The information that is presented in the tooltip/popover
+   */
+  info: React.ReactNode;
+  /**
+   * Optional classname to add to the tooltip/popover
+   */
+  className?: string;
+  /**
+   * The info variant
+   */
+  variant?: 'tooltip' | 'popover';
+  /**
+   * Additional props forwarded to the Popover component
+   */
+  popoverProps?: Omit<PopoverProps, 'bodyContent'>;
+  /**
+   * Additional props forwarded to the tooltip component
+   */
+  tooltipProps?: Omit<TooltipProps, 'content'>;
+  /**
+   * Aria label of the info button
+   */
+  ariaLabel?: string;
+}
+
+export const HeaderCellInfoWrapper: React.FunctionComponent<ColumnHelpWrapperProps> = ({
+  children,
+  info,
+  className,
+  variant = 'tooltip',
+  popoverProps,
+  tooltipProps,
+  ariaLabel
+}: ColumnHelpWrapperProps) => (
+  <div className={css(styles.tableColumnHelp, className)}>
+    {children}
+    <span className={css(styles.tableColumnHelpAction)}>
+      {variant === 'tooltip' ? (
+        <Tooltip content={info} {...tooltipProps}>
+          <Button variant="plain" aria-label={ariaLabel || (typeof info === 'string' && info) || 'More info'}>
+            <HelpIcon noVerticalAlign />
+          </Button>
+        </Tooltip>
+      ) : (
+        <Popover bodyContent={info} {...popoverProps}>
+          <Button variant="plain" aria-label={ariaLabel || (typeof info === 'string' && info) || 'More info'}>
+            <HelpIcon noVerticalAlign />
+          </Button>
+        </Popover>
+      )}
+    </span>
+  </div>
+);
+HeaderCellInfoWrapper.displayName = 'HeaderCellInfoWrapper';

--- a/packages/react-table/src/components/Table/base/header-row.tsx
+++ b/packages/react-table/src/components/Table/base/header-row.tsx
@@ -9,6 +9,7 @@ import { evaluateFormatters } from './evaluate-formatters';
 import { evaluateTransforms } from './evaluate-transforms';
 import { mergeProps } from './merge-props';
 import { createElementType, ColumnType, HeaderType, RowsType, RendererType } from './types';
+import { HeaderCellInfoWrapper } from '../HeaderCellInfoWrapper';
 
 export interface HeaderRowProps {
   rowData: RowsType;
@@ -29,7 +30,7 @@ export const HeaderRow: React.FunctionComponent<HeaderRowProps> = ({
     (rowData as []).map((column: ColumnType, columnIndex: number) => {
       const { property, header = {} as HeaderType, props = {} } = column;
       const evaluatedProperty = property || (header && header.property);
-      const { label, transforms = [], formatters = [] } = header;
+      const { label, transforms = [], formatters = [], info = {} } = header;
       const extraParameters = {
         columnIndex,
         property: evaluatedProperty,
@@ -42,13 +43,43 @@ export const HeaderRow: React.FunctionComponent<HeaderRowProps> = ({
         console.warn('Table.Header - Failed to receive a transformed result'); // eslint-disable-line max-len, no-console
       }
 
+      let cellNode;
+      const { tooltip, tooltipProps, popover, popoverProps, ariaLabel, className } = info;
+      if (tooltip) {
+        cellNode = (
+          <HeaderCellInfoWrapper
+            variant="tooltip"
+            info={tooltip}
+            tooltipProps={tooltipProps}
+            ariaLabel={ariaLabel}
+            className={className}
+          >
+            {transformedProps.children || evaluateFormatters(formatters)(label, extraParameters)}
+          </HeaderCellInfoWrapper>
+        );
+      } else if (popover) {
+        cellNode = (
+          <HeaderCellInfoWrapper
+            variant="popover"
+            info={popover}
+            popoverProps={popoverProps}
+            ariaLabel={ariaLabel}
+            className={className}
+          >
+            {transformedProps.children || evaluateFormatters(formatters)(label, extraParameters)}
+          </HeaderCellInfoWrapper>
+        );
+      } else {
+        cellNode = transformedProps.children || evaluateFormatters(formatters)(label, extraParameters);
+      }
+
       return React.createElement(
         renderers.cell as createElementType,
         {
           key: `${columnIndex}-header`,
           ...mergeProps(props, header && header.props, transformedProps)
         },
-        transformedProps.children || evaluateFormatters(formatters)(label, extraParameters)
+        cellNode
       );
     })
   );

--- a/packages/react-table/src/components/Table/base/types.tsx
+++ b/packages/react-table/src/components/Table/base/types.tsx
@@ -6,6 +6,7 @@
  */
 
 import * as React from 'react';
+import { TooltipProps, PopoverProps } from '@patternfly/react-core';
 
 // Cell Type
 export interface CellType {
@@ -30,6 +31,15 @@ export interface HeaderType {
   formatters?: formattersType;
   props?: object;
   property?: string;
+  info?: InfoType;
+}
+export interface InfoType {
+  tooltip?: React.ReactNode;
+  tooltipProps?: Omit<TooltipProps, 'content'>;
+  popover?: React.ReactNode;
+  popoverProps?: Omit<PopoverProps, 'bodyContent'>;
+  ariaLabel?: string;
+  className?: string;
 }
 
 // Rows Types

--- a/packages/react-table/src/components/Table/examples/Table.md
+++ b/packages/react-table/src/components/Table/examples/Table.md
@@ -67,9 +67,32 @@ class SimpleTable extends React.Component {
     super(props);
     this.state = {
       columns: [
-        { title: 'Repositories' },
+        { 
+          title: 'Repositories',
+          header: {
+            info: {
+              tooltip: 'More information about repositories',
+              className: 'repositories-info-tip',
+              tooltipProps: {
+                isContentLeftAligned: true
+              }
+            }
+          }
+        },
         'Branches',
-        { title: 'Pull requests' },
+        { 
+          title: 'Pull requests',
+          header: {
+            info: {
+              popover: <div>More <strong>information</strong> on pull requests</div>,
+              ariaLabel: 'More information on pull requests',
+              popoverProps: {
+                headerContent: 'Pull requests',
+                footerContent: <a href="">Click here for even more info</a>
+              }
+            }
+          }
+        },
         'Workspaces',
         {
           title: 'Last Commit',


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes https://github.com/patternfly/patternfly-react/issues/3969

Example:
https://patternfly-react-pr-4778.surge.sh/documentation/react/components/table#basic
(First help button activates a tooltip on hover over, second help button activates a popover on click)

Tooltip variant:
<img width="333" alt="Screen Shot 2020-09-03 at 1 30 20 PM" src="https://user-images.githubusercontent.com/869106/92147948-ce264980-ede9-11ea-82e5-07d2a7582674.png">

Popover variant:
<img width="454" alt="Screen Shot 2020-09-03 at 1 30 42 PM" src="https://user-images.githubusercontent.com/869106/92147964-d4b4c100-ede9-11ea-9923-becf1ce0059a.png">

