### PR TITLE
fix(tabs): conditionally render aria-controls when mountOnEnter

### DIFF
--- a/packages/react-core/src/components/Tabs/Tabs.tsx
+++ b/packages/react-core/src/components/Tabs/Tabs.tsx
@@ -262,7 +262,12 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
                   ouiaId: childOuiaId,
                   ...rest
                 } = child.props;
-
+                let ariaControls = tabContentId
+                  ? `${tabContentId}`
+                  : `pf-tab-section-${eventKey}-${childId || uniqueId}`;
+                if ((mountOnEnter || unmountOnExit) && eventKey !== activeKey) {
+                  ariaControls = undefined;
+                }
                 return isHidden ? null : (
                   <li
                     key={index}
@@ -272,9 +277,7 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
                       className={css(styles.tabsLink)}
                       onClick={(event: any) => this.handleTabClick(event, eventKey, tabContentRef, mountOnEnter)}
                       id={`pf-tab-${eventKey}-${childId || uniqueId}`}
-                      aria-controls={
-                        tabContentId ? `${tabContentId}` : `pf-tab-section-${eventKey}-${childId || uniqueId}`
-                      }
+                      aria-controls={ariaControls}
                       tabContentRef={tabContentRef}
                       ouiaId={childOuiaId}
                       {...rest}

--- a/packages/react-integration/cypress/integration/tabdemo.spec.ts
+++ b/packages/react-integration/cypress/integration/tabdemo.spec.ts
@@ -26,10 +26,14 @@ describe('Tab Demo Test', () => {
   });
 
   it('Verify tabs mount on enter when specified', () => {
+    cy.get('#pf-tab-0-mountOnEnter').should('have.attr', 'aria-controls', 'pf-tab-section-0-mountOnEnter');
     cy.get('#pf-tab-section-0-mountOnEnter').should('exist');
+    cy.get('#pf-tab-1-mountOnEnter').should('not.have.have.attr', 'aria-controls', 'pf-tab-section-1-mountOnEnter');
     cy.get('#pf-tab-section-1-mountOnEnter').should('not.exist');
     cy.get('#pf-tab-1-mountOnEnter').click();
+    cy.get('#pf-tab-0-mountOnEnter').should('not.have.attr', 'aria-controls', 'pf-tab-section-0-mountOnEnter');
     cy.get('#pf-tab-section-0-mountOnEnter').should('exist');
+    cy.get('#pf-tab-1-mountOnEnter').should('have.have.attr', 'aria-controls', 'pf-tab-section-1-mountOnEnter');
     cy.get('#pf-tab-section-1-mountOnEnter').should('exist');
   });
 


### PR DESCRIPTION
**What**: Closes #4785 

Hey @jessiehuff I took the initiative and conditionally render "aria-controls" .
I also updated its spec test to make sure it is working properly.

Would you mind looking? :pray: 

Thanks.