### PR TITLE
fix(Select): fix crash when opened using Enter with disabled options

### DIFF
--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -195,8 +195,11 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
       this.refCollection[0][0] = this.filterRef.current;
     }
 
-    if (!prevState.openedOnEnter && this.state.openedOnEnter && !this.props.customContent && this.refCollection[0]) {
-      this.refCollection[0][0].focus();
+    if (!prevState.openedOnEnter && this.state.openedOnEnter && !this.props.customContent) {
+      const firstRef = this.refCollection.find(ref => ref !== null);
+      if (firstRef && firstRef[0]) {
+        firstRef[0].focus();
+      }
     }
 
     if (prevProps.children !== this.props.children) {


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5257

When a `<Select>` has a disabled options on top of the options list,
`this.refCollection[0]` will be an array in the shape of `[null, null]`.
This means that trying to call `this.refCollection[0][0].focus()`
will fail with TypeError in this case.

This patch fixes this issue, by finding the first non-null ref in the
collection and focusing on it, instead of assuming the first ref in the
collection is valid.