### PR TITLE
fix(react-table): use direct imports of react-core components

### DIFF
--- a/packages/react-table/src/components/Table/BodyCell.tsx
+++ b/packages/react-table/src/components/Table/BodyCell.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { css } from '@patternfly/react-styles';
 import { Tooltip } from '@patternfly/react-core/dist/js/components/Tooltip/Tooltip';
 import styles from '@patternfly/react-styles/css/components/Table/table';
-import { SelectProps } from '@patternfly/react-core';
+import { SelectProps } from '@patternfly/react-core/dist/js/components/Select';
 
 export interface BodyCellProps {
   'data-label'?: string;

--- a/packages/react-table/src/components/Table/EditableSelectInputCell.tsx
+++ b/packages/react-table/src/components/Table/EditableSelectInputCell.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { css } from '@patternfly/react-styles';
-import { Select, SelectOptionObject, SelectProps } from '@patternfly/react-core';
+import { Select, SelectOptionObject, SelectProps } from '@patternfly/react-core/dist/js/components/Select';
 import inlineStyles from '@patternfly/react-styles/css/components/InlineEdit/inline-edit';
 import formStyles from '@patternfly/react-styles/css/components/Form/form';
 

--- a/packages/react-table/src/components/Table/HeaderCellInfoWrapper.tsx
+++ b/packages/react-table/src/components/Table/HeaderCellInfoWrapper.tsx
@@ -2,7 +2,9 @@ import * as React from 'react';
 import HelpIcon from '@patternfly/react-icons/dist/js/icons/help-icon';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
-import { Button, Tooltip, Popover, TooltipProps, PopoverProps } from '@patternfly/react-core';
+import { Button } from '@patternfly/react-core/dist/js/components/Button/Button';
+import { Tooltip, TooltipProps } from '@patternfly/react-core/dist/js/components/Tooltip/Tooltip';
+import { Popover, PopoverProps } from '@patternfly/react-core/dist/js/components/Popover/Popover';
 
 export interface ColumnHelpWrapperProps {
   /**

--- a/packages/react-table/src/components/Table/Table.tsx
+++ b/packages/react-table/src/components/Table/Table.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 import stylesGrid from '@patternfly/react-styles/css/components/Table/table-grid';
-import { getOUIAProps, OUIAProps, getDefaultOUIAId } from '@patternfly/react-core';
+import { getOUIAProps, OUIAProps, getDefaultOUIAId } from '@patternfly/react-core/dist/js/helpers/ouia';
 import {
   DropdownDirection,
   DropdownPosition

--- a/packages/react-table/src/components/Table/base/types.tsx
+++ b/packages/react-table/src/components/Table/base/types.tsx
@@ -6,7 +6,8 @@
  */
 
 import * as React from 'react';
-import { TooltipProps, PopoverProps } from '@patternfly/react-core';
+import { TooltipProps } from '@patternfly/react-core/dist/js/components/Tooltip/Tooltip';
+import { PopoverProps } from '@patternfly/react-core/dist/js/components/Popover/Popover';
 
 // Cell Type
 export interface CellType {


### PR DESCRIPTION
Recently we have noticed that the about modal background images are being included in insights application builds, even though these applications do not use the about modal component and using direct imports from react-core. Recently there were some changes in the react-table package which are not using the direct imports, causing these images to be included. Here is a trace from webpack:

```bash

 @ ./node_modules/@patternfly/react-styles/css/components/AboutModalBox/about-modal-box.css
 @ ./node_modules/@patternfly/react-styles/css/components/AboutModalBox/about-modal-box.js
 @ ./node_modules/@patternfly/react-core/dist/esm/components/AboutModal/AboutModalBoxContent.js
 @ ./node_modules/@patternfly/react-core/dist/esm/components/AboutModal/AboutModalContainer.js
 @ ./node_modules/@patternfly/react-core/dist/esm/components/AboutModal/AboutModal.js
 @ ./node_modules/@patternfly/react-core/dist/esm/components/AboutModal/index.js
 @ ./node_modules/@patternfly/react-core/dist/esm/components/index.js
 @ ./node_modules/@patternfly/react-core/dist/esm/index.js
 @ ./node_modules/@patternfly/react-table/dist/esm/components/Table/Table.js
 @ ./node_modules/@patternfly/react-table/dist/esm/components/Table/index.js
 @ ./node_modules/@patternfly/react-table/dist/esm/components/index.js
 @ ./node_modules/@patternfly/react-table/dist/esm/index.js
 @ ./node_modules/@redhat-cloud-services/frontend-components/components/cjs/TagModal.js
 @ ./src/js/App/GlobalFilter/TagsModal.js
 @ ./src/js/App/GlobalFilter/GlobalFilter.js
 @ ./src/js/App/GlobalFilter/index.js
 @ ./src/js/App/RootApp.js
 @ ./src/js/chrome/entry.js
 @ ./src/js/chrome.js
```

After using the direct import of commonjs version of react-core, the issue is gone.

@evwilkin @redallen I would also like to again suggest using babel transform imports plugin to dynamically transform any patternfly import path to direct path from js or esm or umd build based on the current build environment. Currently, there is only one properly optimized build and that is commonjs because in multiple components we directly import components from dist/js/... and that causes duplicate asset imports in our applications. Using the babel import will not only fix duplicate assets issues but will also prevent future shorthand imports in all your react packages. That could save us a lot of debugging when our applications bloat for no apparent reason.

cc @karelhala @ryelo 