### PR TITLE
fix(topology): Do not update nodes on layout when fixed

### DIFF
--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/TopologyPackage.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/TopologyPackage.tsx
@@ -181,6 +181,9 @@ const TopologyViewComponent: React.FC<TopologyViewComponentProps> = ({ vis, useS
             </DropdownItem>,
             <DropdownItem key={3} onClick={() => updateLayout('Cola')}>
               Cola
+            </DropdownItem>,
+            <DropdownItem key={3} onClick={() => updateLayout('ColaNoForce')}>
+              ColaNoForce
             </DropdownItem>
           ]}
         />

--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/layouts/defaultLayoutFactory.ts
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/layouts/defaultLayoutFactory.ts
@@ -4,6 +4,8 @@ const defaultLayoutFactory: LayoutFactory = (type: string, graph: Graph): Layout
   switch (type) {
     case 'Cola':
       return new ColaLayout(graph);
+    case 'ColaNoForce':
+      return new ColaLayout(graph, { layoutOnDrag: false });
     case 'Dagre':
       return new DagreLayout(graph);
     case 'Force':

--- a/packages/react-topology/src/layouts/LayoutNode.ts
+++ b/packages/react-topology/src/layouts/LayoutNode.ts
@@ -82,7 +82,7 @@ export class LayoutNode implements d3.SimulationNodeDatum {
     return this.nodeHeight;
   }
   update() {
-    if (this.xx != null && this.yy != null) {
+    if (!this.isFixed && this.xx != null && this.yy != null) {
       this.node.setBounds(
         this.node
           .getBounds()


### PR DESCRIPTION
**What**: 
Prevent layout from updating node positions when the node is fixed. Cola layout (in particular) is updating the node position even though the node is set to fixed. Ignore the updates in this case.

Added a ColaNoForce layout to the integration app to verify the fix.

/cc @christianvogt 
