### PR TITLE
feat(Modal): add top align to modal

### DIFF
--- a/packages/react-core/src/components/Modal/Modal.tsx
+++ b/packages/react-core/src/components/Modal/Modal.tsx
@@ -43,8 +43,8 @@ export interface ModalProps extends React.HTMLProps<HTMLDivElement>, OUIAProps {
   variant?: 'small' | 'medium' | 'large' | 'default';
   /** Alternate position of the modal */
   position?: 'top';
-  /** Custom distance from top */
-  distanceFromTop?: string;
+  /** Custom spacer distance from position */
+  distance?: string;
   /** Flag indicating if modal content should be placed in a modal box body wrapper */
   hasNoBodyWrapper?: boolean;
   /** An ID to use for the ModalBox container */

--- a/packages/react-core/src/components/Modal/Modal.tsx
+++ b/packages/react-core/src/components/Modal/Modal.tsx
@@ -41,6 +41,10 @@ export interface ModalProps extends React.HTMLProps<HTMLDivElement>, OUIAProps {
   description?: React.ReactNode;
   /** Variant of the modal */
   variant?: 'small' | 'medium' | 'large' | 'default';
+  /** Alternate position of the modal */
+  position?: 'top';
+  /** Custom distance from top */
+  distanceFromTop?: string;
   /** Flag indicating if modal content should be placed in a modal box body wrapper */
   hasNoBodyWrapper?: boolean;
   /** An ID to use for the ModalBox container */

--- a/packages/react-core/src/components/Modal/Modal.tsx
+++ b/packages/react-core/src/components/Modal/Modal.tsx
@@ -43,8 +43,8 @@ export interface ModalProps extends React.HTMLProps<HTMLDivElement>, OUIAProps {
   variant?: 'small' | 'medium' | 'large' | 'default';
   /** Alternate position of the modal */
   position?: 'top';
-  /** Can be any valid CSS length/percentage */
-  distance?: string;
+  /** Offset from alternate position. Can be any valid CSS length/percentage */
+  positionOffset?: string;
   /** Flag indicating if modal content should be placed in a modal box body wrapper */
   hasNoBodyWrapper?: boolean;
   /** An ID to use for the ModalBox container */

--- a/packages/react-core/src/components/Modal/Modal.tsx
+++ b/packages/react-core/src/components/Modal/Modal.tsx
@@ -43,7 +43,7 @@ export interface ModalProps extends React.HTMLProps<HTMLDivElement>, OUIAProps {
   variant?: 'small' | 'medium' | 'large' | 'default';
   /** Alternate position of the modal */
   position?: 'top';
-  /** Custom spacer distance from position */
+  /** Can be any valid CSS length/percentage */
   distance?: string;
   /** Flag indicating if modal content should be placed in a modal box body wrapper */
   hasNoBodyWrapper?: boolean;

--- a/packages/react-core/src/components/Modal/ModalBox.tsx
+++ b/packages/react-core/src/components/Modal/ModalBox.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/ModalBox/modal-box';
+import c_modal_box_m_align_top_spacer from '@patternfly/react-tokens/dist/js/c_modal_box_m_align_top_spacer';
 
 export interface ModalBoxProps extends React.HTMLProps<HTMLDivElement> {
   /** Content rendered inside the ModalBox. */
@@ -30,29 +31,32 @@ export const ModalBox: React.FunctionComponent<ModalBoxProps> = ({
   'aria-labelledby': ariaLabelledby,
   'aria-label': ariaLabel = '',
   'aria-describedby': ariaDescribedby,
+  style,
   ...props
-}: ModalBoxProps) => (
-  <div
-    {...props}
-    role="dialog"
-    aria-label={ariaLabel || null}
-    aria-labelledby={ariaLabelledby || null}
-    aria-describedby={ariaDescribedby}
-    aria-modal="true"
-    className={css(
-      styles.modalBox,
-      className,
-      position === 'top' && styles.modifiers.alignTop,
-      variant === 'large' && styles.modifiers.lg,
-      variant === 'small' && styles.modifiers.sm,
-      variant === 'medium' && styles.modifiers.md
-    )}
-    style={{
-      ...(positionOffset && { '--pf-c-modal-box--m-align-top--spacer': positionOffset }),
-      ...props.style
-    }}
-  >
-    {children}
-  </div>
-);
+}: ModalBoxProps) => {
+  if (positionOffset) {
+    (style as any)[c_modal_box_m_align_top_spacer.name] = positionOffset;
+  }
+  return (
+    <div
+      {...props}
+      role="dialog"
+      aria-label={ariaLabel || null}
+      aria-labelledby={ariaLabelledby || null}
+      aria-describedby={ariaDescribedby}
+      aria-modal="true"
+      className={css(
+        styles.modalBox,
+        className,
+        position === 'top' && styles.modifiers.alignTop,
+        variant === 'large' && styles.modifiers.lg,
+        variant === 'small' && styles.modifiers.sm,
+        variant === 'medium' && styles.modifiers.md
+      )}
+      style={style}
+    >
+      {children}
+    </div>
+  );
+}
 ModalBox.displayName = 'ModalBox';

--- a/packages/react-core/src/components/Modal/ModalBox.tsx
+++ b/packages/react-core/src/components/Modal/ModalBox.tsx
@@ -11,8 +11,8 @@ export interface ModalBoxProps extends React.HTMLProps<HTMLDivElement> {
   variant?: 'small' | 'medium' | 'large' | 'default';
   /** Alternate position of the modal */
   position?: 'top';
-  /** Custom distance from top */
-  distanceFromTop?: string;
+  /** Custom spacer distance from position */
+  distance?: string;
   /** Id to use for Modal Box label */
   'aria-labelledby'?: string;
   /** Accessible descriptor of modal */
@@ -26,7 +26,7 @@ export const ModalBox: React.FunctionComponent<ModalBoxProps> = ({
   className = '',
   variant = 'default',
   position,
-  distanceFromTop,
+  distance,
   'aria-labelledby': ariaLabelledby,
   'aria-label': ariaLabel = '',
   'aria-describedby': ariaDescribedby,
@@ -47,9 +47,9 @@ export const ModalBox: React.FunctionComponent<ModalBoxProps> = ({
       variant === 'small' && styles.modifiers.sm,
       variant === 'medium' && styles.modifiers.md
     )}
-    {...(distanceFromTop && {
+    {...(distance && {
       style: {
-        '--pf-c-modal-box--m-align-top--spacer': distanceFromTop,
+        '--pf-c-modal-box--m-align-top--spacer': distance,
         ...props.style
       } as React.CSSProperties
     })}

--- a/packages/react-core/src/components/Modal/ModalBox.tsx
+++ b/packages/react-core/src/components/Modal/ModalBox.tsx
@@ -9,6 +9,10 @@ export interface ModalBoxProps extends React.HTMLProps<HTMLDivElement> {
   className?: string;
   /** Variant of the modal */
   variant?: 'small' | 'medium' | 'large' | 'default';
+  /** Alternate position of the modal */
+  position?: 'top';
+  /** Custom distance from top */
+  distanceFromTop?: string;
   /** Id to use for Modal Box label */
   'aria-labelledby'?: string;
   /** Accessible descriptor of modal */
@@ -21,6 +25,8 @@ export const ModalBox: React.FunctionComponent<ModalBoxProps> = ({
   children,
   className = '',
   variant = 'default',
+  position,
+  distanceFromTop,
   'aria-labelledby': ariaLabelledby,
   'aria-label': ariaLabel = '',
   'aria-describedby': ariaDescribedby,
@@ -36,10 +42,17 @@ export const ModalBox: React.FunctionComponent<ModalBoxProps> = ({
     className={css(
       styles.modalBox,
       className,
+      position === 'top' && styles.modifiers.alignTop,
       variant === 'large' && styles.modifiers.lg,
       variant === 'small' && styles.modifiers.sm,
       variant === 'medium' && styles.modifiers.md
     )}
+    {...(distanceFromTop && {
+      style: {
+        '--pf-c-modal-box--m-align-top--spacer': distanceFromTop,
+        ...props.style
+      } as React.CSSProperties
+    })}
   >
     {children}
   </div>

--- a/packages/react-core/src/components/Modal/ModalBox.tsx
+++ b/packages/react-core/src/components/Modal/ModalBox.tsx
@@ -11,7 +11,7 @@ export interface ModalBoxProps extends React.HTMLProps<HTMLDivElement> {
   variant?: 'small' | 'medium' | 'large' | 'default';
   /** Alternate position of the modal */
   position?: 'top';
-  /** Custom spacer distance from position */
+  /** Can be any valid CSS length/percentage */
   distance?: string;
   /** Id to use for Modal Box label */
   'aria-labelledby'?: string;
@@ -47,12 +47,10 @@ export const ModalBox: React.FunctionComponent<ModalBoxProps> = ({
       variant === 'small' && styles.modifiers.sm,
       variant === 'medium' && styles.modifiers.md
     )}
-    {...(distance && {
-      style: {
-        '--pf-c-modal-box--m-align-top--spacer': distance,
-        ...props.style
-      } as React.CSSProperties
-    })}
+    style={{
+      ...(distance && { '--pf-c-modal-box--m-align-top--spacer': distance }),
+      ...props.style
+    }}
   >
     {children}
   </div>

--- a/packages/react-core/src/components/Modal/ModalBox.tsx
+++ b/packages/react-core/src/components/Modal/ModalBox.tsx
@@ -11,8 +11,8 @@ export interface ModalBoxProps extends React.HTMLProps<HTMLDivElement> {
   variant?: 'small' | 'medium' | 'large' | 'default';
   /** Alternate position of the modal */
   position?: 'top';
-  /** Can be any valid CSS length/percentage */
-  distance?: string;
+  /** Offset from alternate position. Can be any valid CSS length/percentage */
+  positionOffset?: string;
   /** Id to use for Modal Box label */
   'aria-labelledby'?: string;
   /** Accessible descriptor of modal */
@@ -26,7 +26,7 @@ export const ModalBox: React.FunctionComponent<ModalBoxProps> = ({
   className = '',
   variant = 'default',
   position,
-  distance,
+  positionOffset,
   'aria-labelledby': ariaLabelledby,
   'aria-label': ariaLabel = '',
   'aria-describedby': ariaDescribedby,
@@ -48,7 +48,7 @@ export const ModalBox: React.FunctionComponent<ModalBoxProps> = ({
       variant === 'medium' && styles.modifiers.md
     )}
     style={{
-      ...(distance && { '--pf-c-modal-box--m-align-top--spacer': distance }),
+      ...(positionOffset && { '--pf-c-modal-box--m-align-top--spacer': positionOffset }),
       ...props.style
     }}
   >

--- a/packages/react-core/src/components/Modal/ModalBox.tsx
+++ b/packages/react-core/src/components/Modal/ModalBox.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/ModalBox/modal-box';
-import c_modal_box_m_align_top_spacer from '@patternfly/react-tokens/dist/js/c_modal_box_m_align_top_spacer';
+import topSpacer from '@patternfly/react-tokens/dist/js/c_modal_box_m_align_top_spacer';
 
 export interface ModalBoxProps extends React.HTMLProps<HTMLDivElement> {
   /** Content rendered inside the ModalBox. */
@@ -35,7 +35,7 @@ export const ModalBox: React.FunctionComponent<ModalBoxProps> = ({
   ...props
 }: ModalBoxProps) => {
   if (positionOffset) {
-    (style as any)[c_modal_box_m_align_top_spacer.name] = positionOffset;
+    (style as any)[topSpacer.name] = positionOffset;
   }
   return (
     <div
@@ -58,5 +58,5 @@ export const ModalBox: React.FunctionComponent<ModalBoxProps> = ({
       {children}
     </div>
   );
-}
+};
 ModalBox.displayName = 'ModalBox';

--- a/packages/react-core/src/components/Modal/ModalBox.tsx
+++ b/packages/react-core/src/components/Modal/ModalBox.tsx
@@ -35,6 +35,7 @@ export const ModalBox: React.FunctionComponent<ModalBoxProps> = ({
   ...props
 }: ModalBoxProps) => {
   if (positionOffset) {
+    style = style || {};
     (style as any)[topSpacer.name] = positionOffset;
   }
   return (

--- a/packages/react-core/src/components/Modal/ModalContent.tsx
+++ b/packages/react-core/src/components/Modal/ModalContent.tsx
@@ -23,8 +23,8 @@ export interface ModalContentProps extends OUIAProps {
   variant?: 'small' | 'medium' | 'large' | 'default';
   /** Alternate position of the modal */
   position?: 'top';
-  /** Can be any valid CSS length/percentage */
-  distance?: string;
+  /** Offset from alternate position. Can be any valid CSS length/percentage */
+  positionOffset?: string;
   /** Flag to show the modal */
   isOpen?: boolean;
   /** Complex header (more than just text), supersedes title for header content */
@@ -77,7 +77,7 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
   onClose = () => undefined as any,
   variant = 'default',
   position,
-  distance,
+  positionOffset,
   width = -1,
   boxId,
   labelId,
@@ -141,7 +141,7 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
       className={className}
       variant={variant}
       position={position}
-      distance={distance}
+      positionOffset={positionOffset}
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledbyFormatted()}
       aria-describedby={ariaDescribedby || (hasNoBodyWrapper ? null : descriptorId)}

--- a/packages/react-core/src/components/Modal/ModalContent.tsx
+++ b/packages/react-core/src/components/Modal/ModalContent.tsx
@@ -21,6 +21,10 @@ export interface ModalContentProps extends OUIAProps {
   className?: string;
   /** Variant of the modal */
   variant?: 'small' | 'medium' | 'large' | 'default';
+  /** Alternate position of the modal */
+  position?: 'top';
+  /** Custom distance from top */
+  distanceFromTop?: string;
   /** Flag to show the modal */
   isOpen?: boolean;
   /** Complex header (more than just text), supersedes title for header content */
@@ -72,6 +76,8 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
   actions = [],
   onClose = () => undefined as any,
   variant = 'default',
+  position,
+  distanceFromTop,
   width = -1,
   boxId,
   labelId,
@@ -134,6 +140,8 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
       style={boxStyle}
       className={className}
       variant={variant}
+      position={position}
+      distanceFromTop={distanceFromTop}
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledbyFormatted()}
       aria-describedby={ariaDescribedby || (hasNoBodyWrapper ? null : descriptorId)}

--- a/packages/react-core/src/components/Modal/ModalContent.tsx
+++ b/packages/react-core/src/components/Modal/ModalContent.tsx
@@ -23,7 +23,7 @@ export interface ModalContentProps extends OUIAProps {
   variant?: 'small' | 'medium' | 'large' | 'default';
   /** Alternate position of the modal */
   position?: 'top';
-  /** Custom spacer distance from position */
+  /** Can be any valid CSS length/percentage */
   distance?: string;
   /** Flag to show the modal */
   isOpen?: boolean;

--- a/packages/react-core/src/components/Modal/ModalContent.tsx
+++ b/packages/react-core/src/components/Modal/ModalContent.tsx
@@ -23,8 +23,8 @@ export interface ModalContentProps extends OUIAProps {
   variant?: 'small' | 'medium' | 'large' | 'default';
   /** Alternate position of the modal */
   position?: 'top';
-  /** Custom distance from top */
-  distanceFromTop?: string;
+  /** Custom spacer distance from position */
+  distance?: string;
   /** Flag to show the modal */
   isOpen?: boolean;
   /** Complex header (more than just text), supersedes title for header content */
@@ -77,7 +77,7 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
   onClose = () => undefined as any,
   variant = 'default',
   position,
-  distanceFromTop,
+  distance,
   width = -1,
   boxId,
   labelId,
@@ -141,7 +141,7 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
       className={className}
       variant={variant}
       position={position}
-      distanceFromTop={distanceFromTop}
+      distance={distance}
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledbyFormatted()}
       aria-describedby={ariaDescribedby || (hasNoBodyWrapper ? null : descriptorId)}

--- a/packages/react-core/src/components/Modal/__tests__/Generated/__snapshots__/ModalBox.test.tsx.snap
+++ b/packages/react-core/src/components/Modal/__tests__/Generated/__snapshots__/ModalBox.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`ModalBox should match snapshot (auto-generated) 1`] = `
   aria-modal="true"
   className="pf-c-modal-box ''"
   role="dialog"
+  style={Object {}}
 >
   <div>
     ReactNode

--- a/packages/react-core/src/components/Modal/__tests__/Generated/__snapshots__/ModalBox.test.tsx.snap
+++ b/packages/react-core/src/components/Modal/__tests__/Generated/__snapshots__/ModalBox.test.tsx.snap
@@ -8,7 +8,6 @@ exports[`ModalBox should match snapshot (auto-generated) 1`] = `
   aria-modal="true"
   className="pf-c-modal-box ''"
   role="dialog"
-  style={Object {}}
 >
   <div>
     ReactNode

--- a/packages/react-core/src/components/Modal/__tests__/ModalBox.test.tsx
+++ b/packages/react-core/src/components/Modal/__tests__/ModalBox.test.tsx
@@ -29,3 +29,21 @@ test('ModalBox Test isSmall', () => {
   );
   expect(view).toMatchSnapshot();
 });
+
+test('ModalBox Test top aligned', () => {
+  const view = shallow(
+    <ModalBox title="Test Modal Box" id="boxId" position="top">
+      This is a ModalBox
+    </ModalBox>
+  );
+  expect(view).toMatchSnapshot();
+});
+
+test('ModalBox Test top aligned distance', () => {
+  const view = shallow(
+    <ModalBox title="Test Modal Box" id="boxId" position="top" distanceFromTop="50px">
+      This is a ModalBox
+    </ModalBox>
+  );
+  expect(view).toMatchSnapshot();
+});

--- a/packages/react-core/src/components/Modal/__tests__/ModalBox.test.tsx
+++ b/packages/react-core/src/components/Modal/__tests__/ModalBox.test.tsx
@@ -41,7 +41,7 @@ test('ModalBox Test top aligned', () => {
 
 test('ModalBox Test top aligned distance', () => {
   const view = shallow(
-    <ModalBox title="Test Modal Box" id="boxId" position="top" distanceFromTop="50px">
+    <ModalBox title="Test Modal Box" id="boxId" position="top" distance="50px">
       This is a ModalBox
     </ModalBox>
   );

--- a/packages/react-core/src/components/Modal/__tests__/ModalBox.test.tsx
+++ b/packages/react-core/src/components/Modal/__tests__/ModalBox.test.tsx
@@ -41,7 +41,7 @@ test('ModalBox Test top aligned', () => {
 
 test('ModalBox Test top aligned distance', () => {
   const view = shallow(
-    <ModalBox title="Test Modal Box" id="boxId" position="top" distance="50px">
+    <ModalBox title="Test Modal Box" id="boxId" position="top" positionOffset="50px">
       This is a ModalBox
     </ModalBox>
   );

--- a/packages/react-core/src/components/Modal/__tests__/__snapshots__/ModalBox.test.tsx.snap
+++ b/packages/react-core/src/components/Modal/__tests__/__snapshots__/ModalBox.test.tsx.snap
@@ -43,3 +43,36 @@ exports[`ModalBox Test isSmall 1`] = `
   This is a ModalBox
 </div>
 `;
+
+exports[`ModalBox Test top aligned 1`] = `
+<div
+  aria-label={null}
+  aria-labelledby={null}
+  aria-modal="true"
+  className="pf-c-modal-box pf-m-align-top"
+  id="boxId"
+  role="dialog"
+  title="Test Modal Box"
+>
+  This is a ModalBox
+</div>
+`;
+
+exports[`ModalBox Test top aligned distance 1`] = `
+<div
+  aria-label={null}
+  aria-labelledby={null}
+  aria-modal="true"
+  className="pf-c-modal-box pf-m-align-top"
+  id="boxId"
+  role="dialog"
+  style={
+    Object {
+      "--pf-c-modal-box--m-align-top--spacer": "50px",
+    }
+  }
+  title="Test Modal Box"
+>
+  This is a ModalBox
+</div>
+`;

--- a/packages/react-core/src/components/Modal/__tests__/__snapshots__/ModalBox.test.tsx.snap
+++ b/packages/react-core/src/components/Modal/__tests__/__snapshots__/ModalBox.test.tsx.snap
@@ -8,7 +8,6 @@ exports[`ModalBox Test 1`] = `
   className="pf-c-modal-box"
   id="boxId"
   role="dialog"
-  style={Object {}}
   title="Test Modal Box"
 >
   This is a ModalBox
@@ -24,7 +23,6 @@ exports[`ModalBox Test isLarge 1`] = `
   id="boxId"
   isLarge={true}
   role="dialog"
-  style={Object {}}
   title="Test Modal Box"
 >
   This is a ModalBox
@@ -40,7 +38,6 @@ exports[`ModalBox Test isSmall 1`] = `
   id="boxId"
   isSmall={true}
   role="dialog"
-  style={Object {}}
   title="Test Modal Box"
 >
   This is a ModalBox
@@ -55,7 +52,6 @@ exports[`ModalBox Test top aligned 1`] = `
   className="pf-c-modal-box pf-m-align-top"
   id="boxId"
   role="dialog"
-  style={Object {}}
   title="Test Modal Box"
 >
   This is a ModalBox

--- a/packages/react-core/src/components/Modal/__tests__/__snapshots__/ModalBox.test.tsx.snap
+++ b/packages/react-core/src/components/Modal/__tests__/__snapshots__/ModalBox.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`ModalBox Test 1`] = `
   className="pf-c-modal-box"
   id="boxId"
   role="dialog"
+  style={Object {}}
   title="Test Modal Box"
 >
   This is a ModalBox
@@ -23,6 +24,7 @@ exports[`ModalBox Test isLarge 1`] = `
   id="boxId"
   isLarge={true}
   role="dialog"
+  style={Object {}}
   title="Test Modal Box"
 >
   This is a ModalBox
@@ -38,6 +40,7 @@ exports[`ModalBox Test isSmall 1`] = `
   id="boxId"
   isSmall={true}
   role="dialog"
+  style={Object {}}
   title="Test Modal Box"
 >
   This is a ModalBox
@@ -52,6 +55,7 @@ exports[`ModalBox Test top aligned 1`] = `
   className="pf-c-modal-box pf-m-align-top"
   id="boxId"
   role="dialog"
+  style={Object {}}
   title="Test Modal Box"
 >
   This is a ModalBox

--- a/packages/react-core/src/components/Modal/examples/Modal.md
+++ b/packages/react-core/src/components/Modal/examples/Modal.md
@@ -12,6 +12,7 @@ import CaretDownIcon from '@patternfly/react-icons/dist/js/icons/caret-down-icon
 ## Examples
 
 ### Basic
+
 ```js
 import React from 'react';
 import { Modal, Button } from '@patternfly/react-core';
@@ -63,6 +64,7 @@ class SimpleModal extends React.Component {
 ```
 
 ### With description
+
 ```js
 import React from 'react';
 import { Modal, Button } from '@patternfly/react-core';
@@ -115,7 +117,61 @@ class SimpleModal extends React.Component {
 }
 ```
 
+### Top aligned
+
+```js
+import React from 'react';
+import { Modal, ModalVariant, Button } from '@patternfly/react-core';
+
+class TopModal extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isModalOpen: false
+    };
+    this.handleModalToggle = () => {
+      this.setState(({ isModalOpen }) => ({
+        isModalOpen: !isModalOpen
+      }));
+    };
+  }
+
+  render() {
+    const { isModalOpen } = this.state;
+
+    return (
+      <React.Fragment>
+        <Button variant="primary" onClick={this.handleModalToggle}>
+          Show Top Aligned Modal
+        </Button>
+        <Modal
+          position="top"
+          title="Top modal header"
+          isOpen={isModalOpen}
+          onClose={this.handleModalToggle}
+          actions={[
+            <Button key="confirm" variant="primary" onClick={this.handleModalToggle}>
+              Confirm
+            </Button>,
+            <Button key="cancel" variant="link" onClick={this.handleModalToggle}>
+              Cancel
+            </Button>
+          ]}
+        >
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+          consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+          est laborum.
+        </Modal>
+      </React.Fragment>
+    );
+  }
+}
+```
+
 ### Small
+
 ```js
 import React from 'react';
 import { Modal, ModalVariant, Button } from '@patternfly/react-core';
@@ -168,6 +224,7 @@ class SmallModal extends React.Component {
 ```
 
 ### Medium
+
 ```js
 import React from 'react';
 import { Modal, ModalVariant, Button } from '@patternfly/react-core';
@@ -220,6 +277,7 @@ class MediumModal extends React.Component {
 ```
 
 ### Large
+
 ```js
 import React from 'react';
 import { Modal, ModalVariant, Button } from '@patternfly/react-core';
@@ -272,6 +330,7 @@ class LargeModal extends React.Component {
 ```
 
 ### Width
+
 ```js
 import React from 'react';
 import { Modal, Button } from '@patternfly/react-core';
@@ -324,6 +383,7 @@ class WidthModal extends React.Component {
 ```
 
 ### Custom header and footer
+
 ```js
 import React from 'react';
 import { Modal, ModalVariant, Button, Title, TitleSizes } from '@patternfly/react-core';
@@ -393,6 +453,7 @@ class CustomHeaderFooter extends React.Component {
 ```
 
 ### No header
+
 ```js
 import React from 'react';
 import { Modal, ModalVariant, Button } from '@patternfly/react-core';
@@ -445,6 +506,7 @@ class NoHeader extends React.Component {
 ```
 
 ### With wizard
+
 ```js
 import React from 'react';
 import { Modal, Button, Wizard } from '@patternfly/react-core';
@@ -495,7 +557,7 @@ class WithWizard extends React.Component {
             steps={steps}
             onClose={this.handleModalToggle}
             height={400}
-        />
+          />
         </Modal>
       </React.Fragment>
     );
@@ -504,6 +566,7 @@ class WithWizard extends React.Component {
 ```
 
 ### With dropdown
+
 ```js
 import React from 'react';
 import { Modal, Button, Dropdown, DropdownToggle, DropdownItem, KebabToggle } from '@patternfly/react-core';
@@ -541,15 +604,18 @@ class WithDropdown extends React.Component {
     this.onEscapePress = () => {
       const { isDropdownOpen } = this.state;
       if (isDropdownOpen) {
-        this.setState({
-          isDropdownOpen: !isDropdownOpen
-        }, () => {
-          this.onFocus();
-        });
+        this.setState(
+          {
+            isDropdownOpen: !isDropdownOpen
+          },
+          () => {
+            this.onFocus();
+          }
+        );
       } else {
         this.handleModalToggle();
       }
-    }
+    };
   }
 
   render() {
@@ -593,13 +659,20 @@ class WithDropdown extends React.Component {
           onEscapePress={this.onEscapePress}
         >
           <div>
-            Set the dropdown <strong>menuAppendTo</strong> prop to <em>parent</em> in order to allow the dropdown menu break out of the modal container. You'll also want to handle closing of the modal yourself, by listening to the <strong>onEscapePress</strong> callback on the Modal component, so you can close the Dropdown first if it's open.
+            Set the dropdown <strong>menuAppendTo</strong> prop to <em>parent</em> in order to allow the dropdown menu
+            break out of the modal container. You'll also want to handle closing of the modal yourself, by listening to
+            the <strong>onEscapePress</strong> callback on the Modal component, so you can close the Dropdown first if
+            it's open.
           </div>
           <div>
             <Dropdown
               onSelect={this.onSelect}
               toggle={
-                <DropdownToggle id="toggle-id-menu-document-body" onToggle={this.onToggle} toggleIndicator={CaretDownIcon}>
+                <DropdownToggle
+                  id="toggle-id-menu-document-body"
+                  onToggle={this.onToggle}
+                  toggleIndicator={CaretDownIcon}
+                >
                   Dropdown with a menu that can break out
                 </DropdownToggle>
               }

--- a/packages/react-integration/cypress/integration/modal.spec.ts
+++ b/packages/react-integration/cypress/integration/modal.spec.ts
@@ -46,6 +46,7 @@ describe('Modal Test', () => {
   it('Verify Small Modal', () => {
     cy.get('#showSmallModalButton').then((modalButton: JQuery<HTMLButtonElement>) => {
       cy.wrap(modalButton).click();
+      cy.get('.pf-c-modal-box').should('have.class', 'pf-m-align-top');
       cy.get('.pf-c-modal-box.pf-m-sm')
         .then(() => {
           cy.get('.pf-c-modal-box .pf-c-button[aria-label="Close"]').then(closeButton => {

--- a/packages/react-integration/demo-app-ts/src/components/demos/ModalDemo/ModalDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/ModalDemo/ModalDemo.tsx
@@ -149,6 +149,7 @@ export class ModalDemo extends React.Component<React.HTMLProps<HTMLDivElement>, 
     return (
       <Modal
         variant={ModalVariant.small}
+        position="top"
         title="Modal Header"
         isOpen={isSmallModalOpen}
         onClose={this.handleSmallModalToggle}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4819

Adds `position` property for top aligned modals. @mcoker Let me know if this property makes sense. I could change it to something like `isTopAligned` but I wasn't sure if we wanted to add other position type alignments (bottom/left/right) later on.

Adds `distanceFromTop` property to set the custom spacer class `--pf-c-modal-box--m-align-top--spacer`.