### PR TITLE
fix(calendar-month): rely on base styles from react-core/dist/styles/base.css

### DIFF
--- a/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
+++ b/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
@@ -6,7 +6,6 @@ import ArrowLeftIcon from '@patternfly/react-icons/dist/js/icons/arrow-left-icon
 import ArrowRightIcon from '@patternfly/react-icons/dist/js/icons/arrow-right-icon';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/CalendarMonth/calendar-month';
-import commonStyles from '@patternfly/react-styles/css/base/patternfly-common';
 import { getUniqueId } from '../../helpers/util';
 
 export enum Weekday {
@@ -261,7 +260,7 @@ export const CalendarMonth = ({
           <tr>
             {calendar[0].map(({ date }, index) => (
               <th key={index} className={styles.calendarMonthDay} scope="col">
-                <span className={commonStyles.screenReader}>{longWeekdayFormat(date)}</span>
+                <span className="pf-screen-reader">{longWeekdayFormat(date)}</span>
                 <span aria-hidden>{weekdayFormat(date)}</span>
               </th>
             ))}

--- a/packages/react-styles/scripts/generateClassMaps.js
+++ b/packages/react-styles/scripts/generateClassMaps.js
@@ -58,7 +58,7 @@ function generateClassMaps() {
 
   const patternflyCSSFiles = glob.sync('**/*.css', {
     cwd: pfStylesDir,
-    ignore: ['assets/**', '*.css'],
+    ignore: ['assets/**', '*.css', 'base/**'],
     absolute: true
   });
   const srcCSSFiles = glob.sync('src/css/**/*.css');


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: In some cases may fix base styles being loaded incorrectly:
![image](https://user-images.githubusercontent.com/47335686/101948709-83725580-3bc0-11eb-9b8f-90c5f4e1ecf2.png)


<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: React-styles shouldn't reexport `base` styles because `react-core/dist/styles/base.css` already exports them. Including them from react-styles just includes the CSS twice which can cause issues.
