### PR TITLE
fix(datalist): respect isDisabled for dragging

### DIFF
--- a/packages/react-core/src/components/DataList/examples/DataList.md
+++ b/packages/react-core/src/components/DataList/examples/DataList.md
@@ -16,22 +16,6 @@ propComponents:
   ]
 ---
 
-import {
-Button,
-DataList,
-DataListItem,
-DataListItemCells,
-DataListItemRow,
-DataListCell,
-DataListCheck,
-DataListAction,
-DataListToggle,
-DataListContent,
-Dropdown,
-DropdownPosition,
-KebabToggle,
-DropdownItem,
-} from '@patternfly/react-core';
 import CodeBranchIcon from '@patternfly/react-icons/dist/js/icons/code-branch-icon';
 import { css } from '@patternfly/react-styles';
 
@@ -1190,6 +1174,7 @@ class DraggableDataList extends React.Component {
                   aria-labelledby="simple-item1"
                   aria-describedby="Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
                   aria-pressed="false"
+                  isDisabled
                 />
                 <DataListCheck aria-labelledby="simple-item1" name="check1" otherControls />
               </DataListControl>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5048. Closes #5046. Prevents moving the row if `isDisabled` is passed to the button, but other rows can be moved which in turn move the disabled row.

I'm not sure what intended behavior is and I think it was a mistake to expose `isDisabled` on `DataListDragButton` which really should be on `DataListItem`. `isDisabled` on a button doesn't quite capture that the entire **row** shouldn't be draggable nor that other rows shouldn't be able to occupy its index.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
