### PR TITLE
chore(charts): fix stack chart example size

### DIFF
--- a/packages/react-charts/src/components/ChartStack/examples/ChartStack.md
+++ b/packages/react-charts/src/components/ChartStack/examples/ChartStack.md
@@ -272,7 +272,7 @@ class MonthlyResponsiveStack extends React.Component {
             domainPadding={{ x: [30, 25] }}
             legendData={[{ name: 'Sockets' }, { name: 'Cores' }, { name: 'Nodes' }]}
             legendPosition="bottom"
-            height={275}
+            height={225}
             padding={{
               bottom: 75, // Adjusted to accommodate legend
               left: 50,


### PR DESCRIPTION
Fixes this example, where the chart appears much smaller than expected.

**Before**

<img width="1196" alt="Screen Shot 2020-10-09 at 2 20 32 PM" src="https://user-images.githubusercontent.com/17481322/95618206-a2c2fa00-0a3a-11eb-853e-d4def8d3d322.png">

Fixes https://github.com/patternfly/patternfly-react/issues/4989

**After**

<img width="869" alt="Screen Shot 2020-10-09 at 3 04 58 PM" src="https://user-images.githubusercontent.com/17481322/95622114-d99c0e80-0a40-11eb-9851-d95f7eed8a7d.png">
