### PR TITLE
feat(DualListSelector): add support for trees and checkboxes

### DIFF
--- a/packages/react-core/src/components/DualListSelector/DualListSelector.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelector.tsx
@@ -360,6 +360,10 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
         availableTreeOptionsSelected: isChosen ? prevState.availableTreeOptionsSelected : updatedArray
       };
     });
+    const onOptionSelect = this.props.onOptionSelect;
+    if (onOptionSelect) {
+      onOptionSelect(e);
+    }
   };
 
   filterTreeItems = (item: DualListSelectorTreeItemData, inputList: string[]): boolean => {
@@ -496,6 +500,10 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
         this.props.onOptionCheck && this.props.onOptionCheck(evt, itemData.text, updatedChecked);
       }
     );
+    const onOptionSelect = this.props.onOptionSelect;
+    if (onOptionSelect) {
+      onOptionSelect(evt);
+    }
   };
 
   handleKeys = (event: KeyboardEvent) => {

--- a/packages/react-core/src/components/DualListSelector/DualListSelector.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelector.tsx
@@ -59,7 +59,12 @@ export interface DualListSelectorProps {
   /** Optional callback fired when an option is selected */
   onOptionSelect?: (e: React.MouseEvent | React.ChangeEvent) => void;
   /** Optional callback fired when an option is checked */
-  onOptionCheck?: (e: React.ChangeEvent<HTMLInputElement>, checkedId: string, newCheckedItems: string[]) => void;
+  onOptionCheck?: (
+    e: React.MouseEvent | React.ChangeEvent<HTMLInputElement>,
+    checked: boolean,
+    checkedId: string,
+    newCheckedItems: string[]
+  ) => void;
   /** Flag indicating a search bar should be included above both the available and chosen panes. */
   isSearchable?: boolean;
   /** Accessible label for the search input on the available options pane. */
@@ -385,11 +390,14 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
   };
 
   onTreeOptionCheck = (
-    evt: React.ChangeEvent<HTMLInputElement>,
+    evt: React.MouseEvent | React.ChangeEvent<HTMLInputElement>,
+    isChecked: boolean,
     isChosen: boolean,
     itemData: DualListSelectorTreeItemData
   ) => {
-    const checked = evt.target.checked;
+    const checked = (evt as React.ChangeEvent<HTMLInputElement>).target.checked
+      ? (evt as React.ChangeEvent<HTMLInputElement>).target.checked
+      : isChecked;
     const panelOptions = isChosen ? this.state.chosenOptions : this.state.availableOptions;
     const checkedOptionTree = panelOptions
       .map(opt => Object.assign({}, opt))
@@ -416,7 +424,7 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
         chosenTreeOptionsSelected: isChosen ? updatedSelected : prevState.chosenTreeOptionsSelected
       }),
       () => {
-        this.props.onOptionCheck && this.props.onOptionCheck(evt, itemData.id, updatedChecked);
+        this.props.onOptionCheck && this.props.onOptionCheck(evt, isChecked, itemData.id, updatedChecked);
       }
     );
 

--- a/packages/react-core/src/components/DualListSelector/DualListSelector.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelector.tsx
@@ -59,7 +59,7 @@ export interface DualListSelectorProps {
   /** Optional callback fired when an option is selected */
   onOptionSelect?: (e: React.MouseEvent | React.ChangeEvent) => void;
   /** Optional callback fired when an option is checked */
-  onOptionCheck?: (e: React.ChangeEvent<HTMLInputElement>, checkedItem: string, newCheckedItems: string[]) => void;
+  onOptionCheck?: (e: React.ChangeEvent<HTMLInputElement>, checkedId: string, newCheckedItems: string[]) => void;
   /** Flag indicating a search bar should be included above both the available and chosen panes. */
   isSearchable?: boolean;
   /** Accessible label for the search input on the available options pane. */
@@ -140,12 +140,9 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
       } else {
         newChosen = [...prevState.chosenOptions, ...prevState.availableOptions];
       }
-      if (this.props.addAll) {
-        this.props.addAll([], newChosen);
-      }
-      if (this.props.onListChange) {
-        this.props.onListChange([], newChosen);
-      }
+      this.props.addAll && this.props.addAll([], newChosen);
+      this.props.onListChange && this.props.onListChange([], newChosen);
+
       return {
         availableOptions: [],
         availableOptionsSelected: [],
@@ -163,12 +160,9 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
       } else {
         newAvailable = [...prevState.chosenOptions, ...prevState.availableOptions];
       }
-      if (this.props.removeAll) {
-        this.props.removeAll(newAvailable, []);
-      }
-      if (this.props.onListChange) {
-        this.props.onListChange(newAvailable, []);
-      }
+      this.props.removeAll && this.props.removeAll(newAvailable, []);
+      this.props.onListChange && this.props.onListChange(newAvailable, []);
+
       return {
         availableOptions: newAvailable,
         availableOptionsSelected: [],
@@ -191,12 +185,9 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
       });
 
       const newChosen = [...prevState.chosenOptions, ...itemsToRemove];
-      if (this.props.addSelected) {
-        this.props.addSelected(newAvailable, newChosen);
-      }
-      if (this.props.onListChange) {
-        this.props.onListChange(newAvailable, newChosen);
-      }
+      this.props.addSelected && this.props.addSelected(newAvailable, newChosen);
+      this.props.onListChange && this.props.onListChange(newAvailable, newChosen);
+
       return {
         chosenOptionsSelected: [],
         availableOptionsSelected: [],
@@ -222,12 +213,9 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
         .map(opt => Object.assign({}, opt))
         .filter(item => filterTreeItemsWithoutFolders(item as DualListSelectorTreeItemData, nextChosenOptions));
 
-      if (this.props.addSelected) {
-        this.props.addSelected(newAvailable, newChosen);
-      }
-      if (this.props.onListChange) {
-        this.props.onListChange(newAvailable, newChosen);
-      }
+      this.props.addSelected && this.props.addSelected(newAvailable, newChosen);
+      this.props.onListChange && this.props.onListChange(newAvailable, newChosen);
+
       return {
         availableTreeOptionsSelected: [],
         chosenTreeOptionsSelected: [],
@@ -252,12 +240,9 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
       });
 
       const newAvailable = [...prevState.availableOptions, ...itemsToRemove];
-      if (this.props.removeSelected) {
-        this.props.removeSelected(newAvailable, newChosen);
-      }
-      if (this.props.onListChange) {
-        this.props.onListChange(newAvailable, newChosen);
-      }
+      this.props.removeSelected && this.props.removeSelected(newAvailable, newChosen);
+      this.props.onListChange && this.props.onListChange(newAvailable, newChosen);
+
       return {
         chosenOptionsSelected: [],
         availableOptionsSelected: [],
@@ -281,12 +266,9 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
         .map(opt => Object.assign({}, opt))
         .filter(item => filterTreeItemsWithoutFolders(item as DualListSelectorTreeItemData, nextAvailableOptions));
 
-      if (this.props.removeSelected) {
-        this.props.removeSelected(newAvailable, newChosen);
-      }
-      if (this.props.onListChange) {
-        this.props.onListChange(newAvailable, newChosen);
-      }
+      this.props.removeSelected && this.props.removeSelected(newAvailable, newChosen);
+      this.props.onListChange && this.props.onListChange(newAvailable, newChosen);
+
       return {
         availableTreeOptionsSelected: [],
         chosenTreeOptionsSelected: [],
@@ -303,9 +285,10 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
     index: number,
     isChosen: boolean,
     /* eslint-disable @typescript-eslint/no-unused-vars */
-    text?: string,
+    id?: string,
     itemData?: any,
     parentData?: any
+    /* eslint-enable @typescript-eslint/no-unused-vars */
   ) => {
     this.setState(prevState => {
       const originalArray = isChosen ? prevState.chosenOptionsSelected : prevState.availableOptionsSelected;
@@ -322,18 +305,17 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
         availableOptionsSelected: isChosen ? prevState.availableOptionsSelected : updatedArray
       };
     });
-    const onOptionSelect = this.props.onOptionSelect;
-    if (onOptionSelect) {
-      onOptionSelect(e);
-    }
+
+    this.props.onOptionSelect && this.props.onOptionSelect(e);
   };
 
   onTreeOptionSelect = (
     e: React.MouseEvent | React.ChangeEvent,
     index: number,
     isChosen: boolean,
-    text?: string,
+    id?: string,
     itemData?: any,
+    /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
     parentData?: any
   ) => {
     this.setState(prevState => {
@@ -344,19 +326,19 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
         const panelOptions = isChosen ? this.state.chosenOptions : this.state.availableOptions;
         const selectedOptionTree = panelOptions
           .map(opt => Object.assign({}, opt))
-          .filter(item => filterTreeItems(item as DualListSelectorTreeItemData, [text]));
+          .filter(item => filterTreeItems(item as DualListSelectorTreeItemData, [id]));
         const flatSelectedItems = flattenTreeWithFolders(selectedOptionTree as DualListSelectorTreeItemData[]);
 
-        if (selectedOptions.includes(text)) {
-          updatedArray = selectedOptions.filter(text => !flatSelectedItems.includes(text));
+        if (selectedOptions.includes(id)) {
+          updatedArray = selectedOptions.filter(id => !flatSelectedItems.includes(id));
         } else {
-          updatedArray = selectedOptions.concat(flatSelectedItems.filter(text => !selectedOptions.includes(text)));
+          updatedArray = selectedOptions.concat(flatSelectedItems.filter(id => !selectedOptions.includes(id)));
         }
       } else {
-        if (selectedOptions.includes(text)) {
-          updatedArray = selectedOptions.filter(text => !selectedOptions.includes(text));
+        if (selectedOptions.includes(id)) {
+          updatedArray = selectedOptions.filter(id => !selectedOptions.includes(id));
         } else {
-          updatedArray = [...selectedOptions, text];
+          updatedArray = [...selectedOptions, id];
         }
       }
 
@@ -365,16 +347,14 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
         availableTreeOptionsSelected: isChosen ? prevState.availableTreeOptionsSelected : updatedArray
       };
     });
-    const onOptionSelect = this.props.onOptionSelect;
-    if (onOptionSelect) {
-      onOptionSelect(e);
-    }
+
+    this.props.onOptionSelect && this.props.onOptionSelect(e);
   };
 
   isChecked = (treeItem: DualListSelectorTreeItemData, isChosen: boolean) =>
     isChosen
-      ? this.state.chosenTreeOptionsChecked.includes(treeItem.text)
-      : this.state.availableTreeOptionsChecked.includes(treeItem.text);
+      ? this.state.chosenTreeOptionsChecked.includes(treeItem.id)
+      : this.state.availableTreeOptionsChecked.includes(treeItem.id);
   areAllDescendantsChecked = (treeItem: DualListSelectorTreeItemData, isChosen: boolean): boolean =>
     treeItem.children
       ? treeItem.children.every(child => this.areAllDescendantsChecked(child, isChosen))
@@ -386,14 +366,14 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
 
   mapChecked = (item: DualListSelectorTreeItemData, isChosen: boolean): DualListSelectorTreeItemData => {
     const hasCheck = this.areAllDescendantsChecked(item, isChosen);
-    item.checked = false;
+    item.isChecked = false;
 
     if (hasCheck) {
-      item.checked = true;
+      item.isChecked = true;
     } else {
       const hasPartialCheck = this.areSomeDescendantsChecked(item, isChosen);
       if (hasPartialCheck) {
-        item.checked = null;
+        item.isChecked = null;
       }
     }
 
@@ -415,7 +395,7 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
     const panelOptions = isChosen ? this.state.chosenOptions : this.state.availableOptions;
     const checkedOptionTree = panelOptions
       .map(opt => Object.assign({}, opt))
-      .filter(item => filterTreeItems(item as DualListSelectorTreeItemData, [itemData.text]));
+      .filter(item => filterTreeItems(item as DualListSelectorTreeItemData, [itemData.id]));
     const flatTree = flattenTreeWithFolders(checkedOptionTree as DualListSelectorTreeItemData[]);
 
     const prevChecked = isChosen ? this.state.chosenTreeOptionsChecked : this.state.availableTreeOptionsChecked;
@@ -423,11 +403,11 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
     let updatedSelected = [] as string[];
     const selectedOptions = isChosen ? this.state.chosenTreeOptionsSelected : this.state.availableTreeOptionsSelected;
     if (checked) {
-      updatedChecked = prevChecked.concat(flatTree.filter(text => !prevChecked.includes(text)));
-      updatedSelected = selectedOptions.concat(flatTree.filter(text => !selectedOptions.includes(text)));
+      updatedChecked = prevChecked.concat(flatTree.filter(id => !prevChecked.includes(id)));
+      updatedSelected = selectedOptions.concat(flatTree.filter(id => !selectedOptions.includes(id)));
     } else {
-      updatedChecked = prevChecked.filter(text => !flatTree.includes(text));
-      updatedSelected = selectedOptions.filter(text => !flatTree.includes(text));
+      updatedChecked = prevChecked.filter(id => !flatTree.includes(id));
+      updatedSelected = selectedOptions.filter(id => !flatTree.includes(id));
     }
 
     this.setState(
@@ -438,13 +418,11 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
         chosenTreeOptionsSelected: isChosen ? updatedSelected : prevState.chosenTreeOptionsSelected
       }),
       () => {
-        this.props.onOptionCheck && this.props.onOptionCheck(evt, itemData.text, updatedChecked);
+        this.props.onOptionCheck && this.props.onOptionCheck(evt, itemData.id, updatedChecked);
       }
     );
-    const onOptionSelect = this.props.onOptionSelect;
-    if (onOptionSelect) {
-      onOptionSelect(evt);
-    }
+
+    this.props.onOptionSelect && this.props.onOptionSelect(evt);
   };
 
   handleKeys = (event: KeyboardEvent) => {

--- a/packages/react-core/src/components/DualListSelector/DualListSelector.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelector.tsx
@@ -547,7 +547,6 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
           actions={availableOptionsActions}
           id={`${id}-available-pane`}
           isTree={isTree}
-          hasChecks={isTree}
         />
         <div
           className={css(styles.dualListSelectorControls)}
@@ -618,7 +617,6 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
           actions={chosenOptionsActions}
           id={`${id}-chosen-pane`}
           isTree={isTree}
-          hasChecks={isTree}
         />
       </div>
     );

--- a/packages/react-core/src/components/DualListSelector/DualListSelector.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelector.tsx
@@ -419,6 +419,20 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
     return result;
   };
 
