### PR TITLE
fix(datalist): cancel moving for invalid drops

### DIFF
--- a/packages/react-core/src/components/DataList/DataList.tsx
+++ b/packages/react-core/src/components/DataList/DataList.tsx
@@ -164,7 +164,7 @@ export class DataList extends React.Component<DataListProps, DataListState> {
         draggingToItemIndex: null
       });
     }
-  }
+  };
 
   dragEnd0 = (el: HTMLElement) => {
     el.classList.remove(styles.modifiers.ghostRow);
@@ -174,17 +174,18 @@ export class DataList extends React.Component<DataListProps, DataListState> {
 
   isValidDrop = (evt: React.DragEvent) => {
     const ulRect = this.ref.current.getBoundingClientRect();
-    return evt.clientX > ulRect.x &&
+    return (
+      evt.clientX > ulRect.x &&
       evt.clientX < ulRect.x + ulRect.width &&
       evt.clientY > ulRect.y &&
-      evt.clientY < ulRect.y + ulRect.height;
-  }
+      evt.clientY < ulRect.y + ulRect.height
+    );
+  };
 
   dragEnd = (evt: React.DragEvent) => {
     if (this.isValidDrop(evt)) {
       this.dragEnd0(evt.currentTarget as HTMLElement);
-    }
-    else {
+    } else {
       this.onDragCancel();
     }
   };
@@ -202,19 +203,14 @@ export class DataList extends React.Component<DataListProps, DataListState> {
     }
   };
 
-  dragOver = (evt: React.DragEvent) => {
+  dragOver = (evt: React.DragEvent): string | null => {
     evt.preventDefault();
-    
+
     const curListItem = (evt.target as HTMLElement).closest('li');
-    if (
-      !curListItem ||
-      !this.ref.current.contains(curListItem) ||
-      curListItem.id === this.state.draggedItemId
-    ) {
+    if (!curListItem || !this.ref.current.contains(curListItem) || curListItem.id === this.state.draggedItemId) {
       // We're going nowhere, don't bother calling `dragOver0`
       return null;
-    }
-    else {
+    } else {
       this.dragOver0(curListItem.id);
     }
   };

--- a/packages/react-core/src/components/DataList/DataList.tsx
+++ b/packages/react-core/src/components/DataList/DataList.tsx
@@ -139,14 +139,54 @@ export class DataList extends React.Component<DataListProps, DataListState> {
     this.dragStart0(evt.currentTarget as HTMLElement);
   };
 
+  onDragCancel = () => {
+    this.move(this.props.itemOrder);
+    Array.from(this.ref.current.children).forEach(el => {
+      el.classList.remove(styles.modifiers.ghostRow);
+      el.setAttribute('aria-pressed', 'false');
+    });
+    this.setState({
+      draggedItemId: null,
+      draggingToItemIndex: null,
+      dragging: false
+    });
+
+    if (this.props.onDragCancel) {
+      this.props.onDragCancel();
+    }
+  };
+
+  dragLeave = (evt: React.DragEvent) => {
+    // This event false fires when we call `this.move()`, so double check we're out of zone
+    if (!this.isValidDrop(evt)) {
+      this.move(this.props.itemOrder);
+      this.setState({
+        draggingToItemIndex: null
+      });
+    }
+  }
+
   dragEnd0 = (el: HTMLElement) => {
     el.classList.remove(styles.modifiers.ghostRow);
     el.setAttribute('aria-pressed', 'false');
     this.props.onDragFinish(this.state.tempItemOrder);
   };
 
+  isValidDrop = (evt: React.DragEvent) => {
+    const ulRect = this.ref.current.getBoundingClientRect();
+    return evt.clientX > ulRect.x &&
+      evt.clientX < ulRect.x + ulRect.width &&
+      evt.clientY > ulRect.y &&
+      evt.clientY < ulRect.y + ulRect.height;
+  }
+
   dragEnd = (evt: React.DragEvent) => {
-    this.dragEnd0(evt.currentTarget as HTMLElement);
+    if (this.isValidDrop(evt)) {
+      this.dragEnd0(evt.currentTarget as HTMLElement);
+    }
+    else {
+      this.onDragCancel();
+    }
   };
 
   dragOver0 = (id: string) => {
@@ -164,16 +204,23 @@ export class DataList extends React.Component<DataListProps, DataListState> {
 
   dragOver = (evt: React.DragEvent) => {
     evt.preventDefault();
-    const currListItem = (evt.target as Element).closest('li');
-    if (currListItem && currListItem.classList.contains(css(styles.modifiers.ghostRow))) {
-      return;
+    
+    const curListItem = (evt.target as HTMLElement).closest('li');
+    if (
+      !curListItem ||
+      !this.ref.current.contains(curListItem) ||
+      curListItem.id === this.state.draggedItemId
+    ) {
+      // We're going nowhere, don't bother calling `dragOver0`
+      return null;
     }
-    this.dragOver0(currListItem.id);
+    else {
+      this.dragOver0(curListItem.id);
+    }
   };
 
   handleDragButtonKeys = (evt: React.KeyboardEvent) => {
     const { dragging } = this.state;
-    const { onDragCancel } = this.props;
     if (
       evt.key !== ' ' &&
       evt.key !== 'Escape' &&
@@ -201,7 +248,7 @@ export class DataList extends React.Component<DataListProps, DataListState> {
         if (evt.key === 'Enter') {
           this.dragEnd0(dragItem);
         } else {
-          onDragCancel && onDragCancel();
+          this.onDragCancel();
         }
       } else if (evt.key === 'ArrowUp') {
         const nextSelection = dragItem.previousSibling as HTMLElement;
@@ -244,7 +291,8 @@ export class DataList extends React.Component<DataListProps, DataListState> {
 
     const dragProps = isDraggable && {
       onDragOver: this.dragOver,
-      onDrop: this.dragOver
+      onDrop: this.dragOver,
+      onDragLeave: this.dragLeave
     };
 
     return (

--- a/packages/react-core/src/components/DataList/__tests__/__snapshots__/DataList.test.tsx.snap
+++ b/packages/react-core/src/components/DataList/__tests__/__snapshots__/DataList.test.tsx.snap
@@ -198,6 +198,7 @@ exports[`DataList List draggable 1`] = `
   <ul
     aria-label="this is a simple list"
     className="pf-c-data-list pf-m-compact"
+    onDragLeave={[Function]}
     onDragOver={[Function]}
     onDrop={[Function]}
     style={Object {}}

--- a/packages/react-core/src/components/DataList/examples/DataList.md
+++ b/packages/react-core/src/components/DataList/examples/DataList.md
@@ -1162,7 +1162,6 @@ class DraggableDataList extends React.Component {
     };
 
     this.onDragFinish = itemOrder => {
-      console.log('need to save new list', itemOrder);
       this.setState({
         liveText: `Dragging finished`,
         itemOrder


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4941. If the user tries to drag/drop with the mouse outside the `<ul>` cancel the drop altogether. If they use the keyboard and press Escape do the same.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
