### PR TITLE
chore(chart): fixed example button location

### DIFF
--- a/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
+++ b/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
@@ -645,7 +645,7 @@ class LegendLayoutPieChart extends React.Component {
             ariaTitle="Pie chart example"
             constrainToVisibleArea={true}
             data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-            height={275}
+            height={230}
             labels={({ datum }) => `${datum.x}: ${datum.y}`}
             legendComponent={this.getLegend([
               { name: 'Cats' }, 

--- a/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
+++ b/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
@@ -706,7 +706,7 @@ class TooltipChart extends React.Component {
       isVisible: false
     };
     this.showTooltip = () => {
-      this.setState({ isVisible: true });
+      this.setState({ isVisible: !this.state.isVisible });
     };
   }
 
@@ -716,7 +716,7 @@ class TooltipChart extends React.Component {
     return (
       <div>
         <p>This demonstrates an alternate way of applying tooltips by wrapping charts with the Tooltip component</p>
-        <div style={{ height: '285px', width: '230px', textAlign: 'center' }}>
+        <div style={{ height: '230px', width: '230px' }}>
           <Tooltip content={<div>My custom tooltip</div>} isVisible={isVisible} position={TooltipPosition.right} trigger="manual">
             <ChartDonutThreshold
               allowTooltip={false}
@@ -734,6 +734,8 @@ class TooltipChart extends React.Component {
               />
             </ChartDonutThreshold>
           </Tooltip>
+        </div>
+        <div style={{ width: '230px', textAlign: 'center' }}>
           <Button onClick={this.showTooltip}>Show Tooltip</Button>
         </div>
       </div>


### PR DESCRIPTION
Fixes this example, where the "Show Tootip" button appears on top of the copy/code sandbox controls.

**Before**

<img width="1168" alt="Screen Shot 2020-10-09 at 2 03 25 PM" src="https://user-images.githubusercontent.com/17481322/95616861-87ef8600-0a38-11eb-978c-6fad76b8e92b.png">

Fixes https://github.com/patternfly/patternfly-react/issues/4987

**After**

<img width="860" alt="Screen Shot 2020-10-09 at 3 06 57 PM" src="https://user-images.githubusercontent.com/17481322/95622247-17993280-0a41-11eb-84e6-4b724fc8d7a4.png">