+  filterFolders = (tree: DualListSelectorTreeItemData[], subset: string[]): string[] => {
+    let result = [] as string[];
+    tree.forEach(item => {
+      if (item.children) {
+        result = result.concat(this.filterFolders(item.children, subset));
+      } else {
+        if (subset.includes(item.text)) {
+          result.push(item.text);
+        }
+      }
+    });
+    return result;
+  };
+
   flattenTreeWithFolders = (tree: DualListSelectorTreeItemData[]): string[] => {
     let result = [] as string[];
     tree.forEach(item => {
@@ -597,16 +611,16 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
     const availableOptionsStatusToDisplay =
       availableOptionsStatus ||
       (isTree
-        ? `${availableTreeOptionsSelected.length} of ${
-            this.flattenTreeWithFolders(availableOptions as DualListSelectorTreeItemData[]).length
-          } items selected`
+        ? `${
+            this.filterFolders(availableOptions as DualListSelectorTreeItemData[], availableTreeOptionsSelected).length
+          } of ${this.flattenTree(availableOptions as DualListSelectorTreeItemData[]).length} items selected`
         : `${availableOptionsSelected.length} of ${availableOptions.length} items selected`);
     const chosenOptionsStatusToDisplay =
       chosenOptionsStatus ||
       (isTree
-        ? `${chosenTreeOptionsSelected.length} of ${
-            this.flattenTreeWithFolders(chosenOptions as DualListSelectorTreeItemData[]).length
-          } items selected`
+        ? `${
+            this.filterFolders(chosenOptions as DualListSelectorTreeItemData[], chosenTreeOptionsSelected).length
+          } of ${this.flattenTree(chosenOptions as DualListSelectorTreeItemData[]).length} items selected`
         : `${chosenOptionsSelected.length} of ${chosenOptions.length} items selected`);
 
     const available = hasChecks

--- a/packages/react-core/src/components/DualListSelector/DualListSelector.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelector.tsx
@@ -72,8 +72,6 @@ export interface DualListSelectorProps {
   id?: string;
   /* Flag indicating if the dual list selector uses trees instead of simple lists */
   isTree?: boolean;
-  /** Flag indicating if the dual list selector tree options have checkboxes */
-  hasChecks?: boolean;
 }
 
 interface DualListSelectorState {
@@ -501,7 +499,6 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
       onListChange,
       id,
       isTree,
-      hasChecks,
       ...props
     } = this.props;
     const {
@@ -528,10 +525,10 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
           } items selected`
         : `${chosenOptionsSelected.length} of ${chosenOptions.length} items selected`);
 
-    const available = hasChecks
+    const available = isTree
       ? availableOptions.map(item => this.mapChecked(item as DualListSelectorTreeItemData, false))
       : availableOptions;
-    const chosen = hasChecks
+    const chosen = isTree
       ? chosenOptions.map(item => this.mapChecked(item as DualListSelectorTreeItemData, true))
       : chosenOptions;
 
@@ -550,7 +547,7 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
           actions={availableOptionsActions}
           id={`${id}-available-pane`}
           isTree={isTree}
-          hasChecks={hasChecks}
+          hasChecks={isTree}
         />
         <div
           className={css(styles.dualListSelectorControls)}
@@ -621,7 +618,7 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
           actions={chosenOptionsActions}
           id={`${id}-chosen-pane`}
           isTree={isTree}
-          hasChecks={hasChecks}
+          hasChecks={isTree}
         />
       </div>
     );

--- a/packages/react-core/src/components/DualListSelector/DualListSelector.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelector.tsx
@@ -22,16 +22,16 @@ export interface DualListSelectorProps {
   className?: string;
   /** Title applied to the available options pane. */
   availableOptionsTitle?: string;
-  /** Options to display in the available options pane. */
-  availableOptions?: React.ReactNode[];
+  /** Options to display in the available options pane. When using trees, the options should be in the DualListSelectorTreeItemData[] format. */
+  availableOptions?: React.ReactNode[] | DualListSelectorTreeItemData[];
   /** Status message to display above the available options pane. */
   availableOptionsStatus?: string;
   /** Actions to be displayed above the available options pane. */
   availableOptionsActions?: React.ReactNode[];
   /** Title applied to the chosen options pane. */
   chosenOptionsTitle?: string;
-  /** Options to display in the chosen options pane. */
-  chosenOptions?: React.ReactNode[];
+  /** Options to display in the chosen options pane. When using trees, the options should be in the DualListSelectorTreeItemData[] format. */
+  chosenOptions?: React.ReactNode[] | DualListSelectorTreeItemData[];
   /** Status message to display above the chosen options pane.*/
   chosenOptionsStatus?: string;
   /** Actions to be displayed above the chosen options pane. */
@@ -209,7 +209,7 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
       // Get next chosen options from current + new nodes and remap from base
       const currChosen = flattenTree(prevState.chosenOptions as DualListSelectorTreeItemData[]);
       const nextChosenOptions = currChosen.concat(prevState.availableTreeOptionsSelected);
-      const newChosen = this.originalCopy
+      const newChosen = (this.originalCopy as DualListSelectorTreeItemData[])
         .map(opt => Object.assign({}, opt))
         .filter(item => filterTreeItemsWithoutFolders(item as DualListSelectorTreeItemData, nextChosenOptions));
 
@@ -262,7 +262,7 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
       // Get next chosen options from current and remap from base
       const currAvailable = flattenTree(prevState.availableOptions as DualListSelectorTreeItemData[]);
       const nextAvailableOptions = currAvailable.concat(prevState.chosenTreeOptionsSelected);
-      const newAvailable = this.originalCopy
+      const newAvailable = (this.originalCopy as DualListSelectorTreeItemData[])
         .map(opt => Object.assign({}, opt))
         .filter(item => filterTreeItemsWithoutFolders(item as DualListSelectorTreeItemData, nextAvailableOptions));
 

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorPane.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorPane.tsx
@@ -13,8 +13,6 @@ export interface DualListSelectorPaneProps {
   isChosen?: boolean;
   /* Flag indicating if the dual list selector uses trees instead of simple lists */
   isTree?: boolean;
-  /** Flag indicating if the dual list selector tree options have checkboxes */
-  hasChecks?: boolean;
   /** Status to display above the pane. */
   status?: string;
   /** Title of the pane. */
@@ -167,7 +165,6 @@ export class DualListSelectorPane extends React.Component<DualListSelectorPanePr
       actions,
       isSearchable,
       isTree,
-      hasChecks,
       searchInputAriaLabel,
       className,
       status,
@@ -264,7 +261,6 @@ export class DualListSelectorPane extends React.Component<DualListSelectorPanePr
               onOptionSelect={this.onOptionSelect}
               onOptionCheck={onOptionCheck}
               selectedOptions={selectedOptions as string[]}
-              hasChecks={hasChecks}
             />
           </div>
         )}

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorPane.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorPane.tsx
@@ -112,6 +112,23 @@ export class DualListSelectorPane extends React.Component<DualListSelectorPanePr
     }
   };
 
+  filterInput = (item: DualListSelectorTreeItemData, input: string): boolean => {
+    if (this.props.filterOption) {
+      return this.props.filterOption(item, input);
+    } else {
+      if (item.text.toLowerCase().includes(input.toLowerCase()) || input === '') {
+        return true;
+      }
+    }
+    if (item.children) {
+      return (
+        (item.children = item.children
+          .map(opt => Object.assign({}, opt))
+          .filter(child => this.filterInput(child, input))).length > 0
+      );
+    }
+  };
+
   displayOption = (option: React.ReactNode, input: string) => {
     if (this.props.filterOption) {
       return this.props.filterOption(option, input);
@@ -236,7 +253,13 @@ export class DualListSelectorPane extends React.Component<DualListSelectorPanePr
         {options && isTree && (
           <div className={css(styles.dualListSelectorMenu)} ref={this.menuEl} tabIndex={0}>
             <DualListSelectorTree
-              data={options as DualListSelectorTreeItemData[]}
+              data={
+                isSearchable
+                  ? (options as DualListSelectorTreeItemData[])
+                      .map(opt => Object.assign({}, opt))
+                      .filter(item => this.filterInput(item as DualListSelectorTreeItemData, input))
+                  : (options as DualListSelectorTreeItemData[])
+              }
               isChosen={isChosen}
               sendRef={this.sendRef}
               onOptionSelect={this.onOptionSelect}

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorPane.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorPane.tsx
@@ -261,7 +261,6 @@ export class DualListSelectorPane extends React.Component<DualListSelectorPanePr
                   : (options as DualListSelectorTreeItemData[])
               }
               isChosen={isChosen}
-              sendRef={this.sendRef}
               onOptionSelect={this.onOptionSelect}
               onOptionCheck={onOptionCheck}
               selectedOptions={selectedOptions as string[]}

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorPane.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorPane.tsx
@@ -33,7 +33,8 @@ export interface DualListSelectorPaneProps {
     parentData?: any
   ) => void;
   onOptionCheck?: (
-    evt: React.ChangeEvent<HTMLInputElement>,
+    evt: React.MouseEvent | React.ChangeEvent<HTMLInputElement>,
+    isChecked: boolean,
     isChosen: boolean,
     itemData: DualListSelectorTreeItemData
   ) => void;

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorPane.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorPane.tsx
@@ -3,6 +3,7 @@ import styles from '@patternfly/react-styles/css/components/DualListSelector/dua
 import { css } from '@patternfly/react-styles';
 import formStyles from '@patternfly/react-styles/css/components/FormControl/form-control';
 import { DualListSelectorListItem } from './DualListSelectorListItem';
+import { DualListSelectorTree, DualListSelectorTreeItemData } from './DualListSelectorTree';
 import { PickOptional } from '../../helpers';
 
 export interface DualListSelectorPaneProps {
@@ -10,6 +11,10 @@ export interface DualListSelectorPaneProps {
   className?: string;
   /** Flag indicating if this pane is the chosen pane. */
   isChosen?: boolean;
+  /* Flag indicating if the dual list selector uses trees instead of simple lists */
+  isTree?: boolean;
+  /** Flag indicating if the dual list selector tree options have checkboxes */
+  hasChecks?: boolean;
   /** Status to display above the pane. */
   status?: string;
   /** Title of the pane. */
@@ -17,11 +22,23 @@ export interface DualListSelectorPaneProps {
   /** Options to list in the pane. */
   options?: React.ReactNode[];
   /** Options currently selected in the pane. */
-  selectedOptions?: number[];
+  selectedOptions?: string[] | number[];
   /** Callback for search input. */
   onSearch?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   /** Callback for when an option is selected. */
-  onOptionSelect?: (e: React.MouseEvent | React.ChangeEvent, index: number, isChosen: boolean) => void;
+  onOptionSelect?: (
+    e: React.MouseEvent | React.ChangeEvent,
+    index: number,
+    isChosen: boolean,
+    text?: string,
+    itemData?: any,
+    parentData?: any
+  ) => void;
+  onOptionCheck?: (
+    evt: React.ChangeEvent<HTMLInputElement>,
+    isChosen: boolean,
+    itemData: DualListSelectorTreeItemData
+  ) => void;
   /** Actions to place above the pane. */
   actions?: React.ReactNode[];
   /** Filter function for custom filtering based on search string. */
@@ -106,9 +123,16 @@ export class DualListSelectorPane extends React.Component<DualListSelectorPanePr
     }
   };
 
-  onOptionSelect = (e: React.MouseEvent | React.ChangeEvent, index: number, isChosen: boolean) => {
+  onOptionSelect = (
+    e: React.MouseEvent | React.ChangeEvent,
+    index: number,
+    isChosen: boolean,
+    text?: string,
+    itemData?: any,
+    parentItem?: any
+  ) => {
     this.setState({ focusedOption: `${this.props.id}-option-${index}` });
-    this.props.onOptionSelect(e, index, isChosen);
+    this.props.onOptionSelect(e, index, isChosen, text, itemData, parentItem);
   };
 
   componentDidMount() {
@@ -125,6 +149,8 @@ export class DualListSelectorPane extends React.Component<DualListSelectorPanePr
       title,
       actions,
       isSearchable,
+      isTree,
+      hasChecks,
       searchInputAriaLabel,
       className,
       status,
@@ -134,6 +160,7 @@ export class DualListSelectorPane extends React.Component<DualListSelectorPanePr
       /* eslint-disable @typescript-eslint/no-unused-vars */
       filterOption,
       onOptionSelect,
+      onOptionCheck,
       ...props
     } = this.props;
     const { input, focusedOption } = this.state;
@@ -174,7 +201,7 @@ export class DualListSelectorPane extends React.Component<DualListSelectorPanePr
             </div>
           </div>
         )}
-        {options && (
+        {options && !isTree && (
           <div className={css(styles.dualListSelectorMenu)} ref={this.menuEl} tabIndex={0}>
             <ul
               className={css(styles.dualListSelectorList)}
@@ -189,7 +216,7 @@ export class DualListSelectorPane extends React.Component<DualListSelectorPanePr
                   return (
                     <DualListSelectorListItem
                       key={index}
-                      isSelected={selectedOptions.indexOf(index) !== -1}
+                      isSelected={(selectedOptions as number[]).indexOf(index) !== -1}
                       onOptionSelect={this.onOptionSelect}
                       isChosen={isChosen}
                       orderIndex={index}
@@ -204,6 +231,19 @@ export class DualListSelectorPane extends React.Component<DualListSelectorPanePr
                 return;
               })}
             </ul>
+          </div>
+        )}
+        {options && isTree && (
+          <div className={css(styles.dualListSelectorMenu)} ref={this.menuEl} tabIndex={0}>
+            <DualListSelectorTree
+              data={options as DualListSelectorTreeItemData[]}
+              isChosen={isChosen}
+              sendRef={this.sendRef}
+              onOptionSelect={this.onOptionSelect}
+              onOptionCheck={onOptionCheck}
+              selectedOptions={selectedOptions as string[]}
+              hasChecks={hasChecks}
+            />
           </div>
         )}
       </div>

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorTree.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorTree.tsx
@@ -18,18 +18,12 @@ export interface DualListSelectorTreeItemData {
   hasCheck?: boolean;
   /** Flag indicating this option has a badge */
   hasBadge?: boolean;
-  /** Internal callback to pass this ref up to the parent. */
-  sendRef?: (optionRef: React.ReactNode, index: number) => void;
-  /** Internal field used to keep track of the order of filtered options. */
-  filteredIndex?: number;
-  /** Internal field used to keep track of order of unfiltered options. */
-  orderIndex?: number;
   /** Callback fired when an option is selected.  */
   onOptionSelect?: (
     e: React.MouseEvent | React.ChangeEvent,
     index: number,
     isChosen: boolean,
-    text?: string,
+    id?: string,
     itemData?: any,
     parentData?: any
   ) => void;
@@ -43,10 +37,10 @@ export interface DualListSelectorTreeItemData {
   id: string;
   /** Text of the option */
   text: string;
-  /** Checked state of the option */
-  checked: boolean;
   /** Parent item of the option */
   parentItem?: DualListSelectorTreeItem;
+  /** Checked state of the option */
+  isChecked: boolean;
   /** Additional properties to pass to the option checkbox */
   checkProps?: any;
   /** Additional properties to pass to the option badge */
@@ -73,7 +67,7 @@ export interface DualListSelectorTreeProps {
     e: React.MouseEvent | React.ChangeEvent,
     index: number,
     isChosen: boolean,
-    text?: string,
+    id?: string,
     itemData?: any,
     parentData?: any
   ) => void;
@@ -87,8 +81,6 @@ export interface DualListSelectorTreeProps {
   parentItem?: DualListSelectorTreeItemData;
   /** Reference of selected options */
   selectedOptions?: string[];
-  /** Internal callback to pass this ref up to the parent. */
-  sendRef?: (optionRef: React.ReactNode, index: number) => void;
 }
 
 export const DualListSelectorTree: React.FunctionComponent<DualListSelectorTreeProps> = ({
@@ -101,28 +93,26 @@ export const DualListSelectorTree: React.FunctionComponent<DualListSelectorTreeP
   parentItem,
   onOptionSelect,
   onOptionCheck,
-  sendRef,
   selectedOptions = [],
   ...props
 }: DualListSelectorTreeProps) => (
   <ul className={css(styles.dualListSelectorList)} role={isNested ? 'group' : 'tree'} {...props}>
     {data.map(item => (
       <DualListSelectorTreeItem
-        key={item.text}
+        key={item.id}
         text={item.text}
         id={item.id}
         isChosen={isChosen}
-        isSelected={selectedOptions.includes(item.text)}
+        isSelected={selectedOptions.includes(item.id)}
         defaultExpanded={item.defaultExpanded !== undefined ? item.defaultExpanded : defaultAllExpanded}
         onOptionSelect={onOptionSelect}
         onOptionCheck={onOptionCheck}
         hasCheck={item.hasCheck !== undefined ? item.hasCheck : hasChecks}
-        checked={item.checked}
+        isChecked={item.isChecked}
         checkProps={item.checkProps}
         hasBadge={item.hasBadge !== undefined ? item.hasBadge : hasBadges}
         badgeProps={item.badgeProps}
         parentItem={parentItem}
-        sendRef={sendRef}
         itemData={item}
         {...(item.children && {
           children: (
@@ -136,7 +126,6 @@ export const DualListSelectorTree: React.FunctionComponent<DualListSelectorTreeP
               defaultAllExpanded={defaultAllExpanded}
               onOptionSelect={onOptionSelect}
               onOptionCheck={onOptionCheck}
-              sendRef={sendRef}
               selectedOptions={selectedOptions}
             />
           )

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorTree.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorTree.tsx
@@ -56,8 +56,6 @@ export interface DualListSelectorTreeProps {
   isChosen?: boolean;
   /** Flag indicating if the list is nested */
   isNested?: boolean;
-  /** Flag indicating if all options should have checkboxes */
-  hasChecks?: boolean;
   /** Flag indicating if all options should have badges */
   hasBadges?: boolean;
   /** Sets the default expanded behavior */
@@ -86,7 +84,6 @@ export interface DualListSelectorTreeProps {
 export const DualListSelectorTree: React.FunctionComponent<DualListSelectorTreeProps> = ({
   data,
   isChosen,
-  hasChecks = false,
   hasBadges = false,
   isNested = false,
   defaultAllExpanded = false,
@@ -107,7 +104,7 @@ export const DualListSelectorTree: React.FunctionComponent<DualListSelectorTreeP
         defaultExpanded={item.defaultExpanded !== undefined ? item.defaultExpanded : defaultAllExpanded}
         onOptionSelect={onOptionSelect}
         onOptionCheck={onOptionCheck}
-        hasCheck={item.hasCheck !== undefined ? item.hasCheck : hasChecks}
+        hasCheck={item.hasCheck !== undefined ? item.hasCheck : true}
         isChecked={item.isChecked}
         checkProps={item.checkProps}
         hasBadge={item.hasBadge !== undefined ? item.hasBadge : hasBadges}
@@ -120,7 +117,6 @@ export const DualListSelectorTree: React.FunctionComponent<DualListSelectorTreeP
               isNested
               data={item.children}
               parentItem={item}
-              hasChecks={hasChecks}
               hasBadges={hasBadges}
               isChosen={isChosen}
               defaultAllExpanded={defaultAllExpanded}

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorTree.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorTree.tsx
@@ -14,8 +14,6 @@ export interface DualListSelectorTreeItemData {
   isChosen?: boolean;
   /** Flag indicating this option is expanded by default. */
   defaultExpanded?: boolean;
-  /** Flag indicating this option has a checkbox */
-  hasCheck?: boolean;
   /** Flag indicating this option has a badge */
   hasBadge?: boolean;
   /** Callback fired when an option is selected.  */
@@ -104,7 +102,6 @@ export const DualListSelectorTree: React.FunctionComponent<DualListSelectorTreeP
         defaultExpanded={item.defaultExpanded !== undefined ? item.defaultExpanded : defaultAllExpanded}
         onOptionSelect={onOptionSelect}
         onOptionCheck={onOptionCheck}
-        hasCheck={item.hasCheck !== undefined ? item.hasCheck : true}
         isChecked={item.isChecked}
         checkProps={item.checkProps}
         hasBadge={item.hasBadge !== undefined ? item.hasBadge : hasBadges}

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorTree.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorTree.tsx
@@ -1,0 +1,145 @@
+import * as React from 'react';
+import { css } from '@patternfly/react-styles';
+import styles from '@patternfly/react-styles/css/components/DualListSelector/dual-list-selector';
+import { DualListSelectorTreeItem } from './DualListSelectorTreeItem';
+
+export interface DualListSelectorTreeItemData {
+  /** Content rendered inside the dual list selector. */
+  children?: DualListSelectorTreeItemData[];
+  /** Additional classes applied to the dual list selector. */
+  className?: string;
+  /** Flag indicating the option is currently selected. */
+  isSelected?: boolean;
+  /** Flag indicating this option is in the chosen pane. */
+  isChosen?: boolean;
+  /** Flag indicating this option is expanded by default. */
+  defaultExpanded?: boolean;
+  /** Flag indicating this option has a checkbox */
+  hasCheck?: boolean;
+  /** Flag indicating this option has a badge */
+  hasBadge?: boolean;
+  /** Internal callback to pass this ref up to the parent. */
+  sendRef?: (optionRef: React.ReactNode, index: number) => void;
+  /** Internal field used to keep track of the order of filtered options. */
+  filteredIndex?: number;
+  /** Internal field used to keep track of order of unfiltered options. */
+  orderIndex?: number;
+  /** Callback fired when an option is selected.  */
+  onOptionSelect?: (
+    e: React.MouseEvent | React.ChangeEvent,
+    index: number,
+    isChosen: boolean,
+    text?: string,
+    itemData?: any,
+    parentData?: any
+  ) => void;
+  /** Callback fired when an option is checked */
+  onOptionCheck?: (
+    event: React.ChangeEvent<HTMLInputElement>,
+    isChosen: boolean,
+    itemData: DualListSelectorTreeItemData
+  ) => void;
+  /** ID of the option */
+  id: string;
+  /** Text of the option */
+  text: string;
+  /** Checked state of the option */
+  checked: boolean;
+  /** Parent item of the option */
+  parentItem?: DualListSelectorTreeItem;
+  /** Additional properties to pass to the option checkbox */
+  checkProps?: any;
+  /** Additional properties to pass to the option badge */
+  badgeProps?: any;
+}
+
+export interface DualListSelectorTreeProps {
+  /** Data of the tree view */
+  data: DualListSelectorTreeItemData[];
+  /** ID of the tree view */
+  id?: string;
+  /** Flag indicating this list is the chosen pane. */
+  isChosen?: boolean;
+  /** Flag indicating if all options should have checkboxes */
+  hasChecks?: boolean;
+  /** Flag indicating if all options should have badges */
+  hasBadges?: boolean;
+  /** Sets the default expanded behavior */
+  defaultAllExpanded?: boolean;
+  /** Callback fired when an option is selected.  */
+  onOptionSelect?: (
+    e: React.MouseEvent | React.ChangeEvent,
+    index: number,
+    isChosen: boolean,
+    text?: string,
+    itemData?: any,
+    parentData?: any
+  ) => void;
+  /** Callback fired when an option is checked */
+  onOptionCheck?: (
+    event: React.ChangeEvent<HTMLInputElement>,
+    isChosen: boolean,
+    itemData: DualListSelectorTreeItemData
+  ) => void;
+  /** Internal. Parent item of an option */
+  parentItem?: DualListSelectorTreeItemData;
+  /** Reference of selected options */
+  selectedOptions?: string[];
+  /** Internal callback to pass this ref up to the parent. */
+  sendRef?: (optionRef: React.ReactNode, index: number) => void;
+}
+
+export const DualListSelectorTree: React.FunctionComponent<DualListSelectorTreeProps> = ({
+  data,
+  isChosen,
+  hasChecks = false,
+  hasBadges = false,
+  defaultAllExpanded = false,
+  parentItem,
+  onOptionSelect,
+  onOptionCheck,
+  sendRef,
+  selectedOptions = [],
+  ...props
+}: DualListSelectorTreeProps) => (
+  <ul className={css(styles.dualListSelectorList)} {...props}>
+    {data.map(item => (
+      <DualListSelectorTreeItem
+        key={item.text}
+        text={item.text}
+        id={item.id}
+        isChosen={isChosen}
+        isSelected={selectedOptions.includes(item.text)}
+        defaultExpanded={item.defaultExpanded !== undefined ? item.defaultExpanded : defaultAllExpanded}
+        onOptionSelect={onOptionSelect}
+        onOptionCheck={onOptionCheck}
+        hasCheck={item.hasCheck !== undefined ? item.hasCheck : hasChecks}
+        checked={item.checked}
+        checkProps={item.checkProps}
+        hasBadge={item.hasBadge !== undefined ? item.hasBadge : hasBadges}
+        badgeProps={item.badgeProps}
+        parentItem={parentItem}
+        sendRef={sendRef}
+        itemData={item}
+        {...(item.children && {
+          children: (
+            <DualListSelectorTree
+              data={item.children}
+              parentItem={item}
+              hasChecks={hasChecks}
+              hasBadges={hasBadges}
+              isChosen={isChosen}
+              defaultAllExpanded={defaultAllExpanded}
+              onOptionSelect={onOptionSelect}
+              onOptionCheck={onOptionCheck}
+              sendRef={sendRef}
+              selectedOptions={selectedOptions}
+            />
+          )
+        })}
+      />
+    ))}
+  </ul>
+);
+
+DualListSelectorTree.displayName = 'DualListSelectorTree';

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorTree.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorTree.tsx
@@ -60,6 +60,8 @@ export interface DualListSelectorTreeProps {
   id?: string;
   /** Flag indicating this list is the chosen pane. */
   isChosen?: boolean;
+  /** Flag indicating if the list is nested */
+  isNested?: boolean;
   /** Flag indicating if all options should have checkboxes */
   hasChecks?: boolean;
   /** Flag indicating if all options should have badges */
@@ -94,6 +96,7 @@ export const DualListSelectorTree: React.FunctionComponent<DualListSelectorTreeP
   isChosen,
   hasChecks = false,
   hasBadges = false,
+  isNested = false,
   defaultAllExpanded = false,
   parentItem,
   onOptionSelect,
@@ -102,7 +105,7 @@ export const DualListSelectorTree: React.FunctionComponent<DualListSelectorTreeP
   selectedOptions = [],
   ...props
 }: DualListSelectorTreeProps) => (
-  <ul className={css(styles.dualListSelectorList)} {...props}>
+  <ul className={css(styles.dualListSelectorList)} role={isNested ? 'group' : 'tree'} {...props}>
     {data.map(item => (
       <DualListSelectorTreeItem
         key={item.text}
@@ -124,6 +127,7 @@ export const DualListSelectorTree: React.FunctionComponent<DualListSelectorTreeP
         {...(item.children && {
           children: (
             <DualListSelectorTree
+              isNested
               data={item.children}
               parentItem={item}
               hasChecks={hasChecks}

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorTree.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorTree.tsx
@@ -27,7 +27,8 @@ export interface DualListSelectorTreeItemData {
   ) => void;
   /** Callback fired when an option is checked */
   onOptionCheck?: (
-    event: React.ChangeEvent<HTMLInputElement>,
+    event: React.MouseEvent | React.ChangeEvent<HTMLInputElement>,
+    isChecked: boolean,
     isChosen: boolean,
     itemData: DualListSelectorTreeItemData
   ) => void;
@@ -69,7 +70,8 @@ export interface DualListSelectorTreeProps {
   ) => void;
   /** Callback fired when an option is checked */
   onOptionCheck?: (
-    event: React.ChangeEvent<HTMLInputElement>,
+    event: React.MouseEvent | React.ChangeEvent<HTMLInputElement>,
+    isChecked: boolean,
     isChosen: boolean,
     itemData: DualListSelectorTreeItemData
   ) => void;

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorTreeItem.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorTreeItem.tsx
@@ -5,6 +5,7 @@ import { DualListSelectorTreeItemData } from './DualListSelectorTree';
 import { Badge } from '../Badge';
 import AngleRightIcon from '@patternfly/react-icons/dist/js/icons/angle-right-icon';
 import AngleDownIcon from '@patternfly/react-icons/dist/js/icons/angle-down-icon';
+import { flattenTree } from './treeUtils';
 
 export interface DualListSelectorTreeItemProps extends React.HTMLProps<HTMLLIElement> {
   /** Content rendered inside the dual list selector. */
@@ -155,7 +156,7 @@ export class DualListSelectorTreeItem extends React.Component<DualListSelectorTr
             <span className={css(styles.dualListSelectorItemText)}>{text}</span>
             {hasBadge && children && (
               <span className={css(styles.dualListSelectorItemCount)}>
-                <Badge {...badgeProps}>{(children as React.ReactElement).props.data.length}</Badge>
+                <Badge {...badgeProps}>{flattenTree((children as React.ReactElement).props.data).length}</Badge>
               </span>
             )}
           </span>

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorTreeItem.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorTreeItem.tsx
@@ -30,7 +30,8 @@ export interface DualListSelectorTreeItemProps extends React.HTMLProps<HTMLLIEle
   ) => void;
   /** Callback fired when an option is checked */
   onOptionCheck?: (
-    event: React.ChangeEvent<HTMLInputElement>,
+    event: React.MouseEvent | React.ChangeEvent<HTMLInputElement>,
+    isChecked: boolean,
     isChosen: boolean,
     itemData: DualListSelectorTreeItemData
   ) => void;
@@ -96,6 +97,9 @@ export class DualListSelectorTreeItem extends React.Component<DualListSelectorTr
           className={css(styles.dualListSelectorItem, isSelected && styles.modifiers.selected, styles.modifiers.check)}
           ref={this.ref}
           tabIndex={-1}
+          onClick={evt => {
+            onOptionCheck && onOptionCheck(evt, !isChecked, isChosen, itemData);
+          }}
         >
           <span className={css(styles.dualListSelectorItemMain)}>
             {children && (
@@ -117,7 +121,7 @@ export class DualListSelectorTreeItem extends React.Component<DualListSelectorTr
               <input
                 type="checkbox"
                 onChange={(evt: React.ChangeEvent<HTMLInputElement>) =>
-                  onOptionCheck && onOptionCheck(evt, isChosen, itemData)
+                  onOptionCheck && onOptionCheck(evt, !isChecked, isChosen, itemData)
                 }
                 onClick={(evt: React.MouseEvent) => evt.stopPropagation()}
                 ref={elem => elem && (elem.indeterminate = isChecked === null)}

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorTreeItem.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorTreeItem.tsx
@@ -17,8 +17,6 @@ export interface DualListSelectorTreeItemProps extends React.HTMLProps<HTMLLIEle
   isChosen?: boolean;
   /** Flag indicating this option is expanded by default. */
   defaultExpanded?: boolean;
-  /** Flag indicating this option has a checkbox */
-  hasCheck?: boolean;
   /** Flag indicating this option has a badge */
   hasBadge?: boolean;
   /** Callback fired when an option is selected.  */
@@ -61,9 +59,9 @@ export class DualListSelectorTreeItem extends React.Component<DualListSelectorTr
 
   render() {
     const {
-      onOptionSelect,
       onOptionCheck,
       /* eslint-disable @typescript-eslint/no-unused-vars */
+      onOptionSelect,
       children,
       className,
       id,
@@ -71,7 +69,6 @@ export class DualListSelectorTreeItem extends React.Component<DualListSelectorTr
       isSelected,
       isChosen,
       defaultExpanded,
-      hasCheck,
       hasBadge,
       isChecked,
       checkProps,
@@ -96,16 +93,7 @@ export class DualListSelectorTreeItem extends React.Component<DualListSelectorTr
         {...(isExpanded && { 'aria-expanded': 'true' })}
       >
         <div
-          className={css(
-            styles.dualListSelectorItem,
-            isSelected && styles.modifiers.selected,
-            hasCheck && styles.modifiers.check
-          )}
-          onClick={e => {
-            if (!hasCheck) {
-              onOptionSelect(e, null, isChosen, id, itemData, parentItem);
-            }
-          }}
+          className={css(styles.dualListSelectorItem, isSelected && styles.modifiers.selected, styles.modifiers.check)}
           ref={this.ref}
           tabIndex={-1}
         >
@@ -125,20 +113,19 @@ export class DualListSelectorTreeItem extends React.Component<DualListSelectorTr
                 </span>
               </div>
             )}
-            {hasCheck && (
-              <span className={css(styles.dualListSelectorItemCheck)}>
-                <input
-                  type="checkbox"
-                  onChange={(evt: React.ChangeEvent<HTMLInputElement>) =>
-                    onOptionCheck && onOptionCheck(evt, isChosen, itemData)
-                  }
-                  onClick={(evt: React.MouseEvent) => evt.stopPropagation()}
-                  ref={elem => elem && (elem.indeterminate = isChecked === null)}
-                  checked={isChecked || false}
-                  {...checkProps}
-                />
-              </span>
-            )}
+            <span className={css(styles.dualListSelectorItemCheck)}>
+              <input
+                type="checkbox"
+                onChange={(evt: React.ChangeEvent<HTMLInputElement>) =>
+                  onOptionCheck && onOptionCheck(evt, isChosen, itemData)
+                }
+                onClick={(evt: React.MouseEvent) => evt.stopPropagation()}
+                ref={elem => elem && (elem.indeterminate = isChecked === null)}
+                checked={isChecked || false}
+                {...checkProps}
+              />
+            </span>
+
             <span className={css(styles.dualListSelectorItemText)}>{text}</span>
             {hasBadge && children && (
               <span className={css(styles.dualListSelectorItemCount)}>

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorTreeItem.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorTreeItem.tsx
@@ -116,7 +116,9 @@ export class DualListSelectorTreeItem extends React.Component<DualListSelectorTr
             if (children) {
               this.setState({ isExpanded: !this.state.isExpanded });
             }
-            onOptionSelect(e, null, isChosen, text, itemData, parentItem);
+            if (!hasCheck) {
+              onOptionSelect(e, null, isChosen, text, itemData, parentItem);
+            }
           }}
           id={id}
           ref={this.ref}

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorTreeItem.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorTreeItem.tsx
@@ -21,18 +21,12 @@ export interface DualListSelectorTreeItemProps extends React.HTMLProps<HTMLLIEle
   hasCheck?: boolean;
   /** Flag indicating this option has a badge */
   hasBadge?: boolean;
-  /** Internal callback to pass this ref up to the parent. */
-  sendRef?: (optionRef: React.ReactNode, index: number) => void;
-  /** Internal field used to keep track of the order of filtered options. */
-  filteredIndex?: number;
-  /** Internal field used to keep track of order of unfiltered options. */
-  orderIndex?: number;
   /** Callback fired when an option is selected.  */
   onOptionSelect?: (
     e: React.MouseEvent | React.ChangeEvent,
     index: number,
     isChosen: boolean,
-    text?: string,
+    id?: string,
     itemData?: any,
     parentData?: any
   ) => void;
@@ -48,6 +42,8 @@ export interface DualListSelectorTreeItemProps extends React.HTMLProps<HTMLLIEle
   text: string;
   /** Parent item of the option */
   parentItem?: DualListSelectorTreeItemData;
+  /** Flag indicating if this open is checked. */
+  isChecked?: boolean;
   /** Additional properties to pass to the option checkbox */
   checkProps?: any;
   /** Additional properties to pass to the option badge */
@@ -63,21 +59,11 @@ export class DualListSelectorTreeItem extends React.Component<DualListSelectorTr
     isExpanded: this.props.defaultExpanded || false
   };
 
-  componentDidMount() {
-    this.props.sendRef(this.ref.current, this.props.filteredIndex);
-  }
-
-  componentDidUpdate() {
-    this.props.sendRef(this.ref.current, this.props.filteredIndex);
-  }
-
   render() {
     const {
       onOptionSelect,
       onOptionCheck,
       /* eslint-disable @typescript-eslint/no-unused-vars */
-      sendRef,
-      orderIndex,
       children,
       className,
       id,
@@ -87,8 +73,7 @@ export class DualListSelectorTreeItem extends React.Component<DualListSelectorTr
       defaultExpanded,
       hasCheck,
       hasBadge,
-      filteredIndex,
-      checked,
+      isChecked,
       checkProps,
       badgeProps,
       parentItem,
@@ -104,7 +89,7 @@ export class DualListSelectorTreeItem extends React.Component<DualListSelectorTr
           children && styles.modifiers.expandable,
           isExpanded && styles.modifiers.expanded
         )}
-        key={orderIndex}
+        id={id}
         {...props}
         aria-selected={isSelected}
         role="treeitem"
@@ -118,10 +103,9 @@ export class DualListSelectorTreeItem extends React.Component<DualListSelectorTr
           )}
           onClick={e => {
             if (!hasCheck) {
-              onOptionSelect(e, null, isChosen, text, itemData, parentItem);
+              onOptionSelect(e, null, isChosen, id, itemData, parentItem);
             }
           }}
-          id={id}
           ref={this.ref}
           tabIndex={-1}
         >
@@ -149,8 +133,8 @@ export class DualListSelectorTreeItem extends React.Component<DualListSelectorTr
                     onOptionCheck && onOptionCheck(evt, isChosen, itemData)
                   }
                   onClick={(evt: React.MouseEvent) => evt.stopPropagation()}
-                  ref={elem => elem && (elem.indeterminate = checked === null)}
-                  checked={checked || false}
+                  ref={elem => elem && (elem.indeterminate = isChecked === null)}
+                  checked={isChecked || false}
                   {...checkProps}
                 />
               </span>

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorTreeItem.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorTreeItem.tsx
@@ -101,7 +101,7 @@ export class DualListSelectorTreeItem extends React.Component<DualListSelectorTr
         className={css(
           styles.dualListSelectorListItem,
           className,
-          children && 'pf-m-expandable',
+          children && styles.modifiers.expandable,
           isExpanded && styles.modifiers.expanded
         )}
         key={orderIndex}

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorTreeItem.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorTreeItem.tsx
@@ -98,7 +98,12 @@ export class DualListSelectorTreeItem extends React.Component<DualListSelectorTr
     const { isExpanded } = this.state;
     return (
       <li
-        className={css(styles.dualListSelectorListItem, className, isExpanded && styles.modifiers.expanded)}
+        className={css(
+          styles.dualListSelectorListItem,
+          className,
+          children && 'pf-m-expandable',
+          isExpanded && styles.modifiers.expanded
+        )}
         key={orderIndex}
         {...props}
         aria-selected={isSelected}

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorTreeItem.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorTreeItem.tsx
@@ -113,9 +113,6 @@ export class DualListSelectorTreeItem extends React.Component<DualListSelectorTr
         <div
           className={css(styles.dualListSelectorItem, isSelected && styles.modifiers.selected)}
           onClick={e => {
-            if (children) {
-              this.setState({ isExpanded: !this.state.isExpanded });
-            }
             if (!hasCheck) {
               onOptionSelect(e, null, isChosen, text, itemData, parentItem);
             }

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorTreeItem.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorTreeItem.tsx
@@ -1,0 +1,168 @@
+import * as React from 'react';
+import styles from '@patternfly/react-styles/css/components/DualListSelector/dual-list-selector';
+import { css } from '@patternfly/react-styles';
+import { DualListSelectorTreeItemData } from './DualListSelectorTree';
+import { Badge } from '../Badge';
+import AngleRightIcon from '@patternfly/react-icons/dist/js/icons/angle-right-icon';
+import AngleDownIcon from '@patternfly/react-icons/dist/js/icons/angle-down-icon';
+
+export interface DualListSelectorTreeItemProps extends React.HTMLProps<HTMLLIElement> {
+  /** Content rendered inside the dual list selector. */
+  children?: React.ReactNode;
+  /** Additional classes applied to the dual list selector. */
+  className?: string;
+  /** Flag indicating the option is currently selected. */
+  isSelected?: boolean;
+  /** Flag indicating this option is in the chosen pane. */
+  isChosen?: boolean;
+  /** Flag indicating this option is expanded by default. */
+  defaultExpanded?: boolean;
+  /** Flag indicating this option has a checkbox */
+  hasCheck?: boolean;
+  /** Flag indicating this option has a badge */
+  hasBadge?: boolean;
+  /** Internal callback to pass this ref up to the parent. */
+  sendRef?: (optionRef: React.ReactNode, index: number) => void;
+  /** Internal field used to keep track of the order of filtered options. */
+  filteredIndex?: number;
+  /** Internal field used to keep track of order of unfiltered options. */
+  orderIndex?: number;
+  /** Callback fired when an option is selected.  */
+  onOptionSelect?: (
+    e: React.MouseEvent | React.ChangeEvent,
+    index: number,
+    isChosen: boolean,
+    text?: string,
+    itemData?: any,
+    parentData?: any
+  ) => void;
+  /** Callback fired when an option is checked */
+  onOptionCheck?: (
+    event: React.ChangeEvent<HTMLInputElement>,
+    isChosen: boolean,
+    itemData: DualListSelectorTreeItemData
+  ) => void;
+  /** ID of the option */
+  id: string;
+  /** Text of the option */
+  text: string;
+  /** Parent item of the option */
+  parentItem?: DualListSelectorTreeItemData;
+  /** Additional properties to pass to the option checkbox */
+  checkProps?: any;
+  /** Additional properties to pass to the option badge */
+  badgeProps?: any;
+  /** Raw data of the option */
+  itemData?: DualListSelectorTreeItemData;
+}
+
+export class DualListSelectorTreeItem extends React.Component<DualListSelectorTreeItemProps> {
+  private ref = React.createRef<HTMLDivElement>();
+  static displayName = 'DualListSelectorTreeItem';
+  state = {
+    isExpanded: this.props.defaultExpanded || false
+  };
+
+  componentDidMount() {
+    this.props.sendRef(this.ref.current, this.props.filteredIndex);
+  }
+
+  componentDidUpdate() {
+    this.props.sendRef(this.ref.current, this.props.filteredIndex);
+  }
+
+  render() {
+    const {
+      onOptionSelect,
+      onOptionCheck,
+      /* eslint-disable @typescript-eslint/no-unused-vars */
+      sendRef,
+      orderIndex,
+      children,
+      className,
+      id,
+      text,
+      isSelected,
+      isChosen,
+      defaultExpanded,
+      hasCheck,
+      hasBadge,
+      filteredIndex,
+      checked,
+      checkProps,
+      badgeProps,
+      parentItem,
+      itemData,
+      ...props
+    } = this.props;
+    const { isExpanded } = this.state;
+    return (
+      <li
+        className={css(
+          styles.dualListSelectorListItem,
+          className,
+          children && styles.modifiers.expandable,
+          isExpanded && styles.modifiers.expanded
+        )}
+        key={orderIndex}
+        {...props}
+        aria-selected={isSelected}
+        role="treeitem"
+        {...(isExpanded && { 'aria-expanded': 'true' })}
+      >
+        <div
+          className={css(styles.dualListSelectorItem, isSelected && styles.modifiers.selected)}
+          onClick={e => {
+            if (children) {
+              this.setState({ isExpanded: !this.state.isExpanded });
+            }
+            onOptionSelect(e, null, isChosen, text, itemData, parentItem);
+          }}
+          id={id}
+          ref={this.ref}
+          tabIndex={-1}
+        >
+          <span className={css(styles.dualListSelectorItemMain)}>
+            {children && (
+              <div
+                className={css(styles.dualListSelectorItemToggle)}
+                onClick={e => {
+                  if (children) {
+                    this.setState({ isExpanded: !this.state.isExpanded });
+                  }
+                  e.stopPropagation();
+                }}
+              >
+                <span className={css(styles.dualListSelectorItemToggleIcon)}>
+                  {!isExpanded && <AngleRightIcon aria-hidden />}
+                  {isExpanded && <AngleDownIcon aria-hidden />}
+                </span>
+              </div>
+            )}
+            {hasCheck && (
+              <span className={css(styles.dualListSelectorItemCheck)}>
+                <input
+                  type="checkbox"
+                  onChange={(evt: React.ChangeEvent<HTMLInputElement>) =>
+                    onOptionCheck && onOptionCheck(evt, isChosen, itemData)
+                  }
+                  onClick={(evt: React.MouseEvent) => evt.stopPropagation()}
+                  ref={elem => elem && (elem.indeterminate = checked === null)}
+                  checked={checked || false}
+                  {...checkProps}
+                />
+              </span>
+            )}
+            <span className={css(styles.dualListSelectorItemText)}>{text}</span>
+            {hasBadge && children && (
+              <span className={css(styles.dualListSelectorItemCount)}>
+                <Badge {...badgeProps}>{(children as React.ReactElement).props.data.length}</Badge>
+              </span>
+            )}
+          </span>
+        </div>
+        {isExpanded && children}
+      </li>
+    );
+  }
+}

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorTreeItem.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorTreeItem.tsx
@@ -4,7 +4,6 @@ import { css } from '@patternfly/react-styles';
 import { DualListSelectorTreeItemData } from './DualListSelectorTree';
 import { Badge } from '../Badge';
 import AngleRightIcon from '@patternfly/react-icons/dist/js/icons/angle-right-icon';
-import AngleDownIcon from '@patternfly/react-icons/dist/js/icons/angle-down-icon';
 import { flattenTree } from './treeUtils';
 
 export interface DualListSelectorTreeItemProps extends React.HTMLProps<HTMLLIElement> {
@@ -99,12 +98,7 @@ export class DualListSelectorTreeItem extends React.Component<DualListSelectorTr
     const { isExpanded } = this.state;
     return (
       <li
-        className={css(
-          styles.dualListSelectorListItem,
-          className,
-          children && styles.modifiers.expandable,
-          isExpanded && styles.modifiers.expanded
-        )}
+        className={css(styles.dualListSelectorListItem, className, isExpanded && styles.modifiers.expanded)}
         key={orderIndex}
         {...props}
         aria-selected={isSelected}
@@ -112,7 +106,11 @@ export class DualListSelectorTreeItem extends React.Component<DualListSelectorTr
         {...(isExpanded && { 'aria-expanded': 'true' })}
       >
         <div
-          className={css(styles.dualListSelectorItem, isSelected && styles.modifiers.selected)}
+          className={css(
+            styles.dualListSelectorItem,
+            isSelected && styles.modifiers.selected,
+            hasCheck && styles.modifiers.check
+          )}
           onClick={e => {
             if (!hasCheck) {
               onOptionSelect(e, null, isChosen, text, itemData, parentItem);
@@ -134,8 +132,7 @@ export class DualListSelectorTreeItem extends React.Component<DualListSelectorTr
                 }}
               >
                 <span className={css(styles.dualListSelectorItemToggleIcon)}>
-                  {!isExpanded && <AngleRightIcon aria-hidden />}
-                  {isExpanded && <AngleDownIcon aria-hidden />}
+                  <AngleRightIcon aria-hidden />
                 </span>
               </div>
             )}

--- a/packages/react-core/src/components/DualListSelector/__tests__/DualListSelector.test.tsx
+++ b/packages/react-core/src/components/DualListSelector/__tests__/DualListSelector.test.tsx
@@ -28,7 +28,10 @@ describe('DualListSelector', () => {
   test('with tree', () => {
     const view = mount(
       <DualListSelector
-        availableOptions={[{ text: 'Opt1', defaultExpanded: true, children: [{ text: 'Opt3' }] }, { text: 'Opt2' }]}
+        availableOptions={[
+          { id: 'O1', text: 'Opt1', defaultExpanded: true, children: [{ id: 'O3', text: 'Opt3' }] },
+          { id: 'O2', text: 'Opt2' }
+        ]}
         availableOptionsStatus="Test status1"
         chosenOptionsStatus="Test status2"
         id="tree-test"

--- a/packages/react-core/src/components/DualListSelector/__tests__/DualListSelector.test.tsx
+++ b/packages/react-core/src/components/DualListSelector/__tests__/DualListSelector.test.tsx
@@ -4,16 +4,12 @@ import React from 'react';
 
 describe('DualListSelector', () => {
   test('basic', () => {
-    const view = mount(
-      <DualListSelector availableOptions={['Option 1', 'Option 2']} id="firstTest"/>
-    );
+    const view = mount(<DualListSelector availableOptions={['Option 1', 'Option 2']} id="firstTest" />);
     expect(view).toMatchSnapshot();
   });
 
   test('with search inputs', () => {
-    const view = mount(
-      <DualListSelector availableOptions={['Option 1', 'Option 2']} id="secondTest" isSearchable/>
-    );
+    const view = mount(<DualListSelector availableOptions={['Option 1', 'Option 2']} id="secondTest" isSearchable />);
     expect(view).toMatchSnapshot();
   });
 
@@ -24,6 +20,19 @@ describe('DualListSelector', () => {
         availableOptionsStatus="Test status1"
         chosenOptionsStatus="Test status2"
         id="thirdTest"
+      />
+    );
+    expect(view).toMatchSnapshot();
+  });
+
+  test('with tree', () => {
+    const view = mount(
+      <DualListSelector
+        availableOptions={[{ text: 'Opt1', defaultExpanded: true, children: [{ text: 'Opt3' }] }, { text: 'Opt2' }]}
+        availableOptionsStatus="Test status1"
+        chosenOptionsStatus="Test status2"
+        id="tree-test"
+        isTree
       />
     );
     expect(view).toMatchSnapshot();

--- a/packages/react-core/src/components/DualListSelector/__tests__/__snapshots__/DualListSelector.test.tsx.snap
+++ b/packages/react-core/src/components/DualListSelector/__tests__/__snapshots__/DualListSelector.test.tsx.snap
@@ -2003,6 +2003,7 @@ exports[`DualListSelector with tree 1`] = `
                 >
                   <div
                     className="pf-c-dual-list-selector__item pf-m-check"
+                    onClick={[Function]}
                     tabIndex={-1}
                   >
                     <span
@@ -2138,6 +2139,7 @@ exports[`DualListSelector with tree 1`] = `
                         >
                           <div
                             className="pf-c-dual-list-selector__item pf-m-check"
+                            onClick={[Function]}
                             tabIndex={-1}
                           >
                             <span
@@ -2193,6 +2195,7 @@ exports[`DualListSelector with tree 1`] = `
                 >
                   <div
                     className="pf-c-dual-list-selector__item pf-m-check"
+                    onClick={[Function]}
                     tabIndex={-1}
                   >
                     <span

--- a/packages/react-core/src/components/DualListSelector/__tests__/__snapshots__/DualListSelector.test.tsx.snap
+++ b/packages/react-core/src/components/DualListSelector/__tests__/__snapshots__/DualListSelector.test.tsx.snap
@@ -1976,7 +1976,7 @@ exports[`DualListSelector with tree 1`] = `
                 <li
                   aria-expanded="true"
                   aria-selected={false}
-                  className="pf-c-dual-list-selector__list-item pf-m-expanded"
+                  className="pf-c-dual-list-selector__list-item pf-m-expandable pf-m-expanded"
                   role="treeitem"
                 >
                   <div

--- a/packages/react-core/src/components/DualListSelector/__tests__/__snapshots__/DualListSelector.test.tsx.snap
+++ b/packages/react-core/src/components/DualListSelector/__tests__/__snapshots__/DualListSelector.test.tsx.snap
@@ -1948,6 +1948,7 @@ exports[`DualListSelector with tree 1`] = `
           >
             <ul
               className="pf-c-dual-list-selector__list"
+              role="tree"
             >
               <DualListSelectorTreeItem
                 defaultExpanded={true}
@@ -2039,6 +2040,7 @@ exports[`DualListSelector with tree 1`] = `
                     hasBadges={false}
                     hasChecks={false}
                     isChosen={false}
+                    isNested={true}
                     onOptionCheck={[Function]}
                     onOptionSelect={[Function]}
                     parentItem={
@@ -2057,6 +2059,7 @@ exports[`DualListSelector with tree 1`] = `
                   >
                     <ul
                       className="pf-c-dual-list-selector__list"
+                      role="group"
                     >
                       <DualListSelectorTreeItem
                         defaultExpanded={false}
@@ -2419,6 +2422,7 @@ exports[`DualListSelector with tree 1`] = `
           >
             <ul
               className="pf-c-dual-list-selector__list"
+              role="tree"
             />
           </DualListSelectorTree>
         </div>

--- a/packages/react-core/src/components/DualListSelector/__tests__/__snapshots__/DualListSelector.test.tsx.snap
+++ b/packages/react-core/src/components/DualListSelector/__tests__/__snapshots__/DualListSelector.test.tsx.snap
@@ -1976,7 +1976,7 @@ exports[`DualListSelector with tree 1`] = `
                 <li
                   aria-expanded="true"
                   aria-selected={false}
-                  className="pf-c-dual-list-selector__list-item pf-m-expandable pf-m-expanded"
+                  className="pf-c-dual-list-selector__list-item pf-m-expanded"
                   role="treeitem"
                 >
                   <div
@@ -1994,7 +1994,7 @@ exports[`DualListSelector with tree 1`] = `
                         <span
                           className="pf-c-dual-list-selector__item-toggle-icon"
                         >
-                          <AngleDownIcon
+                          <AngleRightIcon
                             aria-hidden={true}
                             color="currentColor"
                             noVerticalAlign={false}
@@ -2011,14 +2011,14 @@ exports[`DualListSelector with tree 1`] = `
                                   "verticalAlign": "-0.125em",
                                 }
                               }
-                              viewBox="0 0 320 512"
+                              viewBox="0 0 256 512"
                               width="1em"
                             >
                               <path
-                                d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
                               />
                             </svg>
-                          </AngleDownIcon>
+                          </AngleRightIcon>
                         </span>
                       </div>
                       <span

--- a/packages/react-core/src/components/DualListSelector/__tests__/__snapshots__/DualListSelector.test.tsx.snap
+++ b/packages/react-core/src/components/DualListSelector/__tests__/__snapshots__/DualListSelector.test.tsx.snap
@@ -1837,13 +1837,16 @@ exports[`DualListSelector with tree 1`] = `
       Object {
         "children": Array [
           Object {
+            "id": "O3",
             "text": "Opt3",
           },
         ],
         "defaultExpanded": true,
+        "id": "O1",
         "text": "Opt1",
       },
       Object {
+        "id": "O2",
         "text": "Opt2",
       },
     ]
@@ -1877,13 +1880,16 @@ exports[`DualListSelector with tree 1`] = `
           Object {
             "children": Array [
               Object {
+                "id": "O3",
                 "text": "Opt3",
               },
             ],
             "defaultExpanded": true,
+            "id": "O1",
             "text": "Opt1",
           },
           Object {
+            "id": "O2",
             "text": "Opt2",
           },
         ]
