### PR TITLE
feat(date-picker): bugfixes and add range picker demo

### DIFF
--- a/packages/react-datetime/package.json
+++ b/packages/react-datetime/package.json
@@ -35,7 +35,6 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
-    "@patternfly/patternfly": "4.65.5",
     "@patternfly/react-core": "^4.79.4",
     "@patternfly/react-icons": "^4.7.18",
     "@patternfly/react-styles": "^4.7.16",

--- a/packages/react-datetime/src/components/CalendarMonth/CalendarMonth.tsx
+++ b/packages/react-datetime/src/components/CalendarMonth/CalendarMonth.tsx
@@ -80,8 +80,10 @@ const isSameDate = (d1: Date, d2: Date) =>
 
 export const isValidDate = (date: Date) => Boolean(date && !isNaN(date as any));
 
+const today = new Date();
+
 export const CalendarMonth = ({
-  date: dateProp = new Date(),
+  date: dateProp = today,
   locale = undefined,
   monthFormat = date => date.toLocaleDateString(locale, { month: 'long' }),
   weekdayFormat = date => date.toLocaleDateString(locale, { weekday: 'narrow' }),
@@ -98,16 +100,20 @@ export const CalendarMonth = ({
   const longMonths = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11].map(monthNum => new Date(1990, monthNum)).map(monthFormat);
   const [isSelectOpen, setIsSelectOpen] = React.useState(false);
   // eslint-disable-next-line prefer-const
-  let [focusedDate, setFocusedDate] = React.useState(dateProp);
+  let [focusedDate, setFocusedDate] = React.useState(new Date(dateProp));
   if (!isValidDate(focusedDate)) {
-    focusedDate = new Date();
+    focusedDate = today;
   }
-  const [hoveredDate, setHoveredDate] = React.useState(focusedDate);
+  const [hoveredDate, setHoveredDate] = React.useState(new Date(focusedDate));
   const focusRef = React.useRef<HTMLButtonElement>();
   const [hiddenMonthId] = React.useState(getUniqueId('hidden-month-span'));
   const [focusDate, setFocusDate] = React.useState(true);
 
-  useEffect(() => setFocusedDate(dateProp), [dateProp]);
+  useEffect(() => {
+    if (!(isValidDate(dateProp) && isSameDate(focusedDate, dateProp))) {
+      setFocusedDate(dateProp);
+    }
+  }, [dateProp]);
   useEffect(() => {
     // When using header controls don't move focus
     if (focusDate) {
@@ -145,7 +151,6 @@ export const CalendarMonth = ({
     }
   };
 
-  const today = new Date();
   const focusedYear = focusedDate.getFullYear();
   const focusedMonth = focusedDate.getMonth();
   const calendar = React.useMemo(() => buildCalendar(focusedYear, focusedMonth, weekStart, validators), [

--- a/packages/react-datetime/src/components/CalendarMonth/CalendarMonth.tsx
+++ b/packages/react-datetime/src/components/CalendarMonth/CalendarMonth.tsx
@@ -34,6 +34,14 @@ export interface CalendarFormat {
   weekStart?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | Weekday;
   /** Which date to start range styles from */
   rangeStart?: Date;
+  /** Aria-label for the previous month button */
+  prevMonthAriaLabel?: string;
+  /** Aria-label for the next month button */
+  nextMonthAriaLabel?: string;
+  /** Aria-label for the year input */
+  yearInputAriaLabel?: string;
+  /** Aria-label for the date cells */
+  cellAriaLabel?: (date: Date) => string;
 }
 
 export interface CalendarProps extends CalendarFormat, Omit<React.HTMLProps<HTMLDivElement>, 'onChange'> {
@@ -95,6 +103,10 @@ export const CalendarMonth = ({
   className,
   onSelectToggle = () => {},
   rangeStart,
+  prevMonthAriaLabel = 'Previous month',
+  nextMonthAriaLabel = 'Next month',
+  yearInputAriaLabel = 'Select year',
+  cellAriaLabel,
   ...props
 }: CalendarProps) => {
   const longMonths = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11].map(monthNum => new Date(1990, monthNum)).map(monthFormat);
@@ -164,7 +176,7 @@ export const CalendarMonth = ({
     <div className={css(styles.calendarMonth, className)} {...props}>
       <div className={styles.calendarMonthHeader}>
         <div className={css(styles.calendarMonthHeaderNavControl, styles.modifiers.prevMonth)}>
-          <Button variant="plain" aria-label="Previous month" onClick={() => onMonthClick(-1)}>
+          <Button variant="plain" aria-label={prevMonthAriaLabel} onClick={() => onMonthClick(-1)}>
             <ArrowLeftIcon aria-hidden={true} />
           </Button>
         </div>
@@ -204,7 +216,7 @@ export const CalendarMonth = ({
         </div>
         <div className={styles.calendarMonthHeaderYear}>
           <TextInput
-            aria-label="Select year"
+            aria-label={yearInputAriaLabel}
             type="number"
             value={yearFormatted}
             onChange={year => {
@@ -217,7 +229,7 @@ export const CalendarMonth = ({
           />
         </div>
         <div className={css(styles.calendarMonthHeaderNavControl, styles.modifiers.nextMonth)}>
-          <Button variant="plain" aria-label="Next month" onClick={() => onMonthClick(1)}>
+          <Button variant="plain" aria-label={nextMonthAriaLabel} onClick={() => onMonthClick(1)}>
             <ArrowRightIcon aria-hidden={true} />
           </Button>
         </div>
@@ -279,7 +291,9 @@ export const CalendarMonth = ({
                       onMouseOver={() => setHoveredDate(date)}
                       tabIndex={isFocused ? 0 : -1}
                       disabled={!isValid}
-                      aria-label={`${dayFormatted} ${monthFormatted} ${yearFormatted}`}
+                      aria-label={
+                        cellAriaLabel ? cellAriaLabel(date) : `${dayFormatted} ${monthFormatted} ${yearFormatted}`
+                      }
                       {...(isFocused && { ref: focusRef })}
                     >
                       {dayFormatted}

--- a/packages/react-datetime/src/components/CalendarMonth/examples/CalendarMonth.md
+++ b/packages/react-datetime/src/components/CalendarMonth/examples/CalendarMonth.md
@@ -21,14 +21,12 @@ import { CalendarMonth } from '@patternfly/react-datetime';
 ```
 
 ### Selectable date
-```
+```js
 import React from 'react';
 import { CalendarMonth } from '@patternfly/react-datetime';
 
 SelectableCalendarMonth = () => {
-  const nextWeek = new Date();
-  nextWeek.setDate(nextWeek.getDate() + 7);
-  const [date, setDate] = React.useState(nextWeek);
+  const [date, setDate] = React.useState(new Date(2020, 10, 24));
   
   return (
     <React.Fragment>

--- a/packages/react-datetime/src/components/CalendarMonth/examples/CalendarMonth.md
+++ b/packages/react-datetime/src/components/CalendarMonth/examples/CalendarMonth.md
@@ -11,8 +11,17 @@ import { CalendarMonth } from '@patternfly/react-datetime';
 Note: CalendarMonth lives in its own package at [@patternfly/react-datetime](https://www.npmjs.com/package/@patternfly/react-datetime).
 
 ## Examples
-### Selectable date
+
+### Default
 ```js
+import React from 'react';
+import { CalendarMonth } from '@patternfly/react-datetime';
+
+<CalendarMonth />
+```
+
+### Selectable date
+```
 import React from 'react';
 import { CalendarMonth } from '@patternfly/react-datetime';
 
@@ -29,3 +38,4 @@ SelectableCalendarMonth = () => {
   );
 }
 ```
+

--- a/packages/react-datetime/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-datetime/src/components/DatePicker/DatePicker.tsx
@@ -82,8 +82,8 @@ export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
   const onTextInput = (value: string) => {
     setValue(value);
     const newValueDate = dateParse(value);
+    setValueDate(newValueDate);
     if (isValidDate(newValueDate)) {
-      setValueDate(newValueDate);
       onChange(value, new Date(newValueDate));
     } else {
       onChange(value);

--- a/packages/react-datetime/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-datetime/src/components/DatePicker/DatePicker.tsx
@@ -82,11 +82,18 @@ export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
     const newValueDate = dateParse(value);
     if (isValidDate(newValueDate)) {
       setValueDate(newValueDate);
-      setErrorText(validators.map(validator => validator(newValueDate)).join('\n') || '');
       onChange(value, newValueDate);
     } else {
-      setErrorText(invalidFormatText);
       onChange(value);
+    }
+  };
+
+  const onBlur = () => {
+    const newValueDate = dateParse(value);
+    if (isValidDate(newValueDate)) {
+      setErrorText(validators.map(validator => validator(newValueDate)).join('\n') || '');
+    } else {
+      setErrorText(invalidFormatText);
     }
   };
 
@@ -148,6 +155,7 @@ export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
             validated={errorText ? 'error' : 'default'}
             value={value}
             onChange={onTextInput}
+            onBlur={onBlur}
           />
           <button
             ref={buttonRef}

--- a/packages/react-datetime/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-datetime/src/components/DatePicker/DatePicker.tsx
@@ -82,7 +82,7 @@ export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
     const newValueDate = dateParse(value);
     if (isValidDate(newValueDate)) {
       setValueDate(newValueDate);
-      onChange(value, newValueDate);
+      onChange(value, new Date(newValueDate));
     } else {
       onChange(value);
     }
@@ -103,7 +103,7 @@ export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
     setValueDate(newValueDate);
     setErrorText(validators.map(validator => validator(newValueDate)).join('\n') || '');
     setPopoverOpen(false);
-    onChange(newValue, newValueDate);
+    onChange(newValue, new Date(newValueDate));
   };
 
   return (

--- a/packages/react-datetime/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-datetime/src/components/DatePicker/DatePicker.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import { css } from '@patternfly/react-styles';
-import '@patternfly/patternfly/patternfly-date-picker.css';
 import styles from '@patternfly/react-styles/css/components/DatePicker/date-picker';
 import buttonStyles from '@patternfly/react-styles/css/components/Button/button';
 import { TextInput } from '@patternfly/react-core/dist/js/components/TextInput/TextInput';
 import { Popover, PopoverProps } from '@patternfly/react-core/dist/js/components/Popover/Popover';
 import { InputGroup } from '@patternfly/react-core/dist/js/components/InputGroup/InputGroup';
 import OutlinedCalendarAltIcon from '@patternfly/react-icons/dist/js/icons/outlined-calendar-alt-icon';
-import { CalendarMonth, CalendarFormat } from '../CalendarMonth';
+import { CalendarMonth, CalendarFormat, isValidDate } from '../CalendarMonth';
 
 export interface DatePickerProps
   extends CalendarFormat,
@@ -42,8 +41,6 @@ export interface DatePickerProps
   validators?: ((date: Date) => string)[];
 }
 
-const isValidDate = (date: Date) => !isNaN(date.getTime());
-
 export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
   className,
   locale = undefined,
@@ -65,6 +62,7 @@ export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
   dayFormat,
   weekStart,
   validators = [],
+  rangeStart,
   ...props
 }: DatePickerProps) => {
   const [value, setValue] = React.useState(valueProp);
@@ -73,6 +71,11 @@ export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
   const [popoverOpen, setPopoverOpen] = React.useState(false);
   const [selectOpen, setSelectOpen] = React.useState(false);
   const buttonRef = React.useRef<HTMLButtonElement>();
+
+  React.useEffect(() => {
+    setValue(valueProp);
+    setValueDate(dateParse(valueProp));
+  }, [valueProp]);
 
   const onTextInput = (value: string) => {
     setValue(value);
@@ -113,6 +116,7 @@ export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
             longWeekdayFormat={longWeekdayFormat}
             dayFormat={dayFormat}
             weekStart={weekStart}
+            rangeStart={rangeStart}
           />
         }
         showClose={false}
@@ -150,6 +154,7 @@ export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
             className={css(buttonStyles.button, buttonStyles.modifiers.control)}
             aria-label={buttonAriaLabel}
             onClick={() => setPopoverOpen(!popoverOpen)}
+            disabled={isDisabled}
           >
             <OutlinedCalendarAltIcon />
           </button>

--- a/packages/react-datetime/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-datetime/src/components/DatePicker/DatePicker.tsx
@@ -77,6 +77,8 @@ export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
     setValueDate(dateParse(valueProp));
   }, [valueProp]);
 
+  const setError = (date: Date) => setErrorText(validators.map(validator => validator(date)).join('\n') || '');
+
   const onTextInput = (value: string) => {
     setValue(value);
     const newValueDate = dateParse(value);
@@ -91,7 +93,7 @@ export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
   const onBlur = () => {
     const newValueDate = dateParse(value);
     if (isValidDate(newValueDate)) {
-      setErrorText(validators.map(validator => validator(newValueDate)).join('\n') || '');
+      setError(newValueDate);
     } else {
       setErrorText(invalidFormatText);
     }
@@ -101,9 +103,19 @@ export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
     const newValue = dateFormat(newValueDate);
     setValue(newValue);
     setValueDate(newValueDate);
-    setErrorText(validators.map(validator => validator(newValueDate)).join('\n') || '');
+    setError(newValueDate);
     setPopoverOpen(false);
     onChange(newValue, new Date(newValueDate));
+  };
+
+  const onKeyPress = (ev: React.KeyboardEvent<HTMLInputElement>) => {
+    if (ev.key === 'Enter' && value) {
+      if (isValidDate(valueDate)) {
+        setError(valueDate);
+      } else {
+        setErrorText(invalidFormatText);
+      }
+    }
   };
 
   return (
@@ -156,6 +168,7 @@ export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
             value={value}
             onChange={onTextInput}
             onBlur={onBlur}
+            onKeyPress={onKeyPress}
           />
           <button
             ref={buttonRef}

--- a/packages/react-datetime/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-datetime/src/components/DatePicker/DatePicker.tsx
@@ -70,6 +70,7 @@ export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
   const [errorText, setErrorText] = React.useState('');
   const [popoverOpen, setPopoverOpen] = React.useState(false);
   const [selectOpen, setSelectOpen] = React.useState(false);
+  const [pristine, setPristine] = React.useState(true);
   const buttonRef = React.useRef<HTMLButtonElement>();
 
   React.useEffect(() => {
@@ -80,6 +81,7 @@ export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
   const setError = (date: Date) => setErrorText(validators.map(validator => validator(date)).join('\n') || '');
 
   const onTextInput = (value: string) => {
+    setPristine(false);
     setValue(value);
     const newValueDate = dateParse(value);
     setValueDate(newValueDate);
@@ -91,6 +93,9 @@ export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
   };
 
   const onBlur = () => {
+    if (pristine) {
+      return;
+    }
     const newValueDate = dateParse(value);
     if (isValidDate(newValueDate)) {
       setError(newValueDate);

--- a/packages/react-datetime/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-datetime/src/components/DatePicker/DatePicker.tsx
@@ -63,6 +63,7 @@ export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
   weekStart,
   validators = [],
   rangeStart,
+  style = {},
   ...props
 }: DatePickerProps) => {
   const [value, setValue] = React.useState(valueProp);
@@ -71,6 +72,8 @@ export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
   const [popoverOpen, setPopoverOpen] = React.useState(false);
   const [selectOpen, setSelectOpen] = React.useState(false);
   const [pristine, setPristine] = React.useState(true);
+  const widthChars = React.useMemo(() => Math.max(dateFormat(new Date()).length, placeholder.length), [dateFormat]);
+  (style as any)['--pf-c-date-picker__input--c-form-control--width-chars'] = widthChars;
   const buttonRef = React.useRef<HTMLButtonElement>();
 
   React.useEffect(() => {
@@ -124,7 +127,7 @@ export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
   };
 
   return (
-    <div className={css(styles.datePicker, className)} {...props}>
+    <div className={css(styles.datePicker, className)} style={style} {...props}>
       <Popover
         position="bottom"
         bodyContent={
@@ -164,27 +167,29 @@ export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
         appendTo={appendTo}
         {...popoverProps}
       >
-        <InputGroup>
-          <TextInput
-            isDisabled={isDisabled}
-            aria-label={ariaLabel}
-            placeholder={placeholder}
-            validated={errorText ? 'error' : 'default'}
-            value={value}
-            onChange={onTextInput}
-            onBlur={onBlur}
-            onKeyPress={onKeyPress}
-          />
-          <button
-            ref={buttonRef}
-            className={css(buttonStyles.button, buttonStyles.modifiers.control)}
-            aria-label={buttonAriaLabel}
-            onClick={() => setPopoverOpen(!popoverOpen)}
-            disabled={isDisabled}
-          >
-            <OutlinedCalendarAltIcon />
-          </button>
-        </InputGroup>
+        <div className={styles.datePickerInput}>
+          <InputGroup>
+            <TextInput
+              isDisabled={isDisabled}
+              aria-label={ariaLabel}
+              placeholder={placeholder}
+              validated={errorText ? 'error' : 'default'}
+              value={value}
+              onChange={onTextInput}
+              onBlur={onBlur}
+              onKeyPress={onKeyPress}
+            />
+            <button
+              ref={buttonRef}
+              className={css(buttonStyles.button, buttonStyles.modifiers.control)}
+              aria-label={buttonAriaLabel}
+              onClick={() => setPopoverOpen(!popoverOpen)}
+              disabled={isDisabled}
+            >
+              <OutlinedCalendarAltIcon />
+            </button>
+          </InputGroup>
+        </div>
       </Popover>
       {helperText && <div className={styles.datePickerHelperText}>{helperText}</div>}
       {errorText && <div className={css(styles.datePickerHelperText, styles.modifiers.error)}>{errorText}</div>}

--- a/packages/react-datetime/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-datetime/src/components/DatePicker/DatePicker.tsx
@@ -52,7 +52,7 @@ export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
   'aria-label': ariaLabel = 'Date picker',
   buttonAriaLabel = 'Toggle date picker',
   onChange = (): any => undefined,
-  invalidFormatText = 'Could not parse date',
+  invalidFormatText = 'Invalid date',
   helperText,
   appendTo,
   popoverProps,

--- a/packages/react-datetime/src/components/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react-datetime/src/components/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`disabled date picker 1`] = `
   onBlur={[Function]}
   onChange={[Function]}
   onFocus={[Function]}
+  onKeyPress={[Function]}
   placeholder="yyyy-MM-dd"
   readOnly={false}
   required={false}

--- a/packages/react-datetime/src/components/DatePicker/examples/DatePicker.md
+++ b/packages/react-datetime/src/components/DatePicker/examples/DatePicker.md
@@ -109,3 +109,27 @@ FrenchMinMaxDate = () => {
   );
 }
 ```
+
+### Controlled
+
+```js
+import React from 'react';
+import { Button } from '@patternfly/react-core';
+import { DatePicker } from '@patternfly/react-datetime';
+
+ControlledDate = () => {
+  const initialValue = '2020-03-17';
+  const [value, setValue] = React.useState(initialValue);
+  return (
+    <React.Fragment>
+      <Button onClick={() => setValue(initialValue)}>
+        Reset date
+      </Button>
+      <DatePicker
+        value={value}
+        onChange={value => setValue(value)}
+      />
+    </React.Fragment>
+  );
+}
+```

--- a/packages/react-datetime/src/demos/DateRangePicker.md
+++ b/packages/react-datetime/src/demos/DateRangePicker.md
@@ -3,6 +3,7 @@ id: Date picker
 section: components
 ---
 
+import { Split, SplitItem } from '@patternfly/react-core';
 import { DatePicker, isValidDate } from '@patternfly/react-datetime';
 
 ## Demos
@@ -12,16 +13,12 @@ import { DatePicker, isValidDate } from '@patternfly/react-datetime';
 Intended to be used as a filter. After selecting a start date the next day is automatically selected. Future dates are not allowed.
 
 ```js
+import { Split, SplitItem } from '@patternfly/react-core';
 import { DatePicker, isValidDate } from '@patternfly/react-datetime';
 
 DateRangePicker = () => {
   const [from, setFrom] = React.useState();
   const [to, setTo] = React.useState();
-
-  const tmpStyleHack = {
-    width: '180px',
-    display: 'inline-block'
-  };
 
   const today = new Date();
   const fromValidator = date => date <= today ? '' : 'You cannot pick a future date';
@@ -41,24 +38,28 @@ DateRangePicker = () => {
   };
 
   return (
-    <div>
-      <DatePicker
-        style={tmpStyleHack}
-        onChange={onFromChange}
-        validators={[fromValidator]}
-        aria-label="Start date"
-      />
-      {' to '}
-      <DatePicker
-        style={tmpStyleHack}
-        value={to}
-        onChange={date => setTo(date)}
-        isDisabled={!isValidDate(from)}
-        rangeStart={from}
-        validators={[toValidator]}
-        aria-label="End date"
-      />
-    </div>
+    <Split>
+      <SplitItem>
+        <DatePicker
+          onChange={onFromChange}
+          validators={[fromValidator]}
+          aria-label="Start date"
+        />
+      </SplitItem>
+      <SplitItem style={{ paddingLeft: '12px', paddingRight: '12px', marginTop: 'auto', marginBottom: 'auto' }}>
+        to
+      </SplitItem>
+      <SplitItem>
+        <DatePicker
+          value={to}
+          onChange={date => setTo(date)}
+          isDisabled={!isValidDate(from)}
+          rangeStart={from}
+          validators={[toValidator]}
+          aria-label="End date"
+        />
+      </SplitItem>
+    </Split>
   );
 }
 ```

--- a/packages/react-datetime/src/demos/DateRangePicker.md
+++ b/packages/react-datetime/src/demos/DateRangePicker.md
@@ -46,6 +46,7 @@ DateRangePicker = () => {
         style={tmpStyleHack}
         onChange={onFromChange}
         validators={[fromValidator]}
+        aria-label="Start date"
       />
       {' to '}
       <DatePicker
@@ -55,6 +56,7 @@ DateRangePicker = () => {
         isDisabled={!isValidDate(from)}
         rangeStart={from}
         validators={[toValidator]}
+        aria-label="End date"
       />
     </div>
   );

--- a/packages/react-datetime/src/demos/DateRangePicker.md
+++ b/packages/react-datetime/src/demos/DateRangePicker.md
@@ -1,0 +1,60 @@
+---
+id: Date picker
+section: components
+---
+
+import { DatePicker, isValidDate } from '@patternfly/react-datetime';
+
+## Demos
+
+### Date range picker
+
+This allows selecting a range as a filter. After selecting a start date the next day is automatically selected. Future dates are not allowed.
+
+```js
+import { DatePicker, isValidDate } from '@patternfly/react-datetime';
+
+DateRangePicker = () => {
+  const [from, setFrom] = React.useState();
+  const [to, setTo] = React.useState();
+
+  const tmpStyleHack = {
+    width: '180px',
+    display: 'inline-block'
+  };
+
+  const today = new Date();
+  const fromValidator = date => date <= today ? '' : 'You cannot pick a future date';
+  const toValidator = date => isValidDate(from) && date >= from && date <= today ? '' : 'To date must be less than from date';
+  const onFromChange = (_str, date) => {
+    if (isValidDate(date)) {
+      setFrom(new Date(date));
+      date.setDate(date.getDate() + 1);
+      if (date > today) {
+        date = today;
+      }
+      setTo(date.toISOString().substring(0, 10));
+    }
+  };
+
+  return (
+    <div>
+      <DatePicker
+        style={tmpStyleHack}
+        onChange={onFromChange}
+        validators={[fromValidator]}
+      />
+      {' to '}
+      <DatePicker
+        style={tmpStyleHack}
+        value={to}
+        onChange={date => setTo(date)}
+        isDisabled={!isValidDate(from)}
+        rangeStart={from}
+        validators={[toValidator]}
+      />
+    </div>
+  );
+}
+```
+

--- a/packages/react-datetime/src/demos/DateRangePicker.md
+++ b/packages/react-datetime/src/demos/DateRangePicker.md
@@ -46,7 +46,7 @@ DateRangePicker = () => {
           aria-label="Start date"
         />
       </SplitItem>
-      <SplitItem style={{ paddingLeft: '12px', paddingRight: '12px', marginTop: 'auto', marginBottom: 'auto' }}>
+      <SplitItem style={{ padding: '6px 12px 0 12px' }}>
         to
       </SplitItem>
       <SplitItem>

--- a/packages/react-datetime/src/demos/DateRangePicker.md
+++ b/packages/react-datetime/src/demos/DateRangePicker.md
@@ -10,7 +10,7 @@ import { DatePicker, isValidDate } from '@patternfly/react-datetime';
 
 ### Date range picker
 
-Intended to be used as a filter. After selecting a start date the next day is automatically selected. Future dates are not allowed.
+Intended to be used as a filter. After selecting a start date the next day is automatically selected.
 
 ```js
 import { Split, SplitItem } from '@patternfly/react-core';
@@ -20,16 +20,11 @@ DateRangePicker = () => {
   const [from, setFrom] = React.useState();
   const [to, setTo] = React.useState();
 
-  const today = new Date();
-  const fromValidator = date => date <= today ? '' : 'You cannot pick a future date';
-  const toValidator = date => isValidDate(from) && date >= from && date <= today ? '' : 'To date must be less than from date';
+  const toValidator = date => isValidDate(from) && date >= from ? '' : 'To date must be less than from date';
   const onFromChange = (_str, date) => {
     setFrom(new Date(date));
     if (isValidDate(date)) {
       date.setDate(date.getDate() + 1);
-      if (date > today) {
-        date = today;
-      }
       setTo(date.toISOString().substring(0, 10));
     }
     else {
@@ -42,7 +37,6 @@ DateRangePicker = () => {
       <SplitItem>
         <DatePicker
           onChange={onFromChange}
-          validators={[fromValidator]}
           aria-label="Start date"
         />
       </SplitItem>

--- a/packages/react-datetime/src/demos/DateRangePicker.md
+++ b/packages/react-datetime/src/demos/DateRangePicker.md
@@ -9,7 +9,7 @@ import { DatePicker, isValidDate } from '@patternfly/react-datetime';
 
 ### Date range picker
 
-This allows selecting a range as a filter. After selecting a start date the next day is automatically selected. Future dates are not allowed.
+Intended to be used as a filter. After selecting a start date the next day is automatically selected. Future dates are not allowed.
 
 ```js
 import { DatePicker, isValidDate } from '@patternfly/react-datetime';
@@ -27,13 +27,16 @@ DateRangePicker = () => {
   const fromValidator = date => date <= today ? '' : 'You cannot pick a future date';
   const toValidator = date => isValidDate(from) && date >= from && date <= today ? '' : 'To date must be less than from date';
   const onFromChange = (_str, date) => {
+    setFrom(new Date(date));
     if (isValidDate(date)) {
-      setFrom(new Date(date));
       date.setDate(date.getDate() + 1);
       if (date > today) {
         date = today;
       }
       setTo(date.toISOString().substring(0, 10));
+    }
+    else {
+      setTo('');
     }
   };
 

--- a/packages/react-docs/patternfly-docs.source.js
+++ b/packages/react-docs/patternfly-docs.source.js
@@ -38,8 +38,9 @@ module.exports = (sourceMD, sourceProps) => {
   // Charts MD (no demos yet)
   sourceMD(path.join(reactChartsPath, '/**/examples/*.md'), 'react');
 
-  // Date-time MD (no demos yet)
+  // Date-time MD
   sourceMD(path.join(reactDateTimePath, '/**/examples/*.md'), 'react');
+  sourceMD(path.join(reactDateTimePath, '/**/demos/*.md'), 'react-demos');
 
   // Catalog view MD
   sourceMD(path.join(reactCatalogViewPath, '/**/examples/*.md'), 'react');


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4732

Bugfixes:
- Remove `'@patternfly/patternfly/patternfly-date-picker.css'` left over from `flatpickr` implementation and remove unused `@patternfly/patternfly` dependency
- Allow `value={null}` or other invalid dates in DatePicker and CalendarMonth
- Memoize weeks, days, and validity of days to only recompute when the year, month, or weekStart changes. Scrolling between months and years is noticeably faster.
- Only validate DatePicker `onBlur` per @mcarrano's suggestion
  - Don't validate if field was untouched per @nicolethoen's suggestion
- Clone dates before passing them to consumers (before consumers could mutate component state since dates are mutable)
- Add `ariaLabel` props to `CalendarMonth` per @nicolethoen 

Demo https://patternfly-react-pr-5184.surge.sh/components/date-picker/react-demos
- Expose `isValidDate` helper
- Add hovered date support to CalendarMonth for the range picker


<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
