### PR TITLE
feat(textarea): support isDisabled

### DIFF
--- a/packages/react-core/src/components/TextArea/TextArea.tsx
+++ b/packages/react-core/src/components/TextArea/TextArea.tsx
@@ -15,6 +15,10 @@ export interface TextAreaProps extends Omit<HTMLProps<HTMLTextAreaElement>, 'onC
   className?: string;
   /** Flag to show if the TextArea is required. */
   isRequired?: boolean;
+  /** Flag to show if the TextArea is disabled. */
+  isDisabled?: boolean;
+  /** Flag to show if the TextArea is read only. */
+  isReadOnly?: boolean;
   /** Value to indicate if the textarea is modified to show that validation state.
    * If set to success, textarea will be modified to indicate valid state.
    * If set to error, textarea will be modified to indicate error state.
@@ -38,6 +42,7 @@ export class TextAreaBase extends React.Component<TextAreaProps> {
     innerRef: React.createRef<HTMLTextAreaElement>(),
     className: '',
     isRequired: false,
+    isDisabled: false,
     validated: 'default',
     resizeOrientation: 'both',
     'aria-label': null as string
@@ -58,8 +63,21 @@ export class TextAreaBase extends React.Component<TextAreaProps> {
   };
 
   render() {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { className, value, onChange, validated, isRequired, resizeOrientation, innerRef, ...props } = this.props;
+    const {
+      className,
+      value,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      onChange,
+      validated,
+      isRequired,
+      isDisabled,
+      isReadOnly,
+      resizeOrientation,
+      innerRef,
+      readOnly,
+      disabled,
+      ...props
+    } = this.props;
     const orientation = `resize${capitalize(resizeOrientation)}` as 'resizeVertical' | 'resizeHorizontal';
     return (
       <textarea
@@ -74,6 +92,8 @@ export class TextAreaBase extends React.Component<TextAreaProps> {
         {...(typeof this.props.defaultValue !== 'string' && { value })}
         aria-invalid={validated === ValidatedOptions.error}
         required={isRequired}
+        disabled={isDisabled || disabled}
+        readOnly={isReadOnly || readOnly}
         ref={innerRef}
         {...props}
       />

--- a/packages/react-core/src/components/TextArea/__tests__/Generated/__snapshots__/TextArea.test.tsx.snap
+++ b/packages/react-core/src/components/TextArea/__tests__/Generated/__snapshots__/TextArea.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`TextArea should match snapshot (auto-generated) 1`] = `
   aria-label="null"
   className="''"
   innerRef={null}
+  isDisabled={false}
   isRequired={false}
   onChange={[Function]}
   resizeOrientation="both"

--- a/packages/react-core/src/components/TextArea/__tests__/TextArea.test.tsx
+++ b/packages/react-core/src/components/TextArea/__tests__/TextArea.test.tsx
@@ -23,6 +23,26 @@ test('simple text input', () => {
   expect(view).toMatchSnapshot();
 });
 
+test('disabled text input using isDisabled', () => {
+  const view = mount(<TextArea {...props} aria-label="is disabled textarea" isDisabled />);
+  expect(view).toMatchSnapshot();
+});
+
+test('disabled text input using disabled', () => {
+  const view = mount(<TextArea {...props} aria-label="disabled textarea" disabled />);
+  expect(view).toMatchSnapshot();
+});
+
+test('read only text input using isReadOnly', () => {
+  const view = mount(<TextArea {...props} aria-label="is read only textarea" isReadOnly />);
+  expect(view).toMatchSnapshot();
+});
+
+test('read only text input using readOnly', () => {
+  const view = mount(<TextArea {...props} aria-label="read only textarea" readOnly />);
+  expect(view).toMatchSnapshot();
+});
+
 test('invalid text area', () => {
   const view = mount(<TextArea {...props} required validated={'error'} aria-label="invalid textarea" />);
   expect(view).toMatchSnapshot();

--- a/packages/react-core/src/components/TextArea/__tests__/__snapshots__/TextArea.test.tsx.snap
+++ b/packages/react-core/src/components/TextArea/__tests__/__snapshots__/TextArea.test.tsx.snap
@@ -1,5 +1,68 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`disabled text input using disabled 1`] = `
+<TextArea
+  aria-label="disabled textarea"
+  disabled={true}
+  onChange={[MockFunction]}
+  value="test textarea"
+>
+  <TextArea
+    aria-label="disabled textarea"
+    className=""
+    disabled={true}
+    innerRef={null}
+    isDisabled={false}
+    isRequired={false}
+    onChange={[MockFunction]}
+    resizeOrientation="both"
+    validated="default"
+    value="test textarea"
+  >
+    <textarea
+      aria-invalid={false}
+      aria-label="disabled textarea"
+      className="pf-c-form-control"
+      disabled={true}
+      onChange={[Function]}
+      required={false}
+      value="test textarea"
+    />
+  </TextArea>
+</TextArea>
+`;
+
+exports[`disabled text input using isDisabled 1`] = `
+<TextArea
+  aria-label="is disabled textarea"
+  isDisabled={true}
+  onChange={[MockFunction]}
+  value="test textarea"
+>
+  <TextArea
+    aria-label="is disabled textarea"
+    className=""
+    innerRef={null}
+    isDisabled={true}
+    isRequired={false}
+    onChange={[MockFunction]}
+    resizeOrientation="both"
+    validated="default"
+    value="test textarea"
+  >
+    <textarea
+      aria-invalid={false}
+      aria-label="is disabled textarea"
+      className="pf-c-form-control"
+      disabled={true}
+      onChange={[Function]}
+      required={false}
+      value="test textarea"
+    />
+  </TextArea>
+</TextArea>
+`;
+
 exports[`horizontally resizable text area 1`] = `
 <TextArea
   aria-label="horizontal resize textarea"
@@ -13,6 +76,7 @@ exports[`horizontally resizable text area 1`] = `
     aria-label="horizontal resize textarea"
     className=""
     innerRef={null}
+    isDisabled={false}
     isRequired={false}
     onChange={[MockFunction]}
     required={true}
@@ -44,6 +108,7 @@ exports[`invalid text area 1`] = `
     aria-label="invalid textarea"
     className=""
     innerRef={null}
+    isDisabled={false}
     isRequired={false}
     onChange={[MockFunction]}
     required={true}
@@ -63,6 +128,70 @@ exports[`invalid text area 1`] = `
 </TextArea>
 `;
 
+exports[`read only text input using isReadOnly 1`] = `
+<TextArea
+  aria-label="is read only textarea"
+  isReadOnly={true}
+  onChange={[MockFunction]}
+  value="test textarea"
+>
+  <TextArea
+    aria-label="is read only textarea"
+    className=""
+    innerRef={null}
+    isDisabled={false}
+    isReadOnly={true}
+    isRequired={false}
+    onChange={[MockFunction]}
+    resizeOrientation="both"
+    validated="default"
+    value="test textarea"
+  >
+    <textarea
+      aria-invalid={false}
+      aria-label="is read only textarea"
+      className="pf-c-form-control"
+      onChange={[Function]}
+      readOnly={true}
+      required={false}
+      value="test textarea"
+    />
+  </TextArea>
+</TextArea>
+`;
+
+exports[`read only text input using readOnly 1`] = `
+<TextArea
+  aria-label="read only textarea"
+  onChange={[MockFunction]}
+  readOnly={true}
+  value="test textarea"
+>
+  <TextArea
+    aria-label="read only textarea"
+    className=""
+    innerRef={null}
+    isDisabled={false}
+    isRequired={false}
+    onChange={[MockFunction]}
+    readOnly={true}
+    resizeOrientation="both"
+    validated="default"
+    value="test textarea"
+  >
+    <textarea
+      aria-invalid={false}
+      aria-label="read only textarea"
+      className="pf-c-form-control"
+      onChange={[Function]}
+      readOnly={true}
+      required={false}
+      value="test textarea"
+    />
+  </TextArea>
+</TextArea>
+`;
+
 exports[`simple text input 1`] = `
 <TextArea
   aria-label="simple textarea"
@@ -73,6 +202,7 @@ exports[`simple text input 1`] = `
     aria-label="simple textarea"
     className=""
     innerRef={null}
+    isDisabled={false}
     isRequired={false}
     onChange={[MockFunction]}
     resizeOrientation="both"
@@ -103,6 +233,7 @@ exports[`validated text area error 1`] = `
     aria-label="validated textarea"
     className=""
     innerRef={null}
+    isDisabled={false}
     isRequired={false}
     onChange={[MockFunction]}
     required={true}
@@ -134,6 +265,7 @@ exports[`validated text area success 1`] = `
     aria-label="validated textarea"
     className=""
     innerRef={null}
+    isDisabled={false}
     isRequired={false}
     onChange={[MockFunction]}
     required={true}
@@ -165,6 +297,7 @@ exports[`validated text area warning 1`] = `
     aria-label="validated textarea"
     className=""
     innerRef={null}
+    isDisabled={false}
     isRequired={false}
     onChange={[MockFunction]}
     required={true}
@@ -195,6 +328,7 @@ exports[`vertically resizable text area 1`] = `
     aria-label="vertical resize textarea"
     className=""
     innerRef={null}
+    isDisabled={false}
     isRequired={false}
     onChange={[MockFunction]}
     resizeOrientation="vertical"

--- a/packages/react-core/src/components/TextArea/examples/TextArea.md
+++ b/packages/react-core/src/components/TextArea/examples/TextArea.md
@@ -190,3 +190,11 @@ import { TextArea } from '@patternfly/react-core';
 
 <TextArea defaultValue="default value" aria-label="uncontrolled text area example" />
 ```
+
+### Disabled
+```js
+import React from 'react';
+import { TextArea } from '@patternfly/react-core';
+
+<TextArea aria-label="disabled text area example" isDisabled />
+```

--- a/packages/react-integration/cypress/integration/textarea.spec.ts
+++ b/packages/react-integration/cypress/integration/textarea.spec.ts
@@ -102,4 +102,20 @@ describe('Text Area Demo Test', () => {
       });
     cy.get('#textarea5.pf-m-warning').should('exist');
   });
+
+  it('Verify Text Area can not be changed when disabled', () => {
+    cy.get('#textarea6-a').should('be.disabled');
+    cy.get('#textarea6-a').type('testing', { force: true });
+    cy.get('#textarea6-a').should('have.value', 'disabled text area');
+
+    cy.get('#textarea6-b').should('be.disabled');
+    cy.get('#textarea6-a').type('testing', { force: true });
+    cy.get('#textarea6-b').should('have.value', 'isDisabled text area');
+
+    cy.get('#textarea7-a').type('testing', { force: true });
+    cy.get('#textarea7-a').should('have.value', 'readOnly text area');
+
+    cy.get('#textarea7-b').type('testing', { force: true });
+    cy.get('#textarea7-b').should('have.value', 'isReadOnly text area');
+  });
 });

--- a/packages/react-integration/demo-app-ts/src/components/demos/TextAreaDemo/TextAreaDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TextAreaDemo/TextAreaDemo.tsx
@@ -124,6 +124,12 @@ export class TextAreaDemo extends React.Component<{}, TextAreaState> {
           validated={validated}
           aria-label="text area example 5"
         />
+        <Text>Disabled text area </Text>
+        <TextArea id="textarea6-a" value={'disabled text area'} aria-label="text area example 6 a" disabled />
+        <TextArea id="textarea6-b" value={'isDisabled text area'} aria-label="text area example 6 b" isDisabled />
+        <Text>Read only text area </Text>
+        <TextArea id="textarea7-a" value={'readOnly text area'} aria-label="text area example 7 a" readOnly />
+        <TextArea id="textarea7-b" value={'isReadOnly text area'} aria-label="text area example 7 b" isReadOnly />
       </React.Fragment>
     );
   }


### PR DESCRIPTION
**What**: Closes #5068 

It is a breaking change. If someone is using `disabled` in the props then after updating with this change Typescript will show an error message saying `disabled` is not a valid props of `TextArea`.