@@ -1929,13 +1935,16 @@ exports[`DualListSelector with tree 1`] = `
                 Object {
                   "children": Array [
                     Object {
+                      "id": "O3",
                       "text": "Opt3",
                     },
                   ],
                   "defaultExpanded": true,
+                  "id": "O1",
                   "text": "Opt1",
                 },
                 Object {
+                  "id": "O2",
                   "text": "Opt2",
                 },
               ]
@@ -1944,7 +1953,6 @@ exports[`DualListSelector with tree 1`] = `
             onOptionCheck={[Function]}
             onOptionSelect={[Function]}
             selectedOptions={Array []}
-            sendRef={[Function]}
           >
             <ul
               className="pf-c-dual-list-selector__list"
@@ -1954,29 +1962,32 @@ exports[`DualListSelector with tree 1`] = `
                 defaultExpanded={true}
                 hasBadge={false}
                 hasCheck={false}
+                id="O1"
                 isChosen={false}
                 isSelected={false}
                 itemData={
                   Object {
                     "children": Array [
                       Object {
+                        "id": "O3",
                         "text": "Opt3",
                       },
                     ],
                     "defaultExpanded": true,
+                    "id": "O1",
                     "text": "Opt1",
                   }
                 }
-                key="Opt1"
+                key="O1"
                 onOptionCheck={[Function]}
                 onOptionSelect={[Function]}
-                sendRef={[Function]}
                 text="Opt1"
               >
                 <li
                   aria-expanded="true"
                   aria-selected={false}
                   className="pf-c-dual-list-selector__list-item pf-m-expandable pf-m-expanded"
+                  id="O1"
                   role="treeitem"
                 >
                   <div
@@ -2032,6 +2043,7 @@ exports[`DualListSelector with tree 1`] = `
                     data={
                       Array [
                         Object {
+                          "id": "O3",
                           "text": "Opt3",
                         },
                       ]
@@ -2047,15 +2059,16 @@ exports[`DualListSelector with tree 1`] = `
                       Object {
                         "children": Array [
                           Object {
+                            "id": "O3",
                             "text": "Opt3",
                           },
                         ],
                         "defaultExpanded": true,
+                        "id": "O1",
                         "text": "Opt1",
                       }
                     }
                     selectedOptions={Array []}
-                    sendRef={[Function]}
                   >
                     <ul
                       className="pf-c-dual-list-selector__list"
@@ -2065,33 +2078,37 @@ exports[`DualListSelector with tree 1`] = `
                         defaultExpanded={false}
                         hasBadge={false}
                         hasCheck={false}
+                        id="O3"
                         isChosen={false}
                         isSelected={false}
                         itemData={
                           Object {
+                            "id": "O3",
                             "text": "Opt3",
                           }
                         }
-                        key="Opt3"
+                        key="O3"
                         onOptionCheck={[Function]}
                         onOptionSelect={[Function]}
                         parentItem={
                           Object {
                             "children": Array [
                               Object {
+                                "id": "O3",
                                 "text": "Opt3",
                               },
                             ],
                             "defaultExpanded": true,
+                            "id": "O1",
                             "text": "Opt1",
                           }
                         }
-                        sendRef={[Function]}
                         text="Opt3"
                       >
                         <li
                           aria-selected={false}
                           className="pf-c-dual-list-selector__list-item"
+                          id="O3"
                           role="treeitem"
                         >
                           <div
@@ -2119,22 +2136,24 @@ exports[`DualListSelector with tree 1`] = `
                 defaultExpanded={false}
                 hasBadge={false}
                 hasCheck={false}
+                id="O2"
                 isChosen={false}
                 isSelected={false}
                 itemData={
                   Object {
+                    "id": "O2",
                     "text": "Opt2",
                   }
                 }
-                key="Opt2"
+                key="O2"
                 onOptionCheck={[Function]}
                 onOptionSelect={[Function]}
-                sendRef={[Function]}
                 text="Opt2"
               >
                 <li
                   aria-selected={false}
                   className="pf-c-dual-list-selector__list-item"
+                  id="O2"
                   role="treeitem"
                 >
                   <div
@@ -2418,7 +2437,6 @@ exports[`DualListSelector with tree 1`] = `
             onOptionCheck={[Function]}
             onOptionSelect={[Function]}
             selectedOptions={Array []}
-            sendRef={[Function]}
           >
             <ul
               className="pf-c-dual-list-selector__list"

--- a/packages/react-core/src/components/DualListSelector/__tests__/__snapshots__/DualListSelector.test.tsx.snap
+++ b/packages/react-core/src/components/DualListSelector/__tests__/__snapshots__/DualListSelector.test.tsx.snap
@@ -1970,7 +1970,6 @@ exports[`DualListSelector with tree 1`] = `
               <DualListSelectorTreeItem
                 defaultExpanded={true}
                 hasBadge={false}
-                hasCheck={true}
                 id="O1"
                 isChecked={false}
                 isChosen={false}
@@ -2004,7 +2003,6 @@ exports[`DualListSelector with tree 1`] = `
                 >
                   <div
                     className="pf-c-dual-list-selector__item pf-m-check"
-                    onClick={[Function]}
                     tabIndex={-1}
                   >
                     <span
@@ -2101,7 +2099,6 @@ exports[`DualListSelector with tree 1`] = `
                       <DualListSelectorTreeItem
                         defaultExpanded={false}
                         hasBadge={false}
-                        hasCheck={true}
                         id="O3"
                         isChecked={false}
                         isChosen={false}
@@ -2141,7 +2138,6 @@ exports[`DualListSelector with tree 1`] = `
                         >
                           <div
                             className="pf-c-dual-list-selector__item pf-m-check"
-                            onClick={[Function]}
                             tabIndex={-1}
                           >
                             <span
@@ -2173,7 +2169,6 @@ exports[`DualListSelector with tree 1`] = `
               <DualListSelectorTreeItem
                 defaultExpanded={false}
                 hasBadge={false}
-                hasCheck={true}
                 id="O2"
                 isChecked={false}
                 isChosen={false}
@@ -2198,7 +2193,6 @@ exports[`DualListSelector with tree 1`] = `
                 >
                   <div
                     className="pf-c-dual-list-selector__item pf-m-check"
-                    onClick={[Function]}
                     tabIndex={-1}
                   >
                     <span

--- a/packages/react-core/src/components/DualListSelector/__tests__/__snapshots__/DualListSelector.test.tsx.snap
+++ b/packages/react-core/src/components/DualListSelector/__tests__/__snapshots__/DualListSelector.test.tsx.snap
@@ -1872,7 +1872,6 @@ exports[`DualListSelector with tree 1`] = `
     id="tree-test"
   >
     <DualListSelectorPane
-      hasChecks={true}
       id="tree-test-available-pane"
       isChosen={false}
       isSearchable={false}
@@ -1959,7 +1958,6 @@ exports[`DualListSelector with tree 1`] = `
                 },
               ]
             }
