### PR TITLE
fix(table): set button type on compoundExpand transform button

### DIFF
--- a/packages/react-integration/cypress/integration/tableeditablecompoundexpandable.spec.ts
+++ b/packages/react-integration/cypress/integration/tableeditablecompoundexpandable.spec.ts
@@ -1,0 +1,20 @@
+describe('Table Compound Expandable Test', () => {
+  it('Navigate to demo section', () => {
+    cy.visit('http://localhost:3000/');
+    cy.get('#table-editable-compound-expandable-demo-nav-item-link').click();
+    cy.url().should('eq', 'http://localhost:3000/table-editable-compound-expandable-demo-nav-link');
+  });
+
+  it('Test expandable/collapsible', () => {
+    cy.get('button.pf-c-table__button')
+      .first()
+      .click();
+
+    cy.get('button.pf-c-table__button')
+      .first()
+      .click();
+
+    // should not have changed the url
+    cy.url().should('eq', 'http://localhost:3000/table-editable-compound-expandable-demo-nav-link');
+  });
+});

--- a/packages/react-integration/demo-app-ts/src/Demos.ts
+++ b/packages/react-integration/demo-app-ts/src/Demos.ts
@@ -662,6 +662,11 @@ export const Demos: DemoInterface[] = [
     componentType: Examples.TableEditableDemo
   },
   {
+    id: 'table-editable-compound-expandable-demo',
+    name: 'Table Editable Compound Expandable Demo',
+    componentType: Examples.TableEditableCompoundExpandableDemo
+  },
+  {
     id: 'table-first-cell-as-header-demo',
     name: 'Table First Cell As Header Demo',
     componentType: Examples.TableFirstCellAsHeaderDemo

--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableEditableCompoundExpandableDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableEditableCompoundExpandableDemo.tsx
@@ -1,0 +1,239 @@
+import * as React from 'react';
+import { Table, TableHeader, TableBody, TableProps, compoundExpand, IRow, ICell } from '@patternfly/react-table';
+
+import CodeBranchIcon from '@patternfly/react-icons/dist/js/icons/code-branch-icon';
+import CodeIcon from '@patternfly/react-icons/dist/js/icons/code-icon';
+import CubeIcon from '@patternfly/react-icons/dist/js/icons/cube-icon';
+
+import { DemoSortableTable } from './TableSortableForCompoundExpandableDemo';
+
+interface TableState {
+  columns: (ICell | string)[];
+  rows: IRow[];
+}
+
+export class TableEditableCompoundExpandableDemo extends React.Component<TableProps, TableState> {
+  static displayName = 'TableEditableCompoundExpandableDemo';
+  constructor(props: TableProps) {
+    super(props);
+    this.state = {
+      columns: [
+        'Repositories',
+        {
+          title: 'Branches',
+          cellTransforms: [compoundExpand]
+        },
+        {
+          title: 'Pull requests',
+          cellTransforms: [compoundExpand]
+        },
+        {
+          title: 'Workspaces',
+          cellTransforms: [compoundExpand]
+        },
+        'Last Commit',
+        ''
+      ],
+      rows: [
+        {
+          isOpen: true,
+          cells: [
+            { title: <a href="#">siemur/test-space</a>, props: { component: 'th' } },
+            {
+              title: (
+                <React.Fragment>
+                  <CodeBranchIcon key="icon" /> 10
+                </React.Fragment>
+              ),
+              props: { isOpen: true, ariaControls: 'compoound-expansion-table-1' }
+            },
+            {
+              title: (
+                <React.Fragment>
+                  <CodeIcon key="icon" /> 4
+                </React.Fragment>
+              ),
+              props: { isOpen: false, ariaControls: 'compoound-expansion-table-2' }
+            },
+            {
+              title: (
+                <React.Fragment>
+                  <CubeIcon key="icon" /> 4
+                </React.Fragment>
+              ),
+              props: { isOpen: false, ariaControls: 'compoound-expansion-table-3' }
+            },
+            '20 minutes',
+            { title: <a href="#">Open in Github</a> }
+          ]
+        },
+        {
+          parent: 0,
+          compoundParent: 1,
+          cells: [
+            {
+              title: (
+                <DemoSortableTable
+                  firstColumnRows={['parent-0', 'compound-1', 'three', 'four', 'five']}
+                  id="compoound-expansion-table-1"
+                />
+              ),
+              props: { colSpan: 6, className: 'pf-m-no-padding' }
+            }
+          ]
+        },
+        {
+          parent: 0,
+          compoundParent: 2,
+          cells: [
+            {
+              title: (
+                <DemoSortableTable
+                  firstColumnRows={['parent-0', 'compound-2', 'three', 'four', 'five']}
+                  id="compoound-expansion-table-2"
+                />
+              ),
+              props: { colSpan: 6, className: 'pf-m-no-padding' }
+            }
+          ]
+        },
+        {
+          parent: 0,
+          compoundParent: 3,
+          cells: [
+            {
+              title: (
+                <DemoSortableTable
+                  firstColumnRows={['parent-0', 'compound-3', 'three', 'four', 'five']}
+                  id="compoound-expansion-table-3"
+                />
+              ),
+              props: { colSpan: 6, className: 'pf-m-no-padding' }
+            }
+          ]
+        },
+        {
+          isOpen: false,
+          cells: [
+            { title: <a href="#">siemur/test-space</a>, props: { component: 'th' } },
+            {
+              title: (
+                <React.Fragment>
+                  <CodeBranchIcon key="icon" /> 3
+                </React.Fragment>
+              ),
+              props: { isOpen: false, ariaControls: 'compoound-expansion-table-4' }
+            },
+            {
+              title: (
+                <React.Fragment>
+                  <CodeIcon key="icon" /> 4
+                </React.Fragment>
+              ),
+              props: { isOpen: false, ariaControls: 'compoound-expansion-table-5' }
+            },
+            {
+              title: (
+                <React.Fragment>
+                  <CubeIcon key="icon" /> 2
+                </React.Fragment>
+              ),
+              props: { isOpen: false, ariaControls: 'compoound-expansion-table-6' }
+            },
+            '20 minutes',
+            { title: <a href="#">Open in Github</a> }
+          ]
+        },
+        {
+          parent: 4,
+          compoundParent: 1,
+          cells: [
+            {
+              title: (
+                <DemoSortableTable
+                  firstColumnRows={['parent-4', 'compound-1', 'three', 'four', 'five']}
+                  id="compoound-expansion-table-4"
+                />
+              ),
+              props: { colSpan: 6, className: 'pf-m-no-padding' }
+            }
+          ]
+        },
+        {
+          parent: 4,
+          compoundParent: 2,
+          cells: [
+            {
+              title: (
+                <DemoSortableTable
+                  firstColumnRows={['parent-4', 'compound-2', 'three', 'four', 'five']}
+                  id="compoound-expansion-table-5"
+                />
+              ),
+              props: { colSpan: 6, className: 'pf-m-no-padding' }
+            }
+          ]
+        },
+        {
+          parent: 4,
+          compoundParent: 3,
+          cells: [
+            {
+              title: (
+                <DemoSortableTable
+                  firstColumnRows={['parent-4', 'compound-3', 'three', 'four', 'five']}
+                  id="compoound-expansion-table-6"
+                />
+              ),
+              props: { colSpan: 6, className: 'pf-m-no-padding' }
+            }
+          ]
+        }
+      ]
+    };
+    this.onExpand = this.onExpand.bind(this);
+  }
+
+  onExpand(event: React.MouseEvent, rowIndex: number, colIndex: number, isOpen: boolean) {
+    const newRows = Array.from(this.state.rows);
+    const rowCells = newRows[rowIndex].cells;
+
+    if (!isOpen) {
+      // set all other expanded cells false in this row if we are expanding
+      (rowCells as ICell[]).forEach(cell => {
+        if (cell.props) {
+          cell.props.isOpen = false;
+        }
+      });
+      (rowCells as ICell[])[colIndex].props.isOpen = true;
+      newRows[rowIndex].isOpen = true;
+    } else {
+      (rowCells as ICell[])[colIndex].props.isOpen = false;
+      newRows[rowIndex].isOpen = (rowCells as ICell[]).some(cell => cell.props && cell.props.isOpen);
+    }
+    this.setState({
+      rows: newRows
+    });
+  }
+
+  componentDidMount() {
+    window.scrollTo(0, 0);
+  }
+
+  render() {
+    const { columns, rows } = this.state;
+
+    return (
+      <Table
+        caption="Editable compound expandable table"
+        onRowEdit={() => {}}
+        onExpand={this.onExpand}
+        rows={rows}
+        cells={columns}
+      >
+        <TableHeader />
+        <TableBody />
+      </Table>
+    );
+  }
+}

--- a/packages/react-integration/demo-app-ts/src/components/demos/index.ts
+++ b/packages/react-integration/demo-app-ts/src/components/demos/index.ts
@@ -129,6 +129,7 @@ export * from './TableDemo/TableCompactExpandableDemo';
 export * from './TableDemo/TableCompoundExpandableDemo';
 export * from './TableDemo/TableControlTextDemo';
 export * from './TableDemo/TableEditableDemo';
+export * from './TableDemo/TableEditableCompoundExpandableDemo';
 export * from './TableDemo/TableFirstCellAsHeaderDemo';
 export * from './TableDemo/TableHeadersWrappableDemo';
 export * from './TableDemo/TableRowWrapperDemo';

--- a/packages/react-table/src/components/Table/Table.test.tsx
+++ b/packages/react-table/src/components/Table/Table.test.tsx
@@ -275,7 +275,7 @@ test('Control text table', () => {
 test('Header width table', () => {
   columns[0] = { ...(columns[0] as object), transforms: [cellWidth(10)] };
   columns[2] = { ...(columns[2] as object), transforms: [cellWidth(30)] };
-  columns[4] = { ...(columns[4] as object), transforms: [cellWidth('max')] };
+  columns[4] = { ...(columns[4] as object), transforms: [cellWidth(100)] };
   const view = mount(
     <Table aria-label="Aria labeled" cells={columns} rows={rows}>
       <TableHeader />

--- a/packages/react-table/src/components/Table/utils/decorators/compoundExpand.tsx
+++ b/packages/react-table/src/components/Table/utils/decorators/compoundExpand.tsx
@@ -33,6 +33,7 @@ export const compoundExpand: ITransform = (
     className: css(styles.tableCompoundExpansionToggle, props.isOpen && styles.modifiers.expanded),
     children: props.isOpen !== undefined && (
       <button
+        type="button"
         className={css(styles.tableButton)}
         onClick={onToggle}
         aria-expanded={props.isOpen}


### PR DESCRIPTION
This PR fixes an issue where when selecting a compound expandable table cell, when the table is also "editable", would cause a full page refresh instead of expanding the cell as expected. It's a patch for https://github.com/patternfly/patternfly-react/issues/5118

This is happening because when the table is "editable" the table is wrapped in a form, and the compoundExpand buttons do not have a type attribute set, and the default action of selecting a button when inside of a form is to attempt to submit the form.

<img width="400" alt="Screen Shot 2020-10-23 at 6 04 30 PM" src="https://user-images.githubusercontent.com/5942899/97060830-a8ecc680-1562-11eb-94c3-69caa093a7c5.png">

To reproduce the issue, add `onRowEdit={() => {}}` to a compound expandable table and then select one of the expandable cells. Notice it attempts to submit the form to the current url and a "?" query param token is added to the url.

The fix is simply to add `type="button"` to those expandable button elements so that they are treated as regular buttons and not "submit" buttons. I added a cypress test to verify this, but important to note that I didn't go as far as actually building a full editable-compound-expand table functionality in the integration app. I just added enough of a demo to verify the fix.

Hoping we can accept this incremental fix as a step toward the goal of further hardening the editable table feature and make it work fully with compound expand in a follow-up PR so we can promote editable table from beta to standard feature. Any hesitation or concern with this approach? I'm happy to try and build the full solution for the integration app in this PR, but might be nice to get this fix in place first just so the bug isn't causing issues for others who may want to press ahead using both of these complex feature together before we can get a full demo ready in the main react docs.

avoid editable table form submission on selecting compound expandable cells by setting btn type
add cypress test to verify selecting editable compound table cells does not cause page refresh
update test for header width table to use correct value

<img width="400" alt="Screen Shot 2020-10-23 at 6 17 20 PM" src="https://user-images.githubusercontent.com/5942899/97060843-b5711f00-1562-11eb-8504-3ca59277b2f0.png">


