### PR TITLE
feat(browserslist): adds @patternfly/browserslist-config package

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,1 @@
+extends @patternfly/browserslist-config

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,124 +1,113 @@
 {
-    "env": {
-        "browser": true,
-        "node": true,
-        "es6": true
-    },
-    "plugins": [
-        "@typescript-eslint",
-        "jsdoc",
-        "react",
-        "prettier",
-        "patternfly-react"
-    ],
-    "extends": [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/recommended",
-        "plugin:react/recommended",
-        "plugin:jsdoc/recommended"
-    ],
-    "parserOptions": {
-        "sourceType": "module",
-        "ecmaFeatures": {
-            "jsx": true
-        }
-    },
-    "settings": {
-        "react": {
-            "version": "16.4.0"
-        }
-    },
-    "globals": {
-        "describe": "readonly",
-        "test": "readonly",
-        "jest": "readonly",
-        "expect": "readonly",
-        "require": "readonly",
-        "global": "writable",
-        "it": "readonly",
-        "afterEach": "readonly",
-        "beforeEach": "readonly"
-    },
-    "rules": {
-        "@typescript-eslint/adjacent-overload-signatures": "error",
-        "@typescript-eslint/array-type": "error",
-        "@typescript-eslint/ban-types": "error",
-        "@typescript-eslint/camelcase": "off",
-        "@typescript-eslint/class-name-casing": "error",
-        "@typescript-eslint/consistent-type-assertions": "error",
-        "@typescript-eslint/consistent-type-definitions": "error",
-        "@typescript-eslint/explicit-member-accessibility": "off",
-        "@typescript-eslint/indent": "off",
-        "@typescript-eslint/interface-name-prefix": "error",
-        "@typescript-eslint/no-empty-function": "off",
-        "@typescript-eslint/no-empty-interface": "off",
-        "@typescript-eslint/no-misused-new": "error",
-        "@typescript-eslint/no-namespace": "error",
-        "@typescript-eslint/no-var-requires": "off",
-        "@typescript-eslint/prefer-for-of": "error",
-        "@typescript-eslint/prefer-function-type": "error",
-        "@typescript-eslint/prefer-namespace-keyword": "error",
-        "@typescript-eslint/triple-slash-reference": "error",
-        "@typescript-eslint/unified-signatures": "error",
-        "@typescript-eslint/explicit-function-return-type": "off",
-        "@typescript-eslint/no-explicit-any": "off",
-        "@typescript-eslint/no-use-before-define": "off",
-        "@typescript-eslint/no-inferrable-types": "off",
-        "jsdoc/require-returns": "off",
-        "arrow-body-style": "error",
-        "camelcase": ["error", {
-            "ignoreDestructuring": true
-        }],
-        "constructor-super": "error",
-        "curly": "error",
-        "dot-notation": "error",
-        "eqeqeq": [
-            "error",
-            "smart"
-        ],
-        "guard-for-in": "error",
-        "max-classes-per-file": [
-            "error",
-            1
-        ],
-        "max-len": "off",
-        "no-bitwise": "error",
-        "no-caller": "error",
-        "no-cond-assign": "error",
-        "no-console": "error",
-        "no-debugger": "error",
-        "no-empty": "error",
-        "no-eval": "error",
-        "no-new-wrappers": "error",
-        "no-prototype-builtins": "off",
-        "no-shadow": "error",
-        "no-throw-literal": "error",
-        "no-trailing-spaces": "off",
-        "no-undef-init": "error",
-        "no-unsafe-finally": "error",
-        "no-unused-expressions": ["error", {
-            "allowTernary": true,
-            "allowShortCircuit": true
-        }],
-        "no-unused-labels": "error",
-        "no-var": "error",
-        "object-shorthand": "error",
-        "one-var": [
-            "error",
-            "never"
-        ],
-        "patternfly-react/import-tokens-icons": "error",
-        "patternfly-react/no-anonymous-functions": "error",
-        "prefer-const": "error",
-        "prettier/prettier": "error",
-        "radix": [
-            "error",
-            "as-needed"
-        ],
-        "react/prop-types": 0,
-        "react/display-name": 0,
-        "react/no-unescaped-entities": ["error", {"forbid": [">", "}"]}],
-        "spaced-comment": "error",
-        "use-isnan": "error"
+  "env": {
+    "browser": true,
+    "node": true,
+    "es6": true
+  },
+  "plugins": ["@typescript-eslint", "jsdoc", "react", "prettier", "patternfly-react", "compat"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:react/recommended",
+    "plugin:jsdoc/recommended",
+    "plugin:compat/recommended"
+  ],
+  "parserOptions": {
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "jsx": true
     }
+  },
+  "settings": {
+    "react": {
+      "version": "16.4.0"
+    }
+  },
+  "globals": {
+    "describe": "readonly",
+    "test": "readonly",
+    "jest": "readonly",
+    "expect": "readonly",
+    "require": "readonly",
+    "global": "writable",
+    "it": "readonly",
+    "afterEach": "readonly",
+    "beforeEach": "readonly"
+  },
+  "rules": {
+    "@typescript-eslint/adjacent-overload-signatures": "error",
+    "@typescript-eslint/array-type": "error",
+    "@typescript-eslint/ban-types": "error",
+    "@typescript-eslint/camelcase": "off",
+    "@typescript-eslint/class-name-casing": "error",
+    "@typescript-eslint/consistent-type-assertions": "error",
+    "@typescript-eslint/consistent-type-definitions": "error",
+    "@typescript-eslint/explicit-member-accessibility": "off",
+    "@typescript-eslint/indent": "off",
+    "@typescript-eslint/interface-name-prefix": "error",
+    "@typescript-eslint/no-empty-function": "off",
+    "@typescript-eslint/no-empty-interface": "off",
+    "@typescript-eslint/no-misused-new": "error",
+    "@typescript-eslint/no-namespace": "error",
+    "@typescript-eslint/no-var-requires": "off",
+    "@typescript-eslint/prefer-for-of": "error",
+    "@typescript-eslint/prefer-function-type": "error",
+    "@typescript-eslint/prefer-namespace-keyword": "error",
+    "@typescript-eslint/triple-slash-reference": "error",
+    "@typescript-eslint/unified-signatures": "error",
+    "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-use-before-define": "off",
+    "@typescript-eslint/no-inferrable-types": "off",
+    "jsdoc/require-returns": "off",
+    "arrow-body-style": "error",
+    "camelcase": [
+      "error",
+      {
+        "ignoreDestructuring": true
+      }
+    ],
+    "constructor-super": "error",
+    "curly": "error",
+    "dot-notation": "error",
+    "eqeqeq": ["error", "smart"],
+    "guard-for-in": "error",
+    "max-classes-per-file": ["error", 1],
+    "max-len": "off",
+    "no-bitwise": "error",
+    "no-caller": "error",
+    "no-cond-assign": "error",
+    "no-console": "error",
+    "no-debugger": "error",
+    "no-empty": "error",
+    "no-eval": "error",
+    "no-new-wrappers": "error",
+    "no-prototype-builtins": "off",
+    "no-shadow": "error",
+    "no-throw-literal": "error",
+    "no-trailing-spaces": "off",
+    "no-undef-init": "error",
+    "no-unsafe-finally": "error",
+    "no-unused-expressions": [
+      "error",
+      {
+        "allowTernary": true,
+        "allowShortCircuit": true
+      }
+    ],
+    "no-unused-labels": "error",
+    "no-var": "error",
+    "object-shorthand": "error",
+    "one-var": ["error", "never"],
+    "patternfly-react/import-tokens-icons": "error",
+    "patternfly-react/no-anonymous-functions": "error",
+    "prefer-const": "error",
+    "prettier/prettier": "error",
+    "radix": ["error", "as-needed"],
+    "react/prop-types": 0,
+    "react/display-name": 0,
+    "react/no-unescaped-entities": ["error", { "forbid": [">", "}"] }],
+    "spaced-comment": "error",
+    "use-isnan": "error"
+  }
 }