-            hasChecks={true}
             isChosen={false}
             onOptionCheck={[Function]}
             onOptionSelect={[Function]}
@@ -2075,7 +2073,6 @@ exports[`DualListSelector with tree 1`] = `
                     }
                     defaultAllExpanded={false}
                     hasBadges={false}
-                    hasChecks={true}
                     isChosen={false}
                     isNested={true}
                     onOptionCheck={[Function]}
@@ -2442,7 +2439,6 @@ exports[`DualListSelector with tree 1`] = `
       </div>
     </div>
     <DualListSelectorPane
-      hasChecks={true}
       id="tree-test-chosen-pane"
       isChosen={true}
       isSearchable={false}
@@ -2487,7 +2483,6 @@ exports[`DualListSelector with tree 1`] = `
         >
           <DualListSelectorTree
             data={Array []}
-            hasChecks={true}
             isChosen={true}
             onOptionCheck={[Function]}
             onOptionSelect={[Function]}

--- a/packages/react-core/src/components/DualListSelector/__tests__/__snapshots__/DualListSelector.test.tsx.snap
+++ b/packages/react-core/src/components/DualListSelector/__tests__/__snapshots__/DualListSelector.test.tsx.snap
@@ -28,6 +28,7 @@ exports[`DualListSelector basic 1`] = `
       id="firstTest-available-pane"
       isChosen={false}
       isSearchable={false}
