### PR TITLE
fix(console): remove css imports

### DIFF
--- a/packages/react-console/src/components/AccessConsoles/AccessConsoles.tsx
+++ b/packages/react-console/src/components/AccessConsoles/AccessConsoles.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from '@patternfly/react-styles';
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 
-import constants from '../common/constants';
+import { constants } from '../common/constants';
 
 import styles from '@patternfly/react-styles/css/components/Consoles/AccessConsoles';
 import '@patternfly/react-styles/css/components/Consoles/AccessConsoles.css';

--- a/packages/react-console/src/components/AccessConsoles/__tests__/AccessConsole.test.tsx
+++ b/packages/react-console/src/components/AccessConsoles/__tests__/AccessConsole.test.tsx
@@ -5,7 +5,7 @@ import { AccessConsoles } from '../AccessConsoles';
 import { SerialConsole } from '../../SerialConsole';
 import { VncConsole } from '../../VncConsole';
 import { DesktopViewer } from '../../DesktopViewer';
-import constants from '../../common/constants';
+import { constants } from '../../common/constants';
 
 const { SERIAL_CONSOLE_TYPE, VNC_CONSOLE_TYPE, LOADING } = constants;
 

--- a/packages/react-console/src/components/AccessConsoles/examples/AccessConsoles.md
+++ b/packages/react-console/src/components/AccessConsoles/examples/AccessConsoles.md
@@ -1,5 +1,5 @@
 ---
-id: AccessConsoles
+id: Access consoles
 section: extensions
 propComponents: ['AccessConsoles']
 ouia: false

--- a/packages/react-console/src/components/DesktopViewer/ConnectWithRemoteViewer.tsx
+++ b/packages/react-console/src/components/DesktopViewer/ConnectWithRemoteViewer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button, ExpandableSection } from '@patternfly/react-core';
 
-import constants from '../common/constants';
+import { constants } from '../common/constants';
 
 import { MoreInformationDefaultContent } from './MoreInformationDefaultContent';
 import { MoreInformationDefaultRDPContent } from './MoreInformationDefaultRDPContent';

--- a/packages/react-console/src/components/DesktopViewer/__tests__/DesktopViewer.test.tsx
+++ b/packages/react-console/src/components/DesktopViewer/__tests__/DesktopViewer.test.tsx
@@ -4,7 +4,7 @@ import { render, mount } from 'enzyme';
 import { DesktopViewer } from '../DesktopViewer';
 import { MoreInformationDefaultContent } from '../MoreInformationDefaultContent';
 import { generateDescriptorFile } from '../consoleDescriptorGenerator';
-import constants from '../../common/constants';
+import { constants } from '../../common/constants';
 
 const { SPICE_CONSOLE_TYPE, RDP_CONSOLE_TYPE, DEFAULT_RDP_PORT } = constants;
 

--- a/packages/react-console/src/components/DesktopViewer/consoleDescriptorGenerator.tsx
+++ b/packages/react-console/src/components/DesktopViewer/consoleDescriptorGenerator.tsx
@@ -1,7 +1,7 @@
 import { saveAs } from 'file-saver';
 
 import { ConsoleDetailPropType } from './ConsoleDetailPropType';