--- a/packages/browserslist-config/README.md
+++ b/packages/browserslist-config/README.md
@@ -1,0 +1,53 @@
+# @patternfly/browserslist-config
+
+This package provides the definition of the browsers PatternFly React supports.
+It uses [`browserslist`](https://github.com/browserslist/browserslist#browserslist-) API so it can be used in tools like `eslint`, `babel`, `postcss`, `autoprefixer` and more.
+
+### Installing
+
+```
+yarn add -D @patternfly/browserslist-config
+```
+
+or
+
+```
+npm install @patternfly/browserslist-config --save-dev
+```
+
+### Usage
+
+Add `browserslist` field in your `package.json` file:
+
+```diff
+{
++  "browserslist": [
++    "extends @patternfly/browserslist-config"
++  ]
+}
+```
+
+### Integrate with babel
+
+To make babel read your browserslist-config and replace `core-js` instances with spesific polyfills, use the `@babel/preset-env` preset with `"useBuiltIns": "entry"` param:
+
+```json
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "useBuiltIns": "entry"
+      }
+    ]
+  ]
+}
+```
+
+Learn more about entry built-ins: https://babeljs.io/docs/en/next/babel-preset-env.html#usebuiltins
+
+### Integrate with eslint
+
+The eslint integration is seemless and should work out of the box if you are already using the `eslint-plugin-patternfly-react` package.
+
+If not, install the [`eslint-plugin-compat`](https://github.com/amilajack/eslint-plugin-compat) plugin.

--- a/packages/browserslist-config/index.js
+++ b/packages/browserslist-config/index.js
@@ -1,0 +1,1 @@
+module.exports = ['last 1 Chrome version', 'last 1 Firefox version', 'last 1 Safari version', 'last 1 Edge version'];

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@patternfly/browserslist-config",
+  "version": "1.0.0",
+  "description": "browserslist config",
+  "main": "index.js",
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/patternfly/patternfly-react.git"
+  },
+  "keywords": [
+    "react",
+    "patternfly"
+  ],
+  "author": "Red Hat",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/patternfly/patternfly-react/issues"
+  },
+  "homepage": "https://github.com/patternfly/patternfly-react#readme",
+  "scripts": {
+  },
+  "dependencies": {},
+  "devDependencies": {
+  }
+}