+      onOptionCheck={[Function]}
       onOptionSelect={[Function]}
       options={
         Array [
@@ -363,6 +364,7 @@ exports[`DualListSelector basic 1`] = `
       id="firstTest-chosen-pane"
       isChosen={true}
       isSearchable={false}
+      onOptionCheck={[Function]}
       onOptionSelect={[Function]}
       options={Array []}
       searchInputAriaLabel="Chosen search input"
@@ -468,6 +470,7 @@ exports[`DualListSelector with actions 1`] = `
       id="fourthTest-available-pane"
       isChosen={false}
       isSearchable={false}
+      onOptionCheck={[Function]}
       onOptionSelect={[Function]}
       options={
         Array [
@@ -622,7 +625,7 @@ exports[`DualListSelector with actions 1`] = `
             aria-disabled={false}
             aria-label="Add all"
             className="pf-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Button-plain-13"
+            data-ouia-component-id="OUIA-Generated-Button-plain-17"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe={true}
             disabled={false}
@@ -673,7 +676,7 @@ exports[`DualListSelector with actions 1`] = `
             aria-disabled={true}
             aria-label="Add selected"
             className="pf-c-button pf-m-plain pf-m-disabled"
-            data-ouia-component-id="OUIA-Generated-Button-plain-14"
+            data-ouia-component-id="OUIA-Generated-Button-plain-18"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe={true}
             disabled={true}
@@ -724,7 +727,7 @@ exports[`DualListSelector with actions 1`] = `
             aria-disabled={true}
             aria-label="Remove selected"
             className="pf-c-button pf-m-plain pf-m-disabled"
-            data-ouia-component-id="OUIA-Generated-Button-plain-15"
+            data-ouia-component-id="OUIA-Generated-Button-plain-19"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe={true}
             disabled={true}
@@ -775,7 +778,7 @@ exports[`DualListSelector with actions 1`] = `
             aria-disabled={false}
             aria-label="Remove all"
             className="pf-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Button-plain-16"
+            data-ouia-component-id="OUIA-Generated-Button-plain-20"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe={true}
             disabled={false}
@@ -823,6 +826,7 @@ exports[`DualListSelector with actions 1`] = `
       id="fourthTest-chosen-pane"
       isChosen={true}
       isSearchable={false}
+      onOptionCheck={[Function]}
       onOptionSelect={[Function]}
       options={
         Array [
@@ -991,6 +995,7 @@ exports[`DualListSelector with custom status 1`] = `
       id="thirdTest-available-pane"
       isChosen={false}
       isSearchable={false}
+      onOptionCheck={[Function]}
       onOptionSelect={[Function]}
       options={
         Array [
@@ -1326,6 +1331,7 @@ exports[`DualListSelector with custom status 1`] = `
       id="thirdTest-chosen-pane"
       isChosen={true}
       isSearchable={false}
+      onOptionCheck={[Function]}
       onOptionSelect={[Function]}
       options={Array []}
       searchInputAriaLabel="Chosen search input"
@@ -1406,6 +1412,7 @@ exports[`DualListSelector with search inputs 1`] = `
       id="secondTest-available-pane"
       isChosen={false}
       isSearchable={true}
+      onOptionCheck={[Function]}
       onOptionSelect={[Function]}
       options={
         Array [
@@ -1755,6 +1762,7 @@ exports[`DualListSelector with search inputs 1`] = `
       id="secondTest-chosen-pane"
       isChosen={true}
       isSearchable={true}
+      onOptionCheck={[Function]}
       onOptionSelect={[Function]}
       options={Array []}
       searchInputAriaLabel="Chosen search input"
@@ -1813,6 +1821,606 @@ exports[`DualListSelector with search inputs 1`] = `
             className="pf-c-dual-list-selector__list"
             role="listbox"
           />
+        </div>
+      </div>
+    </DualListSelectorPane>
+  </div>
+</DualListSelector>
+`;
+
+exports[`DualListSelector with tree 1`] = `
+<DualListSelector
+  addAllAriaLabel="Add all"
+  addSelectedAriaLabel="Add selected"
+  availableOptions={
+    Array [
+      Object {
+        "children": Array [
+          Object {
+            "text": "Opt3",
+          },
+        ],
+        "defaultExpanded": true,
+        "text": "Opt1",
+      },
+      Object {
+        "text": "Opt2",
+      },
+    ]
+  }
+  availableOptionsSearchAriaLabel="Available search input"
+  availableOptionsStatus="Test status1"
+  availableOptionsTitle="Available options"
+  chosenOptions={Array []}
+  chosenOptionsSearchAriaLabel="Chosen search input"
+  chosenOptionsStatus="Test status2"
+  chosenOptionsTitle="Chosen options"
+  controlsAriaLabel="Selector controls"
+  id="tree-test"
+  isTree={true}
+  removeAllAriaLabel="Remove all"
+  removeSelectedAriaLabel="Remove selected"
+>
+  <div
+    className="pf-c-dual-list-selector"
+    id="tree-test"
+  >
+    <DualListSelectorPane
+      id="tree-test-available-pane"
+      isChosen={false}
+      isSearchable={false}
+      isTree={true}
+      onOptionCheck={[Function]}
+      onOptionSelect={[Function]}
+      options={
+        Array [
+          Object {
+            "children": Array [
+              Object {
+                "text": "Opt3",
+              },
+            ],
+            "defaultExpanded": true,
+            "text": "Opt1",
+          },
+          Object {
+            "text": "Opt2",
+          },
+        ]
+      }
+      searchInputAriaLabel="Available search input"
+      selectedOptions={Array []}
+      status="Test status1"
+      title="Available options"
+    >
+      <div
+        className="pf-c-dual-list-selector__pane pf-m-available"
+      >
+        <div
+          className="pf-c-dual-list-selector__header"
+        >
+          <div
+            className="pf-c-dual-list-selector__title"
+          >
+            <div
+              className="pf-c-dual-list-selector__title-text"
+            >
+              Available options
+            </div>
+          </div>
+        </div>
+        <div
+          className="pf-c-dual-list-selector__status"
+        >
+          <div
+            className="pf-c-dual-list-selector__status-text"
+            id="tree-test-available-pane-status"
+          >
+            Test status1
+          </div>
+        </div>
+        <div
+          className="pf-c-dual-list-selector__menu"
+          tabIndex={0}
+        >
+          <DualListSelectorTree
+            data={
+              Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "text": "Opt3",
+                    },
+                  ],
+                  "defaultExpanded": true,
+                  "text": "Opt1",
+                },
+                Object {
+                  "text": "Opt2",
+                },
+              ]
+            }
+            isChosen={false}
+            onOptionCheck={[Function]}
+            onOptionSelect={[Function]}
+            selectedOptions={Array []}
+            sendRef={[Function]}
+          >
+            <ul
+              className="pf-c-dual-list-selector__list"
+            >
+              <DualListSelectorTreeItem
+                defaultExpanded={true}
+                hasBadge={false}
+                hasCheck={false}
+                isChosen={false}
+                isSelected={false}
+                itemData={
+                  Object {
+                    "children": Array [
+                      Object {
+                        "text": "Opt3",
+                      },
+                    ],
+                    "defaultExpanded": true,
+                    "text": "Opt1",
+                  }
+                }
+                key="Opt1"
+                onOptionCheck={[Function]}
+                onOptionSelect={[Function]}
+                sendRef={[Function]}
+                text="Opt1"
+              >
+                <li
+                  aria-expanded="true"
+                  aria-selected={false}
+                  className="pf-c-dual-list-selector__list-item pf-m-expandable pf-m-expanded"
+                  role="treeitem"
+                >
+                  <div
+                    className="pf-c-dual-list-selector__item"
+                    onClick={[Function]}
+                    tabIndex={-1}
+                  >
+                    <span
+                      className="pf-c-dual-list-selector__item-main"
+                    >
+                      <div
+                        className="pf-c-dual-list-selector__item-toggle"
+                        onClick={[Function]}
+                      >
+                        <span
+                          className="pf-c-dual-list-selector__item-toggle-icon"
+                        >
+                          <AngleDownIcon
+                            aria-hidden={true}
+                            color="currentColor"
+                            noVerticalAlign={false}
+                            size="sm"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              aria-labelledby={null}
+                              fill="currentColor"
+                              height="1em"
+                              role="img"
+                              style={
+                                Object {
+                                  "verticalAlign": "-0.125em",
+                                }
+                              }
+                              viewBox="0 0 320 512"
+                              width="1em"
+                            >
+                              <path
+                                d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                              />
+                            </svg>
+                          </AngleDownIcon>
+                        </span>
+                      </div>
+                      <span
+                        className="pf-c-dual-list-selector__item-text"
+                      >
+                        Opt1
+                      </span>
+                    </span>
+                  </div>
+                  <DualListSelectorTree
+                    data={
+                      Array [
+                        Object {
+                          "text": "Opt3",
+                        },
+                      ]
+                    }
+                    defaultAllExpanded={false}
+                    hasBadges={false}
+                    hasChecks={false}
+                    isChosen={false}
+                    onOptionCheck={[Function]}
+                    onOptionSelect={[Function]}
+                    parentItem={
+                      Object {
+                        "children": Array [
+                          Object {
+                            "text": "Opt3",
+                          },
+                        ],
+                        "defaultExpanded": true,
+                        "text": "Opt1",
+                      }
+                    }
+                    selectedOptions={Array []}
+                    sendRef={[Function]}
+                  >
+                    <ul
+                      className="pf-c-dual-list-selector__list"
+                    >
+                      <DualListSelectorTreeItem
+                        defaultExpanded={false}
+                        hasBadge={false}
+                        hasCheck={false}
+                        isChosen={false}
+                        isSelected={false}
+                        itemData={
+                          Object {
+                            "text": "Opt3",
+                          }
+                        }
+                        key="Opt3"
+                        onOptionCheck={[Function]}
+                        onOptionSelect={[Function]}
+                        parentItem={
+                          Object {
+                            "children": Array [
+                              Object {
+                                "text": "Opt3",
+                              },
+                            ],
+                            "defaultExpanded": true,
+                            "text": "Opt1",
+                          }
+                        }
+                        sendRef={[Function]}
+                        text="Opt3"
+                      >
+                        <li
+                          aria-selected={false}
+                          className="pf-c-dual-list-selector__list-item"
+                          role="treeitem"
+                        >
+                          <div
+                            className="pf-c-dual-list-selector__item"
+                            onClick={[Function]}
+                            tabIndex={-1}
+                          >
+                            <span
+                              className="pf-c-dual-list-selector__item-main"
+                            >
+                              <span
+                                className="pf-c-dual-list-selector__item-text"
+                              >
+                                Opt3
+                              </span>
+                            </span>
+                          </div>
+                        </li>
+                      </DualListSelectorTreeItem>
+                    </ul>
+                  </DualListSelectorTree>
+                </li>
+              </DualListSelectorTreeItem>
+              <DualListSelectorTreeItem
+                defaultExpanded={false}
+                hasBadge={false}
+                hasCheck={false}
+                isChosen={false}
+                isSelected={false}
+                itemData={
+                  Object {
+                    "text": "Opt2",
+                  }
+                }
+                key="Opt2"
+                onOptionCheck={[Function]}
+                onOptionSelect={[Function]}
+                sendRef={[Function]}
+                text="Opt2"
+              >
+                <li
+                  aria-selected={false}
+                  className="pf-c-dual-list-selector__list-item"
+                  role="treeitem"
+                >
+                  <div
+                    className="pf-c-dual-list-selector__item"
+                    onClick={[Function]}
+                    tabIndex={-1}
+                  >
+                    <span
+                      className="pf-c-dual-list-selector__item-main"
+                    >
+                      <span
+                        className="pf-c-dual-list-selector__item-text"
+                      >
+                        Opt2
+                      </span>
+                    </span>
+                  </div>
+                </li>
+              </DualListSelectorTreeItem>
+            </ul>
+          </DualListSelectorTree>
+        </div>
+      </div>
+    </DualListSelectorPane>
+    <div
+      aria-label="Selector controls"
+      className="pf-c-dual-list-selector__controls"
+      tabIndex={0}
+    >
+      <div
+        className="pf-c-dual-list-selector__controls-item"
+      >
+        <Button
+          aria-disabled={false}
+          aria-label="Add all"
+          isDisabled={false}
+          onClick={[Function]}
+          tabIndex={-1}
+          variant="plain"
+        >
+          <button
+            aria-disabled={false}
+            aria-label="Add all"
+            className="pf-c-button pf-m-plain"
+            data-ouia-component-id="OUIA-Generated-Button-plain-13"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={false}
+            onClick={[Function]}
+            role={null}
+            tabIndex={-1}
+            type="button"
+          >
+            <AngleDoubleRightIcon
+              color="currentColor"
+              noVerticalAlign={false}
+              size="sm"
+            >
+              <svg
+                aria-hidden={true}
+                aria-labelledby={null}
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style={
+                  Object {
+                    "verticalAlign": "-0.125em",
+                  }
+                }
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                />
+              </svg>
+            </AngleDoubleRightIcon>
+          </button>
+        </Button>
+      </div>
+      <div
+        className="pf-c-dual-list-selector__controls-item"
+      >
+        <Button
+          aria-disabled={true}
+          aria-label="Add selected"
+          isDisabled={true}
+          onClick={[Function]}
+          tabIndex={-1}
+          variant="plain"
+        >
+          <button
+            aria-disabled={true}
+            aria-label="Add selected"
+            className="pf-c-button pf-m-plain pf-m-disabled"
+            data-ouia-component-id="OUIA-Generated-Button-plain-14"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={true}
+            onClick={[Function]}
+            role={null}
+            tabIndex={-1}
+            type="button"
+          >
+            <AngleRightIcon
+              color="currentColor"
+              noVerticalAlign={false}
+              size="sm"
+            >
+              <svg
+                aria-hidden={true}
+                aria-labelledby={null}
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style={
+                  Object {
+                    "verticalAlign": "-0.125em",
+                  }
+                }
+                viewBox="0 0 256 512"
+                width="1em"
+              >
+                <path
+                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                />
+              </svg>
+            </AngleRightIcon>
+          </button>
+        </Button>
+      </div>
+      <div
+        className="pf-c-dual-list-selector__controls-item"
+      >
+        <Button
+          aria-disabled={true}
+          aria-label="Remove selected"
+          isDisabled={true}
+          onClick={[Function]}
+          tabIndex={-1}
+          variant="plain"
+        >
+          <button
+            aria-disabled={true}
+            aria-label="Remove selected"
+            className="pf-c-button pf-m-plain pf-m-disabled"
+            data-ouia-component-id="OUIA-Generated-Button-plain-15"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={true}
+            onClick={[Function]}
+            role={null}
+            tabIndex={-1}
+            type="button"
+          >
+            <AngleLeftIcon
+              color="currentColor"
+              noVerticalAlign={false}
+              size="sm"
+            >
+              <svg
+                aria-hidden={true}
+                aria-labelledby={null}
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style={
+                  Object {
+                    "verticalAlign": "-0.125em",
+                  }
+                }
+                viewBox="0 0 256 512"
+                width="1em"
+              >
+                <path
+                  d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                />
+              </svg>
+            </AngleLeftIcon>
+          </button>
+        </Button>
+      </div>
+      <div
+        className="pf-c-dual-list-selector__controls-item"
+      >
+        <Button
+          aria-disabled={true}
+          aria-label="Remove all"
+          isDisabled={true}
+          onClick={[Function]}
+          tabIndex={-1}
+          variant="plain"
+        >
+          <button
+            aria-disabled={true}
+            aria-label="Remove all"
+            className="pf-c-button pf-m-plain pf-m-disabled"
+            data-ouia-component-id="OUIA-Generated-Button-plain-16"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={true}
+            onClick={[Function]}
+            role={null}
+            tabIndex={-1}
+            type="button"
+          >
+            <AngleDoubleLeftIcon
+              color="currentColor"
+              noVerticalAlign={false}
+              size="sm"
+            >
+              <svg
+                aria-hidden={true}
+                aria-labelledby={null}
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style={
+                  Object {
+                    "verticalAlign": "-0.125em",
+                  }
+                }
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                />
+              </svg>
+            </AngleDoubleLeftIcon>
+          </button>
+        </Button>
+      </div>
+    </div>
+    <DualListSelectorPane
+      id="tree-test-chosen-pane"
+      isChosen={true}
+      isSearchable={false}
+      isTree={true}
+      onOptionCheck={[Function]}
+      onOptionSelect={[Function]}
+      options={Array []}
+      searchInputAriaLabel="Chosen search input"
+      selectedOptions={Array []}
+      status="Test status2"
+      title="Chosen options"
+    >
+      <div
+        className="pf-c-dual-list-selector__pane pf-m-chosen"
+      >
+        <div
+          className="pf-c-dual-list-selector__header"
+        >
+          <div
+            className="pf-c-dual-list-selector__title"
+          >
+            <div
+              className="pf-c-dual-list-selector__title-text"
+            >
+              Chosen options
+            </div>
+          </div>
+        </div>
+        <div
+          className="pf-c-dual-list-selector__status"
+        >
+          <div
+            className="pf-c-dual-list-selector__status-text"
+            id="tree-test-chosen-pane-status"
+          >
+            Test status2
+          </div>
+        </div>
+        <div
+          className="pf-c-dual-list-selector__menu"
+          tabIndex={0}
+        >
+          <DualListSelectorTree
+            data={Array []}
+            isChosen={true}
+            onOptionCheck={[Function]}
+            onOptionSelect={[Function]}
+            selectedOptions={Array []}
+            sendRef={[Function]}
+          >
+            <ul
+              className="pf-c-dual-list-selector__list"
+            />
+          </DualListSelectorTree>
         </div>
       </div>
     </DualListSelectorPane>

--- a/packages/react-core/src/components/DualListSelector/__tests__/__snapshots__/DualListSelector.test.tsx.snap
+++ b/packages/react-core/src/components/DualListSelector/__tests__/__snapshots__/DualListSelector.test.tsx.snap
@@ -1838,15 +1838,18 @@ exports[`DualListSelector with tree 1`] = `
         "children": Array [
           Object {
             "id": "O3",
+            "isChecked": false,
             "text": "Opt3",
           },
         ],
         "defaultExpanded": true,
         "id": "O1",
+        "isChecked": false,
         "text": "Opt1",
       },
       Object {
         "id": "O2",
+        "isChecked": false,
         "text": "Opt2",
       },
     ]
@@ -1869,6 +1872,7 @@ exports[`DualListSelector with tree 1`] = `
     id="tree-test"
   >
     <DualListSelectorPane
+      hasChecks={true}
       id="tree-test-available-pane"
       isChosen={false}
       isSearchable={false}
@@ -1881,15 +1885,18 @@ exports[`DualListSelector with tree 1`] = `
             "children": Array [
               Object {
                 "id": "O3",
+                "isChecked": false,
                 "text": "Opt3",
               },
             ],
             "defaultExpanded": true,
             "id": "O1",
+            "isChecked": false,
             "text": "Opt1",
           },
           Object {
             "id": "O2",
+            "isChecked": false,
             "text": "Opt2",
           },
         ]
@@ -1936,19 +1943,23 @@ exports[`DualListSelector with tree 1`] = `
                   "children": Array [
                     Object {
                       "id": "O3",
+                      "isChecked": false,
                       "text": "Opt3",
                     },
                   ],
                   "defaultExpanded": true,
                   "id": "O1",
+                  "isChecked": false,
                   "text": "Opt1",
                 },
                 Object {
                   "id": "O2",
+                  "isChecked": false,
                   "text": "Opt2",
                 },
               ]
             }
+            hasChecks={true}
             isChosen={false}
             onOptionCheck={[Function]}
             onOptionSelect={[Function]}
@@ -1961,8 +1972,9 @@ exports[`DualListSelector with tree 1`] = `
               <DualListSelectorTreeItem
                 defaultExpanded={true}
                 hasBadge={false}
-                hasCheck={false}
+                hasCheck={true}
                 id="O1"
+                isChecked={false}
                 isChosen={false}
                 isSelected={false}
                 itemData={
@@ -1970,11 +1982,13 @@ exports[`DualListSelector with tree 1`] = `
                     "children": Array [
                       Object {
                         "id": "O3",
+                        "isChecked": false,
                         "text": "Opt3",
                       },
                     ],
                     "defaultExpanded": true,
                     "id": "O1",
+                    "isChecked": false,
                     "text": "Opt1",
                   }
                 }
