### PR TITLE
fix(topology): adjust topology node layout when new nodes are added

### DIFF
--- a/packages/react-topology/src/layouts/BaseLayout.ts
+++ b/packages/react-topology/src/layouts/BaseLayout.ts
@@ -64,6 +64,7 @@ export class BaseLayout implements Layout {
     this.graph = graph;
     this.options = {
       ...LAYOUT_DEFAULTS,
+      onSimulationEnd: this.onSimulationEnd,
       ...options
     };
 
@@ -77,6 +78,8 @@ export class BaseLayout implements Layout {
     this.forceSimulation = new ForceSimulation(this.options);
     this.startListening();
   }
+
+  protected onSimulationEnd = () => {};
 
   destroy(): void {
     if (this.options.allowDrag) {


### PR DESCRIPTION
**What**: 
Closes https://github.com/patternfly/patternfly-react/issues/5248

**Description**
Update topology cola layout to run one round of force simulation after the cola layout when nodes are added. This will slightly adjust the graph to accommodate new nodes preventing initial overlap.

/cc @christianvogt 