### PR TITLE
chore(form): add more tests around keyboard interactivity in forms

### DIFF
--- a/packages/react-core/src/components/Divider/examples/Divider.md
+++ b/packages/react-core/src/components/Divider/examples/Divider.md
@@ -11,7 +11,7 @@ propComponents: ['Divider']
 import React from 'react';
 import { Divider } from '@patternfly/react-core';
 
-<Divider/>
+<Divider />
 ```
 
 ### Using li
@@ -88,7 +88,7 @@ import { Divider, Flex, FlexItem } from '@patternfly/react-core';
 
 <Flex>
   <FlexItem>first item</FlexItem>
-  <Divider isVertical 
+  <Divider isVertical
     inset={{
       default: 'insetMd',
       md: 'insetNone',

--- a/packages/react-integration/cypress/integration/form.spec.ts
+++ b/packages/react-integration/cypress/integration/form.spec.ts
@@ -30,7 +30,7 @@ describe('Form Demo Test', () => {
   it('Verify form validates form group', () => {
     cy.get('#age-validated.pf-m-success').should('not.exist');
     cy.get('.pf-c-form__helper-text').contains('Enter age');
-    // type string that is not a number so it is not invalid
+    // type string that is not a number so it is invalid
     cy.get('#age-validated').type('hi');
     cy.get('#age-validated').should('have.value', 'hi');
     cy.get('#age-validated').then(textinput => {
@@ -60,8 +60,51 @@ describe('Form Demo Test', () => {
     cy.get('.pf-c-form__group-label').should('have.class', 'pf-m-no-padding-top');
   });
 
-  it('Verify selecting the form label help icon launches popover', () => {
+  it('Verify selecting the form label help icon with click launches popover', () => {
     cy.get('#helper-text-target').click();
     cy.get('.pf-c-popover').should('exist');
+    cy.get('[aria-label="Close"]').click();
+  });
+
+  it('Verify selecting the form label help icon with keypress launches popover', () => {
+    cy.get('#helper-text-target').type('{enter}');
+    cy.get('.pf-c-popover').should('exist');
+    cy.get('[aria-label="Close"]').type('{enter}');
+  });
+
+  it('Verify keypress can control the multi-select-typeahead', () => {
+    cy.get('[id*="pf-select-toggle-id"][id*="select-multi-typeahead-typeahead"]').type('{downarrow}{downarrow}{enter}');
+    cy.get('.pf-c-chip__text')
+      .should('exist')
+      .and('have.text', 'Florida');
+
+    cy.get('.pf-c-chip__text').then($chipText => {
+      const idAttrValue = $chipText.attr('id');
+      cy.get(`#remove_${idAttrValue}`).click();
+    });
+
+    cy.get('[id*="pf-select-toggle-id"][id*="select-multi-typeahead-typeahead"]').type('New J');
+
+    cy.get('.pf-c-select__menu-item')
+      .should('exist')
+      .and('have.text', 'New Jersey');
+    cy.focused().type('{backspace}{backspace}{backspace}{backspace}orth');
+    cy.get('.pf-c-select__menu-item')
+      .should('exist')
+      .and('have.text', 'North Carolina');
+    cy.focused().type('{backspace}{backspace}{backspace}{backspace}{backspace}');
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    cy.tab();
+    cy.get('.pf-c-select__menu-item').should('not.exist');
+  });
+
+  it('Verify pressing spacebar selects the checkbox component', () => {
+    const $checkbox = cy.get('#subscribe');
+    $checkbox.should('not.be.checked');
+    $checkbox.type(' ');
+    $checkbox.should('be.checked');
+    $checkbox.type(' '); // should be unchecked but isn't
+    // $checkbox.should('not.be.checked');
   });
 });

