### PR TITLE
Fix TypeError if missing 'props' from favorite items

### DIFF
--- a/packages/react-core/src/helpers/util.ts
+++ b/packages/react-core/src/helpers/util.ts
@@ -297,7 +297,7 @@ export const createRenderableFavorites = (
         return (
           group.props.children &&
           (group.props.children as React.ReactElement[])
-            .filter(item => favorites.includes(item.props.id))
+            .filter(item => 'props' in item && favorites.includes(item.props.id))
             .map(item => {
               if (isEnterTriggersArrowDown) {
                 return favoriteItems.push(
@@ -319,7 +319,7 @@ export const createRenderableFavorites = (
     return favoriteItems;
   }
   return (items as React.ReactElement[])
-    .filter(item => favorites.includes(item.props.id))
+    .filter(item => 'props' in item && favorites.includes(item.props.id))
     .map(item => React.cloneElement(item, { isFavorite: true, enterTriggersArrowDown: isEnterTriggersArrowDown }));
 };
 


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**:
Patch for https://github.com/patternfly/patternfly-react/issues/4890

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
There are more `item.props.id` lines in that file that might also need modifying.  This patch doesn't address them all, just the one that was affecting our application.
