### PR TITLE
fix(textinput): remove Button and React.Fragment from the ref example

### DIFF
--- a/packages/react-core/src/components/TextInput/examples/TextInput.md
+++ b/packages/react-core/src/components/TextInput/examples/TextInput.md
@@ -121,24 +121,23 @@ class InvalidTextInput extends React.Component {
 
 ```js
 import React from 'react';
-import { TextInput, Button } from '@patternfly/react-core';
+import { TextInput } from '@patternfly/react-core';
 
 TextInputSelectAll = () => {
   const [value, setValue] = React.useState('select all on click');
   const ref = React.useRef(null);
   return (
-    <React.Fragment>
-      <TextInput
-        ref={ref}
-        value={value}
-        onFocus={() => ref && ref.current && ref.current.select()}
-        onChange={value => setValue(value)}
-        aria-label="select-all"
-      />
-    </React.Fragment>
+    <TextInput
+      ref={ref}
+      value={value}
+      onFocus={() => ref && ref.current && ref.current.select()}
+      onChange={value => setValue(value)}
+      aria-label="select-all"
+    />
   );
 };
 ```
+
 ### Icon variants
 ```js
 import React from 'react';


### PR DESCRIPTION
A small nitpick change to one of the examples in `TextInput`:
Remove redundant components: `React.Fragment` and `Button`
closes: #5220 
