### PR TITLE
fix(eslint): fix @patternfly/react-icons/createIcon differently

### DIFF
--- a/packages/eslint-plugin-patternfly-react/lib/rules/import-tokens-icons.js
+++ b/packages/eslint-plugin-patternfly-react/lib/rules/import-tokens-icons.js
@@ -4,6 +4,9 @@
  * @returns string of non-treeshaken import
  */
 function makeImport(specifier, moduleName) {
+  if (moduleName.endsWith('createIcon') && moduleName.startsWith('@patternfly/react-icons')) {
+    return `import { ${specifier.local.name} } from '@patternfly/react-icons/dist/js/createIcon';`;
+  }
   let res = `import ${specifier.local.name} from '`;
   res += moduleName.replace(/\/dist\/(js|esm)/, '');
   res += '/dist/js';
@@ -38,7 +41,14 @@ module.exports = {
     return {
       ImportDeclaration(node) {
         if (/@patternfly\/react-(tokens|icons)(\/dist\/(js|esm))?/.test(node.source.value)) {
-          const esmSpecifiers = node.specifiers.filter(specifier => specifier.type === 'ImportSpecifier');
+          const esmSpecifiers = node.specifiers.filter(
+            specifier =>
+              specifier.type === 'ImportSpecifier' &&
+              !(
+                node.source.value.startsWith('@patternfly/react-icons') &&
+                node.source.value.endsWith('/dist/js/createIcon')
+              )
+          );
           if (esmSpecifiers.length > 0) {
             context.report({
               node,


### PR DESCRIPTION
**What**:

Importing from `@patternfly/react-icons/createIcon` is changed to `@patternfly/react-icons/dis/js/non-existed-file` by eslint.
This patch fixes this problem by checking if there are imports from '@patternfly/react-icon/createIcon` and change their source to `@patternfly/react-icons/dis/js/createIcon`.

// cc @redallen 