### PR TITLE
feat(packages): bump Victory package

### DIFF
--- a/packages/react-charts/package.json
+++ b/packages/react-charts/package.json
@@ -35,7 +35,22 @@
     "hoist-non-react-statics": "^3.3.0",
     "lodash": "^4.17.19",
     "tslib": "1.13.0",
-    "victory": "^35.3.5"
+    "victory": "^35.3.5",
+    "victory-area": "^35.2.0",
+    "victory-axis": "^35.2.0",
+    "victory-bar": "^35.2.0",
+    "victory-chart": "^35.2.0",
+    "victory-core": "^35.2.0",
+    "victory-create-container": "^35.2.0",
+    "victory-group": "^35.2.0",
+    "victory-legend": "^35.2.0",
+    "victory-line": "^35.2.0",
+    "victory-pie": "^35.2.0",
+    "victory-scatter": "^35.2.0",
+    "victory-stack": "^35.2.0",
+    "victory-tooltip": "^35.2.0",
+    "victory-voronoi-container": "^35.2.0",
+    "victory-zoom-container": "^35.2.0"
   },
   "peerDependencies": {
     "react": "^16.8.0",

--- a/packages/react-charts/package.json
+++ b/packages/react-charts/package.json
@@ -35,22 +35,7 @@
     "hoist-non-react-statics": "^3.3.0",
     "lodash": "^4.17.19",
     "tslib": "1.13.0",
-    "victory": "^35.2.0",
-    "victory-area": "^35.2.0",
-    "victory-axis": "^35.2.0",
-    "victory-bar": "^35.2.0",
-    "victory-chart": "^35.2.0",
-    "victory-core": "^35.2.0",
-    "victory-create-container": "^35.2.0",
-    "victory-group": "^35.2.0",
-    "victory-legend": "^35.2.0",
-    "victory-line": "^35.2.0",
-    "victory-pie": "^35.2.0",
-    "victory-scatter": "^35.2.0",
-    "victory-stack": "^35.2.0",
-    "victory-tooltip": "^35.2.0",
-    "victory-voronoi-container": "^35.2.0",
-    "victory-zoom-container": "^35.2.0"
+    "victory": "^35.3.5"
   },
   "peerDependencies": {
     "react": "^16.8.0",

--- a/packages/react-charts/src/components/Chart/__snapshots__/Chart.test.tsx.snap
+++ b/packages/react-charts/src/components/Chart/__snapshots__/Chart.test.tsx.snap
@@ -492,6 +492,7 @@ exports[`Chart 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         dependentAxis={true}
@@ -1057,6 +1058,7 @@ exports[`Chart 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         fixLabelOverlap={false}
@@ -1641,6 +1643,7 @@ exports[`Chart 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         dependentAxis={true}
@@ -2224,6 +2227,7 @@ exports[`Chart 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         endAngle={360}
@@ -3722,6 +3726,7 @@ exports[`Chart 2`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         dependentAxis={true}
@@ -4287,6 +4292,7 @@ exports[`Chart 2`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         fixLabelOverlap={false}
@@ -4871,6 +4877,7 @@ exports[`Chart 2`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         dependentAxis={true}
@@ -5454,6 +5461,7 @@ exports[`Chart 2`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         endAngle={360}
@@ -6952,6 +6960,7 @@ exports[`renders axis and component children 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         dependentAxis={true}
@@ -7517,6 +7526,7 @@ exports[`renders axis and component children 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         fixLabelOverlap={false}
@@ -8101,6 +8111,7 @@ exports[`renders axis and component children 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         dependentAxis={true}
@@ -8684,6 +8695,7 @@ exports[`renders axis and component children 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         endAngle={360}

--- a/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
+++ b/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
@@ -12,7 +12,7 @@ import {
   RangePropType,
   ScalePropType,
   StringOrNumberOrList,
-  TickLabelProps
+  LabelProps
 } from 'victory-core';
 import { VictoryAxis, VictoryAxisProps, VictoryAxisTTargetType } from 'victory-axis';
 import { ChartContainer } from '../ChartContainer';
@@ -338,7 +338,7 @@ export interface ChartAxisProps extends VictoryAxisProps {
       [K in keyof React.CSSProperties]: string | number | ((tick?: any) => string | number);
     };
     tickLabels?: {
-      [K in keyof TickLabelProps]: string | number | ((tick?: any) => string | number);
+      [K in keyof LabelProps]: string | number | ((tick?: any) => string | number);
     };
   };
   /**

--- a/packages/react-charts/src/components/ChartAxis/__snapshots__/ChartAxis.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartAxis/__snapshots__/ChartAxis.test.tsx.snap
@@ -2412,6 +2412,7 @@ exports[`renders component data 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         dependentAxis={true}
@@ -2977,6 +2978,7 @@ exports[`renders component data 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         fixLabelOverlap={false}
@@ -3561,6 +3563,7 @@ exports[`renders component data 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         dependentAxis={true}
@@ -4144,6 +4147,7 @@ exports[`renders component data 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         endAngle={360}

--- a/packages/react-charts/src/components/ChartBar/__snapshots__/ChartBar.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartBar/__snapshots__/ChartBar.test.tsx.snap
@@ -2400,6 +2400,7 @@ exports[`renders component data 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         dependentAxis={true}
@@ -2965,6 +2966,7 @@ exports[`renders component data 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         fixLabelOverlap={false}
@@ -3549,6 +3551,7 @@ exports[`renders component data 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         dependentAxis={true}
@@ -4132,6 +4135,7 @@ exports[`renders component data 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         endAngle={360}

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletGroupTitle.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletGroupTitle.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { PaddingProps, Line, StringOrNumberOrCallback } from 'victory-core';
+import { PaddingProps, Line, StringOrNumberOrCallback, VictoryLabelStyleObject } from 'victory-core';
 import { ChartContainer } from '../ChartContainer';
 import { ChartLabel } from '../ChartLabel';
 import { ChartBulletStyles, ChartThemeDefinition } from '../ChartTheme';
@@ -137,10 +137,14 @@ export const ChartBulletGroupTitle: React.FunctionComponent<ChartBulletGroupTitl
   };
 
   const labelPadding = {
-    bottom: getPaddingForSide('bottom', padding, Number(theme.legend.style.labels.padding)),
-    left: getPaddingForSide('left', padding, Number(theme.legend.style.labels.padding)),
-    right: getPaddingForSide('right', padding, Number(theme.legend.style.labels.padding)),
-    top: getPaddingForSide('top', padding, Number(theme.legend.style.labels.padding))
+    bottom: getPaddingForSide(
+      'bottom',
+      padding,
+      Number((theme.legend.style.labels as VictoryLabelStyleObject).padding)
+    ),
+    left: getPaddingForSide('left', padding, Number((theme.legend.style.labels as VictoryLabelStyleObject).padding)),
+    right: getPaddingForSide('right', padding, Number((theme.legend.style.labels as VictoryLabelStyleObject).padding)),
+    top: getPaddingForSide('top', padding, Number((theme.legend.style.labels as VictoryLabelStyleObject).padding))
   };
 
   // Horizontal divider to render under the group title

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletGroupTitle.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletGroupTitle.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { PaddingProps, Line, StringOrNumberOrCallback, VictoryLabelStyleObject } from 'victory-core';
+import { PaddingProps, Line, StringOrNumberOrCallback } from 'victory-core';
 import { ChartContainer } from '../ChartContainer';
 import { ChartLabel } from '../ChartLabel';
 import { ChartBulletStyles, ChartThemeDefinition } from '../ChartTheme';
@@ -137,14 +137,10 @@ export const ChartBulletGroupTitle: React.FunctionComponent<ChartBulletGroupTitl
   };
 
   const labelPadding = {
-    bottom: getPaddingForSide(
-      'bottom',
-      padding,
-      Number((theme.legend.style.labels as VictoryLabelStyleObject).padding)
-    ),
-    left: getPaddingForSide('left', padding, Number((theme.legend.style.labels as VictoryLabelStyleObject).padding)),
-    right: getPaddingForSide('right', padding, Number((theme.legend.style.labels as VictoryLabelStyleObject).padding)),
-    top: getPaddingForSide('top', padding, Number((theme.legend.style.labels as VictoryLabelStyleObject).padding))
+    bottom: getPaddingForSide('bottom', padding, Number((theme.legend.style.labels as any).padding)),
+    left: getPaddingForSide('left', padding, Number((theme.legend.style.labels as any).padding)),
+    right: getPaddingForSide('right', padding, Number((theme.legend.style.labels as any).padding)),
+    top: getPaddingForSide('top', padding, Number((theme.legend.style.labels as any).padding))
   };
 
   // Horizontal divider to render under the group title

--- a/packages/react-charts/src/components/ChartContainer/__snapshots__/ChartContainer.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartContainer/__snapshots__/ChartContainer.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`ChartContainer 1`] = `
   portalComponent={<Portal />}
   portalZIndex={99}
   responsive={true}
+  role="img"
   theme={
     Object {
       "area": Object {
@@ -464,6 +465,7 @@ exports[`ChartContainer 2`] = `
   portalComponent={<Portal />}
   portalZIndex={99}
   responsive={true}
+  role="img"
   theme={
     Object {
       "area": Object {
@@ -922,6 +924,7 @@ exports[`renders container via ChartLegend 1`] = `
   portalComponent={<Portal />}
   portalZIndex={99}
   responsive={true}
+  role="img"
   theme={
     Object {
       "area": Object {

--- a/packages/react-charts/src/components/ChartCursorContainer/__snapshots__/ChartCursorContainer.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartCursorContainer/__snapshots__/ChartCursorContainer.test.tsx.snap
@@ -479,6 +479,7 @@ exports[`ChartVoronoiContainer 1`] = `
   portalComponent={<Portal />}
   portalZIndex={99}
   responsive={true}
+  role="img"
   theme={
     Object {
       "area": Object {
@@ -1410,6 +1411,7 @@ exports[`ChartVoronoiContainer 2`] = `
   portalComponent={<Portal />}
   portalZIndex={99}
   responsive={true}
+  role="img"
   theme={
     Object {
       "area": Object {
@@ -1894,6 +1896,7 @@ exports[`renders container via ChartGroup 1`] = `
       portalComponent={<Portal />}
       portalZIndex={99}
       responsive={true}
+      role="img"
       theme={
         Object {
           "area": Object {

--- a/packages/react-charts/src/components/ChartCursorTooltip/ChartCursorTooltip.tsx
+++ b/packages/react-charts/src/components/ChartCursorTooltip/ChartCursorTooltip.tsx
@@ -3,10 +3,9 @@ import hoistNonReactStatics from 'hoist-non-react-statics';
 import {
   Helpers,
   NumberOrCallback,
-  OrientationTypes,
+  OrientationOrCallback,
   StringOrNumberOrCallback,
   TextAnchorType,
-  VictoryNumberCallback,
   VictoryStyleObject
 } from 'victory-core';
 import { VictoryTooltip } from 'victory-tooltip';
@@ -159,7 +158,7 @@ export interface ChartCursorTooltipProps extends ChartTooltipProps {
    * values. If this prop is not provided it will be determined from the sign of the datum, and the value of the
    * horizontal prop.
    */
-  orientation?: OrientationTypes | VictoryNumberCallback;
+  orientation?: OrientationOrCallback;
   /**
    * The pointerLength prop determines the length of the triangular pointer extending from the flyout. This prop may be
    * given as a positive number or a function of datum.
@@ -170,7 +169,7 @@ export interface ChartCursorTooltipProps extends ChartTooltipProps {
    * it will be determined based on the overall orientation of the flyout in relation to its data point, and any center
    * or centerOffset values. Valid values are 'top', 'bottom', 'left' and 'right.
    */
-  pointerOrientation?: OrientationTypes | ((...args: any[]) => OrientationTypes);
+  pointerOrientation?: OrientationOrCallback;
   /**
    * The pointerWidth prop determines the width of the base of the triangular pointer extending from
    * the flyout. This prop may be given as a positive number or a function of datum.

--- a/packages/react-charts/src/components/ChartCursorTooltip/__snapshots__/ChartCursorFlyout.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartCursorTooltip/__snapshots__/ChartCursorFlyout.test.tsx.snap
@@ -998,6 +998,7 @@ exports[`allows tooltip via container component 1`] = `
       portalComponent={<Portal />}
       portalZIndex={99}
       responsive={true}
+      role="img"
       theme={
         Object {
           "area": Object {

--- a/packages/react-charts/src/components/ChartCursorTooltip/__snapshots__/ChartCursorTooltip.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartCursorTooltip/__snapshots__/ChartCursorTooltip.test.tsx.snap
@@ -988,6 +988,7 @@ exports[`allows tooltip via container component 1`] = `
       portalComponent={<Portal />}
       portalZIndex={99}
       responsive={true}
+      role="img"
       theme={
         Object {
           "area": Object {

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
@@ -598,9 +598,13 @@ export const ChartDonutUtilization: React.FunctionComponent<ChartDonutUtilizatio
         // Merge just the first color of dynamic (blue, green, etc.) with static (gray) for expected colorScale
         if (newTheme.pie.colorScale instanceof Array) {
           newTheme.pie.colorScale[0] = donutThresholds[i].color;
+        } else {
+          newTheme.pie.colorScale = donutThresholds[i].color;
         }
         if (newTheme.legend.colorScale instanceof Array) {
           newTheme.legend.colorScale[0] = donutThresholds[i].color;
+        } else {
+          newTheme.legend.colorScale = donutThresholds[i].color;
         }
       };
       for (let i = 0; i < donutThresholds.length; i++) {

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
@@ -596,8 +596,12 @@ export const ChartDonutUtilization: React.FunctionComponent<ChartDonutUtilizatio
       const donutThresholds = getDonutThresholds();
       const mergeThemeProps = (i: number) => {
         // Merge just the first color of dynamic (blue, green, etc.) with static (gray) for expected colorScale
-        newTheme.pie.colorScale[0] = donutThresholds[i].color;
-        newTheme.legend.colorScale[0] = donutThresholds[i].color;
+        if (newTheme.pie.colorScale instanceof Array) {
+          newTheme.pie.colorScale[0] = donutThresholds[i].color;
+        }
+        if (newTheme.legend.colorScale instanceof Array) {
+          newTheme.legend.colorScale[0] = donutThresholds[i].color;
+        }
       };
       for (let i = 0; i < donutThresholds.length; i++) {
         if (invert) {

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
@@ -293,7 +293,12 @@ export const ChartLegendTooltip: React.FunctionComponent<ChartLegendTooltipProps
   theme = getTheme(themeColor, themeVariant),
   ...rest
 }: ChartLegendTooltipProps) => {
-  const pointerLength = theme && theme.tooltip ? Number(theme.tooltip.pointerLength) : 10;
+  const pointerLength =
+    theme && theme.tooltip
+      ? theme.tooltip.pointerLength instanceof Function
+        ? theme.tooltip.pointerLength({ datum, index: rest.index || 0, ...rest })
+        : Number(theme.tooltip.pointerLength)
+      : 10;
   const legendTooltipProps = {
     legendData: getLegendTooltipVisibleData({ activePoints, legendData, text, theme }),
     legendProps: getLegendTooltipDataProps(labelComponent.props.legendComponent),

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
@@ -19,6 +19,7 @@ import {
   getLegendTooltipVisibleText,
   getTheme
 } from '../ChartUtils';
+import { isFunction } from 'lodash';
 
 /**
  * The ChartLegendTooltip is based on ChartCursorTooltip, which is intended to be used with a voronoi cursor
@@ -295,7 +296,7 @@ export const ChartLegendTooltip: React.FunctionComponent<ChartLegendTooltipProps
 }: ChartLegendTooltipProps) => {
   const pointerLength =
     theme && theme.tooltip
-      ? theme.tooltip.pointerLength instanceof Function
+      ? isFunction(theme.tooltip.pointerLength)
         ? theme.tooltip.pointerLength({ datum, index: rest.index || 0, ...rest })
         : Number(theme.tooltip.pointerLength)
       : 10;

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
@@ -297,7 +297,7 @@ export const ChartLegendTooltip: React.FunctionComponent<ChartLegendTooltipProps
   const pointerLength =
     theme && theme.tooltip
       ? isFunction(theme.tooltip.pointerLength)
-        ? theme.tooltip.pointerLength({ datum, index: rest.index || 0, ...rest })
+        ? theme.tooltip.pointerLength({ index: rest.index || 0, datum, ...rest })
         : Number(theme.tooltip.pointerLength)
       : 10;
   const legendTooltipProps = {

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
@@ -2,10 +2,9 @@ import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import {
   NumberOrCallback,
-  OrientationTypes,
+  OrientationOrCallback,
   StringOrNumberOrCallback,
   TextAnchorType,
-  VictoryNumberCallback,
   VictoryStyleObject
 } from 'victory-core';
 import { VictoryTooltip } from 'victory-tooltip';
@@ -196,7 +195,7 @@ export interface ChartLegendTooltipProps extends ChartCursorTooltipProps {
    * values. If this prop is not provided it will be determined from the sign of the datum, and the value of the
    * horizontal prop.
    */
-  orientation?: OrientationTypes | VictoryNumberCallback;
+  orientation?: OrientationOrCallback;
   /**
    * The pointerLength prop determines the length of the triangular pointer extending from the flyout. This prop may be
    * given as a positive number or a function of datum.
@@ -207,7 +206,7 @@ export interface ChartLegendTooltipProps extends ChartCursorTooltipProps {
    * it will be determined based on the overall orientation of the flyout in relation to its data point, and any center
    * or centerOffset values. Valid values are 'top', 'bottom', 'left' and 'right.
    */
-  pointerOrientation?: OrientationTypes | ((...args: any[]) => OrientationTypes);
+  pointerOrientation?: OrientationOrCallback;
   /**
    * The pointerWidth prop determines the width of the base of the triangular pointer extending from
    * the flyout. This prop may be given as a positive number or a function of datum.
@@ -294,7 +293,7 @@ export const ChartLegendTooltip: React.FunctionComponent<ChartLegendTooltipProps
   theme = getTheme(themeColor, themeVariant),
   ...rest
 }: ChartLegendTooltipProps) => {
-  const pointerLength = theme && theme.tooltip ? theme.tooltip.pointerLength : 10;
+  const pointerLength = theme && theme.tooltip ? Number(theme.tooltip.pointerLength) : 10;
   const legendTooltipProps = {
     legendData: getLegendTooltipVisibleData({ activePoints, legendData, text, theme }),
     legendProps: getLegendTooltipDataProps(labelComponent.props.legendComponent),

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipContent.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipContent.tsx
@@ -187,7 +187,7 @@ export const ChartLegendTooltipContent: React.FunctionComponent<ChartLegendToolt
   theme = getTheme(themeColor, themeVariant),
   ...rest
 }: ChartLegendTooltipContentProps) => {
-  const pointerLength = theme && theme.tooltip ? theme.tooltip.pointerLength : 10;
+  const pointerLength = theme && theme.tooltip ? Number(theme.tooltip.pointerLength) : 10;
   const legendProps = getLegendTooltipDataProps(legendComponent.props);
   const visibleLegendData = getLegendTooltipVisibleData({
     activePoints,

--- a/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltip.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltip.test.tsx.snap
@@ -1016,6 +1016,7 @@ exports[`allows tooltip via container component 1`] = `
       portalComponent={<Portal />}
       portalZIndex={99}
       responsive={true}
+      role="img"
       theme={
         Object {
           "area": Object {
@@ -1497,6 +1498,7 @@ exports[`allows tooltip via container component 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         dependentAxis={true}
@@ -2062,6 +2064,7 @@ exports[`allows tooltip via container component 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         fixLabelOverlap={false}
@@ -2646,6 +2649,7 @@ exports[`allows tooltip via container component 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         dependentAxis={true}
@@ -3229,6 +3233,7 @@ exports[`allows tooltip via container component 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         endAngle={360}

--- a/packages/react-charts/src/components/ChartLine/__snapshots__/ChartLine.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartLine/__snapshots__/ChartLine.test.tsx.snap
@@ -2368,6 +2368,7 @@ exports[`renders component data 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         dependentAxis={true}
@@ -2933,6 +2934,7 @@ exports[`renders component data 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         fixLabelOverlap={false}
@@ -3517,6 +3519,7 @@ exports[`renders component data 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         dependentAxis={true}
@@ -4100,6 +4103,7 @@ exports[`renders component data 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         endAngle={360}

--- a/packages/react-charts/src/components/ChartPie/__snapshots__/ChartPie.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartPie/__snapshots__/ChartPie.test.tsx.snap
@@ -462,6 +462,7 @@ exports[`ChartPie 1`] = `
           portalComponent={<Portal />}
           portalZIndex={99}
           responsive={true}
+          role="img"
         />
       }
       data={
@@ -1872,6 +1873,7 @@ exports[`ChartPie 2`] = `
           portalComponent={<Portal />}
           portalZIndex={99}
           responsive={true}
+          role="img"
         />
       }
       data={
@@ -3282,6 +3284,7 @@ exports[`renders component data 1`] = `
           portalComponent={<Portal />}
           portalZIndex={99}
           responsive={true}
+          role="img"
         />
       }
       data={

--- a/packages/react-charts/src/components/ChartScatter/__snapshots__/ChartScatter.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartScatter/__snapshots__/ChartScatter.test.tsx.snap
@@ -2352,6 +2352,7 @@ exports[`renders component data 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         dependentAxis={true}
@@ -2917,6 +2918,7 @@ exports[`renders component data 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         fixLabelOverlap={false}
@@ -3501,6 +3503,7 @@ exports[`renders component data 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         dependentAxis={true}
@@ -4084,6 +4087,7 @@ exports[`renders component data 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         endAngle={360}

--- a/packages/react-charts/src/components/ChartStack/__snapshots__/ChartStack.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartStack/__snapshots__/ChartStack.test.tsx.snap
@@ -2314,6 +2314,7 @@ exports[`renders component data 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         dependentAxis={true}
@@ -2879,6 +2880,7 @@ exports[`renders component data 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         fixLabelOverlap={false}
@@ -3463,6 +3465,7 @@ exports[`renders component data 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         dependentAxis={true}
@@ -4046,6 +4049,7 @@ exports[`renders component data 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         endAngle={360}

--- a/packages/react-charts/src/components/ChartThreshold/__snapshots__/ChartThreshold.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartThreshold/__snapshots__/ChartThreshold.test.tsx.snap
@@ -1418,6 +1418,7 @@ exports[`renders component data 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         dependentAxis={true}
@@ -1983,6 +1984,7 @@ exports[`renders component data 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         fixLabelOverlap={false}
@@ -2567,6 +2569,7 @@ exports[`renders component data 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         dependentAxis={true}
@@ -3150,6 +3153,7 @@ exports[`renders component data 1`] = `
             portalComponent={<Portal />}
             portalZIndex={99}
             responsive={true}
+            role="img"
           />
         }
         endAngle={360}

--- a/packages/react-charts/src/components/ChartTooltip/ChartTooltip.tsx
+++ b/packages/react-charts/src/components/ChartTooltip/ChartTooltip.tsx
@@ -5,7 +5,7 @@ import {
   OrientationTypes,
   StringOrNumberOrCallback,
   TextAnchorType,
-  VictoryNumberCallback,
+  OrientationOrCallback,
   VictoryStyleObject
 } from 'victory-core';
 import { VictoryTooltip, VictoryTooltipProps } from 'victory-tooltip';
@@ -154,7 +154,7 @@ export interface ChartTooltipProps extends VictoryTooltipProps {
    * values. If this prop is not provided it will be determined from the sign of the datum, and the value of the
    * horizontal prop.
    */
-  orientation?: OrientationTypes | VictoryNumberCallback;
+  orientation?: OrientationOrCallback;
   /**
    * The pointerLength prop determines the length of the triangular pointer extending from the flyout. This prop may be
    * given as a positive number or a function of datum.

--- a/packages/react-charts/src/components/ChartTooltip/__snapshots__/ChartTooltip.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartTooltip/__snapshots__/ChartTooltip.test.tsx.snap
@@ -1874,6 +1874,7 @@ exports[`allows tooltip via container component 1`] = `
       portalComponent={<Portal />}
       portalZIndex={99}
       responsive={true}
+      role="img"
       theme={
         Object {
           "area": Object {

--- a/packages/react-charts/src/components/ChartUtils/chart-theme.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-theme.ts
@@ -113,10 +113,8 @@ export const getDonutThresholdStaticTheme = (
   invert?: boolean
 ): ChartThemeDefinition => {
   const staticTheme = cloneDeep(ChartDonutThresholdStaticTheme);
-  if (staticTheme.pie.colorScale instanceof Array) {
-    if (invert) {
-      staticTheme.pie.colorScale = staticTheme.pie.colorScale.reverse();
-    }
+  if (invert && staticTheme.pie.colorScale instanceof Array) {
+    staticTheme.pie.colorScale = staticTheme.pie.colorScale.reverse();
   }
   return getCustomTheme(themeColor, themeVariant, staticTheme);
 };

--- a/packages/react-charts/src/components/ChartUtils/chart-theme.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-theme.ts
@@ -113,8 +113,10 @@ export const getDonutThresholdStaticTheme = (
   invert?: boolean
 ): ChartThemeDefinition => {
   const staticTheme = cloneDeep(ChartDonutThresholdStaticTheme);
-  if (invert) {
-    staticTheme.pie.colorScale = staticTheme.pie.colorScale.reverse();
+  if (staticTheme.pie.colorScale instanceof Array) {
+    if (invert) {
+      staticTheme.pie.colorScale = staticTheme.pie.colorScale.reverse();
+    }
   }
   return getCustomTheme(themeColor, themeVariant, staticTheme);
 };

--- a/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
@@ -49,7 +49,7 @@ export const getCursorTooltipCenterOffset = ({
   offsetCursorDimensionY = false,
   theme
 }: ChartCursorTooltipCenterOffsetInterface) => {
-  const pointerLength = theme && theme.tooltip ? theme.tooltip.pointerLength : 10;
+  const pointerLength = theme && theme.tooltip ? Number(theme.tooltip.pointerLength) : 10;
   const offsetX = ({ center, flyoutWidth, width }: any) => {
     const offset = flyoutWidth / 2 + pointerLength;
     return width > center.x + flyoutWidth + pointerLength ? offset : -offset;

--- a/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
 import chart_color_black_500 from '@patternfly/react-tokens/dist/js/chart_color_black_500';
+import { isFunction } from 'lodash';
 import { ColorScalePropType, Helpers, OrientationTypes, StringOrNumberOrCallback } from 'victory-core';
 import { ChartLegendProps } from '../ChartLegend';
 import { ChartLegendTooltipStyles, ChartThemeDefinition } from '../ChartTheme';
@@ -49,7 +50,12 @@ export const getCursorTooltipCenterOffset = ({
   offsetCursorDimensionY = false,
   theme
 }: ChartCursorTooltipCenterOffsetInterface) => {
-  const pointerLength = theme && theme.tooltip ? Number(theme.tooltip.pointerLength) : 10;
+  const pointerLength =
+    theme && theme.tooltip
+      ? isFunction(theme.tooltip.pointerLength)
+        ? theme.tooltip.pointerLength({ index: 0 })
+        : Number(theme.tooltip.pointerLength)
+      : 10;
   const offsetX = ({ center, flyoutWidth, width }: any) => {
     const offset = flyoutWidth / 2 + pointerLength;
     return width > center.x + flyoutWidth + pointerLength ? offset : -offset;

--- a/packages/react-charts/src/components/ChartVoronoiContainer/__snapshots__/ChartVoronoContainer.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartVoronoiContainer/__snapshots__/ChartVoronoContainer.test.tsx.snap
@@ -483,6 +483,7 @@ exports[`ChartVoronoiContainer 1`] = `
   portalComponent={<Portal />}
   portalZIndex={99}
   responsive={true}
+  role="img"
   theme={
     Object {
       "area": Object {
@@ -1419,6 +1420,7 @@ exports[`ChartVoronoiContainer 2`] = `
   portalComponent={<Portal />}
   portalZIndex={99}
   responsive={true}
+  role="img"
   theme={
     Object {
       "area": Object {
@@ -1907,6 +1909,7 @@ exports[`renders container via ChartGroup 1`] = `
       portalComponent={<Portal />}
       portalZIndex={99}
       responsive={true}
+      role="img"
       theme={
         Object {
           "area": Object {

--- a/packages/react-console/package.json
+++ b/packages/react-console/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@patternfly/patternfly": "4.59.1",
-    "@patternfly/react-core": "^4.75.9",
+    "@patternfly/react-core": "^4.75.10",
     "@spice-project/spice-html5": "^0.2.1",
     "@types/file-saver": "^2.0.1",
     "@types/novnc-core": "^0.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19876,91 +19876,91 @@ vfile@^4.0.0:
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
 
-victory-area@^35.2.0:
-  version "35.2.0"
-  resolved "https://registry.yarnpkg.com/victory-area/-/victory-area-35.2.0.tgz#6e47a97d627e66da3609e08068802026aba29e21"
-  integrity sha512-07QHwpZtyLmJoUJjX3HNSE9fDHV9Z2vExEze4HO9MjBA9+zx7d5OgCsYJlPafU2Y1FFgIgLmgYTBW4OO9e/yIQ==
+victory-area@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-area/-/victory-area-35.3.5.tgz#8cc8e560cb52f478cfe3aa7743822a08722845b6"
+  integrity sha512-W5JuMLCVHjysom1vnwFHXmuAXfAjmzZ4RWDVv0GZTUyZKDjZ0yD0XRKvrLcuN7cX702/5I3T1tf8N7TBICD7Lw==
   dependencies:
     d3-shape "^1.2.0"
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.2.0"
+    victory-core "^35.3.5"
 
-victory-axis@^35.2.0:
-  version "35.2.0"
-  resolved "https://registry.yarnpkg.com/victory-axis/-/victory-axis-35.2.0.tgz#ae747d19c38dd30f2e80296cb11b944f6e99707c"
-  integrity sha512-6OlAMGtbBwkRcx8YyPqMjjS7JfoYWWZ2OPM2Zxm04dCy94LO2eZqC31IV7SHW3A0h/+j33JDnkLrbuaAWOf+hw==
+victory-axis@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-axis/-/victory-axis-35.3.5.tgz#5305b1215f844b17f2278500619d4c9b47ab2b8f"
+  integrity sha512-E3E/MjwoFIWLGbn3TU13eUwa+t0FrG4M44uwKUmpmt6U7YCHmMcxb/WkOTyvAuytQl0jcPRI+mI3dNcqxCYhbQ==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.2.0"
+    victory-core "^35.3.5"
 
-victory-bar@^35.2.0:
-  version "35.2.0"
-  resolved "https://registry.yarnpkg.com/victory-bar/-/victory-bar-35.2.0.tgz#2cfde9d7f390cce24ddf82106d1220e0c81a9cce"
-  integrity sha512-QyLPhrL/8pFFGX04aq5hUsaIFcB9OOD5b+9PujpobHZjLICHlkkY25SBV1bKTBkzblxZF+kldNHS60EovCNNhw==
+victory-bar@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-bar/-/victory-bar-35.3.5.tgz#60ce981ef6acf2fd86519cfa31856ab5e8a80874"
+  integrity sha512-BDqdWOSubHb+aMvtN6zm5HaNNv4N66xSrHNIr2GC+FFnLp4wWuKtVdx5O4bmiVYWkdXMj1zrMu6KnWfe3/qb1w==
   dependencies:
     d3-shape "^1.2.0"
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.2.0"
+    victory-core "^35.3.5"
 
-victory-box-plot@^35.2.0:
-  version "35.2.0"
-  resolved "https://registry.yarnpkg.com/victory-box-plot/-/victory-box-plot-35.2.0.tgz#8691b5fb5449006532c6b887769c0f5678f0f60c"
-  integrity sha512-6HWVo/7QTnYiN6MExis9mmiCb45HRAfidW31CBQ8jCf6k//DOPYpKBPNJfChosdr2f5DUS42bQXlvraCdmDSRA==
+victory-box-plot@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-box-plot/-/victory-box-plot-35.3.5.tgz#cc7d98d7ddc8c3df2faeb3798f3b87fca4c7d022"
+  integrity sha512-rsX7sQt1qhNVc/1+hSBsU0Rb5WvbBbE/2uQ+7NWKVF744O4/VJLYEYV0DqmrjJtlUo6KP40oL+Ns04c1kv+rzA==
   dependencies:
     d3-array "^1.2.0"
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.2.0"
+    victory-core "^35.3.5"
 
-victory-brush-container@^35.2.0:
-  version "35.2.0"
-  resolved "https://registry.yarnpkg.com/victory-brush-container/-/victory-brush-container-35.2.0.tgz#cec3994a332490e1d6e9c756e5a1d71a93234d9c"
-  integrity sha512-KgfdxiP5/ka18uu+gvgDizTMa+RknKforIX6sE9Kx++BvX3QZZvS7N6wmiot7jud4Pyo90rtxJoRG4NigIxVWA==
+victory-brush-container@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-brush-container/-/victory-brush-container-35.3.5.tgz#7dfa23334f0b5b29ad5eeee20c06f3b3d856a893"
+  integrity sha512-UrzPDKt/PPxhrhbt9xyKxlny52ACAvJHBXdGOohLgtaFjt6xHyFTO6mvmjXtZlt8SxHf3KTc2lezi37b4DsmgA==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-core "^35.2.0"
+    victory-core "^35.3.5"
 
-victory-brush-line@^35.2.0:
-  version "35.2.0"
-  resolved "https://registry.yarnpkg.com/victory-brush-line/-/victory-brush-line-35.2.0.tgz#2657057eb8a48ed2ad847f86f2a24a4fe9fceeab"
-  integrity sha512-9NAszFUobuOE3cLIdXHQJJ5V41INo5iMJQg5lbhJRI83QQsw4gNIYpRPr3CBhjTaPBDvfVxwEubUBfwWAE/jWg==
+victory-brush-line@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-brush-line/-/victory-brush-line-35.3.5.tgz#82f26f7010398df981fd8705696a9cfd26b8be13"
+  integrity sha512-YEhTLEY5ImnSBj5fMDGLGpbVPlFkd04PkACXJP4dNsgv4xwJPBbcgRY2DAvkdbpj7Zu6TenRG9AzEU9afM7chw==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-core "^35.2.0"
+    victory-core "^35.3.5"
 
-victory-candlestick@^35.2.0:
-  version "35.2.0"
-  resolved "https://registry.yarnpkg.com/victory-candlestick/-/victory-candlestick-35.2.0.tgz#ca6cafd24b4ee9784cbef56a14eedfda225f9581"
-  integrity sha512-lYia+78umewrD5Rcl+YpBHweoyAf/OAWaCP164BWOCDrp8WQ7a4h6xD6FCk0btAvi8sC8WUsPeA5tIe+YtnFCQ==
+victory-candlestick@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-candlestick/-/victory-candlestick-35.3.5.tgz#0398c94ff369d9d624b3baa9ac5a28ac204ab54f"
+  integrity sha512-V+dK9tqjYMNK7MgJ+zZy1eif9l77xBgMIORVMbwauBPIkiL8Z5eulO+Y9/vq33/4JezDrJFH41WEW+Lg9PonzA==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.2.0"
+    victory-core "^35.3.5"
 
-victory-chart@^35.2.0:
-  version "35.2.0"
-  resolved "https://registry.yarnpkg.com/victory-chart/-/victory-chart-35.2.0.tgz#42deb6988c79ff2d3a1bd3c2c869666bb58c399b"
-  integrity sha512-Jn/hlSEJh6pOlSyBvVzoQti5gWilKmWR9qew2HsO7NyZSwkxUI41I9kh+0YlzbScT4ANIq2bJxgaQrH9qeGBFg==
+victory-chart@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-chart/-/victory-chart-35.3.5.tgz#b99aea41a2fc487a58587057b3ee4e132e450246"
+  integrity sha512-ByKrqQzZbkw1mvqdSvRrfsSiAZpJ8AAWjeLa1BAfgKwXf/qdoKwU8flCG5cySWNhorUHyNrzFY9vYmzvA0nW8A==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-axis "^35.2.0"
-    victory-core "^35.2.0"
-    victory-polar-axis "^35.2.0"
-    victory-shared-events "^35.2.0"
+    victory-axis "^35.3.5"
+    victory-core "^35.3.5"
+    victory-polar-axis "^35.3.5"
+    victory-shared-events "^35.3.5"
 
-victory-core@^35.2.0:
-  version "35.2.0"
-  resolved "https://registry.yarnpkg.com/victory-core/-/victory-core-35.2.0.tgz#65b00995648fd149f0ef3e2121f441dfd775dc9e"
-  integrity sha512-ha4j1vfWKEJVhN1NT61Aoq1WJbpLWG4RSHuuDaTyRkdp2Zz2mYEo+F0UAYxbcXhcdE3fik4ZZULiv8ve64fIYw==
+victory-core@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-core/-/victory-core-35.3.5.tgz#0b89235a312ab9b430642c5593517b3cba649faa"
+  integrity sha512-HhxuXA26X5QZQ/TYsXNUfKtZDHMgTDoA97ln32fV2EDHk1+Sg4KIbMJAaOgsy+2b8y5uUE2Gc37gzABKGhc8dA==
   dependencies:
     d3-ease "^1.0.0"
     d3-interpolate "^1.1.1"
@@ -19971,209 +19971,210 @@ victory-core@^35.2.0:
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
 
-victory-create-container@^35.2.0:
-  version "35.2.0"
-  resolved "https://registry.yarnpkg.com/victory-create-container/-/victory-create-container-35.2.0.tgz#dd2cec040fa7189ec59cff9114df6b97c3332609"
-  integrity sha512-krxZpJKSwMDc6sfAeSRkjF6tdDa7P12LFOCA9unW33Vr2WsQQs8s6+ol+fch8TFB8i5Q6yDISRj69sxzQztwzA==
+victory-create-container@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-create-container/-/victory-create-container-35.3.5.tgz#d958da42979a2c641a4eaf82363d16fb8ed8fff6"
+  integrity sha512-bDk7F/3a8pXOYjq61MEgpX4f7koatZb2v35n2ZgxoUliXIS1YQ+4bC9gYU3QPVoFDH2xGpwF/MSIKOecxcwwbA==
   dependencies:
     lodash "^4.17.19"
-    victory-brush-container "^35.2.0"
-    victory-core "^35.2.0"
-    victory-cursor-container "^35.2.0"
-    victory-selection-container "^35.2.0"
-    victory-voronoi-container "^35.2.0"
-    victory-zoom-container "^35.2.0"
+    victory-brush-container "^35.3.5"
+    victory-core "^35.3.5"
+    victory-cursor-container "^35.3.5"
+    victory-selection-container "^35.3.5"
+    victory-voronoi-container "^35.3.5"
+    victory-zoom-container "^35.3.5"
 
-victory-cursor-container@^35.2.0:
-  version "35.2.0"
-  resolved "https://registry.yarnpkg.com/victory-cursor-container/-/victory-cursor-container-35.2.0.tgz#b5f04357c991253cfe894ffa89e2be200b8a17f2"
-  integrity sha512-VIl1h15Js2Mvkd1YOAgiFKuOxV+Lsn+GcbWS3gPuDDZlTVL82+n/nmcBXf+t6v41tZz9GUfcVphp8MCAT/tiog==
-  dependencies:
-    lodash "^4.17.19"
-    prop-types "^15.5.8"
-    victory-core "^35.2.0"
-
-victory-errorbar@^35.2.0:
-  version "35.2.0"
-  resolved "https://registry.yarnpkg.com/victory-errorbar/-/victory-errorbar-35.2.0.tgz#bd5897628d042fdada078d8379e009803dad41ff"
-  integrity sha512-JamxvyjxHwcbJU7eV3HnGbi1SdhvoOKC3zadJr/e/jItMtJrMQWIdErpj/XcL9ScQkLBEq8Plzya3YQo7tSvKA==
+victory-cursor-container@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-cursor-container/-/victory-cursor-container-35.3.5.tgz#821a15990fc33b3ca2c448ffa1d74ad6cf9b88fb"
+  integrity sha512-e1XdEFmh+/VOl6kxMzbqe94DsbOnmzDtFVVx58z1XCMONJIxCVtppG0D88FCyrj8fHFIVnUlHkSObYM9G1kRvg==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.2.0"
+    victory-core "^35.3.5"
 
-victory-group@^35.2.0:
-  version "35.2.0"
-  resolved "https://registry.yarnpkg.com/victory-group/-/victory-group-35.2.0.tgz#f314b50f2a617c7248708ad3cd0bd10a3f7d083a"
-  integrity sha512-crv7to0RkJktrRk8fNoPuXsEYCplQk9Q+BV0AxLTEnPkRyxgUCjHgEgqQ8wqCXfPLYtyjUUteJhGDjinm3e4FQ==
+victory-errorbar@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-errorbar/-/victory-errorbar-35.3.5.tgz#92313a0c7948a754d25b8f772b33cddbfe71d112"
+  integrity sha512-JfuZSCI8lu8AQZ7eja+5eId9Vc4v7qG1Vy/aFp2j+glxINKCCf7Z/oJDKkIRp+ayzFb98T6Cz5LlXdLk9Kj4dw==
+  dependencies:
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    victory-core "^35.3.5"
+
+victory-group@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-group/-/victory-group-35.3.5.tgz#12bcbf6ebf65376a4990891534bc18de7c60fcec"
+  integrity sha512-pRTSb1bPOCQCpK5/eHsTuqiSfb8YRGUKVV1YpZAjDy7tVauF10gdbtItCE1W16rgEd9BrU9MgQZp0May76G2Mw==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-core "^35.2.0"
-    victory-shared-events "^35.2.0"
+    victory-core "^35.3.5"
+    victory-shared-events "^35.3.5"
 
-victory-histogram@^35.2.0:
-  version "35.2.0"
-  resolved "https://registry.yarnpkg.com/victory-histogram/-/victory-histogram-35.2.0.tgz#be97f87b3fa7ddeafe6ef1e6602f1703b28fa63e"
-  integrity sha512-Rl7BO8FVtOW7dbgtcDc1iNbZWRKBpACtauIgOAPeFwRfohTPOGzbFTiayo/5eqm7wHR4NfB94MY63eOD2vozqQ==
+victory-histogram@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-histogram/-/victory-histogram-35.3.5.tgz#95ccffc8ee08cce5b88b24da9ab1240414f4300f"
+  integrity sha512-eztr8KjA5AAgPLCLWvqnyETOpMhZC+VuUbcISPHJ0n+0Icxy1eawHSPX8pbhPprYg0OoVnDApNsq4gJDcHSk3Q==
   dependencies:
     d3-array "^2.4.0"
     d3-scale "^1.0.0"
     lodash "^4.17.19"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-bar "^35.2.0"
-    victory-core "^35.2.0"
+    victory-bar "^35.3.5"
+    victory-core "^35.3.5"
 
-victory-legend@^35.2.0:
-  version "35.2.0"
-  resolved "https://registry.yarnpkg.com/victory-legend/-/victory-legend-35.2.0.tgz#741fed1db9d1e93c29094c23dd6d2b0381f63915"
-  integrity sha512-PiAD3pMg8E7scRRfSHRxgXjWS1xFY0t3BXLYEN4NzxDIyYshHZTWAfn5kOnEDuugd7vovEsog+kyMyXhy/miIg==
+victory-legend@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-legend/-/victory-legend-35.3.5.tgz#91796f69f74a3fff66564f0754b6f19bf3d7ada8"
+  integrity sha512-wDSYd88q6INYeM94vGd+jqNYLnTF8Q6zuqfQzuksq+QCkJfFVFkOpD83PPzPVYohCwmlPLCPnVo2VEew3fglAQ==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.2.0"
+    victory-core "^35.3.5"
 
-victory-line@^35.2.0:
-  version "35.2.0"
-  resolved "https://registry.yarnpkg.com/victory-line/-/victory-line-35.2.0.tgz#99edb0d78db4335fb2d7ffb9bd1a6007edad3e22"
-  integrity sha512-Rx51MW46yJfOvGpj71FfYAPOBdSUPQYTpSFdKUEmtFoZwu84dUtHiAbmISk8d8vQTYJDDsGFxgmi2XantR13RA==
+victory-line@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-line/-/victory-line-35.3.5.tgz#4e6a955ebad3404a5c2326de979b868bd973e8b8"
+  integrity sha512-//5Lk/LwdBrnBa5Y3y9zkImFL45EySnS+uRUT8OrJOD41Tx5vVRpTAtJ1Ia+lhQ3QKfFvpk/x4tI1nJljE001Q==
   dependencies:
     d3-shape "^1.2.0"
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.2.0"
+    victory-core "^35.3.5"
 
-victory-pie@^35.2.0:
-  version "35.2.0"
-  resolved "https://registry.yarnpkg.com/victory-pie/-/victory-pie-35.2.0.tgz#728ea5b8b35fc7a87c69681c8863a370b3c495c4"
-  integrity sha512-nt9iRb2GGcKE46bmG8P5LbX+ouYQJi4/e85rfGjUtEVusz2jo2mQ17eeQpZJAJi9R7WlUtM33MxnaqtnZwHYjA==
+victory-pie@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-pie/-/victory-pie-35.3.5.tgz#fe3de4251fa2c1748bc941209ce44087918cea78"
+  integrity sha512-HR8p8wK5J9Etikicll0cRGchKiB2v7w5iqyV4BzBx2FTvE/5VzAWBm0RjyRqS5ykM2TfDc3lrz1zXsPB2vhcpw==
   dependencies:
     d3-shape "^1.0.0"
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.2.0"
+    victory-core "^35.3.5"
 
-victory-polar-axis@^35.2.0:
-  version "35.2.0"
-  resolved "https://registry.yarnpkg.com/victory-polar-axis/-/victory-polar-axis-35.2.0.tgz#cdd3237bfdcd2ca82d7beff1d2eb75c3c25a302d"
-  integrity sha512-kZJz1ecEN90ycvEWt3scYlsZUAVddpy/nE0MVok/ALI6LU9cJ1cGBvwTxhtXSjs8Yfcl7G3l880MhWIqG5JdyQ==
+victory-polar-axis@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-polar-axis/-/victory-polar-axis-35.3.5.tgz#f89ebbbe9b3d7f0d4153271fd2a92284987cf786"
+  integrity sha512-i0PdkxxgIFeW1jGHkczGPlHW4reWWXDEhaN/L4dByqv0GmOCRY+HoMxnNgQ9nNQideeHt3BuJWgd4SjPOS6a3A==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.2.0"
+    victory-core "^35.3.5"
 
-victory-scatter@^35.2.0:
-  version "35.2.0"
-  resolved "https://registry.yarnpkg.com/victory-scatter/-/victory-scatter-35.2.0.tgz#bb691587c278e2890b43063290292bb0858c18c2"
-  integrity sha512-C/yjqT5z2ymWu0vPUZFbiEchLSbwCoo/Fwv6VHfia/sI05W1huZ9+5voUstMe9SqLnT/31XF+lUb+xIffcE6qg==
+victory-scatter@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-scatter/-/victory-scatter-35.3.5.tgz#f4651c7ebb0eb626689308f58b53bf85f01336da"
+  integrity sha512-we21KDpK6vWZBZnY2LddA4nGmYF3rif5MC9F1hxxJpVX5nVLCqXXJsQgLB8zUKYbWRZVIzzpIp/sDYc1MvSC1g==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.2.0"
+    victory-core "^35.3.5"
 
-victory-selection-container@^35.2.0:
-  version "35.2.0"
-  resolved "https://registry.yarnpkg.com/victory-selection-container/-/victory-selection-container-35.2.0.tgz#2ad22f05bce7e740c333b65e75f3255b3e2fd61e"
-  integrity sha512-mHvTdGxClA2m0HBIleg578GGcsRp7qLL8Rj2n8/iFetzLf9GLE9CtF+a1HKd8yLAeij6XmCNq8MIvO4ERg725g==
+victory-selection-container@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-selection-container/-/victory-selection-container-35.3.5.tgz#9bca411d8b2c6b3bc2ec33aa2a7ebceb5faeb563"
+  integrity sha512-iFQZjtD69PYO8RWf4FXKsyS06WGin+0gSUTSW22zEOOTdrzW94yy+F3/EPIUpbwwtMNDm2moctuLgF8Tjd//zA==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.2.0"
+    victory-core "^35.3.5"
 
-victory-shared-events@^35.2.0:
-  version "35.2.0"
-  resolved "https://registry.yarnpkg.com/victory-shared-events/-/victory-shared-events-35.2.0.tgz#345e11acf3cd91a1ea98a406072519161486e97c"
-  integrity sha512-M+dvtCwK/YsnZ6ruKjrir0WfK0n5b63tLer3GwdiEdMyaWgn4hEDhafpH5PYagyG00ujSqadgf3DMRQoimv+dw==
+victory-shared-events@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-shared-events/-/victory-shared-events-35.3.5.tgz#e3efe1c27c85c710957a005ba6b3270e5da758a5"
+  integrity sha512-KUEYZsHTEkO8GlENUoJm5DvcKfvJFrVB4ebtU8kArkTrh/bQFaIWmmyWgGxfFlOzxUcWrxJntXinHse3QKtq8Q==
+  dependencies:
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.19"
+    prop-types "^15.5.8"
+    react-fast-compare "^2.0.0"
+    victory-core "^35.3.5"
+
+victory-stack@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-stack/-/victory-stack-35.3.5.tgz#aff896c3bae4c2bcfc337be8d6dbc7557ca495eb"
+  integrity sha512-nO8u7qVvhsreIRxI+8hrzqXqmXr/vgEObS168MuAmhDV7JUV2cnDK9MEHMPPAvM2Anq4o/AYLBifSjQbwkCulQ==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-core "^35.2.0"
+    victory-core "^35.3.5"
+    victory-shared-events "^35.3.5"
 
-victory-stack@^35.2.0:
-  version "35.2.0"
-  resolved "https://registry.yarnpkg.com/victory-stack/-/victory-stack-35.2.0.tgz#b2005101b85edfb62af1692f6d9173bd80f41b5c"
-  integrity sha512-ofNCYpTj5Qq8ruYLFo46aQ4WyNZ514wqZUytGhs9+muJTClCjmnP4f6jfbsghZbPPucv0fGwABoiXcYIc+fJ5Q==
+victory-tooltip@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-tooltip/-/victory-tooltip-35.3.5.tgz#985ee8e84162d042304e90cdaf05bfbdfc5f7ca7"
+  integrity sha512-i0VfBYPsm1z3MSoe8a8EPrB4Ytg+6avjBCHbr5//9Sa9eqWzslx1cvVdl1+q6ibC2fCNQpW8W6pmk8FIYHfMAg==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    react-fast-compare "^2.0.0"
-    victory-core "^35.2.0"
-    victory-shared-events "^35.2.0"
+    victory-core "^35.3.5"
 
-victory-tooltip@^35.2.0:
-  version "35.2.0"
-  resolved "https://registry.yarnpkg.com/victory-tooltip/-/victory-tooltip-35.2.0.tgz#56189f6d61ba4262405e32a84a2ee75d98826db2"
-  integrity sha512-w6M2g+c0ZFfKM80Cife/9kCOd3xiXSaSCjdokp2GRBA8zD9CkbiCAGYLsF+CQBSoeZpMCyzC6bsiEtzb4SD48g==
-  dependencies:
-    lodash "^4.17.19"
-    prop-types "^15.5.8"
-    victory-core "^35.2.0"
-
-victory-voronoi-container@^35.2.0:
-  version "35.2.0"
-  resolved "https://registry.yarnpkg.com/victory-voronoi-container/-/victory-voronoi-container-35.2.0.tgz#38155b9c97836eb1785ac2720e9c3204b37d33ac"
-  integrity sha512-mevciZwcVuQ9k4PqTSz/3hSF+XyHR1DbYoZsAZJlocsezncYtdxKYbw7MOraubio/H5wCgsICi/llmxiPFmPHg==
+victory-voronoi-container@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-voronoi-container/-/victory-voronoi-container-35.3.5.tgz#6932a71dc68d207eca30f5c540349d79c0d69678"
+  integrity sha512-+qkb0Bk4KpVtNjGDBWeXVBQajuJk5oxH2n9C1fMbLYNKlxjojXTYm5PkZlc5zH4aDSkhK/XFQWf+W67fnqHlTw==
   dependencies:
     delaunay-find "0.0.5"
     lodash "^4.17.19"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-core "^35.2.0"
-    victory-tooltip "^35.2.0"
+    victory-core "^35.3.5"
+    victory-tooltip "^35.3.5"
 
-victory-voronoi@^35.2.0:
-  version "35.2.0"
-  resolved "https://registry.yarnpkg.com/victory-voronoi/-/victory-voronoi-35.2.0.tgz#e6d7341566dff915ac597baa660961f8f52b469e"
-  integrity sha512-TJ6t2Bxl5wu451igdJ/vIKddBIHxSJgGbuGybYgj0CTjl4KH9U16Gx8ILILm2bW07/Am1PFWQpjFjK+3Gn5NdA==
+victory-voronoi@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-voronoi/-/victory-voronoi-35.3.5.tgz#ba7975b61b2414797e5385ca6d9c5b9c1581a7c6"
+  integrity sha512-H8W6So0hCM2l8vJEeaFaHnG0T9oh1FoNWMZXkr8kxo+/38GbvLQLtLovdccYyMNmp5BDxaZ3MZGT0QipbnCVYg==
   dependencies:
     d3-voronoi "^1.1.2"
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.2.0"
+    victory-core "^35.3.5"
 
-victory-zoom-container@^35.2.0:
-  version "35.2.0"
-  resolved "https://registry.yarnpkg.com/victory-zoom-container/-/victory-zoom-container-35.2.0.tgz#94e869ce6e6eca22816e1575402c7e304af39a6f"
-  integrity sha512-cmR5IAfL92+ESYk6klwxINlFAQ5kO5DbjncqmThLjc2sVKG+zVffgkD4K2foRXjlOsxN0+nNWDmmRwwSzkENXQ==
+victory-zoom-container@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory-zoom-container/-/victory-zoom-container-35.3.5.tgz#474819052a2422d72f5066b5e906d8fb7b41e6a7"
+  integrity sha512-pVYNB0X0d6wzmM+T4HRobkC8JXfrd1fOJmNbipz4p4NN5Zef+s7bI/8TvoU4kpOmcgjJREO6qNy9bdg+fpndfg==
   dependencies:
     lodash "^4.17.19"
     prop-types "^15.5.8"
-    victory-core "^35.2.0"
+    victory-core "^35.3.5"
 
-victory@^35.2.0:
-  version "35.2.0"
-  resolved "https://registry.yarnpkg.com/victory/-/victory-35.2.0.tgz#2fdb76fd6cc56a8f1ee9a3bf848c8e24703281ad"
-  integrity sha512-G33seLKbpE73S5WrXatfMT+CpxFXz4MzVSWSL3gah6KeVYunnK7WBkg9Xvwt+zJx5XMaRru8yWamtui5cg6UVg==
+victory@^35.3.5:
+  version "35.3.5"
+  resolved "https://registry.yarnpkg.com/victory/-/victory-35.3.5.tgz#4ddce964a9003182dac81e46b2b4a6c81b13964b"
+  integrity sha512-/sJCSTWVsR92kZeRHtYqgzKlAxYTAk5GgxcMLZKhv61gcan//m6FgMWRkLTeGPZAmVwa+e3iFq5gDxzqcrBw1w==
   dependencies:
-    victory-area "^35.2.0"
-    victory-axis "^35.2.0"
-    victory-bar "^35.2.0"
-    victory-box-plot "^35.2.0"
-    victory-brush-container "^35.2.0"
-    victory-brush-line "^35.2.0"
-    victory-candlestick "^35.2.0"
-    victory-chart "^35.2.0"
-    victory-core "^35.2.0"
-    victory-create-container "^35.2.0"
-    victory-cursor-container "^35.2.0"
-    victory-errorbar "^35.2.0"
-    victory-group "^35.2.0"
-    victory-histogram "^35.2.0"
-    victory-legend "^35.2.0"
-    victory-line "^35.2.0"
-    victory-pie "^35.2.0"
-    victory-polar-axis "^35.2.0"
-    victory-scatter "^35.2.0"
-    victory-selection-container "^35.2.0"
-    victory-shared-events "^35.2.0"
-    victory-stack "^35.2.0"
-    victory-tooltip "^35.2.0"
-    victory-voronoi "^35.2.0"
-    victory-voronoi-container "^35.2.0"
-    victory-zoom-container "^35.2.0"
+    victory-area "^35.3.5"
+    victory-axis "^35.3.5"
+    victory-bar "^35.3.5"
+    victory-box-plot "^35.3.5"
+    victory-brush-container "^35.3.5"
+    victory-brush-line "^35.3.5"
+    victory-candlestick "^35.3.5"
+    victory-chart "^35.3.5"
+    victory-core "^35.3.5"
+    victory-create-container "^35.3.5"
+    victory-cursor-container "^35.3.5"
+    victory-errorbar "^35.3.5"
+    victory-group "^35.3.5"
+    victory-histogram "^35.3.5"
+    victory-legend "^35.3.5"
+    victory-line "^35.3.5"
+    victory-pie "^35.3.5"
+    victory-polar-axis "^35.3.5"
+    victory-scatter "^35.3.5"
+    victory-selection-container "^35.3.5"
+    victory-shared-events "^35.3.5"
+    victory-stack "^35.3.5"
+    victory-tooltip "^35.3.5"
+    victory-voronoi "^35.3.5"
+    victory-voronoi-container "^35.3.5"
+    victory-zoom-container "^35.3.5"
 
 vinyl-file@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19876,7 +19876,7 @@ vfile@^4.0.0:
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
 
-victory-area@^35.3.5:
+victory-area@^35.2.0, victory-area@^35.3.5:
   version "35.3.5"
   resolved "https://registry.yarnpkg.com/victory-area/-/victory-area-35.3.5.tgz#8cc8e560cb52f478cfe3aa7743822a08722845b6"
   integrity sha512-W5JuMLCVHjysom1vnwFHXmuAXfAjmzZ4RWDVv0GZTUyZKDjZ0yD0XRKvrLcuN7cX702/5I3T1tf8N7TBICD7Lw==
@@ -19886,7 +19886,7 @@ victory-area@^35.3.5:
     prop-types "^15.5.8"
     victory-core "^35.3.5"
 
-victory-axis@^35.3.5:
+victory-axis@^35.2.0, victory-axis@^35.3.5:
   version "35.3.5"
   resolved "https://registry.yarnpkg.com/victory-axis/-/victory-axis-35.3.5.tgz#5305b1215f844b17f2278500619d4c9b47ab2b8f"
   integrity sha512-E3E/MjwoFIWLGbn3TU13eUwa+t0FrG4M44uwKUmpmt6U7YCHmMcxb/WkOTyvAuytQl0jcPRI+mI3dNcqxCYhbQ==
@@ -19895,7 +19895,7 @@ victory-axis@^35.3.5:
     prop-types "^15.5.8"
     victory-core "^35.3.5"
 
-victory-bar@^35.3.5:
+victory-bar@^35.2.0, victory-bar@^35.3.5:
   version "35.3.5"
   resolved "https://registry.yarnpkg.com/victory-bar/-/victory-bar-35.3.5.tgz#60ce981ef6acf2fd86519cfa31856ab5e8a80874"
   integrity sha512-BDqdWOSubHb+aMvtN6zm5HaNNv4N66xSrHNIr2GC+FFnLp4wWuKtVdx5O4bmiVYWkdXMj1zrMu6KnWfe3/qb1w==
@@ -19944,7 +19944,7 @@ victory-candlestick@^35.3.5:
     prop-types "^15.5.8"
     victory-core "^35.3.5"
 
-victory-chart@^35.3.5:
+victory-chart@^35.2.0, victory-chart@^35.3.5:
   version "35.3.5"
   resolved "https://registry.yarnpkg.com/victory-chart/-/victory-chart-35.3.5.tgz#b99aea41a2fc487a58587057b3ee4e132e450246"
   integrity sha512-ByKrqQzZbkw1mvqdSvRrfsSiAZpJ8AAWjeLa1BAfgKwXf/qdoKwU8flCG5cySWNhorUHyNrzFY9vYmzvA0nW8A==
@@ -19957,7 +19957,7 @@ victory-chart@^35.3.5:
     victory-polar-axis "^35.3.5"
     victory-shared-events "^35.3.5"
 
-victory-core@^35.3.5:
+victory-core@^35.2.0, victory-core@^35.3.5:
   version "35.3.5"
   resolved "https://registry.yarnpkg.com/victory-core/-/victory-core-35.3.5.tgz#0b89235a312ab9b430642c5593517b3cba649faa"
   integrity sha512-HhxuXA26X5QZQ/TYsXNUfKtZDHMgTDoA97ln32fV2EDHk1+Sg4KIbMJAaOgsy+2b8y5uUE2Gc37gzABKGhc8dA==
@@ -19971,7 +19971,7 @@ victory-core@^35.3.5:
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
 
-victory-create-container@^35.3.5:
+victory-create-container@^35.2.0, victory-create-container@^35.3.5:
   version "35.3.5"
   resolved "https://registry.yarnpkg.com/victory-create-container/-/victory-create-container-35.3.5.tgz#d958da42979a2c641a4eaf82363d16fb8ed8fff6"
   integrity sha512-bDk7F/3a8pXOYjq61MEgpX4f7koatZb2v35n2ZgxoUliXIS1YQ+4bC9gYU3QPVoFDH2xGpwF/MSIKOecxcwwbA==
@@ -20002,7 +20002,7 @@ victory-errorbar@^35.3.5:
     prop-types "^15.5.8"
     victory-core "^35.3.5"
 
-victory-group@^35.3.5:
+victory-group@^35.2.0, victory-group@^35.3.5:
   version "35.3.5"
   resolved "https://registry.yarnpkg.com/victory-group/-/victory-group-35.3.5.tgz#12bcbf6ebf65376a4990891534bc18de7c60fcec"
   integrity sha512-pRTSb1bPOCQCpK5/eHsTuqiSfb8YRGUKVV1YpZAjDy7tVauF10gdbtItCE1W16rgEd9BrU9MgQZp0May76G2Mw==
@@ -20026,7 +20026,7 @@ victory-histogram@^35.3.5:
     victory-bar "^35.3.5"
     victory-core "^35.3.5"
 
-victory-legend@^35.3.5:
+victory-legend@^35.2.0, victory-legend@^35.3.5:
   version "35.3.5"
   resolved "https://registry.yarnpkg.com/victory-legend/-/victory-legend-35.3.5.tgz#91796f69f74a3fff66564f0754b6f19bf3d7ada8"
   integrity sha512-wDSYd88q6INYeM94vGd+jqNYLnTF8Q6zuqfQzuksq+QCkJfFVFkOpD83PPzPVYohCwmlPLCPnVo2VEew3fglAQ==
@@ -20035,7 +20035,7 @@ victory-legend@^35.3.5:
     prop-types "^15.5.8"
     victory-core "^35.3.5"
 
-victory-line@^35.3.5:
+victory-line@^35.2.0, victory-line@^35.3.5:
   version "35.3.5"
   resolved "https://registry.yarnpkg.com/victory-line/-/victory-line-35.3.5.tgz#4e6a955ebad3404a5c2326de979b868bd973e8b8"
   integrity sha512-//5Lk/LwdBrnBa5Y3y9zkImFL45EySnS+uRUT8OrJOD41Tx5vVRpTAtJ1Ia+lhQ3QKfFvpk/x4tI1nJljE001Q==
@@ -20045,7 +20045,7 @@ victory-line@^35.3.5:
     prop-types "^15.5.8"
     victory-core "^35.3.5"
 
-victory-pie@^35.3.5:
+victory-pie@^35.2.0, victory-pie@^35.3.5:
   version "35.3.5"
   resolved "https://registry.yarnpkg.com/victory-pie/-/victory-pie-35.3.5.tgz#fe3de4251fa2c1748bc941209ce44087918cea78"
   integrity sha512-HR8p8wK5J9Etikicll0cRGchKiB2v7w5iqyV4BzBx2FTvE/5VzAWBm0RjyRqS5ykM2TfDc3lrz1zXsPB2vhcpw==
@@ -20064,7 +20064,7 @@ victory-polar-axis@^35.3.5:
     prop-types "^15.5.8"
     victory-core "^35.3.5"
 
-victory-scatter@^35.3.5:
+victory-scatter@^35.2.0, victory-scatter@^35.3.5:
   version "35.3.5"
   resolved "https://registry.yarnpkg.com/victory-scatter/-/victory-scatter-35.3.5.tgz#f4651c7ebb0eb626689308f58b53bf85f01336da"
   integrity sha512-we21KDpK6vWZBZnY2LddA4nGmYF3rif5MC9F1hxxJpVX5nVLCqXXJsQgLB8zUKYbWRZVIzzpIp/sDYc1MvSC1g==
@@ -20093,7 +20093,7 @@ victory-shared-events@^35.3.5:
     react-fast-compare "^2.0.0"
     victory-core "^35.3.5"
 
-victory-stack@^35.3.5:
+victory-stack@^35.2.0, victory-stack@^35.3.5:
   version "35.3.5"
   resolved "https://registry.yarnpkg.com/victory-stack/-/victory-stack-35.3.5.tgz#aff896c3bae4c2bcfc337be8d6dbc7557ca495eb"
   integrity sha512-nO8u7qVvhsreIRxI+8hrzqXqmXr/vgEObS168MuAmhDV7JUV2cnDK9MEHMPPAvM2Anq4o/AYLBifSjQbwkCulQ==
@@ -20104,7 +20104,7 @@ victory-stack@^35.3.5:
     victory-core "^35.3.5"
     victory-shared-events "^35.3.5"
 
-victory-tooltip@^35.3.5:
+victory-tooltip@^35.2.0, victory-tooltip@^35.3.5:
   version "35.3.5"
   resolved "https://registry.yarnpkg.com/victory-tooltip/-/victory-tooltip-35.3.5.tgz#985ee8e84162d042304e90cdaf05bfbdfc5f7ca7"
   integrity sha512-i0VfBYPsm1z3MSoe8a8EPrB4Ytg+6avjBCHbr5//9Sa9eqWzslx1cvVdl1+q6ibC2fCNQpW8W6pmk8FIYHfMAg==
@@ -20113,7 +20113,7 @@ victory-tooltip@^35.3.5:
     prop-types "^15.5.8"
     victory-core "^35.3.5"
 
-victory-voronoi-container@^35.3.5:
+victory-voronoi-container@^35.2.0, victory-voronoi-container@^35.3.5:
   version "35.3.5"
   resolved "https://registry.yarnpkg.com/victory-voronoi-container/-/victory-voronoi-container-35.3.5.tgz#6932a71dc68d207eca30f5c540349d79c0d69678"
   integrity sha512-+qkb0Bk4KpVtNjGDBWeXVBQajuJk5oxH2n9C1fMbLYNKlxjojXTYm5PkZlc5zH4aDSkhK/XFQWf+W67fnqHlTw==
@@ -20135,7 +20135,7 @@ victory-voronoi@^35.3.5:
     prop-types "^15.5.8"
     victory-core "^35.3.5"
 
-victory-zoom-container@^35.3.5:
+victory-zoom-container@^35.2.0, victory-zoom-container@^35.3.5:
   version "35.3.5"
   resolved "https://registry.yarnpkg.com/victory-zoom-container/-/victory-zoom-container-35.3.5.tgz#474819052a2422d72f5066b5e906d8fb7b41e6a7"
   integrity sha512-pVYNB0X0d6wzmM+T4HRobkC8JXfrd1fOJmNbipz4p4NN5Zef+s7bI/8TvoU4kpOmcgjJREO6qNy9bdg+fpndfg==


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: The latest release of Victory contains some accessibility function I need to use. When I tried to upgrade the version of Victory packages in `react-chart`, I found that we only need to keep the `victory` dependency in `package.json` file and we could remove all the other `victory-` dependencies. This will simplify the upgrade of `victory` package in the future.
