### PR TITLE
fix(VncConsole): replace novnc-core usage with the original @novnc/novnc

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,7 +16,7 @@ module.exports = {
   transform: {
     '^.+\\.[jt]sx?$': 'babel-jest'
   },
-  transformIgnorePatterns: ['node_modules/(?!@patternfly|novnc-core|@popperjs|lodash)'],
+  transformIgnorePatterns: ['node_modules/(?!@patternfly|@novnc|@popperjs|lodash)'],
   testPathIgnorePatterns: [
     '<rootDir>/packages/react-integration/'
   ],

--- a/packages/react-console/package.json
+++ b/packages/react-console/package.json
@@ -36,9 +36,8 @@
     "@patternfly/react-core": "^4.80.1",
     "@spice-project/spice-html5": "^0.2.1",
     "@types/file-saver": "^2.0.1",
-    "@types/novnc-core": "^0.1.2",
     "file-saver": "^1.3.8",
-    "novnc-core": "^0.3.0",
+    "@novnc/novnc": "^1.2.0",
     "tslib": "^1.11.1",
     "xterm": "^4.8.1",
     "xterm-addon-fit": "^0.2.1"

--- a/packages/react-console/src/components/VncConsole/VncActions.tsx
+++ b/packages/react-console/src/components/VncConsole/VncActions.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@patternfly/react-styles';
-import { Dropdown, DropdownItem, DropdownToggle, Button } from '@patternfly/react-core';
+import { Dropdown, DropdownItem, DropdownToggle, Button, ButtonVariant } from '@patternfly/react-core';
 
 import styles from '@patternfly/react-styles/css/components/Consoles/VncConsole';
 
@@ -42,7 +42,9 @@ export const VncActions: React.FunctionComponent<VncActionProps> = ({
           </DropdownItem>
         ]}
       />
-      <Button onClick={onDisconnect}>{textDisconnect}</Button>
+      <Button variant={ButtonVariant.secondary} onClick={onDisconnect}>
+        {textDisconnect}
+      </Button>
     </div>
   );
 

--- a/packages/react-console/src/components/VncConsole/VncConsole.tsx
+++ b/packages/react-console/src/components/VncConsole/VncConsole.tsx
@@ -3,9 +3,9 @@ import React from 'react';
 import { css } from '@patternfly/react-styles';
 import { EmptyState, EmptyStateBody, EmptyStateIcon, Spinner } from '@patternfly/react-core';
 
-import * as NovncLog from 'novnc-core/lib/util/logging';
+import { initLogging } from '@novnc/novnc/core/util/logging';
 /** Has bad types. https://github.com/larryprice/novnc-core/issues/5 */
-import RFB from 'novnc-core';
+import RFB from '@novnc/novnc/core/rfb';
 
 import { VncActions } from './VncActions';
 import { constants } from '../common/constants';
