### PR TITLE
feat(DataList): add draggable feature for basic list

### DIFF
--- a/packages/react-core/src/components/DataList/DataList.tsx
+++ b/packages/react-core/src/components/DataList/DataList.tsx
@@ -226,7 +226,8 @@ export class DataList extends React.Component<DataListProps, DataListState> {
     };
 
     const dragProps = isDraggable && {
-      onDragOver: this.dragOver
+      onDragOver: this.dragOver,
+      onDrop: this.dragOver
     };
 
     return (

--- a/packages/react-core/src/components/DataList/DataList.tsx
+++ b/packages/react-core/src/components/DataList/DataList.tsx
@@ -112,7 +112,7 @@ export class DataList extends React.Component<DataListProps, DataListState> {
 
     arr.splice(oldIndex, 1);
     arr.splice(newIndex, 0, ghost);
-    onDragMove(oldIndex, newIndex);
+    onDragMove && onDragMove(oldIndex, newIndex);
     return arr;
   };
 
@@ -127,7 +127,7 @@ export class DataList extends React.Component<DataListProps, DataListState> {
         item => (item as React.ReactElement).props.id === evt.currentTarget.id
       ) as React.ReactElement
     });
-    onDragStart(evt.currentTarget.id);
+    onDragStart && onDragStart(evt.currentTarget.id);
   };
 
   dragEnd = (evt: React.DragEvent) => {
@@ -178,7 +178,7 @@ export class DataList extends React.Component<DataListProps, DataListState> {
     const dragInd = this.getIndex(dragItem.id);
 
     if (evt.key === ' ' || (evt.key === 'Enter' && !dragging)) {
-      onDragStart(dragItem.id);
+      onDragStart && onDragStart(dragItem.id);
       this.setState({
         dragging: true,
         draggedItem: React.Children.toArray(children).find(
@@ -196,7 +196,7 @@ export class DataList extends React.Component<DataListProps, DataListState> {
           data.splice(to, 1, draggedItem);
           onDragFinish(data);
         } else {
-          onDragCancel();
+          onDragCancel && onDragCancel();
         }
       } else if (evt.key === 'ArrowUp') {
         this.setState(prevState => {

--- a/packages/react-core/src/components/DataList/DataList.tsx
+++ b/packages/react-core/src/components/DataList/DataList.tsx
@@ -32,8 +32,8 @@ export interface DataListProps extends Omit<React.HTMLProps<HTMLUListElement>, '
   isCompact?: boolean;
   /** Determines which wrapping modifier to apply to the DataList */
   wrapModifier?: DataListWrapModifier | 'nowrap' | 'truncate' | 'breakWord';
-  /** Order of items in list */
-  itemOrder: string[];
+  /** Order of items in a draggable DataList */
+  itemOrder?: string[];
 }
 
 interface DataListState {

--- a/packages/react-core/src/components/DataList/DataList.tsx
+++ b/packages/react-core/src/components/DataList/DataList.tsx
@@ -9,7 +9,7 @@ export enum DataListWrapModifier {
   breakWord = 'breakWord'
 }
 
-export interface DataListProps extends React.HTMLProps<HTMLUListElement> {
+export interface DataListProps extends Omit<React.HTMLProps<HTMLUListElement>, 'onDragStart'> {
   /** Content rendered inside the DataList list */
   children?: React.ReactNode;
   /** Additional classes added to the DataList list */

--- a/packages/react-core/src/components/DataList/DataList.tsx
+++ b/packages/react-core/src/components/DataList/DataList.tsx
@@ -98,7 +98,8 @@ export class DataList extends React.Component<DataListProps, DataListState> {
 
   move = (arr: React.ReactElement[], oldIndex: number, newIndex: number) => {
     const ghost = React.cloneElement(this.state.draggedItem, {
-      className: css(this.state.draggedItem.props.className, styles.modifiers.ghostRow)
+      className: css(this.state.draggedItem.props.className, styles.modifiers.ghostRow),
+      'aria-pressed': true
     });
 
     arr.splice(oldIndex, 1);

--- a/packages/react-core/src/components/DataList/DataList.tsx
+++ b/packages/react-core/src/components/DataList/DataList.tsx
@@ -37,7 +37,6 @@ export interface DataListProps extends Omit<React.HTMLProps<HTMLUListElement>, '
 }
 
 interface DataListState {
-  childrenCopy: React.ReactNode;
   draggedItemId: string;
   draggingToItemIndex: number;
   dragging: boolean;
@@ -58,8 +57,7 @@ export const DataListContext = React.createContext<Partial<DataListContextProps>
   isSelectable: false
 });
 
-// Moves i1 to i2 and the rest of the array shifts down
-function moveItem(arr: string[], i1: string, toIndex: number) {
+const moveItem = (arr: string[], i1: string, toIndex: number) => {
   const fromIndex = arr.indexOf(i1);
   if (fromIndex === toIndex) {
     return arr;
@@ -68,7 +66,7 @@ function moveItem(arr: string[], i1: string, toIndex: number) {
   arr.splice(toIndex, 0, temp[0]);
 
   return arr;
-}
+};
 
 export class DataList extends React.Component<DataListProps, DataListState> {
   static displayName = 'DataList';
@@ -84,8 +82,7 @@ export class DataList extends React.Component<DataListProps, DataListState> {
   ref = React.createRef<HTMLUListElement>();
 
   state: DataListState = {
-    childrenCopy: this.props.children,
-    tempItemOrder: [], // Doesn't matter, set in constructor
+    tempItemOrder: [],
     draggedItemId: null,
     draggingToItemIndex: null,
     dragging: false
@@ -93,7 +90,6 @@ export class DataList extends React.Component<DataListProps, DataListState> {
 
   componentDidUpdate(oldProps: DataListProps) {
     if (this.dragFinished) {
-      this.arrayCopy = React.Children.toArray(this.props.children) as React.ReactElement[];
       this.dragFinished = false;
 
       this.setState({
@@ -109,7 +105,6 @@ export class DataList extends React.Component<DataListProps, DataListState> {
 
   getIndex = (id: string) => Array.from(this.ref.current.children).findIndex(item => item.id === id);
 
-  // Moves dom node
   move = (itemOrder: string[]) => {
     const ulNode = this.ref.current;
     const nodes = Array.from(ulNode.children);
@@ -157,7 +152,6 @@ export class DataList extends React.Component<DataListProps, DataListState> {
   dragOver0 = (id: string) => {
     const draggingToItemIndex = Array.from(this.ref.current.children).findIndex(item => item.id === id);
     if (draggingToItemIndex !== this.state.draggingToItemIndex) {
-      console.log('draggedItemId', this.state.draggedItemId, 'draggingToItemIndex', draggingToItemIndex);
       const tempItemOrder = moveItem([...this.props.itemOrder], this.state.draggedItemId, draggingToItemIndex);
       this.move(tempItemOrder);
 
@@ -178,8 +172,8 @@ export class DataList extends React.Component<DataListProps, DataListState> {
   };
 
   handleDragButtonKeys = (evt: React.KeyboardEvent) => {
-    const { draggedItemId: draggedItem, dragging } = this.state;
-    const { children, onDragFinish, onDragStart, onDragCancel } = this.props;
+    const { dragging } = this.state;
+    const { onDragCancel } = this.props;
     if (
       evt.key !== ' ' &&
       evt.key !== 'Escape' &&
@@ -195,7 +189,6 @@ export class DataList extends React.Component<DataListProps, DataListState> {
     evt.preventDefault();
 
     const dragItem = (evt.target as Element).closest('li');
-    const dragInd = this.getIndex(dragItem.id);
 
     if (evt.key === ' ' || (evt.key === 'Enter' && !dragging)) {
       this.dragStart0(dragItem);

--- a/packages/react-core/src/components/DataList/DataList.tsx
+++ b/packages/react-core/src/components/DataList/DataList.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/DataList/data-list';
+import { PickOptional } from '../../helpers/typeUtils';
 
 export enum DataListWrapModifier {
   nowrap = 'nowrap',
@@ -18,6 +18,8 @@ export interface DataListProps extends React.HTMLProps<HTMLUListElement> {
   'aria-label': string;
   /** Optional callback to make DataList selectable, fired when DataListItem selected */
   onSelectDataListItem?: (id: string) => void;
+  /** Optional callback to make DataList draggable, fired when dragging ends */
+  onDragFinish?: (newList: React.ReactElement[]) => void;
   /** Id of DataList item currently selected */
   selectedDataListItemId?: string;
   /** Flag indicating if DataList should have compact styling */
@@ -26,53 +28,232 @@ export interface DataListProps extends React.HTMLProps<HTMLUListElement> {
   wrapModifier?: DataListWrapModifier | 'nowrap' | 'truncate' | 'breakWord';
 }
 
+interface DataListState {
+  childrenCopy: React.ReactNode;
+  renderable: React.ReactElement[];
+  draggedItem: React.ReactElement;
+  dragging: boolean;
+  to: number;
+}
+
 interface DataListContextProps {
   isSelectable: boolean;
   selectedDataListItemId: string;
   updateSelectedDataListItem: (id: string) => void;
+  isDraggable: boolean;
+  dragStart: (e: React.DragEvent) => void;
+  dragEnd: (e: React.DragEvent) => void;
+  dragKeyHandler: (e: React.KeyboardEvent) => void;
 }
 
 export const DataListContext = React.createContext<Partial<DataListContextProps>>({
   isSelectable: false
 });
 
-export const DataList: React.FunctionComponent<DataListProps> = ({
-  children = null,
-  className = '',
-  'aria-label': ariaLabel,
-  selectedDataListItemId = '',
-  onSelectDataListItem,
-  isCompact = false,
-  wrapModifier = null,
-  ...props
-}: DataListProps) => {
-  const isSelectable = onSelectDataListItem !== undefined;
+export class DataList extends React.Component<DataListProps, DataListState> {
+  static displayName = 'DataList';
+  static defaultProps: PickOptional<DataListProps> = {
+    children: null,
+    className: '',
+    selectedDataListItemId: '',
+    isCompact: false,
+    wrapModifier: null
+  };
+  dragFinished: boolean = false;
+  arrayCopy: React.ReactElement[] = React.Children.toArray(this.props.children) as React.ReactElement[];
 
-  const updateSelectedDataListItem = (id: string) => {
-    onSelectDataListItem(id);
+  state: DataListState = {
+    childrenCopy: this.props.children,
+    renderable: React.Children.toArray(this.props.children) as React.ReactElement[],
+    to: -1,
+    draggedItem: null,
+    dragging: false
   };
 
-  return (
-    <DataListContext.Provider
-      value={{
-        isSelectable,
-        selectedDataListItemId,
-        updateSelectedDataListItem
-      }}
-    >
-      <ul
-        className={css(
-          styles.dataList,
-          isCompact && styles.modifiers.compact,
-          className,
-          wrapModifier && styles.modifiers[wrapModifier]
-        )}
-        aria-label={ariaLabel}
-        {...props}
+  static getDerivedStateFromProps(props: DataListProps, state: DataListState) {
+    if (props.children !== state.childrenCopy) {
+      return {
+        renderable: React.Children.toArray(props.children) as React.ReactElement[],
+        childrenCopy: props.children
+      };
+    }
+
+    return null;
+  }
+
+  componentDidUpdate() {
+    if (this.dragFinished) {
+      this.arrayCopy = React.Children.toArray(this.props.children) as React.ReactElement[];
+      this.dragFinished = false;
+
+      this.setState({
+        renderable: React.Children.toArray(this.props.children) as React.ReactElement[],
+        to: -1,
+        draggedItem: null
+      });
+    }
+  }
+
+  getIndex = (id: string) => this.state.renderable.findIndex(item => item.props.id === id);
+
+  move = (arr: React.ReactElement[], oldIndex: number, newIndex: number) => {
+    const ghost = React.cloneElement(this.state.draggedItem, {
+      className: css(this.state.draggedItem.props.className, styles.modifiers.ghostRow)
+    });
+
+    arr.splice(oldIndex, 1);
+    arr.splice(newIndex, 0, ghost);
+    return arr;
+  };
+
+  dragStart = (e: React.DragEvent) => {
+    const { children } = this.props;
+    e.dataTransfer.effectAllowed = 'move';
+    e.dataTransfer.setData('text/plain', e.currentTarget.id);
+    // e.dataTransfer.setDragImage(React.createElement('div'), 0, 0);
+
+    this.setState({
+      draggedItem: React.Children.toArray(children).find(
+        item => (item as React.ReactElement).props.id === e.currentTarget.id
+      ) as React.ReactElement
+    });
+  };
+
+  dragEnd = (evt: React.DragEvent) => {
+    const { to, renderable, draggedItem } = this.state;
+    const { onDragFinish } = this.props;
+
+    const data = renderable;
+    data.splice(to, 1, draggedItem);
+    this.dragFinished = true;
+    onDragFinish(data);
+  };
+
+  dragOver = (evt: React.DragEvent) => {
+    const { to } = this.state;
+    evt.preventDefault();
+    const currListItem = (evt.target as Element).closest('li');
+
+    const currInd = currListItem ? this.getIndex(currListItem.id) : 0;
+    if (currInd !== to) {
+      this.setState(prevState => ({
+        to: currInd,
+        renderable: this.move(this.arrayCopy, prevState.to === -1 ? currInd : prevState.to, currInd)
+      }));
+    }
+  };
+
+  handleDragButtonKeys = (evt: React.KeyboardEvent) => {
+    const { to, draggedItem, dragging, renderable } = this.state;
+    const { children, onDragFinish } = this.props;
+    if (
+      evt.key !== ' ' &&
+      evt.key !== 'Escape' &&
+      evt.key !== 'Enter' &&
+      evt.key !== 'ArrowUp' &&
+      evt.key !== 'ArrowDown'
+    ) {
+      if (dragging) {
+        this.setState({
+          dragging: false
+        });
+        this.dragFinished = true;
+      }
+      return;
+    }
+    evt.preventDefault();
+
+    const dragItem = (evt.target as Element).closest('li');
+    const dragInd = this.getIndex(dragItem.id);
+
+    if (evt.key === ' ') {
+      this.setState({
+        dragging: true,
+        draggedItem: React.Children.toArray(children).find(
+          item => (item as React.ReactElement).props.id === dragItem.id
+        ) as React.ReactElement
+      });
+    } else if (dragging) {
+      if (evt.key === 'Escape' || evt.key === 'Enter') {
+        this.setState({
+          dragging: false
+        });
+        this.dragFinished = true;
+        if (evt.key === 'Enter') {
+          const data = renderable;
+          data.splice(to, 1, draggedItem);
+          onDragFinish(data);
+        }
+      } else if (evt.key === 'ArrowUp') {
+        this.setState(prevState => {
+          const prevTo = prevState.to === -1 ? dragInd : prevState.to;
+          const next = prevTo - 1 >= 0 ? prevTo - 1 : 0;
+          return {
+            to: next,
+            renderable: this.move(this.arrayCopy, prevTo, next)
+          };
+        });
+      } else if (evt.key === 'ArrowDown') {
+        this.setState(prevState => {
+          const prevTo = prevState.to === -1 ? dragInd : prevState.to;
+          const next = prevTo + 1 < this.arrayCopy.length ? prevTo + 1 : this.arrayCopy.length - 1;
+          return {
+            to: next,
+            renderable: this.move(this.arrayCopy, prevTo, next)
+          };
+        });
+      }
+    }
+  };
+
+  render() {
+    const {
+      className,
+      children,
+      onSelectDataListItem,
+      selectedDataListItemId,
+      isCompact,
+      onDragFinish,
+      wrapModifier,
+      ...props
+    } = this.props;
+    const { renderable } = this.state;
+    const isSelectable = onSelectDataListItem !== undefined;
+    const isDraggable = onDragFinish !== undefined;
+
+    const updateSelectedDataListItem = (id: string) => {
+      onSelectDataListItem(id);
+    };
+
+    const dragProps = isDraggable && {
+      onDragOver: this.dragOver
+    };
+
+    return (
+      <DataListContext.Provider
+        value={{
+          isSelectable,
+          selectedDataListItemId,
+          updateSelectedDataListItem,
+          isDraggable,
+          dragStart: this.dragStart,
+          dragEnd: this.dragEnd,
+          dragKeyHandler: this.handleDragButtonKeys
+        }}
       >
-        {children}
-      </ul>
-    </DataListContext.Provider>
-  );
-};
-DataList.displayName = 'DataList';
+        <ul
+          className={css(
+            styles.dataList,
+            isCompact && styles.modifiers.compact,
+            wrapModifier && styles.modifiers[wrapModifier],
+            className
+          )}
+          {...props}
+          {...dragProps}
+        >
+          {isDraggable ? renderable : children}
+        </ul>
+      </DataListContext.Provider>
+    );
+  }
+}

--- a/packages/react-core/src/components/DataList/DataList.tsx
+++ b/packages/react-core/src/components/DataList/DataList.tsx
@@ -95,7 +95,8 @@ export class DataList extends React.Component<DataListProps, DataListState> {
       this.setState({
         renderable: React.Children.toArray(this.props.children) as React.ReactElement[],
         to: -1,
-        draggedItem: null
+        draggedItem: null,
+        dragging: false
       });
     }
   }
@@ -128,7 +129,8 @@ export class DataList extends React.Component<DataListProps, DataListState> {
     this.setState(
       {
         draggedItem: dragItem,
-        to: dragInd
+        to: dragInd,
+        dragging: true
       },
       () => {
         this.setState({
@@ -153,7 +155,7 @@ export class DataList extends React.Component<DataListProps, DataListState> {
     const { to } = this.state;
     evt.preventDefault();
     const currListItem = (evt.target as Element).closest('li');
-    if ((evt.target as HTMLElement).classList.contains('ghost-row')) {
+    if (currListItem && currListItem.classList.contains(css(styles.modifiers.ghostRow))) {
       return;
     }
     const currInd = currListItem ? this.getIndex(currListItem.id) : 0;
@@ -245,7 +247,7 @@ export class DataList extends React.Component<DataListProps, DataListState> {
       wrapModifier,
       ...props
     } = this.props;
-    const { renderable } = this.state;
+    const { renderable, dragging } = this.state;
     const isSelectable = onSelectDataListItem !== undefined;
     const isDraggable = onDragFinish !== undefined;
 
@@ -277,6 +279,10 @@ export class DataList extends React.Component<DataListProps, DataListState> {
             wrapModifier && styles.modifiers[wrapModifier],
             className
           )}
+          style={{
+            ...(dragging && { overflowAnchor: 'none' }),
+            ...props.style
+          }}
           {...props}
           {...dragProps}
         >

--- a/packages/react-core/src/components/DataList/DataList.tsx
+++ b/packages/react-core/src/components/DataList/DataList.tsx
@@ -121,12 +121,21 @@ export class DataList extends React.Component<DataListProps, DataListState> {
     evt.dataTransfer.effectAllowed = 'move';
     evt.dataTransfer.setData('text/plain', evt.currentTarget.id);
     // e.dataTransfer.setDragImage(React.createElement('div'), 0, 0);
-
-    this.setState({
-      draggedItem: React.Children.toArray(children).find(
-        item => (item as React.ReactElement).props.id === evt.currentTarget.id
-      ) as React.ReactElement
-    });
+    const dragItem = React.Children.toArray(children).find(
+      item => (item as React.ReactElement).props.id === evt.currentTarget.id
+    ) as React.ReactElement;
+    const dragInd = this.getIndex(dragItem.props.id);
+    this.setState(
+      {
+        draggedItem: dragItem,
+        to: dragInd
+      },
+      () => {
+        this.setState({
+          renderable: this.move(this.arrayCopy, dragInd, dragInd)
+        });
+      }
+    );
     onDragStart && onDragStart(evt.currentTarget.id);
   };
 
@@ -144,7 +153,9 @@ export class DataList extends React.Component<DataListProps, DataListState> {
     const { to } = this.state;
     evt.preventDefault();
     const currListItem = (evt.target as Element).closest('li');
-
+    if ((evt.target as HTMLElement).classList.contains('ghost-row')) {
+      return;
+    }
     const currInd = currListItem ? this.getIndex(currListItem.id) : 0;
     if (currInd !== to) {
       this.setState(prevState => ({

--- a/packages/react-core/src/components/DataList/DataListCheck.tsx
+++ b/packages/react-core/src/components/DataList/DataListCheck.tsx
@@ -17,6 +17,8 @@ export interface DataListCheckProps extends Omit<React.HTMLProps<HTMLInputElemen
   onChange?: (checked: boolean, event: React.FormEvent<HTMLInputElement>) => void;
   /** Aria-labelledby of the DataList checkbox */
   'aria-labelledby': string;
+  /** Flag to indicate if other controls are used in the DataListItem */
+  otherControls?: boolean;
 }
 
 export const DataListCheck: React.FunctionComponent<DataListCheckProps> = ({
@@ -27,10 +29,11 @@ export const DataListCheck: React.FunctionComponent<DataListCheckProps> = ({
   isDisabled = false,
   isChecked = null,
   checked = null,
+  otherControls = false,
   ...props
-}: DataListCheckProps) => (
-  <div className={css(styles.dataListItemControl, className)}>
-    <div className={css('pf-c-data-list__check')}>
+}: DataListCheckProps) => {
+  const check = (
+    <div className={css(styles.dataListCheck)}>
       <input
         {...props}
         type="checkbox"
@@ -40,6 +43,12 @@ export const DataListCheck: React.FunctionComponent<DataListCheckProps> = ({
         checked={isChecked || checked}
       />
     </div>
-  </div>
-);
+  );
+  return (
+    <React.Fragment>
+      {!otherControls && <div className={css(styles.dataListItemControl, className)}>{check}</div>}
+      {otherControls && check}
+    </React.Fragment>
+  );
+};
 DataListCheck.displayName = 'DataListCheck';

--- a/packages/react-core/src/components/DataList/DataListControl.tsx
+++ b/packages/react-core/src/components/DataList/DataListControl.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { css } from '@patternfly/react-styles';
+import styles from '@patternfly/react-styles/css/components/DataList/data-list';
+
+export interface DataListControlProps extends React.HTMLProps<HTMLDivElement> {
+  /** Children of the data list control */
+  children?: React.ReactNode;
+  /** Additional classes added to the DataList item control */
+  className?: string;
+}
+
+export const DataListControl: React.FunctionComponent<DataListControlProps> = ({
+  children,
+  className = '',
+  ...props
+}: DataListControlProps) => (
+  <div className={css(styles.dataListItemControl, className)} {...props}>
+    {children}
+  </div>
+);
+DataListControl.displayName = 'DataListControl';

--- a/packages/react-core/src/components/DataList/DataListDragButton.tsx
+++ b/packages/react-core/src/components/DataList/DataListDragButton.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { css } from '@patternfly/react-styles';
+import styles from '@patternfly/react-styles/css/components/DataList/data-list';
+import GripVerticalIcon from '@patternfly/react-icons/dist/js/icons/grip-vertical-icon';
+import { DataListContext } from './DataList';
+
+export interface DataListDragButtonProps extends React.HTMLProps<HTMLButtonElement> {
+  /** Additional classes added to the drag button */
+  className?: string;
+  /** Sets button type */
+  type?: 'button' | 'submit' | 'reset';
+  /** Flag indicating if drag is disabled for the item */
+  isDisabled?: boolean;
+}
+
+export const DataListDragButton: React.FunctionComponent<DataListDragButtonProps> = ({
+  className = '',
+  isDisabled = false,
+  ...props
+}: DataListDragButtonProps) => (
+  <DataListContext.Consumer>
+    {({ dragKeyHandler }) => (
+      <button
+        className={css(styles.dataListItemDraggableButton, isDisabled && styles.modifiers.disabled, className)}
+        onKeyDown={dragKeyHandler}
+        type="button"
+        disabled={isDisabled}
+        {...props}
+      >
+        <span className={css(styles.dataListItemDraggableIcon)}>
+          <GripVerticalIcon />
+        </span>
+      </button>
+    )}
+  </DataListContext.Consumer>
+);
+DataListDragButton.displayName = 'DataListDragButton';

--- a/packages/react-core/src/components/DataList/DataListItem.tsx
+++ b/packages/react-core/src/components/DataList/DataListItem.tsx
@@ -22,65 +22,77 @@ export interface DataListItemChildProps {
   rowid: string;
 }
 
-export const DataListItem: React.FunctionComponent<DataListItemProps> = ({
-  isExpanded = false,
-  className = '',
-  id = '',
-  'aria-labelledby': ariaLabelledBy,
-  children,
-  ...props
-}: DataListItemProps) => (
-  <DataListContext.Consumer>
-    {({ isSelectable, selectedDataListItemId, updateSelectedDataListItem }) => {
-      const selectDataListItem = (event: React.MouseEvent) => {
-        let target: any = event.target;
-        while (event.currentTarget !== target) {
-          if (
-            ('onclick' in target && target.onclick) ||
-            target.parentNode.classList.contains(styles.dataListItemAction) ||
-            target.parentNode.classList.contains(styles.dataListItemControl)
-          ) {
-            // check other event handlers are not present.
-            return;
-          } else {
-            target = target.parentNode;
-          }
-        }
-        updateSelectedDataListItem(id);
-      };
+export class DataListItem extends React.Component<DataListItemProps> {
+  static displayName = 'DataListItem';
+  static defaultProps: DataListItemProps = {
+    isExpanded: false,
+    className: '',
+    id: '',
+    children: null,
+    'aria-labelledby': ''
+  };
+  render() {
+    const { children, isExpanded, className, id, 'aria-labelledby': ariaLabelledBy, ...props } = this.props;
+    return (
+      <DataListContext.Consumer>
+        {({ isSelectable, selectedDataListItemId, updateSelectedDataListItem, isDraggable, dragStart, dragEnd }) => {
+          const selectDataListItem = (event: React.MouseEvent) => {
+            let target: any = event.target;
+            while (event.currentTarget !== target) {
+              if (
+                ('onclick' in target && target.onclick) ||
+                target.parentNode.classList.contains(styles.dataListItemAction) ||
+                target.parentNode.classList.contains(styles.dataListItemControl)
+              ) {
+                // check other event handlers are not present.
+                return;
+              } else {
+                target = target.parentNode;
+              }
+            }
+            updateSelectedDataListItem(id);
+          };
 
-      const onKeyDown = (event: React.KeyboardEvent) => {
-        if (event.key === KeyTypes.Enter) {
-          updateSelectedDataListItem(id);
-        }
-      };
+          const onKeyDown = (event: React.KeyboardEvent) => {
+            if (event.key === KeyTypes.Enter) {
+              updateSelectedDataListItem(id);
+            }
+          };
 
-      return (
-        <li
-          id={id}
-          className={css(
-            styles.dataListItem,
-            isExpanded && styles.modifiers.expanded,
-            isSelectable && styles.modifiers.selectable,
-            selectedDataListItemId && selectedDataListItemId === id && styles.modifiers.selected,
-            className
-          )}
-          aria-labelledby={ariaLabelledBy}
-          {...(isSelectable && { tabIndex: 0, onClick: selectDataListItem, onKeyDown })}
-          {...(isSelectable && selectedDataListItemId === id && { 'aria-selected': true })}
-          {...props}
-        >
-          {React.Children.map(
-            children,
-            child =>
-              React.isValidElement(child) &&
-              React.cloneElement(child as React.ReactElement<any>, {
-                rowid: ariaLabelledBy
-              })
-          )}
-        </li>
-      );
-    }}
-  </DataListContext.Consumer>
-);
-DataListItem.displayName = 'DataListItem';
+          const dragProps = isDraggable && {
+            draggable: true,
+            onDragEnd: dragEnd,
+            onDragStart: dragStart
+          };
+
+          return (
+            <li
+              id={id}
+              className={css(
+                styles.dataListItem,
+                isExpanded && styles.modifiers.expanded,
+                isSelectable && styles.modifiers.selectable,
+                selectedDataListItemId && selectedDataListItemId === id && styles.modifiers.selected,
+                className
+              )}
+              aria-labelledby={ariaLabelledBy}
+              {...(isSelectable && { tabIndex: 0, onClick: selectDataListItem, onKeyDown })}
+              {...(isSelectable && selectedDataListItemId === id && { 'aria-selected': true })}
+              {...props}
+              {...dragProps}
+            >
+              {React.Children.map(
+                children,
+                child =>
+                  React.isValidElement(child) &&
+                  React.cloneElement(child as React.ReactElement<any>, {
+                    rowid: ariaLabelledBy
+                  })
+              )}
+            </li>
+          );
+        }}
+      </DataListContext.Consumer>
+    );
+  }
+}

--- a/packages/react-core/src/components/DataList/__tests__/DataList.test.tsx
+++ b/packages/react-core/src/components/DataList/__tests__/DataList.test.tsx
@@ -22,6 +22,11 @@ describe('DataList', () => {
     expect(view).toMatchSnapshot();
   });
 
+  test('List draggable', () => {
+    const view = shallow(<DataList aria-label="this is a simple list" isCompact onDragFinish={jest.fn()} />);
+    expect(view).toMatchSnapshot();
+  });
+
   test('List', () => {
     const view = shallow(<DataList key="list-id-1" className="data-list-custom" aria-label="this is a simple list" />);
     expect(view).toMatchSnapshot();

--- a/packages/react-core/src/components/DataList/__tests__/Generated/__snapshots__/DataList.test.tsx.snap
+++ b/packages/react-core/src/components/DataList/__tests__/Generated/__snapshots__/DataList.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`DataList should match snapshot (auto-generated) 1`] = `
   <ul
     aria-label="string"
     className="pf-c-data-list ''"
+    style={Object {}}
   >
     ReactNode
   </ul>

--- a/packages/react-core/src/components/DataList/__tests__/Generated/__snapshots__/DataList.test.tsx.snap
+++ b/packages/react-core/src/components/DataList/__tests__/Generated/__snapshots__/DataList.test.tsx.snap
@@ -4,6 +4,10 @@ exports[`DataList should match snapshot (auto-generated) 1`] = `
 <ContextProvider
   value={
     Object {
+      "dragEnd": [Function],
+      "dragKeyHandler": [Function],
+      "dragStart": [Function],
+      "isDraggable": false,
       "isSelectable": true,
       "selectedDataListItemId": "''",
       "updateSelectedDataListItem": [Function],

--- a/packages/react-core/src/components/DataList/__tests__/Generated/__snapshots__/DataListCheck.test.tsx.snap
+++ b/packages/react-core/src/components/DataList/__tests__/Generated/__snapshots__/DataListCheck.test.tsx.snap
@@ -1,20 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataListCheck should match snapshot (auto-generated) 1`] = `
-<div
-  className="pf-c-data-list__item-control ''"
->
+<Fragment>
   <div
-    className="pf-c-data-list__check"
+    className="pf-c-data-list__item-control ''"
   >
-    <input
-      aria-invalid={false}
-      aria-labelledby="string"
-      checked={null}
-      disabled={false}
-      onChange={[Function]}
-      type="checkbox"
-    />
+    <div
+      className="pf-c-data-list__check"
+    >
+      <input
+        aria-invalid={false}
+        aria-labelledby="string"
+        checked={null}
+        disabled={false}
+        onChange={[Function]}
+        type="checkbox"
+      />
+    </div>
   </div>
-</div>
+</Fragment>
 `;

--- a/packages/react-core/src/components/DataList/__tests__/__snapshots__/DataList.test.tsx.snap
+++ b/packages/react-core/src/components/DataList/__tests__/__snapshots__/DataList.test.tsx.snap
@@ -119,6 +119,10 @@ exports[`DataList List 1`] = `
 <ContextProvider
   value={
     Object {
+      "dragEnd": [Function],
+      "dragKeyHandler": [Function],
+      "dragStart": [Function],
+      "isDraggable": false,
       "isSelectable": false,
       "selectedDataListItemId": "",
       "updateSelectedDataListItem": [Function],
@@ -136,6 +140,10 @@ exports[`DataList List compact 1`] = `
 <ContextProvider
   value={
     Object {
+      "dragEnd": [Function],
+      "dragKeyHandler": [Function],
+      "dragStart": [Function],
+      "isDraggable": false,
       "isSelectable": false,
       "selectedDataListItemId": "",
       "updateSelectedDataListItem": [Function],
@@ -153,6 +161,10 @@ exports[`DataList List default 1`] = `
 <ContextProvider
   value={
     Object {
+      "dragEnd": [Function],
+      "dragKeyHandler": [Function],
+      "dragStart": [Function],
+      "isDraggable": false,
       "isSelectable": false,
       "selectedDataListItemId": "",
       "updateSelectedDataListItem": [Function],
@@ -162,6 +174,28 @@ exports[`DataList List default 1`] = `
   <ul
     aria-label="this is a simple list"
     className="pf-c-data-list"
+  />
+</ContextProvider>
+`;
+
+exports[`DataList List draggable 1`] = `
+<ContextProvider
+  value={
+    Object {
+      "dragEnd": [Function],
+      "dragKeyHandler": [Function],
+      "dragStart": [Function],
+      "isDraggable": true,
+      "isSelectable": false,
+      "selectedDataListItemId": "",
+      "updateSelectedDataListItem": [Function],
+    }
+  }
+>
+  <ul
+    aria-label="this is a simple list"
+    className="pf-c-data-list pf-m-compact"
+    onDragOver={[Function]}
   />
 </ContextProvider>
 `;

--- a/packages/react-core/src/components/DataList/__tests__/__snapshots__/DataList.test.tsx.snap
+++ b/packages/react-core/src/components/DataList/__tests__/__snapshots__/DataList.test.tsx.snap
@@ -197,7 +197,6 @@ exports[`DataList List draggable 1`] = `
     className="pf-c-data-list pf-m-compact"
     onDragOver={[Function]}
     onDrop={[Function]}
-    role="listbox"
   />
 </ContextProvider>
 `;

--- a/packages/react-core/src/components/DataList/__tests__/__snapshots__/DataList.test.tsx.snap
+++ b/packages/react-core/src/components/DataList/__tests__/__snapshots__/DataList.test.tsx.snap
@@ -196,6 +196,7 @@ exports[`DataList List draggable 1`] = `
     aria-label="this is a simple list"
     className="pf-c-data-list pf-m-compact"
     onDragOver={[Function]}
+    onDrop={[Function]}
   />
 </ContextProvider>
 `;

--- a/packages/react-core/src/components/DataList/__tests__/__snapshots__/DataList.test.tsx.snap
+++ b/packages/react-core/src/components/DataList/__tests__/__snapshots__/DataList.test.tsx.snap
@@ -197,6 +197,7 @@ exports[`DataList List draggable 1`] = `
     className="pf-c-data-list pf-m-compact"
     onDragOver={[Function]}
     onDrop={[Function]}
+    role="listbox"
   />
 </ContextProvider>
 `;

--- a/packages/react-core/src/components/DataList/__tests__/__snapshots__/DataList.test.tsx.snap
+++ b/packages/react-core/src/components/DataList/__tests__/__snapshots__/DataList.test.tsx.snap
@@ -132,6 +132,7 @@ exports[`DataList List 1`] = `
   <ul
     aria-label="this is a simple list"
     className="pf-c-data-list data-list-custom"
+    style={Object {}}
   />
 </ContextProvider>
 `;
@@ -153,6 +154,7 @@ exports[`DataList List compact 1`] = `
   <ul
     aria-label="this is a simple list"
     className="pf-c-data-list pf-m-compact"
+    style={Object {}}
   />
 </ContextProvider>
 `;
@@ -174,6 +176,7 @@ exports[`DataList List default 1`] = `
   <ul
     aria-label="this is a simple list"
     className="pf-c-data-list"
+    style={Object {}}
   />
 </ContextProvider>
 `;
@@ -197,6 +200,7 @@ exports[`DataList List draggable 1`] = `
     className="pf-c-data-list pf-m-compact"
     onDragOver={[Function]}
     onDrop={[Function]}
+    style={Object {}}
   />
 </ContextProvider>
 `;

--- a/packages/react-core/src/components/DataList/examples/DataList.md
+++ b/packages/react-core/src/components/DataList/examples/DataList.md
@@ -1140,9 +1140,13 @@ class DraggableDataList extends React.Component {
         <DataListItem aria-labelledby="simple-item1" id="data1" key="1">
           <DataListItemRow>
             <DataListControl>
-              <DataListDragButton />
-
-              <DataListCheck aria-labelledby="check-item1" name="check1" otherControls />
+              <DataListDragButton
+                aria-label="Reorder"
+                aria-labelledby="simple-item1"
+                aria-describedby="Press space to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
+                aria-pressed="false"
+              />
+              <DataListCheck aria-labelledby="simple-item1" name="check1" otherControls />
             </DataListControl>
             <DataListItemCells
               dataListCells={[
@@ -1156,8 +1160,13 @@ class DraggableDataList extends React.Component {
         <DataListItem aria-labelledby="simple-item2" id="data2" key="2">
           <DataListItemRow>
             <DataListControl>
-              <DataListDragButton />
-              <DataListCheck aria-labelledby="check-item2" name="check2" otherControls />
+              <DataListDragButton
+                aria-label="Reorder"
+                aria-labelledby="simple-item2"
+                aria-describedby="Press space to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
+                aria-pressed="false"
+              />
+              <DataListCheck aria-labelledby="simple-item2" name="check2" otherControls />
             </DataListControl>
             <DataListItemCells
               dataListCells={[
@@ -1171,8 +1180,13 @@ class DraggableDataList extends React.Component {
         <DataListItem aria-labelledby="simple-item3" id="data3" key="3">
           <DataListItemRow>
             <DataListControl>
-              <DataListDragButton />
-              <DataListCheck aria-labelledby="check-item3" name="check3" otherControls />
+              <DataListDragButton
+                aria-label="Reorder"
+                aria-labelledby="simple-item3"
+                aria-describedby="Press space to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
+                aria-pressed="false"
+              />
+              <DataListCheck aria-labelledby="simple-item3" name="check3" otherControls />
             </DataListControl>
             <DataListItemCells
               dataListCells={[
@@ -1186,8 +1200,13 @@ class DraggableDataList extends React.Component {
         <DataListItem aria-labelledby="simple-item4" id="data4" key="4">
           <DataListItemRow>
             <DataListControl>
-              <DataListDragButton />
-              <DataListCheck aria-labelledby="check-item4" name="check4" otherControls />
+              <DataListDragButton
+                aria-label="Reorder"
+                aria-labelledby="simple-item4"
+                aria-describedby="Press space to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
+                aria-pressed="false"
+              />
+              <DataListCheck aria-labelledby="simple-item4" name="check4" otherControls />
             </DataListControl>
             <DataListItemCells
               dataListCells={[

--- a/packages/react-core/src/components/DataList/examples/DataList.md
+++ b/packages/react-core/src/components/DataList/examples/DataList.md
@@ -1137,6 +1137,7 @@ class DraggableDataList extends React.Component {
 
     this.state = {
       liveText: '',
+      id: '',
       list: [
         <DataListItem aria-labelledby="simple-item1" id="data1" key="1">
           <DataListItemRow>
@@ -1223,13 +1224,15 @@ class DraggableDataList extends React.Component {
 
     this.onDragStart = id => {
       this.setState({
+        id: id,
         liveText: `Dragging started for item id: ${id}.`
       });
     };
 
     this.onDragMove = (oldIndex, newIndex) => {
+      const {id} = this.state;
       this.setState({
-        liveText: `Dragging index ${oldIndex} to ${newIndex}.`
+        liveText: `Dragging item ${id}.`;
       });
     };
 

--- a/packages/react-core/src/components/DataList/examples/DataList.md
+++ b/packages/react-core/src/components/DataList/examples/DataList.md
@@ -1144,7 +1144,7 @@ class DraggableDataList extends React.Component {
               <DataListDragButton
                 aria-label="Reorder"
                 aria-labelledby="simple-item1"
-                aria-describedby="Press space to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
+                aria-describedby="Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
                 aria-pressed="false"
               />
               <DataListCheck aria-labelledby="simple-item1" name="check1" otherControls />
@@ -1164,7 +1164,7 @@ class DraggableDataList extends React.Component {
               <DataListDragButton
                 aria-label="Reorder"
                 aria-labelledby="simple-item2"
-                aria-describedby="Press space to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
+                aria-describedby="Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
                 aria-pressed="false"
               />
               <DataListCheck aria-labelledby="simple-item2" name="check2" otherControls />
@@ -1184,7 +1184,7 @@ class DraggableDataList extends React.Component {
               <DataListDragButton
                 aria-label="Reorder"
                 aria-labelledby="simple-item3"
-                aria-describedby="Press space to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
+                aria-describedby="Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
                 aria-pressed="false"
               />
               <DataListCheck aria-labelledby="simple-item3" name="check3" otherControls />
@@ -1204,7 +1204,7 @@ class DraggableDataList extends React.Component {
               <DataListDragButton
                 aria-label="Reorder"
                 aria-labelledby="simple-item4"
-                aria-describedby="Press space to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
+                aria-describedby="Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
                 aria-pressed="false"
               />
               <DataListCheck aria-labelledby="simple-item4" name="check4" otherControls />

--- a/packages/react-core/src/components/DataList/examples/DataList.md
+++ b/packages/react-core/src/components/DataList/examples/DataList.md
@@ -1136,6 +1136,7 @@ class DraggableDataList extends React.Component {
     super(props);
 
     this.state = {
+      liveText: '',
       list: [
         <DataListItem aria-labelledby="simple-item1" id="data1" key="1">
           <DataListItemRow>
@@ -1220,21 +1221,50 @@ class DraggableDataList extends React.Component {
       ]
     };
 
+    this.onDragStart = id => {
+      this.setState({
+        liveText: `Dragging started for item id: ${id}.`
+      });
+    };
+
+    this.onDragMove = (oldIndex, newIndex) => {
+      this.setState({
+        liveText: `Dragging index ${oldIndex} to ${newIndex}.`
+      });
+    };
+
+    this.onDragCancel = () => {
+      this.setState({
+        liveText: `Dragging cancelled. List is unchanged.`
+      });
+    };
+
     this.onDragFinish = updatedList => {
       console.log('saving new list');
       this.setState({
-        list: updatedList
+        list: updatedList,
+        liveText: `Dragging finished`
       });
     };
   }
 
   render() {
-    const { list } = this.state;
+    const { list, liveText } = this.state;
     return (
       <React.Fragment>
-        <DataList aria-label="draggable data list example" isCompact onDragFinish={this.onDragFinish}>
+        <DataList
+          aria-label="draggable data list example"
+          isCompact
+          onDragFinish={this.onDragFinish}
+          onDragStart={this.onDragStart}
+          onDragMove={this.onDragMove}
+          onDragCancel={this.onDragCancel}
+        >
           {list}
         </DataList>
+        <div className="pf-screen-reader" aria-live="assertive">
+          {liveText}
+        </div>
       </React.Fragment>
     );
   }

--- a/packages/react-core/src/components/DataList/examples/DataList.md
+++ b/packages/react-core/src/components/DataList/examples/DataList.md
@@ -38,6 +38,7 @@ import { css } from '@patternfly/react-styles';
 ## Examples
 
 ### Basic
+
 ```js
 import React from 'react';
 import {
@@ -89,6 +90,7 @@ SimpleDataList = () => (
 ```
 
 ### Compact
+
 ```js
 import React from 'react';
 import {
@@ -140,6 +142,7 @@ SimpleDataList = () => (
 ```
 
 ### Checkboxes, actions and additional cells
+
 ```js
 import React from 'react';
 import {
@@ -356,6 +359,7 @@ class CheckboxActionDataList extends React.Component {
 ```
 
 ### Actions: single and multiple
+
 ```js
 import React from 'react';
 import {
@@ -467,6 +471,7 @@ class ActionsDataList extends React.Component {
 ```
 
 ### Expandable
+
 ```js
 import React from 'react';
 import {
@@ -564,7 +569,12 @@ class ExpandableDataList extends React.Component {
                 </DataListCell>
               ]}
             />
-            <DataListAction aria-labelledby="ex-item1 ex-action1" id="ex-action1" aria-label="Actions" isPlainButtonAction>
+            <DataListAction
+              aria-labelledby="ex-item1 ex-action1"
+              id="ex-action1"
+              aria-label="Actions"
+              isPlainButtonAction
+            >
               <Dropdown
                 isPlain
                 position={DropdownPosition.right}
@@ -619,7 +629,12 @@ class ExpandableDataList extends React.Component {
                 </DataListCell>
               ]}
             />
-            <DataListAction aria-labelledby="ex-item2 ex-action2" id="ex-action2" aria-label="Actions" isPlainButtonAction>
+            <DataListAction
+              aria-labelledby="ex-item2 ex-action2"
+              id="ex-action2"
+              aria-label="Actions"
+              isPlainButtonAction
+            >
               <Dropdown
                 isPlain
                 position={DropdownPosition.right}
@@ -674,7 +689,12 @@ class ExpandableDataList extends React.Component {
                 </DataListCell>
               ]}
             />
-            <DataListAction aria-labelledby="ex-item3 ex-action3" id="ex-action3" aria-label="Actions" isPlainButtonAction>
+            <DataListAction
+              aria-labelledby="ex-item3 ex-action3"
+              id="ex-action3"
+              aria-label="Actions"
+              isPlainButtonAction
+            >
               <Dropdown
                 isPlain
                 position={DropdownPosition.right}
@@ -709,6 +729,7 @@ class ExpandableDataList extends React.Component {
 ```
 
 ### Width modifiers
+
 ```js
 import React from 'react';
 import {
@@ -913,6 +934,7 @@ class ModifiersDataList extends React.Component {
 ```
 
 ### Selectable rows
+
 ```js
 import React from 'react';
 import {
@@ -1052,6 +1074,7 @@ class SelectableDataList extends React.Component {
 ```
 
 ### Controlling text
+
 ```js
 import React from 'react';
 import {
@@ -1063,7 +1086,7 @@ import {
   DataListCell,
   DataListCheck,
   DataListAction,
-  DataListWrapModifier,
+  DataListWrapModifier
 } from '@patternfly/react-core';
 
 SimpleDataList = () => (
@@ -1075,11 +1098,126 @@ SimpleDataList = () => (
             <DataListCell key="primary content" wrapModifier={DataListWrapModifier.breakWord}>
               <span id="simple-item1">Primary content</span>
             </DataListCell>,
-            <DataListCell key="secondary content" wrapModifier={DataListWrapModifier.truncate}>Really really really really really really really really really really really really really really long description that should be truncated before it ends</DataListCell>
+            <DataListCell key="secondary content" wrapModifier={DataListWrapModifier.truncate}>
+              Really really really really really really really really really really really really really really long
+              description that should be truncated before it ends
+            </DataListCell>
           ]}
         />
       </DataListItemRow>
     </DataListItem>
   </DataList>
 );
+```
+
+### Draggable
+
+```js
+import React from 'react';
+import {
+  Button,
+  Dropdown,
+  DropdownItem,
+  DropdownPosition,
+  KebabToggle,
+  DataList,
+  DataListItem,
+  DataListCell,
+  DataListItemRow,
+  DataListCheck,
+  DataListControl,
+  DataListDragButton,
+  DataListItemCells,
+  DataListAction
+} from '@patternfly/react-core';
+
+class DraggableDataList extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      list: [
+        <DataListItem aria-labelledby="simple-item1" id="data1" key="1">
+          <DataListItemRow>
+            <DataListControl>
+              <DataListDragButton />
+
+              <DataListCheck aria-labelledby="check-item1" name="check1" otherControls />
+            </DataListControl>
+            <DataListItemCells
+              dataListCells={[
+                <DataListCell key="item1">
+                  <span id="simple-item1">Item 1</span>
+                </DataListCell>
+              ]}
+            />
+          </DataListItemRow>
+        </DataListItem>,
+        <DataListItem aria-labelledby="simple-item2" id="data2" key="2">
+          <DataListItemRow>
+            <DataListControl>
+              <DataListDragButton />
+              <DataListCheck aria-labelledby="check-item2" name="check2" otherControls />
+            </DataListControl>
+            <DataListItemCells
+              dataListCells={[
+                <DataListCell key="item2">
+                  <span id="simple-item2">Item 2</span>
+                </DataListCell>
+              ]}
+            />
+          </DataListItemRow>
+        </DataListItem>,
+        <DataListItem aria-labelledby="simple-item3" id="data3" key="3">
+          <DataListItemRow>
+            <DataListControl>
+              <DataListDragButton />
+              <DataListCheck aria-labelledby="check-item3" name="check3" otherControls />
+            </DataListControl>
+            <DataListItemCells
+              dataListCells={[
+                <DataListCell key="item3">
+                  <span id="simple-item3">Item 3</span>
+                </DataListCell>
+              ]}
+            />
+          </DataListItemRow>
+        </DataListItem>,
+        <DataListItem aria-labelledby="simple-item4" id="data4" key="4">
+          <DataListItemRow>
+            <DataListControl>
+              <DataListDragButton />
+              <DataListCheck aria-labelledby="check-item4" name="check4" otherControls />
+            </DataListControl>
+            <DataListItemCells
+              dataListCells={[
+                <DataListCell key="item4">
+                  <span id="simple-item4">Item 4</span>
+                </DataListCell>
+              ]}
+            />
+          </DataListItemRow>
+        </DataListItem>
+      ]
+    };
+
+    this.onDragFinish = updatedList => {
+      console.log('saving new list');
+      this.setState({
+        list: updatedList
+      });
+    };
+  }
+
+  render() {
+    const { list } = this.state;
+    return (
+      <React.Fragment>
+        <DataList aria-label="draggable data list example" isCompact onDragFinish={this.onDragFinish}>
+          {list}
+        </DataList>
+      </React.Fragment>
+    );
+  }
+}
 ```

--- a/packages/react-core/src/components/DataList/examples/DataList.md
+++ b/packages/react-core/src/components/DataList/examples/DataList.md
@@ -1138,88 +1138,7 @@ class DraggableDataList extends React.Component {
     this.state = {
       liveText: '',
       id: '',
-      list: [
-        <DataListItem aria-labelledby="simple-item1" id="data1" key="1">
-          <DataListItemRow>
-            <DataListControl>
-              <DataListDragButton
-                aria-label="Reorder"
-                aria-labelledby="simple-item1"
-                aria-describedby="Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
-                aria-pressed="false"
-              />
-              <DataListCheck aria-labelledby="simple-item1" name="check1" otherControls />
-            </DataListControl>
-            <DataListItemCells
-              dataListCells={[
-                <DataListCell key="item1">
-                  <span id="simple-item1">Item 1</span>
-                </DataListCell>
-              ]}
-            />
-          </DataListItemRow>
-        </DataListItem>,
-        <DataListItem aria-labelledby="simple-item2" id="data2" key="2">
-          <DataListItemRow>
-            <DataListControl>
-              <DataListDragButton
-                aria-label="Reorder"
-                aria-labelledby="simple-item2"
-                aria-describedby="Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
-                aria-pressed="false"
-              />
-              <DataListCheck aria-labelledby="simple-item2" name="check2" otherControls />
-            </DataListControl>
-            <DataListItemCells
-              dataListCells={[
-                <DataListCell key="item2">
-                  <span id="simple-item2">Item 2</span>
-                </DataListCell>
-              ]}
-            />
-          </DataListItemRow>
-        </DataListItem>,
-        <DataListItem aria-labelledby="simple-item3" id="data3" key="3">
-          <DataListItemRow>
-            <DataListControl>
-              <DataListDragButton
-                aria-label="Reorder"
-                aria-labelledby="simple-item3"
-                aria-describedby="Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
-                aria-pressed="false"
-              />
-              <DataListCheck aria-labelledby="simple-item3" name="check3" otherControls />
-            </DataListControl>
-            <DataListItemCells
-              dataListCells={[
-                <DataListCell key="item3">
-                  <span id="simple-item3">Item 3</span>
-                </DataListCell>
-              ]}
-            />
-          </DataListItemRow>
-        </DataListItem>,
-        <DataListItem aria-labelledby="simple-item4" id="data4" key="4">
-          <DataListItemRow>
-            <DataListControl>
-              <DataListDragButton
-                aria-label="Reorder"
-                aria-labelledby="simple-item4"
-                aria-describedby="Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
-                aria-pressed="false"
-              />
-              <DataListCheck aria-labelledby="simple-item4" name="check4" otherControls />
-            </DataListControl>
-            <DataListItemCells
-              dataListCells={[
-                <DataListCell key="item4">
-                  <span id="simple-item4">Item 4</span>
-                </DataListCell>
-              ]}
-            />
-          </DataListItemRow>
-        </DataListItem>
-      ]
+      itemOrder: ['data1', 'data2', 'data3', 'data4']
     };
 
     this.onDragStart = id => {
@@ -1242,11 +1161,11 @@ class DraggableDataList extends React.Component {
       });
     };
 
-    this.onDragFinish = updatedList => {
-      console.log('saving new list');
+    this.onDragFinish = itemOrder => {
+      console.log('need to save new list', itemOrder);
       this.setState({
-        list: updatedList,
-        liveText: `Dragging finished`
+        liveText: `Dragging finished`,
+        itemOrder
       });
     };
   }
@@ -1262,8 +1181,88 @@ class DraggableDataList extends React.Component {
           onDragStart={this.onDragStart}
           onDragMove={this.onDragMove}
           onDragCancel={this.onDragCancel}
+          itemOrder={this.state.itemOrder}
         >
-          {list}
+          <DataListItem aria-labelledby="simple-item1" id="data1" key="1">
+            <DataListItemRow>
+              <DataListControl>
+                <DataListDragButton
+                  aria-label="Reorder"
+                  aria-labelledby="simple-item1"
+                  aria-describedby="Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
+                  aria-pressed="false"
+                />
+                <DataListCheck aria-labelledby="simple-item1" name="check1" otherControls />
+              </DataListControl>
+              <DataListItemCells
+                dataListCells={[
+                  <DataListCell key="item1">
+                    <span id="simple-item1">Item 1</span>
+                  </DataListCell>
+                ]}
+              />
+            </DataListItemRow>
+          </DataListItem>
+          <DataListItem aria-labelledby="simple-item2" id="data2" key="2">
+            <DataListItemRow>
+              <DataListControl>
+                <DataListDragButton
+                  aria-label="Reorder"
+                  aria-labelledby="simple-item2"
+                  aria-describedby="Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
+                  aria-pressed="false"
+                />
+                <DataListCheck aria-labelledby="simple-item2" name="check2" otherControls />
+              </DataListControl>
+              <DataListItemCells
+                dataListCells={[
+                  <DataListCell key="item2">
+                    <span id="simple-item2">Item 2</span>
+                  </DataListCell>
+                ]}
+              />
+            </DataListItemRow>
+          </DataListItem>
+          <DataListItem aria-labelledby="simple-item3" id="data3" key="3">
+            <DataListItemRow>
+              <DataListControl>
+                <DataListDragButton
+                  aria-label="Reorder"
+                  aria-labelledby="simple-item3"
+                  aria-describedby="Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
+                  aria-pressed="false"
+                />
+                <DataListCheck aria-labelledby="simple-item3" name="check3" otherControls />
+              </DataListControl>
+              <DataListItemCells
+                dataListCells={[
+                  <DataListCell key="item3">
+                    <span id="simple-item3">Item 3</span>
+                  </DataListCell>
+                ]}
+              />
+            </DataListItemRow>
+          </DataListItem>
+          <DataListItem aria-labelledby="simple-item4" id="data4" key="4">
+            <DataListItemRow>
+              <DataListControl>
+                <DataListDragButton
+                  aria-label="Reorder"
+                  aria-labelledby="simple-item4"
+                  aria-describedby="Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
+                  aria-pressed="false"
+                />
+                <DataListCheck aria-labelledby="simple-item4" name="check4" otherControls />
+              </DataListControl>
+              <DataListItemCells
+                dataListCells={[
+                  <DataListCell key="item4">
+                    <span id="simple-item4">Item 4</span>
+                  </DataListCell>
+                ]}
+              />
+            </DataListItemRow>
+          </DataListItem>
         </DataList>
         <div className="pf-screen-reader" aria-live="assertive">
           {liveText}

--- a/packages/react-core/src/components/DataList/examples/DataList.md
+++ b/packages/react-core/src/components/DataList/examples/DataList.md
@@ -1230,9 +1230,9 @@ class DraggableDataList extends React.Component {
     };
 
     this.onDragMove = (oldIndex, newIndex) => {
-      const {id} = this.state;
+      const { id } = this.state;
       this.setState({
-        liveText: `Dragging item ${id}.`;
+        liveText: `Dragging item ${id}.`
       });
     };
 

--- a/packages/react-core/src/components/DataList/index.ts
+++ b/packages/react-core/src/components/DataList/index.ts
@@ -2,6 +2,8 @@ export * from './DataList';
 export * from './DataListAction';
 export * from './DataListCell';
 export * from './DataListCheck';
+export * from './DataListControl';
+export * from './DataListDragButton';
 export * from './DataListItem';
 export * from './DataListItemCells';
 export * from './DataListItemRow';

--- a/packages/react-integration/cypress/integration/datalist.spec.ts
+++ b/packages/react-integration/cypress/integration/datalist.spec.ts
@@ -78,3 +78,21 @@ describe('Data List Compact Demo Test', () => {
     cy.get('#row2.pf-m-selected').should('be.visible');
   });
 });
+
+describe('Data List Draggable Demo Test', () => {
+  it('Navigate to demo section', () => {
+    cy.visit('http://localhost:3000/');
+    cy.get('#data-list-draggable-demo-nav-item-link').click();
+    cy.url().should('eq', 'http://localhost:3000/data-list-draggable-demo-nav-link');
+  });
+
+  it('Verify drag', () => {
+    cy.get('#data1').contains('Item 1');
+    cy.get('#drag1').type(' ');
+    cy.get('#drag1').type('{downarrow}');
+    cy.get('#data1').should('have.class', 'pf-m-ghost-row');
+    cy.get('#drag1').type('{downarrow}');
+    cy.get('#drag1').type('{enter}');
+    cy.get('#data1').should('not.have.class', 'pf-m-ghost-row');
+  });
+});

--- a/packages/react-integration/demo-app-ts/src/Demos.ts
+++ b/packages/react-integration/demo-app-ts/src/Demos.ts
@@ -181,6 +181,11 @@ export const Demos: DemoInterface[] = [
     componentType: Examples.DataListDemo
   },
   {
+    id: 'data-list-draggable-demo',
+    name: 'Data List Draggable Demo',
+    componentType: Examples.DataListDraggableDemo
+  },
+  {
     id: 'data-list-compact-demo',
     name: 'Data List Compact Demo',
     componentType: Examples.DataListCompactDemo

--- a/packages/react-integration/demo-app-ts/src/components/demos/DataListDemo/DataListDraggableDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DataListDemo/DataListDraggableDemo.tsx
@@ -13,83 +13,137 @@ import {
 export class DataListDraggableDemo extends React.Component {
   static displayName = 'DataListDraggableDemo';
   state = {
-    list: [
-      <DataListItem aria-labelledby="simple-item1" id="data1" key="1">
-        <DataListItemRow>
-          <DataListControl>
-            <DataListDragButton id="drag1" />
-            <DataListCheck aria-labelledby="check-item1" name="check1" otherControls />
-          </DataListControl>
-          <DataListItemCells
-            dataListCells={[
-              <DataListCell key="item1">
-                <span id="simple-item1">Item 1</span>
-              </DataListCell>
-            ]}
-          />
-        </DataListItemRow>
-      </DataListItem>,
-      <DataListItem aria-labelledby="simple-item2" id="data2" key="2">
-        <DataListItemRow>
-          <DataListControl>
-            <DataListDragButton id="drag2" />
-            <DataListCheck aria-labelledby="check-item2" name="check2" otherControls />
-          </DataListControl>
-          <DataListItemCells
-            dataListCells={[
-              <DataListCell key="item2">
-                <span id="simple-item2">Item 2</span>
-              </DataListCell>
-            ]}
-          />
-        </DataListItemRow>
-      </DataListItem>,
-      <DataListItem aria-labelledby="simple-item3" id="data3" key="3">
-        <DataListItemRow>
-          <DataListControl>
-            <DataListDragButton id="drag3" />
-            <DataListCheck aria-labelledby="check-item3" name="check3" otherControls />
-          </DataListControl>
-          <DataListItemCells
-            dataListCells={[
-              <DataListCell key="item3">
-                <span id="simple-item3">Item 3</span>
-              </DataListCell>
-            ]}
-          />
-        </DataListItemRow>
-      </DataListItem>,
-      <DataListItem aria-labelledby="simple-item4" id="data4" key="4">
-        <DataListItemRow>
-          <DataListControl>
-            <DataListDragButton id="drag4" />
-            <DataListCheck aria-labelledby="check-item4" name="check4" otherControls />
-          </DataListControl>
-          <DataListItemCells
-            dataListCells={[
-              <DataListCell key="item4">
-                <span id="simple-item4">Item 4</span>
-              </DataListCell>
-            ]}
-          />
-        </DataListItemRow>
-      </DataListItem>
-    ]
+    liveText: '',
+    id: '',
+    itemOrder: ['data1', 'data2', 'data3', 'data4']
   };
 
-  onDragFinish = (updatedList: React.ReactElement[]) => {
+  onDragStart = (id: string) => {
     this.setState({
-      list: updatedList
+      id,
+      liveText: `Dragging started for item id: ${id}.`
+    });
+  };
+
+  onDragMove = (oldIndex: number, newIndex: number) => {
+    const { id } = this.state;
+    this.setState({
+      liveText: `Dragging item ${id}.`
+    });
+  };
+
+  onDragCancel = () => {
+    this.setState({
+      liveText: `Dragging cancelled. List is unchanged.`
+    });
+  };
+
+  onDragFinish = (itemOrder: string[]) => {
+    console.log('need to save new list', itemOrder);
+    this.setState({
+      liveText: `Dragging finished`,
+      itemOrder
     });
   };
 
   render() {
-    const { list } = this.state;
+    const { liveText, itemOrder } = this.state;
     return (
       <React.Fragment>
-        <DataList aria-label="draggable data list example" isCompact onDragFinish={this.onDragFinish}>
-          {list}
+        <DataList
+          aria-label="draggable data list example"
+          isCompact
+          onDragFinish={this.onDragFinish}
+          onDragStart={this.onDragStart}
+          onDragMove={this.onDragMove}
+          onDragCancel={this.onDragCancel}
+          itemOrder={itemOrder}
+        >
+          <DataListItem aria-labelledby="simple-item1" id="data1" key="1">
+            <DataListItemRow>
+              <DataListControl>
+                <DataListDragButton
+                  id="drag1"
+                  aria-label="Reorder"
+                  aria-labelledby="simple-item1"
+                  aria-describedby="Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
+                  aria-pressed="false"
+                />
+                <DataListCheck aria-labelledby="simple-item1" name="check1" otherControls />
+              </DataListControl>
+              <DataListItemCells
+                dataListCells={[
+                  <DataListCell key="item1">
+                    <span id="simple-item1">Item 1</span>
+                  </DataListCell>
+                ]}
+              />
+            </DataListItemRow>
+          </DataListItem>
+          <DataListItem aria-labelledby="simple-item2" id="data2" key="2">
+            <DataListItemRow>
+              <DataListControl>
+                <DataListDragButton
+                  aria-label="Reorder"
+                  aria-labelledby="simple-item2"
+                  aria-describedby="Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
+                  aria-pressed="false"
+                />
+                <DataListCheck aria-labelledby="simple-item2" name="check2" otherControls />
+              </DataListControl>
+              <DataListItemCells
+                dataListCells={[
+                  <DataListCell key="item2">
+                    <span id="simple-item2">Item 2</span>
+                  </DataListCell>
+                ]}
+              />
+            </DataListItemRow>
+          </DataListItem>
+          <DataListItem aria-labelledby="simple-item3" id="data3" key="3">
+            <DataListItemRow>
+              <DataListControl>
+                <DataListDragButton
+                  aria-label="Reorder"
+                  aria-labelledby="simple-item3"
+                  aria-describedby="Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
+                  aria-pressed="false"
+                />
+                <DataListCheck aria-labelledby="simple-item3" name="check3" otherControls />
+              </DataListControl>
+              <DataListItemCells
+                dataListCells={[
+                  <DataListCell key="item3">
+                    <span id="simple-item3">Item 3</span>
+                  </DataListCell>
+                ]}
+              />
+            </DataListItemRow>
+          </DataListItem>
+          <DataListItem aria-labelledby="simple-item4" id="data4" key="4">
+            <DataListItemRow>
+              <DataListControl>
+                <DataListDragButton
+                  aria-label="Reorder"
+                  aria-labelledby="simple-item4"
+                  aria-describedby="Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
+                  aria-pressed="false"
+                />
+                <DataListCheck aria-labelledby="simple-item4" name="check4" otherControls />
+              </DataListControl>
+              <DataListItemCells
+                dataListCells={[
+                  <DataListCell key="item4">
+                    <span id="simple-item4">Item 4</span>
+                  </DataListCell>
+                ]}
+              />
+            </DataListItemRow>
+          </DataListItem>
         </DataList>
+        <div className="pf-screen-reader" aria-live="assertive">
+          {liveText}
+        </div>
       </React.Fragment>
     );
   }

--- a/packages/react-integration/demo-app-ts/src/components/demos/DataListDemo/DataListDraggableDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DataListDemo/DataListDraggableDemo.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import {
+  DataList,
+  DataListItem,
+  DataListCell,
+  DataListItemRow,
+  DataListCheck,
+  DataListControl,
+  DataListDragButton,
+  DataListItemCells
+} from '@patternfly/react-core';
+
+export class DataListDraggableDemo extends React.Component {
+  static displayName = 'DataListDraggableDemo';
+  state = {
+    list: [
+      <DataListItem aria-labelledby="simple-item1" id="data1" key="1">
+        <DataListItemRow>
+          <DataListControl>
+            <DataListDragButton id="drag1" />
+            <DataListCheck aria-labelledby="check-item1" name="check1" otherControls />
+          </DataListControl>
+          <DataListItemCells
+            dataListCells={[
+              <DataListCell key="item1">
+                <span id="simple-item1">Item 1</span>
+              </DataListCell>
+            ]}
+          />
+        </DataListItemRow>
+      </DataListItem>,
+      <DataListItem aria-labelledby="simple-item2" id="data2" key="2">
+        <DataListItemRow>
+          <DataListControl>
+            <DataListDragButton id="drag2" />
+            <DataListCheck aria-labelledby="check-item2" name="check2" otherControls />
+          </DataListControl>
+          <DataListItemCells
+            dataListCells={[
+              <DataListCell key="item2">
+                <span id="simple-item2">Item 2</span>
+              </DataListCell>
+            ]}
+          />
+        </DataListItemRow>
+      </DataListItem>,
+      <DataListItem aria-labelledby="simple-item3" id="data3" key="3">
+        <DataListItemRow>
+          <DataListControl>
+            <DataListDragButton id="drag3" />
+            <DataListCheck aria-labelledby="check-item3" name="check3" otherControls />
+          </DataListControl>
+          <DataListItemCells
+            dataListCells={[
+              <DataListCell key="item3">
+                <span id="simple-item3">Item 3</span>
+              </DataListCell>
+            ]}
+          />
+        </DataListItemRow>
+      </DataListItem>,
+      <DataListItem aria-labelledby="simple-item4" id="data4" key="4">
+        <DataListItemRow>
+          <DataListControl>
+            <DataListDragButton id="drag4" />
+            <DataListCheck aria-labelledby="check-item4" name="check4" otherControls />
+          </DataListControl>
+          <DataListItemCells
+            dataListCells={[
+              <DataListCell key="item4">
+                <span id="simple-item4">Item 4</span>
+              </DataListCell>
+            ]}
+          />
+        </DataListItemRow>
+      </DataListItem>
+    ]
+  };
+
+  onDragFinish = (updatedList: React.ReactElement[]) => {
+    this.setState({
+      list: updatedList
+    });
+  };
+
+  render() {
+    const { list } = this.state;
+    return (
+      <React.Fragment>
+        <DataList aria-label="draggable data list example" isCompact onDragFinish={this.onDragFinish}>
+          {list}
+        </DataList>
+      </React.Fragment>
+    );
+  }
+}

--- a/packages/react-integration/demo-app-ts/src/components/demos/DataListDemo/DataListDraggableDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DataListDemo/DataListDraggableDemo.tsx
@@ -39,7 +39,6 @@ export class DataListDraggableDemo extends React.Component {
   };
 
   onDragFinish = (itemOrder: string[]) => {
-    console.log('need to save new list', itemOrder);
     this.setState({
       liveText: `Dragging finished`,
       itemOrder

--- a/packages/react-integration/demo-app-ts/src/components/demos/index.ts
+++ b/packages/react-integration/demo-app-ts/src/components/demos/index.ts
@@ -31,6 +31,7 @@ export * from './ContextSelectorDemo/ContextSelectorDemo';
 export * from './ClipboardCopyDemo/ClipboardCopyDemo';
 export * from './ClipboardCopyDemo/ClipboardCopyExpandedDemo';
 export * from './DataListDemo/DataListDemo';
+export * from './DataListDemo/DataListDraggableDemo';
 export * from './DataListDemo/DataListCompactDemo';
 export * from './ToolbarDemo/ToolbarDemo';
 export * from './DescriptionListDemo/DescriptionListDemo';


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4708

Basic implementation of draggable. DataLists with nested state dependencies (like expandable) I am having trouble getting to work, because the whole list needs to be saved in the state in order to update, but you cannot access state variables inside of itself.

@mcoker The draggable ghost defaults to a copy of the whole row, and I haven't found a great way to change this yet, but it at least seems to preserve the spacing. The entire row is also draggable by default instead of just the chip button (with mouse), but it doesn't interfere with other actions so I'm not sure this is an issue.

For keyboard, hitting `space` or `enter` on a drag chip button begins the drag. Use the `up arrow` or `down arrow` to move the row (showing the ghost placeholder) and `enter` to confirm/finish the drag. `Escape` will cancel the drag, or hitting any other key (like `Tab` to continue tabbing through the DOM).