### PR TITLE
fix compound expandable data labels

### DIFF
--- a/packages/react-core/src/components/Nav/NavExpandable.tsx
+++ b/packages/react-core/src/components/Nav/NavExpandable.tsx
@@ -94,19 +94,20 @@ export class NavExpandable extends React.Component<NavExpandableProps, NavExpand
   };
 
   render() {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const {
+      /* eslint-disable @typescript-eslint/no-unused-vars */
       id,
-      title,
-      srText,
-      children,
-      className,
-      isActive,
       groupId,
       isExpanded,
       onExpand,
       ouiaId,
       ouiaSafe,
+      /* eslint-enable @typescript-eslint/no-unused-vars */
+      title,
+      srText,
+      children,
+      className,
+      isActive,
       ...props
     } = this.props;
 

--- a/packages/react-integration/demo-app-ts/src/components/demos/ModalDemo/ModalDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/ModalDemo/ModalDemo.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Modal, ModalVariant, Button, Title, TitleSizes } from '@patternfly/react-core';
 import WarningTriangleIcon from '@patternfly/react-icons/dist/js/icons/warning-triangle-icon';
-import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 
 interface ModalDemoState {
   isModalOpen: boolean;

--- a/packages/react-table/src/components/Table/BodyCell.tsx
+++ b/packages/react-table/src/components/Table/BodyCell.tsx
@@ -52,7 +52,7 @@ export const BodyCell: React.FunctionComponent<BodyCellProps> = ({
   ...props
 }: BodyCellProps) => {
   const mappedProps = {
-    ...(dataLabel && !parentId ? { 'data-label': dataLabel } : {}),
+    ...(dataLabel && parentId === undefined ? { 'data-label': dataLabel } : {}),
     ...props
   };
 

--- a/packages/react-table/src/components/Table/Table.test.tsx
+++ b/packages/react-table/src/components/Table/Table.test.tsx
@@ -181,8 +181,8 @@ test('Collapsible table', () => {
 
 test('Compound Expandable table', () => {
   const compoundColumns: ColumnsType = [
-    { title: 'col1', cell: { transforms: [compoundExpand] } },
-    { title: 'col2', cell: { transforms: [compoundExpand] } }
+    { title: 'col1', cellTransforms: [compoundExpand] },
+    { title: 'col2', cellTransforms: [compoundExpand] }
   ];
   const compoundRows: IRow[] = [
     {

--- a/packages/react-table/src/components/Table/examples/Table.md
+++ b/packages/react-table/src/components/Table/examples/Table.md
@@ -786,7 +786,7 @@ class CompactTable extends React.Component {
         { title: 'Header cell' },
         'Branches',
         { title: 'Pull requests', props: { className: 'pf-u-text-align-center' } },
-        '' // deliberately empty
+        { title: '' /* deliberately empty */, dataLabel: 'Label for mobile view' }
       ],
       rows: [['one', 'two', 'three', 'four'], ['one', 'two', 'three', 'four'], ['one', 'two', 'three', 'four']]
     };
@@ -823,7 +823,7 @@ class CompactTableBorderlessRows extends React.Component {
         { title: 'Header cell' },
         'Branches',
         { title: 'Pull requests', props: { className: 'pf-u-text-align-center' } },
-        '' // deliberately empty
+        { title: '' /* deliberately empty */, dataLabel: 'Label for mobile view' }
       ],
       rows: [['one', 'two', 'three', 'four'], ['one', 'two', 'three', 'four'], ['one', 'two', 'three', 'four']]
     };
@@ -870,7 +870,7 @@ class CompactExpandableTable extends React.Component {
         },
         'Branches',
         { title: 'Pull requests' },
-        '' // deliberately empty
+        { title: '' /* deliberately empty */, dataLabel: 'Label for mobile view' }
       ],
       rows: [
         {
@@ -1115,7 +1115,10 @@ class CompoundExpandableTable extends React.Component {
           cellTransforms: [compoundExpand]
         },
         'Last Commit',
-        ''
+        {
+          title: '',
+          dataLabel: 'Action'
+        }
       ],
       rows: [
         {

--- a/packages/react-table/src/components/Table/utils/headerUtils.tsx
+++ b/packages/react-table/src/components/Table/utils/headerUtils.tsx
@@ -210,10 +210,10 @@ const addAdditionalCellTranforms = (cell: ICell, additional: any) => ({
  * Function to change expanded row with additional transforms.
  *
  * @param {*} header info with cellTransforms.
- * @param {*} extraObject with onCollapse function.
+ * @param {*} extra object with onCollapse/onExpand function.
  */
-const expandContent = (header: (ICell | string)[], { onCollapse }: { onCollapse: OnCollapse }) => {
-  if (!onCollapse) {
+const expandContent = (header: (ICell | string)[], extra: any) => {
+  if (!extra.onCollapse && !extra.onExpand) {
     return header;
   }
   return header.map((cell: ICell | string) => {


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes https://github.com/patternfly/patternfly-react/issues/4922

- Manually add `dataLabel` to columns with no titles so they appear in mobile view with some text
- Do not add a `data-label` to cells that are expandable

<img width="757" alt="Screen Shot 2020-10-14 at 1 25 59 PM" src="https://user-images.githubusercontent.com/869106/96024499-cebaf280-0e21-11eb-856f-fea775342d65.png">
