### PR TITLE
feat(Toolbar): add flag to match page insets

### DIFF
--- a/packages/react-core/src/components/Toolbar/Toolbar.tsx
+++ b/packages/react-core/src/components/Toolbar/Toolbar.tsx
@@ -23,6 +23,8 @@ export interface ToolbarProps extends React.HTMLProps<HTMLDivElement> {
   children?: React.ReactNode;
   /** Id of the data toolbar */
   id?: string;
+  /** Flag indicating the toolbar should use the Page insets */
+  usePageInsets?: boolean;
   /** Insets at various breakpoints. */
   inset?: {
     default?: 'insetNone' | 'insetSm' | 'insetMd' | 'insetLg' | 'insetXl' | 'inset2xl';
@@ -103,6 +105,7 @@ export class Toolbar extends React.Component<ToolbarProps, ToolbarState> {
       className,
       children,
       inset,
+      usePageInsets,
       ...props
     } = this.props;
 
@@ -114,7 +117,16 @@ export class Toolbar extends React.Component<ToolbarProps, ToolbarState> {
     const showClearFiltersButton = numberOfFilters > 0;
 
     return (
-      <div className={css(styles.toolbar, formatBreakpointMods(inset, styles), className)} id={randomId} {...props}>
+      <div
+        className={css(
+          styles.toolbar,
+          usePageInsets && styles.modifiers.pageInsets,
+          formatBreakpointMods(inset, styles),
+          className
+        )}
+        id={randomId}
+        {...props}
+      >
         <ToolbarContext.Provider
           value={{
             isExpanded,

--- a/packages/react-core/src/components/Toolbar/__tests__/ToolbarToggleGroup.test.tsx
+++ b/packages/react-core/src/components/Toolbar/__tests__/ToolbarToggleGroup.test.tsx
@@ -40,4 +40,22 @@ describe('Toolbar', () => {
     );
     expect(view).toMatchSnapshot();
   });
+
+  it('should render with page inset flag', () => {
+    const items = (
+      <React.Fragment>
+        <ToolbarItem>Test</ToolbarItem>
+        <ToolbarItem>Test 2</ToolbarItem>
+        <ToolbarItem variant="separator" />
+        <ToolbarItem>Test 3 </ToolbarItem>
+      </React.Fragment>
+    );
+
+    const view = mount(
+      <Toolbar id="toolbar" usePageInsets>
+        <ToolbarContent>{items}</ToolbarContent>
+      </Toolbar>
+    );
+    expect(view).toMatchSnapshot();
+  });
 });

--- a/packages/react-core/src/components/Toolbar/__tests__/__snapshots__/ToolbarToggleGroup.test.tsx.snap
+++ b/packages/react-core/src/components/Toolbar/__tests__/__snapshots__/ToolbarToggleGroup.test.tsx.snap
@@ -139,3 +139,136 @@ exports[`Toolbar should render inset 1`] = `
   </div>
 </Toolbar>
 `;
+
+exports[`Toolbar should render with page inset flag 1`] = `
+<Toolbar
+  id="toolbar"
+  usePageInsets={true}
+>
+  <div
+    className="pf-c-toolbar pf-m-page-insets"
+    id="toolbar"
+  >
+    <ToolbarContent
+      isExpanded={false}
+      showClearFiltersButton={false}
+    >
+      <div
+        className="pf-c-toolbar__content"
+      >
+        <div
+          className="pf-c-toolbar__content-section"
+        >
+          <ToolbarItem>
+            <div
+              className="pf-c-toolbar__item"
+            >
+              Test
+            </div>
+          </ToolbarItem>
+          <ToolbarItem>
+            <div
+              className="pf-c-toolbar__item"
+            >
+              Test 2
+            </div>
+          </ToolbarItem>
+          <ToolbarItem
+            variant="separator"
+          >
+            <Divider
+              className="pf-m-vertical"
+            >
+              <hr
+                className="pf-c-divider pf-m-vertical"
+              />
+            </Divider>
+          </ToolbarItem>
+          <ToolbarItem>
+            <div
+              className="pf-c-toolbar__item"
+            >
+              Test 3 
+            </div>
+          </ToolbarItem>
+        </div>
+        <ToolbarExpandableContent
+          chipContainerRef={
+            Object {
+              "current": null,
+            }
+          }
+          clearFiltersButtonText="Clear all filters"
+          expandableContentRef={
+            Object {
+              "current": <div
+                class="pf-c-toolbar__expandable-content"
+                id="toolbar-expandable-content-1"
+              >
+                <div
+                  class="pf-c-toolbar__group"
+                />
+              </div>,
+            }
+          }
+          id="toolbar-expandable-content-1"
+          isExpanded={false}
+          showClearFiltersButton={false}
+        >
+          <div
+            className="pf-c-toolbar__expandable-content"
+            id="toolbar-expandable-content-1"
+          >
+            <ForwardRef>
+              <ToolbarGroupWithRef
+                innerRef={null}
+              >
+                <div
+                  className="pf-c-toolbar__group"
+                />
+              </ToolbarGroupWithRef>
+            </ForwardRef>
+          </div>
+        </ToolbarExpandableContent>
+      </div>
+    </ToolbarContent>
+    <ToolbarChipGroupContent
+      chipGroupContentRef={
+        Object {
+          "current": <div
+            class="pf-c-toolbar__content pf-m-hidden"
+            hidden=""
+          >
+            <div
+              class="pf-c-toolbar__group"
+            />
+          </div>,
+        }
+      }
+      clearFiltersButtonText="Clear all filters"
+      collapseListedFiltersBreakpoint="lg"
+      isExpanded={false}
+      numberOfFilters={0}
+      showClearFiltersButton={false}
+    >
+      <div
+        className="pf-c-toolbar__content pf-m-hidden"
+        hidden={true}
+      >
+        <ForwardRef
+          className=""
+        >
+          <ToolbarGroupWithRef
+            className=""
+            innerRef={null}
+          >
+            <div
+              className="pf-c-toolbar__group"
+            />
+          </ToolbarGroupWithRef>
+        </ForwardRef>
+      </div>
+    </ToolbarChipGroupContent>
+  </div>
+</Toolbar>
+`;


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4900

Adds a flag `usePageInsets` that indicates the toolbar should use Page's insets.