### PR TITLE
fix(charts): Incorrect colorScale prop type

### DIFF
--- a/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -3,7 +3,6 @@ import hoistNonReactStatics from 'hoist-non-react-statics';
 import {
   AnimatePropTypeInterface,
   CategoryPropType,
-  ColorScalePropType,
   DataGetterPropType,
   EventCallbackInterface,
   EventPropTypeInterface,
@@ -110,7 +109,7 @@ export interface ChartDonutProps extends ChartPieProps {
    * values from this color scale to the pie slices unless colors are explicitly provided in the
    * data object
    */
-  colorScale?: ColorScalePropType;
+  colorScale?: string[];
   /**
    * The constrainToVisibleArea prop determines whether to coerce tooltips so that they fit within the visible area of
    * the chart. When this prop is set to true, tooltip pointers will still point to the correct data point, but the

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import {
   AnimatePropTypeInterface,
   CategoryPropType,
-  ColorScalePropType,
   Data,
   DataGetterPropType,
   EventCallbackInterface,
@@ -106,7 +105,7 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    * values from this color scale to the pie slices unless colors are explicitly provided in the
    * data object
    */
-  colorScale?: ColorScalePropType;
+  colorScale?: string[];
   /**
    * The constrainToVisibleArea prop determines whether to coerce tooltips so that they fit within the visible area of
    * the chart. When this prop is set to true, tooltip pointers will still point to the correct data point, but the

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
@@ -4,7 +4,6 @@ import orderBy from 'lodash/orderBy';
 import {
   AnimatePropTypeInterface,
   CategoryPropType,
-  ColorScalePropType,
   Data,
   DataGetterPropType,
   EventCallbackInterface,
@@ -108,7 +107,7 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    * values from this color scale to the pie slices unless colors are explicitly provided in the
    * data object
    */
-  colorScale?: ColorScalePropType;
+  colorScale?: string[];
   /**
    * The constrainToVisibleArea prop determines whether to coerce tooltips so that they fit within the visible area of
    * the chart. When this prop is set to true, tooltip pointers will still point to the correct data point, but the

--- a/packages/react-charts/src/components/ChartGroup/ChartGroup.tsx
+++ b/packages/react-charts/src/components/ChartGroup/ChartGroup.tsx
@@ -3,7 +3,6 @@ import hoistNonReactStatics from 'hoist-non-react-statics';
 import {
   AnimatePropTypeInterface,
   CategoryPropType,
-  ColorScalePropType,
   D3Scale,
   DataGetterPropType,
   DomainPropType,
@@ -82,7 +81,7 @@ export interface ChartGroupProps extends VictoryGroupProps {
    * values from this color scale to the bars unless colors are explicitly provided in the
    * `dataAttributes` prop.
    */
-  colorScale?: ColorScalePropType;
+  colorScale?: string[];
   /**
    * The containerComponent prop takes an entire component which will be used to
    * create a container element for standalone charts.

--- a/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
+++ b/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import {
   BlockProps,
-  ColorScalePropType,
   EventCallbackInterface,
   EventPropTypeInterface,
   OrientationTypes,
@@ -74,13 +73,10 @@ export interface ChartLegendProps extends VictoryLegendProps {
    * The colorScale prop defines a color scale to be applied to each data
    * symbol in ChartLegend. This prop should be given as an array of CSS
    * colors, or as a string corresponding to one of the built in color
-   * scales: "grayscale", "qualitative", "heatmap", "warm", "cool", "red",
-   * "green", "blue". ChartLegend will assign a color to each symbol by
-   * index, unless they are explicitly specified in the data object.
-   * Colors will repeat when there are more symbols than colors in the
+   * scales. Colors will repeat when there are more symbols than colors in the
    * provided colorScale.
    */
-  colorScale?: ColorScalePropType;
+  colorScale?: string[];
   /**
    * The containerComponent prop takes an entire component which will be used to
    * create a container element for standalone charts.

--- a/packages/react-charts/src/components/ChartPie/ChartPie.tsx
+++ b/packages/react-charts/src/components/ChartPie/ChartPie.tsx
@@ -3,7 +3,6 @@ import hoistNonReactStatics from 'hoist-non-react-statics';
 import {
   AnimatePropTypeInterface,
   CategoryPropType,
-  ColorScalePropType,
   DataGetterPropType,
   EventCallbackInterface,
   EventPropTypeInterface,
@@ -96,7 +95,7 @@ export interface ChartPieProps extends VictoryPieProps {
    * values from this color scale to the pie slices unless colors are explicitly provided in the
    * data object
    */
-  colorScale?: ColorScalePropType;
+  colorScale?: string[];
   /**
    * The constrainToVisibleArea prop determines whether to coerce tooltips so that they fit within the visible area of
    * the chart. When this prop is set to true, tooltip pointers will still point to the correct data point, but the

--- a/packages/react-charts/src/components/ChartStack/ChartStack.tsx
+++ b/packages/react-charts/src/components/ChartStack/ChartStack.tsx
@@ -3,7 +3,6 @@ import hoistNonReactStatics from 'hoist-non-react-statics';
 import {
   AnimatePropTypeInterface,
   CategoryPropType,
-  ColorScalePropType,
   D3Scale,
   DomainPropType,
   DomainPaddingPropType,
@@ -75,7 +74,7 @@ export interface ChartStackProps extends VictoryStackProps {
    * values from this color scale to the bars unless colors are explicitly provided in the
    * `dataAttributes` prop.
    */
-  colorScale?: ColorScalePropType;
+  colorScale?: string[];
   /**
    * The containerComponent prop takes an entire component which will be used to
    * create a container element for standalone charts.

--- a/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import chart_color_black_500 from '@patternfly/react-tokens/dist/js/chart_color_black_500';
-import { ColorScalePropType, Helpers, OrientationTypes, StringOrNumberOrCallback } from 'victory-core';
+import { Helpers, OrientationTypes, StringOrNumberOrCallback } from 'victory-core';
 import { ChartLegendProps } from '../ChartLegend';
 import { ChartLegendTooltipStyles, ChartThemeDefinition } from '../ChartTheme';
 import { getLegendDimensions, getTextSizeWorkAround } from './chart-legend';
@@ -26,7 +26,7 @@ interface ChartLegendTooltipFlyoutInterface {
 
 interface ChartLegendTooltipVisibleDataInterface {
   activePoints?: any[];
-  colorScale?: ColorScalePropType;
+  colorScale?: string[];
   legendData: any;
   text?: StringOrNumberOrCallback | string[] | number[];
   textAsLegendData?: boolean;


### PR DESCRIPTION
The chart `colorScale` props use Victory's `ColorScalePropType` type, which was previously defined as a string array. The `ColorScalePropType` type is now defined as:

`"grayscale", "qualitative", "heatmap", "warm", "cool", "red", "green", "blue" | string[]`

PatternFly charts will never use these color string types as they only have meaning for Victory's 'material' and 'grayscale' themes.

Note: `colorScale` still accepts a string array, just as before. Just not the unused strings; "grayscale", "qualitative", "heatmap" etc.

Fixes https://github.com/patternfly/patternfly-react/issues/5129
