### PR TITLE
fix(jumplinks): allow hrefs with spaces

### DIFF
--- a/packages/react-core/src/components/JumpLinks/JumpLinks.tsx
+++ b/packages/react-core/src/components/JumpLinks/JumpLinks.tsx
@@ -24,7 +24,12 @@ const getScrollItems = (children: React.ReactNode, hasScrollSpy: boolean) =>
   React.Children.toArray(children).map((child: any) => {
     if (hasScrollSpy && typeof document !== 'undefined' && child.type === JumpLinksItem) {
       const scrollNode = child.props.node || child.props.href;
-      if (typeof scrollNode === 'string' && typeof document !== 'undefined') {
+      if (typeof scrollNode === 'string') {
+        if (scrollNode.startsWith('#')) {
+          // Allow spaces and other special characters as `id`s
+          // https://stackoverflow.com/questions/70579/what-are-valid-values-for-the-id-attribute-in-html
+          return document.getElementById(scrollNode.substr(1)) as HTMLElement;
+        }
         return document.querySelector(scrollNode) as HTMLElement;
       } else if (scrollNode instanceof HTMLElement) {
         return scrollNode;

--- a/packages/react-core/src/components/JumpLinks/JumpLinksItem.tsx
+++ b/packages/react-core/src/components/JumpLinks/JumpLinksItem.tsx
@@ -18,6 +18,8 @@ export interface JumpLinksItemProps extends Omit<React.HTMLProps<HTMLLIElement>,
 export const JumpLinksItem: React.FunctionComponent<JumpLinksItemProps> = ({
   isActive,
   href,
+  // eslint-disable-next-line
+  node,
   children,
   onClick,
   ...props

--- a/packages/react-core/src/demos/JumpLinks.md
+++ b/packages/react-core/src/demos/JumpLinks.md
@@ -8,7 +8,11 @@ beta: true
 
 ### Scrollspy h2 elements
 
-This demo shows JumpLinkItems spying on h2 elements on the scrollable body of a page. The titles are given a tab index to allow the jump links to focus them.
+This demo shows JumpLinkItems spying on h2 elements in a scrollable PageGroup. The titles are given a tab index to allow the jump links to focus them.
+
+When implementing be sure to:
+1. Find the correct scrollableSelector for your page via [Firefox's debugging scrollable overflow](https://developer.mozilla.org/en-US/docs/Tools/Page_Inspector/How_to/Debug_Scrollable_Overflow) or by adding `hasOverflowScroll` to a [PageSection](/components/page#pagesection) or [PageGroup](/components/page#pagegroup).
+2. Provide `href`s to your JumpLinksItems which match the `id` of your titles or other components you are scrolling to. If you wish to scroll to a different item than you're linking to use `scrollNode` instead.
 
 ```js isFullscreen
 import React from 'react';

--- a/packages/react-core/src/demos/JumpLinks.md
+++ b/packages/react-core/src/demos/JumpLinks.md
@@ -12,7 +12,7 @@ This demo shows JumpLinkItems spying on h2 elements in a scrollable PageGroup. T
 
 When implementing be sure to:
 1. Find the correct scrollableSelector for your page via [Firefox's debugging scrollable overflow](https://developer.mozilla.org/en-US/docs/Tools/Page_Inspector/How_to/Debug_Scrollable_Overflow) or by adding `hasOverflowScroll` to a [PageSection](/components/page#pagesection) or [PageGroup](/components/page#pagegroup).
-2. Provide `href`s to your JumpLinksItems which match the `id` of your titles or other components you are scrolling to. If you wish to scroll to a different item than you're linking to use `scrollNode` instead.
+2. Provide `href`s to your JumpLinksItems which match the `id` of elements you want to spy on. If you wish to scroll to a different item than you're linking to use the `node` prop instead.
 
 ```js isFullscreen
 import React from 'react';


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5218

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: Previously wasn't working because `id`s [can't include spaces.](https://www.quora.com/jQuery-How-can-I-select-a-div-whose-id-contains-a-space)