-import constants from '../common/constants';
+import { constants } from '../common/constants';
 
 const {
   VNC_CONSOLE_TYPE,

--- a/packages/react-console/src/components/SerialConsole/SerialConsole.tsx
+++ b/packages/react-console/src/components/SerialConsole/SerialConsole.tsx
@@ -6,10 +6,10 @@ import { Button, EmptyState, EmptyStateBody, EmptyStateIcon, Spinner } from '@pa
 import { XTerm, XTermProps } from './XTerm';
 import { SerialConsoleActions } from './SerialConsoleActions';
 
-import constants from '../common/constants';
+import { constants } from '../common/constants';
 
 import styles from '@patternfly/react-styles/css/components/Consoles/SerialConsole';
-import 'xterm/css/xterm.css';
+import '@patternfly/react-styles/css/components/Consoles/xterm.css';
 import '@patternfly/react-styles/css/components/Consoles/SerialConsole.css';
 
 const { CONNECTED, DISCONNECTED, LOADING } = constants;

--- a/packages/react-console/src/components/SerialConsole/SerialConsole.tsx
+++ b/packages/react-console/src/components/SerialConsole/SerialConsole.tsx
@@ -9,6 +9,7 @@ import { SerialConsoleActions } from './SerialConsoleActions';
 import constants from '../common/constants';
 
 import styles from '@patternfly/react-styles/css/components/Consoles/SerialConsole';
+import 'xterm/css/xterm.css';
 import '@patternfly/react-styles/css/components/Consoles/SerialConsole.css';
 
 const { CONNECTED, DISCONNECTED, LOADING } = constants;

--- a/packages/react-console/src/components/SerialConsole/__tests__/SerialConsole.test.tsx
+++ b/packages/react-console/src/components/SerialConsole/__tests__/SerialConsole.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow, render } from 'enzyme';
 import { SerialConsole } from '../SerialConsole';
-import constants from '../../common/constants';
+import { constants } from '../../common/constants';
 
 const { CONNECTED, DISCONNECTED, LOADING } = constants;
 

--- a/packages/react-console/src/components/SpiceConsole/SpiceConsole.tsx
+++ b/packages/react-console/src/components/SpiceConsole/SpiceConsole.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from '@patternfly/react-styles';
 import { SpiceMainConn, sendCtrlAltDel } from '@spice-project/spice-html5';
 
-import constants from '../common/constants';
+import { constants } from '../common/constants';
 import { SpiceActions } from './SpiceActions';
 
 const { CONNECTED, CONNECTING, DISCONNECTED } = constants;

--- a/packages/react-console/src/components/VncConsole/VncConsole.tsx
+++ b/packages/react-console/src/components/VncConsole/VncConsole.tsx
@@ -8,7 +8,7 @@ import * as NovncLog from 'novnc-core/lib/util/logging';
 import RFB from 'novnc-core';
 
 import { VncActions } from './VncActions';
-import constants from '../common/constants';
+import { constants } from '../common/constants';
 
 import styles from '@patternfly/react-styles/css/components/Consoles/VncConsole';
 import '@patternfly/react-styles/css/components/Consoles/VncConsole.css';

--- a/packages/react-console/src/components/common/constants.tsx
+++ b/packages/react-console/src/components/common/constants.tsx
@@ -16,7 +16,7 @@ const DEFAULT_RDP_FILENAME = 'console.rdp';
 const DEFAULT_RDP_MIMETYPE = 'application/rdp';
 const DEFAULT_RDP_PORT = 3389;
 
