### PR TITLE
chore(ci): fix linting errors in Nav and Modal demo

### DIFF
--- a/packages/react-core/src/components/Nav/NavExpandable.tsx
+++ b/packages/react-core/src/components/Nav/NavExpandable.tsx
@@ -94,23 +94,23 @@ export class NavExpandable extends React.Component<NavExpandableProps, NavExpand
   };
 
   render() {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const {
-      id,
       title,
       srText,
       children,
       className,
       isActive,
-      groupId,
-      isExpanded,
-      onExpand,
       ouiaId,
-      ouiaSafe,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      groupId,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      id,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      isExpanded,
       ...props
     } = this.props;
 
-    const { expandedState } = this.state;
+    const { expandedState, ouiaStateId } = this.state;
 
     const onClick = () => {
       this.setState(prevState => ({ expandedState: !prevState.expandedState }));
@@ -127,10 +127,7 @@ export class NavExpandable extends React.Component<NavExpandableProps, NavExpand
               isActive && styles.modifiers.current,
               className
             )}
-            {...getOUIAProps(
-              NavExpandable.displayName,
-              this.props.ouiaId !== undefined ? this.props.ouiaId : this.state.ouiaStateId
-            )}
+            {...getOUIAProps(NavExpandable.displayName, ouiaId !== undefined ? ouiaId : ouiaStateId)}
             onClick={(e: React.MouseEvent<HTMLLIElement, MouseEvent>) => this.handleToggle(e, context.onToggle)}
             {...props}
           >

--- a/packages/react-integration/demo-app-ts/src/components/demos/ModalDemo/ModalDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/ModalDemo/ModalDemo.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Modal, ModalVariant, Button, Title, TitleSizes } from '@patternfly/react-core';
 import WarningTriangleIcon from '@patternfly/react-icons/dist/js/icons/warning-triangle-icon';
-import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 
 interface ModalDemoState {
   isModalOpen: boolean;


### PR DESCRIPTION
**What**: Closes #

in https://github.com/patternfly/patternfly-react/pull/5014 the pf4 lint job fails.
It looks like it is due to a very small issue with the Nav component and the Modal demo.

```
/home/circleci/project/packages/react-core/src/components/Nav/NavExpandable.tsx
   99:7  error  'id' is assigned a value but never used          @typescript-eslint/no-unused-vars
  105:7  error  'groupId' is assigned a value but never used     @typescript-eslint/no-unused-vars
  106:7  error  'isExpanded' is assigned a value but never used  @typescript-eslint/no-unused-vars
  107:7  error  'onExpand' is assigned a value but never used    @typescript-eslint/no-unused-vars
  108:7  error  'ouiaId' is assigned a value but never used      @typescript-eslint/no-unused-vars
  109:7  error  'ouiaSafe' is assigned a value but never used    @typescript-eslint/no-unused-vars

/home/circleci/project/packages/react-integration/demo-app-ts/src/components/demos/ModalDemo/ModalDemo.tsx
  4:8  error  'ExclamationTriangleIcon' is defined but never used  @typescript-eslint/no-unused-vars
```