### PR TITLE
bump core, fix react-console version

### DIFF
--- a/packages/react-catalog-view-extension/package.json
+++ b/packages/react-catalog-view-extension/package.json
@@ -35,7 +35,7 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
-    "@patternfly/patternfly": "4.59.1",
+    "@patternfly/patternfly": "4.65.3",
     "@patternfly/react-core": "^4.75.10",
     "@patternfly/react-styles": "^4.7.13",
     "classnames": "^2.2.5",

--- a/packages/react-charts/package.json
+++ b/packages/react-charts/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/patternfly/patternfly-react#readme",
   "dependencies": {
-    "@patternfly/patternfly": "4.59.1",
+    "@patternfly/patternfly": "4.65.3",
     "@patternfly/react-styles": "^4.7.13",
     "@patternfly/react-tokens": "^4.9.16",
     "hoist-non-react-statics": "^3.3.0",

--- a/packages/react-console/package.json
+++ b/packages/react-console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patternfly/react-console",
-  "version": "1.0.0",
+  "version": "4.0.0",
   "description": "This package provides VncConsole, SerialConsole and DesktopViewer React components to be used alongside patternfly-react to access virtual machine or server consoles.",
   "main": "dist/js/index.js",
   "module": "dist/esm/index.js",
@@ -32,7 +32,7 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
-    "@patternfly/patternfly": "4.59.1",
+    "@patternfly/patternfly": "4.65.3",
     "@patternfly/react-core": "^4.75.10",
     "@spice-project/spice-html5": "^0.2.1",
     "@types/file-saver": "^2.0.1",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -44,7 +44,7 @@
     "tslib": "1.13.0"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "4.59.1",
+    "@patternfly/patternfly": "4.65.3",
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",
     "@rollup/plugin-replace": "^2.3.1",

--- a/packages/react-core/src/components/ActionList/ActionListItem.tsx
+++ b/packages/react-core/src/components/ActionList/ActionListItem.tsx
@@ -8,5 +8,9 @@ export interface ActionListItemProps extends React.HTMLProps<HTMLDivElement> {
 export const ActionListItem: React.FunctionComponent<ActionListItemProps> = ({
   children,
   ...props
-}: ActionListItemProps) => <div {...props}>{children}</div>;
+}: ActionListItemProps) => (
+  <div className="pf-c-action-list__item" {...props}>
+    {children}
+  </div>
+);
 ActionListItem.displayName = 'ActionListItem';

--- a/packages/react-core/src/components/ActionList/ActionListItem.tsx
+++ b/packages/react-core/src/components/ActionList/ActionListItem.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react';
-import { css } from '@patternfly/react-styles';
-import styles from '@patternfly/react-styles/css/components/ActionList/action-list';
 
 export interface ActionListItemProps extends React.HTMLProps<HTMLDivElement> {
   /** Children of the action list item */
@@ -10,9 +8,5 @@ export interface ActionListItemProps extends React.HTMLProps<HTMLDivElement> {
 export const ActionListItem: React.FunctionComponent<ActionListItemProps> = ({
   children,
   ...props
-}: ActionListItemProps) => (
-  <div className={css(styles.actionListItem)} {...props}>
-    {children}
-  </div>
-);
+}: ActionListItemProps) => <div {...props}>{children}</div>;
 ActionListItem.displayName = 'ActionListItem';

--- a/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
+++ b/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
@@ -68,11 +68,7 @@ export const TreeViewListItem: React.FunctionComponent<TreeViewListItemProps> = 
   return (
     <li
       id={id}
-      className={css(
-        styles.treeViewListItem,
-        !!children && styles.modifiers.expandable,
-        isExpanded && styles.modifiers.expanded
-      )}
+      className={css(styles.treeViewListItem, isExpanded && styles.modifiers.expanded)}
       {...(isExpanded && { 'aria-expanded': 'true' })}
       role="treeitem"
       tabIndex={0}

--- a/packages/react-core/src/components/TreeView/__tests__/__snapshots__/TreeView.test.tsx.snap
+++ b/packages/react-core/src/components/TreeView/__tests__/__snapshots__/TreeView.test.tsx.snap
@@ -211,7 +211,7 @@ exports[`tree view renders active successfully 1`] = `
         >
           <li
             aria-expanded="true"
-            className="pf-c-tree-view__list-item pf-m-expandable pf-m-expanded"
+            className="pf-c-tree-view__list-item pf-m-expanded"
             id="AppLaunch"
             role="treeitem"
             tabIndex={0}
@@ -483,7 +483,7 @@ exports[`tree view renders active successfully 1`] = `
                     }
                   >
                     <li
