### PR TITLE
fix(primary-detail-demo): enable static drawer open on mobile view

### DIFF
--- a/packages/react-core/src/components/Drawer/examples/Drawer.md
+++ b/packages/react-core/src/components/Drawer/examples/Drawer.md
@@ -944,6 +944,8 @@ class DrawerWithSection extends React.Component {
 
 ### Static drawer
 
+**Note:** For mobile viewports, all drawer variants behave the same way. At the `md` breakpoint, or where `.pf-m-static{-on-[lg, xl, 2xl]}` is applied, the `static drawer` variant’s `close button` is automatically hidden because the drawer panel doesn’t close by design.
+
 ```js
 import React from 'react';
 import {

--- a/packages/react-core/src/components/Drawer/examples/Drawer.md
+++ b/packages/react-core/src/components/Drawer/examples/Drawer.md
@@ -954,31 +954,60 @@ import {
   DrawerPanelBody,
   DrawerHead,
   DrawerActions,
-  DrawerCloseButton
+  DrawerCloseButton,
+  Button
 } from '@patternfly/react-core';
 
-StaticDrawer = () => {
-  const panelContent = (
-    <DrawerPanelContent>
-      <DrawerHead>
-        <span>drawer-panel</span>
-        <DrawerActions>
-          <DrawerCloseButton onClick={this.onClick} />
-        </DrawerActions>
-      </DrawerHead>
-    </DrawerPanelContent>
-  );
+class StaticDrawer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isExpanded: false
+    };
 
-  const drawerContent =
-    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.';
+    this.onClick = () => {
+      const isExpanded = !this.state.isExpanded;
+      this.setState({
+        isExpanded
+      });
+    };
 
-  return (
-    <Drawer isStatic>
-      <DrawerContent panelContent={panelContent}>
-        <DrawerContentBody>{drawerContent}</DrawerContentBody>
-      </DrawerContent>
-    </Drawer>
-  );
+    this.onCloseClick = () => {
+      this.setState({
+        isExpanded: false
+      });
+    };
+  }
+
+  render() {
+    const { isExpanded } = this.state;
+    const panelContent = (
+      <DrawerPanelContent>
+        <DrawerHead>
+          <span>drawer-panel</span>
+          <DrawerActions>
+            <DrawerCloseButton onClick={this.onCloseClick} />
+          </DrawerActions>
+        </DrawerHead>
+      </DrawerPanelContent>
+    );
+
+    const drawerContent =
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.';
+    
+    return (
+      <React.Fragment>
+        <Button className='pf-u-hidden-on-md' aria-expanded={isExpanded} onClick={this.onClick}>
+          Toggle Drawer
+        </Button>
+        <Drawer isStatic isExpanded={isExpanded} onExpand={this.onExpand}>
+          <DrawerContent panelContent={panelContent}>
+            <DrawerContentBody>{drawerContent}</DrawerContentBody>
+          </DrawerContent>
+        </Drawer>
+      </React.Fragment>
+    );
+  }
 };
 ```
 

--- a/packages/react-core/src/demos/PrimaryDetail.md
+++ b/packages/react-core/src/demos/PrimaryDetail.md
@@ -1777,19 +1777,27 @@ class PrimaryDetailSimpleListInCard extends React.Component {
       drawerPanelBodyContent: 1,
       activeItem: 0,
       isKebabDropdownOpen: false,
-      isDropdownOpen: false
+      isDropdownOpen: false,
+      isExpanded: false
     };
 
     this.onSelectListItem = (listItem, listItemProps) => {
       const id = listItemProps.id;
       this.setState({
-        drawerPanelBodyContent: id.charAt(id.length - 1)
+        drawerPanelBodyContent: id.charAt(id.length - 1),
+        isExpanded: true
       });
     };
+
+    this.onClose = () => {
+      this.setState({
+        isExpanded: false
+      })
+    }
   }
 
   render() {
-    const { drawerPanelBodyContent, selectedListItemId, activeItem } = this.state;
+    const { drawerPanelBodyContent, selectedListItemId, activeItem, isExpanded } = this.state;
 
     const PageNav = (
       <Nav onSelect={this.onNavSelect} aria-label="Nav">
@@ -1842,8 +1850,11 @@ class PrimaryDetailSimpleListInCard extends React.Component {
       <DrawerPanelContent widthOnXl={75}>
         <DrawerHead>
           <Title headingLevel="h2" size="xl">
-            List item {drawerPanelBodyContent} details
+            {`List item ${drawerPanelBodyContent} details`}
           </Title>
+          <DrawerActions>
+            <DrawerCloseButton onClick={this.onClose} />
+          </DrawerActions>
         </DrawerHead>
         <DrawerPanelBody>
           <Flex spaceItems={{ default: 'spaceItemsLg' }} direction={{ default: 'column' }}>
@@ -1925,7 +1936,7 @@ class PrimaryDetailSimpleListInCard extends React.Component {
           <Divider component="div" />
           <PageSection>
             <Card>
-              <Drawer isStatic>
+              <Drawer isStatic isExpanded={isExpanded}>
                 <DrawerContent panelContent={panelContent}>
                   <DrawerContentBody>{drawerContent}</DrawerContentBody>
                 </DrawerContent>
@@ -2010,7 +2021,8 @@ class PrimaryDetailDataListInCard extends React.Component {
       activeItem: 0,
       isKebabDropdownOpen: false,
       isDropdownOpen: false,
-      selectedDataListItemId: 'dataListItem1'
+      selectedDataListItemId: 'dataListItem1',
+      isExpanded: false
     };
 
     this.onDropdownToggle = isOpen => {
@@ -2028,13 +2040,18 @@ class PrimaryDetailDataListInCard extends React.Component {
       const element = document.getElementById('toggle-id');
       element.focus();
     };
-
     this.onSelectDataListItem = id => {
       this.setState({
         selectedDataListItemId: id,
-        drawerPanelBodyContent: id.charAt(id.length - 1)
+        drawerPanelBodyContent: id.charAt(id.length - 1),
+        isExpanded: true
       });
     };
+    this.onClose = () => {
+      this.setState({
+        isExpanded: false
+      })
+    }
   }
 
   render() {
@@ -2043,7 +2060,8 @@ class PrimaryDetailDataListInCard extends React.Component {
       selectedListItemId,
       activeItem,
       isDropdownOpen,
-      selectedDataListItemId
+      selectedDataListItemId,
+      isExpanded
     } = this.state;
 
     const PageNav = (
@@ -2099,6 +2117,9 @@ class PrimaryDetailDataListInCard extends React.Component {
           <Title size="lg" headingLevel="h2">
             Patternfly-elements
           </Title>
+          <DrawerActions>
+            <DrawerCloseButton onClick={this.onClose} />
+          </DrawerActions>
         </DrawerHead>
         <DrawerPanelBody>
           <Flex spaceItems={{ default: 'spaceItemsLg' }} direction={{ default: 'column' }}>
@@ -2238,7 +2259,7 @@ class PrimaryDetailDataListInCard extends React.Component {
           <Divider component="div" />
           <PageSection>
             <Card>
-              <Drawer isStatic>
+              <Drawer isStatic isExpanded={isExpanded}>
                 <DrawerContent panelContent={panelContent}>
                   <DrawerContentBody>{drawerContent}</DrawerContentBody>
                 </DrawerContent>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4807 .
Fixed this issue in both [Primary detail simple list in card](https://www.patternfly.org/v4/demos/primary-detail/react-demos/primary-detail-simple-list-in-card) and [Primary detail data list in card](https://www.patternfly.org/v4/demos/primary-detail/react-demos/primary-detail-data-list-in-card), where we use static drawer. When on mobile view, we could use `isExpand` to control the panel. Also I add the `DrawerCloseButton`, which will only be shown on mobile view to close the panel.
