### PR TITLE
Fix typescript complaining about missing default export when importing React

### DIFF
--- a/packages/react-charts/src/components/ChartCursorTooltip/ChartCursorFlyout.tsx
+++ b/packages/react-charts/src/components/ChartCursorTooltip/ChartCursorFlyout.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import PropTypes from 'prop-types';
 import { Helpers, CommonProps, Path } from 'victory-core';
 import isPlainObject from 'lodash/isPlainObject';

--- a/packages/react-core/src/components/TreeView/TreeView.tsx
+++ b/packages/react-core/src/components/TreeView/TreeView.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { TreeViewList } from './TreeViewList';
 import { TreeViewListItem } from './TreeViewListItem';
 

--- a/packages/react-core/src/components/TreeView/TreeViewList.tsx
+++ b/packages/react-core/src/components/TreeView/TreeViewList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/TreeView/tree-view';
 import { TreeViewSearch } from './TreeViewSearch';

--- a/packages/react-core/src/components/TreeView/TreeViewSearch.tsx
+++ b/packages/react-core/src/components/TreeView/TreeViewSearch.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/TreeView/tree-view';
 import formStyles from '@patternfly/react-styles/css/components/FormControl/form-control';

--- a/packages/react-inline-edit-extension/src/components/ConfirmButtons/ConfirmButtons.tsx
+++ b/packages/react-inline-edit-extension/src/components/ConfirmButtons/ConfirmButtons.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { css } from '@patternfly/react-styles';
 import { CancelButton } from '../CancelButton';
 import { ConfirmButton } from '../ConfirmButton';


### PR DESCRIPTION
All the remaining places where we use `import React from 'react'` are
either example code which is not typescript or tests code.

Fixes #4936