--- a/packages/eslint-plugin-patternfly-react/lib/config/recommended.js
+++ b/packages/eslint-plugin-patternfly-react/lib/config/recommended.js
@@ -59,7 +59,8 @@ module.exports = {
     'plugin:jest/recommended',
     'prettier',
     'prettier/react',
-    'plugin:react-hooks/recommended'
+    'plugin:react-hooks/recommended',
+    'plugin:compat/recommended'
   ],
   env: {
     es6: true,
@@ -67,6 +68,6 @@ module.exports = {
     node: true,
     jest: true
   },
-  plugins: ['prettier', 'jest', 'react', 'react-hooks', 'patternfly-react'],
+  plugins: ['prettier', 'jest', 'react', 'react-hooks', 'patternfly-react', 'compat'],
   parser: 'babel-eslint'
 };

--- a/packages/eslint-plugin-patternfly-react/package.json
+++ b/packages/eslint-plugin-patternfly-react/package.json
@@ -28,6 +28,7 @@
     "eslint-config-standard": "^11.0.0",
     "eslint-config-standard-jsx": "^5.0.0",
     "eslint-config-standard-react": "^6.0.0",
+    "eslint-plugin-compat": "^3.8.0",
     "eslint-plugin-import": "^2.13.0",
     "eslint-plugin-jest": "^21.15.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -31,7 +31,9 @@
   "scripts": {
     "clean": "rimraf dist",
     "build:umd": "rollup -c && rollup -c --environment IS_PRODUCTION",
-    "generate": "node scripts/copyStyles.js",
+    "generate": "yarn generate:copy-styles && yarn generate:supported-browsers-regex",
+    "generate:copy-styles": "node scripts/copyStyles.js",
+    "generate:supported-browsers-regex": "scripts/generate-supported-browsers-regex.sh",
     "gen:tests": "yo tsx-docgen"
   },
   "dependencies": {
@@ -48,6 +50,7 @@
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",
     "@rollup/plugin-replace": "^2.3.1",
+    "browserslist-useragent-regexp": "^2.1.0",
     "css": "^2.2.3",
     "fs-extra": "^6.0.1",
     "generator-tsx-docgen": "^0.1.0",

--- a/packages/react-core/scripts/generate-supported-browsers-regex.sh
+++ b/packages/react-core/scripts/generate-supported-browsers-regex.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+DESTINATION_PATH=src/helpers/SupportedBrowsers/supportedBrowsersRegex.ts
+SUPPORTED_BROWSERS_REGEX=$(npx browserslist-useragent-regexp --allowHigherVersions)
+
+echo "export default $SUPPORTED_BROWSERS_REGEX;" > $DESTINATION_PATH

--- a/packages/react-core/src/helpers/SupportedBrowsers/.gitignore
+++ b/packages/react-core/src/helpers/SupportedBrowsers/.gitignore
@@ -1,0 +1,1 @@
+supportedBrowsersRegex.ts

--- a/packages/react-core/src/helpers/SupportedBrowsers/index.ts
+++ b/packages/react-core/src/helpers/SupportedBrowsers/index.ts
@@ -1,0 +1,2 @@
+export { default as supportedBrowsersRegex } from './supportedBrowsersRegex';
+export { default as isBrowserSupported } from './isBrowserSupported';

--- a/packages/react-core/src/helpers/SupportedBrowsers/isBrowserSupported.ts
+++ b/packages/react-core/src/helpers/SupportedBrowsers/isBrowserSupported.ts
@@ -1,0 +1,10 @@
+// @ts-ignore
+import supportedBrowsersRegex from './supportedBrowsersRegex';
+
+/**
+ * Is the browser supported by patternfly
+ * @param  userAgent=navigator.userAgent The browser user-agent string.
+ * @return                               Boolean indication if patternfly
+ *                                       supported the given user-agent.
+ */
+export default (userAgent = navigator.userAgent) => supportedBrowsersRegex.test(userAgent);

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -52,9 +52,5 @@
   },
   "keywords": [
     "gatsby"
-  ],
-  "browserslist": [
-    "last 2 versions",
-    "not ie <= 11"
   ]
 }

