### PR TITLE
chore(modal): add/update test cypress tests for modal

### DIFF
--- a/packages/react-integration/cypress/integration/modal.spec.ts
+++ b/packages/react-integration/cypress/integration/modal.spec.ts
@@ -208,4 +208,41 @@ describe('Modal Test', () => {
         });
     });
   });
+
+  it('Verify focustrap for basic modal', () => {
+    cy.get('#tabstop-test').focus();
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    cy.tab().click(); // click first btn to open first modal
+    cy.focused().should('have.attr', 'aria-label', 'Close');
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    cy.tab();
+    cy.focused().should('have.attr', 'data-id', 'modal-01-cancel-btn');
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    cy.tab();
+    cy.focused().should('have.attr', 'data-id', 'modal-01-confirm-btn');
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    cy.tab();
+    cy.focused().should('have.attr', 'aria-label', 'Close');
+    cy.focused().click();
+  });
+
+  it('Verify escape key closes modal', () => {
+    cy.get('#tabstop-test').focus();
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    cy.tab()
+      .tab()
+      .click(); // open second modal
+
+    cy.get('.pf-c-modal-box').should('exist');
+    // press escape key
+    cy.get('body').trigger('keydown', { keyCode: 27, which: 27 });
+    cy.get('.pf-c-modal-box').should('not.exist');
+  });
 });

--- a/packages/react-integration/demo-app-ts/src/components/demos/ModalDemo/ModalDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/ModalDemo/ModalDemo.tsx
@@ -115,10 +115,10 @@ export class ModalDemo extends React.Component<React.HTMLProps<HTMLDivElement>, 
         isOpen={isModalOpen}
         onClose={this.handleModalToggle}
         actions={[
-          <Button key="cancel" variant="secondary" onClick={this.handleModalToggle}>
+          <Button key="cancel" data-id="modal-01-cancel-btn" variant="secondary" onClick={this.handleModalToggle}>
             Cancel
           </Button>,
-          <Button key="confirm" variant="primary" onClick={this.handleModalToggle}>
+          <Button key="confirm" data-id="modal-01-confirm-btn" variant="primary" onClick={this.handleModalToggle}>
             Confirm
           </Button>
         ]}
@@ -296,6 +296,7 @@ export class ModalDemo extends React.Component<React.HTMLProps<HTMLDivElement>, 
         isOpen={isCustomHeaderFooterModalOpen}
         header={header}
         title="custom header example"
+        aria-labelledby="customHeaderTitle"
         aria-describedby="custom-header-example"
         onClose={this.handleCustomHeaderFooterModalToggle}
         footer={footer}
@@ -433,7 +434,7 @@ export class ModalDemo extends React.Component<React.HTMLProps<HTMLDivElement>, 
 
     return (
       <React.Fragment>
-        <div style={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap' }}>
+        <div id="tabstop-test" tabIndex={0} style={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap' }}>
           <Button style={buttonStyle} variant="primary" onClick={this.handleModalToggle} id="showDefaultModalButton">
             Show Modal
           </Button>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Steps toward closing https://github.com/patternfly/patternfly-react/issues/3953

This PR adds adds a couple of new tests for modal which test to ensure focustrap is working as expected as well as that pressing escape key with an open modal would close it. I spent some time trying to also verify that pressing enter on the close button (or cancel/confirm) would also close the modal, but for some reason the trigger/type functions for cypress didn't actually close the modal. I tried several combinations of the following:

`....trigger('keydown', { keyCode: 13, which: 13 });`
`....type('{enter}')`

Any idea why these won't simulate the keypress event? The functionality does obviously work, just that cypress can't seem to invoke it. I could cheap out and go for `click()` which works fine, but the main point of the issue is to test keyboard interactivity so not sure that would fully exercise the right path in the code.

In any case, what's here should help prevent regressions to keyboard interactivity in the future, would be cool to get it merged and circle back to the pressing enter issue if possible.

I also fixed a small issue where one of the examples in the test suite was missing an accessible name.

<img width="1122" alt="Screen Shot 2020-10-29 at 9 28 59 PM" src="https://user-images.githubusercontent.com/5942899/97654572-90d0e780-1a39-11eb-8559-6c225a125c80.png">
