### PR TITLE
fix(Skeleton): Update skeleton examples

### DIFF
--- a/packages/react-core/src/components/Skeleton/examples/Skeleton.md
+++ b/packages/react-core/src/components/Skeleton/examples/Skeleton.md
@@ -14,7 +14,7 @@ beta: true
 import React from 'react';
 import { Skeleton } from '@patternfly/react-core';
 
-<Skeleton />;
+<Skeleton screenreaderText="Loading contents" />;
 ```
 
 ### Percentage widths
@@ -62,25 +62,25 @@ import { Skeleton } from '@patternfly/react-core';
 
 <React.Fragment>
   --pf-global--FontSize--4xl
-  <Skeleton fontSize="4xl" />
+  <Skeleton fontSize="4xl" screenreaderText="Loading font size 4xl" />
   <br />
   --pf-global--FontSize--3xl
-  <Skeleton fontSize="3xl" />
+  <Skeleton fontSize="3xl" screenreaderText="Loading font size 3xl" />
   <br />
   --pf-global--FontSize--2xl
-  <Skeleton fontSize="2xl" />
+  <Skeleton fontSize="2xl" screenreaderText="Loading font size 2xl" />
   <br />
   --pf-global--FontSize--xl
-  <Skeleton fontSize="xl" />
+  <Skeleton fontSize="xl" screenreaderText="Loading font size xl" />
   <br />
   --pf-global--FontSize--lg
-  <Skeleton fontSize="lg" />
+  <Skeleton fontSize="lg" screenreaderText="Loading font size lg" />
   <br />
   --pf-global--FontSize--md
-  <Skeleton fontSize="md" />
+  <Skeleton fontSize="md" screenreaderText="Loading font size md" />
   <br />
   --pf-global--FontSize--sm
-  <Skeleton fontSize="sm" />
+  <Skeleton fontSize="sm" screenreaderText="Loading font size sm" />
 </React.Fragment>;
 ```
 
@@ -92,36 +92,36 @@ import { Skeleton } from '@patternfly/react-core';
 
 <React.Fragment>
   Small circle
-  <Skeleton shape="circle" width="15%" />
+  <Skeleton shape="circle" width="15%" screenreaderText="Loading small circle contents" />
   <br />
   Medium circle
-  <Skeleton shape="circle" width="30%" />
+  <Skeleton shape="circle" width="30%" screenreaderText="Loading medium circle contents" />
   <br />
   Large circle
-  <Skeleton shape="circle" width="50%" />
+  <Skeleton shape="circle" width="50%" screenreaderText="Loading large circle contents" />
   <br />
   Small square
-  <Skeleton shape="square" width="15%" />
+  <Skeleton shape="square" width="15%" screenreaderText="Loading small square contents" />
   <br />
   Medium square
-  <Skeleton shape="square" width="30%" />
+  <Skeleton shape="square" width="30%" screenreaderText="Loading medium square contents" />
   <br />
   Large square
-  <Skeleton shape="square" width="50%" />
+  <Skeleton shape="square" width="50%" screenreaderText="Loading large square contents" />
   <br />
   Small rectangle
   <div style={{ height: '200px' }}>
-    <Skeleton height="50%" width="50%" />
+    <Skeleton height="50%" width="50%" screenreaderText="Loading small rectangle contents" />
   </div>
   <br />
   Medium rectangle
   <div style={{ height: '200px' }}>
-    <Skeleton height="75%" width="75%" />
+    <Skeleton height="75%" width="75%" screenreaderText="Loading medium rectangle contents" />
   </div>
   <br />
   Large rectangle
   <div style={{ height: '200px' }}>
-    <Skeleton height="100%" />
+    <Skeleton height="100%" screenreaderText="Loading large rectangle contents" />
   </div>
 </React.Fragment>;
 ```


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5071

I'm noticing that when I created the screenreaderText prop, I should have added it to all existing examples and shown the custom variations that could exist in our examples.
