### PR TITLE
feat(toggleGroup): add suport to text + icon

### DIFF
--- a/packages/react-core/src/components/ToggleGroup/ToggleGroupItem.tsx
+++ b/packages/react-core/src/components/ToggleGroup/ToggleGroupItem.tsx
@@ -2,19 +2,15 @@ import * as React from 'react';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/ToggleGroup/toggle-group';
 import ToggleGroupContext from './ToggleGroupContext';
-
-export enum ToggleGroupItemVariant {
-  icon = 'icon',
-  text = 'text'
-}
+import { ToggleGroupItemVariant, ToggleGroupItemElement } from './ToggleGroupItemElement';
 
 export interface ToggleGroupItemProps extends Omit<React.HTMLProps<HTMLDivElement>, 'onChange'> {
-  /** Content rendered inside the toggle group item */
-  children?: React.ReactNode;
+  /** Text rendered inside the toggle group item */
+  text?: React.ReactNode;
+  /** Icon rendered inside the toggle group item */
+  icon?: React.ReactNode;
   /** Additional classes added to the toggle group item */
   className?: string;
-  /** Adds toggle group item variant styles */
-  variant?: ToggleGroupItemVariant | 'icon' | 'text';
   /** Flag indicating if the toggle group item is disabled */
   isDisabled?: boolean;
   /** Flag indicating if the toggle group item is selected */
@@ -28,9 +24,9 @@ export interface ToggleGroupItemProps extends Omit<React.HTMLProps<HTMLDivElemen
 }
 
 export const ToggleGroupItem: React.FunctionComponent<ToggleGroupItemProps> = ({
-  children,
+  text,
+  icon,
   className,
-  variant = 'text',
   isDisabled = false,
   isSelected = false,
   'aria-label': ariaLabel = '',
@@ -44,7 +40,7 @@ export const ToggleGroupItem: React.FunctionComponent<ToggleGroupItemProps> = ({
     onChange(!isSelected, event);
   };
 
-  if (!ariaLabel && variant === ToggleGroupItemVariant.icon) {
+  if (!ariaLabel && icon && !text) {
     /* eslint-disable no-console */
     console.warn('An accessible aria-label is required when using the toggle group item icon variant.');
   }
@@ -63,11 +59,8 @@ export const ToggleGroupItem: React.FunctionComponent<ToggleGroupItemProps> = ({
         {...(isDisabled && { disabled: true })}
         {...(buttonId && { id: buttonId })}
       >
-        <span
-          className={css(variant === 'icon' && styles.toggleGroupIcon, variant === 'text' && styles.toggleGroupText)}
-        >
-          {children}
-        </span>
+        {icon ? <ToggleGroupItemElement variant={ToggleGroupItemVariant.icon}>{icon}</ToggleGroupItemElement> : null}
+        {text ? <ToggleGroupItemElement variant={ToggleGroupItemVariant.text}>{text}</ToggleGroupItemElement> : null}
       </button>
     </div>
   );

--- a/packages/react-core/src/components/ToggleGroup/ToggleGroupItemElement.tsx
+++ b/packages/react-core/src/components/ToggleGroup/ToggleGroupItemElement.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { css } from '@patternfly/react-styles';
+import styles from '@patternfly/react-styles/css/components/ToggleGroup/toggle-group';
+
+export enum ToggleGroupItemVariant {
+  icon = 'icon',
+  text = 'text'
+}
+
+export interface ToggleGroupItemElementProps {
+  /** Content rendered inside the toggle group item */
+  children?: React.ReactNode;
+  /** Adds toggle group item variant styles */
+  variant?: ToggleGroupItemVariant | 'icon' | 'text';
+}
+
+export const ToggleGroupItemElement: React.FunctionComponent<ToggleGroupItemElementProps> = ({ variant, children }) => (
+  <span className={css(variant === 'icon' && styles.toggleGroupIcon, variant === 'text' && styles.toggleGroupText)}>
+    {children}
+  </span>
+);
+ToggleGroupItemElement.displayName = 'ToggleGroupItemElement';

--- a/packages/react-core/src/components/ToggleGroup/__tests__/ToggleGroup.test.tsx
+++ b/packages/react-core/src/components/ToggleGroup/__tests__/ToggleGroup.test.tsx
@@ -9,29 +9,29 @@ const props = {
 };
 
 test('basic selected', () => {
-  const view = shallow(<ToggleGroupItem selected buttonId="toggleGroupItem" aria-label="basic selected" />);
+  const view = shallow(<ToggleGroupItem text="test" selected buttonId="toggleGroupItem" aria-label="basic selected" />);
   expect(view).toMatchSnapshot();
 });
 
 test('basic not selected', () => {
-  const view = shallow(<ToggleGroupItem buttonId="toggleGroupItem" aria-label="basic not selected" />);
+  const view = shallow(<ToggleGroupItem text="test" buttonId="toggleGroupItem" aria-label="basic not selected" />);
   expect(view).toMatchSnapshot();
 });
 
 test('icon variant', () => {
-  const view = shallow(<ToggleGroupItem selected variant="icon" buttonId="toggleGroupItem" aria-label="icon variant" />);
+  const view = shallow(<ToggleGroupItem selected icon="icon" buttonId="toggleGroupItem" aria-label="icon variant" />);
   expect(view).toMatchSnapshot();
 });
 
 test('isDisabled', () => {
-  const view = shallow(<ToggleGroupItem isDisabled buttonId="toggleGroupItem" aria-label="isDisabled" />);
+  const view = shallow(<ToggleGroupItem text="test" isDisabled buttonId="toggleGroupItem" aria-label="isDisabled" />);
   expect(view).toMatchSnapshot();
 });
 
 test('item passes selection and event to onChange handler', () => {
   const selected = true;
   const event = {};
-  const view = shallow(<ToggleGroupItem buttonId="toggleGroupItem" onChange={props.onChange} aria-label="onChange handler" />);
+  const view = shallow(<ToggleGroupItem text="test" buttonId="toggleGroupItem" onChange={props.onChange} aria-label="onChange handler" />);
   view.find('button').simulate('click', event, selected);
   expect(props.onChange).toBeCalledWith(selected, event);
 });
@@ -39,8 +39,8 @@ test('item passes selection and event to onChange handler', () => {
 test('default theme has dividers', () => {
   const view = mount(
     <ToggleGroup>
-      <ToggleGroupItem>Test</ToggleGroupItem>
-      <ToggleGroupItem>Test</ToggleGroupItem>
+      <ToggleGroupItem text="Test" />
+      <ToggleGroupItem text="Test" />
     </ToggleGroup>
   );
   const dividerEl = view.find('Divider');
@@ -50,8 +50,8 @@ test('default theme has dividers', () => {
 test('light theme', () => {
   const view = shallow(
     <ToggleGroup variant="light">
-      <ToggleGroupItem>Test</ToggleGroupItem>
-      <ToggleGroupItem>Test</ToggleGroupItem>
+      <ToggleGroupItem text="Test" />
+      <ToggleGroupItem text="Test" />
     </ToggleGroup>
   );
   expect(view).toMatchSnapshot();

--- a/packages/react-core/src/components/ToggleGroup/__tests__/ToggleGroupItemElement.test.tsx
+++ b/packages/react-core/src/components/ToggleGroup/__tests__/ToggleGroupItemElement.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { ToggleGroupItemElement, ToggleGroupItemVariant } from '../ToggleGroupItemElement';
+
+test('text variant', () => {
+  const view = shallow(<ToggleGroupItemElement variant={ToggleGroupItemVariant.text}>Test</ToggleGroupItemElement>);
+  expect(view).toMatchSnapshot();
+});
+
+test('icon variant', () => {
+  const view = shallow(<ToggleGroupItemElement variant={ToggleGroupItemVariant.icon}>ICON</ToggleGroupItemElement>);
+  expect(view).toMatchSnapshot();
+});
+
+test('empty', () => {
+  const view = shallow(<ToggleGroupItemElement />);
+  expect(view).toMatchSnapshot();
+});

--- a/packages/react-core/src/components/ToggleGroup/__tests__/__snapshots__/ToggleGroup.test.tsx.snap
+++ b/packages/react-core/src/components/ToggleGroup/__tests__/__snapshots__/ToggleGroup.test.tsx.snap
@@ -11,9 +11,11 @@ exports[`basic not selected 1`] = `
     id="toggleGroupItem"
     onClick={[Function]}
   >
-    <span
-      className="pf-c-toggle-group__text"
-    />
+    <ToggleGroupItemElement
+      variant="text"
+    >
+      test
+    </ToggleGroupItemElement>
   </button>
 </div>
 `;
@@ -30,9 +32,11 @@ exports[`basic selected 1`] = `
     id="toggleGroupItem"
     onClick={[Function]}
   >
-    <span
-      className="pf-c-toggle-group__text"
-    />
+    <ToggleGroupItemElement
+      variant="text"
+    >
+      test
+    </ToggleGroupItemElement>
   </button>
 </div>
 `;
@@ -49,9 +53,11 @@ exports[`icon variant 1`] = `
     id="toggleGroupItem"
     onClick={[Function]}
   >
-    <span
-      className="pf-c-toggle-group__icon"
-    />
+    <ToggleGroupItemElement
+      variant="icon"
+    >
+      icon
+    </ToggleGroupItemElement>
   </button>
 </div>
 `;
@@ -68,9 +74,11 @@ exports[`isDisabled 1`] = `
     id="toggleGroupItem"
     onClick={[Function]}
   >
-    <span
-      className="pf-c-toggle-group__text"
-    />
+    <ToggleGroupItemElement
+      variant="text"
+    >
+      test
+    </ToggleGroupItemElement>
   </button>
 </div>
 `;
@@ -87,17 +95,17 @@ exports[`light theme 1`] = `
     className="pf-c-toggle-group"
     role="group"
   >
-    <ToggleGroupItem>
-      Test
-    </ToggleGroupItem>
+    <ToggleGroupItem
+      text="Test"
+    />
     <Divider
       component="div"
       isVertical={true}
       key="0 divider"
     />
-    <ToggleGroupItem>
-      Test
-    </ToggleGroupItem>
+    <ToggleGroupItem
+      text="Test"
+    />
   </div>
 </ContextProvider>
 `;

--- a/packages/react-core/src/components/ToggleGroup/__tests__/__snapshots__/ToggleGroupItemElement.test.tsx.snap
+++ b/packages/react-core/src/components/ToggleGroup/__tests__/__snapshots__/ToggleGroupItemElement.test.tsx.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`empty 1`] = `
+<span
+  className=""
+/>
+`;
+
+exports[`icon variant 1`] = `
+<span
+  className="pf-c-toggle-group__icon"
+>
+  ICON
+</span>
+`;
+
+exports[`text variant 1`] = `
+<span
+  className="pf-c-toggle-group__text"
+>
+  Test
+</span>
+`;

--- a/packages/react-core/src/components/ToggleGroup/examples/ToggleGroup.md
+++ b/packages/react-core/src/components/ToggleGroup/examples/ToggleGroup.md
@@ -7,12 +7,13 @@ beta: true
 ---
 import './toggleGroup.css';
 
-import { ToggleGroup, ToggleGroupItem, ToggleGroupItemVariant } from '@patternfly/react-core';
+import { ToggleGroup, ToggleGroupItem} from '@patternfly/react-core';
 import UndoIcon from '@patternfly/react-icons/dist/js/icons/undo-icon';
 import CopyIcon from '@patternfly/react-icons/dist/js/icons/copy-icon';
-import ShareSquareIcon from '@patternfly/react-icons/dist/js/icons/share-square-icon'; 
+import ShareSquareIcon from '@patternfly/react-icons/dist/js/icons/share-square-icon';
 
 ## Examples
+
 ### Default with multiple selectable
 ```js
 import React from 'react';
@@ -37,26 +38,21 @@ class DefaultToggleGroupExample extends React.Component {
       });
     };
   }
-  
+
   render() {
     const { isSelected } = this.state;
-    
+
     return (
       <ToggleGroup aria-label="Default with multiple selectable">
-        <ToggleGroupItem key={0} buttonId="first" isSelected={isSelected.first} onChange={this.handleItemClick}>
-          Option 1
-        </ToggleGroupItem>
-        <ToggleGroupItem key={1} buttonId="second" isSelected={isSelected.second} onChange={this.handleItemClick}>
-          Option 2
-        </ToggleGroupItem>
-        <ToggleGroupItem key={2} isDisabled>
-          Option 3
-        </ToggleGroupItem>
+        <ToggleGroupItem text="Option 1" key={0} buttonId="first" isSelected={isSelected.first} onChange={this.handleItemClick} />
+        <ToggleGroupItem text="Option 2" key={1} buttonId="second" isSelected={isSelected.second} onChange={this.handleItemClick} />
+        <ToggleGroupItem text="Option 3" key={2} isDisabled/>
       </ToggleGroup>
     );
   }
 }
 ```
+
 ### Default with single selectable
 ```js
 import React from 'react';
@@ -73,33 +69,28 @@ class DefaultAsRadioToggleGroupExample extends React.Component {
       this.setState({ isSelected: id });
     };
   }
-  
+
   render() {
     const { isSelected } = this.state;
-    
+
     return (
       <ToggleGroup aria-label="Default with single selectable">
-        <ToggleGroupItem buttonId="firstRadio" isSelected={isSelected === "firstRadio"} onChange={this.handleItemClick}>
-          Option 1
-        </ToggleGroupItem>
-        <ToggleGroupItem buttonId="secondRadio" isSelected={isSelected === "secondRadio"} onChange={this.handleItemClick}>
-          Option 2
-        </ToggleGroupItem>
-        <ToggleGroupItem buttonId="thirdRadio" isSelected={isSelected === "thirdRadio"} onChange={this.handleItemClick}>
-          Option 3
-        </ToggleGroupItem>
+        <ToggleGroupItem text="Option 1" buttonId="firstRadio" isSelected={isSelected === "firstRadio"} onChange={this.handleItemClick} />
+        <ToggleGroupItem text="Option 2" buttonId="secondRadio" isSelected={isSelected === "secondRadio"} onChange={this.handleItemClick} />
+        <ToggleGroupItem text="Option 3" buttonId="thirdRadio" isSelected={isSelected === "thirdRadio"} onChange={this.handleItemClick} />
       </ToggleGroup>
     );
   }
 }
 ```
+
 ### Icons
 ```js
 import React from 'react';
-import { ToggleGroup, ToggleGroupItem, ToggleGroupItemVariant } from '@patternfly/react-core';
+import { ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
 import UndoIcon from '@patternfly/react-icons/dist/js/icons/undo-icon';
 import CopyIcon from '@patternfly/react-icons/dist/js/icons/copy-icon';
-import ShareSquareIcon from '@patternfly/react-icons/dist/js/icons/share-square-icon'; 
+import ShareSquareIcon from '@patternfly/react-icons/dist/js/icons/share-square-icon';
 
 class IconToggleGroupExample extends React.Component {
   constructor(props) {
@@ -121,20 +112,56 @@ class IconToggleGroupExample extends React.Component {
       });
     };
   }
-  
+
   render() {
     const { isSelected } = this.state;
     return (
       <ToggleGroup aria-label="Icon variant toggle group">
-        <ToggleGroupItem aria-label="copy icon button" buttonId="third" variant={ToggleGroupItemVariant.icon} isSelected={isSelected.third} onChange={this.handleItemClick}>
-          <CopyIcon />
-        </ToggleGroupItem>
-        <ToggleGroupItem aria-label="undo icon button" buttonId="fourth" variant={ToggleGroupItemVariant.icon} isSelected={isSelected.fourth} onChange={this.handleItemClick}>
-          <UndoIcon />
-        </ToggleGroupItem>
-        <ToggleGroupItem aria-label="share square icon button" buttonId="fifth"  variant={ToggleGroupItemVariant.icon} isSelected={isSelected.fifth} onChange={this.handleItemClick}>
-          <ShareSquareIcon />
-        </ToggleGroupItem>
+        <ToggleGroupItem icon={<CopyIcon />} aria-label="copy icon button" buttonId="third" isSelected={isSelected.third} onChange={this.handleItemClick} />
+        <ToggleGroupItem icon={<UndoIcon />} aria-label="undo icon button" buttonId="fourth" isSelected={isSelected.fourth} onChange={this.handleItemClick} />
+        <ToggleGroupItem icon={<ShareSquareIcon />} aria-label="share square icon button" buttonId="fifth" isSelected={isSelected.fifth} onChange={this.handleItemClick} />
+      </ToggleGroup>
+    );
+  }
+}
+```
+
+### Text and icons
+```js
+import React from 'react';
+import { ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
+import UndoIcon from '@patternfly/react-icons/dist/js/icons/undo-icon';
+import CopyIcon from '@patternfly/react-icons/dist/js/icons/copy-icon';
+import ShareSquareIcon from '@patternfly/react-icons/dist/js/icons/share-square-icon';
+
+class TextIconToggleGroupExample extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isSelected: {
+        third: false,
+        fourth: false,
+        fifth: true
+      }
+    };
+    this.handleItemClick = (isSelected, event) => {
+      const id = event.currentTarget.id;
+      this.setState(prevState => {
+        prevState.isSelected[id] = isSelected;
+        return {
+          isSelected: prevState.isSelected
+        };
+      });
+    };
+  }
+
+  render() {
+    const { isSelected } = this.state;
+    return (
+      <ToggleGroup aria-label="Icon variant toggle group">
+        <ToggleGroupItem icon={<CopyIcon />} text="Copy" aria-label="copy icon button" buttonId="third" isSelected={isSelected.third} onChange={this.handleItemClick} />
+        <ToggleGroupItem icon={<UndoIcon />} text="Undo" aria-label="undo icon button" buttonId="fourth" isSelected={isSelected.fourth} onChange={this.handleItemClick} />
+        <ToggleGroupItem icon={<ShareSquareIcon />} text="Share" aria-label="share square icon button" buttonId="fifth" isSelected={isSelected.fifth} onChange={this.handleItemClick} />
       </ToggleGroup>
     );
   }
@@ -165,21 +192,15 @@ constructor(props) {
       });
     };
   }
-  
+
   render() {
     const { isSelected } = this.state;
-    
+
     return (
       <ToggleGroup variant={ToggleGroupVariant.light} aria-label="Light variant toggle group">
-        <ToggleGroupItem buttonId="sixth" isSelected={isSelected.sixth} onChange={this.handleItemClick}>
-          Option 1
-        </ToggleGroupItem>
-        <ToggleGroupItem buttonId="seventh" isSelected={isSelected.seventh} onChange={this.handleItemClick}>
-          Option 2
-        </ToggleGroupItem>
-        <ToggleGroupItem isDisabled>
-          Option 3
-        </ToggleGroupItem>
+        <ToggleGroupItem text="Option 1" buttonId="sixth" isSelected={isSelected.sixth} onChange={this.handleItemClick} />
+        <ToggleGroupItem text="Option 2" buttonId="seventh" isSelected={isSelected.seventh} onChange={this.handleItemClick} />
+        <ToggleGroupItem text="Option 3" isDisabled />
       </ToggleGroup>
     );
   }

--- a/packages/react-integration/demo-app-ts/src/components/demos/ToggleGroupDemo/ToggleGroupDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/ToggleGroupDemo/ToggleGroupDemo.tsx
@@ -1,11 +1,5 @@
 import React from 'react';
-import {
-  ToggleGroup,
-  ToggleGroupItem,
-  ToggleGroupItemVariant,
-  ToggleGroupVariant,
-  ToggleGroupProps
-} from '@patternfly/react-core';
+import { ToggleGroup, ToggleGroupItem, ToggleGroupVariant, ToggleGroupProps } from '@patternfly/react-core';
 import UndoIcon from '@patternfly/react-icons/dist/js/icons/undo-icon';
 import CopyIcon from '@patternfly/react-icons/dist/js/icons/copy-icon';
 import ShareSquareIcon from '@patternfly/react-icons/dist/js/icons/share-square-icon';
@@ -57,58 +51,65 @@ export class ToggleGroupDemo extends React.Component<ToggleGroupProps, ToggleGro
     return (
       <>
         <ToggleGroup>
-          <ToggleGroupItem key={0} buttonId="first" isSelected={isSelected.first} onChange={this.handleItemClick}>
-            Option 1
-          </ToggleGroupItem>
-          <ToggleGroupItem key={1} buttonId="second" isSelected={isSelected.second} onChange={this.handleItemClick}>
-            Option 2
-          </ToggleGroupItem>
-          <ToggleGroupItem key={2} buttonId="disabled" isDisabled>
-            Option 3
-          </ToggleGroupItem>
+          <ToggleGroupItem
+            text="Option 1"
+            key={0}
+            buttonId="first"
+            isSelected={isSelected.first}
+            onChange={this.handleItemClick}
+          />
+          <ToggleGroupItem
+            text="Option 2"
+            key={1}
+            buttonId="second"
+            isSelected={isSelected.second}
+            onChange={this.handleItemClick}
+          />
+          <ToggleGroupItem text="Option 3" key={2} buttonId="disabled" isDisabled />
         </ToggleGroup>
         <ToggleGroup>
           <ToggleGroupItem
+            icon={<CopyIcon />}
             key={3}
             buttonId="third"
-            variant={ToggleGroupItemVariant.icon}
             isSelected={isSelected.third}
             onChange={this.handleItemClick}
             aria-label="copy icon button"
-          >
-            <CopyIcon />
-          </ToggleGroupItem>
+          />
           <ToggleGroupItem
+            icon={<UndoIcon />}
             key={4}
             buttonId="fourth"
-            variant={ToggleGroupItemVariant.icon}
             isSelected={isSelected.fourth}
             onChange={this.handleItemClick}
             aria-label="undo icon button"
-          >
-            <UndoIcon />
-          </ToggleGroupItem>
+          />
           <ToggleGroupItem
+            icon={<ShareSquareIcon />}
+            text="Share"
             key={5}
             buttonId="fifth"
-            variant={ToggleGroupItemVariant.icon}
             isSelected={isSelected.fifth}
             onChange={this.handleItemClick}
             aria-label="share square icon button"
-          >
-            <ShareSquareIcon />
-          </ToggleGroupItem>
+          />
         </ToggleGroup>
         <ToggleGroup variant={ToggleGroupVariant.light}>
-          <ToggleGroupItem key={6} buttonId="sixth" isSelected={isSelected.sixth} onChange={this.handleItemClick}>
-            Option 1
-          </ToggleGroupItem>
-          <ToggleGroupItem key={7} buttonId="seventh" isSelected={isSelected.seventh} onChange={this.handleItemClick}>
-            Option 2
-          </ToggleGroupItem>
-          <ToggleGroupItem key={8} isDisabled>
-            Option 3
-          </ToggleGroupItem>
+          <ToggleGroupItem
+            text="Option 1"
+            key={6}
+            buttonId="sixth"
+            isSelected={isSelected.sixth}
+            onChange={this.handleItemClick}
+          />
+          <ToggleGroupItem
+            text="Option 2"
+            key={7}
+            buttonId="seventh"
+            isSelected={isSelected.seventh}
+            onChange={this.handleItemClick}
+          />
+          <ToggleGroupItem icon={<CopyIcon />} text="Option 3" key={8} isDisabled />
         </ToggleGroup>
       </>
     );


### PR DESCRIPTION
**What**: Closes #4716 

I am still not sure whether the text can be passed through the `children` or the `text` props.

WDYT?

//cc @mcoker 