@@ -101,7 +101,7 @@ export const VncConsole: React.FunctionComponent<VncConsoleProps> = ({
   };
 
   React.useEffect(() => {
-    NovncLog.init_logging(vncLogging);
+    initLogging(vncLogging);
     try {
       const protocol = encrypt ? 'wss' : 'ws';
       const url = `${protocol}://${host}:${port}/${path}`;
@@ -111,7 +111,7 @@ export const VncConsole: React.FunctionComponent<VncConsoleProps> = ({
         shared,
         credentials
       };
-      rfb = (new RFB() as any)(novncElem, url, options);
+      rfb = new RFB(novncElem, url, options);
       addEventListeners();
       rfb.viewOnly = viewOnly;
       rfb.scaleViewport = scaleViewport;

--- a/packages/react-console/src/components/VncConsole/VncConsole.tsx
+++ b/packages/react-console/src/components/VncConsole/VncConsole.tsx
@@ -200,16 +200,18 @@ export const VncConsole: React.FunctionComponent<VncConsoleProps> = ({
   }
 
   return (
-    <div className={css(styles.consoleVnc)}>
-      {children}
-      <React.Fragment>
-        {rightContent}
-        <div>
-          {emptyState}
-          {novncStaticComponent}
-        </div>
-      </React.Fragment>
-    </div>
+    <>
+      {rightContent}
+      <div className={css(styles.consoleVnc)}>
+        {children}
+        <React.Fragment>
+          <div>
+            {emptyState}
+            {novncStaticComponent}
+          </div>
+        </React.Fragment>
+      </div>
+    </>
   );
 };
 VncConsole.displayName = 'VncConsole';

--- a/packages/react-console/src/components/VncConsole/__tests__/__snapshots__/VncConsole.test.tsx.snap
+++ b/packages/react-console/src/components/VncConsole/__tests__/__snapshots__/VncConsole.test.tsx.snap
@@ -1,20 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`placeholder render test 1`] = `
-<div
-  className="pf-c-console__vnc"
->
-  <div>
-    <EmptyState>
-      <EmptyStateIcon
-        component={[Function]}
-        variant="container"
-      />
-      <EmptyStateBody>
-        Connecting
-      </EmptyStateBody>
-    </EmptyState>
-    <div />
+<Fragment>
+  <div
+    className="pf-c-console__vnc"
+  >
+    <div>
+      <EmptyState>
+        <EmptyStateIcon
+          component={[Function]}
+          variant="container"
+        />
+        <EmptyStateBody>
+          Connecting
+        </EmptyStateBody>
+      </EmptyState>
+      <div />
+    </div>
   </div>
-</div>
+</Fragment>
 `;

--- a/packages/react-console/src/components/VncConsole/__tests__/__snapshots__/VncConsoleActions.test.tsx.snap
+++ b/packages/react-console/src/components/VncConsole/__tests__/__snapshots__/VncConsoleActions.test.tsx.snap
@@ -28,13 +28,14 @@ exports[`VncActions renders correctly component hierarchy 1`] = `
   />
   <Button
     onClick={[MockFunction]}
+    variant="secondary"
   >
     Disconnect
   </Button>
 </div>
 `;
 
-exports[`VncActions renders correctly html 1`] = `"<div class=\\"pf-c-console__actions-vnc\\"><div id=\\"pf-c-console__send-shortcut\\" class=\\"pf-c-dropdown\\" data-ouia-component-type=\\"PF4/Dropdown\\" data-ouia-safe=\\"true\\" data-ouia-component-id=\\"OUIA-Generated-Dropdown-1\\"><button data-ouia-component-type=\\"PF4/DropdownToggle\\" data-ouia-safe=\\"true\\" data-ouia-component-id=\\"OUIA-Generated-DropdownToggle-1\\" id=\\"pf-c-console__actions-vnc-toggle-id\\" class=\\"pf-c-dropdown__toggle\\" type=\\"button\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\"><span class=\\"pf-c-dropdown__toggle-text\\">My Send Shortcut description</span><span class=\\"pf-c-dropdown__toggle-icon\\"><svg style=\\"vertical-align:-0.125em\\" fill=\\"currentColor\\" height=\\"1em\\" width=\\"1em\\" viewBox=\\"0 0 320 512\\" aria-hidden=\\"true\\" role=\\"img\\"><path d=\\"M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z\\"></path></svg></span></button></div><button aria-disabled=\\"false\\" class=\\"pf-c-button pf-m-primary\\" type=\\"button\\" data-ouia-component-type=\\"PF4/Button\\" data-ouia-safe=\\"true\\" data-ouia-component-id=\\"OUIA-Generated-Button-primary-1\\">Disconnect</button></div>"`;
+exports[`VncActions renders correctly html 1`] = `"<div class=\\"pf-c-console__actions-vnc\\"><div id=\\"pf-c-console__send-shortcut\\" class=\\"pf-c-dropdown\\" data-ouia-component-type=\\"PF4/Dropdown\\" data-ouia-safe=\\"true\\" data-ouia-component-id=\\"OUIA-Generated-Dropdown-1\\"><button data-ouia-component-type=\\"PF4/DropdownToggle\\" data-ouia-safe=\\"true\\" data-ouia-component-id=\\"OUIA-Generated-DropdownToggle-1\\" id=\\"pf-c-console__actions-vnc-toggle-id\\" class=\\"pf-c-dropdown__toggle\\" type=\\"button\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\"><span class=\\"pf-c-dropdown__toggle-text\\">My Send Shortcut description</span><span class=\\"pf-c-dropdown__toggle-icon\\"><svg style=\\"vertical-align:-0.125em\\" fill=\\"currentColor\\" height=\\"1em\\" width=\\"1em\\" viewBox=\\"0 0 320 512\\" aria-hidden=\\"true\\" role=\\"img\\"><path d=\\"M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z\\"></path></svg></span></button></div><button aria-disabled=\\"false\\" class=\\"pf-c-button pf-m-secondary\\" type=\\"button\\" data-ouia-component-type=\\"PF4/Button\\" data-ouia-safe=\\"true\\" data-ouia-component-id=\\"OUIA-Generated-Button-secondary-1\\">Disconnect</button></div>"`;
 
 exports[`placeholder render test 1`] = `
 <div
@@ -62,6 +63,7 @@ exports[`placeholder render test 1`] = `
   />
   <Button
     onClick={[MockFunction]}
+    variant="secondary"
   >
     Disconnect
   </Button>

--- a/packages/react-console/src/declarations.d.ts
+++ b/packages/react-console/src/declarations.d.ts
@@ -2,3 +2,14 @@ declare module '@spice-project/spice-html5' {
   export const SpiceMainConn: any;
   export const sendCtrlAltDel: any;
 }
+
+declare module '@novnc/novnc/core/rfb' {
+  class RFB {
+    constructor(target: any, url: any, options: any);
+  }
+  export = RFB;
+}
+
+declare module '@novnc/novnc/core/util/logging' {
+  export const initLogging: any;
+}

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -43,7 +43,7 @@
     "rimraf": "^2.6.3",
     "serve": "^11.3.2",
     "shx": "^0.3.2",
-    "theme-patternfly-org": "0.2.11"
+    "theme-patternfly-org": "0.2.12"
   },
   "keywords": [
     "gatsby"

--- a/packages/react-styles/src/css/components/Consoles/VncConsole.css
+++ b/packages/react-styles/src/css/components/Consoles/VncConsole.css
@@ -5,4 +5,5 @@
   grid-area: actions-extra;
   display: flex;
   justify-content: flex-end;
+  column-gap: var(--pf-global--spacer--sm)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4232,6 +4232,13 @@ ast-types@^0.13.2:
   dependencies:
     tslib "^2.0.1"
 
+ast-types@^0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.14.2.tgz#600b882df8583e3cd4f2df5fa20fa83759d4bdfd"
+  integrity sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==
+  dependencies:
+    tslib "^2.0.1"
+
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
@@ -16167,14 +16174,14 @@ react-docgen@^5.1.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-react-docgen@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-5.3.0.tgz#9aabde5e69f1993c8ba839fd9a86696504654589"
-  integrity sha512-hUrv69k6nxazOuOmdGeOpC/ldiKy7Qj/UFpxaQi0eDMrUFUTIPGtY5HJu7BggSmiyAMfREaESbtBL9UzdQ+hyg==
+react-docgen@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-5.3.1.tgz#940b519646a6c285c2950b96512aed59e8f90934"
+  integrity sha512-YG7YujVTwlLslr2Ny8nQiUfbBuEwKsLHJdQTSdEga1eY/nRFh/7LjCWUn6ogYhu2WDKg4z+6W/BJtUi+DPUIlA==
   dependencies:
     "@babel/core" "^7.7.5"
     "@babel/runtime" "^7.7.6"
-    ast-types "^0.13.2"
+    ast-types "^0.14.2"
     commander "^2.19.0"
     doctrine "^3.0.0"
     neo-async "^2.6.1"
@@ -18763,10 +18770,10 @@ textextensions@^2.5.0:
   resolved "https://registry.yarnpkg.com/textextensions/-/textextensions-2.6.0.tgz#d7e4ab13fe54e32e08873be40d51b74229b00fc4"
   integrity sha512-49WtAWS+tcsy93dRt6P0P3AMD2m5PvXRhuEA0kaXos5ZLlujtYmpmFsB+QvWUSxE1ZsstmYXfQ7L40+EcQgpAQ==
 
-theme-patternfly-org@0.2.11:
-  version "0.2.11"
-  resolved "https://registry.yarnpkg.com/theme-patternfly-org/-/theme-patternfly-org-0.2.11.tgz#25a36413b3e596b50d91430b0508a9483fb66fb0"
-  integrity sha512-fNl4DhzJm3wkREg0NZDZihLQ+Tr1DCLF0IFVUM2/SUzJMIYZbpu1Sto5IlwfxNF3Rd0HtDcYIeK5upXjuk0Jmw==
+theme-patternfly-org@0.2.12:
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/theme-patternfly-org/-/theme-patternfly-org-0.2.12.tgz#93da9b95da28f95233eea80cd3de902df6b4dc46"
+  integrity sha512-8Db0LUNizF2HsZdhTClpka0CQjCGr4TzqgjK51VzEyQMfzUhQM+PJeUcE9AfOmRoNUWyCHaPAHR0gm8bJAHytw==
   dependencies:
     "@babel/core" "^7.0.0"
     "@babel/plugin-proposal-class-properties" "^7.0.0"
@@ -18806,7 +18813,7 @@ theme-patternfly-org@0.2.11:
     prismjs "^1.17.1"
     puppeteer "^5.3.1"
     puppeteer-cluster "^0.22.0"
-    react-docgen "^5.3.0"
+    react-docgen "^5.3.1"
     react-live "^2.2.0"
     react-ssr-prepass "^1.2.1"
     remark-footnotes "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2498,6 +2498,11 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@novnc/novnc@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@novnc/novnc/-/novnc-1.2.0.tgz#535ffd7d074022d35205deae2753100f1f2b29f3"
+  integrity sha512-FaUckOedGhSbwQBXk/KGyxKt9ngskg4wPw6ghbHWXOUEmQscAZr3467lTU5DSfppwHJt5k+lQiHoeYUuY90l2Q==
+
 "@npmcli/move-file@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@npmcli/move-file/-/move-file-1.0.1.tgz#de103070dac0f48ce49cf6693c23af59c0f70464"
@@ -3226,11 +3231,6 @@
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
-
-"@types/novnc-core@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@types/novnc-core/-/novnc-core-0.1.2.tgz#2f20dc578d2e29bb109a59d75624a8fdf74383b6"
-  integrity sha512-x0YhIrX0E/PmAqLvPh1CKzpXKIOnN8OST6xn1OMyTmLlFg4sAgpz6pnDBOj1ZZeQVYo4a9rjoZlmlwS1AuUYfg==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -14266,11 +14266,6 @@ normalize-url@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
-
-novnc-core@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/novnc-core/-/novnc-core-0.3.0.tgz#92a5c823727e2154287b239a987f2b1c9dce6e34"
-  integrity sha512-B00+HU2AisvvonHAfPPibONKXFxy47fe978awH5nb6JXxsVJAgT5m7nNJ2fjrbNVcpJ4C2EPg/uZcfgvFl8tSQ==
 
 npm-api@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
novnc-core does not really keep up to date with the latest releases, so
let's just keep depending on the original package.

None of the packages have correct or up to date typings so just add the
types in our declarations file.

Closes #5157