-                      className="pf-c-tree-view__list-item pf-m-expandable"
+                      className="pf-c-tree-view__list-item"
                       id="App1"
                       role="treeitem"
                       tabIndex={0}
@@ -643,7 +643,7 @@ exports[`tree view renders active successfully 1`] = `
                     }
                   >
                     <li
-                      className="pf-c-tree-view__list-item pf-m-expandable"
+                      className="pf-c-tree-view__list-item"
                       id="App2"
                       role="treeitem"
                       tabIndex={0}
@@ -749,7 +749,7 @@ exports[`tree view renders active successfully 1`] = `
           onSelect={[MockFunction]}
         >
           <li
-            className="pf-c-tree-view__list-item pf-m-expandable"
+            className="pf-c-tree-view__list-item"
             id="Cost"
             role="treeitem"
             tabIndex={0}
@@ -846,7 +846,7 @@ exports[`tree view renders active successfully 1`] = `
           onSelect={[MockFunction]}
         >
           <li
-            className="pf-c-tree-view__list-item pf-m-expandable"
+            className="pf-c-tree-view__list-item"
             id="Sources"
             role="treeitem"
             tabIndex={0}
@@ -937,7 +937,7 @@ exports[`tree view renders active successfully 1`] = `
           onSelect={[MockFunction]}
         >
           <li
-            className="pf-c-tree-view__list-item pf-m-expandable"
+            className="pf-c-tree-view__list-item"
             id="Long"
             role="treeitem"
             tabIndex={0}
@@ -1205,7 +1205,7 @@ exports[`tree view renders badges successfully 1`] = `
         >
           <li
             aria-expanded="true"
-            className="pf-c-tree-view__list-item pf-m-expandable pf-m-expanded"
+            className="pf-c-tree-view__list-item pf-m-expanded"
             id="AppLaunch"
             role="treeitem"
             tabIndex={0}
@@ -1490,7 +1490,7 @@ exports[`tree view renders badges successfully 1`] = `
                     }
                   >
                     <li
-                      className="pf-c-tree-view__list-item pf-m-expandable"
+                      className="pf-c-tree-view__list-item"
                       id="App1"
                       role="treeitem"
                       tabIndex={0}
@@ -1663,7 +1663,7 @@ exports[`tree view renders badges successfully 1`] = `
                     }
                   >
                     <li
-                      className="pf-c-tree-view__list-item pf-m-expandable"
+                      className="pf-c-tree-view__list-item"
                       id="App2"
                       role="treeitem"
                       tabIndex={0}
@@ -1782,7 +1782,7 @@ exports[`tree view renders badges successfully 1`] = `
           onSelect={[MockFunction]}
         >
           <li
-            className="pf-c-tree-view__list-item pf-m-expandable"
+            className="pf-c-tree-view__list-item"
             id="Cost"
             role="treeitem"
             tabIndex={0}
@@ -1892,7 +1892,7 @@ exports[`tree view renders badges successfully 1`] = `
           onSelect={[MockFunction]}
         >
           <li
-            className="pf-c-tree-view__list-item pf-m-expandable"
+            className="pf-c-tree-view__list-item"
             id="Sources"
             role="treeitem"
             tabIndex={0}
@@ -1996,7 +1996,7 @@ exports[`tree view renders badges successfully 1`] = `
           onSelect={[MockFunction]}
         >
           <li
-            className="pf-c-tree-view__list-item pf-m-expandable"
+            className="pf-c-tree-view__list-item"
             id="Long"
             role="treeitem"
             tabIndex={0}
@@ -2240,7 +2240,7 @@ exports[`tree view renders basic successfully 1`] = `
         >
           <li
             aria-expanded="true"
-            className="pf-c-tree-view__list-item pf-m-expandable pf-m-expanded"
+            className="pf-c-tree-view__list-item pf-m-expanded"
             id="AppLaunch"
             role="treeitem"
             tabIndex={0}
@@ -2476,7 +2476,7 @@ exports[`tree view renders basic successfully 1`] = `
                     }
                   >
                     <li
