### PR TITLE
[WIP] feat(ChartBar): add accessibility support

### DIFF
--- a/packages/react-charts/src/components/ChartAccessible/examples/ChartAccessible.md
+++ b/packages/react-charts/src/components/ChartAccessible/examples/ChartAccessible.md
@@ -112,11 +112,11 @@ function BasicWithRightAlignedLegend() {
 - Use `ChartGroup` to apply theme color scales and other properties to multiple components
 
 ### Note
-Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the
+Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 
 components used in the examples above, Victory pass-thru props are also documented here:
 
-- For `Chart` props, see [VictoryChart](https://formidable.com/open-source/victory/docs/victory-chart)
-- For `ChartAxis` props, see [VictoryAxis](https://formidable.com/open-source/victory/docs/victory-axis)
-- For `ChartBar` props, see [VictoryBar](https://formidable.com/open-source/victory/docs/victory-bar)
-- For `ChartGroup` props, see [VictoryGroup](https://formidable.com/open-source/victory/docs/victory-group)
-- For `ChartVoronoiContainer` props, see [VictoryVoronoiContainer](https://formidable.com/open-source/victory/docs/victory-voronoi-container)
+ - For `Chart` props, see [VictoryChart](https://formidable.com/open-source/victory/docs/victory-chart)
+ - For `ChartAxis` props, see [VictoryAxis](https://formidable.com/open-source/victory/docs/victory-axis)
+ - For `ChartBar` props, see [VictoryBar](https://formidable.com/open-source/victory/docs/victory-bar)
+ - For `ChartGroup` props, see [VictoryGroup](https://formidable.com/open-source/victory/docs/victory-group)
+ - For `ChartVoronoiContainer` props, see [VictoryVoronoiContainer](https://formidable.com/open-source/victory/docs/victory-voronoi-container)

--- a/packages/react-charts/src/components/ChartAccessible/examples/ChartAccessible.md
+++ b/packages/react-charts/src/components/ChartAccessible/examples/ChartAccessible.md
@@ -56,12 +56,7 @@ function BasicWithRightAlignedLegend() {
       { name: 'Mice', x: '2018', y: 5 }
     ]
   };
-  const ariaLabel = Object.assign(
-    ...Object.keys(data).map(type => ({
-      [type]: data[type].map(entry => `There are ${entry.y} ${entry.name} in ${entry.x}`)
-    }))
-  );
-  console.log(ariaLabel);
+  const ariaLabelTemplate = datum => `There are ${datum.y} ${datum.name} in ${datum.x}`;
   return (
     <div style={{ height: '250px', width: '600px' }}>
       <Chart
@@ -92,10 +87,10 @@ function BasicWithRightAlignedLegend() {
         <ChartAxis />
         <ChartAxis dependentAxis showGrid />
         <ChartGroup offset={11}>
-          <ChartBar data={data.cat} ariaLabel={ariaLabel.cat} />
-          <ChartBar data={data.dog} ariaLabel={ariaLabel.dog} />
-          <ChartBar data={data.birds} ariaLabel={ariaLabel.birds} />
-          <ChartBar data={data.mice} ariaLabel={ariaLabel.mice} />
+          <ChartBar data={data.cat} ariaLabel={({datum}) => ariaLabelTemplate(datum)} />
+          <ChartBar data={data.dog} ariaLabel={({datum}) => ariaLabelTemplate(datum)} />
+          <ChartBar data={data.birds} ariaLabel={({datum}) => ariaLabelTemplate(datum)} />
+          <ChartBar data={data.mice} ariaLabel={({datum}) => ariaLabelTemplate(datum)} />
         </ChartGroup>
       </Chart>
     </div>

--- a/packages/react-charts/src/components/ChartAccessible/examples/ChartAccessible.md
+++ b/packages/react-charts/src/components/ChartAccessible/examples/ChartAccessible.md
@@ -1,0 +1,122 @@
+---
+id: Accessible chart
+section: charts
+propComponents: [
+  'Chart',
+  'ChartAxis',
+  'ChartBar',
+  'ChartGroup',
+  'ChartVoronoiContainer'
+]
+hideDarkMode: true
+---
+
+import { Chart, ChartAxis, ChartBar, ChartGroup, ChartThemeColor, ChartVoronoiContainer } from '@patternfly/react-charts';
+import { VictoryZoomContainer } from 'victory-zoom-container';
+
+## Introduction
+Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
+
+PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
+
+
+## Examples
+### Bar chart with right aligned legend
+
+This demo demonstrate the accessibility function in a Bar chart. You can now focus on the whole chart or the contents in the chart. At the same time, you could use screen reader like VoiceOver to read the chart and contents as you defined in format.
+
+```js
+import React from 'react';
+import { Chart, ChartAxis, ChartBar, ChartGroup, ChartVoronoiContainer } from '@patternfly/react-charts';
+
+function BasicWithRightAlignedLegend() {
+  const data = {
+    cat: [
+      { name: 'Cats', x: '2015', y: 1 },
+      { name: 'Cats', x: '2016', y: 2 },
+      { name: 'Cats', x: '2017', y: 5 },
+      { name: 'Cats', x: '2018', y: 3 }
+    ],
+    dog: [
+      { name: 'Dogs', x: '2015', y: 2 },
+      { name: 'Dogs', x: '2016', y: 1 },
+      { name: 'Dogs', x: '2017', y: 7 },
+      { name: 'Dogs', x: '2018', y: 4 }
+    ],
+    birds: [
+      { name: 'Birds', x: '2015', y: 4 },
+      { name: 'Birds', x: '2016', y: 4 },
+      { name: 'Birds', x: '2017', y: 9 },
+      { name: 'Birds', x: '2018', y: 7 }
+    ],
+    mice: [
+      { name: 'Mice', x: '2015', y: 3 },
+      { name: 'Mice', x: '2016', y: 3 },
+      { name: 'Mice', x: '2017', y: 8 },
+      { name: 'Mice', x: '2018', y: 5 }
+    ]
+  };
+  const ariaLabel = Object.assign(
+    ...Object.keys(data).map(type => ({
+      [type]: data[type].map(entry => `There are ${entry.y} ${entry.name} in ${entry.x}`)
+    }))
+  );
+  console.log(ariaLabel);
+  return (
+    <div style={{ height: '250px', width: '600px' }}>
+      <Chart
+        ariaDesc="Average number of pets"
+        ariaTitle="Accessible Bar chart example"
+        containerComponent={
+          <ChartVoronoiContainer
+            role="group"
+            tabIndex={0}
+            labels={({ datum }) => `${datum.name}: ${datum.y}`}
+            constrainToVisibleArea
+          />
+        }
+        domain={{ y: [0, 9] }}
+        domainPadding={{ x: [30, 25] }}
+        legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
+        legendOrientation="vertical"
+        legendPosition="right"
+        height={250}
+        padding={{
+          bottom: 50,
+          left: 50,
+          right: 200, // Adjusted to accommodate legend
+          top: 50
+        }}
+        width={600}
+      >
+        <ChartAxis />
+        <ChartAxis dependentAxis showGrid />
+        <ChartGroup offset={11}>
+          <ChartBar data={data.cat} ariaLabel={ariaLabel.cat} />
+          <ChartBar data={data.dog} ariaLabel={ariaLabel.dog} />
+          <ChartBar data={data.birds} ariaLabel={ariaLabel.birds} />
+          <ChartBar data={data.mice} ariaLabel={ariaLabel.mice} />
+        </ChartGroup>
+      </Chart>
+    </div>
+  );
+}
+```
+
+## Documentation
+### Tips
+- See Victory's [FAQ](https://formidable.com/open-source/victory/docs/faq)
+- For single data points or zero values, you may want to set the `domain` prop
+- `ChartLegend` may be used as a standalone component, instead of using `legendData`
+- The `theme` and `themeColor` props should be applied at the most top level component
+- Use `ChartGroup` to apply theme color scales and other properties to multiple components
+
+### Note
+Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the
+components used in the examples above, Victory pass-thru props are also documented here:
+
+- For `Chart` props, see [VictoryChart](https://formidable.com/open-source/victory/docs/victory-chart)
+- For `ChartAxis` props, see [VictoryAxis](https://formidable.com/open-source/victory/docs/victory-axis)
+- For `ChartBar` props, see [VictoryBar](https://formidable.com/open-source/victory/docs/victory-bar)
+- For `ChartGroup` props, see [VictoryGroup](https://formidable.com/open-source/victory/docs/victory-group)
+- For `ChartVoronoiContainer` props, see [VictoryVoronoiContainer](https://formidable.com/open-source/victory/docs/victory-voronoi-container)

--- a/packages/react-charts/src/components/ChartBar/ChartBar.tsx
+++ b/packages/react-charts/src/components/ChartBar/ChartBar.tsx
@@ -19,7 +19,7 @@ import {
   StringOrNumberOrList,
   VictoryStyleInterface
 } from 'victory-core';
-import { VictoryBar, VictoryBarAlignmentType, VictoryBarProps, VictoryBarTTargetType } from 'victory-bar';
+import { Bar, VictoryBar, VictoryBarAlignmentType, VictoryBarProps, VictoryBarTTargetType } from 'victory-bar';
 import { ChartContainer } from '../ChartContainer';
 import { ChartThemeDefinition } from '../ChartTheme';
 import { getTheme } from '../ChartUtils';
@@ -422,12 +422,20 @@ export interface ChartBarProps extends VictoryBarProps {
    * @example 'last_quarter_profit', () => 10, 1, 'employees.salary', ["employees", "salary"]
    */
   y0?: DataGetterPropType;
+  /**
+   * Use ariaLabel prop to determine how screen reader will read the contents in the chart.
+   * If you don't define this prop, the content in the chart will not be accessible.
+   *
+   * @example ['There are 7 cats in 2015', 'There are 5 cats in 2016', 'There are 8 cats in 2017', 'There are 2 cats in 2018']
+   */
+  ariaLabel?: string[];
 }
 
 export const ChartBar: React.FunctionComponent<ChartBarProps> = ({
   containerComponent = <ChartContainer />,
   themeColor,
   themeVariant,
+  ariaLabel,
 
   // destructure last
   theme = getTheme(themeColor, themeVariant),
@@ -440,7 +448,14 @@ export const ChartBar: React.FunctionComponent<ChartBarProps> = ({
   });
 
   // Note: containerComponent is required for theme
-  return <VictoryBar containerComponent={container} theme={theme} {...rest} />;
+  return (
+    <VictoryBar
+      containerComponent={container}
+      theme={theme}
+      dataComponent={ariaLabel && <Bar ariaLabel={({ index }) => ariaLabel[Number(index)]} tabIndex={0} />}
+      {...rest}
+    />
+  );
 };
 ChartBar.displayName = 'ChartBar';
 

--- a/packages/react-charts/src/components/ChartBar/ChartBar.tsx
+++ b/packages/react-charts/src/components/ChartBar/ChartBar.tsx
@@ -45,6 +45,13 @@ export interface ChartBarProps extends VictoryBarProps {
    */
   animate?: boolean | AnimatePropTypeInterface;
   /**
+   * Use ariaLabel prop to determine how screen reader will read the contents in the chart.
+   * If you don't define this prop, the content in the chart will not be accessible.
+   *
+   * @example 'There are 7 cats in 2015'
+   */
+  ariaLabel?: string;
+  /**
    * The barRatio prop specifies an approximate ratio between bar widths and spaces between bars.
    * When width is not specified via the barWidth prop or in bar styles, the barRatio prop will
    * be used to calculate a default width for each bar given the total number of bars in the data series
@@ -422,13 +429,6 @@ export interface ChartBarProps extends VictoryBarProps {
    * @example 'last_quarter_profit', () => 10, 1, 'employees.salary', ["employees", "salary"]
    */
   y0?: DataGetterPropType;
-  /**
-   * Use ariaLabel prop to determine how screen reader will read the contents in the chart.
-   * If you don't define this prop, the content in the chart will not be accessible.
-   *
-   * @example ['There are 7 cats in 2015', 'There are 5 cats in 2016', 'There are 8 cats in 2017', 'There are 2 cats in 2018']
-   */
-  ariaLabel?: string[];
 }
 
 export const ChartBar: React.FunctionComponent<ChartBarProps> = ({
@@ -452,7 +452,7 @@ export const ChartBar: React.FunctionComponent<ChartBarProps> = ({
     <VictoryBar
       containerComponent={container}
       theme={theme}
-      dataComponent={ariaLabel && <Bar ariaLabel={({ index }) => ariaLabel[Number(index)]} tabIndex={0} />}
+      dataComponent={ariaLabel && <Bar ariaLabel={ariaLabel} tabIndex={0} />}
       {...rest}
     />
   );

--- a/packages/react-charts/src/components/ChartBar/examples/ChartBar.md
+++ b/packages/react-charts/src/components/ChartBar/examples/ChartBar.md
@@ -34,7 +34,7 @@ import { Chart, ChartAxis, ChartBar, ChartGroup, ChartVoronoiContainer } from '@
     ariaDesc="Average number of pets"
     ariaTitle="Bar chart example"
     containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
-    domain={{y: [0,9]}}
+    domain={{ y: [0, 9] }}
     domainPadding={{ x: [30, 25] }}
     legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
     legendOrientation="vertical"
@@ -144,7 +144,7 @@ import { Chart, ChartBar, ChartVoronoiContainer } from '@patternfly/react-charts
     ariaDesc="Average number of pets"
     ariaTitle="Bar chart example"
     containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
-    domain={{y: [0,9]}}
+    domain={{ y: [0, 9] }}
     domainPadding={{ x: [30, 25] }}
     legendData={[{ name: 'Cats' }]}
     legendOrientation="vertical"
@@ -163,8 +163,92 @@ import { Chart, ChartBar, ChartVoronoiContainer } from '@patternfly/react-charts
 </div>
 ```
 
+### Basic with right aligned legend (Accessibility Demo)
+
+This demo demonstrate the accessibility function in a Bar chart. You can now focus on the whole chart or the contents in the chart. At the same time, you could use screen reader like VoiceOver to read the chart and contents as you defined in format.
+
+```js
+import React from 'react';
+import { Chart, ChartAxis, ChartBar, ChartGroup, ChartVoronoiContainer } from '@patternfly/react-charts';
+
+function BasicWithRightAlignedLegendAccessibilityDemo() {
+  const data = {
+    cat: [
+      { name: 'Cats', x: '2015', y: 1 },
+      { name: 'Cats', x: '2016', y: 2 },
+      { name: 'Cats', x: '2017', y: 5 },
+      { name: 'Cats', x: '2018', y: 3 }
+    ],
+    dog: [
+      { name: 'Dogs', x: '2015', y: 2 },
+      { name: 'Dogs', x: '2016', y: 1 },
+      { name: 'Dogs', x: '2017', y: 7 },
+      { name: 'Dogs', x: '2018', y: 4 }
+    ],
+    birds: [
+      { name: 'Birds', x: '2015', y: 4 },
+      { name: 'Birds', x: '2016', y: 4 },
+      { name: 'Birds', x: '2017', y: 9 },
+      { name: 'Birds', x: '2018', y: 7 }
+    ],
+    mice: [
+      { name: 'Mice', x: '2015', y: 3 },
+      { name: 'Mice', x: '2016', y: 3 },
+      { name: 'Mice', x: '2017', y: 8 },
+      { name: 'Mice', x: '2018', y: 5 }
+    ]
+  };
+  const ariaLabel = Object.assign(
+    ...Object.keys(data).map(type => ({
+      [type]: data[type].map(entry => `There are ${entry.y} ${entry.name} in ${entry.x}`)
+    }))
+  );
+  console.log(ariaLabel);
+  return (
+    <div style={{ height: '250px', width: '600px' }}>
+      <Chart
+        ariaDesc="Average number of pets"
+        ariaTitle="Accessible Bar chart example"
+        containerComponent={
+          <ChartVoronoiContainer
+            role="group"
+            tabIndex={0}
+            labels={({ datum }) => `${datum.name}: ${datum.y}`}
+            constrainToVisibleArea
+          />
+        }
+        domain={{ y: [0, 9] }}
+        domainPadding={{ x: [30, 25] }}
+        legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
+        legendOrientation="vertical"
+        legendPosition="right"
+        height={250}
+        padding={{
+          bottom: 50,
+          left: 50,
+          right: 200, // Adjusted to accommodate legend
+          top: 50
+        }}
+        width={600}
+      >
+        <ChartAxis />
+        <ChartAxis dependentAxis showGrid />
+        <ChartGroup offset={11}>
+          <ChartBar data={data.cat} ariaLabel={ariaLabel.cat} />
+          <ChartBar data={data.dog} ariaLabel={ariaLabel.dog} />
+          <ChartBar data={data.birds} ariaLabel={ariaLabel.birds} />
+          <ChartBar data={data.mice} ariaLabel={ariaLabel.mice} />
+        </ChartGroup>
+      </Chart>
+    </div>
+  );
+}
+```
+
 ## Documentation
+
 ### Tips
+
 - See Victory's [FAQ](https://formidable.com/open-source/victory/docs/faq)
 - For single data points or zero values, you may want to set the `domain` prop
 - `ChartLegend` may be used as a standalone component, instead of using `legendData`
@@ -172,11 +256,12 @@ import { Chart, ChartBar, ChartVoronoiContainer } from '@patternfly/react-charts
 - Use `ChartGroup` to apply theme color scales and other properties to multiple components
 
 ### Note
-Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 
+
+Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the
 components used in the examples above, Victory pass-thru props are also documented here:
 
- - For `Chart` props, see [VictoryChart](https://formidable.com/open-source/victory/docs/victory-chart)
- - For `ChartAxis` props, see [VictoryAxis](https://formidable.com/open-source/victory/docs/victory-axis)
- - For `ChartBar` props, see [VictoryBar](https://formidable.com/open-source/victory/docs/victory-bar)
- - For `ChartGroup` props, see [VictoryGroup](https://formidable.com/open-source/victory/docs/victory-group)
- - For `ChartVoronoiContainer` props, see [VictoryVoronoiContainer](https://formidable.com/open-source/victory/docs/victory-voronoi-container)
+- For `Chart` props, see [VictoryChart](https://formidable.com/open-source/victory/docs/victory-chart)
+- For `ChartAxis` props, see [VictoryAxis](https://formidable.com/open-source/victory/docs/victory-axis)
+- For `ChartBar` props, see [VictoryBar](https://formidable.com/open-source/victory/docs/victory-bar)
+- For `ChartGroup` props, see [VictoryGroup](https://formidable.com/open-source/victory/docs/victory-group)
+- For `ChartVoronoiContainer` props, see [VictoryVoronoiContainer](https://formidable.com/open-source/victory/docs/victory-voronoi-container)

--- a/packages/react-charts/src/components/ChartBar/examples/ChartBar.md
+++ b/packages/react-charts/src/components/ChartBar/examples/ChartBar.md
@@ -172,11 +172,11 @@ import { Chart, ChartBar, ChartVoronoiContainer } from '@patternfly/react-charts
 - Use `ChartGroup` to apply theme color scales and other properties to multiple components
 
 ### Note
-Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the
+Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 
 components used in the examples above, Victory pass-thru props are also documented here:
 
-- For `Chart` props, see [VictoryChart](https://formidable.com/open-source/victory/docs/victory-chart)
-- For `ChartAxis` props, see [VictoryAxis](https://formidable.com/open-source/victory/docs/victory-axis)
-- For `ChartBar` props, see [VictoryBar](https://formidable.com/open-source/victory/docs/victory-bar)
-- For `ChartGroup` props, see [VictoryGroup](https://formidable.com/open-source/victory/docs/victory-group)
-- For `ChartVoronoiContainer` props, see [VictoryVoronoiContainer](https://formidable.com/open-source/victory/docs/victory-voronoi-container)
+ - For `Chart` props, see [VictoryChart](https://formidable.com/open-source/victory/docs/victory-chart)
+ - For `ChartAxis` props, see [VictoryAxis](https://formidable.com/open-source/victory/docs/victory-axis)
+ - For `ChartBar` props, see [VictoryBar](https://formidable.com/open-source/victory/docs/victory-bar)
+ - For `ChartGroup` props, see [VictoryGroup](https://formidable.com/open-source/victory/docs/victory-group)
+ - For `ChartVoronoiContainer` props, see [VictoryVoronoiContainer](https://formidable.com/open-source/victory/docs/victory-voronoi-container)

--- a/packages/react-charts/src/components/ChartBar/examples/ChartBar.md
+++ b/packages/react-charts/src/components/ChartBar/examples/ChartBar.md
@@ -163,92 +163,8 @@ import { Chart, ChartBar, ChartVoronoiContainer } from '@patternfly/react-charts
 </div>
 ```
 
-### Basic with right aligned legend (Accessibility Demo)
-
-This demo demonstrate the accessibility function in a Bar chart. You can now focus on the whole chart or the contents in the chart. At the same time, you could use screen reader like VoiceOver to read the chart and contents as you defined in format.
-
-```js
-import React from 'react';
-import { Chart, ChartAxis, ChartBar, ChartGroup, ChartVoronoiContainer } from '@patternfly/react-charts';
-
-function BasicWithRightAlignedLegendAccessibilityDemo() {
-  const data = {
-    cat: [
-      { name: 'Cats', x: '2015', y: 1 },
-      { name: 'Cats', x: '2016', y: 2 },
-      { name: 'Cats', x: '2017', y: 5 },
-      { name: 'Cats', x: '2018', y: 3 }
-    ],
-    dog: [
-      { name: 'Dogs', x: '2015', y: 2 },
-      { name: 'Dogs', x: '2016', y: 1 },
-      { name: 'Dogs', x: '2017', y: 7 },
-      { name: 'Dogs', x: '2018', y: 4 }
-    ],
-    birds: [
-      { name: 'Birds', x: '2015', y: 4 },
-      { name: 'Birds', x: '2016', y: 4 },
-      { name: 'Birds', x: '2017', y: 9 },
-      { name: 'Birds', x: '2018', y: 7 }
-    ],
-    mice: [
-      { name: 'Mice', x: '2015', y: 3 },
-      { name: 'Mice', x: '2016', y: 3 },
-      { name: 'Mice', x: '2017', y: 8 },
-      { name: 'Mice', x: '2018', y: 5 }
-    ]
-  };
-  const ariaLabel = Object.assign(
-    ...Object.keys(data).map(type => ({
-      [type]: data[type].map(entry => `There are ${entry.y} ${entry.name} in ${entry.x}`)
-    }))
-  );
-  console.log(ariaLabel);
-  return (
-    <div style={{ height: '250px', width: '600px' }}>
-      <Chart
-        ariaDesc="Average number of pets"
-        ariaTitle="Accessible Bar chart example"
-        containerComponent={
-          <ChartVoronoiContainer
-            role="group"
-            tabIndex={0}
-            labels={({ datum }) => `${datum.name}: ${datum.y}`}
-            constrainToVisibleArea
-          />
-        }
-        domain={{ y: [0, 9] }}
-        domainPadding={{ x: [30, 25] }}
-        legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
-        legendOrientation="vertical"
-        legendPosition="right"
-        height={250}
-        padding={{
-          bottom: 50,
-          left: 50,
-          right: 200, // Adjusted to accommodate legend
-          top: 50
-        }}
-        width={600}
-      >
-        <ChartAxis />
-        <ChartAxis dependentAxis showGrid />
-        <ChartGroup offset={11}>
-          <ChartBar data={data.cat} ariaLabel={ariaLabel.cat} />
-          <ChartBar data={data.dog} ariaLabel={ariaLabel.dog} />
-          <ChartBar data={data.birds} ariaLabel={ariaLabel.birds} />
-          <ChartBar data={data.mice} ariaLabel={ariaLabel.mice} />
-        </ChartGroup>
-      </Chart>
-    </div>
-  );
-}
-```
-
 ## Documentation
-
 ### Tips
-
 - See Victory's [FAQ](https://formidable.com/open-source/victory/docs/faq)
 - For single data points or zero values, you may want to set the `domain` prop
 - `ChartLegend` may be used as a standalone component, instead of using `legendData`
@@ -256,7 +172,6 @@ function BasicWithRightAlignedLegendAccessibilityDemo() {
 - Use `ChartGroup` to apply theme color scales and other properties to multiple components
 
 ### Note
-
 Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the
 components used in the examples above, Victory pass-thru props are also documented here:
 


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5131 .
Since now we can define the `role` of a SVG image in Victory, we are able to add accessibility function to the chart.
The first demo I add is in the Bar Chart. There are 2 aspects that need to be done if a user wants to add a11y feature.

1. Add a11y feature to the whole Bar Chart
    Simply pass 2 props `role='group'` and `tabIndex={0}` to `<ChartVoronoiContainer>`. The first prop is to make sure we can access the contents in the SVG image. The second prop is to make sure we can focus on the whole Bar Chart. Here, VO will read `ariaTitle` and `ariaDesc` we defined before.
2. Add a11y feature to each individual Bar
    Here I add a new prop for `<ChartBar>` named `ariaLabel`, which will read the string array of `aria-label` that given by users. In the demo, I also show how a user could map the data to generate the formatted `aria-label` they want. In `<ChartBar>` component, I will check whether user pass the `ariaLabel` prop into the component. If so, I will create an `aria-label` and `tabIndex={0}` for every individual Bar. If not, users will not be able to focus on the content inside the Bar Chart. Here, VO will read out the aria-label for every Bar when we press Tab to focus on them one by one.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
This is only a draft version and needs a lot of reviews and suggestion. There are several additional issues.

1. When I Tab among the bars, it will be in the render order. As you can see in the demo, if I start from `2015 Cats` and press Tab, it will go to `2016 Cats -> 2017 Cats -> 2018 Cats -> 2015 Dogs...`. However, what we expected and what looks more reasonable is I start from `2015 Cats` and press Tab it will go to `2015 Dogs -> 2015 Birds -> 2015 Mice -> 2016 Cats...`. Is there a good way to solve the problem? Although we can still use VO to read them no matter what order it is. If we change the `tabIndex` of each bar, it may change the Tab behavior of the whole page.
2. When the Bar Chart is extremely huge with a lot of data, user may not want to use Tab to go over them because they need to hit Tab for many times. Is there a good solution for this? (@dlabrecq mentioned we may use `Skip to Content` component, but what's the condition to trigger that component?)
3. This is only a demo for Bar Chart because it's simple, any idea on how to read out those complex charts?
4. Any better way to pass `ariaLabel` of every individual bar? Now it's a little bit complex for our users to map the data. Can we do the mapping procedure for them?