### PR TITLE
TreeView: add support for indeterminate checkboxes without requiring consumer to use refs

### DIFF
--- a/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
+++ b/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
@@ -6,6 +6,10 @@ import AngleDownIcon from '@patternfly/react-icons/dist/js/icons/angle-down-icon
 import { TreeViewDataItem } from './TreeView';
 import { Badge } from '../Badge';
 
+interface CheckProps extends Partial<React.InputHTMLAttributes<HTMLInputElement>> {
+  checked?: boolean | null;
+}
+
 export interface TreeViewListItemProps {
   /** Internal content of a tree view item */
   name: React.ReactNode;
@@ -22,7 +26,7 @@ export interface TreeViewListItemProps {
   /** Flag indicating if a tree view item has a checkbox */
   hasCheck?: boolean;
   /** Additional properties of the tree view item checkbox */
-  checkProps?: any;
+  checkProps?: CheckProps;
   /** Flag indicating if a tree view item has a badge */
   hasBadge?: boolean;
   /** Additional properties of the tree view item badge */
@@ -102,6 +106,7 @@ export const TreeViewListItem: React.FunctionComponent<TreeViewListItemProps> = 
                 type="checkbox"
                 onChange={(evt: React.ChangeEvent) => onCheck && onCheck(evt, itemData, parentItem)}
                 onClick={(evt: React.MouseEvent) => evt.stopPropagation()}
+                ref={elem => elem && (elem.indeterminate = checkProps.checked === null)}
                 {...checkProps}
               />
             </span>

--- a/packages/react-core/src/components/TreeView/examples/TreeView.md
+++ b/packages/react-core/src/components/TreeView/examples/TreeView.md
@@ -372,15 +372,13 @@ class CheckboxTreeView extends React.Component {
       const hasCheck = areAllDescendantsChecked(item);
       // Reset checked properties to be updated
       item.checkProps.checked = false;
-      item.checkProps.ref = elem => elem && (elem.indeterminate = false);
 
       if (hasCheck) {
         item.checkProps.checked = true;
       } else {
         const hasPartialCheck = areSomeDescendantsChecked(item);
         if (hasPartialCheck) {
-          item.checkProps.checked = false;
-          item.checkProps.ref = elem => elem && (elem.indeterminate = true);
+          item.checkProps.checked = null;
         }
       }
 


### PR DESCRIPTION
Currently, in order to show an indeterminate (partially-checked) checkbox in a TreeViewListItem, the consumer has to use a ref to set the element's `indeterminate` prop. This is what we already do internally in our regular Checkbox when the consumer passes a null value for `isChecked`. This PR adds support for rendering this indeterminate state just by passing a null value for `checkProps: { checked }` on a tree item instead of using a ref. I updated the existing tree view example to use this approach instead of the ref.

This isn't a breaking change: if a consumer is already using their own ref to set this property, that will still work.

I considered refactoring the tree view to use our `<Checkbox>` component instead of a native `<checkbox>` so we wouldn't have to duplicate this logic in both components, but the tree view checkbox needs to be pretty bare for the styles to work correctly and it seemed overkill to add props to `<Checkbox>` that disabled a bunch of its features and styles.