### PR TITLE
fix(datepicker): remove date-fns and allow more customization

### DIFF
--- a/packages/react-datetime/package.json
+++ b/packages/react-datetime/package.json
@@ -39,8 +39,7 @@
     "@patternfly/react-core": "^4.79.2",
     "@patternfly/react-icons": "^4.7.18",
     "@patternfly/react-styles": "^4.7.16",
-    "@patternfly/react-tokens": "^4.9.18",
-    "date-fns": "^2.16.1"
+    "@patternfly/react-tokens": "^4.9.18"
   },
   "peerDependencies": {
     "react": "^16.8.0",

--- a/packages/react-datetime/src/components/CalendarMonth/CalendarMonth.tsx
+++ b/packages/react-datetime/src/components/CalendarMonth/CalendarMonth.tsx
@@ -9,9 +9,17 @@ import styles from '@patternfly/react-styles/css/components/CalendarMonth/calend
 import commonStyles from '@patternfly/react-styles/css/base/patternfly-common';
 import { getUniqueId } from '@patternfly/react-core/dist/js/helpers/util';
 
-export interface CalendarProps extends Omit<React.HTMLProps<HTMLDivElement>, 'onChange'> {
-  /** Month/year to base other dates around */
-  date: Date;
+export enum Weekday {
+  Sunday = 0,
+  Monday,
+  Tuesday,
+  Wednesday,
+  Thursday,
+  Friday,
+  Saturday
+}
+
+export interface CalendarFormat {
   /** How to format months in Select */
   monthFormat?: (date: Date) => React.ReactNode;
   /** How to format week days in header */
@@ -19,11 +27,16 @@ export interface CalendarProps extends Omit<React.HTMLProps<HTMLDivElement>, 'on
   /** How to format days in header for screen readers */
   longWeekdayFormat?: (date: Date) => React.ReactNode;
   /** How to format days in buttons in table cells */
-  buttonFormat?: (date: Date) => React.ReactNode;
+  dayFormat?: (date: Date) => React.ReactNode;
   /** If using the default formatters which locale to use. Undefined defaults to current locale. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation */
   locale?: string;
   /** Day of week that starts the week. 0 is Sunday, 6 is Saturday. */
-  weekStart?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  weekStart?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | Weekday;
+}
+
+export interface CalendarProps extends CalendarFormat, Omit<React.HTMLProps<HTMLDivElement>, 'onChange'> {
+  /** Month/year to base other dates around */
+  date: Date;
   /** Callback when date is selected */
   onChange?: (date: Date) => void;
   /** Functions that returns if a date is valid and selectable */
@@ -65,8 +78,8 @@ export const CalendarMonth = ({
   monthFormat = date => date.toLocaleDateString(locale, { month: 'long' }),
   weekdayFormat = date => date.toLocaleDateString(locale, { weekday: 'narrow' }),
   longWeekdayFormat = date => date.toLocaleDateString(locale, { weekday: 'long' }),
-  buttonFormat = date => date.getDate(),
-  weekStart = 0,
+  dayFormat = date => date.getDate(),
+  weekStart = 0, // Use the American Sunday as a default
   onChange = () => {},
   validators = [() => true],
   className,
@@ -200,7 +213,7 @@ export const CalendarMonth = ({
                 const isFocused = isSameDate(day, focusedDate);
                 const isValid = validators.every(validator => validator(day));
                 const isAdjacentMonth = day.getMonth() !== focusedDate.getMonth();
-                const dayFormatted = buttonFormat(day);
+                const dayFormatted = dayFormat(day);
 
                 return (
                   <td

--- a/packages/react-datetime/src/components/CalendarMonth/CalendarMonth.tsx
+++ b/packages/react-datetime/src/components/CalendarMonth/CalendarMonth.tsx
@@ -12,13 +12,13 @@ import { getUniqueId } from '@patternfly/react-core/dist/js/helpers/util';
 export interface CalendarProps extends Omit<React.HTMLProps<HTMLDivElement>, 'onChange'> {
   /** Month/year to base other dates around */
   date: Date;
-  /** How to format months in Select according to date-fns */
+  /** How to format months in Select */
   monthFormat?: (date: Date) => React.ReactNode;
-  /** How to format week days in header according to date-fns */
+  /** How to format week days in header */
   weekdayFormat?: (date: Date) => React.ReactNode;
-  /** How to format days in header for screen readers according to date-fns */
+  /** How to format days in header for screen readers */
   longWeekdayFormat?: (date: Date) => React.ReactNode;
-  /** How to format days in buttons in table cells according to date-fns */
+  /** How to format days in buttons in table cells */
   buttonFormat?: (date: Date) => React.ReactNode;
   /** If using the default formatters which locale to use. Undefined defaults to current locale. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation */
   locale?: string;

--- a/packages/react-datetime/src/components/CalendarMonth/CalendarMonth.tsx
+++ b/packages/react-datetime/src/components/CalendarMonth/CalendarMonth.tsx
@@ -6,42 +6,41 @@ import ArrowLeftIcon from '@patternfly/react-icons/dist/js/icons/arrow-left-icon
 import ArrowRightIcon from '@patternfly/react-icons/dist/js/icons/arrow-right-icon';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/CalendarMonth/calendar-month';
-// https://date-fns.org/v2.16.1/docs/format
-import { format } from 'date-fns';
-import { Locales, Locale } from '../../helpers';
 import commonStyles from '@patternfly/react-styles/css/base/patternfly-common';
 import { getUniqueId } from '@patternfly/react-core/dist/js/helpers/util';
 
 export interface CalendarProps extends Omit<React.HTMLProps<HTMLDivElement>, 'onChange'> {
   /** Month/year to base other dates around */
   date: Date;
-  /** How to format months in dropdown according to date-fns */
-  monthFormat?: string;
-  /** How to format days in header according to date-fns */
-  dayFormat?: string;
+  /** How to format months in Select according to date-fns */
+  monthFormat?: (date: Date) => React.ReactNode;
+  /** How to format week days in header according to date-fns */
+  weekdayFormat?: (date: Date) => React.ReactNode;
   /** How to format days in header for screen readers according to date-fns */
-  longDayFormat?: string;
-  /** How to format days in buttons according to date-fns */
-  buttonFormat?: string;
+  longWeekdayFormat?: (date: Date) => React.ReactNode;
+  /** How to format days in buttons in table cells according to date-fns */
+  buttonFormat?: (date: Date) => React.ReactNode;
+  /** If using the default formatters which locale to use. Undefined defaults to current locale. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation */
+  locale?: string;
+  /** Day of week that starts the week. 0 is Sunday, 6 is Saturday. */
+  weekStart?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
   /** Callback when date is selected */
   onChange?: (date: Date) => void;
-  /** Specify the locale of the date. */
-  locale?: Locale;
   /** Functions that returns if a date is valid and selectable */
-  validators?: [(date: Date) => boolean];
+  validators?: ((date: Date) => boolean)[];
   /** Classname to add to outer div */
   className?: string;
   /** @hide Internal prop to allow pressing escape in select menu to not close popover */
   onSelectToggle?: (open: boolean) => void;
 }
 
-// Must be numeric given current design
-const yearFormat = 'yyyy';
+// Must be numeric given current header design
+const yearFormat = (date: Date) => date.getFullYear();
 
-const buildCalendar = (year: number, month: number, locale: Locale) => {
+const buildCalendar = (year: number, month: number, weekStart: number) => {
   const selectedDate = new Date(year, month);
   const firstDayOfWeek = new Date(selectedDate);
-  firstDayOfWeek.setDate(firstDayOfWeek.getDate() - firstDayOfWeek.getDay() + locale.options.weekStartsOn);
+  firstDayOfWeek.setDate(firstDayOfWeek.getDate() - firstDayOfWeek.getDay() + weekStart);
   // We will always show 6 weeks like google calendar
   // Assume we just want the numbers for now...
   const calendarWeeks = [] as Date[][];
@@ -62,24 +61,19 @@ const isSameDate = (d1: Date, d2: Date) =>
 
 export const CalendarMonth = ({
   date: dateProp = new Date(),
-  monthFormat = 'MMMM',
-  dayFormat = 'EEEEE',
-  longDayFormat = 'EEEE',
-  buttonFormat = 'd',
+  locale = undefined,
+  monthFormat = date => date.toLocaleDateString(locale, { month: 'long' }),
+  weekdayFormat = date => date.toLocaleDateString(locale, { weekday: 'narrow' }),
+  longWeekdayFormat = date => date.toLocaleDateString(locale, { weekday: 'long' }),
+  buttonFormat = date => date.getDate(),
+  weekStart = 0,
   onChange = () => {},
-  locale = Locales.enUS,
   validators = [() => true],
   className,
   onSelectToggle = () => {},
   ...props
 }: CalendarProps) => {
-  const longMonthNames = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
-    .map(monthNum => new Date(1990, monthNum))
-    .map(date => format(date, monthFormat, { locale }))
-    .reduce((prev, cur, index) => {
-      prev[cur] = index;
-      return prev;
-    }, {} as { [key: string]: number });
+  const longMonths = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11].map(monthNum => new Date(1990, monthNum)).map(monthFormat);
   const [isSelectOpen, setIsSelectOpen] = React.useState(false);
   const [focusedDate, setFocusedDate] = React.useState(dateProp);
   const focusRef = React.useRef<HTMLButtonElement>();
@@ -123,9 +117,9 @@ export const CalendarMonth = ({
   };
 
   const today = new Date();
-  const calendar = buildCalendar(focusedDate.getFullYear(), focusedDate.getMonth(), locale);
-  const monthFormatted = format(focusedDate, monthFormat, { locale });
-  const yearFormatted = format(focusedDate, yearFormat, { locale });
+  const calendar = buildCalendar(focusedDate.getFullYear(), focusedDate.getMonth(), weekStart);
+  const monthFormatted = monthFormat(focusedDate);
+  const yearFormatted = yearFormat(focusedDate);
   return (
     <div className={css(styles.calendarMonth, className)} {...props}>
       <div className={styles.calendarMonthHeader}>
@@ -147,22 +141,23 @@ export const CalendarMonth = ({
               setIsSelectOpen(!isSelectOpen);
               onSelectToggle(!isSelectOpen);
             }}
-            onSelect={(_ev, longMonth) => {
+            onSelect={(_ev, monthNum) => {
               // When we put CalendarMonth in a Popover we want the Popover's onDocumentClick
               // to see the SelectOption as a child so it doesn't close the Popover.
               setIsSelectOpen(false);
               onSelectToggle(false);
-              const monthNum = longMonthNames[longMonth as string];
               const newDate = new Date(focusedDate);
-              newDate.setMonth(monthNum);
+              newDate.setMonth(Number(monthNum as string));
               setFocusedDate(newDate);
               setFocusDate(false);
             }}
             variant="single"
             selections={monthFormatted}
           >
-            {Object.keys(longMonthNames).map((longMonth, index) => (
-              <SelectOption key={index} value={longMonth} isSelected={longMonth === monthFormatted} />
+            {longMonths.map((longMonth, index) => (
+              <SelectOption key={index} value={index} isSelected={longMonth === monthFormatted}>
+                {longMonth}
+              </SelectOption>
             ))}
           </Select>
         </div>
@@ -190,8 +185,8 @@ export const CalendarMonth = ({
           <tr>
             {calendar[0].map((date, index) => (
               <th key={index} className={styles.calendarMonthDay} scope="col">
-                <span className={commonStyles.screenReader}>{format(date, longDayFormat, { locale })}</span>
-                <span aria-hidden>{format(date, dayFormat, { locale })}</span>
+                <span className={commonStyles.screenReader}>{longWeekdayFormat(date)}</span>
+                <span aria-hidden>{weekdayFormat(date)}</span>
               </th>
             ))}
           </tr>
@@ -205,7 +200,7 @@ export const CalendarMonth = ({
                 const isFocused = isSameDate(day, focusedDate);
                 const isValid = validators.every(validator => validator(day));
                 const isAdjacentMonth = day.getMonth() !== focusedDate.getMonth();
-                const dayFormatted = format(day, buttonFormat);
+                const dayFormatted = buttonFormat(day);
 
                 return (
                   <td

--- a/packages/react-datetime/src/components/CalendarMonth/examples/CalendarMonth.md
+++ b/packages/react-datetime/src/components/CalendarMonth/examples/CalendarMonth.md
@@ -8,10 +8,10 @@ beta: true
 
 import { CalendarMonth } from '@patternfly/react-datetime';
 
-Note: CalendarMonth lives in its own package at [@patternfly/react-datetime](https://www.npmjs.com/package/@patternfly/react-datetime) and uses format strings from [date-fns@^2.0.0](https://date-fns.org/docs/format).
+Note: CalendarMonth lives in its own package at [@patternfly/react-datetime](https://www.npmjs.com/package/@patternfly/react-datetime).
 
 ## Examples
-### Date selected
+### Selectable date
 ```js
 import React from 'react';
 import { CalendarMonth } from '@patternfly/react-datetime';

--- a/packages/react-datetime/src/components/CalendarMonth/examples/CalendarMonth.md
+++ b/packages/react-datetime/src/components/CalendarMonth/examples/CalendarMonth.md
@@ -2,7 +2,7 @@
 id: Calendar month
 section: components
 cssPrefix: pf-c-calendar-month
-propComponents: ['CalendarMonth']
+propComponents: ['CalendarMonth', 'CalendarFormat']
 beta: true
 ---
 

--- a/packages/react-datetime/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-datetime/src/components/DatePicker/DatePicker.tsx
@@ -3,165 +3,108 @@ import { css } from '@patternfly/react-styles';
 import '@patternfly/patternfly/patternfly-date-picker.css';
 import styles from '@patternfly/react-styles/css/components/DatePicker/date-picker';
 import buttonStyles from '@patternfly/react-styles/css/components/Button/button';
-import { Locales, Locale } from '../../helpers';
 import { TextInput } from '@patternfly/react-core/dist/js/components/TextInput/TextInput';
 import { Popover, PopoverProps } from '@patternfly/react-core/dist/js/components/Popover/Popover';
 import { InputGroup } from '@patternfly/react-core/dist/js/components/InputGroup/InputGroup';
 import OutlinedCalendarAltIcon from '@patternfly/react-icons/dist/js/icons/outlined-calendar-alt-icon';
-import { parse, format, isValid as isNotNull } from 'date-fns';
 import { CalendarMonth } from '../CalendarMonth';
 
 export interface DatePickerProps
   extends Omit<React.HTMLProps<HTMLInputElement>, 'onChange' | 'onFocus' | 'onBlur' | 'disabled' | 'ref'> {
   /** Additional classes added to the date time picker. */
   className?: string;
-  /** Flag indicating whether the value of the date picker is invalid. */
-  isInvalid?: boolean;
   /** Accessible label for the date picker */
   'aria-label'?: string;
-  /** The minimum date that a user can start picking from. */
-  minDate?: string;
-  /** The maximum date that a user can pick to. */
-  maxDate?: string;
-  /** The case sensitive date format according to date-fns */
-  dateFormat?: string;
+  /** How to format the date in the TextInput */
+  dateFormat?: (date: Date) => string;
+  /** How to format the date in the TextInput */
+  dateParse?: (value: string) => Date;
   /** Flag indicating the date picker is disabled*/
   isDisabled?: boolean;
-  /** Specify the locale of the date. */
-  locale?: Locale;
   /** String to display in the empty date picker field as a hint for the expected date format */
   placeholder?: string;
-  /** A date string. Defaults to the current date. */
+  /** Value of TextInput */
   value?: string;
-  /** Error message to display when the date is provided in an invalid format. */
-  invalidFormatErrorMessage?: string;
-  /** Error message to display when the date is provided in outside the valid date range. */
-  dateOutOfRangeErrorMessage?: string;
-  /** Error message to display when the date is provided before the provided minDate. */
-  beforeMinDateErrorMessage?: string;
-  /** Error message to display when the date is provided after the provided maxDate. */
-  afterEndDateErrorMessage?: string;
+  /** Error message to display when the TextInput cannot be parsed. */
+  invalidFormatText?: string;
   /** Callback called every time the input value changes */
   onChange?: (value: string, date?: Date) => void;
   /** Text for label */
   helperText?: React.ReactNode;
-  /** Aria label for the button */
+  /** Aria label for the button to open the date picker */
   buttonAriaLabel?: string;
   /** The element to append the popover to */
   appendTo?: HTMLElement | ((ref?: HTMLElement) => HTMLElement);
   /** Props to pass to the Popover */
   popoverProps?: Omit<PopoverProps, 'appendTo'>;
+  /** How to format months in Calendar */
+  monthFormat?: (date: Date) => React.ReactNode;
+  /** How to format week days in Calendar */
+  weekdayFormat?: (date: Date) => React.ReactNode;
+  /** How to format days in Calendar */
+  longWeekdayFormat?: (date: Date) => React.ReactNode;
+  /** How to format days in Calendar */
+  buttonFormat?: (date: Date) => React.ReactNode;
+  /** If using the default formatters which locale to use. Undefined defaults to current locale. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation */
+  locale?: string;
+  /** Day of week that starts the week in Calendar. 0 is Sunday, 6 is Saturday. */
+  weekStart?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  /** Functions that returns an error message if a date is invalid */
+  validators?: ((date: Date) => string)[];
 }
+
+const isValidDate = (date: Date) => !isNaN(date.getTime());
 
 export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
   className,
-  isInvalid = false,
-  minDate: minDateProp = '',
-  maxDate: maxDateProp = '',
-  dateFormat = 'MM/dd/yyyy',
+  locale = undefined,
+  dateFormat = (date: Date) => date.toISOString().substring(0, 10),
+  dateParse = (val: string) => new Date(`${val}T00:00:00`),
   isDisabled = false,
-  locale = Locales.enUS,
-  placeholder = 'MM/dd/yyyy',
-  value: valueProp = '',
+  placeholder = 'yyyy-MM-dd',
+  value: valueProp = dateFormat(new Date()),
   'aria-label': ariaLabel = 'Date picker',
   buttonAriaLabel = 'Toggle date picker',
   onChange = (): any => undefined,
-  invalidFormatErrorMessage,
-  dateOutOfRangeErrorMessage,
-  beforeMinDateErrorMessage,
-  afterEndDateErrorMessage,
+  invalidFormatText = 'Could not parse date',
   helperText,
   appendTo,
   popoverProps,
+  monthFormat,
+  weekdayFormat,
+  longWeekdayFormat,
+  buttonFormat,
+  weekStart,
+  validators = [],
   ...props
 }: DatePickerProps) => {
-  const myParse = (date: string) => parse(date, dateFormat, new Date(), { locale });
-  const getDefaultValueDate = () => {
-    let res = myParse(valueProp);
-    if (!isNotNull(res)) {
-      if (isNotNull(minDate)) {
-        res = new Date(minDate);
-      } else if (isNotNull(maxDate)) {
-        res = new Date(maxDate);
-      } else {
-        res = new Date();
-      }
-    }
-
-    return res;
-  };
-
-  const [invalid, setInvalid] = React.useState(isInvalid);
-  const [invalidText, setInvalidText] = React.useState('');
   const [value, setValue] = React.useState(valueProp);
-  const [minDate, setMinDate] = React.useState(myParse(minDateProp));
-  const [maxDate, setMaxDate] = React.useState(myParse(maxDateProp));
-  const [valueDate, setValueDate] = React.useState(getDefaultValueDate());
+  const [valueDate, setValueDate] = React.useState(dateParse(value));
+  const [errorText, setErrorText] = React.useState('');
   const [popoverOpen, setPopoverOpen] = React.useState(false);
   const [selectOpen, setSelectOpen] = React.useState(false);
   const buttonRef = React.useRef<HTMLButtonElement>();
 
-  React.useEffect(() => {
-    setValueDate(getDefaultValueDate());
-  }, [valueProp]);
-
-  React.useEffect(() => {
-    setMinDate(myParse(minDateProp));
-  }, [minDateProp]);
-
-  React.useEffect(() => {
-    setMaxDate(myParse(maxDateProp));
-  }, [maxDateProp]);
-
-  const rangeValidator = (date: Date, setText: boolean) => {
-    let isValid = true;
-    if (!isNotNull(date)) {
-      isValid = false;
-      if (setText) {
-        setInvalidText(invalidFormatErrorMessage || `Please use format: ${dateFormat}.`);
-      }
-    } else if (isNotNull(minDate) && isNotNull(maxDate)) {
-      if (date < minDate || date > maxDate) {
-        isValid = false;
-        if (setText) {
-          setInvalidText(dateOutOfRangeErrorMessage || `The date is outside the allowable range.`);
-        }
-      }
-    } else if (isNotNull(minDate) && date < minDate) {
-      isValid = false;
-      if (setText) {
-        setInvalidText(beforeMinDateErrorMessage || `Date is before the allowable range.`);
-      }
-    } else if (isNotNull(maxDate) && date > maxDate) {
-      isValid = false;
-      if (setText) {
-        setInvalidText(afterEndDateErrorMessage || `Date is after the allowable range.`);
-      }
-    }
-    if (setText) {
-      setInvalid(!isValid);
-    }
-
-    return isValid;
-  };
-
   const onTextInput = (value: string) => {
     setValue(value);
-    const newValueDate = myParse(value);
-    if (isNotNull(newValueDate)) {
+    const newValueDate = dateParse(value);
+    if (isValidDate(newValueDate)) {
       setValueDate(newValueDate);
+      setErrorText(validators.map(validator => validator(newValueDate)).join('\n') || '');
+      onChange(value, newValueDate);
+    } else {
+      setErrorText(invalidFormatText);
+      onChange(value);
     }
-    rangeValidator(newValueDate, true);
   };
 
-  const onDateClick = (valueDate: Date) => {
-    const newValue = format(valueDate, dateFormat, { locale });
+  const onDateClick = (newValueDate: Date) => {
+    const newValue = dateFormat(newValueDate);
     setValue(newValue);
-    setValueDate(valueDate);
-    if (rangeValidator(valueDate, true)) {
-      onChange(newValue, valueDate);
-      setPopoverOpen(false);
-    }
+    setValueDate(newValueDate);
+    setErrorText(validators.map(validator => validator(newValueDate)).join('\n') || '');
+    setPopoverOpen(false);
+    onChange(newValue, newValueDate);
   };
 
   return (
@@ -173,8 +116,14 @@ export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
             date={valueDate}
             onChange={onDateClick}
             locale={locale}
-            validators={[date => rangeValidator(date, false)]}
+            // Use truthy values of strings
+            validators={validators.map(validator => (date: Date) => !validator(date))}
             onSelectToggle={open => setSelectOpen(open)}
+            monthFormat={monthFormat}
+            weekdayFormat={weekdayFormat}
+            longWeekdayFormat={longWeekdayFormat}
+            buttonFormat={buttonFormat}
+            weekStart={weekStart}
           />
         }
         showClose={false}
@@ -203,7 +152,7 @@ export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
             isDisabled={isDisabled}
             aria-label={ariaLabel}
             placeholder={placeholder}
-            validated={invalid ? 'error' : 'default'}
+            validated={errorText ? 'error' : 'default'}
             value={value}
             onChange={onTextInput}
           />
@@ -218,7 +167,7 @@ export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
         </InputGroup>
       </Popover>
       {helperText && <div className={styles.datePickerHelperText}>{helperText}</div>}
-      {invalid && <div className={css(styles.datePickerHelperText, styles.modifiers.error)}>{invalidText}</div>}
+      {errorText && <div className={css(styles.datePickerHelperText, styles.modifiers.error)}>{errorText}</div>}
     </div>
   );
 };

--- a/packages/react-datetime/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-datetime/src/components/DatePicker/DatePicker.tsx
@@ -7,10 +7,11 @@ import { TextInput } from '@patternfly/react-core/dist/js/components/TextInput/T
 import { Popover, PopoverProps } from '@patternfly/react-core/dist/js/components/Popover/Popover';
 import { InputGroup } from '@patternfly/react-core/dist/js/components/InputGroup/InputGroup';
 import OutlinedCalendarAltIcon from '@patternfly/react-icons/dist/js/icons/outlined-calendar-alt-icon';
-import { CalendarMonth } from '../CalendarMonth';
+import { CalendarMonth, CalendarFormat } from '../CalendarMonth';
 
 export interface DatePickerProps
-  extends Omit<React.HTMLProps<HTMLInputElement>, 'onChange' | 'onFocus' | 'onBlur' | 'disabled' | 'ref'> {
+  extends CalendarFormat,
+    Omit<React.HTMLProps<HTMLInputElement>, 'onChange' | 'onFocus' | 'onBlur' | 'disabled' | 'ref'> {
   /** Additional classes added to the date time picker. */
   className?: string;
   /** Accessible label for the date picker */
@@ -37,18 +38,6 @@ export interface DatePickerProps
   appendTo?: HTMLElement | ((ref?: HTMLElement) => HTMLElement);
   /** Props to pass to the Popover */
   popoverProps?: Omit<PopoverProps, 'appendTo'>;
-  /** How to format months in Calendar */
-  monthFormat?: (date: Date) => React.ReactNode;
-  /** How to format week days in Calendar */
-  weekdayFormat?: (date: Date) => React.ReactNode;
-  /** How to format days in Calendar */
-  longWeekdayFormat?: (date: Date) => React.ReactNode;
-  /** How to format days in Calendar */
-  buttonFormat?: (date: Date) => React.ReactNode;
-  /** If using the default formatters which locale to use. Undefined defaults to current locale. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation */
-  locale?: string;
-  /** Day of week that starts the week in Calendar. 0 is Sunday, 6 is Saturday. */
-  weekStart?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
   /** Functions that returns an error message if a date is invalid */
   validators?: ((date: Date) => string)[];
 }
@@ -62,7 +51,7 @@ export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
   dateParse = (val: string) => new Date(`${val}T00:00:00`),
   isDisabled = false,
   placeholder = 'yyyy-MM-dd',
-  value: valueProp = dateFormat(new Date()),
+  value: valueProp = '',
   'aria-label': ariaLabel = 'Date picker',
   buttonAriaLabel = 'Toggle date picker',
   onChange = (): any => undefined,
@@ -73,7 +62,7 @@ export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
   monthFormat,
   weekdayFormat,
   longWeekdayFormat,
-  buttonFormat,
+  dayFormat,
   weekStart,
   validators = [],
   ...props
@@ -122,7 +111,7 @@ export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
             monthFormat={monthFormat}
             weekdayFormat={weekdayFormat}
             longWeekdayFormat={longWeekdayFormat}
-            buttonFormat={buttonFormat}
+            dayFormat={dayFormat}
             weekStart={weekStart}
           />
         }

--- a/packages/react-datetime/src/components/DatePicker/__tests__/DatePicker.test.tsx
+++ b/packages/react-datetime/src/components/DatePicker/__tests__/DatePicker.test.tsx
@@ -3,6 +3,6 @@ import { DatePicker } from '../DatePicker';
 import React from 'react';
 
 test('disabled date picker', () => {
-  const view = mount(<DatePicker isDisabled aria-label="disabled date picker" />);
+  const view = mount(<DatePicker value="2020-11-20" isDisabled aria-label="disabled date picker" />);
   expect(view.find('input')).toMatchSnapshot();
 });

--- a/packages/react-datetime/src/components/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react-datetime/src/components/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -13,6 +13,6 @@ exports[`disabled date picker 1`] = `
   readOnly={false}
   required={false}
   type="text"
-  value="2020-11-19"
+  value="2020-11-20"
 />
 `;

--- a/packages/react-datetime/src/components/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react-datetime/src/components/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -9,10 +9,10 @@ exports[`disabled date picker 1`] = `
   onBlur={[Function]}
   onChange={[Function]}
   onFocus={[Function]}
-  placeholder="MM/dd/yyyy"
+  placeholder="yyyy-MM-dd"
   readOnly={false}
   required={false}
   type="text"
-  value=""
+  value="2020-11-19"
 />
 `;

--- a/packages/react-datetime/src/components/DatePicker/examples/DatePicker.md
+++ b/packages/react-datetime/src/components/DatePicker/examples/DatePicker.md
@@ -2,11 +2,11 @@
 id: Date picker
 section: components
 cssPrefix: pf-c-date-picker
-propComponents: ['DatePicker']
+propComponents: ['DatePicker', 'CalendarFormat']
 beta: true
 ---
 
-import { DatePicker } from '@patternfly/react-datetime';
+import { DatePicker, Weekday } from '@patternfly/react-datetime';
 
 Note: DatePicker lives in its own package at [@patternfly/react-datetime](https://www.npmjs.com/package/@patternfly/react-datetime).
 
@@ -17,6 +17,35 @@ import React from 'react';
 import { DatePicker } from '@patternfly/react-datetime';
 
 <DatePicker value="2020-03-05" onChange={(str, date) => console.log('onChange', str, date)} />
+```
+
+### American format
+```js
+import React from 'react';
+import { DatePicker } from '@patternfly/react-datetime';
+
+AmericanFormat = () => {
+  const dateFormat = date => date.toLocaleDateString('en-US', { year: 'numeric', month: '2-digit', day: '2-digit' });
+  const dateParse = date => {
+    const split = date.split('/');
+    if (split.length !== 3) {
+      return new Date();
+    }
+    let month = split[0];
+    let day = split[1];
+    let year = split[2];
+    return new Date(`${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}T00:00:00`);
+  };
+
+  return (
+    <DatePicker
+      value="03/05/2020"
+      placeholder="MM/dd/yyyy"
+      dateFormat={dateFormat}
+      dateParse={dateParse}
+    />
+  );
+}
 ```
 
 ### Helper text
@@ -53,7 +82,7 @@ MinMaxDate = () => {
 
 ```js
 import React from 'react';
-import { DatePicker } from '@patternfly/react-datetime';
+import { DatePicker, Weekday } from '@patternfly/react-datetime';
 
 FrenchMinMaxDate = () => {
   const minDate = new Date(2020, 2, 16);
@@ -75,7 +104,7 @@ FrenchMinMaxDate = () => {
       placeholder="aaaa-mm-jj"
       invalidFormatText="Cette date est invalide."
       locale="fr"
-      weekStart={1}
+      weekStart={Weekday.Monday}
     />
   );
 }

--- a/packages/react-datetime/src/components/DatePicker/examples/DatePicker.md
+++ b/packages/react-datetime/src/components/DatePicker/examples/DatePicker.md
@@ -16,7 +16,7 @@ Note: DatePicker lives in its own package at [@patternfly/react-datetime](https:
 import React from 'react';
 import { DatePicker } from '@patternfly/react-datetime';
 
-<DatePicker value="2020-03-05" onChange={(str, date) => console.log('onChange', str, date)} />
+<DatePicker onChange={(str, date) => console.log('onChange', str, date)} />
 ```
 
 ### American format

--- a/packages/react-datetime/src/components/DatePicker/examples/DatePicker.md
+++ b/packages/react-datetime/src/components/DatePicker/examples/DatePicker.md
@@ -6,9 +6,9 @@ propComponents: ['DatePicker']
 beta: true
 ---
 
-import { DatePicker, Locales } from '@patternfly/react-datetime';
+import { DatePicker } from '@patternfly/react-datetime';
 
-Note: DatePicker lives in its own package at [@patternfly/react-datetime](https://www.npmjs.com/package/@patternfly/react-datetime) and uses format strings from [date-fns@^2.0.0](https://date-fns.org/docs/format).
+Note: DatePicker lives in its own package at [@patternfly/react-datetime](https://www.npmjs.com/package/@patternfly/react-datetime).
 
 ## Examples
 ### Basic
@@ -16,7 +16,7 @@ Note: DatePicker lives in its own package at [@patternfly/react-datetime](https:
 import React from 'react';
 import { DatePicker } from '@patternfly/react-datetime';
 
-<DatePicker value="03/05/2020" />
+<DatePicker value="2020-03-05" onChange={(str, date) => console.log('onChange', str, date)} />
 ```
 
 ### Helper text
@@ -24,7 +24,7 @@ import { DatePicker } from '@patternfly/react-datetime';
 import React from 'react';
 import { DatePicker } from '@patternfly/react-datetime';
 
-<DatePicker value="03/05/2020" helperText="Select a date." />
+<DatePicker value="2020-03-05" helperText="Use the calendar button to select a date." />
 ```
 
 ### Min and max date
@@ -32,22 +32,51 @@ import { DatePicker } from '@patternfly/react-datetime';
 import React from 'react';
 import { DatePicker } from '@patternfly/react-datetime';
 
-<DatePicker minDate="03/16/2020" maxDate="03/20/2020"/>
+MinMaxDate = () => {
+  const minDate = new Date(2020, 2, 16);
+  const maxDate = new Date(2020, 2, 20);
+  const rangeValidator = date => {
+    if (date < minDate) {
+      return 'Date is before the allowable range.';
+    }
+    else if (date > maxDate) {
+      return 'Date is after the allowable range.';
+    }
+
+    return '';
+  };
+  return <DatePicker value="2020-03-17" validators={[rangeValidator]} />;
+}
 ```
 
 ### French
 
 ```js
 import React from 'react';
-import { DatePicker, Locales } from '@patternfly/react-datetime';
+import { DatePicker } from '@patternfly/react-datetime';
 
-<DatePicker 
-  locale={Locales.fr}
-  dateFormat="dd.MM.yyyy" 
-  placeholder="jj.mm.aaaa"
-  invalidFormatErrorMessage="Cette date est invalide."
-  dateOutOfRangeErrorMessage="Cette date dépasse la limite, que ce soit en borne inférieure ou supérieure."
-  beforeMinDateErrorMessage="Cette date est antérieure à la première date valide."
-  afterEndDateErrorMessage="Cette date est postérieure à la dernière date valide."
-/>
+FrenchMinMaxDate = () => {
+  const minDate = new Date(2020, 2, 16);
+  const maxDate = new Date(2020, 2, 20);
+  const rangeValidator = date => {
+    if (date < minDate) {
+      return 'Cette date est antérieure à la première date valide.';
+    }
+    else if (date > maxDate) {
+      return 'Cette date est postérieure à la dernière date valide.';
+    }
+
+    return '';
+  };
+  return (
+    <DatePicker
+      value="2020-03-17"
+      validators={[rangeValidator]}
+      placeholder="aaaa-mm-jj"
+      invalidFormatText="Cette date est invalide."
+      locale="fr"
+      weekStart={1}
+    />
+  );
+}
 ```

--- a/packages/react-datetime/src/components/DatePicker/examples/DatePicker.md
+++ b/packages/react-datetime/src/components/DatePicker/examples/DatePicker.md
@@ -34,7 +34,7 @@ AmericanFormat = () => {
     let month = split[0];
     let day = split[1];
     let year = split[2];
-    return new Date(`${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}T00:00:00`);
+    return new Date(`${year.padStart(4, '0')}-${month.padStart(2, '0')}-${day.padStart(2, '0')}T00:00:00`);
   };
 
   return (

--- a/packages/react-datetime/src/helpers/index.ts
+++ b/packages/react-datetime/src/helpers/index.ts
@@ -1,1 +1,0 @@
-export * from './locales';

--- a/packages/react-datetime/src/helpers/locales.ts
+++ b/packages/react-datetime/src/helpers/locales.ts
@@ -1,4 +1,0 @@
-import * as DateFnsLocales from 'date-fns/locale';
-
-export const Locales = { ...DateFnsLocales };
-export type Locale = typeof Locales[keyof typeof Locales];

--- a/packages/react-datetime/src/index.ts
+++ b/packages/react-datetime/src/index.ts
@@ -1,2 +1,1 @@
 export * from './components';
-export * from './helpers';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7018,7 +7018,7 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-date-fns@^2.0.1, date-fns@^2.16.1:
+date-fns@^2.0.1:
   version "2.16.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
   integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Remove `date-fns` and amend API to be more flexible given feedback from @nicolethoen and @karelhala .

- Change default formatting/parsing to `yyyy-MM-dd`.
  - Allows relying on default browser formatting/parsing in DatePicker via native date methods like `date.toISOString().substring(0, 10)` and ``new Date(`${val}T00:00:00`)``.
  - Allows CalendarMonth to render any ReactNodes via format functions:
     ```js
     monthFormat = date => date.toLocaleDateString(locale, { month: 'long' }),
     weekdayFormat = date => date.toLocaleDateString(locale, { weekday: 'narrow' }),
     longWeekdayFormat = date => date.toLocaleDateString(locale, { weekday: 'long' }),
     buttonFormat = date => date.getDate()
     ```
      - `locale` defaults to the browser's locale giving decent i18n out of the box. We can force `en-US` to make our Calendar look consistent regardless of language.
- Expose new `weekStart` prop
- Remove `minDate`, `maxDate`, `invalidFormatErrorMessage`, `dateOutOfRangeErrorMessage`, `beforeMinDateErrorMessage`, and `afterEndDateErrorMessage` in favor of `validators?: ((date: Date) => string)[];`. This is more elegant and allows greater flexibility moving forward.

Closes #5142
Closes #5156

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