@@ -1991,7 +2005,7 @@ exports[`DualListSelector with tree 1`] = `
                   role="treeitem"
                 >
                   <div
-                    className="pf-c-dual-list-selector__item"
+                    className="pf-c-dual-list-selector__item pf-m-check"
                     onClick={[Function]}
                     tabIndex={-1}
                   >
@@ -2033,6 +2047,16 @@ exports[`DualListSelector with tree 1`] = `
                         </span>
                       </div>
                       <span
+                        className="pf-c-dual-list-selector__item-check"
+                      >
+                        <input
+                          checked={false}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          type="checkbox"
+                        />
+                      </span>
+                      <span
                         className="pf-c-dual-list-selector__item-text"
                       >
                         Opt1
@@ -2044,13 +2068,14 @@ exports[`DualListSelector with tree 1`] = `
                       Array [
                         Object {
                           "id": "O3",
+                          "isChecked": false,
                           "text": "Opt3",
                         },
                       ]
                     }
                     defaultAllExpanded={false}
                     hasBadges={false}
-                    hasChecks={false}
+                    hasChecks={true}
                     isChosen={false}
                     isNested={true}
                     onOptionCheck={[Function]}
@@ -2060,11 +2085,13 @@ exports[`DualListSelector with tree 1`] = `
                         "children": Array [
                           Object {
                             "id": "O3",
+                            "isChecked": false,
                             "text": "Opt3",
                           },
                         ],
                         "defaultExpanded": true,
                         "id": "O1",
+                        "isChecked": false,
                         "text": "Opt1",
                       }
                     }
@@ -2077,13 +2104,15 @@ exports[`DualListSelector with tree 1`] = `
                       <DualListSelectorTreeItem
                         defaultExpanded={false}
                         hasBadge={false}
-                        hasCheck={false}
+                        hasCheck={true}
                         id="O3"
+                        isChecked={false}
                         isChosen={false}
                         isSelected={false}
                         itemData={
                           Object {
                             "id": "O3",
+                            "isChecked": false,
                             "text": "Opt3",
                           }
                         }
@@ -2095,11 +2124,13 @@ exports[`DualListSelector with tree 1`] = `
                             "children": Array [
                               Object {
                                 "id": "O3",
+                                "isChecked": false,
                                 "text": "Opt3",
                               },
                             ],
                             "defaultExpanded": true,
                             "id": "O1",
+                            "isChecked": false,
                             "text": "Opt1",
                           }
                         }
@@ -2112,13 +2143,23 @@ exports[`DualListSelector with tree 1`] = `
                           role="treeitem"
                         >
                           <div
-                            className="pf-c-dual-list-selector__item"
+                            className="pf-c-dual-list-selector__item pf-m-check"
                             onClick={[Function]}
                             tabIndex={-1}
                           >
                             <span
                               className="pf-c-dual-list-selector__item-main"
                             >
+                              <span
+                                className="pf-c-dual-list-selector__item-check"
+                              >
+                                <input
+                                  checked={false}
+                                  onChange={[Function]}
+                                  onClick={[Function]}
+                                  type="checkbox"
+                                />
+                              </span>
                               <span
                                 className="pf-c-dual-list-selector__item-text"
                               >
@@ -2135,13 +2176,15 @@ exports[`DualListSelector with tree 1`] = `
               <DualListSelectorTreeItem
                 defaultExpanded={false}
                 hasBadge={false}
-                hasCheck={false}
+                hasCheck={true}
                 id="O2"