-                      className="pf-c-tree-view__list-item pf-m-expandable"
+                      className="pf-c-tree-view__list-item"
                       id="App1"
                       role="treeitem"
                       tabIndex={0}
@@ -2618,7 +2618,7 @@ exports[`tree view renders basic successfully 1`] = `
                     }
                   >
                     <li
-                      className="pf-c-tree-view__list-item pf-m-expandable"
+                      className="pf-c-tree-view__list-item"
                       id="App2"
                       role="treeitem"
                       tabIndex={0}
@@ -2706,7 +2706,7 @@ exports[`tree view renders basic successfully 1`] = `
           onSelect={[MockFunction]}
         >
           <li
-            className="pf-c-tree-view__list-item pf-m-expandable"
+            className="pf-c-tree-view__list-item"
             id="Cost"
             role="treeitem"
             tabIndex={0}
@@ -2785,7 +2785,7 @@ exports[`tree view renders basic successfully 1`] = `
           onSelect={[MockFunction]}
         >
           <li
-            className="pf-c-tree-view__list-item pf-m-expandable"
+            className="pf-c-tree-view__list-item"
             id="Sources"
             role="treeitem"
             tabIndex={0}
@@ -2858,7 +2858,7 @@ exports[`tree view renders basic successfully 1`] = `
           onSelect={[MockFunction]}
         >
           <li
-            className="pf-c-tree-view__list-item pf-m-expandable"
+            className="pf-c-tree-view__list-item"
             id="Long"
             role="treeitem"
             tabIndex={0}
@@ -3126,7 +3126,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
         >
           <li
             aria-expanded="true"
-            className="pf-c-tree-view__list-item pf-m-expandable pf-m-expanded"
+            className="pf-c-tree-view__list-item pf-m-expanded"
             id="AppLaunch"
             role="treeitem"
             tabIndex={0}
@@ -3408,7 +3408,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
                     }
                   >
                     <li
-                      className="pf-c-tree-view__list-item pf-m-expandable"
+                      className="pf-c-tree-view__list-item"
                       id="App1"
                       role="treeitem"
                       tabIndex={0}
@@ -3578,7 +3578,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
                     }
                   >
                     <li
-                      className="pf-c-tree-view__list-item pf-m-expandable"
+                      className="pf-c-tree-view__list-item"
                       id="App2"
                       role="treeitem"
                       tabIndex={0}
@@ -3694,7 +3694,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
           onSelect={[MockFunction]}
         >
           <li
-            className="pf-c-tree-view__list-item pf-m-expandable"
+            className="pf-c-tree-view__list-item"
             id="Cost"
             role="treeitem"
             tabIndex={0}
@@ -3801,7 +3801,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
           onSelect={[MockFunction]}
         >
           <li
-            className="pf-c-tree-view__list-item pf-m-expandable"
+            className="pf-c-tree-view__list-item"
             id="Sources"
             role="treeitem"
             tabIndex={0}
@@ -3902,7 +3902,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
           onSelect={[MockFunction]}
         >
           <li
-            className="pf-c-tree-view__list-item pf-m-expandable"
+            className="pf-c-tree-view__list-item"
             id="Long"
             role="treeitem"
             tabIndex={0}
@@ -4207,7 +4207,7 @@ exports[`tree view renders icons successfully 1`] = `
         >
           <li
             aria-expanded="true"
-            className="pf-c-tree-view__list-item pf-m-expandable pf-m-expanded"
+            className="pf-c-tree-view__list-item pf-m-expanded"
             id="AppLaunch"
             role="treeitem"
             tabIndex={0}
@@ -4535,7 +4535,7 @@ exports[`tree view renders icons successfully 1`] = `
                     }
                   >
                     <li
-                      className="pf-c-tree-view__list-item pf-m-expandable"
+                      className="pf-c-tree-view__list-item"
                       id="App1"
                       role="treeitem"
                       tabIndex={0}
@@ -4737,7 +4737,7 @@ exports[`tree view renders icons successfully 1`] = `
                     }
                   >
                     <li
-                      className="pf-c-tree-view__list-item pf-m-expandable"
+                      className="pf-c-tree-view__list-item"
                       id="App2"
                       role="treeitem"
                       tabIndex={0}
@@ -4885,7 +4885,7 @@ exports[`tree view renders icons successfully 1`] = `
           onSelect={[MockFunction]}
         >
           <li