--- a/packages/react-integration/demo-app-ts/src/components/demos/FormDemo/FormDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/FormDemo/FormDemo.tsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import {
+  Divider,
   Form,
   FormGroup,
   FormProps,
@@ -23,6 +24,7 @@ export interface FormState {
   selected: string[];
   validatedValue: string;
   validated: ValidatedOptions.default | ValidatedOptions.error | ValidatedOptions.warning | ValidatedOptions.success;
+  checkboxChecked: boolean;
 }
 
 export class FormDemo extends Component<FormProps, FormState> {
@@ -34,8 +36,11 @@ export class FormDemo extends Component<FormProps, FormState> {
       isOpen: false,
       selected: [],
       validatedValue: '',
-      validated: ValidatedOptions.default
+      validated: ValidatedOptions.default,
+      checkboxChecked: false
     };
+
+    this.handleCheckboxChange = this.handleCheckboxChange.bind(this);
   }
   handleTextInputChange = (value: string) => {
     this.setState({ value, isValid: /^\d+$/.test(value) });
@@ -81,8 +86,14 @@ export class FormDemo extends Component<FormProps, FormState> {
     window.scrollTo(0, 0);
   }
 
+  handleCheckboxChange(checked: boolean, event: any) {
+    const target = event.target;
+    const value = target.type === 'checkbox' ? target.checked : target.value;
+    this.setState({ ['checkboxChecked']: value });
+  }
+
   render() {
-    const { value, isValid, isOpen, selected, validatedValue, validated } = this.state;
+    const { value, isValid, isOpen, selected, validatedValue, validated, checkboxChecked } = this.state;
     const titleId = 'multi-typeahead-select-id';
     const options = [
       { value: 'Alabama', disabled: false },
@@ -95,7 +106,7 @@ export class FormDemo extends Component<FormProps, FormState> {
 
     return (
       <React.Fragment>
-        <Form>
+        <Form id="form-demo-1">
           <FormGroup
             label="Age"
             labelIcon={
@@ -130,55 +141,61 @@ export class FormDemo extends Component<FormProps, FormState> {
             />
           </FormGroup>
         </Form>
-        <div>
-          <div>
-            <Form>
-              <span id={titleId} hidden>
-                Select a state
-              </span>
-              <Select
-                id={this.props.id}
-                variant={SelectVariant.typeaheadMulti}
-                aria-label="Select a state"
-                onToggle={this.onToggle}
-                onSelect={this.onSelect}
-                onClear={this.clearSelection}
-                selections={selected}
-                isOpen={isOpen}
-                aria-labelledby={titleId}
-                placeholderText="Select a state"
-              >
-                {options.map((option, index) => (
-                  <SelectOption isDisabled={option.disabled} key={index} value={option.value} />
-                ))}
-              </Select>
-              <FormSection>
-                <FormGroup
-                  id="formgroup-validated"
-                  label="Validated Age"
-                  type="number"
-                  helperText="Enter age"
-                  helperTextInvalid="Age must be a number"
-                  fieldId="age2"
-                  validated={validated}
-                >
-                  <TextInput
-                    validated={validated}
-                    value={validatedValue}
-                    id="age-validated"
-                    aria-describedby="age-helper-validated"
-                    onChange={this.handleValidatedTextInputChange}
-                  />
-                </FormGroup>
-              </FormSection>
-              <FormSection>
-                <FormGroup hasNoPaddingTop id="formgroup-checkbox" label="Subscribe" fieldId="subscribe">
-                  <Checkbox id="subscribe" label="Mailing list" />
-                </FormGroup>
-              </FormSection>
-            </Form>
-          </div>
-        </div>
+
+        <Divider className="pf-u-my-xl" />
+
+        <Form id="form-demo-2">
+          <FormGroup fieldId="select-state-typeahead">
+            <span id={titleId} hidden>
+              Select a state
+            </span>
+            <Select
+              variant={SelectVariant.typeaheadMulti}
+              aria-label="Select a state"
+              onToggle={this.onToggle}
+              onSelect={this.onSelect}
+              onClear={this.clearSelection}
+              selections={selected}
+              isOpen={isOpen}
+              aria-labelledby={titleId}
+              placeholderText="Select a state"
+            >
+              {options.map((option, index) => (
+                <SelectOption isDisabled={option.disabled} key={index} value={option.value} />
+              ))}
+            </Select>
+          </FormGroup>
+          <FormSection>
+            <FormGroup
+              id="formgroup-validated"
+              label="Validated Age"
+              type="number"
+              helperText="Enter age"
+              helperTextInvalid="Age must be a number"
+              fieldId="age2"
+              validated={validated}
+            >
+              <TextInput
+                validated={validated}
+                value={validatedValue}
+                id="age-validated"
+                aria-describedby="age-helper-validated"
+                onChange={this.handleValidatedTextInputChange}
+              />
+            </FormGroup>
+          </FormSection>
+          <FormSection>
+            <FormGroup hasNoPaddingTop id="formgroup-checkbox" label="Subscribe" fieldId="subscribe">
+              <Checkbox
+                id="subscribe"
+                name="subscribe"
+                label="Mailing list"
+                isChecked={checkboxChecked}
+                onChange={this.handleCheckboxChange}
+              />
+            </FormGroup>
+          </FormSection>
+        </Form>
       </React.Fragment>
     );
   }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Steps toward closing https://github.com/patternfly/patternfly-react/issues/3953

This PR adds more cypress tests to the Forms demo to verify basic keyboard interactions are in place. I did notice that cypress has a hard time working with our Form controls. Things like the cypress tab plugin do not successfully tab around the typeahead multiselect (and forms in general) and using trigger/type functions to press enter were also inconsistent. Despite this, I was able to add some useful tests.

For checkbox, I wanted to verify that pressing the spacebar would check/uncheck the box but support for spacebar seems incomplete in cypress. The functionality does of course work in our components, just that after spending a couple hours trying to get cypress to verify this, I had to call a stopping point. Any help here would be great, otherwise we may be better served to raise an issue in the cypress repo.