+                isChecked={false}
                 isChosen={false}
                 isSelected={false}
                 itemData={
                   Object {
                     "id": "O2",
+                    "isChecked": false,
                     "text": "Opt2",
                   }
                 }
@@ -2157,13 +2200,23 @@ exports[`DualListSelector with tree 1`] = `
                   role="treeitem"
                 >
                   <div
-                    className="pf-c-dual-list-selector__item"
+                    className="pf-c-dual-list-selector__item pf-m-check"
                     onClick={[Function]}
                     tabIndex={-1}
                   >
                     <span
                       className="pf-c-dual-list-selector__item-main"
                     >
+                      <span
+                        className="pf-c-dual-list-selector__item-check"
+                      >
+                        <input
+                          checked={false}
+                          onChange={[Function]}
+                          onClick={[Function]}
+                          type="checkbox"
+                        />
+                      </span>
                       <span
                         className="pf-c-dual-list-selector__item-text"
                       >
@@ -2389,6 +2442,7 @@ exports[`DualListSelector with tree 1`] = `
       </div>
     </div>
     <DualListSelectorPane
+      hasChecks={true}
       id="tree-test-chosen-pane"
       isChosen={true}
       isSearchable={false}
@@ -2433,6 +2487,7 @@ exports[`DualListSelector with tree 1`] = `
         >
           <DualListSelectorTree
             data={Array []}
+            hasChecks={true}
             isChosen={true}
             onOptionCheck={[Function]}
             onOptionSelect={[Function]}

--- a/packages/react-core/src/components/DualListSelector/examples/DualListSelector.md
+++ b/packages/react-core/src/components/DualListSelector/examples/DualListSelector.md
@@ -280,7 +280,6 @@ class TreeDualListSelector extends React.Component {
         id="basicSelector"
         isSearchable
         isTree
-        hasChecks
       />
     );
   }

--- a/packages/react-core/src/components/DualListSelector/examples/DualListSelector.md
+++ b/packages/react-core/src/components/DualListSelector/examples/DualListSelector.md
@@ -272,6 +272,7 @@ class TreeDualListSelector extends React.Component {
         chosenOptions={this.state.chosenOptions}
         onListChange={this.onListChange}
         id="basicSelector"
+        isSearchable
         isTree
         hasChecks
       />

--- a/packages/react-core/src/components/DualListSelector/examples/DualListSelector.md
+++ b/packages/react-core/src/components/DualListSelector/examples/DualListSelector.md
@@ -14,9 +14,7 @@ import PficonSortCommonAscIcon from '@patternfly/react-icons/dist/js/icons/pfico
 
 ```js
 import React from 'react';
-import { 
-  DualListSelector
-} from '@patternfly/react-core';
+import { DualListSelector } from '@patternfly/react-core';
 
 class BasicDualListSelector extends React.Component {
   constructor(props) {
@@ -25,15 +23,15 @@ class BasicDualListSelector extends React.Component {
       availableOptions: ['Option 1', 'Option 2', 'Option 3', 'Option 4'],
       chosenOptions: []
     };
-    
+
     this.onListChange = (newAvailableOptions, newChosenOptions) => {
       this.setState({
         availableOptions: newAvailableOptions.sort(),
-        chosenOptions: newChosenOptions.sort(),
-      })
+        chosenOptions: newChosenOptions.sort()
+      });
     };
   }
-  
+
   render() {
     return (
       <DualListSelector
@@ -45,16 +43,13 @@ class BasicDualListSelector extends React.Component {
     );
   }
 }
-
 ```
 
 ### Basic with search
 
 ```js
 import React from 'react';
-import { 
-  DualListSelector
-} from '@patternfly/react-core';
+import { DualListSelector } from '@patternfly/react-core';
 
 class BasicDualListSelectorWithSearch extends React.Component {
   constructor(props) {
@@ -63,15 +58,15 @@ class BasicDualListSelectorWithSearch extends React.Component {
       availableOptions: ['Option 1', 'Option 2', 'Option 3', 'Option 4'],
       chosenOptions: []
     };
-    
+
     this.onListChange = (newAvailableOptions, newChosenOptions) => {
       this.setState({
         availableOptions: newAvailableOptions.sort(),
-        chosenOptions: newChosenOptions.sort(),
-      })
+        chosenOptions: newChosenOptions.sort()
+      });
     };
   }
-  
+
   render() {
     return (
       <DualListSelector
@@ -84,39 +79,26 @@ class BasicDualListSelectorWithSearch extends React.Component {
     );
   }
 }
-
 ```
 
 ### Using more complex options with actions
 
 ```js
 import React from 'react';
-import { 
-  Button,
-  ButtonVariant,
-  Dropdown,
-  DropdownItem,
-  DualListSelector,
-  KebabToggle
-} from '@patternfly/react-core';
+import { Button, ButtonVariant, Dropdown, DropdownItem, DualListSelector, KebabToggle } from '@patternfly/react-core';
 import PficonSortCommonAscIcon from '@patternfly/react-icons/dist/js/icons/pficon-sort-common-asc-icon';
 
 class ComplexDualListSelector extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      availableOptions: [
-        <span>Option 1</span>, 
-        <span>Option 3</span>, 
-        <span>Option 4</span>, 
-        <span>Option 2</span>
-      ],
+      availableOptions: [<span>Option 1</span>, <span>Option 3</span>, <span>Option 4</span>, <span>Option 2</span>],
       chosenOptions: [],
       isAvailableKebabOpen: false,
-      isChosenKebabOpen: false,
+      isChosenKebabOpen: false
     };
-    
-    this.onSort = (panel) => {
+
+    this.onSort = panel => {
       if (panel === 'available') {
         this.setState(prevState => {
           const available = prevState.availableOptions.sort((a, b) => {
@@ -126,11 +108,11 @@ class ComplexDualListSelector extends React.Component {
             return returnValue;
           });
           return {
-            availableOptions: available,
-          }
+            availableOptions: available
+          };
         });
       }
-      
+
       if (panel === 'chosen') {
         this.setState(prevState => {
           const chosen = prevState.chosenOptions.sort((a, b) => {
@@ -140,33 +122,33 @@ class ComplexDualListSelector extends React.Component {
             return returnValue;
           });
           return {
-            chosenOptions: chosen,
-          }
+            chosenOptions: chosen
+          };
         });
       }
     };
-    
+
     this.onListChange = (newAvailableOptions, newChosenOptions) => {
       this.setState({
         availableOptions: newAvailableOptions,
         chosenOptions: newChosenOptions
-      })
+      });
     };
-    
+
     this.onToggle = (isOpen, pane) => {
       this.setState(prevState => {
         return {
-          isAvailableKebabOpen: pane === "available" ? isOpen : prevState.isAvailableKebabOpen,
-          isChosenKebabOpen: pane === "chosen" ? isOpen : prevState.isChosenKebabOpen
-        }
+          isAvailableKebabOpen: pane === 'available' ? isOpen : prevState.isAvailableKebabOpen,
+          isChosenKebabOpen: pane === 'chosen' ? isOpen : prevState.isChosenKebabOpen
+        };
       });
     };
-    
+
     this.filterOption = (option, input) => {
       return option.props.children.includes(input);
-    }
+    };
   }