-            className="pf-c-tree-view__list-item pf-m-expandable"
+            className="pf-c-tree-view__list-item"
             id="Cost"
             role="treeitem"
             tabIndex={0}
@@ -5024,7 +5024,7 @@ exports[`tree view renders icons successfully 1`] = `
           onSelect={[MockFunction]}
         >
           <li
-            className="pf-c-tree-view__list-item pf-m-expandable"
+            className="pf-c-tree-view__list-item"
             id="Sources"
             role="treeitem"
             tabIndex={0}
@@ -5157,7 +5157,7 @@ exports[`tree view renders icons successfully 1`] = `
           onSelect={[MockFunction]}
         >
           <li
-            className="pf-c-tree-view__list-item pf-m-expandable"
+            className="pf-c-tree-view__list-item"
             id="Long"
             role="treeitem"
             tabIndex={0}
@@ -5503,7 +5503,7 @@ exports[`tree view renders individual flag options successfully 1`] = `
         >
           <li
             aria-expanded="true"
-            className="pf-c-tree-view__list-item pf-m-expandable pf-m-expanded"
+            className="pf-c-tree-view__list-item pf-m-expanded"
             id="AppLaunch"
             role="treeitem"
             tabIndex={0}
@@ -5841,7 +5841,7 @@ exports[`tree view renders individual flag options successfully 1`] = `
                     }
                   >
                     <li
-                      className="pf-c-tree-view__list-item pf-m-expandable"
+                      className="pf-c-tree-view__list-item"
                       id="App1"
                       role="treeitem"
                       tabIndex={0}
@@ -6016,7 +6016,7 @@ exports[`tree view renders individual flag options successfully 1`] = `
                     }
                   >
                     <li
-                      className="pf-c-tree-view__list-item pf-m-expandable"
+                      className="pf-c-tree-view__list-item"
                       id="App2"
                       role="treeitem"
                       tabIndex={0}
@@ -6158,7 +6158,7 @@ exports[`tree view renders individual flag options successfully 1`] = `
           onSelect={[MockFunction]}
         >
           <li
-            className="pf-c-tree-view__list-item pf-m-expandable"
+            className="pf-c-tree-view__list-item"
             id="Cost"
             role="treeitem"
             tabIndex={0}
@@ -6313,7 +6313,7 @@ exports[`tree view renders individual flag options successfully 1`] = `
           onSelect={[MockFunction]}
         >
           <li
-            className="pf-c-tree-view__list-item pf-m-expandable"
+            className="pf-c-tree-view__list-item"
             id="Sources"
             role="treeitem"
             tabIndex={0}
@@ -6404,7 +6404,7 @@ exports[`tree view renders individual flag options successfully 1`] = `
           onSelect={[MockFunction]}
         >
           <li
-            className="pf-c-tree-view__list-item pf-m-expandable"
+            className="pf-c-tree-view__list-item"
             id="Long"
             role="treeitem"
             tabIndex={0}
@@ -6711,7 +6711,7 @@ exports[`tree view renders search successfully 1`] = `
         >
           <li
             aria-expanded="true"
-            className="pf-c-tree-view__list-item pf-m-expandable pf-m-expanded"
+            className="pf-c-tree-view__list-item pf-m-expanded"
             id="AppLaunch"
             role="treeitem"
             tabIndex={0}
@@ -6983,7 +6983,7 @@ exports[`tree view renders search successfully 1`] = `
                     }
                   >
                     <li
-                      className="pf-c-tree-view__list-item pf-m-expandable"
+                      className="pf-c-tree-view__list-item"
                       id="App1"
                       role="treeitem"
                       tabIndex={0}
@@ -7143,7 +7143,7 @@ exports[`tree view renders search successfully 1`] = `
                     }
                   >
                     <li
-                      className="pf-c-tree-view__list-item pf-m-expandable"
+                      className="pf-c-tree-view__list-item"
                       id="App2"
                       role="treeitem"
                       tabIndex={0}
@@ -7249,7 +7249,7 @@ exports[`tree view renders search successfully 1`] = `
           onSelect={[MockFunction]}
         >
           <li
-            className="pf-c-tree-view__list-item pf-m-expandable"
+            className="pf-c-tree-view__list-item"
             id="Cost"
             role="treeitem"
             tabIndex={0}
