### PR TITLE
fix(ToggleGroup): Fix bug with ToggleGroupItem button being clicked in form in modal closing modal

### DIFF
--- a/packages/react-core/src/components/ToggleGroup/ToggleGroupItem.tsx
+++ b/packages/react-core/src/components/ToggleGroup/ToggleGroupItem.tsx
@@ -48,6 +48,7 @@ export const ToggleGroupItem: React.FunctionComponent<ToggleGroupItemProps> = ({
   return (
     <div className={css(styles.toggleGroupItem, className)} {...props}>
       <button
+        type="button"
         className={css(
           styles.toggleGroupButton,
           toggleGroupContext.variant === 'light' && styles.modifiers.light,

--- a/packages/react-core/src/components/ToggleGroup/__tests__/__snapshots__/ToggleGroup.test.tsx.snap
+++ b/packages/react-core/src/components/ToggleGroup/__tests__/__snapshots__/ToggleGroup.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`basic not selected 1`] = `
     className="pf-c-toggle-group__button"
     id="toggleGroupItem"
     onClick={[Function]}
+    type="button"
   >
     <ToggleGroupItemElement
       variant="text"
@@ -31,6 +32,7 @@ exports[`basic selected 1`] = `
     className="pf-c-toggle-group__button"
     id="toggleGroupItem"
     onClick={[Function]}
+    type="button"
   >
     <ToggleGroupItemElement
       variant="text"
@@ -52,6 +54,7 @@ exports[`icon variant 1`] = `
     className="pf-c-toggle-group__button"
     id="toggleGroupItem"
     onClick={[Function]}
+    type="button"
   >
     <ToggleGroupItemElement
       variant="icon"
@@ -73,6 +76,7 @@ exports[`isDisabled 1`] = `
     disabled={true}
     id="toggleGroupItem"
     onClick={[Function]}
+    type="button"
   >
     <ToggleGroupItemElement
       variant="text"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5195 

Added `type="button"` to button in ToggleGroupItem.

Cf https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button

"If your buttons are not for submitting form data to a server, be sure to set their type attribute to button. Otherwise they will try to submit form data and to load the (nonexistent) response, possibly destroying the current state of the document."

//cc @tlabaj 