--- a/packages/react-integration/demo-app-ts/package.json
+++ b/packages/react-integration/demo-app-ts/package.json
@@ -19,11 +19,5 @@
     "@types/react-router-dom": "^4.3.1",
     "react-scripts": "2.1.3",
     "typescript": "^3.8.3"
-  },
-  "browserslist": [
-    ">0.2%",
-    "not dead",
-    "not ie <= 11",
-    "not op_mini all"
-  ]
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2252,6 +2252,14 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime-corejs3@^7.9.6":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz#02c3029743150188edeb66541195f54600278419"
+  integrity sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==
+  dependencies:
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@7.3.1":
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.1.tgz#574b03e8e8a9898eaf4a872a92ea20b7846f6f2a"
@@ -4200,6 +4208,11 @@
   version "13.5.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.5.0.tgz#4e498dbf355795a611a87ae5ef811a8660d42662"
 
+"@types/node@^14.0.4":
+  version "14.6.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.6.4.tgz#a145cc0bb14ef9c4777361b7bbafa5cf8e3acb5a"
+  integrity sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ==
+
 "@types/node@^8.5.7":
   version "8.10.59"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.59.tgz#9e34261f30183f9777017a13d185dfac6b899e04"
@@ -5210,6 +5223,11 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argue-cli@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/argue-cli/-/argue-cli-1.2.1.tgz#27b2304f86370642ad2dcbb69f00fd728215073f"
+  integrity sha512-Em3HDMlqiVLNOgXUCYz5NG1mx/44aijsxUOO8elmfvAN4/3ar1S3WPTua7WGhsMbeQm8clOwpDZ09sN7C2FnOg==
+
 argv@^0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/argv/-/argv-0.0.2.tgz#ecbd16f8949b157183711b1bda334f37840185ab"
