### PR TITLE
Fix TS type for isChecked prop of Checkbox so it allows null (indeterminate)

### DIFF
--- a/packages/react-core/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react-core/src/components/Checkbox/Checkbox.tsx
@@ -11,8 +11,8 @@ export interface CheckboxProps
   isValid?: boolean;
   /** Flag to show if the Checkbox is disabled. */
   isDisabled?: boolean;
-  /** Flag to show if the Checkbox is checked. */
-  isChecked?: boolean;
+  /** Flag to show if the Checkbox is checked. If null, the checkbox will be indeterminate (partially checked). */
+  isChecked?: boolean | null;
   checked?: boolean;
   /** A callback for when the Checkbox selection changes. */
   onChange?: (checked: boolean, event: React.FormEvent<HTMLInputElement>) => void;


### PR DESCRIPTION
Our Checkbox component supports a null value for `isChecked`, in order to show the indeterminate (partially-checked) state. We demonstrate this in the Controlled example of the checkbox docs page.

However, when trying to pass this null value into the prop in a TypeScript app, TS gives an error since the type of this prop is `boolean` (null is not assignable). This doesn't cause an issue in our examples since they are plain JS.

This PR simply changes the `isChecked` prop type to `boolean | null` so TS won't complain when a null value is passed.