### PR TITLE
fix(react-docs): change overview to get-started

### DIFF
--- a/packages/react-core/src/demos/Banner.md
+++ b/packages/react-core/src/demos/Banner.md
@@ -1,6 +1,6 @@
 ---
 id: Banner
-section: demos
+section: components
 ---
 
 import { css } from '@patternfly/react-styles';

--- a/packages/react-core/src/demos/Card/Card.md
+++ b/packages/react-core/src/demos/Card/Card.md
@@ -1,7 +1,6 @@
 ---
 id: Card
-section: demos
-experimentalStage: early
+section: components
 ---
 
 import BellIcon from '@patternfly/react-icons/dist/js/icons/bell-icon';

--- a/packages/react-core/src/demos/NotificationDrawer/NotificationDrawer.md
+++ b/packages/react-core/src/demos/NotificationDrawer/NotificationDrawer.md
@@ -1,6 +1,6 @@
 ---
 id: Notification drawer
-section: demos
+section: components
 ---
 
 ## Examples

--- a/packages/react-core/src/demos/Page/Page.md
+++ b/packages/react-core/src/demos/Page/Page.md
@@ -1,6 +1,6 @@
 ---
 id: Page
-section: demos
+section: components
 ---
 
 import {

--- a/packages/react-core/src/demos/TileDemo.md
+++ b/packages/react-core/src/demos/TileDemo.md
@@ -1,6 +1,6 @@
 ---
-id: Tiles
-section: demos
+id: Tile
+section: components
 ---
 
 import { Tile} from '@patternfly/react-core';

--- a/packages/react-docs/RELEASE-NOTES.md
+++ b/packages/react-docs/RELEASE-NOTES.md
@@ -1,6 +1,6 @@
 ---
 id: Release notes
-section: overview
+section: get-started
 releaseNoteTOC: true
 ---
 

--- a/packages/react-docs/UPGRADE-GUIDE.md
+++ b/packages/react-docs/UPGRADE-GUIDE.md
@@ -1,6 +1,6 @@
 ---
 id: Upgrade guide
-section: overview
+section: get-started
 ---
 
 Hey, Flyers! We’ve been busy for the past 12 weeks keeping up with changes to PatternFly’s HTML and CSS. We’ve replaced `babel` with `tsc` as our compiler of choice and removed prop-types in favor of using our `.d.ts` types, which are supported in most editors.

--- a/packages/react-docs/patternfly-docs.source.js
+++ b/packages/react-docs/patternfly-docs.source.js
@@ -16,11 +16,11 @@ module.exports = (sourceMD, sourceProps) => {
 
   // React MD
   sourceMD(path.join(reactCorePath, '/**/examples/*.md'), 'react');
-  sourceMD(path.join(reactCorePath, '/**/demos/**/*.md'), 'react');
+  sourceMD(path.join(reactCorePath, '/**/demos/**/*.md'), 'react-demos');
 
   // React-table MD
   sourceMD(path.join(reactTablePath, '/**/examples/*.md'), 'react');
-  sourceMD(path.join(reactTablePath, '/**/demos/*.md'), 'react');
+  sourceMD(path.join(reactTablePath, '/**/demos/*.md'), 'react-demos');
 
   // Charts MD (no demos yet)
   sourceMD(path.join(reactChartsPath, '/**/examples/*.md'), 'react');

--- a/packages/react-table/src/demos/Table.md
+++ b/packages/react-table/src/demos/Table.md
@@ -1,6 +1,6 @@
 ---
 id: Table
-section: demos
+section: components
 ---
 
 import CodeIcon from '@patternfly/react-icons/dist/js/icons/code-icon';


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Matches new org design: https://www.patternfly.org/v4/get-started/release-notes/react. Closes #4861

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
