### PR TITLE
chore(charts): Legend tooltip example: Fix createContainer property order

### DIFF
--- a/packages/react-charts/src/components/ChartArea/examples/ChartArea.md
+++ b/packages/react-charts/src/components/ChartArea/examples/ChartArea.md
@@ -97,7 +97,7 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor, ChartLegendTo
 class BottomAlignedLegend extends React.Component {
   render() {
     // Note: Container order is important
-    const CursorVoronoiContainer = createContainer("cursor", "voronoi");
+    const CursorVoronoiContainer = createContainer("voronoi", "cursor");
     const legendData = [{ childName: 'cats', name: 'Cats' }, { childName: 'dogs', name: 'Dogs' }, { childName: 'birds', name: 'Birds' }];
 
     return (

--- a/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
+++ b/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
@@ -352,9 +352,6 @@ class InteractiveLegendChart extends React.Component {
       const { hiddenSeries } = this.state; // Skip if already hidden                
       return hiddenSeries.has(index);
     };
-
-    // Note: Container order is important
-    this.CursorVoronoiContainer = createContainer("cursor", "voronoi");
   };
 
   componentDidMount() {
@@ -373,6 +370,9 @@ class InteractiveLegendChart extends React.Component {
   // 4. Omit tooltip when all data series are hidden
   render() {
     const { hiddenSeries, width } = this.state;
+
+    // Note: Container order is important
+    const CursorVoronoiContainer = createContainer("voronoi", "cursor");
     const allHidden = hiddenSeries.length === this.series.length;
     const tooltip = ({ datum }) => datum.childName.includes('area-') && datum.y !== null ? `${datum.y}` : null;
 
@@ -384,7 +384,7 @@ class InteractiveLegendChart extends React.Component {
             ariaDesc="Average number of pets"
             ariaTitle="Area chart example"
             containerComponent={
-              <this.CursorVoronoiContainer
+              <CursorVoronoiContainer
                 cursorDimension="x"
                 labels={!allHidden ? tooltip : undefined}
                 labelComponent={<ChartLegendTooltip legendData={this.getLegendData()} title={(datum) => datum.x}/>}

--- a/packages/react-charts/src/components/ChartLine/examples/ChartLine.md
+++ b/packages/react-charts/src/components/ChartLine/examples/ChartLine.md
@@ -103,7 +103,7 @@ import { Chart, ChartAxis, ChartGroup, ChartLine, ChartThemeColor, ChartLegendTo
 class BottomAlignedLegend extends React.Component {
   render() {
     // Note: Container order is important
-    const CursorVoronoiContainer = createContainer("cursor", "voronoi");
+    const CursorVoronoiContainer = createContainer("voronoi", "cursor");
     const legendData = [{ childName: 'cats', name: 'Cats' }, { childName: 'dogs', name: 'Dogs', symbol: { type: 'dash' }}, { childName: 'birds', name: 'Birds' }, { childName: 'mice', name: 'Mice' }];
 
     return (

--- a/packages/react-charts/src/components/ChartStack/examples/ChartStack.md
+++ b/packages/react-charts/src/components/ChartStack/examples/ChartStack.md
@@ -328,7 +328,7 @@ class MultiColorChart extends React.Component {
     const { width } = this.state;
     
     // Note: Container order is important
-    const CursorVoronoiContainer = createContainer("cursor", "voronoi");
+    const CursorVoronoiContainer = createContainer("voronoi", "cursor");
     const legendData = [{ childName: 'cats', name: 'Cats' }, { childName: 'dogs', name: 'Dogs' }, { childName: 'birds', name: 'Birds' }];
     
     return (

--- a/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
+++ b/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
@@ -113,7 +113,7 @@ import { Chart, ChartAxis, ChartGroup, ChartLine, ChartThemeColor, ChartTooltip,
 class CombinedCursorVoronoiContainer extends React.Component {
   render() {
     // Note: Container order is important
-    const CursorVoronoiContainer = createContainer("cursor", "voronoi");
+    const CursorVoronoiContainer = createContainer("voronoi", "cursor");
 
     return (
       <div>
@@ -205,7 +205,7 @@ import global_FontWeight_bold from '@patternfly/react-tokens/dist/js/global_Font
 class EmbeddedLegend extends React.Component {
   render() {
     // Note: Container order is important
-    const CursorVoronoiContainer = createContainer("cursor", "voronoi");
+    const CursorVoronoiContainer = createContainer("voronoi", "cursor");
     const legendData = [{ childName: 'cats', name: 'Cats' }, { childName: 'dogs', name: 'Dogs', symbol: { type: 'dash' }}, { childName: 'birds', name: 'Birds' }, { childName: 'mice', name: 'Mice' }];
     
     return (
@@ -309,7 +309,7 @@ class EmbeddedHtml extends React.Component {
 
   render() {
     // Note: Container order is important
-    const CursorVoronoiContainer = createContainer("cursor", "voronoi");
+    const CursorVoronoiContainer = createContainer("voronoi", "cursor");
     const legendData = [{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }];
 
     // Custom HTML component to create a legend layout


### PR DESCRIPTION
This fixes the `createContainer` property order for the chart legend tooltip examples.

Ensures the tooltip continues to work after charts are re-rendered (e.g., when the browser window is resized).

Fixes https://github.com/patternfly/patternfly-react/issues/5005
