### PR TITLE
remove Get Started, add Developer Resources, move release notes & upgrade guide

### DIFF
--- a/packages/react-docs/RELEASE-NOTES.md
+++ b/packages/react-docs/RELEASE-NOTES.md
@@ -1,6 +1,6 @@
 ---
 id: Release notes
-section: get-started
+section: developer-resources
 ---
 
 ## 2020.14 release notes (2020-10-27)

--- a/packages/react-docs/UPGRADE-GUIDE.md
+++ b/packages/react-docs/UPGRADE-GUIDE.md
@@ -1,6 +1,6 @@
 ---
 id: Upgrade guide
-section: get-started
+section: developer-resources
 ---
 
 Hey, Flyers! We’ve been busy for the past 12 weeks keeping up with changes to PatternFly’s HTML and CSS. We’ve replaced `babel` with `tsc` as our compiler of choice and removed prop-types in favor of using our `.d.ts` types, which are supported in most editors.

--- a/packages/react-docs/patternfly-docs.config.js
+++ b/packages/react-docs/patternfly-docs.config.js
@@ -6,7 +6,7 @@ module.exports = {
   hasVersionSwitcher: false,
   hasDesignGuidelines: false,
   sideNavItems: [
-    { section: 'get-started' },
+    { section: 'developer-resources' },
     { section: 'charts' },
     { section: 'components' },
     { section: 'demos' },


### PR DESCRIPTION
See original issue https://github.com/patternfly/patternfly-org/issues/2200

Closes #5090 

This PR:
- removes Get Started nav section from the workspace
- adds Developer Resources nav section to the workspace
- moves Release notes & Upgrade guide to Developer Resources

