### PR TITLE
fix(react-icons): use lying cast

### DIFF
--- a/packages/react-icons/src/createIcon.tsx
+++ b/packages/react-icons/src/createIcon.tsx
@@ -31,7 +31,7 @@ export interface IconDefinition {
   yOffset?: number;
 }
 
-export interface SVGIconProps extends Omit<React.SVGProps<SVGElement>, 'size' | 'ref'> {
+export interface SVGIconProps extends Omit<React.HTMLProps<SVGElement>, 'size' | 'ref'> {
   color?: string;
   size?: IconSize | keyof typeof IconSize;
   title?: string;
@@ -80,7 +80,7 @@ export function createIcon({
           aria-labelledby={hasTitle ? this.id : null}
           aria-hidden={hasTitle ? null : true}
           role="img"
-          {...props}
+          {...(props as Omit<React.SVGProps<SVGElement>, 'ref'>)} // Lie.
         >
           {hasTitle && <title id={this.id}>{title}</title>}
           <path d={svgPath} />


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Fixes @jcaianirh 's problem in OpenShift which uses `<CheckIcon alt="" />`. This becomes `<svg alt="">` which is invalid ([should be `<svg aria-label="">`](https://www.scottohara.me/blog/2019/05/22/contextual-images-svgs-and-a11y.html)), but we'll continue lying that it's okay.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
