### PR TITLE
fix(page): hide PageSideBar onClick on mobile when isManagedSidebar

### DIFF
--- a/packages/react-core/src/components/Page/Page.tsx
+++ b/packages/react-core/src/components/Page/Page.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import ReactDOM from "react-dom";
 import styles from '@patternfly/react-styles/css/components/Page/page';
 import { css } from '@patternfly/react-styles';
 import globalBreakpointXl from '@patternfly/react-tokens/dist/js/global_breakpoint_xl';
@@ -126,10 +125,9 @@ export class Page extends React.Component<PageProps, PageState> {
     }
   }
 
-  isMobile = () => {
+  isMobile = () =>
     // eslint-disable-next-line radix
-    return window.innerWidth < Number.parseInt(globalBreakpointXl.value, 10);
-  }
+    window.innerWidth < Number.parseInt(globalBreakpointXl.value, 10);
 
   handleResize = debounce(() => {
     const { onPageResize } = this.props;
@@ -147,7 +145,7 @@ export class Page extends React.Component<PageProps, PageState> {
         this.setState({ mobileIsNavOpen: false });
       }
     }
-  }
+  };
 
   onNavToggleMobile = () => {
     this.setState(prevState => ({

--- a/packages/react-core/src/components/Page/Page.tsx
+++ b/packages/react-core/src/components/Page/Page.tsx
@@ -110,7 +110,6 @@ export class Page extends React.Component<PageProps, PageState> {
     if (isManagedSidebar || onPageResize) {
       window.addEventListener('resize', this.handleResize);
       const currentRef = this.outerRef.current;
-      console.log('currentRef', currentRef)
       if (currentRef) {
         currentRef.addEventListener('mousedown', this.handleClickMobile);
         currentRef.addEventListener('touchstart', this.handleClickMobile);
@@ -143,7 +142,7 @@ export class Page extends React.Component<PageProps, PageState> {
       onPageResize({ mobileView, windowSize: window.innerWidth });
     }
     this.setState({ mobileView });
-  }
+  };
 
   handleResize = debounce(this.resize, 100);
 

--- a/packages/react-core/src/components/Page/Page.tsx
+++ b/packages/react-core/src/components/Page/Page.tsx
@@ -144,7 +144,7 @@ export class Page extends React.Component<PageProps, PageState> {
     this.setState({ mobileView });
   };
 
-  handleResize = debounce(this.resize, 100);
+  handleResize = debounce(this.resize, 250);
 
   handleClickMobile = (ev: any) => {
     if (this.isMobile() && this.state.mobileIsNavOpen && this.outerRef.current) {

--- a/packages/react-core/src/components/Page/Page.tsx
+++ b/packages/react-core/src/components/Page/Page.tsx
@@ -91,7 +91,7 @@ export class Page extends React.Component<PageProps, PageState> {
     isNotificationDrawerExpanded: false,
     onNotificationDrawerExpand: () => null
   };
-  outerRef = React.createRef<HTMLDivElement>();
+  mainRef = React.createRef<HTMLDivElement>();
 
   constructor(props: PageProps) {
     super(props);
@@ -109,10 +109,10 @@ export class Page extends React.Component<PageProps, PageState> {
     const { isManagedSidebar, onPageResize } = this.props;
     if (isManagedSidebar || onPageResize) {
       window.addEventListener('resize', this.handleResize);
-      const currentRef = this.outerRef.current;
+      const currentRef = this.mainRef.current;
       if (currentRef) {
-        currentRef.addEventListener('mousedown', this.handleClickMobile);
-        currentRef.addEventListener('touchstart', this.handleClickMobile);
+        currentRef.addEventListener('mousedown', this.handleMainClick);
+        currentRef.addEventListener('touchstart', this.handleMainClick);
       }
       // Initial check if should be shown
       this.resize();
@@ -123,10 +123,10 @@ export class Page extends React.Component<PageProps, PageState> {
     const { isManagedSidebar, onPageResize } = this.props;
     if (isManagedSidebar || onPageResize) {
       window.removeEventListener('resize', this.handleResize);
-      const currentRef = this.outerRef.current;
+      const currentRef = this.mainRef.current;
       if (currentRef) {
-        currentRef.removeEventListener('mousedown', this.handleClickMobile);
-        currentRef.removeEventListener('touchstart', this.handleClickMobile);
+        currentRef.removeEventListener('mousedown', this.handleMainClick);
+        currentRef.removeEventListener('touchstart', this.handleMainClick);
       }
     }
   }
@@ -146,12 +146,9 @@ export class Page extends React.Component<PageProps, PageState> {
 
   handleResize = debounce(this.resize, 250);
 
-  handleClickMobile = (ev: any) => {
-    if (this.isMobile() && this.state.mobileIsNavOpen && this.outerRef.current) {
-      const sidebarNode = this.outerRef.current.getElementsByClassName(styles.pageSidebar)[0];
-      if (sidebarNode && !sidebarNode.contains(ev.target)) {
-        this.setState({ mobileIsNavOpen: false });
-      }
+  handleMainClick = (ev: any) => {
+    if (this.isMobile() && this.state.mobileIsNavOpen && this.mainRef.current) {
+      this.setState({ mobileIsNavOpen: false });
     }
   };
 
@@ -202,6 +199,7 @@ export class Page extends React.Component<PageProps, PageState> {
 
     const main = (
       <main
+        ref={this.mainRef}
         role={role}
         id={mainContainerId}
         className={css(styles.pageMain)}
@@ -230,7 +228,7 @@ export class Page extends React.Component<PageProps, PageState> {
 
     return (
       <PageContextProvider value={context}>
-        <div ref={this.outerRef} {...rest} className={css(styles.page, className)}>
+        <div {...rest} className={css(styles.page, className)}>
           {skipToContent}
           {header}
           {sidebar}

--- a/packages/react-core/src/components/Page/Page.tsx
+++ b/packages/react-core/src/components/Page/Page.tsx
@@ -109,10 +109,14 @@ export class Page extends React.Component<PageProps, PageState> {
     const { isManagedSidebar, onPageResize } = this.props;
     if (isManagedSidebar || onPageResize) {
       window.addEventListener('resize', this.handleResize);
-      document.addEventListener('mousedown', this.handleClickMobile);
-      document.addEventListener('touchstart', this.handleClickMobile);
+      const currentRef = this.outerRef.current;
+      console.log('currentRef', currentRef)
+      if (currentRef) {
+        currentRef.addEventListener('mousedown', this.handleClickMobile);
+        currentRef.addEventListener('touchstart', this.handleClickMobile);
+      }
       // Initial check if should be shown
-      this.handleResize();
+      this.resize();
     }
   }
 
@@ -120,8 +124,11 @@ export class Page extends React.Component<PageProps, PageState> {
     const { isManagedSidebar, onPageResize } = this.props;
     if (isManagedSidebar || onPageResize) {
       window.removeEventListener('resize', this.handleResize);
-      document.removeEventListener('mousedown', this.handleClickMobile);
-      document.removeEventListener('touchstart', this.handleClickMobile);
+      const currentRef = this.outerRef.current;
+      if (currentRef) {
+        currentRef.removeEventListener('mousedown', this.handleClickMobile);
+        currentRef.removeEventListener('touchstart', this.handleClickMobile);
+      }
     }
   }
 
@@ -129,17 +136,19 @@ export class Page extends React.Component<PageProps, PageState> {
     // eslint-disable-next-line radix
     window.innerWidth < Number.parseInt(globalBreakpointXl.value, 10);
 
-  handleResize = debounce(() => {
+  resize = () => {
     const { onPageResize } = this.props;
     const mobileView = this.isMobile();
     if (onPageResize) {
       onPageResize({ mobileView, windowSize: window.innerWidth });
     }
     this.setState({ mobileView });
-  }, 250);
+  }
+
+  handleResize = debounce(this.resize, 100);
 
   handleClickMobile = (ev: any) => {
-    if (this.isMobile() && this.outerRef.current) {
+    if (this.isMobile() && this.state.mobileIsNavOpen && this.outerRef.current) {
       const sidebarNode = this.outerRef.current.getElementsByClassName(styles.pageSidebar)[0];
       if (sidebarNode && !sidebarNode.contains(ev.target)) {
         this.setState({ mobileIsNavOpen: false });

--- a/packages/react-core/src/components/Page/__tests__/Generated/__snapshots__/Page.test.tsx.snap
+++ b/packages/react-core/src/components/Page/__tests__/Generated/__snapshots__/Page.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Page should match snapshot (auto-generated) 1`] = `
   value={
     Object {
       "isManagedSidebar": false,
-      "isNavOpen": true,
+      "isNavOpen": false,
       "onNavToggle": [Function],
     }
   }

--- a/packages/react-core/src/components/Page/__tests__/Generated/__snapshots__/Page.test.tsx.snap
+++ b/packages/react-core/src/components/Page/__tests__/Generated/__snapshots__/Page.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Page should match snapshot (auto-generated) 1`] = `
   value={
     Object {
       "isManagedSidebar": false,
-      "isNavOpen": false,
+      "isNavOpen": true,
       "onNavToggle": [Function],
     }
   }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4480. Fixes resize event listener never detaching.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: Doesn't close when nav item clicked. I think that's a bit too opinionated since designs can use side navs for more than just navigation. It's also tricky to code, but can be achieved consumer-side.