@@ -5428,6 +5446,11 @@ assert@^1.1.1:
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
+
+ast-metadata-inferer@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/ast-metadata-inferer/-/ast-metadata-inferer-0.4.0.tgz#6be85ceeffcf267bd79db8e1ae731da44880b45f"
+  integrity sha512-tKHdBe8N/Vq2nLAm4YPBVREVZjMux6KrqyPfNQgIbDl0t7HaNSmy8w4OyVHYg/cvyn5BW7o7pVwpjPte89Zhcg==
 
 ast-types-flow@0.0.7, ast-types-flow@^0.0.7:
   version "0.0.7"
@@ -6679,6 +6702,19 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
+browserslist-useragent-regexp@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/browserslist-useragent-regexp/-/browserslist-useragent-regexp-2.1.0.tgz#2485686e08ff9699ce298bb8ab4cc6b1bb4da7d3"
+  integrity sha512-tp2GxiN2g5/5T5TR5VtPc2bUYyHBrvdnoblJlKiF814kB+/U8++Qk8a/znxNVUNHLqEzjyX1Y2X5QmSrXSZJtQ==
+  dependencies:
+    "@babel/runtime-corejs3" "^7.9.6"
+    "@types/node" "^14.0.4"
+    argue-cli "^1.2.0"
+    browserslist "^4.5.6"
+    chalk "^4.0.0"
+    easy-table "^1.1.1"
+    useragent "^2.3.0"
+
 browserslist@4.4.1:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.4.1.tgz#42e828954b6b29a7a53e352277be429478a69062"
@@ -6712,6 +6748,16 @@ browserslist@^4.11.1, browserslist@^4.12.0:
     electron-to-chromium "^1.3.413"
     node-releases "^1.1.53"
     pkg-up "^2.0.0"
+
+browserslist@^4.12.2, browserslist@^4.5.6:
+  version "4.14.1"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.14.1.tgz#cb2b490ba881d45dc3039078c7ed04411eaf3fa3"
+  integrity sha512-zyBTIHydW37pnb63c7fHFXUG6EcqWOqoMdDx6cdyaDFriZ20EoVxcE95S54N+heRqY8m8IUgB5zYta/gCwSaaA==
+  dependencies:
+    caniuse-lite "^1.0.30001124"
+    electron-to-chromium "^1.3.562"
+    escalade "^3.0.2"
+    node-releases "^1.1.60"
 
 browserslist@^4.3.4:
   version "4.14.0"
@@ -7100,6 +7146,11 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
+caniuse-db@^1.0.30001090:
+  version "1.0.30001124"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30001124.tgz#b8bcd26a3a482ef633f9b8d934d9414ef0cf0e57"
+  integrity sha512-IlMKWAmKcQkx7QDelzH/yl+vMgXBhhQXxN4awbWSAuGgSbU3AuxTrHqOPA5Wsu1N1wRLzkpwgIa33AiVEPpDZQ==
+
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001004:
   version "1.0.30001004"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001004.tgz#d879b73981b255488316da946c39327d8c00a586"
