### PR TITLE
TreeView: Replace button wrapper around actions with a div

### DIFF
--- a/packages/react-core/src/components/TreeView/TreeView.tsx
+++ b/packages/react-core/src/components/TreeView/TreeView.tsx
@@ -23,10 +23,8 @@ export interface TreeViewDataItem {
   hasBadge?: boolean;
   /** Additional properties of the tree view item badge */
   badgeProps?: any;
-  /** Action of a tree view item, nested inside a button */
+  /** Action of a tree view item, can be a Button or Dropdown */
   action?: React.ReactNode;
-  /** Additional properties of the tree view item action button */
-  actionProps?: any;
 }
 
 export interface TreeViewProps {
@@ -98,7 +96,6 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
         icon={item.icon !== undefined ? item.icon : icon}
         expandedIcon={item.expandedIcon !== undefined ? item.expandedIcon : expandedIcon}
         action={item.action}
-        actionProps={item.actionProps}
         compareItems={compareItems}
         {...(item.children && {
           children: (

--- a/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
+++ b/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
@@ -37,10 +37,8 @@ export interface TreeViewListItemProps {
   icon?: React.ReactNode;
   /** Expanded icon of a tree view item */
   expandedIcon?: React.ReactNode;
-  /** Action of a tree view item, nested inside a button */
+  /** Action of a tree view item, can be a Button or Dropdown */
   action?: React.ReactNode;
-  /** Additional properties of the tree view item action button */
-  actionProps?: any;
   /** Callback for item comparison function */
   compareItems?: (item: TreeViewDataItem, itemToCheck: TreeViewDataItem) => boolean;
 }
@@ -64,13 +62,6 @@ export const TreeViewListItem: React.FunctionComponent<TreeViewListItemProps> = 
   icon,
   expandedIcon,
   action,
-  actionProps = {
-    onClick: (evt: React.MouseEvent) => {
-      evt.stopPropagation();
-      evt.preventDefault();
-      onSelect && onSelect(evt, itemData, parentItem);
-    }
-  },
   compareItems
 }: TreeViewListItemProps) => {
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
@@ -132,11 +123,7 @@ export const TreeViewListItem: React.FunctionComponent<TreeViewListItemProps> = 
             </span>
           )}
         </button>
-        {action && (
-          <button className={css(styles.treeViewAction)} {...actionProps}>
-            {action}
-          </button>
-        )}
+        {action && <div className={css(styles.treeViewAction)}>{action}</div>}
       </div>
       {isExpanded && children}
     </li>

--- a/packages/react-core/src/components/TreeView/__tests__/TreeView.test.tsx
+++ b/packages/react-core/src/components/TreeView/__tests__/TreeView.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { TreeView } from '../TreeView';
+import { Button } from '@patternfly/react-core';
 import { FolderIcon, FolderOpenIcon, FlagIcon } from '@patternfly/react-icons';
 
 const options = [
@@ -92,7 +93,11 @@ const flagOptions = [
     name: 'Cost Management',
     id: 'Cost',
     hasBadge: true,
-    action: <FolderIcon />,
+    action: (
+      <Button>
+        <FolderIcon />
+      </Button>
+    ),
     children: [
       {
         name: 'Application 3',

--- a/packages/react-core/src/components/TreeView/__tests__/TreeView.test.tsx
+++ b/packages/react-core/src/components/TreeView/__tests__/TreeView.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { TreeView } from '../TreeView';
 import { Button } from '@patternfly/react-core';
-import { FolderIcon, FolderOpenIcon, FlagIcon } from '@patternfly/react-icons';
+import { FolderIcon, FolderOpenIcon } from '@patternfly/react-icons';
 
 const options = [
   {
@@ -94,7 +94,7 @@ const flagOptions = [
     id: 'Cost',
     hasBadge: true,
     action: (
-      <Button>
+      <Button variant="plain" aria-label="Folder action">
         <FolderIcon />
       </Button>
     ),

--- a/packages/react-core/src/components/TreeView/__tests__/__snapshots__/TreeView.test.tsx.snap
+++ b/packages/react-core/src/components/TreeView/__tests__/__snapshots__/TreeView.test.tsx.snap
@@ -5326,11 +5326,13 @@ exports[`tree view renders individual flag options successfully 1`] = `
         "name": "ApplicationLauncher",
       },
       Object {
-        "action": <FolderIcon
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
-        />,
+        "action": <Button>
+          <FolderIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
+          />
+        </Button>,
         "children": Array [
           Object {
             "children": Array [
@@ -6081,11 +6083,13 @@ exports[`tree view renders individual flag options successfully 1`] = `
         </TreeViewListItem>
         <TreeViewListItem
           action={
-            <FolderIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
-            />
+            <Button>
+              <FolderIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
+              />
+            </Button>
           }
           activeItems={
             Array [
@@ -6112,11 +6116,13 @@ exports[`tree view renders individual flag options successfully 1`] = `
           id="Cost"
           itemData={
             Object {
-              "action": <FolderIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
-              />,
+              "action": <Button>
+                <FolderIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
+                />
+              </Button>,
               "children": Array [
                 Object {
                   "children": Array [
@@ -6203,35 +6209,48 @@ exports[`tree view renders individual flag options successfully 1`] = `
                   </Badge>
                 </span>
               </button>
-              <button
+              <div
                 className="pf-c-tree-view__action"
-                onClick={[Function]}
               >
-                <FolderIcon
-                  color="currentColor"
-                  noVerticalAlign={false}
-                  size="sm"
-                >
-                  <svg
-                    aria-hidden={true}
-                    aria-labelledby={null}
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style={
-                      Object {
-                        "verticalAlign": "-0.125em",
-                      }
-                    }
-                    viewBox="0 0 512 512"
-                    width="1em"
+                <Button>
+                  <button
+                    aria-disabled={false}
+                    aria-label={null}
+                    className="pf-c-button pf-m-primary"
+                    data-ouia-component-id="OUIA-Generated-Button-primary-1"
+                    data-ouia-component-type="PF4/Button"
+                    data-ouia-safe={true}
+                    disabled={false}
+                    role={null}
+                    type="button"
                   >
-                    <path
-                      d="M464 128H272l-64-64H48C21.49 64 0 85.49 0 112v288c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V176c0-26.51-21.49-48-48-48z"
-                    />
-                  </svg>
-                </FolderIcon>
-              </button>
+                    <FolderIcon
+                      color="currentColor"
+                      noVerticalAlign={false}
+                      size="sm"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        aria-labelledby={null}
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        style={
+                          Object {
+                            "verticalAlign": "-0.125em",
+                          }
+                        }
+                        viewBox="0 0 512 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M464 128H272l-64-64H48C21.49 64 0 85.49 0 112v288c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V176c0-26.51-21.49-48-48-48z"
+                        />
+                      </svg>
+                    </FolderIcon>
+                  </button>
+                </Button>
+              </div>
             </div>
           </li>
         </TreeViewListItem>

--- a/packages/react-core/src/components/TreeView/__tests__/__snapshots__/TreeView.test.tsx.snap
+++ b/packages/react-core/src/components/TreeView/__tests__/__snapshots__/TreeView.test.tsx.snap
@@ -5326,7 +5326,10 @@ exports[`tree view renders individual flag options successfully 1`] = `
         "name": "ApplicationLauncher",
       },
       Object {
-        "action": <Button>
+        "action": <Button
+          aria-label="Folder action"
+          variant="plain"
+        >
           <FolderIcon
             color="currentColor"
             noVerticalAlign={false}
@@ -6083,7 +6086,10 @@ exports[`tree view renders individual flag options successfully 1`] = `
         </TreeViewListItem>
         <TreeViewListItem
           action={
-            <Button>
+            <Button
+              aria-label="Folder action"
+              variant="plain"
+            >
               <FolderIcon
                 color="currentColor"
                 noVerticalAlign={false}
@@ -6116,7 +6122,10 @@ exports[`tree view renders individual flag options successfully 1`] = `
           id="Cost"
           itemData={
             Object {
-              "action": <Button>
+              "action": <Button
+                aria-label="Folder action"
+                variant="plain"
+              >
                 <FolderIcon
                   color="currentColor"
                   noVerticalAlign={false}
@@ -6212,12 +6221,15 @@ exports[`tree view renders individual flag options successfully 1`] = `
               <div
                 className="pf-c-tree-view__action"
               >
-                <Button>
+                <Button
+                  aria-label="Folder action"
+                  variant="plain"
+                >
                   <button
                     aria-disabled={false}
-                    aria-label={null}
-                    className="pf-c-button pf-m-primary"
-                    data-ouia-component-id="OUIA-Generated-Button-primary-1"
+                    aria-label="Folder action"
+                    className="pf-c-button pf-m-plain"
+                    data-ouia-component-id="OUIA-Generated-Button-plain-1"
                     data-ouia-component-type="PF4/Button"
                     data-ouia-safe={true}
                     disabled={false}

--- a/packages/react-core/src/components/TreeView/examples/TreeView.md
+++ b/packages/react-core/src/components/TreeView/examples/TreeView.md
@@ -610,15 +610,20 @@ class IconTreeView extends React.Component {
       {
         name: 'ApplicationLauncher',
         id: 'AppLaunch',
-        action: <EllipsisVIcon />,
-        actionProps: {
-          'aria-label': 'Launch app'
-        },
+        action: (
+          <Button aria-label="Launch app">
+            <EllipsisVIcon />
+          </Button>
+        ),
         children: [
           {
             name: 'Application 1',
             id: 'App1',
-            action: <ClipboardIcon />,
+            action: (
+              <Button aria-label="Launch app 1">
+                <ClipboardIcon />
+              </Button>
+            ),
             actionProps: {
               'aria-label': 'Launch app 1'
             },
@@ -627,10 +632,11 @@ class IconTreeView extends React.Component {
           {
             name: 'Application 2',
             id: 'App2',
-            action: <HamburgerIcon />,
-            actionProps: {
-              'aria-label': 'Launch app 2'
-            },
+            action: (
+              <Button aria-label="Launch app 2">
+                <HamburgerIcon />
+              </Button>
+            ),
             children: [
               { name: 'Settings', id: 'App2Settings' },
               {

--- a/packages/react-core/src/components/TreeView/examples/TreeView.md
+++ b/packages/react-core/src/components/TreeView/examples/TreeView.md
@@ -611,7 +611,7 @@ class IconTreeView extends React.Component {
         name: 'ApplicationLauncher',
         id: 'AppLaunch',
         action: (
-          <Button aria-label="Launch app">
+          <Button variant="plain" aria-label="Launch app">
             <EllipsisVIcon />
           </Button>
         ),
@@ -620,7 +620,7 @@ class IconTreeView extends React.Component {
             name: 'Application 1',
             id: 'App1',
             action: (
-              <Button aria-label="Launch app 1">
+              <Button variant="plain" aria-label="Launch app 1">
                 <ClipboardIcon />
               </Button>
             ),
@@ -633,7 +633,7 @@ class IconTreeView extends React.Component {
             name: 'Application 2',
             id: 'App2',
             action: (
-              <Button aria-label="Launch app 2">
+              <Button variant="plain" aria-label="Launch app 2">
                 <HamburgerIcon />
               </Button>
             ),

--- a/packages/react-integration/demo-app-ts/src/components/demos/TreeViewDemo/TreeViewDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TreeViewDemo/TreeViewDemo.tsx
@@ -1,4 +1,4 @@
-import { TreeView, TreeViewDataItem } from '@patternfly/react-core';
+import { Button, TreeView, TreeViewDataItem } from '@patternfly/react-core';
 import FolderIcon from '@patternfly/react-icons/dist/js/icons/folder-icon';
 import FolderOpenIcon from '@patternfly/react-icons/dist/js/icons/folder-open-icon';
 import React, { Component } from 'react';
@@ -157,7 +157,11 @@ export class TreeViewDemo extends Component {
         name: 'Cost Management',
         id: 'FCost',
         hasBadge: true,
-        action: <FolderIcon />,
+        action: (
+          <Button>
+            <FolderIcon />
+          </Button>
+        ),
         children: [
           {
             name: 'Application 3',

--- a/packages/react-integration/demo-app-ts/src/components/demos/TreeViewDemo/TreeViewDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TreeViewDemo/TreeViewDemo.tsx
@@ -158,7 +158,7 @@ export class TreeViewDemo extends Component {
         id: 'FCost',
         hasBadge: true,
         action: (
-          <Button>
+          <Button variant="plain" aria-label="Folder action">
             <FolderIcon />
           </Button>
         ),


### PR DESCRIPTION
Resolves #4799.
Relevant core change: https://github.com/patternfly/patternfly/pull/3522

Allows any arbitrary JSX to be used in the `action` prop on a TreeViewListItem, wrapping it in a plain div with `.pf-c-tree-view__action` instead of a button. Replaces the existing examples which pass bare icons to this prop with buttons containing those icons.

This makes it possible to render a `<Dropdown>` in the action container of a tree view item without resulting in a button-in-a-button.

BREAKING CHANGES: existing consumers who want to keep the previous behavior must wrap the contents of their `action` in a `<Button>` and pass the values of their `actionProps` directly to the button.