### PR TITLE
chore(charts): fix legend example size

### DIFF
--- a/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
+++ b/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
@@ -645,7 +645,7 @@ class LegendLayoutPieChart extends React.Component {
             ariaTitle="Pie chart example"
             constrainToVisibleArea={true}
             data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-            height={275}
+            height={230}
             labels={({ datum }) => `${datum.x}: ${datum.y}`}
             legendComponent={this.getLegend([
               { name: 'Cats' }, 


### PR DESCRIPTION
Fixes an example, where the "Legend layout" example appears much smaller than expected.

**Before**

<img width="1188" alt="Screen Shot 2020-10-09 at 2 23 37 PM" src="https://user-images.githubusercontent.com/17481322/95618464-1b29bb00-0a3b-11eb-9afd-5a06888f30f4.png">

**After**

<img width="885" alt="Screen Shot 2020-10-09 at 3 05 53 PM" src="https://user-images.githubusercontent.com/17481322/95622168-f33d5600-0a40-11eb-868f-f44a729c5955.png">

Fixes https://github.com/patternfly/patternfly-react/issues/4990