### PR TITLE
Feat(PageHeader) - Changing logoComponent to revert to span if it is a and no href is provided

### DIFF
--- a/packages/react-core/src/components/Page/PageHeader.tsx
+++ b/packages/react-core/src/components/Page/PageHeader.tsx
@@ -6,13 +6,18 @@ import BarsIcon from '@patternfly/react-icons/dist/js/icons/bars-icon';
 import { Button, ButtonVariant } from '../../components/Button';
 import { PageContextConsumer, PageContextProps } from './Page';
 
+interface LogoProps {
+  href?: string;
+  ['key']: any;
+}
+
 export interface PageHeaderProps extends React.HTMLProps<HTMLDivElement> {
   /** Additional classes added to the page header */
   className?: string;
   /** Component to render the logo/brand, use <Brand /> */
   logo?: React.ReactNode;
   /** Additional props passed to the logo anchor container */
-  logoProps?: object;
+  logoProps?: LogoProps;
   /** Component to use to wrap the passed <logo> */
   logoComponent?: React.ReactNode;
   /** Component to render the header tools, use <PageHeaderTools />  */
@@ -36,7 +41,7 @@ export interface PageHeaderProps extends React.HTMLProps<HTMLDivElement> {
 export const PageHeader: React.FunctionComponent<PageHeaderProps> = ({
   className = '',
   logo = null as React.ReactNode,
-  logoProps = { href: '/' },
+  logoProps = null as LogoProps,
   logoComponent = 'a',
   headerTools = null as React.ReactNode,
   topNav = null as React.ReactNode,
@@ -49,7 +54,12 @@ export const PageHeader: React.FunctionComponent<PageHeaderProps> = ({
   'aria-controls': ariaControls = null,
   ...props
 }: PageHeaderProps) => {
-  const LogoComponent = logoComponent as any;
+  let detectedLogoComponent = logoComponent;
+  if (logoComponent === 'a' && !logoProps?.href) {
+    detectedLogoComponent = 'span';
+  }
+  const LogoComponent = detectedLogoComponent as any;
+
   if ([false, true].includes(deprecatedIsManagedSidebar)) {
     console.warn(
       'isManagedSidebar is deprecated in the PageHeader component. To make the sidebar toggle uncontrolled, pass this prop in the Page component'

--- a/packages/react-core/src/components/Page/PageHeader.tsx
+++ b/packages/react-core/src/components/Page/PageHeader.tsx
@@ -36,7 +36,7 @@ export interface PageHeaderProps extends React.HTMLProps<HTMLDivElement> {
 export const PageHeader: React.FunctionComponent<PageHeaderProps> = ({
   className = '',
   logo = null as React.ReactNode,
-  logoProps = null as object,
+  logoProps = { href: '/' },
   logoComponent = 'a',
   headerTools = null as React.ReactNode,
   topNav = null as React.ReactNode,

--- a/packages/react-core/src/components/Page/PageHeader.tsx
+++ b/packages/react-core/src/components/Page/PageHeader.tsx
@@ -8,7 +8,7 @@ import { PageContextConsumer, PageContextProps } from './Page';
 
 interface LogoProps {
   href?: string;
-  ['key']: any;
+  [key: string]: any;
 }
 
 export interface PageHeaderProps extends React.HTMLProps<HTMLDivElement> {

--- a/packages/react-core/src/components/Page/PageHeader.tsx
+++ b/packages/react-core/src/components/Page/PageHeader.tsx
@@ -8,6 +8,9 @@ import { PageContextConsumer, PageContextProps } from './Page';
 
 interface LogoProps {
   href?: string;
+  onClick?: any;
+  name?: string;
+  download?: string;
   [key: string]: any;
 }
 
@@ -55,9 +58,12 @@ export const PageHeader: React.FunctionComponent<PageHeaderProps> = ({
   ...props
 }: PageHeaderProps) => {
   let detectedLogoComponent = logoComponent;
-  if (logoComponent === 'a' && !logoProps?.href) {
-    detectedLogoComponent = 'span';
+  if (logoComponent === 'a') {
+    if (!logoProps?.href && !logoProps?.name && !logoProps?.onClick && !logoProps?.target) {
+      detectedLogoComponent = 'span';
+    }
   }
+
   const LogoComponent = detectedLogoComponent as any;
 
   if ([false, true].includes(deprecatedIsManagedSidebar)) {

--- a/packages/react-core/src/components/Page/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/packages/react-core/src/components/Page/__tests__/__snapshots__/Page.test.tsx.snap
@@ -43,12 +43,11 @@ exports[`Check dark page against snapshot 1`] = `
         <div
           className="pf-c-page__header-brand"
         >
-          <a
+          <span
             className="pf-c-page__header-brand-link"
-            href="/"
           >
             Logo
-          </a>
+          </span>
         </div>
         PageHeaderTools | Avatar
       </header>
@@ -155,12 +154,11 @@ exports[`Check page horizontal layout example against snapshot 1`] = `
         <div
           className="pf-c-page__header-brand"
         >
-          <a
+          <span
             className="pf-c-page__header-brand-link"
-            href="/"
           >
             Logo
-          </a>
+          </span>
         </div>
         <div
           className="pf-c-page__header-nav"
@@ -268,12 +266,11 @@ exports[`Check page to verify breadcrumb is created - PageBreadcrumb syntax 1`] 
         <div
           className="pf-c-page__header-brand"
         >
-          <a
+          <span
             className="pf-c-page__header-brand-link"
-            href="/"
           >
             Logo
-          </a>
+          </span>
         </div>
         <div
           className="pf-c-page__header-nav"
@@ -549,12 +546,11 @@ exports[`Check page to verify breadcrumb is created 1`] = `
         <div
           className="pf-c-page__header-brand"
         >
-          <a
+          <span
             className="pf-c-page__header-brand-link"
-            href="/"
           >
             Logo
-          </a>
+          </span>
         </div>
         <div
           className="pf-c-page__header-nav"
@@ -829,12 +825,11 @@ exports[`Check page to verify grouped nav and breadcrumb - new components syntax
         <div
           className="pf-c-page__header-brand"
         >
-          <a
+          <span
             className="pf-c-page__header-brand-link"
-            href="/"
           >
             Logo
-          </a>
+          </span>
         </div>
         <div
           className="pf-c-page__header-nav"
@@ -1378,12 +1373,11 @@ exports[`Check page to verify grouped nav and breadcrumb - old / props syntax 1`
         <div
           className="pf-c-page__header-brand"
         >
-          <a
+          <span
             className="pf-c-page__header-brand-link"
-            href="/"
           >
             Logo
-          </a>
+          </span>
         </div>
         <div
           className="pf-c-page__header-nav"
@@ -1855,12 +1849,11 @@ exports[`Check page to verify nav is created - PageNavigation syntax 1`] = `
         <div
           className="pf-c-page__header-brand"
         >
-          <a
+          <span
             className="pf-c-page__header-brand-link"
-            href="/"
           >
             Logo
-          </a>
+          </span>
         </div>
         <div
           className="pf-c-page__header-nav"
@@ -2197,12 +2190,11 @@ exports[`Check page to verify skip to content points to main content region 1`] 
         <div
           className="pf-c-page__header-brand"
         >
-          <a
+          <span
             className="pf-c-page__header-brand-link"
-            href="/"
           >
             Logo
-          </a>
+          </span>
         </div>
         <div
           className="pf-c-page__header-nav"
@@ -2477,12 +2469,11 @@ exports[`Check page vertical layout example against snapshot 1`] = `
         <div
           className="pf-c-page__header-brand"
         >
-          <a
+          <span
             className="pf-c-page__header-brand-link"
-            href="/"
           >
             Logo
-          </a>
+          </span>
         </div>
         PageHeaderTools | Avatar
       </header>

--- a/packages/react-core/src/components/Page/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/packages/react-core/src/components/Page/__tests__/__snapshots__/Page.test.tsx.snap
@@ -45,6 +45,7 @@ exports[`Check dark page against snapshot 1`] = `
         >
           <a
             className="pf-c-page__header-brand-link"
+            href="/"
           >
             Logo
           </a>
@@ -156,6 +157,7 @@ exports[`Check page horizontal layout example against snapshot 1`] = `
         >
           <a
             className="pf-c-page__header-brand-link"
+            href="/"
           >
             Logo
           </a>
@@ -268,6 +270,7 @@ exports[`Check page to verify breadcrumb is created - PageBreadcrumb syntax 1`] 
         >
           <a
             className="pf-c-page__header-brand-link"
+            href="/"
           >
             Logo
           </a>
@@ -548,6 +551,7 @@ exports[`Check page to verify breadcrumb is created 1`] = `
         >
           <a
             className="pf-c-page__header-brand-link"
+            href="/"
           >
             Logo
           </a>
@@ -827,6 +831,7 @@ exports[`Check page to verify grouped nav and breadcrumb - new components syntax
         >
           <a
             className="pf-c-page__header-brand-link"
+            href="/"
           >
             Logo
           </a>
@@ -1375,6 +1380,7 @@ exports[`Check page to verify grouped nav and breadcrumb - old / props syntax 1`
         >
           <a
             className="pf-c-page__header-brand-link"
+            href="/"
           >
             Logo
           </a>
@@ -1851,6 +1857,7 @@ exports[`Check page to verify nav is created - PageNavigation syntax 1`] = `
         >
           <a
             className="pf-c-page__header-brand-link"
+            href="/"
           >
             Logo
           </a>
@@ -2192,6 +2199,7 @@ exports[`Check page to verify skip to content points to main content region 1`] 
         >
           <a
             className="pf-c-page__header-brand-link"
+            href="/"
           >
             Logo
           </a>
@@ -2471,6 +2479,7 @@ exports[`Check page vertical layout example against snapshot 1`] = `
         >
           <a
             className="pf-c-page__header-brand-link"
+            href="/"
           >
             Logo
           </a>

--- a/packages/react-core/src/components/Page/__tests__/__snapshots__/PageHeader.test.tsx.snap
+++ b/packages/react-core/src/components/Page/__tests__/__snapshots__/PageHeader.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`Check page vertical layout example against snapshot 1`] = `
     >
       <a
         className="pf-c-page__header-brand-link"
+        href="/"
       >
         Logo
       </a>

--- a/packages/react-core/src/components/Page/__tests__/__snapshots__/PageHeader.test.tsx.snap
+++ b/packages/react-core/src/components/Page/__tests__/__snapshots__/PageHeader.test.tsx.snap
@@ -12,12 +12,11 @@ exports[`Check page vertical layout example against snapshot 1`] = `
     <div
       className="pf-c-page__header-brand"
     >
-      <a
+      <span
         className="pf-c-page__header-brand-link"
-        href="/"
       >
         Logo
-      </a>
+      </span>
     </div>
     PageHeaderTools | Avatar
   </header>

--- a/packages/react-virtualized-extension/src/components/Virtualized/__snapshots__/VirtualizedTable.test.tsx.snap
+++ b/packages/react-virtualized-extension/src/components/Virtualized/__snapshots__/VirtualizedTable.test.tsx.snap
@@ -1386,7 +1386,7 @@ exports[`Actions virtualized table 1`] = `
                                         data-key={5}
                                         data-label=""
                                         onMouseEnter={[Function]}
-                                        scope=""
+                                        scope={null}
                                       />
                                     </ThBase>
                                   </Th>
@@ -2546,7 +2546,7 @@ exports[`Selectable virtualized table 1`] = `
                                         data-key={0}
                                         data-label=""
                                         onMouseEnter={[Function]}
-                                        scope=""
+                                        scope={null}
                                       >
                                         <SelectColumn
                                           aria-label="Select all rows"
@@ -4593,7 +4593,7 @@ exports[`Simple Actions table 1`] = `
                                         data-key={5}
                                         data-label=""
                                         onMouseEnter={[Function]}
-                                        scope=""
+                                        scope={null}
                                       />
                                     </ThBase>
                                   </Th>

--- a/packages/react-virtualized-extension/src/components/Virtualized/__snapshots__/VirtualizedTable.test.tsx.snap
+++ b/packages/react-virtualized-extension/src/components/Virtualized/__snapshots__/VirtualizedTable.test.tsx.snap
@@ -1386,7 +1386,7 @@ exports[`Actions virtualized table 1`] = `
                                         data-key={5}
                                         data-label=""
                                         onMouseEnter={[Function]}
-                                        scope={null}
+                                        scope=""
                                       />
                                     </ThBase>
                                   </Th>
@@ -2546,7 +2546,7 @@ exports[`Selectable virtualized table 1`] = `
                                         data-key={0}
                                         data-label=""
                                         onMouseEnter={[Function]}
-                                        scope={null}
+                                        scope=""
                                       >
                                         <SelectColumn
                                           aria-label="Select all rows"
@@ -4593,7 +4593,7 @@ exports[`Simple Actions table 1`] = `
                                         data-key={5}
                                         data-label=""
                                         onMouseEnter={[Function]}
-                                        scope={null}
+                                        scope=""
                                       />
                                     </ThBase>
                                   </Th>


### PR DESCRIPTION
Proposed - adds a default href='/' in logoProps. 

#4665 pointed out that it doesn't make sense for the logoComponent to default to an `a` if it doesn't have a link attribute.  

I see three options for fixing this: 

1.  (done in this PR) - leave the logoComponent default to "a", and have a default href="/" in logoProps.  This seemed the cleanest and most straightforward fix for this to me.  I reviewed a number of sites and the vast majority have their header logo link to their home page. 

2. Default the logoComponent to  be a `span`, with no default href - this may risk breaking any settings who are using the default "a" but have an href or other in logoProps.

3. As suggested in #4665, have some kind of detection of what is being passed in and conditionally show it as span or a depending.  This could possibly be achieved with something like this - 

```
const getDefaultLogoComponentType = (logoProps: { [key: string]: any }): string => {
  let logoComponentType = 'span';
  if (logoProps.href || logoProps.onClick) {
    logoComponentType = 'a';
  }
  return logoComponentType;
};


export const PageHeader: React.FunctionComponent<PageHeaderProps> = ({
  ...
  logoComponent = getDefaultLogoComponentType(logoProps),
  ...props
}: PageHeaderProps) => {

```

However, testing out all the various ways this could be set up, with different router types etc., could get messy, and  to me, somewhat defeats the purpose of having defaultProps.  

Please LMK thoughts on this front.

<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4665

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