@@ -7120,6 +7171,11 @@ caniuse-lite@^1.0.30001023:
 caniuse-lite@^1.0.30001039, caniuse-lite@^1.0.30001043:
   version "1.0.30001048"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001048.tgz#4bb4f1bc2eb304e5e1154da80b93dee3f1cf447e"
+
+caniuse-lite@^1.0.30001124:
+  version "1.0.30001124"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001124.tgz#5d9998190258e11630d674fc50ea8e579ae0ced2"
+  integrity sha512-zQW8V3CdND7GHRH6rxm6s59Ww4g/qGWTheoboW9nfeMg7sUoopIfKCcNZUjwYRCOrvereh3kwDpZj4VLQ7zGtA==
 
 capture-exit@^1.2.0:
   version "1.2.0"
@@ -7181,6 +7237,14 @@ chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.
 chalk@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+chalk@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -8210,6 +8274,11 @@ core-js@^3.3.2:
 core-js@^3.6.4:
   version "3.6.4"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.4.tgz#440a83536b458114b9cb2ac1580ba377dc470647"
+
+core-js@^3.6.5:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
+  integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -9643,6 +9712,15 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
+easy-table@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/easy-table/-/easy-table-1.1.1.tgz#c1b9b9ad68a017091a1c235e4bcba277540e143f"
+  integrity sha512-C9Lvm0WFcn2RgxbMnTbXZenMIWcBtkzMr+dWqq/JsVoGFSVUVlPqeOa5LP5kM0I3zoOazFpckOEb2/0LDFfToQ==
+  dependencies:
+    ansi-regex "^3.0.0"
+  optionalDependencies:
+    wcwidth ">=1.0.1"
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -9692,6 +9770,11 @@ electron-to-chromium@^1.3.341:
 electron-to-chromium@^1.3.413:
   version "1.3.418"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.418.tgz#840021191f466b803a873e154113620c9f53cec6"
+
+electron-to-chromium@^1.3.562:
+  version "1.3.562"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.562.tgz#79c20277ee1c8d0173a22af00e38433b752bc70f"
+  integrity sha512-WhRe6liQ2q/w1MZc8mD8INkenHivuHdrr4r5EQHNomy3NJux+incP6M6lDMd0paShP3MD0WGe5R1TWmEClf+Bg==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -10140,6 +10223,20 @@ eslint-module-utils@^2.4.1:
   dependencies:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
+
+eslint-plugin-compat@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-compat/-/eslint-plugin-compat-3.8.0.tgz#2348d6105e7e87b823ae3b97b349512a2a45a7f2"
+  integrity sha512-5CuWUSZXZkXLCQJBriEpndn/YWrvggDSHTpRJq++kR8GVcsWbTdp8Eh+nBA7JlrNi7ZJ/+kniOVXmn3bpnxuRA==
+  dependencies:
+    ast-metadata-inferer "^0.4.0"
+    browserslist "^4.12.2"
+    caniuse-db "^1.0.30001090"
+    core-js "^3.6.5"
+    find-up "^4.1.0"
+    lodash.memoize "4.1.2"
+    mdn-browser-compat-data "^1.0.28"
+    semver "7.3.2"
 
 eslint-plugin-flowtype@2.50.1:
   version "2.50.1"
@@ -10783,7 +10880,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.0, extend@~3.0.2:
+extend@3.0.2, extend@^3.0.0, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
 
@@ -16314,7 +16411,7 @@ lodash.maxby@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.maxby/-/lodash.maxby-4.6.0.tgz#082240068f3c7a227aa00a8380e4f38cf0786e3d"
 
-lodash.memoize@^4.1.2:
+lodash.memoize@4.1.2, lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
 
@@ -16506,7 +16603,7 @@ lru-cache@4.0.0:
     pseudomap "^1.0.1"
     yallist "^2.0.0"
 