-const constants = {
+export const constants = {
   NONE_TYPE,
   SERIAL_CONSOLE_TYPE,
   SPICE_CONSOLE_TYPE,
@@ -35,5 +35,3 @@ const constants = {
   DEFAULT_RDP_MIMETYPE,
   DEFAULT_RDP_PORT
 };
-
-export default constants;

--- a/packages/react-console/src/components/index.ts
+++ b/packages/react-console/src/components/index.ts
@@ -4,3 +4,4 @@ export * from './DesktopViewer';
 export * from './SerialConsole';
 export * from './SpiceConsole';
 export * from './VncConsole';
+export * from './common/constants';

--- a/packages/react-styles/src/css/components/Consoles/SerialConsole.css
+++ b/packages/react-styles/src/css/components/Consoles/SerialConsole.css
@@ -1,5 +1,3 @@
-@import 'xterm/css/xterm.css';
-
 .pf-c-console__serial {
   grid-area: main;
 }

--- a/packages/react-styles/src/css/components/Consoles/VncConsole.css
+++ b/packages/react-styles/src/css/components/Consoles/VncConsole.css
@@ -1,5 +1,5 @@
 .pf-c-console__vnc {
-    grid-area: main;
+  grid-area: main;
 }
 .pf-c-console__actions-vnc {
   grid-area: actions-extra;

--- a/packages/react-styles/src/css/components/Consoles/xterm.css
+++ b/packages/react-styles/src/css/components/Consoles/xterm.css
@@ -1,0 +1,171 @@
+/**
+ * Copyright (c) 2014 The xterm.js authors. All rights reserved.
+ * Copyright (c) 2012-2013, Christopher Jeffrey (MIT License)
+ * https://github.com/chjj/term.js
+ * @license MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * Originally forked from (with the author's permission):
+ *   Fabrice Bellard's javascript vt100 for jslinux:
+ *   http://bellard.org/jslinux/
+ *   Copyright (c) 2011 Fabrice Bellard
+ *   The original design remains. The terminal itself
+ *   has been extended to include xterm CSI codes, among
+ *   other features.
+ */
+
+/**
+ *  Default styles for xterm.js
+ */
+
+.xterm {
+    font-feature-settings: "liga" 0;
+    position: relative;
+    user-select: none;
+    -ms-user-select: none;
+    -webkit-user-select: none;
+}
+
+.xterm.focus,
+.xterm:focus {
+    outline: none;
+}
+
+.xterm .xterm-helpers {
+    position: absolute;
+    top: 0;
+    /**
+     * The z-index of the helpers must be higher than the canvases in order for
+     * IMEs to appear on top.
+     */
+    z-index: 5;
+}
+
+.xterm .xterm-helper-textarea {
+    padding: 0;
+    border: 0;
+    margin: 0;
+    /* Move textarea out of the screen to the far left, so that the cursor is not visible */
+    position: absolute;
+    opacity: 0;
+    left: -9999em;
+    top: 0;
+    width: 0;
+    height: 0;
+    z-index: -5;
+    /** Prevent wrapping so the IME appears against the textarea at the correct position */
+    white-space: nowrap;
+    overflow: hidden;
+    resize: none;
+}
+
+.xterm .composition-view {
+    /* TODO: Composition position got messed up somewhere */
+    background: #000;
+    color: #FFF;
+    display: none;
+    position: absolute;
+    white-space: nowrap;
+    z-index: 1;
+}
+
+.xterm .composition-view.active {
+    display: block;
+}
+
+.xterm .xterm-viewport {
+    /* On OS X this is required in order for the scroll bar to appear fully opaque */
+    background-color: #000;
+    overflow-y: scroll;
+    cursor: default;
+    position: absolute;
+    right: 0;
+    left: 0;
+    top: 0;
+    bottom: 0;
+}
+
+.xterm .xterm-screen {
+    position: relative;
+}
+
+.xterm .xterm-screen canvas {
+    position: absolute;
+    left: 0;
+    top: 0;
+}
+
+.xterm .xterm-scroll-area {
+    visibility: hidden;
+}
+
+.xterm-char-measure-element {
+    display: inline-block;
+    visibility: hidden;
+    position: absolute;
+    top: 0;
+    left: -9999em;
+    line-height: normal;
+}
+
+.xterm {
+    cursor: text;
+}
+
+.xterm.enable-mouse-events {
+    /* When mouse events are enabled (eg. tmux), revert to the standard pointer cursor */
+    cursor: default;
+}
+
+.xterm.xterm-cursor-pointer {
+    cursor: pointer;
+}
+
+.xterm.column-select.focus {
+    /* Column selection mode */
+    cursor: crosshair;
+}
+
+.xterm .xterm-accessibility,
+.xterm .xterm-message {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    z-index: 10;
+    color: transparent;
+}
+
+.xterm .live-region {
+    position: absolute;
+    left: -9999px;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+}
+
+.xterm-dim {
+    opacity: 0.5;
+}
+
+.xterm-underline {
+    text-decoration: underline;
+}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Not all webpack loaders support CSS imports

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
