### PR TITLE
fix(duplicate-cjs): add transformer-cjs-imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,13 +67,15 @@
     "tslint": "^5.12.0",
     "tslint-config-prettier": "^1.18.0",
     "tslint-plugin-prettier": "^2.0.1",
-    "tslint-react": "^3.6.0"
+    "tslint-react": "^3.6.0",
+    "ttypescript": "^1.5.12"
   },
   "scripts": {
+    "analyze": "yarn workspace @patternfly/react-docs analyze",
     "bootstrap": "lerna bootstrap",
     "build": "yarn build:generate && yarn build:esm && yarn build:cjs",
     "build:cjs": "tsc --build packages/tsconfig.cjs.json -v",
-    "build:esm": "tsc --build packages/tsconfig.json -v",
+    "build:esm": "ttsc --build packages/tsconfig.json -v",
     "build:integration": "lerna run build:demo-app --stream",
     "build:docs": "yarn workspace @patternfly/react-docs build:docs",
     "build:umd": "yarn workspace @patternfly/react-core build:umd",

--- a/packages/react-docs/patternfly-a11y.config.js
+++ b/packages/react-docs/patternfly-a11y.config.js
@@ -1,5 +1,10 @@
 const { fullscreenRoutes } = require('theme-patternfly-org/routes');
 
+/**
+ * Wait for a selector before running axe
+ *
+ * @param page page from puppeteer
+ */
 async function waitFor(page) {
   await page.waitForSelector('#root > *');
 }

--- a/packages/transformer-cjs-imports/index.js
+++ b/packages/transformer-cjs-imports/index.js
@@ -1,0 +1,27 @@
+// Tutorial: https://levelup.gitconnected.com/writing-typescript-custom-ast-transformer-part-2-5322c2b1660e
+const ts = require('typescript');
+
+// We import `@patternfly/**/dist/cjs` to avoid parsing massive modules
+// like tokens and icons and for cross-module imports with types.
+// HOWEVER we would like for the ESM output to reference `@patternfly/**/dist/esm`
+// for better tree-shaking and smaller bundlers. A large offender of this is Popover. 
+function transformerCJSImports(context) {
+  // Only transform for ESM build
+  if (context.getCompilerOptions().target !== 2) {
+    return node => node;
+  }
+  function visit(node) {
+    if (ts.isImportDeclaration(node) && /@patternfly\/.*\/dist\/js/.test(node.moduleSpecifier.text)) {
+      const newNode = ts.getMutableClone(node);
+      const newPath = node.moduleSpecifier.text.replace(/dist\/js/, 'dist/esm');
+      newNode.moduleSpecifier = ts.createStringLiteral(newPath)
+      return newNode;
+    }
+    return ts.visitEachChild(node, child => visit(child), context);
+  }
+  return node => ts.visitNode(node, visit);
+}
+
+module.exports = () => ({
+  before: transformerCJSImports
+});

--- a/packages/transformer-cjs-imports/index.js
+++ b/packages/transformer-cjs-imports/index.js
@@ -1,20 +1,31 @@
-// Tutorial: https://levelup.gitconnected.com/writing-typescript-custom-ast-transformer-part-2-5322c2b1660e
+// https://levelup.gitconnected.com/writing-typescript-custom-ast-transformer-part-2-5322c2b1660e
 const ts = require('typescript');
 
-// We import `@patternfly/**/dist/cjs` to avoid parsing massive modules
-// like tokens and icons and for cross-module imports with types.
-// HOWEVER we would like for the ESM output to reference `@patternfly/**/dist/esm`
-// for better tree-shaking and smaller bundlers. A large offender of this is Popover. 
+/**
+ * We import `@patternfly/react-[tokens,icons]/dist/js` to avoid parsing massive modules
+ * as well as for cross-module imports with types to `@patternfly/react-core`.
+ * HOWEVER we would like for the ESM output to reference `@patternfly/react-[]/dist/esm`
+ * for better tree-shaking and smaller bundlers.
+ * A large offender of this is Tooltip's Popover helper.
+ *
+ * @param context TS context
+ */
 function transformerCJSImports(context) {
   // Only transform for ESM build
   if (context.getCompilerOptions().target !== 2) {
     return node => node;
   }
+  /**
+   * If a node is an import, change its moduleSpecifier
+   * Otherwise iterate over all its childern.
+   *
+   * @param node TS Node
+   */
   function visit(node) {
     if (ts.isImportDeclaration(node) && /@patternfly\/.*\/dist\/js/.test(node.moduleSpecifier.text)) {
       const newNode = ts.getMutableClone(node);
       const newPath = node.moduleSpecifier.text.replace(/dist\/js/, 'dist/esm');
-      newNode.moduleSpecifier = ts.createStringLiteral(newPath)
+      newNode.moduleSpecifier = ts.createStringLiteral(newPath);
       return newNode;
     }
     return ts.visitEachChild(node, child => visit(child), context);

--- a/packages/transformer-cjs-imports/package.json
+++ b/packages/transformer-cjs-imports/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "transformer-cjs-imports",
+  "version": "4.0.0",
+  "description": "Transform CJS imports to ESM in typescript depending on module target.",
+  "main": "index.js",
+  "author": "Red Hat",
+  "license": "MIT",
+  "peerDependencies": {
+    "typescript": ">=3.7.2"
+  }
+}

--- a/packages/tsconfig.base.json
+++ b/packages/tsconfig.base.json
@@ -16,7 +16,10 @@
     "sourceMap": true,
     "declarationMap": true,
     "strict": true,
-    "strictNullChecks": false
+    "strictNullChecks": false,
+    "plugins": [
+      { "transform": "transformer-cjs-imports" },
+    ]
   },
   "exclude": [
     "**/**.test.tsx",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18069,7 +18069,7 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.3.3:
+resolve@>=1.9.0, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.3.3:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
@@ -20262,6 +20262,13 @@ tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
   integrity sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=
+
+ttypescript@^1.5.12:
+  version "1.5.12"
+  resolved "https://registry.yarnpkg.com/ttypescript/-/ttypescript-1.5.12.tgz#27a8356d7d4e719d0075a8feb4df14b52384f044"
+  integrity sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==
+  dependencies:
+    resolve ">=1.9.0"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4562. Decreases bundle sizes in product and on our docs site ~10% by having ESM builds only import ESM files:
![image](https://user-images.githubusercontent.com/47335686/94608236-14e15500-026b-11eb-808a-82aa995f4f2e.png)
Notice that there are no longer any CJS imports (like `/dist/js`) for `@patternfly` in our docs build.

**Changes:**
- Add [ttypescript](https://www.npmjs.com/package/ttypescript) (transformer typescript)
  - Allows hooking into `tsc` similar to babel plugins
- Add simple import transformer for `/@patternfly\/.*\/dist\/js/` following [this](https://levelup.gitconnected.com/writing-typescript-custom-ast-transformer-part-2-5322c2b1660e) tutorial
<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: See also #4906
