### PR TITLE
feat(Drawer): add splitter feature

### DIFF
--- a/packages/react-core/src/components/Drawer/Drawer.tsx
+++ b/packages/react-core/src/components/Drawer/Drawer.tsx
@@ -23,12 +23,14 @@ export interface DrawerContextProps {
   isExpanded: boolean;
   isStatic: boolean;
   onExpand?: () => void;
+  position?: string;
 }
 
 export const DrawerContext = React.createContext<Partial<DrawerContextProps>>({
   isExpanded: false,
   isStatic: false,
-  onExpand: () => {}
+  onExpand: () => {},
+  position: 'right'
 });
 
 export const Drawer: React.SFC<DrawerProps> = ({
@@ -41,7 +43,7 @@ export const Drawer: React.SFC<DrawerProps> = ({
   onExpand = () => {},
   ...props
 }: DrawerProps) => (
-  <DrawerContext.Provider value={{ isExpanded, isStatic, onExpand }}>
+  <DrawerContext.Provider value={{ isExpanded, isStatic, onExpand, position }}>
     <div
       className={css(
         styles.drawer,

--- a/packages/react-core/src/components/Drawer/DrawerPanelContent.tsx
+++ b/packages/react-core/src/components/Drawer/DrawerPanelContent.tsx
@@ -11,6 +11,18 @@ export interface DrawerPanelContentProps extends React.HTMLProps<HTMLDivElement>
   children?: React.ReactNode;
   /** Flag indicating that the drawer panel should not have a border. */
   hasNoBorder?: boolean;
+  /** Flag indicating that the drawer panel should be resizable. */
+  isResizable?: boolean;
+  /** The minimum size of a resizable drawer, in pixels. Defaults to the starting width of the drawer. */
+  minSize?: number;
+  /** The maximum size of a resizable drawer, in pixels. Defaults to the max width of the parent container. */
+  maxSize?: number;
+  /** The increment amount for keyboard drawer resizing, in pixels. */
+  increment?: number;
+  /** Aria label for the resizable drawer splitter. */
+  resizeAriaLabel?: string;
+  /** Aria described by label for the resizable drawer splitter. */
+  resizeAriaDescribedBy?: string;
   /** Width for drawer panel at various breakpoints */
   widths?: {
     default?: 'width_25' | 'width_33' | 'width_50' | 'width_66' | 'width_75' | 'width_100';
@@ -19,38 +31,171 @@ export interface DrawerPanelContentProps extends React.HTMLProps<HTMLDivElement>
     '2xl'?: 'width_25' | 'width_33' | 'width_50' | 'width_66' | 'width_75' | 'width_100';
   };
 }
+let isResizing: boolean = null;
+let newSize: number = 0;
 
-export const DrawerPanelContent: React.SFC<DrawerPanelContentProps> = ({
+export const DrawerPanelContent: React.FunctionComponent<DrawerPanelContentProps> = ({
   className = '',
   children,
   hasNoBorder = false,
+  isResizable = false,
+  minSize,
+  maxSize,
+  increment = 5,
+  resizeAriaLabel = 'Resize',
+  resizeAriaDescribedBy = 'Press space to begin resizing, and use the arrow keys to grow or shrink the panel. Press enter or escape to finish resizing.',
   widths,
   ...props
-}: DrawerPanelContentProps) => (
-  <DrawerContext.Consumer>
-    {({ isExpanded, isStatic, onExpand }) => {
-      const hidden = isStatic ? false : !isExpanded;
+}: DrawerPanelContentProps) => {
+  const panel = React.useRef<HTMLDivElement>();
+  const { position, isExpanded, isStatic, onExpand } = React.useContext(DrawerContext);
 
-      return (
-        <div
-          className={css(
-            styles.drawerPanel,
-            hasNoBorder && styles.modifiers.noBorder,
-            formatBreakpointMods(widths, styles),
-            className
+  const handleMousedown = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    document.addEventListener('mousemove', callbackMouseMove);
+    document.addEventListener('mouseup', callbackMouseUp);
+    isResizing = true;
+  };
+
+  const handleMousemove = (e: MouseEvent) => {
+    if (!isResizing) {
+      return;
+    }
+    const panelRect = panel.current.getBoundingClientRect();
+    const parentRect = panel.current.parentElement.getBoundingClientRect();
+    const min = minSize ? minSize : 0;
+    const max = maxSize ? maxSize : position === 'bottom' ? parentRect.height : parentRect.width;
+    const mousePos = position === 'bottom' ? e.clientY : e.clientX;
+
+    let newSize = 0;
+    if (position === 'right') {
+      newSize = panelRect.right - mousePos;
+    } else if (position === 'left') {
+      newSize = mousePos - panelRect.left;
+    } else {
+      newSize = panelRect.bottom - mousePos;
+    }
+
+    if (newSize >= min && newSize <= max) {
+      if (position === 'bottom') {
+        panel.current.style.overflowAnchor = 'none';
+      }
+      if (maxSize) {
+        panel.current.style.setProperty('--pf-c-drawer__panel--FlexBasis', newSize + 'px');
+      } else {
+        panel.current.style.setProperty('--pf-c-drawer__panel--FlexBasis', (newSize / max) * 100 + '%');
+      }
+    }
+  };
+
+  const handleMouseup = () => {
+    if (!isResizing) {
+      return;
+    }
+    isResizing = false;
+    document.removeEventListener('mousemove', callbackMouseMove);
+    document.removeEventListener('mouseup', callbackMouseUp);
+  };
+
+  const callbackMouseMove = React.useCallback(handleMousemove, []);
+  const callbackMouseUp = React.useCallback(handleMouseup, []);
+
+  const handleKeys = (e: React.KeyboardEvent) => {
+    const key = e.key;
+    if (
+      key !== ' ' &&
+      key !== 'Escape' &&
+      key !== 'Enter' &&
+      key !== 'ArrowUp' &&
+      key !== 'ArrowDown' &&
+      key !== 'ArrowLeft' &&
+      key !== 'ArrowRight'
+    ) {
+      if (isResizing) {
+        e.preventDefault();
+      }
+      return;
+    }
+    e.preventDefault();
+
+    if (key === ' ' || key === 'Escape' || key === 'Enter') {
+      if (key === ' ') {
+        isResizing = true;
+      } else {
+        isResizing = false;
+      }
+      const panelRect = panel.current.getBoundingClientRect();
+      newSize = position === 'bottom' ? panelRect.height : panelRect.width;
+    }
+
+    if (isResizing) {
+      const parentRect = panel.current.parentElement.getBoundingClientRect();
+      const min = minSize ? minSize : 0;
+      const max = maxSize ? maxSize : position === 'bottom' ? parentRect.height : parentRect.width;
+
+      let delta = 0;
+      if (key === 'ArrowRight') {
+        delta = position === 'left' ? increment : -increment;
+      } else if (key === 'ArrowLeft') {
+        delta = position === 'left' ? -increment : increment;
+      } else if (key === 'ArrowUp') {
+        delta = increment;
+      } else if (key === 'ArrowDown') {
+        delta = -increment;
+      }
+      if (newSize + delta >= min && newSize + delta <= max) {
+        newSize = newSize + delta;
+        if (position === 'bottom') {
+          panel.current.style.overflowAnchor = 'none';
+        }
+        if (maxSize) {
+          panel.current.style.setProperty('--pf-c-drawer__panel--FlexBasis', newSize + 'px');
+        } else {
+          panel.current.style.setProperty('--pf-c-drawer__panel--FlexBasis', (newSize / max) * 100 + '%');
+        }
+      }
+    }
+  };
+  const hidden = isStatic ? false : !isExpanded;
+  return (
+    <div
+      className={css(
+        styles.drawerPanel,
+        isResizable && styles.modifiers.resizable,
+        hasNoBorder && styles.modifiers.noBorder,
+        formatBreakpointMods(widths, styles),
+        className
+      )}
+      ref={panel}
+      onTransitionEnd={ev => {
+        if (!hidden && ev.nativeEvent.propertyName === 'transform') {
+          onExpand();
+        }
+      }}
+      hidden={hidden}
+      {...props}
+    >
+      {!hidden && (
+        <React.Fragment>
+          {isResizable && (
+            <div
+              className={css(styles.drawerSplitter, position !== 'bottom' && styles.modifiers.vertical)}
+              role="separator"
+              tabIndex={0}
+              aria-orientation={position === 'bottom' ? 'horizontal' : 'vertical'}
+              aria-label={resizeAriaLabel}
+              aria-describedby={resizeAriaDescribedBy}
+              onMouseDown={handleMousedown}
+              onKeyDown={handleKeys}
+            >
+              <div className={css(styles.drawerSplitterHandle)} aria-hidden></div>
+            </div>
           )}
-          onTransitionEnd={ev => {
-            if (!hidden && ev.nativeEvent.propertyName === 'transform') {
-              onExpand();
-            }
-          }}
-          hidden={hidden}
-          {...props}
-        >
-          {!hidden && children}
-        </div>
-      );
-    }}
-  </DrawerContext.Consumer>
-);
+          {children}
+        </React.Fragment>
+      )}
+    </div>
+  );
+};
 DrawerPanelContent.displayName = 'DrawerPanelContent';

--- a/packages/react-core/src/components/Drawer/__tests__/Drawer.test.tsx
+++ b/packages/react-core/src/components/Drawer/__tests__/Drawer.test.tsx
@@ -67,3 +67,28 @@ test(`Drawer expands from bottom`, () => {
   );
   expect(view).toMatchSnapshot();
 });
+
+test(`Drawer has resizable css`, () => {
+  const panelContent = (
+    <DrawerPanelContent isResizable>
+      <DrawerHead>
+        <span>drawer-panel</span>
+        <DrawerActions>
+          <DrawerCloseButton />
+        </DrawerActions>
+      </DrawerHead>
+      <DrawerPanelBody>drawer-panel</DrawerPanelBody>
+    </DrawerPanelContent>
+  );
+  const drawerContent =
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.';
+
+  const view = mount(
+    <Drawer isExpanded={true} position="left">
+      <DrawerContent panelContent={panelContent}>
+        <DrawerContentBody>{drawerContent}</DrawerContentBody>
+      </DrawerContent>
+    </Drawer>
+  );
+  expect(view).toMatchSnapshot();
+});

--- a/packages/react-core/src/components/Drawer/__tests__/Generated/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/react-core/src/components/Drawer/__tests__/Generated/__snapshots__/Drawer.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`Drawer should match snapshot (auto-generated) 1`] = `
       "isExpanded": false,
       "isStatic": false,
       "onExpand": [Function],
+      "position": "right",
     }
   }
 >

--- a/packages/react-core/src/components/Drawer/__tests__/Generated/__snapshots__/DrawerPanelContent.test.tsx.snap
+++ b/packages/react-core/src/components/Drawer/__tests__/Generated/__snapshots__/DrawerPanelContent.test.tsx.snap
@@ -1,7 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DrawerPanelContent should match snapshot (auto-generated) 1`] = `
-<ContextConsumer>
-  <Component />
-</ContextConsumer>
+<div
+  className="pf-c-drawer__panel ''"
+  hasNoPadding={false}
+  hidden={true}
+  onTransitionEnd={[Function]}
+/>
 `;

--- a/packages/react-core/src/components/Drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/react-core/src/components/Drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -134,6 +134,159 @@ exports[`Drawer expands from bottom 1`] = `
 </Drawer>
 `;
 
+exports[`Drawer has resizable css 1`] = `
+<Drawer
+  isExpanded={true}
+  position="left"
+>
+  <div
+    className="pf-c-drawer pf-m-expanded pf-m-panel-left"
+  >
+    <DrawerContent
+      panelContent={
+        <DrawerPanelContent
+          isResizable={true}
+        >
+          <DrawerHead>
+            <span>
+              drawer-panel
+            </span>
+            <DrawerActions>
+              <DrawerCloseButton />
+            </DrawerActions>
+          </DrawerHead>
+          <DrawerPanelBody>
+            drawer-panel
+          </DrawerPanelBody>
+        </DrawerPanelContent>
+      }
+    >
+      <DrawerMain>
+        <div
+          className="pf-c-drawer__main"
+        >
+          <div
+            className="pf-c-drawer__content"
+          >
+            <DrawerContentBody>
+              <div
+                className="pf-c-drawer__body"
+              >
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.
+              </div>
+            </DrawerContentBody>
+          </div>
+          <DrawerPanelContent
+            isResizable={true}
+          >
+            <div
+              className="pf-c-drawer__panel pf-m-resizable"
+              hidden={false}
+              onTransitionEnd={[Function]}
+            >
+              <div
+                aria-describedby="Press space to begin resizing, and use the arrow keys to grow or shrink the panel. Press enter or escape to finish resizing."
+                aria-label="Resize"
+                aria-orientation="vertical"
+                className="pf-c-drawer__splitter pf-m-vertical"
+                onKeyDown={[Function]}
+                onMouseDown={[Function]}
+                role="separator"
+                tabIndex={0}
+              >
+                <div
+                  aria-hidden={true}
+                  className="pf-c-drawer__splitter-handle"
+                />
+              </div>
+              <DrawerHead>
+                <DrawerPanelBody
+                  hasNoPadding={false}
+                >
+                  <div
+                    className="pf-c-drawer__body"
+                  >
+                    <div
+                      className="pf-c-drawer__head"
+                    >
+                      <span>
+                        drawer-panel
+                      </span>
+                      <DrawerActions>
+                        <div
+                          className="pf-c-drawer__actions"
+                        >
+                          <DrawerCloseButton>
+                            <div
+                              className="pf-c-drawer__close"
+                            >
+                              <Button
+                                aria-label="Close drawer panel"
+                                onClick={[Function]}
+                                variant="plain"
+                              >
+                                <button
+                                  aria-disabled={false}
+                                  aria-label="Close drawer panel"
+                                  className="pf-c-button pf-m-plain"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-5"
+                                  data-ouia-component-type="PF4/Button"
+                                  data-ouia-safe={true}
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  role={null}
+                                  type="button"
+                                >
+                                  <TimesIcon
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 352 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                      />
+                                    </svg>
+                                  </TimesIcon>
+                                </button>
+                              </Button>
+                            </div>
+                          </DrawerCloseButton>
+                        </div>
+                      </DrawerActions>
+                    </div>
+                  </div>
+                </DrawerPanelBody>
+              </DrawerHead>
+              <DrawerPanelBody>
+                <div
+                  className="pf-c-drawer__body"
+                >
+                  drawer-panel
+                </div>
+              </DrawerPanelBody>
+            </div>
+          </DrawerPanelContent>
+        </div>
+      </DrawerMain>
+    </DrawerContent>
+  </div>
+</Drawer>
+`;
+
 exports[`Drawer isExpanded = false and isInline = false and isStatic = false 1`] = `
 <Drawer
   isExpanded={false}

--- a/packages/react-core/src/components/Drawer/examples/Drawer.md
+++ b/packages/react-core/src/components/Drawer/examples/Drawer.md
@@ -11,7 +11,7 @@ propComponents:
     DrawerSection,
     DrawerHead,
     DrawerActions,
-    DrawerCloseButton
+    DrawerCloseButton,
   ]
 section: components
 beta: true
@@ -20,6 +20,7 @@ beta: true
 ## Examples
 
 ### Basic
+
 ```js
 import React from 'react';
 import {
@@ -44,7 +45,7 @@ class SimpleDrawer extends React.Component {
     this.drawerRef = React.createRef();
 
     this.onExpand = () => {
-      this.drawerRef.current && this.drawerRef.current.focus()
+      this.drawerRef.current && this.drawerRef.current.focus();
     };
 
     this.onClick = () => {
@@ -66,7 +67,9 @@ class SimpleDrawer extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
-          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer-panel
+          </span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -94,6 +97,7 @@ class SimpleDrawer extends React.Component {
 ```
 
 ### Panel on right
+
 ```js
 import React from 'react';
 import {
@@ -117,7 +121,7 @@ class SimpleDrawerPanelRight extends React.Component {
     this.drawerRef = React.createRef();
 
     this.onExpand = () => {
-      this.drawerRef.current && this.drawerRef.current.focus()
+      this.drawerRef.current && this.drawerRef.current.focus();
     };
 
     this.onClick = () => {
@@ -139,7 +143,9 @@ class SimpleDrawerPanelRight extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
-          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer-panel
+          </span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -167,6 +173,7 @@ class SimpleDrawerPanelRight extends React.Component {
 ```
 
 ### Panel on left
+
 ```js
 import React from 'react';
 import {
@@ -190,7 +197,7 @@ class SimpleDrawerPanelLeft extends React.Component {
     this.drawerRef = React.createRef();
 
     this.onExpand = () => {
-      this.drawerRef.current && this.drawerRef.current.focus()
+      this.drawerRef.current && this.drawerRef.current.focus();
     };
 
     this.onClick = () => {
@@ -212,7 +219,9 @@ class SimpleDrawerPanelLeft extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
-          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer-panel
+          </span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -240,6 +249,7 @@ class SimpleDrawerPanelLeft extends React.Component {
 ```
 
 ### Panel on bottom
+
 ```js
 import React from 'react';
 import {
@@ -263,7 +273,7 @@ class SimpleDrawerPanelBottom extends React.Component {
     this.drawerRef = React.createRef();
 
     this.onExpand = () => {
-      this.drawerRef.current && this.drawerRef.current.focus()
+      this.drawerRef.current && this.drawerRef.current.focus();
     };
 
     this.onClick = () => {
@@ -285,7 +295,9 @@ class SimpleDrawerPanelBottom extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
-          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer-panel
+          </span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -315,6 +327,7 @@ class SimpleDrawerPanelBottom extends React.Component {
 ```
 
 ### Basic inline
+
 ```js
 import React from 'react';
 import {
@@ -338,7 +351,7 @@ class SimpleDrawerInlineContent extends React.Component {
     this.drawerRef = React.createRef();
 
     this.onExpand = () => {
-      this.drawerRef.current && this.drawerRef.current.focus()
+      this.drawerRef.current && this.drawerRef.current.focus();
     };
 
     this.onClick = () => {
@@ -360,7 +373,9 @@ class SimpleDrawerInlineContent extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
-          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer-panel
+          </span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -388,6 +403,7 @@ class SimpleDrawerInlineContent extends React.Component {
 ```
 
 ### Inline panel on right
+
 ```js
 import React from 'react';
 import {
@@ -411,7 +427,7 @@ class DrawerInlineContentPanelRight extends React.Component {
     this.drawerRef = React.createRef();
 
     this.onExpand = () => {
-      this.drawerRef.current && this.drawerRef.current.focus()
+      this.drawerRef.current && this.drawerRef.current.focus();
     };
 
     this.onClick = () => {
@@ -433,7 +449,9 @@ class DrawerInlineContentPanelRight extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
-          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer-panel
+          </span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -461,6 +479,7 @@ class DrawerInlineContentPanelRight extends React.Component {
 ```
 
 ### Inline panel on left
+
 ```js
 import React from 'react';
 import {
@@ -484,7 +503,7 @@ class DrawerInlineContentPanelLeft extends React.Component {
     this.drawerRef = React.createRef();
 
     this.onExpand = () => {
-      this.drawerRef.current && this.drawerRef.current.focus()
+      this.drawerRef.current && this.drawerRef.current.focus();
     };
 
     this.onClick = () => {
@@ -506,7 +525,9 @@ class DrawerInlineContentPanelLeft extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
-          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer-panel
+          </span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -534,6 +555,7 @@ class DrawerInlineContentPanelLeft extends React.Component {
 ```
 
 ### Stacked content body elements
+
 ```js
 import React from 'react';
 import {
@@ -557,7 +579,7 @@ class DrawerStackedContentBodyElements extends React.Component {
     this.drawerRef = React.createRef();
 
     this.onExpand = () => {
-      this.drawerRef.current && this.drawerRef.current.focus()
+      this.drawerRef.current && this.drawerRef.current.focus();
     };
 
     this.onClick = () => {
@@ -579,7 +601,9 @@ class DrawerStackedContentBodyElements extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
-          <h3 className= "pf-c-title pf-m-2xl" tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer title </h3>
+          <h3 className="pf-c-title pf-m-2xl" tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer title{' '}
+          </h3>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -609,6 +633,7 @@ class DrawerStackedContentBodyElements extends React.Component {
 ```
 
 ### Stacked content body elements
+
 ```js
 import React from 'react';
 import {
@@ -632,7 +657,7 @@ class DrawerStackedContentBodyElements extends React.Component {
     this.drawerRef = React.createRef();
 
     this.onExpand = () => {
-      this.drawerRef.current && this.drawerRef.current.focus()
+      this.drawerRef.current && this.drawerRef.current.focus();
     };
 
     this.onClick = () => {
@@ -654,7 +679,9 @@ class DrawerStackedContentBodyElements extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
-          <h3 className= "pf-c-title pf-m-2xl" tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer title </h3>
+          <h3 className="pf-c-title pf-m-2xl" tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer title{' '}
+          </h3>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -667,7 +694,7 @@ class DrawerStackedContentBodyElements extends React.Component {
 
     return (
       <React.Fragment>
-        <Button aria-expanded={isExpanded} onClick={this.onClick} >
+        <Button aria-expanded={isExpanded} onClick={this.onClick}>
           Toggle Drawer
         </Button>
         <Drawer isExpanded={isExpanded} onExpand={this.onExpand}>
@@ -684,6 +711,7 @@ class DrawerStackedContentBodyElements extends React.Component {
 ```
 
 ### Modified content padding
+
 ```js
 import React from 'react';
 import {
@@ -707,7 +735,7 @@ class DrawerModifiedContentPadding extends React.Component {
     this.drawerRef = React.createRef();
 
     this.onExpand = () => {
-      this.drawerRef.current && this.drawerRef.current.focus()
+      this.drawerRef.current && this.drawerRef.current.focus();
     };
 
     this.onClick = () => {
@@ -729,7 +757,9 @@ class DrawerModifiedContentPadding extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
-          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer-panel
+          </span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -759,6 +789,7 @@ class DrawerModifiedContentPadding extends React.Component {
 ```
 
 ### Modified panel padding
+
 ```js
 import React from 'react';
 import {
@@ -782,7 +813,7 @@ class DrawerModifiedPanelPadding extends React.Component {
     this.drawerRef = React.createRef();
 
     this.onExpand = () => {
-      this.drawerRef.current && this.drawerRef.current.focus()
+      this.drawerRef.current && this.drawerRef.current.focus();
     };
 
     this.onClick = () => {
@@ -804,7 +835,9 @@ class DrawerModifiedPanelPadding extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead hasNoPadding>
-          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer-panel
+          </span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -832,6 +865,7 @@ class DrawerModifiedPanelPadding extends React.Component {
 ```
 
 ### Additional section above drawer content
+
 ```js
 import React from 'react';
 import {
@@ -856,7 +890,7 @@ class DrawerWithSection extends React.Component {
     this.drawerRef = React.createRef();
 
     this.onExpand = () => {
-      this.drawerRef.current && this.drawerRef.current.focus()
+      this.drawerRef.current && this.drawerRef.current.focus();
     };
 
     this.onClick = () => {
@@ -878,7 +912,9 @@ class DrawerWithSection extends React.Component {
     const panelContent = (
       <DrawerPanelContent>
         <DrawerHead>
-          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer-panel
+          </span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -907,6 +943,7 @@ class DrawerWithSection extends React.Component {
 ```
 
 ### Static drawer
+
 ```js
 import React from 'react';
 import {
@@ -946,6 +983,7 @@ StaticDrawer = () => {
 ```
 
 ### Breakpoint
+
 ```js
 import React from 'react';
 import {
@@ -969,7 +1007,7 @@ class SimpleDrawer extends React.Component {
     this.drawerRef = React.createRef();
 
     this.onExpand = () => {
-      this.drawerRef.current && this.drawerRef.current.focus()
+      this.drawerRef.current && this.drawerRef.current.focus();
     };
 
     this.onClick = () => {
@@ -991,7 +1029,9 @@ class SimpleDrawer extends React.Component {
     const panelContent = (
       <DrawerPanelContent widths={{ default: 'width_33' }}>
         <DrawerHead>
-          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>drawer-panel</span>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer-panel
+          </span>
           <DrawerActions>
             <DrawerCloseButton onClick={this.onCloseClick} />
           </DrawerActions>
@@ -1008,6 +1048,320 @@ class SimpleDrawer extends React.Component {
           Toggle Drawer
         </Button>
         <Drawer isExpanded={isExpanded} onExpand={this.onExpand}>
+          <DrawerContent panelContent={panelContent}>
+            <DrawerContentBody>{drawerContent}</DrawerContentBody>
+          </DrawerContent>
+        </Drawer>
+      </React.Fragment>
+    );
+  }
+}
+```
+
+### Resizable on right
+
+```js
+import React from 'react';
+import {
+  Drawer,
+  DrawerPanelContent,
+  DrawerContent,
+  DrawerContentBody,
+  DrawerPanelBody,
+  DrawerHead,
+  DrawerActions,
+  DrawerCloseButton,
+  Button,
+  Title
+} from '@patternfly/react-core';
+
+class ResizableDrawer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isExpanded: false,
+      isResizing: false
+    };
+    this.drawerRef = React.createRef();
+
+    this.onExpand = () => {
+      this.drawerRef.current && this.drawerRef.current.focus();
+    };
+
+    this.onClick = () => {
+      const isExpanded = !this.state.isExpanded;
+      this.setState({
+        isExpanded
+      });
+    };
+
+    this.onCloseClick = () => {
+      this.setState({
+        isExpanded: false
+      });
+    };
+  }
+
+  render() {
+    const { isExpanded } = this.state;
+    const panelContent = (
+      <DrawerPanelContent isResizable>
+        <DrawerHead>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer-panel
+          </span>
+          <DrawerActions>
+            <DrawerCloseButton onClick={this.onCloseClick} />
+          </DrawerActions>
+        </DrawerHead>
+      </DrawerPanelContent>
+    );
+
+    const drawerContent =
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.';
+
+    return (
+      <React.Fragment>
+        <Button aria-expanded={isExpanded} onClick={this.onClick}>
+          Toggle Drawer
+        </Button>
+        <Drawer isExpanded={isExpanded} onExpand={this.onExpand}>
+          <DrawerContent panelContent={panelContent}>
+            <DrawerContentBody>{drawerContent}</DrawerContentBody>
+          </DrawerContent>
+        </Drawer>
+      </React.Fragment>
+    );
+  }
+}
+```
+
+### Resizable on left
+
+```js
+import React from 'react';
+import {
+  Drawer,
+  DrawerPanelContent,
+  DrawerContent,
+  DrawerContentBody,
+  DrawerPanelBody,
+  DrawerHead,
+  DrawerActions,
+  DrawerCloseButton,
+  Button,
+  Title
+} from '@patternfly/react-core';
+
+class ResizableDrawer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isExpanded: false,
+      isResizing: false
+    };
+    this.drawerRef = React.createRef();
+
+    this.onExpand = () => {
+      this.drawerRef.current && this.drawerRef.current.focus();
+    };
+
+    this.onClick = () => {
+      const isExpanded = !this.state.isExpanded;
+      this.setState({
+        isExpanded
+      });
+    };
+
+    this.onCloseClick = () => {
+      this.setState({
+        isExpanded: false
+      });
+    };
+  }
+
+  render() {
+    const { isExpanded } = this.state;
+    const panelContent = (
+      <DrawerPanelContent isResizable>
+        <DrawerHead>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer-panel
+          </span>
+          <DrawerActions>
+            <DrawerCloseButton onClick={this.onCloseClick} />
+          </DrawerActions>
+        </DrawerHead>
+      </DrawerPanelContent>
+    );
+
+    const drawerContent =
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.';
+
+    return (
+      <React.Fragment>
+        <Button aria-expanded={isExpanded} onClick={this.onClick}>
+          Toggle Drawer
+        </Button>
+        <Drawer isExpanded={isExpanded} onExpand={this.onExpand} position="left">
+          <DrawerContent panelContent={panelContent}>
+            <DrawerContentBody>{drawerContent}</DrawerContentBody>
+          </DrawerContent>
+        </Drawer>
+      </React.Fragment>
+    );
+  }
+}
+```
+
+### Resizable on bottom
+
+```js
+import React from 'react';
+import {
+  Drawer,
+  DrawerPanelContent,
+  DrawerContent,
+  DrawerContentBody,
+  DrawerPanelBody,
+  DrawerHead,
+  DrawerActions,
+  DrawerCloseButton,
+  Button,
+  Title
+} from '@patternfly/react-core';
+
+class ResizableDrawer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isExpanded: false,
+      isResizing: false
+    };
+    this.drawerRef = React.createRef();
+
+    this.onExpand = () => {
+      this.drawerRef.current && this.drawerRef.current.focus();
+    };
+
+    this.onClick = () => {
+      const isExpanded = !this.state.isExpanded;
+      this.setState({
+        isExpanded
+      });
+    };
+
+    this.onCloseClick = () => {
+      this.setState({
+        isExpanded: false
+      });
+    };
+  }
+
+  render() {
+    const { isExpanded } = this.state;
+    const panelContent = (
+      <DrawerPanelContent isResizable>
+        <DrawerHead>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer-panel
+          </span>
+          <DrawerActions>
+            <DrawerCloseButton onClick={this.onCloseClick} />
+          </DrawerActions>
+        </DrawerHead>
+      </DrawerPanelContent>
+    );
+
+    const drawerContent =
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.';
+
+    return (
+      <React.Fragment>
+        <Button aria-expanded={isExpanded} onClick={this.onClick}>
+          Toggle Drawer
+        </Button>
+        <div style={{ height: '400px' }}>
+          <Drawer isExpanded={isExpanded} onExpand={this.onExpand} position="bottom">
+            <DrawerContent panelContent={panelContent}>
+              <DrawerContentBody>{drawerContent}</DrawerContentBody>
+            </DrawerContent>
+          </Drawer>
+        </div>
+      </React.Fragment>
+    );
+  }
+}
+```
+
+### Resizable on inline
+
+```js
+import React from 'react';
+import {
+  Drawer,
+  DrawerPanelContent,
+  DrawerContent,
+  DrawerContentBody,
+  DrawerPanelBody,
+  DrawerHead,
+  DrawerActions,
+  DrawerCloseButton,
+  Button,
+  Title
+} from '@patternfly/react-core';
+
+class ResizableDrawer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isExpanded: false,
+      isResizing: false
+    };
+    this.drawerRef = React.createRef();
+
+    this.onExpand = () => {
+      this.drawerRef.current && this.drawerRef.current.focus();
+    };
+
+    this.onClick = () => {
+      const isExpanded = !this.state.isExpanded;
+      this.setState({
+        isExpanded
+      });
+    };
+
+    this.onCloseClick = () => {
+      this.setState({
+        isExpanded: false
+      });
+    };
+  }
+
+  render() {
+    const { isExpanded } = this.state;
+    const panelContent = (
+      <DrawerPanelContent isResizable>
+        <DrawerHead>
+          <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
+            drawer-panel
+          </span>
+          <DrawerActions>
+            <DrawerCloseButton onClick={this.onCloseClick} />
+          </DrawerActions>
+        </DrawerHead>
+      </DrawerPanelContent>
+    );
+
+    const drawerContent =
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.';
+
+    return (
+      <React.Fragment>
+        <Button aria-expanded={isExpanded} onClick={this.onClick}>
+          Toggle Drawer
+        </Button>
+        <Drawer isExpanded={isExpanded} onExpand={this.onExpand} isInline>
           <DrawerContent panelContent={panelContent}>
             <DrawerContentBody>{drawerContent}</DrawerContentBody>
           </DrawerContent>

--- a/packages/react-integration/cypress/integration/drawer.spec.ts
+++ b/packages/react-integration/cypress/integration/drawer.spec.ts
@@ -23,6 +23,10 @@ describe('Drawer Demo Test', () => {
     cy.get('.pf-c-drawer').should('have.class', 'pf-m-panel-bottom');
   });
 
+  it('Verify resizable drawer', () => {
+    cy.get('.pf-c-drawer__panel').should('have.class', 'pf-m-resizable');
+  });
+
   it('Verify that focus gets sent to drawer', () => {
     cy.get('#toggleButton').click();
     setTimeout(() => cy.focused().contains('drawer-panel'), 1000);

--- a/packages/react-integration/cypress/integration/drawer.spec.ts
+++ b/packages/react-integration/cypress/integration/drawer.spec.ts
@@ -23,15 +23,6 @@ describe('Drawer Demo Test', () => {
     cy.get('.pf-c-drawer').should('have.class', 'pf-m-panel-bottom');
   });
 
-  it('Verify resizable drawer', () => {
-    cy.get('.pf-c-drawer__panel').should('have.class', 'pf-m-resizable');
-  });
-
-  it('Verify that focus gets sent to drawer', () => {
-    cy.get('#toggleButton').click();
-    setTimeout(() => cy.focused().contains('drawer-panel'), 1000);
-  });
-
   it('Verify panel widths', () => {
     // Large viewport
     const $drawerPanel = cy.get('.pf-c-drawer__panel');
@@ -49,5 +40,28 @@ describe('Drawer Demo Test', () => {
     // 2Xl viewport
     cy.viewport(1450, 660);
     cy.get('.pf-c-drawer__panel').should('have.css', 'flex-basis', '25%');
+  });
+
+  it('Verify resizable drawer', () => {
+    cy.get('.pf-c-drawer__panel').should('have.class', 'pf-m-resizable');
+    cy.get('.pf-c-drawer').should('not.have.class', 'pf-m-expanded');
+    cy.get('#toggleButton').click();
+    cy.get('.pf-c-drawer').should('have.class', 'pf-m-expanded');
+    cy.get('.pf-c-drawer__panel').should('not.have.css', 'overflow-anchor', 'none');
+    cy.get('.pf-c-drawer__splitter')
+      .trigger('mousedown', { which: 1 })
+      .trigger('mousemove', { clientX: 300, clientY: 300 })
+      .trigger('mouseup', { force: true });
+    cy.get('.pf-c-drawer__panel').should('have.css', 'overflow-anchor', 'none');
+    cy.get('.pf-c-drawer__splitter')
+      .trigger('keydown', { keyCode: 32, which: 32 })
+      .trigger('keydown', { keyCode: 40, which: 40 })
+      .trigger('keydown', { keyCode: 40, which: 40 })
+      .trigger('keydown', { keyCode: 40, which: 40 });
+  });
+
+  it('Verify that focus gets sent to drawer', () => {
+    cy.get('#toggleButton').click();
+    setTimeout(() => cy.focused().contains('drawer-panel'), 1000);
   });
 });

--- a/packages/react-integration/demo-app-ts/src/components/demos/DrawerDemo/DrawerDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DrawerDemo/DrawerDemo.tsx
@@ -53,6 +53,7 @@ export class DrawerDemo extends React.Component<DrawerProps, DrawerDemoState> {
           xl: 'width_33',
           '2xl': 'width_25'
         }}
+        isResizable
       >
         <DrawerHead>
           <span ref={this.drawerRef} tabIndex={isExpanded ? 0 : -1}>

--- a/packages/react-integration/demo-app-ts/src/components/demos/DrawerDemo/DrawerDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DrawerDemo/DrawerDemo.tsx
@@ -54,6 +54,7 @@ export class DrawerDemo extends React.Component<DrawerProps, DrawerDemoState> {
           '2xl': 'width_25'
         }}
         isResizable
+        increment={50}
       >
         <DrawerHead>
           <span ref={this.drawerRef} tabIndex={isExpanded ? 0 : -1}>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5050 

To enable resize, `isResizable` is passed to the `DrawerPanelContent` component.

Other additions:
- `minSize` / `maxSize` properties to customize resize limits. Defaults to the bounds of the parent container.
- `increment` property to customize keyboard size jump per keystroke. Defaults to `5px`.
- `resizeAriaLabel` / `resizeAriaDescribedBy` properties to customize labelling of the splitter div.

Keyboard interaction:
Tab over to the splitter and press `space` to begin resizing using the arrow keys. Press `enter` or `escape` to stop resizing.

@mcoker I've implemented the resizing by overriding the `--pf-c-drawer__panel--FlexBasis` css variable, since it appears height/width won't change without it. Is that all right or would there be a better class/css variable? 
There's also an odd effect when resizing the left drawer, where the drawer contents look like they drag a little. This is because `margin-right` has to be updated in sync with the size, so I'm not sure if there's anything I can do for that.

Direct link: https://patternfly-react-pr-5193.surge.sh/components/drawer#resizable-on-right