### PR TITLE
feat(ChipGroup): Add event handler prop for overflow-chip click 

### DIFF
--- a/packages/react-core/src/components/ChipGroup/ChipGroup.tsx
+++ b/packages/react-core/src/components/ChipGroup/ChipGroup.tsx
@@ -33,7 +33,7 @@ export interface ChipGroupProps extends React.HTMLProps<HTMLUListElement>, OUIAP
   /** Function that is called when clicking on the chip group close button */
   onClick?: (event: React.MouseEvent) => void;
   /** Function that is called when clicking on the toggle expand/collapse button */
-  onToggleCollapseClick?: (event: React.MouseEvent) => void;
+  onOverflowChipClick?: (event: React.MouseEvent) => void;
   /** Position of the tooltip which is displayed if the category name text is longer */
   tooltipPosition?: 'auto' | 'top' | 'bottom' | 'left' | 'right';
 }
@@ -63,7 +63,7 @@ export class ChipGroup extends React.Component<ChipGroupProps, ChipGroupState> {
     isClosable: false,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     onClick: (_e: React.MouseEvent) => undefined as any,
-    onToggleCollapseClick: (_e: React.MouseEvent) => undefined as any,
+    onOverflowChipClick: (_e: React.MouseEvent) => undefined as any,
     closeBtnAriaLabel: 'Close chip group',
     tooltipPosition: 'top',
     'aria-label': 'Chip group category'
@@ -117,10 +117,10 @@ export class ChipGroup extends React.Component<ChipGroupProps, ChipGroupState> {
       closeBtnAriaLabel,
       'aria-label': ariaLabel,
       onClick,
+      onOverflowChipClick,
       numChips,
       expandedText,
       collapsedText,
-      onToggleCollapseClick,
       ouiaId,
       /* eslint-disable @typescript-eslint/no-unused-vars */
       defaultIsOpen,
@@ -164,7 +164,7 @@ export class ChipGroup extends React.Component<ChipGroupProps, ChipGroupState> {
                     isOverflowChip
                     onClick={event => {
                       this.toggleCollapse();
-                      onToggleCollapseClick(event);
+                      onOverflowChipClick(event);
                     }}
                     component="button"
                   >

--- a/packages/react-core/src/components/ChipGroup/ChipGroup.tsx
+++ b/packages/react-core/src/components/ChipGroup/ChipGroup.tsx
@@ -32,6 +32,8 @@ export interface ChipGroupProps extends React.HTMLProps<HTMLUListElement>, OUIAP
   closeBtnAriaLabel?: string;
   /** Function that is called when clicking on the chip group close button */
   onClick?: (event: React.MouseEvent) => void;
+  /** Function that is called when clicking on the toggle expand/collapse button */
+  onToggleCollapseClick?: (event: React.MouseEvent) => void;
   /** Position of the tooltip which is displayed if the category name text is longer */
   tooltipPosition?: 'auto' | 'top' | 'bottom' | 'left' | 'right';
 }
@@ -61,6 +63,7 @@ export class ChipGroup extends React.Component<ChipGroupProps, ChipGroupState> {
     isClosable: false,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     onClick: (_e: React.MouseEvent) => undefined as any,
+    onToggleCollapseClick: (_e: React.MouseEvent) => undefined as any,
     closeBtnAriaLabel: 'Close chip group',
     tooltipPosition: 'top',
     'aria-label': 'Chip group category'
@@ -117,6 +120,7 @@ export class ChipGroup extends React.Component<ChipGroupProps, ChipGroupState> {
       numChips,
       expandedText,
       collapsedText,
+      onToggleCollapseClick,
       ouiaId,
       /* eslint-disable @typescript-eslint/no-unused-vars */
       defaultIsOpen,
@@ -156,7 +160,14 @@ export class ChipGroup extends React.Component<ChipGroupProps, ChipGroupState> {
               ))}
               {numChildren > numChips && (
                 <li className={css(styles.chipGroupListItem)}>
-                  <Chip isOverflowChip onClick={this.toggleCollapse} component="button">
+                  <Chip
+                    isOverflowChip
+                    onClick={event => {
+                      this.toggleCollapse();
+                      onToggleCollapseClick(event);
+                    }}
+                    component="button"
+                  >
                     {isOpen ? expandedText : collapsedTextResult}
                   </Chip>
                 </li>

--- a/packages/react-core/src/components/ChipGroup/ChipGroup.tsx
+++ b/packages/react-core/src/components/ChipGroup/ChipGroup.tsx
@@ -32,7 +32,7 @@ export interface ChipGroupProps extends React.HTMLProps<HTMLUListElement>, OUIAP
   closeBtnAriaLabel?: string;
   /** Function that is called when clicking on the chip group close button */
   onClick?: (event: React.MouseEvent) => void;
-  /** Function that is called when clicking on the toggle expand/collapse button */
+  /** Function that is called when clicking on the overflow (expand/collapse) chip button */
   onOverflowChipClick?: (event: React.MouseEvent) => void;
   /** Position of the tooltip which is displayed if the category name text is longer */
   tooltipPosition?: 'auto' | 'top' | 'bottom' | 'left' | 'right';

--- a/packages/react-core/src/components/ChipGroup/__tests__/__snapshots__/ChipGroup.test.tsx.snap
+++ b/packages/react-core/src/components/ChipGroup/__tests__/__snapshots__/ChipGroup.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`ChipGroup chip group default 1`] = `
   isClosable={false}
   numChips={3}
   onClick={[Function]}
+  onOverflowChipClick={[Function]}
   tooltipPosition="top"
 >
   <GenerateId
@@ -129,6 +130,7 @@ exports[`ChipGroup chip group with category 1`] = `
   isClosable={false}
   numChips={3}
   onClick={[Function]}
+  onOverflowChipClick={[Function]}
   tooltipPosition="top"
 >
   <GenerateId
@@ -254,6 +256,7 @@ exports[`ChipGroup chip group with category and tooltip 1`] = `
   isClosable={false}
   numChips={3}
   onClick={[Function]}
+  onOverflowChipClick={[Function]}
   tooltipPosition="top"
 >
   <GenerateId
@@ -379,6 +382,7 @@ exports[`ChipGroup chip group with closable category 1`] = `
   isClosable={true}
   numChips={3}
   onClick={[Function]}
+  onOverflowChipClick={[Function]}
   tooltipPosition="top"
 >
   <GenerateId

--- a/packages/react-core/src/components/ChipGroup/examples/ChipGroup.md
+++ b/packages/react-core/src/components/ChipGroup/examples/ChipGroup.md
@@ -7,7 +7,9 @@ ouia: true
 ---
 
 ## Examples
+
 ### Single
+
 ```js
 import React from 'react';
 import { Badge, Chip } from '@patternfly/react-core';
@@ -73,7 +75,7 @@ class SingleChip extends React.Component {
         </Chip>
         <br /> <br />
         {overflowchip && (
-          <Chip key="chip5" component='button' onClick={() => this.deleteItem('overflowchip')} isOverflowChip>
+          <Chip key="chip5" component="button" onClick={() => this.deleteItem('overflowchip')} isOverflowChip>
             {overflowchip.name}
           </Chip>
         )}
@@ -84,6 +86,7 @@ class SingleChip extends React.Component {
 ```
 
 ### Simple inline chip group
+
 ```js
 import React from 'react';
 import { Chip, ChipGroup } from '@patternfly/react-core';
@@ -122,6 +125,7 @@ class SimpleInlineChipGroup extends React.Component {
 ```
 
 ### Chip groups with categories
+
 ```js
 import React from 'react';
 import { Chip, ChipGroup } from '@patternfly/react-core';
@@ -132,7 +136,7 @@ class SimpleCategoryChipGroup extends React.Component {
     this.state = {
       chips: ['Chip one', 'Chip two', 'Chip three', 'Chip four', 'Chip five']
     };
-   this.deleteItem = id => {
+    this.deleteItem = id => {
       const copyOfChips = this.state.chips;
       const index = copyOfChips.indexOf(id);
       if (index !== -1) {
@@ -159,6 +163,7 @@ class SimpleCategoryChipGroup extends React.Component {
 ```
 
 ### Chip groups with categories removable
+
 ```js
 import React from 'react';
 import { Chip, ChipGroup } from '@patternfly/react-core';
@@ -170,7 +175,7 @@ class CategoryChipGroupRemovable extends React.Component {
       chips: ['Chip one', 'Chip two', 'Chip three'],
       chips2: ['Chip one', 'Chip two', 'Chip three', 'Chip 4']
     };
-   this.deleteItem = id => {
+    this.deleteItem = id => {
       const copyOfChips = this.state.chips;
       const index = copyOfChips.indexOf(id);
       if (index !== -1) {
@@ -190,11 +195,11 @@ class CategoryChipGroupRemovable extends React.Component {
 
     this.deleteCategory = () => {
       this.setState({ chips: [] });
-    }
+    };
 
-    this.deleteCategory2= () => {
+    this.deleteCategory2 = () => {
       this.setState({ chips2: [] });
-    }
+    };
   }
 
   render() {
@@ -202,21 +207,21 @@ class CategoryChipGroupRemovable extends React.Component {
 
     return (
       <React.Fragment>
-      <ChipGroup categoryName="Category one" isClosable onClick={this.deleteCategory}>
-        {chips.map(currentChip => (
-          <Chip key={currentChip} onClick={() => this.deleteItem(currentChip)}>
-            {currentChip}
-          </Chip>
-        ))}
-      </ChipGroup>
-      <br /> <br />
-      <ChipGroup categoryName="Category two has a very long name" isClosable onClick={this.deleteCategory2}>
-        {chips2.map(currentChip => (
-          <Chip key={currentChip} onClick={() => this.deleteItem2(currentChip)}>
-            {currentChip}
-          </Chip>
-        ))}
-      </ChipGroup>
+        <ChipGroup categoryName="Category one" isClosable onClick={this.deleteCategory}>
+          {chips.map(currentChip => (
+            <Chip key={currentChip} onClick={() => this.deleteItem(currentChip)}>
+              {currentChip}
+            </Chip>
+          ))}
+        </ChipGroup>
+        <br /> <br />
+        <ChipGroup categoryName="Category two has a very long name" isClosable onClick={this.deleteCategory2}>
+          {chips2.map(currentChip => (
+            <Chip key={currentChip} onClick={() => this.deleteItem2(currentChip)}>
+              {currentChip}
+            </Chip>
+          ))}
+        </ChipGroup>
       </React.Fragment>
     );
   }

--- a/packages/react-core/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/packages/react-core/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
@@ -10169,6 +10169,7 @@ exports[`typeahead multi select renders selected successfully 1`] = `
               isClosable={false}
               numChips={3}
               onClick={[Function]}
+              onOverflowChipClick={[Function]}
               tooltipPosition="top"
             >
               <GenerateId

--- a/packages/react-integration/cypress/integration/chipgroupwithoverflowchipeventhandler.spec.ts
+++ b/packages/react-integration/cypress/integration/chipgroupwithoverflowchipeventhandler.spec.ts
@@ -1,0 +1,13 @@
+describe('Chip Group with Custom Overflow Chip Event Handler', () => {
+  it('Navigate to demo section', () => {
+    cy.visit('http://localhost:3000/');
+    cy.get('#chipgroup-with-overflow-chip-event-handler-demo-nav-item-link').click();
+    cy.url().should('eq', 'http://localhost:3000/chipgroup-with-overflow-chip-event-handler-demo-nav-link');
+  });
+
+  it('Verify additional text is shown from custom event handler when overflow chip is clicked', () => {
+    cy.get('.pf-c-title').should('not.exist');
+    cy.get('.pf-m-overflow').click();
+    cy.get('.pf-c-title').should('exist');
+  });
+});

--- a/packages/react-integration/demo-app-ts/src/Demos.ts
+++ b/packages/react-integration/demo-app-ts/src/Demos.ts
@@ -166,6 +166,11 @@ export const Demos: DemoInterface[] = [
     componentType: Examples.ChipWithCategoryGroupDemo
   },
   {
+    id: 'chipgroup-with-overflow-chip-event-handler-demo',
+    name: 'ChipGroup With Overflow Event Handler',
+    componentType: Examples.ChipGroupWithOverflowChipEventHandler
+  },
+  {
     id: 'clipboard-copy-demo',
     name: 'ClipboardCopy Demo',
     componentType: Examples.ClipboardCopyDemo

--- a/packages/react-integration/demo-app-ts/src/components/demos/ChipGroupDemo/ChipGroupDefaultIsOpenDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/ChipGroupDemo/ChipGroupDefaultIsOpenDemo.tsx
@@ -31,7 +31,7 @@ export class ChipGroupDefaultIsOpenDemo extends Component<{}, BadgeChipState> {
           count: 3
         },
         {
-          name: 'grapfruit',
+          name: 'grapefruit',
           isRead: true,
           count: 1
         }

--- a/packages/react-integration/demo-app-ts/src/components/demos/ChipGroupDemo/ChipGroupWithOverflowChipEventHandler.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/ChipGroupDemo/ChipGroupWithOverflowChipEventHandler.tsx
@@ -9,6 +9,8 @@ interface ChipGroupWithOverflowChipEventHandlerState {
 }
 
 export class ChipGroupWithOverflowChipEventHandler extends Component<{}, ChipGroupWithOverflowChipEventHandlerState> {
+  deleteItem: (id: string) => void;
+
   constructor(props: {}) {
     super(props);
     this.state = {
@@ -31,6 +33,17 @@ export class ChipGroupWithOverflowChipEventHandler extends Component<{}, ChipGro
       ],
       shouldShowAdditionalText: false
     };
+
+    this.deleteItem = (id: string) => {
+      const copyOfChipArray = this.state.chipArray;
+      const index = copyOfChipArray.findIndex(chipObj => chipObj.name === id);
+
+      if (index !== -1) {
+        copyOfChipArray.splice(index, 1);
+        this.setState({ chipArray: copyOfChipArray });
+      }
+    };
+
     this.handleOverflowChipClick = this.handleOverflowChipClick.bind(this);
   }
 
@@ -48,7 +61,9 @@ export class ChipGroupWithOverflowChipEventHandler extends Component<{}, ChipGro
       <>
         <ChipGroup onOverflowChipClick={() => this.handleOverflowChipClick()}>
           {chipArray.map(chip => (
-            <Chip key={chip.name}>{chip.name}</Chip>
+            <Chip key={chip.name} onClick={() => this.deleteItem(chip.name)}>
+              {chip.name}
+            </Chip>
           ))}
         </ChipGroup>
         {this.state.shouldShowAdditionalText && (

--- a/packages/react-integration/demo-app-ts/src/components/demos/ChipGroupDemo/ChipGroupWithOverflowChipEventHandler.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/ChipGroupDemo/ChipGroupWithOverflowChipEventHandler.tsx
@@ -1,0 +1,60 @@
+import React, { Component } from 'react';
+import { Chip, ChipGroup } from '@patternfly/react-core';
+
+interface ChipGroupWithOverflowChipEventHandlerState {
+  chipArray: {
+    name: string;
+  }[];
+  shouldShowAdditionalText: boolean;
+}
+
+export class ChipGroupWithOverflowChipEventHandler extends Component<{}, ChipGroupWithOverflowChipEventHandlerState> {
+  constructor(props: {}) {
+    super(props);
+    this.state = {
+      chipArray: [
+        {
+          name: 'Lemons'
+        },
+        {
+          name: 'Limes'
+        },
+        {
+          name: 'Peaches'
+        },
+        {
+          name: 'Pears'
+        },
+        {
+          name: 'Tangerines'
+        }
+      ],
+      shouldShowAdditionalText: false
+    };
+    this.handleOverflowChipClick = this.handleOverflowChipClick.bind(this);
+  }
+
+  componentDidMount() {
+    window.scrollTo(0, 0);
+  }
+
+  handleOverflowChipClick() {
+    this.setState({ shouldShowAdditionalText: !this.state.shouldShowAdditionalText });
+  }
+
+  render() {
+    const { chipArray } = this.state;
+    return (
+      <>
+        <ChipGroup onOverflowChipClick={() => this.handleOverflowChipClick()}>
+          {chipArray.map(chip => (
+            <Chip key={chip.name}>{chip.name}</Chip>
+          ))}
+        </ChipGroup>
+        {this.state.shouldShowAdditionalText && (
+          <h1 className="pf-c-title pf-m-2xl pf-u-p-lg">Full results are currently expanded.</h1>
+        )}
+      </>
+    );
+  }
+}

--- a/packages/react-integration/demo-app-ts/src/components/demos/index.ts
+++ b/packages/react-integration/demo-app-ts/src/components/demos/index.ts
@@ -28,6 +28,7 @@ export * from './CheckboxDemo/CheckboxDemo';
 export * from './ChipGroupDemo/ChipGroupDefaultIsOpenDemo';
 export * from './ChipGroupDemo/ChipGroupDemo';
 export * from './ChipGroupDemo/ChipGroupWithCategoryDemo';
+export * from './ChipGroupDemo/ChipGroupWithOverflowChipEventHandler';
 export * from './ContextSelectorDemo/ContextSelectorDemo';
 export * from './ConsolesDemo/ConsolesDemo';
 export * from './ClipboardCopyDemo/ClipboardCopyDemo';


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5190 

Adds an optional prop called `onOverflowChipClick` that, when used, calls the provided handler function when the overflow (toggle expand/collapse) chip is clicked.  

There is already an onClick prop, hence naming this differently.  Let me know if you have a better idea for a name for this prop.

//cc @tlabaj
