### PR TITLE
fix(tslib): lock tslib to 1.13.0 for consumers

### DIFF
--- a/packages/react-catalog-view-extension/package.json
+++ b/packages/react-catalog-view-extension/package.json
@@ -46,7 +46,7 @@
     "node-sass": "^4.14.1",
     "rimraf": "^2.6.2",
     "shx": "^0.3.2",
-    "tslib": "^1.11.1",
+    "tslib": "1.13.0",
     "typescript": "^3.8.3"
   },
   "peerDependencies": {

--- a/packages/react-charts/package.json
+++ b/packages/react-charts/package.json
@@ -34,7 +34,7 @@
     "@patternfly/react-tokens": "^4.9.12",
     "hoist-non-react-statics": "^3.3.0",
     "lodash": "^4.17.19",
-    "tslib": "^1.11.1",
+    "tslib": "1.13.0",
     "victory": "^35.0.7",
     "victory-area": "^35.0.7",
     "victory-axis": "^35.0.7",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -41,7 +41,7 @@
     "focus-trap": "4.0.2",
     "react-dropzone": "9.0.0",
     "tippy.js": "5.1.2",
-    "tslib": "^1.11.1"
+    "tslib": "1.13.0"
   },
   "devDependencies": {
     "@patternfly/patternfly": "4.50.4",

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -36,7 +36,7 @@
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",
     "rimraf": "^2.6.2",
-    "tslib": "^1.11.1",
+    "tslib": "1.13.0",
     "typescript": "^3.8.3"
   },
   "peerDependencies": {

--- a/packages/react-inline-edit-extension/package.json
+++ b/packages/react-inline-edit-extension/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.6.2",
-    "tslib": "^1.11.1",
+    "tslib": "1.13.0",
     "typescript": "^3.8.3"
   }
 }

--- a/packages/react-table/package.json
+++ b/packages/react-table/package.json
@@ -36,7 +36,7 @@
     "@patternfly/react-styles": "^4.7.8",
     "@patternfly/react-tokens": "^4.9.12",
     "lodash": "^4.17.19",
-    "tslib": "^1.11.1"
+    "tslib": "1.13.0"
   },
   "peerDependencies": {
     "react": "^16.8.0",

--- a/packages/react-table/src/demos/Table.md
+++ b/packages/react-table/src/demos/Table.md
@@ -211,7 +211,6 @@ class BulkSelectTableDemo extends React.Component {
 
   render() {
     const { loading, res } = this.state;
-    console.log('res', res);
     const rows = res.map(post => ({
       cells: [post.title, post.body],
       selected: post.selected

--- a/packages/react-topology/package.json
+++ b/packages/react-topology/package.json
@@ -43,7 +43,7 @@
     "point-in-svg-path": "^1.0.1",
     "popper.js": "^1.16.1",
     "react-measure": "^2.3.0",
-    "tslib": "^1.11.1",
+    "tslib": "1.13.0",
     "webcola": "3.4.0"
   },
   "peerDependencies": {

--- a/packages/react-virtualized-extension/package.json
+++ b/packages/react-virtualized-extension/package.json
@@ -35,7 +35,7 @@
     "@patternfly/react-styles": "^4.7.8",
     "linear-layout-vector": "0.0.1",
     "react-virtualized": "^9.21.1",
-    "tslib": "^1.11.1"
+    "tslib": "1.13.0"
   },
   "peerDependencies": {
     "react": "^16.8.0",

--- a/scripts/generators/package/package.json.hbs
+++ b/scripts/generators/package/package.json.hbs
@@ -36,7 +36,7 @@
   "devDependencies": {
     {{#if buildsWithTypescript}}
     "rimraf": "^2.6.2",
-    "tslib": "^1.11.1",
+    "tslib": "1.13.0",,
     "typescript": "^3.8.3"
     {{/if}}
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -20210,7 +20210,7 @@ ts-loader@^8.0.4:
     micromatch "^4.0.0"
     semver "^6.0.0"
 
-tslib@^1.10.0, tslib@^1.11.1, tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
+tslib@1.13.0, tslib@^1.10.0, tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Our semver of tslib was ^1.11.1, but version 1.14.0 recently released breaking changes that consumers might install if they don't have a lockfile. This PR pins it to the older version until the Typescript team fixes it or we upgrade to tslib 2.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: I filed an issue upstream: https://github.com/microsoft/tslib/issues/128