-  
+
   render() {
     const dropdownItems = [
       <DropdownItem key="link">Link</DropdownItem>,
@@ -177,33 +159,43 @@ class ComplexDualListSelector extends React.Component {
         Second Action
       </DropdownItem>
     ];
-    
+
     const availableOptionsActions = [
-      <Button variant={ButtonVariant.plain} onClick={() => this.onSort("available")} aria-label="Sort" key="availableSortButton">
-        <PficonSortCommonAscIcon/>
+      <Button
+        variant={ButtonVariant.plain}
+        onClick={() => this.onSort('available')}
+        aria-label="Sort"
+        key="availableSortButton"
+      >
+        <PficonSortCommonAscIcon />
       </Button>,
       <Dropdown
-        toggle={<KebabToggle onToggle={(isOpen) => this.onToggle(isOpen, "available")} id="toggle-id-1" />}
+        toggle={<KebabToggle onToggle={isOpen => this.onToggle(isOpen, 'available')} id="toggle-id-1" />}
         isOpen={this.state.isAvailableKebabOpen}
         isPlain
         dropdownItems={dropdownItems}
         key="availableDropdown"
       />
     ];
-    
+
     const chosenOptionsActions = [
-      <Button variant={ButtonVariant.plain} onClick={() => this.onSort("chosen")} aria-label="Sort" key="chosenSortButton">
-        <PficonSortCommonAscIcon/>
+      <Button
+        variant={ButtonVariant.plain}
+        onClick={() => this.onSort('chosen')}
+        aria-label="Sort"
+        key="chosenSortButton"
+      >
+        <PficonSortCommonAscIcon />
       </Button>,
       <Dropdown
-        toggle={<KebabToggle onToggle={(isOpen) => this.onToggle(isOpen, "chosen")} id="toggle-id-2" />}
+        toggle={<KebabToggle onToggle={isOpen => this.onToggle(isOpen, 'chosen')} id="toggle-id-2" />}
         isOpen={this.state.isChosenKebabOpen}
         isPlain
         dropdownItems={dropdownItems}
         key="chosenDropdown"
       />
     ];
-    
+
     return (
       <DualListSelector
         isSearchable
@@ -221,5 +213,63 @@ class ComplexDualListSelector extends React.Component {
     );
   }
 }
+```
 
+### Expandable options with checkboxes
+
+```js
+import React from 'react';
+import { DualListSelector } from '@patternfly/react-core';
+
+class TreeDualListSelector extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      chosenOptions: [],
+      availableOptions: [
+        {
+          text: 'Folder 1',
+          checked: false,
+          checkProps: { 'aria-label': 'Custom aria label checkbox' },
+          hasBadge: true,
+          badgeProps: { isRead: true },
+          children: [
+            { text: 'Option 1', checked: false },
+            {
+              text: 'Folder 1A',
+              checked: false,
+              children: [
+                { text: 'Option 2', checked: false },
+                { text: 'Option 3', checked: false }
+              ]
+            },
+            { text: 'Option 4', checked: false }
+          ]
+        },
+        { text: 'Option 5', checked: false },
+        { text: 'Folder 2', checked: false, children: [{ text: 'Option 6', checked: false }] }
+      ]
+    };
+
+    this.onListChange = (newAvailableOptions, newChosenOptions) => {
+      this.setState({
+        availableOptions: newAvailableOptions,
+        chosenOptions: newChosenOptions
+      });
+    };
+  }
+
+  render() {
+    return (
+      <DualListSelector
+        availableOptions={this.state.availableOptions}
+        chosenOptions={this.state.chosenOptions}
+        onListChange={this.onListChange}
+        id="basicSelector"
+        isTree
+        hasChecks
+      />
+    );
+  }
+}
 ```

--- a/packages/react-core/src/components/DualListSelector/examples/DualListSelector.md
+++ b/packages/react-core/src/components/DualListSelector/examples/DualListSelector.md
@@ -230,24 +230,30 @@ class TreeDualListSelector extends React.Component {
         {
           text: 'Folder 1',
           checked: false,
-          checkProps: { 'aria-label': 'Custom aria label checkbox' },
+          checkProps: { 'aria-label': 'Folder 1' },
           hasBadge: true,
           badgeProps: { isRead: true },
           children: [
-            { text: 'Option 1', checked: false },
+            { text: 'Option 1', checked: false, checkProps: { 'aria-label': 'Option 1' } },
             {
               text: 'Folder 1A',
               checked: false,
+              checkProps: { 'aria-label': 'Folder 1A' },
               children: [
-                { text: 'Option 2', checked: false },
-                { text: 'Option 3', checked: false }
+                { text: 'Option 2', checked: false, checkProps: { 'aria-label': 'Option 2' } },
+                { text: 'Option 3', checked: false, checkProps: { 'aria-label': 'Option 3' } }
               ]
             },
-            { text: 'Option 4', checked: false }
+            { text: 'Option 4', checked: false, checkProps: { 'aria-label': 'Option 4' } }
           ]
         },
-        { text: 'Option 5', checked: false },
-        { text: 'Folder 2', checked: false, children: [{ text: 'Option 6', checked: false }] }
+        { text: 'Option 5', checked: false, checkProps: { 'aria-label': 'Option 5' } },
+        {
+          text: 'Folder 2',
+          checked: false,
+          checkProps: { 'aria-label': 'Folder 2' },
+          children: [{ text: 'Option 6', checked: false, checkProps: { 'aria-label': 'Option 6' } }]
+        }
       ]
     };
 

--- a/packages/react-core/src/components/DualListSelector/examples/DualListSelector.md
+++ b/packages/react-core/src/components/DualListSelector/examples/DualListSelector.md
@@ -228,31 +228,37 @@ class TreeDualListSelector extends React.Component {
       chosenOptions: [],
       availableOptions: [
         {
+          id: 'F1',
           text: 'Folder 1',
-          checked: false,
+          isChecked: false,
           checkProps: { 'aria-label': 'Folder 1' },
           hasBadge: true,
           badgeProps: { isRead: true },
           children: [
-            { text: 'Option 1', checked: false, checkProps: { 'aria-label': 'Option 1' } },
+            { id: 'O1', text: 'Option 1', isChecked: false, checkProps: { 'aria-label': 'Option 1' } },
             {
+              id: 'F1A',
               text: 'Folder 1A',
-              checked: false,
+              isChecked: false,
               checkProps: { 'aria-label': 'Folder 1A' },
               children: [
-                { text: 'Option 2', checked: false, checkProps: { 'aria-label': 'Option 2' } },
-                { text: 'Option 3', checked: false, checkProps: { 'aria-label': 'Option 3' } }
+                { id: 'O2', text: 'Option 2', isChecked: false, checkProps: { 'aria-label': 'Option 2' } },
+                { id: 'O3', text: 'Option 3', isChecked: false, checkProps: { 'aria-label': 'Option 3' } }
               ]
             },
-            { text: 'Option 4', checked: false, checkProps: { 'aria-label': 'Option 4' } }
+            { id: 'O4', text: 'Option 4', isChecked: false, checkProps: { 'aria-label': 'Option 4' } }
           ]
         },
-        { text: 'Option 5', checked: false, checkProps: { 'aria-label': 'Option 5' } },
+        { id: 'O5', text: 'Option 5', isChecked: false, checkProps: { 'aria-label': 'Option 5' } },
         {
+          id: 'F2',
           text: 'Folder 2',
-          checked: false,
+          isChecked: false,
           checkProps: { 'aria-label': 'Folder 2' },
-          children: [{ text: 'Option 6', checked: false, checkProps: { 'aria-label': 'Option 6' } }]
+          children: [
+            { id: 'O6', text: 'Option 6', isChecked: false, checkProps: { 'aria-label': 'Option 6' } },
+            { id: 'O7', text: 'Option 5', isChecked: false, checkProps: { 'aria-label': 'Option 5 duplicate' } }
+          ]
         }
       ]
     };

--- a/packages/react-core/src/components/DualListSelector/treeUtils.ts
+++ b/packages/react-core/src/components/DualListSelector/treeUtils.ts
@@ -6,7 +6,7 @@ export function flattenTree(tree: DualListSelectorTreeItemData[]): string[] {
     if (item.children) {
       result = result.concat(flattenTree(item.children));
     } else {
-      result.push(item.text);
+      result.push(item.id);
     }
   });
   return result;
@@ -15,7 +15,7 @@ export function flattenTree(tree: DualListSelectorTreeItemData[]): string[] {
 export function flattenTreeWithFolders(tree: DualListSelectorTreeItemData[]): string[] {
   let result = [] as string[];
   tree.forEach(item => {
-    result.push(item.text);
+    result.push(item.id);
     if (item.children) {
       result = result.concat(flattenTreeWithFolders(item.children));
     }
@@ -23,14 +23,14 @@ export function flattenTreeWithFolders(tree: DualListSelectorTreeItemData[]): st
   return result;
 }
 
-export function filterFolders(tree: DualListSelectorTreeItemData[], subset: string[]): string[] {
+export function filterFolders(tree: DualListSelectorTreeItemData[], inputList: string[]): string[] {
   let result = [] as string[];
   tree.forEach(item => {
     if (item.children) {
-      result = result.concat(filterFolders(item.children, subset));
+      result = result.concat(filterFolders(item.children, inputList));
     } else {
-      if (subset.includes(item.text)) {
-        result.push(item.text);
+      if (inputList.includes(item.id)) {
+        result.push(item.id);
       }
     }
   });
@@ -38,7 +38,7 @@ export function filterFolders(tree: DualListSelectorTreeItemData[], subset: stri
 }
 
 export function filterTreeItems(item: DualListSelectorTreeItemData, inputList: string[]): boolean {
-  if (inputList.includes(item.text)) {
+  if (inputList.includes(item.id)) {
     return true;
   }
   if (item.children) {
@@ -59,7 +59,7 @@ export function filterTreeItemsWithoutFolders(item: DualListSelectorTreeItemData
     );
   }
 
-  if (inputList.includes(item.text)) {
+  if (inputList.includes(item.id)) {
     return true;
   }
 }
@@ -73,7 +73,7 @@ export function filterRestTreeItems(item: DualListSelectorTreeItemData, inputLis
     return child;
   }
 
-  if (!inputList.includes(item.text)) {
+  if (!inputList.includes(item.id)) {
     return true;
   }
 }

--- a/packages/react-core/src/components/DualListSelector/treeUtils.ts
+++ b/packages/react-core/src/components/DualListSelector/treeUtils.ts
@@ -1,0 +1,79 @@
+import { DualListSelectorTreeItemData } from './DualListSelectorTree';
+
+export function flattenTree(tree: DualListSelectorTreeItemData[]): string[] {
+  let result = [] as string[];
+  tree.forEach(item => {
+    if (item.children) {
+      result = result.concat(flattenTree(item.children));
+    } else {
+      result.push(item.text);
+    }
+  });
+  return result;
+}
+
+export function flattenTreeWithFolders(tree: DualListSelectorTreeItemData[]): string[] {
+  let result = [] as string[];
+  tree.forEach(item => {
+    result.push(item.text);
+    if (item.children) {
+      result = result.concat(flattenTreeWithFolders(item.children));
+    }
+  });
+  return result;
+}
+
+export function filterFolders(tree: DualListSelectorTreeItemData[], subset: string[]): string[] {
+  let result = [] as string[];
+  tree.forEach(item => {
+    if (item.children) {
+      result = result.concat(filterFolders(item.children, subset));
+    } else {
+      if (subset.includes(item.text)) {
+        result.push(item.text);
+      }
+    }
+  });
+  return result;
+}
+
+export function filterTreeItems(item: DualListSelectorTreeItemData, inputList: string[]): boolean {
+  if (inputList.includes(item.text)) {
+    return true;
+  }
+  if (item.children) {
+    return (
+      (item.children = item.children
+        .map(opt => Object.assign({}, opt))
+        .filter(child => filterTreeItems(child, inputList))).length > 0
+    );
+  }
+}
+
+export function filterTreeItemsWithoutFolders(item: DualListSelectorTreeItemData, inputList: string[]): boolean {
+  if (item.children) {
+    return (
+      (item.children = item.children
+        .map(opt => Object.assign({}, opt))
+        .filter(child => filterTreeItems(child, inputList))).length > 0
+    );
+  }
+
+  if (inputList.includes(item.text)) {
+    return true;
+  }
+}
+
+export function filterRestTreeItems(item: DualListSelectorTreeItemData, inputList: string[]): boolean {
+  if (item.children) {
+    const child =
+      (item.children = item.children
+        .map(opt => Object.assign({}, opt))
+        .filter(child => filterRestTreeItems(child, inputList))).length > 0;
+    return child;
+  }
+
+  if (!inputList.includes(item.text)) {
+    return true;
+  }
+}

--- a/packages/react-core/src/components/TreeView/TreeView.tsx
+++ b/packages/react-core/src/components/TreeView/TreeView.tsx
@@ -92,7 +92,7 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
           hasCheck={item.hasCheck !== undefined ? item.hasCheck : hasChecks}
           checkProps={item.checkProps}
           hasBadge={item.hasBadge !== undefined ? item.hasBadge : hasBadges}
-          badgeProps={item.checkProps}
+          badgeProps={item.badgeProps}
           activeItems={activeItems}
           parentItem={parentItem}
           itemData={item}

--- a/packages/react-core/src/components/TreeView/examples/TreeView.md
+++ b/packages/react-core/src/components/TreeView/examples/TreeView.md
@@ -40,7 +40,10 @@ class DefaultTreeView extends React.Component {
           {
             name: 'Application 1',
             id: 'App1',
-            children: [{ name: 'Settings', id: 'App1Settings' }, { name: 'Current', id: 'App1Current' }]
+            children: [
+              { name: 'Settings', id: 'App1Settings' },
+              { name: 'Current', id: 'App1Current' }
+            ]
           },
           {
             name: 'Application 2',
@@ -68,7 +71,10 @@ class DefaultTreeView extends React.Component {
           {
             name: 'Application 3',
             id: 'App3',
-            children: [{ name: 'Settings', id: 'App3Settings' }, { name: 'Current', id: 'App3Current' }]
+            children: [
+              { name: 'Settings', id: 'App3Settings' },
+              { name: 'Current', id: 'App3Current' }
+            ]
           }
         ]
       },
@@ -106,7 +112,10 @@ class SearchTreeView extends React.Component {
           {
             name: 'Application 1',
             id: 'App1',
-            children: [{ name: 'Settings', id: 'App1Settings' }, { name: 'Current', id: 'App1Current' }]
+            children: [
+              { name: 'Settings', id: 'App1Settings' },
+              { name: 'Current', id: 'App1Current' }
+            ]
           },
           {
             name: 'Application 2',
@@ -134,7 +143,10 @@ class SearchTreeView extends React.Component {
           {
             name: 'Application 3',
             id: 'App3',
-            children: [{ name: 'Settings', id: 'App3Settings' }, { name: 'Current', id: 'App3Current' }]
+            children: [
+              { name: 'Settings', id: 'App3Settings' },
+              { name: 'Current', id: 'App3Current' }
+            ]
           }
         ]
       },
@@ -335,6 +347,7 @@ class CheckboxTreeView extends React.Component {
         .map(opt => Object.assign({}, opt))
         .filter(item => this.filterItems(item, treeViewItem));
       const flatCheckedItems = this.flattenTree(checkedItemTree);
+      console.log('flat', flatCheckedItems);
 
       this.setState(
         prevState => ({
@@ -447,7 +460,10 @@ class IconTreeView extends React.Component {
           {
             name: 'Application 1',
             id: 'App1',
-            children: [{ name: 'Settings', id: 'App1Settings' }, { name: 'Current', id: 'App1Current' }]
+            children: [
+              { name: 'Settings', id: 'App1Settings' },
+              { name: 'Current', id: 'App1Current' }
+            ]
           },
           {
             name: 'Application 2',
@@ -475,7 +491,10 @@ class IconTreeView extends React.Component {
           {
             name: 'Application 3',
             id: 'App3',
-            children: [{ name: 'Settings', id: 'App3Settings' }, { name: 'Current', id: 'App3Current' }]
+            children: [
+              { name: 'Settings', id: 'App3Settings' },
+              { name: 'Current', id: 'App3Current' }
+            ]
           }
         ]
       },
@@ -532,7 +551,10 @@ class BadgesTreeView extends React.Component {
           {
             name: 'Application 1',
             id: 'App1',
-            children: [{ name: 'Settings', id: 'App1Settings' }, { name: 'Current', id: 'App1Current' }]
+            children: [
+              { name: 'Settings', id: 'App1Settings' },
+              { name: 'Current', id: 'App1Current' }
+            ]
           },
           {
             name: 'Application 2',
@@ -560,7 +582,10 @@ class BadgesTreeView extends React.Component {
           {
             name: 'Application 3',
             id: 'App3',
-            children: [{ name: 'Settings', id: 'App3Settings' }, { name: 'Current', id: 'App3Current' }]
+            children: [
+              { name: 'Settings', id: 'App3Settings' },
+              { name: 'Current', id: 'App3Current' }
+            ]
           }
         ]
       },
@@ -652,7 +677,10 @@ class IconTreeView extends React.Component {
             actionProps: {
               'aria-label': 'Launch app 1'
             },
-            children: [{ name: 'Settings', id: 'App1Settings' }, { name: 'Current', id: 'App1Current' }]
+            children: [
+              { name: 'Settings', id: 'App1Settings' },
+              { name: 'Current', id: 'App1Current' }
+            ]
           },
           {
             name: 'Application 2',
@@ -685,7 +713,10 @@ class IconTreeView extends React.Component {
           {
             name: 'Application 3',
             id: 'App3',
-            children: [{ name: 'Settings', id: 'App3Settings' }, { name: 'Current', id: 'App3Current' }]
+            children: [
+              { name: 'Settings', id: 'App3Settings' },
+              { name: 'Current', id: 'App3Current' }
+            ]
           }
         ]
       },

--- a/packages/react-integration/cypress/integration/duallistselectortree.spec.ts
+++ b/packages/react-integration/cypress/integration/duallistselectortree.spec.ts
@@ -1,0 +1,88 @@
+describe('Dual List Selector TreeDemo Test', () => {
+  it('Navigate to demo section', () => {
+    cy.visit('http://localhost:3000/');
+    cy.get('#dual-list-selector-tree-demo-nav-item-link').click();
+    cy.url().should('eq', 'http://localhost:3000/dual-list-selector-tree-demo-nav-link');
+  });
+
+  it('Verify existence', () => {
+    cy.get('.pf-c-dual-list-selector').should('exist');
+  });
+
+  it('Verify expanding options', () => {
+    cy.get('.pf-c-dual-list-selector__list')
+      .eq(0)
+      .find('li')
+      .should('have.length', 3);
+    cy.get('.pf-c-dual-list-selector__list-item .pf-c-dual-list-selector__item-toggle')
+      .eq(0)
+      .click();
+    cy.get('.pf-c-dual-list-selector__list-item')
+      .eq(0)
+      .should('have.class', 'pf-m-expanded');
+    cy.get('.pf-c-dual-list-selector__list')
+      .eq(0)
+      .find('li')
+      .should('have.length', 4);
+  });
+
+  it('Verify available search works', () => {
+    cy.get('.pf-c-dual-list-selector__list')
+      .eq(0)
+      .find('li')
+      .should('have.length', 4);
+    cy.get('.pf-c-dual-list-selector__tools-filter .pf-m-search')
+      .eq(0)
+      .type('Option 2');
+    cy.get('.pf-c-dual-list-selector__list')
+      .eq(0)
+      .find('li')
+      .should('have.length', 1);
+    cy.get('.pf-c-dual-list-selector__tools-filter .pf-m-search')
+      .eq(0)
+      .type('{backspace}{backspace}{backspace}');
+    cy.get('.pf-c-dual-list-selector__list-item .pf-c-dual-list-selector__item-toggle')
+      .last()
+      .click();
+    cy.get('.pf-c-dual-list-selector__list')
+      .eq(0)
+      .find('li')
+      .should('have.length', 5);
+  });
+
+  it('Verify checkbox selects an option', () => {
+    cy.get('.pf-c-dual-list-selector__controls-item button')
+      .eq(1)
+      .should('have.attr', 'disabled');
+    cy.get('.pf-c-dual-list-selector__list-item .pf-c-dual-list-selector__item-check')
+      .last()
+      .click();
+    cy.get('.pf-c-dual-list-selector__controls-item button')
+      .eq(1)
+      .should('not.have.attr', 'disabled');
+    cy.get('.pf-c-dual-list-selector__list-item .pf-c-dual-list-selector__item-check')
+      .eq(1)
+      .click();
+    cy.get('.pf-c-dual-list-selector__controls-item button')
+      .eq(1)
+      .click();
+    cy.get('.pf-c-dual-list-selector__list')
+      .eq(2)
+      .find('li')
+      .should('have.length', 2);
+  });
+
+  it('Verify chosen search works', () => {
+    cy.get('.pf-c-dual-list-selector__list')
+      .eq(2)
+      .find('li')
+      .should('have.length', 2);
+    cy.get('.pf-c-dual-list-selector__tools-filter .pf-m-search')
+      .eq(1)
+      .type('Option 5');
+    cy.get('.pf-c-dual-list-selector__list')
+      .eq(2)
+      .find('li')
+      .should('have.length', 1);
+  });
+});

--- a/packages/react-integration/demo-app-ts/src/Demos.ts
+++ b/packages/react-integration/demo-app-ts/src/Demos.ts
@@ -342,6 +342,11 @@ export const Demos: DemoInterface[] = [
     componentType: Examples.DualListSelectorBasicDemo
   },
   {
+    id: 'dual-list-selector-tree-demo',
+    name: 'DualListSelector Tree Demo',
+    componentType: Examples.DualListSelectorTreeDemo
+  },
+  {
     id: 'dual-list-selector-with-actions-demo',
     name: 'DualListSelector with actions Demo',
     componentType: Examples.DualListSelectorWithActionsDemo

--- a/packages/react-integration/demo-app-ts/src/components/demos/DualListSelector/DualListSelectorTreeDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DualListSelector/DualListSelectorTreeDemo.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { DualListSelector, DualListSelectorProps } from '@patternfly/react-core';
+interface DualListSelectorState {
+  availableOptions: React.ReactNode[];
+  chosenOptions: React.ReactNode[];
+}
+
+export class DualListSelectorTreeDemo extends React.Component<DualListSelectorProps, DualListSelectorState> {
+  static displayName = 'DualListSelectorTreeDemo';
+  onListChange: (newAvailableOptions: React.ReactNode[], newChosenOptions: React.ReactNode[]) => void;
+
+  constructor(props: DualListSelectorProps) {
+    super(props);
+    this.state = {
+      availableOptions: [
+        { text: 'Folder 1', children: [{ text: 'Option 1' }] },
+        { text: 'Option 2' },
+        {
+          text: 'Folder 2',
+          children: [{ text: 'Folder 3', children: [{ text: 'Option 3' }, { text: 'Option 4' }] }, { text: 'Option 5' }]
+        }
+      ],
+      chosenOptions: []
+    };
+
+    this.onListChange = (newAvailableOptions, newChosenOptions) => {
+      this.setState({
+        availableOptions: newAvailableOptions,
+        chosenOptions: newChosenOptions
+      });
+    };
+  }
+
+  render() {
+    return (
+      <DualListSelector
+        isSearchable
+        availableOptions={this.state.availableOptions}
+        chosenOptions={this.state.chosenOptions}
+        onListChange={this.onListChange}
+        isTree
+        hasChecks
+      />
+    );
+  }
+}

--- a/packages/react-integration/demo-app-ts/src/components/demos/DualListSelector/DualListSelectorTreeDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DualListSelector/DualListSelectorTreeDemo.tsx
@@ -50,7 +50,6 @@ export class DualListSelectorTreeDemo extends React.Component<DualListSelectorPr
         chosenOptions={this.state.chosenOptions}
         onListChange={this.onListChange}
         isTree
-        hasChecks
       />
     );
   }

--- a/packages/react-integration/demo-app-ts/src/components/demos/DualListSelector/DualListSelectorTreeDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DualListSelector/DualListSelectorTreeDemo.tsx
@@ -13,11 +13,22 @@ export class DualListSelectorTreeDemo extends React.Component<DualListSelectorPr
     super(props);
     this.state = {
       availableOptions: [
-        { text: 'Folder 1', children: [{ text: 'Option 1' }] },
-        { text: 'Option 2' },
+        { id: 'F1', text: 'Folder 1', children: [{ id: 'O1', text: 'Option 1' }] },
+        { id: 'O2', text: 'Option 2' },
         {
+          id: 'F2',
           text: 'Folder 2',
-          children: [{ text: 'Folder 3', children: [{ text: 'Option 3' }, { text: 'Option 4' }] }, { text: 'Option 5' }]
+          children: [
+            {
+              id: 'F3',
+              text: 'Folder 3',
+              children: [
+                { id: 'O3', text: 'Option 3' },
+                { id: 'O4', text: 'Option 4' }
+              ]
+            },
+            { id: 'O5', text: 'Option 5' }
+          ]
         }
       ],
       chosenOptions: []

--- a/packages/react-integration/demo-app-ts/src/components/demos/index.ts
+++ b/packages/react-integration/demo-app-ts/src/components/demos/index.ts
@@ -67,6 +67,7 @@ export * from './DonutUtilizationChartDemo/DonutUtilizationSimpleDemo';
 export * from './DrawerDemo/DrawerDemo';
 export * from './DropdownDemo/DropdownDemo';
 export * from './DualListSelector/DualListSelectorBasicDemo';
+export * from './DualListSelector/DualListSelectorTreeDemo';
 export * from './DualListSelector/DualListSelectorWithActionsDemo';
 export * from './EmptyStateDemo/EmptyStateDemo';
 export * from './ExpandableSectionDemo/ExpandableSectionDemo';


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5102 

To swap over to using trees, add `isTree` to the `DualListSelector` and update the data structure accordingly. The data is expected to have a `text` attribute to display the content of the item, and this property is used to control selection/checking/etc. The structure is similar to TreeView, but uses `text` in place of `name`. It might be better to swap to using an `id` prop instead of `text`, I haven't decided.

The prop `hasChecks` added to `DualListSelector` will add checkboxes to every option. Alternately, adding a `hasCheck` property to an option will give the individual option a checkbox. Badges are added individually at the moment with a `hasBadge` property added to an option, but if needed a similar apply-to-all property can be added.

Keyboard interaction will require some thought, and maybe requires a follow up issue, because TreeView used tabbing to navigate and DualListSelector skips over tabbing through the options.