-lru-cache@^4.0.0, lru-cache@^4.0.1, lru-cache@^4.1.1:
+lru-cache@4.1.x, lru-cache@^4.0.0, lru-cache@^4.0.1, lru-cache@^4.1.1:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
   dependencies:
@@ -16901,6 +16998,13 @@ mdast-util-toc@^3.1.0:
     mdast-util-to-string "^1.0.5"
     unist-util-is "^2.1.2"
     unist-util-visit "^1.1.0"
+
+mdn-browser-compat-data@^1.0.28:
+  version "1.0.36"
+  resolved "https://registry.yarnpkg.com/mdn-browser-compat-data/-/mdn-browser-compat-data-1.0.36.tgz#73b2e14eef64e3484c717eec01a01fe01d1f7dc9"
+  integrity sha512-3Z4VTxSROuJGs0Q7ZDTXBBgqiNM8KnsJtpKwWVGUJLNnIGzZBHg1UsFtcgD907+YEOPH8a4XXd7m8x+bbM4X6w==
+  dependencies:
+    extend "3.0.2"
 
 mdn-data@2.0.4:
   version "2.0.4"
@@ -21896,6 +22000,10 @@ semver@7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
 
+semver@7.3.2, semver@^7.3.2:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
+
 semver@>=1.0.13:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.1.tgz#29104598a197d6cbe4733eeecbe968f7b43a9667"
@@ -21907,10 +22015,6 @@ semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
 semver@^7.1.2:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.3.tgz#e4345ce73071c53f336445cfc19efb1c311df2a6"
-
-semver@^7.3.2:
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
 
 semver@~5.3.0:
   version "5.3.0"
@@ -23565,6 +23669,12 @@ tmp@0.0.30:
   dependencies:
     os-tmpdir "~1.0.1"
 
+tmp@0.0.x, tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  dependencies:
+    os-tmpdir "~1.0.2"
+
 tmp@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.1.0.tgz#ee434a4e22543082e294ba6201dcc6eafefa2877"
@@ -23576,12 +23686,6 @@ tmp@^0.0.29:
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.29.tgz#f25125ff0dd9da3ccb0c2dd371ee1288bb9128c0"
   dependencies:
     os-tmpdir "~1.0.1"
-
-tmp@^0.0.33:
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
-  dependencies:
-    os-tmpdir "~1.0.2"
 
 tmpl@1.0.x:
   version "1.0.4"
@@ -24370,6 +24474,14 @@ user-home@^2.0.0:
   dependencies:
     os-homedir "^1.0.0"
 
+useragent@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/useragent/-/useragent-2.3.0.tgz#217f943ad540cb2128658ab23fc960f6a88c9972"
+  integrity sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==
+  dependencies:
+    lru-cache "4.1.x"
+    tmp "0.0.x"
+
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -24956,7 +25068,7 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   dependencies:
     minimalistic-assert "^1.0.0"
 
-wcwidth@^1.0.0, wcwidth@^1.0.1:
+wcwidth@>=1.0.1, wcwidth@^1.0.0, wcwidth@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
   dependencies:


### PR DESCRIPTION
new package to provide integration with browserslist

**What**:

The goal is to share the [supported browsers](https://www.patternfly.org/v4/get-started/about#supported-browsers) with consumers.
See: https://forum.patternfly.org/t/what-browser-are-supported-by-pf4/370/5

**Additional issues**:

1. How can we ensure the code **syntax** is compatible with the listed browsers?
> The typescript compiles the code to es2015 so it should be compatible with all modern browsers.

2. How can we ensure the code uses browsers APIs which are compatible with the listed browsers?
> 1. Use eslint-plugin-compat and configure eslint to throw errors when using unsupported browsers based on the browserslist config.
> 2. If the project would use `babel` it would be possible to use `@babel/preset-env` together with `core-js` to fill the missing gap with polyfills based on the browserslist config.

3. How can we ensure the 3rd-party modules are compatible with the supported browsers?

