### PR TITLE
fix(table): change internal column ids to uppercase

### DIFF
--- a/packages/react-table/src/components/Table/utils/headerUtils.test.tsx
+++ b/packages/react-table/src/components/Table/utils/headerUtils.test.tsx
@@ -58,7 +58,7 @@ describe('headerUtils', () => {
       const mixed = calculateColumns(cells, {});
       cells.forEach((oneCell: ICell, key) => {
         test(`${oneCell}`, () => {
-          expect(mixed[key].property).toBe(oneCell.title || oneCell);
+          expect(mixed[key].property).toBe((oneCell.title || oneCell).toUpperCase());
           expect(mixed[key].header.label).toBe(oneCell.title || oneCell);
           expect(mixed[key].header.transforms).toHaveLength(2);
           expect(mixed[key].cell.transforms).toHaveLength(1);
@@ -68,8 +68,8 @@ describe('headerUtils', () => {
     });
 
     test('correct property', () => {
-      expect(calculateColumns(['some'], {})[0].property).toBe('some');
-      expect(calculateColumns(['some with space'], {})[0].property).toBe('some-with-space');
+      expect(calculateColumns(['some'], {})[0].property).toBe('SOME');
+      expect(calculateColumns(['some with space'], {})[0].property).toBe('SOME-WITH-SPACE');
       expect(calculateColumns([''], {})[0].property).toBe('column-0');
     });
 

--- a/packages/react-table/src/components/Table/utils/headerUtils.tsx
+++ b/packages/react-table/src/components/Table/utils/headerUtils.tsx
@@ -109,7 +109,7 @@ const mapHeader = (column: ICell, extra: any, key: number, ...props: any) => {
     property:
       (typeof title === 'string' &&
         title
-          .toLowerCase()
+          .toUpperCase()
           .trim()
           .replace(/\s/g, '-')) ||
       `column-${key}`,

--- a/packages/react-virtualized-extension/src/components/Virtualized/__snapshots__/VirtualizedTable.test.tsx.snap
+++ b/packages/react-virtualized-extension/src/components/Virtualized/__snapshots__/VirtualizedTable.test.tsx.snap
@@ -167,7 +167,7 @@ exports[`Actions virtualized table 1`] = `
               [Function],
             ],
           },
-          "property": "header-cell",
+          "property": "HEADER-CELL",
           "props": Object {
             "data-key": 0,
             "data-label": "Header cell",
@@ -211,7 +211,7 @@ exports[`Actions virtualized table 1`] = `
               [Function],
             ],
           },
-          "property": "branches",
+          "property": "BRANCHES",
           "props": Object {
             "data-key": 1,
             "data-label": "Branches",
@@ -255,7 +255,7 @@ exports[`Actions virtualized table 1`] = `
               [Function],
             ],
           },
-          "property": "pull-requests",
+          "property": "PULL-REQUESTS",
           "props": Object {
             "data-key": 2,
             "data-label": "Pull requests",
@@ -299,7 +299,7 @@ exports[`Actions virtualized table 1`] = `
               [Function],
             ],
           },
-          "property": "workspaces",
+          "property": "WORKSPACES",
           "props": Object {
             "data-key": 3,
             "data-label": "Workspaces",
@@ -343,7 +343,7 @@ exports[`Actions virtualized table 1`] = `
               [Function],
             ],
           },
-          "property": "last-commit",
+          "property": "LAST-COMMIT",
           "props": Object {
             "data-key": 4,
             "data-label": "Last Commit",
@@ -473,7 +473,7 @@ exports[`Actions virtualized table 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "header-cell",
+                    "property": "HEADER-CELL",
                     "props": Object {
                       "data-key": 0,
                       "data-label": "Header cell",
@@ -517,7 +517,7 @@ exports[`Actions virtualized table 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "branches",
+                    "property": "BRANCHES",
                     "props": Object {
                       "data-key": 1,
                       "data-label": "Branches",
@@ -561,7 +561,7 @@ exports[`Actions virtualized table 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "pull-requests",
+                    "property": "PULL-REQUESTS",
                     "props": Object {
                       "data-key": 2,
                       "data-label": "Pull requests",
@@ -605,7 +605,7 @@ exports[`Actions virtualized table 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "workspaces",
+                    "property": "WORKSPACES",
                     "props": Object {
                       "data-key": 3,
                       "data-label": "Workspaces",
@@ -649,7 +649,7 @@ exports[`Actions virtualized table 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "last-commit",
+                    "property": "LAST-COMMIT",
                     "props": Object {
                       "data-key": 4,
                       "data-label": "Last Commit",
@@ -773,7 +773,7 @@ exports[`Actions virtualized table 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "header-cell",
+                        "property": "HEADER-CELL",
                         "props": Object {
                           "data-key": 0,
                           "data-label": "Header cell",
@@ -817,7 +817,7 @@ exports[`Actions virtualized table 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "branches",
+                        "property": "BRANCHES",
                         "props": Object {
                           "data-key": 1,
                           "data-label": "Branches",
@@ -861,7 +861,7 @@ exports[`Actions virtualized table 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "pull-requests",
+                        "property": "PULL-REQUESTS",
                         "props": Object {
                           "data-key": 2,
                           "data-label": "Pull requests",
@@ -905,7 +905,7 @@ exports[`Actions virtualized table 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "workspaces",
+                        "property": "WORKSPACES",
                         "props": Object {
                           "data-key": 3,
                           "data-label": "Workspaces",
@@ -949,7 +949,7 @@ exports[`Actions virtualized table 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "last-commit",
+                        "property": "LAST-COMMIT",
                         "props": Object {
                           "data-key": 4,
                           "data-label": "Last Commit",
@@ -1377,7 +1377,7 @@ exports[`Selectable virtualized table 1`] = `
               [Function],
             ],
           },
-          "property": "header-cell",
+          "property": "HEADER-CELL",
           "props": Object {
             "data-key": 1,
             "data-label": "Header cell",
@@ -1421,7 +1421,7 @@ exports[`Selectable virtualized table 1`] = `
               [Function],
             ],
           },
-          "property": "branches",
+          "property": "BRANCHES",
           "props": Object {
             "data-key": 2,
             "data-label": "Branches",
@@ -1465,7 +1465,7 @@ exports[`Selectable virtualized table 1`] = `
               [Function],
             ],
           },
-          "property": "pull-requests",
+          "property": "PULL-REQUESTS",
           "props": Object {
             "data-key": 3,
             "data-label": "Pull requests",
@@ -1509,7 +1509,7 @@ exports[`Selectable virtualized table 1`] = `
               [Function],
             ],
           },
-          "property": "workspaces",
+          "property": "WORKSPACES",
           "props": Object {
             "data-key": 4,
             "data-label": "Workspaces",
@@ -1553,7 +1553,7 @@ exports[`Selectable virtualized table 1`] = `
               [Function],
             ],
           },
-          "property": "last-commit",
+          "property": "LAST-COMMIT",
           "props": Object {
             "data-key": 5,
             "data-label": "Last Commit",
@@ -1683,7 +1683,7 @@ exports[`Selectable virtualized table 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "header-cell",
+                    "property": "HEADER-CELL",
                     "props": Object {
                       "data-key": 1,
                       "data-label": "Header cell",
@@ -1727,7 +1727,7 @@ exports[`Selectable virtualized table 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "branches",
+                    "property": "BRANCHES",
                     "props": Object {
                       "data-key": 2,
                       "data-label": "Branches",
@@ -1771,7 +1771,7 @@ exports[`Selectable virtualized table 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "pull-requests",
+                    "property": "PULL-REQUESTS",
                     "props": Object {
                       "data-key": 3,
                       "data-label": "Pull requests",
@@ -1815,7 +1815,7 @@ exports[`Selectable virtualized table 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "workspaces",
+                    "property": "WORKSPACES",
                     "props": Object {
                       "data-key": 4,
                       "data-label": "Workspaces",
@@ -1859,7 +1859,7 @@ exports[`Selectable virtualized table 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "last-commit",
+                    "property": "LAST-COMMIT",
                     "props": Object {
                       "data-key": 5,
                       "data-label": "Last Commit",
@@ -1983,7 +1983,7 @@ exports[`Selectable virtualized table 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "header-cell",
+                        "property": "HEADER-CELL",
                         "props": Object {
                           "data-key": 1,
                           "data-label": "Header cell",
@@ -2027,7 +2027,7 @@ exports[`Selectable virtualized table 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "branches",
+                        "property": "BRANCHES",
                         "props": Object {
                           "data-key": 2,
                           "data-label": "Branches",
@@ -2071,7 +2071,7 @@ exports[`Selectable virtualized table 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "pull-requests",
+                        "property": "PULL-REQUESTS",
                         "props": Object {
                           "data-key": 3,
                           "data-label": "Pull requests",
@@ -2115,7 +2115,7 @@ exports[`Selectable virtualized table 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "workspaces",
+                        "property": "WORKSPACES",
                         "props": Object {
                           "data-key": 4,
                           "data-label": "Workspaces",
@@ -2159,7 +2159,7 @@ exports[`Selectable virtualized table 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "last-commit",
+                        "property": "LAST-COMMIT",
                         "props": Object {
                           "data-key": 5,
                           "data-label": "Last Commit",
@@ -2563,7 +2563,7 @@ exports[`Simple Actions table 1`] = `
               [Function],
             ],
           },
-          "property": "header-cell",
+          "property": "HEADER-CELL",
           "props": Object {
             "data-key": 0,
             "data-label": "Header cell",
@@ -2626,7 +2626,7 @@ exports[`Simple Actions table 1`] = `
               [Function],
             ],
           },
-          "property": "branches",
+          "property": "BRANCHES",
           "props": Object {
             "data-key": 1,
             "data-label": "Branches",
@@ -2689,7 +2689,7 @@ exports[`Simple Actions table 1`] = `
               [Function],
             ],
           },
-          "property": "pull-requests",
+          "property": "PULL-REQUESTS",
           "props": Object {
             "data-key": 2,
             "data-label": "Pull requests",
@@ -2752,7 +2752,7 @@ exports[`Simple Actions table 1`] = `
               [Function],
             ],
           },
-          "property": "workspaces",
+          "property": "WORKSPACES",
           "props": Object {
             "data-key": 3,
             "data-label": "Workspaces",
@@ -2815,7 +2815,7 @@ exports[`Simple Actions table 1`] = `
               [Function],
             ],
           },
-          "property": "last-commit",
+          "property": "LAST-COMMIT",
           "props": Object {
             "data-key": 4,
             "data-label": "Last Commit",
@@ -2983,7 +2983,7 @@ exports[`Simple Actions table 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "header-cell",
+                    "property": "HEADER-CELL",
                     "props": Object {
                       "data-key": 0,
                       "data-label": "Header cell",
@@ -3046,7 +3046,7 @@ exports[`Simple Actions table 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "branches",
+                    "property": "BRANCHES",
                     "props": Object {
                       "data-key": 1,
                       "data-label": "Branches",
@@ -3109,7 +3109,7 @@ exports[`Simple Actions table 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "pull-requests",
+                    "property": "PULL-REQUESTS",
                     "props": Object {
                       "data-key": 2,
                       "data-label": "Pull requests",
@@ -3172,7 +3172,7 @@ exports[`Simple Actions table 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "workspaces",
+                    "property": "WORKSPACES",
                     "props": Object {
                       "data-key": 3,
                       "data-label": "Workspaces",
@@ -3235,7 +3235,7 @@ exports[`Simple Actions table 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "last-commit",
+                    "property": "LAST-COMMIT",
                     "props": Object {
                       "data-key": 4,
                       "data-label": "Last Commit",
@@ -3397,7 +3397,7 @@ exports[`Simple Actions table 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "header-cell",
+                        "property": "HEADER-CELL",
                         "props": Object {
                           "data-key": 0,
                           "data-label": "Header cell",
@@ -3460,7 +3460,7 @@ exports[`Simple Actions table 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "branches",
+                        "property": "BRANCHES",
                         "props": Object {
                           "data-key": 1,
                           "data-label": "Branches",
@@ -3523,7 +3523,7 @@ exports[`Simple Actions table 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "pull-requests",
+                        "property": "PULL-REQUESTS",
                         "props": Object {
                           "data-key": 2,
                           "data-label": "Pull requests",
@@ -3586,7 +3586,7 @@ exports[`Simple Actions table 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "workspaces",
+                        "property": "WORKSPACES",
                         "props": Object {
                           "data-key": 3,
                           "data-label": "Workspaces",
@@ -3649,7 +3649,7 @@ exports[`Simple Actions table 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "last-commit",
+                        "property": "LAST-COMMIT",
                         "props": Object {
                           "data-key": 4,
                           "data-label": "Last Commit",
@@ -4045,7 +4045,7 @@ exports[`Simple virtualized table aria-label 1`] = `
               [Function],
             ],
           },
-          "property": "header-cell",
+          "property": "HEADER-CELL",
           "props": Object {
             "data-key": 0,
             "data-label": "Header cell",
@@ -4089,7 +4089,7 @@ exports[`Simple virtualized table aria-label 1`] = `
               [Function],
             ],
           },
-          "property": "branches",
+          "property": "BRANCHES",
           "props": Object {
             "data-key": 1,
             "data-label": "Branches",
@@ -4133,7 +4133,7 @@ exports[`Simple virtualized table aria-label 1`] = `
               [Function],
             ],
           },
-          "property": "pull-requests",
+          "property": "PULL-REQUESTS",
           "props": Object {
             "data-key": 2,
             "data-label": "Pull requests",
@@ -4177,7 +4177,7 @@ exports[`Simple virtualized table aria-label 1`] = `
               [Function],
             ],
           },
-          "property": "workspaces",
+          "property": "WORKSPACES",
           "props": Object {
             "data-key": 3,
             "data-label": "Workspaces",
@@ -4221,7 +4221,7 @@ exports[`Simple virtualized table aria-label 1`] = `
               [Function],
             ],
           },
-          "property": "last-commit",
+          "property": "LAST-COMMIT",
           "props": Object {
             "data-key": 4,
             "data-label": "Last Commit",
@@ -4304,7 +4304,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "header-cell",
+                    "property": "HEADER-CELL",
                     "props": Object {
                       "data-key": 0,
                       "data-label": "Header cell",
@@ -4348,7 +4348,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "branches",
+                    "property": "BRANCHES",
                     "props": Object {
                       "data-key": 1,
                       "data-label": "Branches",
@@ -4392,7 +4392,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "pull-requests",
+                    "property": "PULL-REQUESTS",
                     "props": Object {
                       "data-key": 2,
                       "data-label": "Pull requests",
@@ -4436,7 +4436,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "workspaces",
+                    "property": "WORKSPACES",
                     "props": Object {
                       "data-key": 3,
                       "data-label": "Workspaces",
@@ -4480,7 +4480,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "last-commit",
+                    "property": "LAST-COMMIT",
                     "props": Object {
                       "data-key": 4,
                       "data-label": "Last Commit",
@@ -4557,7 +4557,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "header-cell",
+                        "property": "HEADER-CELL",
                         "props": Object {
                           "data-key": 0,
                           "data-label": "Header cell",
@@ -4601,7 +4601,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "branches",
+                        "property": "BRANCHES",
                         "props": Object {
                           "data-key": 1,
                           "data-label": "Branches",
@@ -4645,7 +4645,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "pull-requests",
+                        "property": "PULL-REQUESTS",
                         "props": Object {
                           "data-key": 2,
                           "data-label": "Pull requests",
@@ -4689,7 +4689,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "workspaces",
+                        "property": "WORKSPACES",
                         "props": Object {
                           "data-key": 3,
                           "data-label": "Workspaces",
@@ -4733,7 +4733,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "last-commit",
+                        "property": "LAST-COMMIT",
                         "props": Object {
                           "data-key": 4,
                           "data-label": "Last Commit",
@@ -4997,7 +4997,7 @@ exports[`Simple virtualized table className 1`] = `
               [Function],
             ],
           },
-          "property": "header-cell",
+          "property": "HEADER-CELL",
           "props": Object {
             "data-key": 0,
             "data-label": "Header cell",
@@ -5041,7 +5041,7 @@ exports[`Simple virtualized table className 1`] = `
               [Function],
             ],
           },
-          "property": "branches",
+          "property": "BRANCHES",
           "props": Object {
             "data-key": 1,
             "data-label": "Branches",
@@ -5085,7 +5085,7 @@ exports[`Simple virtualized table className 1`] = `
               [Function],
             ],
           },
-          "property": "pull-requests",
+          "property": "PULL-REQUESTS",
           "props": Object {
             "data-key": 2,
             "data-label": "Pull requests",
@@ -5129,7 +5129,7 @@ exports[`Simple virtualized table className 1`] = `
               [Function],
             ],
           },
-          "property": "workspaces",
+          "property": "WORKSPACES",
           "props": Object {
             "data-key": 3,
             "data-label": "Workspaces",
@@ -5173,7 +5173,7 @@ exports[`Simple virtualized table className 1`] = `
               [Function],
             ],
           },
-          "property": "last-commit",
+          "property": "LAST-COMMIT",
           "props": Object {
             "data-key": 4,
             "data-label": "Last Commit",
@@ -5256,7 +5256,7 @@ exports[`Simple virtualized table className 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "header-cell",
+                    "property": "HEADER-CELL",
                     "props": Object {
                       "data-key": 0,
                       "data-label": "Header cell",
@@ -5300,7 +5300,7 @@ exports[`Simple virtualized table className 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "branches",
+                    "property": "BRANCHES",
                     "props": Object {
                       "data-key": 1,
                       "data-label": "Branches",
@@ -5344,7 +5344,7 @@ exports[`Simple virtualized table className 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "pull-requests",
+                    "property": "PULL-REQUESTS",
                     "props": Object {
                       "data-key": 2,
                       "data-label": "Pull requests",
@@ -5388,7 +5388,7 @@ exports[`Simple virtualized table className 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "workspaces",
+                    "property": "WORKSPACES",
                     "props": Object {
                       "data-key": 3,
                       "data-label": "Workspaces",
@@ -5432,7 +5432,7 @@ exports[`Simple virtualized table className 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "last-commit",
+                    "property": "LAST-COMMIT",
                     "props": Object {
                       "data-key": 4,
                       "data-label": "Last Commit",
@@ -5509,7 +5509,7 @@ exports[`Simple virtualized table className 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "header-cell",
+                        "property": "HEADER-CELL",
                         "props": Object {
                           "data-key": 0,
                           "data-label": "Header cell",
@@ -5553,7 +5553,7 @@ exports[`Simple virtualized table className 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "branches",
+                        "property": "BRANCHES",
                         "props": Object {
                           "data-key": 1,
                           "data-label": "Branches",
@@ -5597,7 +5597,7 @@ exports[`Simple virtualized table className 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "pull-requests",
+                        "property": "PULL-REQUESTS",
                         "props": Object {
                           "data-key": 2,
                           "data-label": "Pull requests",
@@ -5641,7 +5641,7 @@ exports[`Simple virtualized table className 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "workspaces",
+                        "property": "WORKSPACES",
                         "props": Object {
                           "data-key": 3,
                           "data-label": "Workspaces",
@@ -5685,7 +5685,7 @@ exports[`Simple virtualized table className 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "last-commit",
+                        "property": "LAST-COMMIT",
                         "props": Object {
                           "data-key": 4,
                           "data-label": "Last Commit",
@@ -5955,7 +5955,7 @@ exports[`Sortable Virtualized Table 1`] = `
               [Function],
             ],
           },
-          "property": "header-cell",
+          "property": "HEADER-CELL",
           "props": Object {
             "data-key": 0,
             "data-label": "Header cell",
@@ -5999,7 +5999,7 @@ exports[`Sortable Virtualized Table 1`] = `
               [Function],
             ],
           },
-          "property": "branches",
+          "property": "BRANCHES",
           "props": Object {
             "data-key": 1,
             "data-label": "Branches",
@@ -6043,7 +6043,7 @@ exports[`Sortable Virtualized Table 1`] = `
               [Function],
             ],
           },
-          "property": "pull-requests",
+          "property": "PULL-REQUESTS",
           "props": Object {
             "data-key": 2,
             "data-label": "Pull requests",
@@ -6087,7 +6087,7 @@ exports[`Sortable Virtualized Table 1`] = `
               [Function],
             ],
           },
-          "property": "workspaces",
+          "property": "WORKSPACES",
           "props": Object {
             "data-key": 3,
             "data-label": "Workspaces",
@@ -6131,7 +6131,7 @@ exports[`Sortable Virtualized Table 1`] = `
               [Function],
             ],
           },
-          "property": "last-commit",
+          "property": "LAST-COMMIT",
           "props": Object {
             "data-key": 4,
             "data-label": "Last Commit",
@@ -6215,7 +6215,7 @@ exports[`Sortable Virtualized Table 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "header-cell",
+                    "property": "HEADER-CELL",
                     "props": Object {
                       "data-key": 0,
                       "data-label": "Header cell",
@@ -6259,7 +6259,7 @@ exports[`Sortable Virtualized Table 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "branches",
+                    "property": "BRANCHES",
                     "props": Object {
                       "data-key": 1,
                       "data-label": "Branches",
@@ -6303,7 +6303,7 @@ exports[`Sortable Virtualized Table 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "pull-requests",
+                    "property": "PULL-REQUESTS",
                     "props": Object {
                       "data-key": 2,
                       "data-label": "Pull requests",
@@ -6347,7 +6347,7 @@ exports[`Sortable Virtualized Table 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "workspaces",
+                    "property": "WORKSPACES",
                     "props": Object {
                       "data-key": 3,
                       "data-label": "Workspaces",
@@ -6391,7 +6391,7 @@ exports[`Sortable Virtualized Table 1`] = `
                         [Function],
                       ],
                     },
-                    "property": "last-commit",
+                    "property": "LAST-COMMIT",
                     "props": Object {
                       "data-key": 4,
                       "data-label": "Last Commit",
@@ -6469,7 +6469,7 @@ exports[`Sortable Virtualized Table 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "header-cell",
+                        "property": "HEADER-CELL",
                         "props": Object {
                           "data-key": 0,
                           "data-label": "Header cell",
@@ -6513,7 +6513,7 @@ exports[`Sortable Virtualized Table 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "branches",
+                        "property": "BRANCHES",
                         "props": Object {
                           "data-key": 1,
                           "data-label": "Branches",
@@ -6557,7 +6557,7 @@ exports[`Sortable Virtualized Table 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "pull-requests",
+                        "property": "PULL-REQUESTS",
                         "props": Object {
                           "data-key": 2,
                           "data-label": "Pull requests",
@@ -6601,7 +6601,7 @@ exports[`Sortable Virtualized Table 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "workspaces",
+                        "property": "WORKSPACES",
                         "props": Object {
                           "data-key": 3,
                           "data-label": "Workspaces",
@@ -6645,7 +6645,7 @@ exports[`Sortable Virtualized Table 1`] = `
                             [Function],
                           ],
                         },
-                        "property": "last-commit",
+                        "property": "LAST-COMMIT",
                         "props": Object {
                           "data-key": 4,
                           "data-label": "Last Commit",


### PR DESCRIPTION
**What**: Closes #4835 

Assuming the column data have to be properties of `rowData` (instead of having their own bucket) switching to uppercase solves the naming collision. Also has the added benefit of separating the column data from the rest of the properties.