### PR TITLE
feat(react-core): Update react-core copyStyles.js

### DIFF
--- a/packages/react-core/scripts/copyStyles.js
+++ b/packages/react-core/scripts/copyStyles.js
@@ -4,37 +4,15 @@ const { resolve, dirname, join } = require('path');
 const { parse: parseCSS, stringify: stringifyCSS } = require('css');
 /* eslint-enable @typescript-eslint/no-var-requires */
 
-const baseCSSFilename = 'patternfly-base.css';
 const stylesDir = resolve(__dirname, '../dist/styles');
-const pfDir = dirname(require.resolve(`@patternfly/patternfly/${baseCSSFilename}`));
-
-const css = readFileSync(join(pfDir, baseCSSFilename), 'utf8');
-const ast = parseCSS(css);
+const pfDir = dirname(require.resolve('@patternfly/patternfly/patternfly.css'));
 
 const unusedSelectorRegEx = /(\.fas?|\.sr-only)/;
 const unusedKeyFramesRegEx = /fa-/;
 const unusedFontFamilyRegEx = /Font Awesome 5 Free/;
 const ununsedFontFilesRegExt = /(fa-|\.html$|\.css$)/;
 
-// Core provides font awesome fonts and utlities. React does not use these
-ast.stylesheet.rules = ast.stylesheet.rules.filter(rule => {
-  switch (rule.type) {
-    case 'rule':
-      return !rule.selectors.some(sel => unusedSelectorRegEx.test(sel));
-    case 'keyframes':
-      return !unusedKeyFramesRegEx.test(rule.name);
-    case 'charset':
-    case 'comment':
-      return false;
-    case 'font-face':
-      // eslint-disable-next-line no-case-declarations
-      const fontFamilyDecl = rule.declarations.find(decl => decl.property === 'font-family');
-      return !unusedFontFamilyRegEx.test(fontFamilyDecl.value);
-    default:
-      return true;
-  }
-});
-
+// Copy assets
 copySync(join(pfDir, 'assets/images'), join(stylesDir, 'assets/images'));
 copySync(join(pfDir, 'assets/pficon'), join(stylesDir, 'assets/pficon'));
 copySync(join(pfDir, 'assets/fonts'), join(stylesDir, 'assets/fonts'), {
@@ -42,4 +20,35 @@ copySync(join(pfDir, 'assets/fonts'), join(stylesDir, 'assets/fonts'), {
     return !ununsedFontFilesRegExt.test(src);
   }
 });
-writeFileSync(join(stylesDir, 'base.css'), stringifyCSS(ast));
+
+// Copy css
+const baseCssFiles = {
+  'base.css': 'patternfly-base.css',
+  'base-no-reset.css': 'patternfly-base-no-reset.css'
+};
+
+for (const [targetCss, baseCss] of Object.entries(baseCssFiles)) {
+  const css = readFileSync(join(pfDir, baseCss), 'utf8');
+  const ast = parseCSS(css);
+
+  // Core provides font awesome fonts and utlities. React does not use these
+  ast.stylesheet.rules = ast.stylesheet.rules.filter(rule => {
+    switch (rule.type) {
+      case 'rule':
+        return !rule.selectors.some(sel => unusedSelectorRegEx.test(sel));
+      case 'keyframes':
+        return !unusedKeyFramesRegEx.test(rule.name);
+      case 'charset':
+      case 'comment':
+        return false;
+      case 'font-face':
+        // eslint-disable-next-line no-case-declarations
+        const fontFamilyDecl = rule.declarations.find(decl => decl.property === 'font-family');
+        return !unusedFontFamilyRegEx.test(fontFamilyDecl.value);
+      default:
+        return true;
+    }
+  });
+
+  writeFileSync(join(stylesDir, targetCss), stringifyCSS(ast));
+}


### PR DESCRIPTION
Update react-core's `copyStyles.js` generate script to generate both the pure PF4 `base.css` file and the PF3+PF4 no reset
`base-no-reset.css` file.  This will allow a project using both PF3-react and PF4-react on the same page without resorting to using sass or falling back to PF4's `patternfly-no-reset.css`.

Before this PR, if a project uses PF3 and PF4, and doesn't want to adopt sass, the css imports would be:
```jsx
import 'patternfly-react/dist/css/patternfly-react.css' // PF3-react
import '@patternfly/patternfly/patternfly-no-reset.css' // PF4
```

After this PR is merged, projects just using PF4 can still import the `base.css` normally:
```jsx
import '@patternfly/react-core/dist/style/base.css'
```

But, now projects using PF3 and PF4 can use the new react-core `base-no-reset.css` that includes the optimizations of the current `base.css`:
```jsx
import 'patternfly-react/dist/css/patternfly-react.css' // PF3-react
import '@patternfly/react-core/dist/style/base-no-reset.css' // PF4-react
```

