### PR TITLE
fix(Alert, NotificationDrawer): Added tooltips to truncated titles

### DIFF
--- a/packages/react-core/src/components/Alert/Alert.tsx
+++ b/packages/react-core/src/components/Alert/Alert.tsx
@@ -7,6 +7,7 @@ import { AlertIcon } from './AlertIcon';
 import { capitalize, useOUIAProps, OUIAProps } from '../../helpers';
 import { AlertContext } from './AlertContext';
 import maxLines from '@patternfly/react-tokens/dist/js/c_alert__title_max_lines';
+import { Tooltip } from '../Tooltip';
 
 export enum AlertVariant {
   success = 'success',
@@ -43,6 +44,8 @@ export interface AlertProps extends Omit<React.HTMLProps<HTMLDivElement>, 'actio
   onTimeout?: () => void;
   /** Truncate title to number of lines */
   truncateTitle?: number;
+  /** Position of the tooltip which is displayed if text is truncated */
+  tooltipPosition?: 'auto' | 'top' | 'bottom' | 'left' | 'right';
 }
 
 export const Alert: React.FunctionComponent<AlertProps> = ({
@@ -61,6 +64,7 @@ export const Alert: React.FunctionComponent<AlertProps> = ({
   timeout = false,
   onTimeout,
   truncateTitle = 0,
+  tooltipPosition,
   ...props
 }: AlertProps) => {
   const ouiaProps = useOUIAProps(Alert.displayName, ouiaId, ouiaSafe, variant);
@@ -72,12 +76,14 @@ export const Alert: React.FunctionComponent<AlertProps> = ({
   );
 
   const [disableAlert, setDisableAlert] = useState(false);
+  const [isTooltipVisible, setIsTooltipVisible] = useState(false);
   const titleRef = React.useRef(null);
   React.useEffect(() => {
     if (!titleRef.current || !truncateTitle) {
       return;
     }
     titleRef.current.style.setProperty(maxLines.name, truncateTitle.toString());
+    setIsTooltipVisible(titleRef.current && titleRef.current.offsetHeight < titleRef.current.scrollHeight);
   }, [titleRef, truncateTitle]);
   const customClassName = css(
     styles.alert,
@@ -111,9 +117,17 @@ export const Alert: React.FunctionComponent<AlertProps> = ({
         })}
       >
         <AlertIcon variant={variant} />
-        <h4 ref={titleRef} className={css(styles.alertTitle, truncateTitle && styles.modifiers.truncate)}>
-          {getHeadingContent}
-        </h4>
+        {isTooltipVisible ? (
+          <Tooltip content={getHeadingContent} position={tooltipPosition}>
+            <h4 ref={titleRef} className={css(styles.alertTitle, truncateTitle && styles.modifiers.truncate)}>
+              {getHeadingContent}
+            </h4>
+          </Tooltip>
+        ) : (
+          <h4 ref={titleRef} className={css(styles.alertTitle, truncateTitle && styles.modifiers.truncate)}>
+            {getHeadingContent}
+          </h4>
+        )}
         {actionClose && (
           <AlertContext.Provider value={{ title, variantLabel }}>
             <div className={css(styles.alertAction)}>{actionClose}</div>

--- a/packages/react-core/src/components/Alert/Alert.tsx
+++ b/packages/react-core/src/components/Alert/Alert.tsx
@@ -119,7 +119,11 @@ export const Alert: React.FunctionComponent<AlertProps> = ({
         <AlertIcon variant={variant} />
         {isTooltipVisible ? (
           <Tooltip content={getHeadingContent} position={tooltipPosition}>
-            <h4 ref={titleRef} className={css(styles.alertTitle, truncateTitle && styles.modifiers.truncate)}>
+            <h4
+              tabIndex={0}
+              ref={titleRef}
+              className={css(styles.alertTitle, truncateTitle && styles.modifiers.truncate)}
+            >
               {getHeadingContent}
             </h4>
           </Tooltip>

--- a/packages/react-core/src/components/Alert/Alert.tsx
+++ b/packages/react-core/src/components/Alert/Alert.tsx
@@ -83,13 +83,25 @@ export const Alert: React.FunctionComponent<AlertProps> = ({
       return;
     }
     titleRef.current.style.setProperty(maxLines.name, truncateTitle.toString());
-    setIsTooltipVisible(titleRef.current && titleRef.current.offsetHeight < titleRef.current.scrollHeight);
-  }, [titleRef, truncateTitle]);
+    const showTooltip = titleRef.current && titleRef.current.offsetHeight < titleRef.current.scrollHeight;
+    if (isTooltipVisible !== showTooltip) {
+      setIsTooltipVisible(showTooltip);
+    }
+  }, [titleRef, truncateTitle, isTooltipVisible]);
   const customClassName = css(
     styles.alert,
     isInline && styles.modifiers.inline,
     variant !== AlertVariant.default && styles.modifiers[variant as 'success' | 'danger' | 'warning' | 'info'],
     className
+  );
+  const Title = (
+    <h4
+      {...(isTooltipVisible && { tabIndex: 0 })}
+      ref={titleRef}
+      className={css(styles.alertTitle, truncateTitle && styles.modifiers.truncate)}
+    >
+      {getHeadingContent}
+    </h4>
   );
 
   if (disableAlert === false && timeout && timeout !== 0) {
@@ -119,18 +131,10 @@ export const Alert: React.FunctionComponent<AlertProps> = ({
         <AlertIcon variant={variant} />
         {isTooltipVisible ? (
           <Tooltip content={getHeadingContent} position={tooltipPosition}>
-            <h4
-              tabIndex={0}
-              ref={titleRef}
-              className={css(styles.alertTitle, truncateTitle && styles.modifiers.truncate)}
-            >
-              {getHeadingContent}
-            </h4>
+            {Title}
           </Tooltip>
         ) : (
-          <h4 ref={titleRef} className={css(styles.alertTitle, truncateTitle && styles.modifiers.truncate)}>
-            {getHeadingContent}
-          </h4>
+          Title
         )}
         {actionClose && (
           <AlertContext.Provider value={{ title, variantLabel }}>

--- a/packages/react-core/src/components/NotificationDrawer/NotificationDrawerGroup.tsx
+++ b/packages/react-core/src/components/NotificationDrawer/NotificationDrawerGroup.tsx
@@ -72,7 +72,7 @@ export const NotificationDrawerGroup: React.FunctionComponent<NotificationDrawer
         >
           {isTooltipVisible ? (
             <Tooltip content={title} position={tooltipPosition}>
-              <div ref={titleRef} className={css(styles.notificationDrawerGroupToggleTitle)}>
+              <div tabindex={0} ref={titleRef} className={css(styles.notificationDrawerGroupToggleTitle)}>
                 {title}
               </div>
             </Tooltip>

--- a/packages/react-core/src/components/NotificationDrawer/NotificationDrawerGroup.tsx
+++ b/packages/react-core/src/components/NotificationDrawer/NotificationDrawerGroup.tsx
@@ -72,7 +72,7 @@ export const NotificationDrawerGroup: React.FunctionComponent<NotificationDrawer
         >
           {isTooltipVisible ? (
             <Tooltip content={title} position={tooltipPosition}>
-              <div tabindex={0} ref={titleRef} className={css(styles.notificationDrawerGroupToggleTitle)}>
+              <div tabIndex={0} ref={titleRef} className={css(styles.notificationDrawerGroupToggleTitle)}>
                 {title}
               </div>
             </Tooltip>

--- a/packages/react-core/src/components/NotificationDrawer/NotificationDrawerGroup.tsx
+++ b/packages/react-core/src/components/NotificationDrawer/NotificationDrawerGroup.tsx
@@ -46,12 +46,25 @@ export const NotificationDrawerGroup: React.FunctionComponent<NotificationDrawer
   const [isTooltipVisible, setIsTooltipVisible] = React.useState(false);
   React.useEffect(() => {
     // Title will always truncate on overflow regardless of truncateTitle prop
-    setIsTooltipVisible(titleRef.current && titleRef.current.offsetHeight < titleRef.current.scrollHeight);
+    const showTooltip = titleRef.current && titleRef.current.offsetHeight < titleRef.current.scrollHeight;
+    if (isTooltipVisible !== showTooltip) {
+      setIsTooltipVisible(showTooltip);
+    }
     if (!titleRef.current || !truncateTitle) {
       return;
     }
     titleRef.current.style.setProperty(maxLines.name, truncateTitle.toString());
-  }, [titleRef, truncateTitle]);
+  }, [titleRef, truncateTitle, isTooltipVisible]);
+
+  const Title = (
+    <div
+      {...(isTooltipVisible && { tabIndex: 0 })}
+      ref={titleRef}
+      className={css(styles.notificationDrawerGroupToggleTitle)}
+    >
+      {title}
+    </div>
+  );
 
   return (
     <section
@@ -72,14 +85,10 @@ export const NotificationDrawerGroup: React.FunctionComponent<NotificationDrawer
         >
           {isTooltipVisible ? (
             <Tooltip content={title} position={tooltipPosition}>
-              <div tabIndex={0} ref={titleRef} className={css(styles.notificationDrawerGroupToggleTitle)}>
-                {title}
-              </div>
+              {Title}
             </Tooltip>
           ) : (
-            <div ref={titleRef} className={css(styles.notificationDrawerGroupToggleTitle)}>
-              {title}
-            </div>
+            Title
           )}
           <div className={css(styles.notificationDrawerGroupToggleCount)}>
             <Badge isRead={isRead}>{count}</Badge>

--- a/packages/react-core/src/components/NotificationDrawer/NotificationDrawerGroup.tsx
+++ b/packages/react-core/src/components/NotificationDrawer/NotificationDrawerGroup.tsx
@@ -45,11 +45,12 @@ export const NotificationDrawerGroup: React.FunctionComponent<NotificationDrawer
   const titleRef = React.useRef(null);
   const [isTooltipVisible, setIsTooltipVisible] = React.useState(false);
   React.useEffect(() => {
+    // Title will always truncate on overflow regardless of truncateTitle prop
+    setIsTooltipVisible(titleRef.current && titleRef.current.offsetHeight < titleRef.current.scrollHeight);
     if (!titleRef.current || !truncateTitle) {
       return;
     }
     titleRef.current.style.setProperty(maxLines.name, truncateTitle.toString());
-    setIsTooltipVisible(titleRef.current && titleRef.current.offsetHeight < titleRef.current.scrollHeight);
   }, [titleRef, truncateTitle]);
 
   return (

--- a/packages/react-core/src/components/NotificationDrawer/NotificationDrawerGroup.tsx
+++ b/packages/react-core/src/components/NotificationDrawer/NotificationDrawerGroup.tsx
@@ -6,6 +6,7 @@ import styles from '@patternfly/react-styles/css/components/NotificationDrawer/n
 import maxLines from '@patternfly/react-tokens/dist/js/c_notification_drawer__group_toggle_title_max_lines';
 
 import { Badge } from '../Badge';
+import { Tooltip } from '../Tooltip';
 
 export interface NotificationDrawerGroupProps extends React.HTMLProps<HTMLElement> {
   /**  Content rendered inside the group */
@@ -24,6 +25,8 @@ export interface NotificationDrawerGroupProps extends React.HTMLProps<HTMLElemen
   title: string;
   /** Truncate title to number of lines */
   truncateTitle?: number;
+  /** Position of the tooltip which is displayed if text is truncated */
+  tooltipPosition?: 'auto' | 'top' | 'bottom' | 'left' | 'right';
 }
 
 export const NotificationDrawerGroup: React.FunctionComponent<NotificationDrawerGroupProps> = ({
@@ -36,14 +39,17 @@ export const NotificationDrawerGroup: React.FunctionComponent<NotificationDrawer
   onExpand = (event: any, expanded: boolean) => undefined as any,
   title,
   truncateTitle = 0,
+  tooltipPosition,
   ...props
 }: NotificationDrawerGroupProps) => {
   const titleRef = React.useRef(null);
+  const [isTooltipVisible, setIsTooltipVisible] = React.useState(false);
   React.useEffect(() => {
     if (!titleRef.current || !truncateTitle) {
       return;
     }
     titleRef.current.style.setProperty(maxLines.name, truncateTitle.toString());
+    setIsTooltipVisible(titleRef.current && titleRef.current.offsetHeight < titleRef.current.scrollHeight);
   }, [titleRef, truncateTitle]);
 
   return (
@@ -63,12 +69,21 @@ export const NotificationDrawerGroup: React.FunctionComponent<NotificationDrawer
             }
           }}
         >
-          <div ref={titleRef} className={css(styles.notificationDrawerGroupToggleTitle)}>
-            {title}
-          </div>
+          {isTooltipVisible ? (
+            <Tooltip content={title} position={tooltipPosition}>
+              <div ref={titleRef} className={css(styles.notificationDrawerGroupToggleTitle)}>
+                {title}
+              </div>
+            </Tooltip>
+          ) : (
+            <div ref={titleRef} className={css(styles.notificationDrawerGroupToggleTitle)}>
+              {title}
+            </div>
+          )}
           <div className={css(styles.notificationDrawerGroupToggleCount)}>
             <Badge isRead={isRead}>{count}</Badge>
           </div>
+
           <span className="pf-c-notification-drawer__group-toggle-icon">
             <AngleRightIcon />
           </span>

--- a/packages/react-core/src/components/NotificationDrawer/NotificationDrawerListItemHeader.tsx
+++ b/packages/react-core/src/components/NotificationDrawer/NotificationDrawerListItemHeader.tsx
@@ -69,6 +69,7 @@ export const NotificationDrawerListItemHeader: React.FunctionComponent<Notificat
         {isTooltipVisible ? (
           <Tooltip content={title} position={tooltipPosition}>
             <h2
+              tabIndex={0}
               ref={titleRef}
               className={css(styles.notificationDrawerListItemHeaderTitle, truncateTitle && styles.modifiers.truncate)}
             >

--- a/packages/react-core/src/components/NotificationDrawer/NotificationDrawerListItemHeader.tsx
+++ b/packages/react-core/src/components/NotificationDrawer/NotificationDrawerListItemHeader.tsx
@@ -58,9 +58,22 @@ export const NotificationDrawerListItemHeader: React.FunctionComponent<Notificat
       return;
     }
     titleRef.current.style.setProperty(maxLines.name, truncateTitle.toString());
-    setIsTooltipVisible(titleRef.current && titleRef.current.offsetHeight < titleRef.current.scrollHeight);
-  }, [titleRef, truncateTitle]);
+    const showTooltip = titleRef.current && titleRef.current.offsetHeight < titleRef.current.scrollHeight;
+    if (isTooltipVisible !== showTooltip) {
+      setIsTooltipVisible(showTooltip);
+    }
+  }, [titleRef, truncateTitle, isTooltipVisible]);
   const Icon = variantIcons[variant];
+  const Title = (
+    <h2
+      {...(isTooltipVisible && { tabIndex: 0 })}
+      ref={titleRef}
+      className={css(styles.notificationDrawerListItemHeaderTitle, truncateTitle && styles.modifiers.truncate)}
+    >
+      {srTitle && <span className={css(a11yStyles.screenReader)}>{srTitle}</span>}
+      {title}
+    </h2>
+  );
 
   return (
     <React.Fragment>
@@ -68,23 +81,10 @@ export const NotificationDrawerListItemHeader: React.FunctionComponent<Notificat
         <span className={css(styles.notificationDrawerListItemHeaderIcon)}>{icon ? icon : <Icon />}</span>
         {isTooltipVisible ? (
           <Tooltip content={title} position={tooltipPosition}>
-            <h2
-              tabIndex={0}
-              ref={titleRef}
-              className={css(styles.notificationDrawerListItemHeaderTitle, truncateTitle && styles.modifiers.truncate)}
-            >
-              {srTitle && <span className={css(a11yStyles.screenReader)}>{srTitle}</span>}
-              {title}
-            </h2>
+            {Title}
           </Tooltip>
         ) : (
-          <h2
-            ref={titleRef}
-            className={css(styles.notificationDrawerListItemHeaderTitle, truncateTitle && styles.modifiers.truncate)}
-          >
-            {srTitle && <span className={css(a11yStyles.screenReader)}>{srTitle}</span>}
-            {title}
-          </h2>
+          Title
         )}
       </div>
       {children && <div className={css(styles.notificationDrawerListItemAction)}>{children}</div>}

--- a/packages/react-core/src/components/NotificationDrawer/NotificationDrawerListItemHeader.tsx
+++ b/packages/react-core/src/components/NotificationDrawer/NotificationDrawerListItemHeader.tsx
@@ -11,6 +11,8 @@ import a11yStyles from '@patternfly/react-styles/css/utilities/Accessibility/acc
 
 import maxLines from '@patternfly/react-tokens/dist/js/c_notification_drawer__list_item_header_title_max_lines';
 
+import { Tooltip } from '../Tooltip';
+
 export const variantIcons = {
   success: CheckCircleIcon,
   danger: ExclamationCircleIcon,
@@ -34,6 +36,8 @@ export interface NotificationDrawerListItemHeaderProps extends React.HTMLProps<H
   variant?: 'success' | 'danger' | 'warning' | 'info' | 'default';
   /** Truncate title to number of lines */
   truncateTitle?: number;
+  /** Position of the tooltip which is displayed if text is truncated */
+  tooltipPosition?: 'auto' | 'top' | 'bottom' | 'left' | 'right';
 }
 
 export const NotificationDrawerListItemHeader: React.FunctionComponent<NotificationDrawerListItemHeaderProps> = ({
@@ -44,14 +48,17 @@ export const NotificationDrawerListItemHeader: React.FunctionComponent<Notificat
   title,
   variant = 'default',
   truncateTitle = 0,
+  tooltipPosition,
   ...props
 }: NotificationDrawerListItemHeaderProps) => {
   const titleRef = React.useRef(null);
+  const [isTooltipVisible, setIsTooltipVisible] = React.useState(false);
   React.useEffect(() => {
     if (!titleRef.current || !truncateTitle) {
       return;
     }
     titleRef.current.style.setProperty(maxLines.name, truncateTitle.toString());
+    setIsTooltipVisible(titleRef.current && titleRef.current.offsetHeight < titleRef.current.scrollHeight);
   }, [titleRef, truncateTitle]);
   const Icon = variantIcons[variant];
 
@@ -59,13 +66,25 @@ export const NotificationDrawerListItemHeader: React.FunctionComponent<Notificat
     <React.Fragment>
       <div {...props} className={css(styles.notificationDrawerListItemHeader, className)}>
         <span className={css(styles.notificationDrawerListItemHeaderIcon)}>{icon ? icon : <Icon />}</span>
-        <h2
-          ref={titleRef}
-          className={css(styles.notificationDrawerListItemHeaderTitle, truncateTitle && styles.modifiers.truncate)}
-        >
-          {srTitle && <span className={css(a11yStyles.screenReader)}>{srTitle}</span>}
-          {title}
-        </h2>
+        {isTooltipVisible ? (
+          <Tooltip content={title} position={tooltipPosition}>
+            <h2
+              ref={titleRef}
+              className={css(styles.notificationDrawerListItemHeaderTitle, truncateTitle && styles.modifiers.truncate)}
+            >
+              {srTitle && <span className={css(a11yStyles.screenReader)}>{srTitle}</span>}
+              {title}
+            </h2>
+          </Tooltip>
+        ) : (
+          <h2
+            ref={titleRef}
+            className={css(styles.notificationDrawerListItemHeaderTitle, truncateTitle && styles.modifiers.truncate)}
+          >
+            {srTitle && <span className={css(a11yStyles.screenReader)}>{srTitle}</span>}
+            {title}
+          </h2>
+        )}
       </div>
       {children && <div className={css(styles.notificationDrawerListItemAction)}>{children}</div>}
     </React.Fragment>

--- a/packages/react-core/src/components/NotificationDrawer/examples/NotificationDrawer.md
+++ b/packages/react-core/src/components/NotificationDrawer/examples/NotificationDrawer.md
@@ -47,24 +47,24 @@ class BasicNotificationDrawer extends React.Component {
     super(props);
     this.state = {
       isOpen: new Array(6).fill(false),
-      isDrawerOpen: true 
+      isDrawerOpen: true
     };
     this.onDrawerClose = () => {
       this.setState({
         isDrawerOpen: false
       });
     };
-    this.onToggle = (index) => (isOpen) => {
-      newState = [...this.state.isOpen.slice(0, index), isOpen, ...this.state.isOpen.slice(index+1)];
+    this.onToggle = index => isOpen => {
+      newState = [...this.state.isOpen.slice(0, index), isOpen, ...this.state.isOpen.slice(index + 1)];
       this.setState({ isOpen: newState });
     };
     this.onSelect = event => {
-      this.setState({isOpen: new Array(6).fill(false)});
+      this.setState({ isOpen: new Array(6).fill(false) });
     };
   }
 
   render() {
-    const [ isOpen0, isOpen1, isOpen2, isOpen3, isOpen4, isOpen5, isOpen6 ] = this.state.isOpen;
+    const [isOpen0, isOpen1, isOpen2, isOpen3, isOpen4, isOpen5, isOpen6] = this.state.isOpen;
     const dropdownItems = [
       <DropdownItem key="link">Link</DropdownItem>,
       <DropdownItem key="action" component="button">
@@ -195,10 +195,7 @@ class BasicNotificationDrawer extends React.Component {
               </NotificationDrawerListItemBody>
             </NotificationDrawerListItem>
             <NotificationDrawerListItem isRead>
-              <NotificationDrawerListItemHeader
-                title="Read (default) notification title"
-                srTitle="notification:"
-              >
+              <NotificationDrawerListItemHeader title="Read (default) notification title" srTitle="notification:">
                 <Dropdown
                   position={DropdownPosition.right}
                   onSelect={this.onSelect}

--- a/packages/react-core/src/components/NotificationDrawer/examples/NotificationDrawer.md
+++ b/packages/react-core/src/components/NotificationDrawer/examples/NotificationDrawer.md
@@ -511,10 +511,11 @@ class GroupNotificationDrawer extends React.Component {
               </NotificationDrawerList>
             </NotificationDrawerGroup>
             <NotificationDrawerGroup
-              title="Third notification group"
+              title="Third notification group. This is a long title to show how the title will be truncated if it is long and will be shown in a single line."
               isExpanded={thirdGroupExpanded}
               count={0}
               onExpand={this.toggleThirdDrawer}
+              truncateTitle={1}
             >
               <NotificationDrawerList isHidden={!thirdGroupExpanded}>
                 <EmptyState variant={EmptyStateVariant.full}>

--- a/packages/react-integration/cypress/integration/alert.spec.ts
+++ b/packages/react-integration/cypress/integration/alert.spec.ts
@@ -22,4 +22,29 @@ describe('Alert Demo Test', () => {
     cy.get('#test-button-2').click();
     cy.get('#info-alert').should('not.exist');
   });
+
+  it('Verify isTruncated title and no tooltip on short text', () => {
+    cy.get('#default-alert > .pf-c-alert__title')
+      .should('have.class', 'pf-m-truncate')
+      .then((noTooltipLink: JQuery<HTMLDivElement>) => {
+        cy.wrap(noTooltipLink)
+          .trigger('mouseenter')
+          .get('.pf-c-tooltip')
+          .should('not.exist');
+        cy.wrap(noTooltipLink).trigger('mouseleave');
+      });
+  });
+
+  it('Verify isTruncated alert title and tooltip', () => {
+    cy.get('#long-title-alert > .pf-c-alert__title')
+      .should('have.class', 'pf-m-truncate')
+      .then((tooltipLink: JQuery<HTMLDivElement>) => {
+        cy.get('.pf-c-tooltip').should('not.exist');
+        cy.wrap(tooltipLink)
+          .trigger('mouseenter')
+          .get('.pf-c-tooltip')
+          .should('exist');
+        cy.wrap(tooltipLink).trigger('mouseleave');
+      });
+  });
 });

--- a/packages/react-integration/cypress/integration/alert.spec.ts
+++ b/packages/react-integration/cypress/integration/alert.spec.ts
@@ -23,7 +23,7 @@ describe('Alert Demo Test', () => {
     cy.get('#info-alert').should('not.exist');
   });
 
-  it('Verify isTruncated title and no tooltip on short text', () => {
+  it('Verify truncateTitle and no tooltip on short text', () => {
     cy.get('#default-alert > .pf-c-alert__title')
       .should('have.class', 'pf-m-truncate')
       .then((noTooltipLink: JQuery<HTMLDivElement>) => {
@@ -35,7 +35,7 @@ describe('Alert Demo Test', () => {
       });
   });
 
-  it('Verify isTruncated alert title and tooltip', () => {
+  it('Verify truncateTitle alert and tooltip', () => {
     cy.get('#long-title-alert > .pf-c-alert__title')
       .should('have.class', 'pf-m-truncate')
       .then((tooltipLink: JQuery<HTMLDivElement>) => {

--- a/packages/react-integration/cypress/integration/notificationdrawerbasic.spec.ts
+++ b/packages/react-integration/cypress/integration/notificationdrawerbasic.spec.ts
@@ -112,7 +112,7 @@ describe('Notification Drawer Basic Demo Test', () => {
     });
   });
 
-  it('Verify isTruncated title in header list item header and no tooltip on short text', () => {
+  it('Verify truncateTitle in drawer header list item header and no tooltip on short text', () => {
     cy.get('#info-alert-item > .pf-c-notification-drawer__list-item-header-title')      .should('have.class', 'pf-m-truncate')
       .then((noTooltipLink: JQuery<HTMLDivElement>) => {
         cy.wrap(noTooltipLink)
@@ -123,7 +123,7 @@ describe('Notification Drawer Basic Demo Test', () => {
       });
   });
 
-  it('Verify isTruncated title in group title and tooltip', () => {
+  it('Verify truncateTitle in drawer group title and tooltip', () => {
     cy.get('#long-title-item > .pf-c-notification-drawer__list-item-header-title')
       .should('have.class', 'pf-m-truncate')
       .then((tooltipLink: JQuery<HTMLDivElement>) => {

--- a/packages/react-integration/cypress/integration/notificationdrawerbasic.spec.ts
+++ b/packages/react-integration/cypress/integration/notificationdrawerbasic.spec.ts
@@ -113,7 +113,8 @@ describe('Notification Drawer Basic Demo Test', () => {
   });
 
   it('Verify truncateTitle in drawer header list item header and no tooltip on short text', () => {
-    cy.get('#info-alert-item > .pf-c-notification-drawer__list-item-header-title')      .should('have.class', 'pf-m-truncate')
+    cy.get('#info-alert-item > .pf-c-notification-drawer__list-item-header-title')
+      .should('have.class', 'pf-m-truncate')
       .then((noTooltipLink: JQuery<HTMLDivElement>) => {
         cy.wrap(noTooltipLink)
           .trigger('mouseenter')

--- a/packages/react-integration/cypress/integration/notificationdrawerbasic.spec.ts
+++ b/packages/react-integration/cypress/integration/notificationdrawerbasic.spec.ts
@@ -111,4 +111,28 @@ describe('Notification Drawer Basic Demo Test', () => {
         .should('not.exist');
     });
   });
+
+  it('Verify isTruncated title in header list item header and no tooltip on short text', () => {
+    cy.get('#info-alert-item > .pf-c-notification-drawer__list-item-header-title')      .should('have.class', 'pf-m-truncate')
+      .then((noTooltipLink: JQuery<HTMLDivElement>) => {
+        cy.wrap(noTooltipLink)
+          .trigger('mouseenter')
+          .get('.pf-c-tooltip')
+          .should('not.exist');
+        cy.wrap(noTooltipLink).trigger('mouseleave');
+      });
+  });
+
+  it('Verify isTruncated title in group title and tooltip', () => {
+    cy.get('#long-title-item > .pf-c-notification-drawer__list-item-header-title')
+      .should('have.class', 'pf-m-truncate')
+      .then((tooltipLink: JQuery<HTMLDivElement>) => {
+        cy.get('.pf-c-tooltip').should('not.exist');
+        cy.wrap(tooltipLink)
+          .trigger('mouseenter')
+          .get('.pf-c-tooltip')
+          .should('exist');
+        cy.wrap(tooltipLink).trigger('mouseleave');
+      });
+  });
 });

--- a/packages/react-integration/cypress/integration/notificationdrawergroups.spec.ts
+++ b/packages/react-integration/cypress/integration/notificationdrawergroups.spec.ts
@@ -132,4 +132,27 @@ describe('Notification Drawer Groups Demo Test', () => {
         .should('not.exist');
     });
   });
+
+   it('Verify isTruncated for group title and no tooltip on short text', () => {
+    cy.get('#short-group-title > h1 > .pf-c-notification-drawer__group-toggle > .pf-c-notification-drawer__group-toggle-title')
+      .then((noTooltipLink: JQuery<HTMLDivElement>) => {
+        cy.wrap(noTooltipLink)
+          .trigger('mouseenter')
+          .get('.pf-c-tooltip')
+          .should('not.exist');
+        cy.wrap(noTooltipLink).trigger('mouseleave');
+      });
+  });
+
+  it('Verify isTruncated group title and tooltip', () => {
+    cy.get('#long-group-title > h1 > .pf-c-notification-drawer__group-toggle > .pf-c-notification-drawer__group-toggle-title')
+      .then((tooltipLink: JQuery<HTMLDivElement>) => {
+        cy.get('.pf-c-tooltip').should('not.exist');
+        cy.wrap(tooltipLink)
+          .trigger('mouseenter')
+          .get('.pf-c-tooltip')
+          .should('exist');
+        cy.wrap(tooltipLink).trigger('mouseleave');
+      });
+  });
 });

--- a/packages/react-integration/cypress/integration/notificationdrawergroups.spec.ts
+++ b/packages/react-integration/cypress/integration/notificationdrawergroups.spec.ts
@@ -133,7 +133,7 @@ describe('Notification Drawer Groups Demo Test', () => {
     });
   });
 
-   it('Verify isTruncated for group title and no tooltip on short text', () => {
+   it('Verify truncateTitle for group title and no tooltip on short text', () => {
     cy.get('#short-group-title > h1 > .pf-c-notification-drawer__group-toggle > .pf-c-notification-drawer__group-toggle-title')
       .then((noTooltipLink: JQuery<HTMLDivElement>) => {
         cy.wrap(noTooltipLink)
@@ -144,8 +144,20 @@ describe('Notification Drawer Groups Demo Test', () => {
       });
   });
 
-  it('Verify isTruncated group title and tooltip', () => {
+  it('Verify truncateTitle group title and tooltip', () => {
     cy.get('#long-group-title > h1 > .pf-c-notification-drawer__group-toggle > .pf-c-notification-drawer__group-toggle-title')
+      .then((tooltipLink: JQuery<HTMLDivElement>) => {
+        cy.get('.pf-c-tooltip').should('not.exist');
+        cy.wrap(tooltipLink)
+          .trigger('mouseenter')
+          .get('.pf-c-tooltip')
+          .should('exist');
+        cy.wrap(tooltipLink).trigger('mouseleave');
+      });
+  });
+
+  it('Verify truncated with no truncateTitle prop group title and tooltip on long title', () => {
+    cy.get('#long-title-no-truncate-prop > h1 > .pf-c-notification-drawer__group-toggle > .pf-c-notification-drawer__group-toggle-title')
       .then((tooltipLink: JQuery<HTMLDivElement>) => {
         cy.get('.pf-c-tooltip').should('not.exist');
         cy.wrap(tooltipLink)

--- a/packages/react-integration/cypress/integration/notificationdrawergroups.spec.ts
+++ b/packages/react-integration/cypress/integration/notificationdrawergroups.spec.ts
@@ -133,38 +133,41 @@ describe('Notification Drawer Groups Demo Test', () => {
     });
   });
 
-   it('Verify truncateTitle for group title and no tooltip on short text', () => {
-    cy.get('#short-group-title > h1 > .pf-c-notification-drawer__group-toggle > .pf-c-notification-drawer__group-toggle-title')
-      .then((noTooltipLink: JQuery<HTMLDivElement>) => {
-        cy.wrap(noTooltipLink)
-          .trigger('mouseenter')
-          .get('.pf-c-tooltip')
-          .should('not.exist');
-        cy.wrap(noTooltipLink).trigger('mouseleave');
-      });
+  it('Verify truncateTitle for group title and no tooltip on short text', () => {
+    cy.get(
+      '#short-group-title > h1 > .pf-c-notification-drawer__group-toggle > .pf-c-notification-drawer__group-toggle-title'
+    ).then((noTooltipLink: JQuery<HTMLDivElement>) => {
+      cy.wrap(noTooltipLink)
+        .trigger('mouseenter')
+        .get('.pf-c-tooltip')
+        .should('not.exist');
+      cy.wrap(noTooltipLink).trigger('mouseleave');
+    });
   });
 
   it('Verify truncateTitle group title and tooltip', () => {
-    cy.get('#long-group-title > h1 > .pf-c-notification-drawer__group-toggle > .pf-c-notification-drawer__group-toggle-title')
-      .then((tooltipLink: JQuery<HTMLDivElement>) => {
-        cy.get('.pf-c-tooltip').should('not.exist');
-        cy.wrap(tooltipLink)
-          .trigger('mouseenter')
-          .get('.pf-c-tooltip')
-          .should('exist');
-        cy.wrap(tooltipLink).trigger('mouseleave');
-      });
+    cy.get(
+      '#long-group-title > h1 > .pf-c-notification-drawer__group-toggle > .pf-c-notification-drawer__group-toggle-title'
+    ).then((tooltipLink: JQuery<HTMLDivElement>) => {
+      cy.get('.pf-c-tooltip').should('not.exist');
+      cy.wrap(tooltipLink)
+        .trigger('mouseenter')
+        .get('.pf-c-tooltip')
+        .should('exist');
+      cy.wrap(tooltipLink).trigger('mouseleave');
+    });
   });
 
   it('Verify truncated with no truncateTitle prop group title and tooltip on long title', () => {
-    cy.get('#long-title-no-truncate-prop > h1 > .pf-c-notification-drawer__group-toggle > .pf-c-notification-drawer__group-toggle-title')
-      .then((tooltipLink: JQuery<HTMLDivElement>) => {
-        cy.get('.pf-c-tooltip').should('not.exist');
-        cy.wrap(tooltipLink)
-          .trigger('mouseenter')
-          .get('.pf-c-tooltip')
-          .should('exist');
-        cy.wrap(tooltipLink).trigger('mouseleave');
-      });
+    cy.get(
+      '#long-title-no-truncate-prop > h1 > .pf-c-notification-drawer__group-toggle > .pf-c-notification-drawer__group-toggle-title'
+    ).then((tooltipLink: JQuery<HTMLDivElement>) => {
+      cy.get('.pf-c-tooltip').should('not.exist');
+      cy.wrap(tooltipLink)
+        .trigger('mouseenter')
+        .get('.pf-c-tooltip')
+        .should('exist');
+      cy.wrap(tooltipLink).trigger('mouseleave');
+    });
   });
 });

--- a/packages/react-integration/demo-app-ts/src/components/demos/AlertDemo/AlertDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/AlertDemo/AlertDemo.tsx
@@ -45,9 +45,16 @@ export class AlertDemo extends React.Component<{}, AlertDemoState> {
             Info alert description. <a href="#">This is a link.</a>
           </Alert>
         )}
-        <Alert id="default-alert" title="Default alert title" isInline>
+        <Alert id="default-alert" title="Default alert title" truncateTitle={10} isInline>
           Info alert description
         </Alert>
+        <Alert
+          id="long-title-alert"
+          title="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur pellentesque neque cursus enim fringilla tincidunt. Proin lobortis aliquam dictum. Nam vel ullamcorper nulla, nec blandit dolor. Vivamus pellentesque neque justo, nec accumsan nulla rhoncus id. Suspendisse mollis, tortor quis faucibus volutpat, sem leo fringilla turpis, ac lacinia augue metus in nulla. Cras vestibulum lacinia orci. Pellentesque sodales consequat interdum. Sed porttitor tincidunt metus nec iaculis. Pellentesque non commodo justo. Morbi feugiat rhoncus neque, vitae facilisis diam aliquam nec. Sed dapibus vitae quam at tristique. Nunc vel commodo mi. Mauris et rhoncus leo."
+          isInline
+          truncateTitle={3}
+          tooltipPosition="bottom"
+        />
       </React.Fragment>
     );
   }

--- a/packages/react-integration/demo-app-ts/src/components/demos/NotificationDrawerDemo/NotificationDrawerBasicDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/NotificationDrawerDemo/NotificationDrawerBasicDemo.tsx
@@ -76,9 +76,11 @@ export class BasicNotificationDrawerDemo extends React.Component<
           <NotificationDrawerList>
             <NotificationDrawerListItem variant="info">
               <NotificationDrawerListItemHeader
+                id="info-alert-item"
                 variant="info"
                 title="Unread info notification title"
                 srTitle="Info notification:"
+                truncateTitle={10}
               >
                 <Dropdown
                   position={DropdownPosition.right}
@@ -137,9 +139,12 @@ export class BasicNotificationDrawerDemo extends React.Component<
             </NotificationDrawerListItem>
             <NotificationDrawerListItem variant="success" isRead>
               <NotificationDrawerListItemHeader
+                id="long-title-item"
                 variant="success"
-                title="Read success notification title"
+                title="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur pellentesque neque cursus enim fringilla tincidunt. Proin lobortis aliquam dictum. Nam vel ullamcorper nulla, nec blandit dolor. Vivamus pellentesque neque justo, nec accumsan nulla rhoncus id. Suspendisse mollis, tortor quis faucibus volutpat, sem leo fringilla turpis, ac lacinia augue metus in nulla. Cras vestibulum lacinia orci. Pellentesque sodales consequat interdum. Sed porttitor tincidunt metus nec iaculis. Pellentesque non commodo justo. Morbi feugiat rhoncus neque, vitae facilisis diam aliquam nec. Sed dapibus vitae quam at tristique. Nunc vel commodo mi. Mauris et rhoncus leo."
                 srTitle="Success notification:"
+                truncateTitle={1}
+                tooltipPosition="bottom"
               >
                 <Dropdown
                   position={DropdownPosition.right}

--- a/packages/react-integration/demo-app-ts/src/components/demos/NotificationDrawerDemo/NotificationDrawerGroupsDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/NotificationDrawerDemo/NotificationDrawerGroupsDemo.tsx
@@ -112,6 +112,7 @@ export class GroupsNotificationDrawerDemo extends React.Component<
         <NotificationDrawerBody>
           <NotificationDrawerGroupList>
             <NotificationDrawerGroup
+              id="short-group-title"
               title="First notification group"
               isExpanded={firstGroupExpanded}
               count={2}
@@ -223,10 +224,13 @@ export class GroupsNotificationDrawerDemo extends React.Component<
               </NotificationDrawerList>
             </NotificationDrawerGroup>
             <NotificationDrawerGroup
-              title="Second notification group"
+              id="long-group-title"
+              title="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur pellentesque neque cursus enim fringilla tincidunt. Proin lobortis aliquam dictum. Nam vel ullamcorper nulla, nec blandit dolor. Vivamus pellentesque neque justo, nec accumsan nulla rhoncus id. Suspendisse mollis, tortor quis faucibus volutpat, sem leo fringilla turpis, ac lacinia augue metus in nulla. Cras vestibulum lacinia orci. Pellentesque sodales consequat interdum. Sed porttitor tincidunt metus nec iaculis. Pellentesque non commodo justo. Morbi feugiat rhoncus neque, vitae facilisis diam aliquam nec. Sed dapibus vitae quam at tristique. Nunc vel commodo mi. Mauris et rhoncus leo."
               isExpanded={secondGroupExpanded}
               count={2}
               onExpand={this.toggleSecondDrawer}
+              truncateTitle={1}
+              tooltipPosition="bottom"
             >
               <NotificationDrawerList isHidden={!secondGroupExpanded}>
                 <NotificationDrawerListItem variant="info">

--- a/packages/react-integration/demo-app-ts/src/components/demos/NotificationDrawerDemo/NotificationDrawerGroupsDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/NotificationDrawerDemo/NotificationDrawerGroupsDemo.tsx
@@ -117,6 +117,7 @@ export class GroupsNotificationDrawerDemo extends React.Component<
               isExpanded={firstGroupExpanded}
               count={2}
               onExpand={this.toggleFirstDrawer}
+              truncateTitle={1}
             >
               <NotificationDrawerList isHidden={!firstGroupExpanded}>
                 <NotificationDrawerListItem variant="info">
@@ -338,7 +339,8 @@ export class GroupsNotificationDrawerDemo extends React.Component<
               </NotificationDrawerList>
             </NotificationDrawerGroup>
             <NotificationDrawerGroup
-              title="Third notification group"
+              id="long-title-no-truncate-prop"
+              title="Third notification group. This is a long title to show how the title will be truncated if it is long and will be shown in a single line."
               isExpanded={thirdGroupExpanded}
               count={0}
               onExpand={this.toggleThirdDrawer}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**:   Added tooltips to truncated titles for Alert, NotificationDrawerListItemHeader and NotificationDrawerGroup.
Added truncatedTitle Prop to demo app and updated integration test
Closes #4760 
Closes #4752