@@ -7346,7 +7346,7 @@ exports[`tree view renders search successfully 1`] = `
           onSelect={[MockFunction]}
         >
           <li
-            className="pf-c-tree-view__list-item pf-m-expandable"
+            className="pf-c-tree-view__list-item"
             id="Sources"
             role="treeitem"
             tabIndex={0}
@@ -7437,7 +7437,7 @@ exports[`tree view renders search successfully 1`] = `
           onSelect={[MockFunction]}
         >
           <li
-            className="pf-c-tree-view__list-item pf-m-expandable"
+            className="pf-c-tree-view__list-item"
             id="Long"
             role="treeitem"
             tabIndex={0}

--- a/packages/react-datetime/package.json
+++ b/packages/react-datetime/package.json
@@ -35,7 +35,7 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
-    "@patternfly/patternfly": "4.59.1",
+    "@patternfly/patternfly": "4.65.3",
     "@patternfly/react-core": "^4.75.10",
     "@patternfly/react-icons": "^4.7.16",
     "@patternfly/react-styles": "^4.7.13",

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -22,7 +22,7 @@
     "test:a11y": "patternfly-a11y --config patternfly-a11y.config"
   },
   "dependencies": {
-    "@patternfly/patternfly": "4.59.1",
+    "@patternfly/patternfly": "4.65.3",
     "@patternfly/react-catalog-view-extension": "^4.8.97",
     "@patternfly/react-charts": "^6.11.9",
     "@patternfly/react-core": "^4.75.10",

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -32,7 +32,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.14.0",
     "@fortawesome/free-regular-svg-icons": "^5.14.0",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
-    "@patternfly/patternfly": "4.59.1",
+    "@patternfly/patternfly": "4.65.3",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",
     "rimraf": "^2.6.2",

--- a/packages/react-styles/package.json
+++ b/packages/react-styles/package.json
@@ -19,7 +19,7 @@
     "clean": "rimraf dist css"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "4.59.1",
+    "@patternfly/patternfly": "4.65.3",
     "camel-case": "^3.0.0",
     "css": "^2.2.3",
     "fs-extra": "^6.0.1",

--- a/packages/react-table/package.json
+++ b/packages/react-table/package.json
@@ -35,7 +35,7 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
-    "@patternfly/patternfly": "4.59.1",
+    "@patternfly/patternfly": "4.65.3",
     "@patternfly/react-core": "^4.75.10",
     "@patternfly/react-icons": "^4.7.16",
     "@patternfly/react-styles": "^4.7.13",
@@ -46,9 +46,5 @@
   "peerDependencies": {
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
-  },
-  "devDependencies": {
-    "rimraf": "^2.6.2",
-    "typescript": "^3.8.3"
   }
 }

--- a/packages/react-tokens/package.json
+++ b/packages/react-tokens/package.json
@@ -29,7 +29,7 @@
     "clean": "rimraf dist"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "4.59.1",
+    "@patternfly/patternfly": "4.65.3",
     "css": "^2.2.3",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2644,10 +2644,10 @@
     webpack-dev-server "^3.11.0"
     xmldoc "^1.1.2"
 
-"@patternfly/patternfly@4.59.1":
-  version "4.59.1"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.59.1.tgz#87c03b860f2eec494dfc3ae67f04bf178f06491b"
-  integrity sha512-zk3aqg62JXMTzzJMJsyVgt5fXlcxUUkRKkaxUv/hwpjhGiyLexZ1l3Gupb9ziYl74p38KzbbfcfdnlFCwJZfgg==
+"@patternfly/patternfly@4.65.3":
+  version "4.65.3"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.65.3.tgz#d63c79e69ca5e4c62506c99c31bc4961740525c9"
+  integrity sha512-8JydLuP51ai3zo+K6UmV1wUu5S8mXjPedXFeB68efq6b1ru4LueZHyBlVzweUWrj4KPUqMfe6hphMbLo5z6BPg==
 
 "@reach/router@^1.2.1", "@reach/router@^1.3.4":
   version "1.3.4"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Bumps core and fixes broken CI build.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: I believe `pf-c-action-list__item` should be hardcoded (see https://github.com/patternfly/patternfly/pull/3662) and that `pf-m-expandable` on TreeView can be removed (see https://github.com/patternfly/patternfly/pull/3661).
