### PR TITLE
fix(Tabs): Handle activeKey props update with mountOnEnter on Tabs

### DIFF
--- a/packages/react-core/src/components/Tabs/Tabs.tsx
+++ b/packages/react-core/src/components/Tabs/Tabs.tsx
@@ -194,6 +194,16 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
     }
   }
 
+  componentDidUpdate(prevProps: TabsProps) {
+    const { activeKey, mountOnEnter } = this.props;
+    const { shownKeys } = this.state;
+    if (prevProps.activeKey !== activeKey && mountOnEnter && shownKeys.indexOf(activeKey) < 0) {
+      this.setState({
+        shownKeys: shownKeys.concat(activeKey)
+      });
+    }
+  }
+
   render() {
     const {
       className,


### PR DESCRIPTION
The "shownKeys" state array needs to be updated on props changed

Fixes #4805
