### PR TITLE
chore(charts): Annotate Victory types for example docs

### DIFF
--- a/packages/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/react-charts/src/components/Chart/Chart.tsx
@@ -32,8 +32,8 @@ export interface ChartProps extends VictoryChartProps {
    * The animate prop should also be used to specify enter and exit
    * transition configurations with the `onExit` and `onEnter` namespaces respectively.
    *
-   * @example
-   * {duration: 500, onExit: () => {}, onEnter: {duration: 500, before: () => ({y: 0})})}
+   * @propType boolean | object
+   * @example {duration: 500, onExit: () => {}, onEnter: {duration: 500, before: () => ({y: 0})})}
    */
   animate?: boolean | AnimatePropTypeInterface;
   /**
@@ -78,11 +78,15 @@ export interface ChartProps extends VictoryChartProps {
    */
   containerComponent?: React.ReactElement<any>;
   /**
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   defaultAxes?: AxesType;
   /**
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   defaultPolarAxes?: AxesType;
   /**
@@ -92,7 +96,10 @@ export interface ChartProps extends VictoryChartProps {
    * If this prop is not provided, a domain will be calculated from data, or other
    * available information.
    *
-   * @example [-1, 1], {x: [0, 100], y: [0, 1]}
+   * @propType number[] | { x: number[], y: number[] }
+   * @example [low, high], { x: [low, high], y: [low, high] }
+   *
+   * [-1, 1], {x: [0, 100], y: [0, 1]}
    */
   domain?: DomainPropType;
   /**
@@ -100,6 +107,11 @@ export interface ChartProps extends VictoryChartProps {
    * beginning and end of a domain. This prop is useful for explicitly spacing ticks farther
    * from the origin to prevent crowding. This prop should be given as an object with
    * numbers specified for x and y.
+   *
+   * @propType number | number[] | { x: number[], y: number[] }
+   * @example [left, right], { x: [left, right], y: [bottom, top] }
+   *
+   * {x: [10, -10], y: 5}
    */
   domainPadding?: DomainPaddingPropType;
   /**
@@ -112,6 +124,8 @@ export interface ChartProps extends VictoryChartProps {
   /**
    * Similar to data accessor props `x` and `y`, this prop may be used to functionally
    * assign eventKeys to data
+   *
+   * @propType number | string | Function
    */
   eventKey?: StringOrNumberOrCallback;
   /**
@@ -129,6 +143,7 @@ export interface ChartProps extends VictoryChartProps {
    * element (i.e. a single bar), and the object returned from the mutation function
    * will override the props of the selected element via object assignment.
    *
+   * @propType object[]
    * @example
    * events={[
    *   {
@@ -158,6 +173,8 @@ export interface ChartProps extends VictoryChartProps {
   events?: EventPropTypeInterface<string, string[] | number[] | string | number>[];
   /**
    * Chart uses the standard externalEventMutations prop.
+   *
+   * @propType object[]
    */
   externalEventMutations?: EventCallbackInterface<string | string[], StringOrNumberOrList>[];
   /**
@@ -183,6 +200,8 @@ export interface ChartProps extends VictoryChartProps {
   horizontal?: boolean;
   /**
    * When the innerRadius prop is set, polar charts will be hollow rather than circular.
+   *
+   * @propType number | Function
    */
   innerRadius?: number;
   /**
@@ -239,7 +258,7 @@ export interface ChartProps extends VictoryChartProps {
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
-   * examples:
+   * @example
    *
    * maxDomain={0}
    * maxDomain={{ y: 0 }}
@@ -254,7 +273,7 @@ export interface ChartProps extends VictoryChartProps {
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
-   * examples:
+   * @example
    *
    * minDomain={0}
    * minDomain={{ y: 0 }}
@@ -265,10 +284,14 @@ export interface ChartProps extends VictoryChartProps {
    * the edge of the chart and any rendered child components. This prop can be given
    * as a number or as an object with padding specified for top, bottom, left
    * and right.
+   *
+   * @propType number | { top: number, bottom: number, left: number, right: number }
    */
   padding?: PaddingProps;
   /**
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   prependDefaultAxes?: boolean;
   /**
@@ -283,7 +306,8 @@ export interface ChartProps extends VictoryChartProps {
    * chart must share the same range, so setting this prop on children nested within Chart, ChartStack, or
    * ChartGroup will have no effect. This prop is usually not set manually.
    *
-   * examples:
+   * @propType number[] | { x: number[], y: number[] }
+   * @example [low, high] | { x: [low, high], y: [low, high] }
    *
    * Cartesian: range={{ x: [50, 250], y: [50, 250] }}
    * Polar: range={{ x: [0, 360], y: [0, 250] }}
@@ -294,6 +318,7 @@ export interface ChartProps extends VictoryChartProps {
    * given as a string specifying a supported scale ("linear", "time", "log", "sqrt"),
    * as a d3 scale function, or as an object with scales specified for x and y
    *
+   * @propType string | { x: string, y: string }
    * @example d3Scale.time(), {x: "linear", y: "log"}
    */
   scale?:
@@ -306,7 +331,9 @@ export interface ChartProps extends VictoryChartProps {
   /**
    * The sharedEvents prop is used internally to coordinate events between components.
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   sharedEvents?: { events: any[]; getEventState: Function };
   /**
@@ -321,7 +348,7 @@ export interface ChartProps extends VictoryChartProps {
    * value refers to the dependent variable. This may cause confusion in horizontal charts, as the independent variable
    * will corresponds to the y axis.
    *
-   * examples:
+   * @example
    *
    * singleQuadrantDomainPadding={false}
    * singleQuadrantDomainPadding={{ x: false }}
@@ -344,11 +371,16 @@ export interface ChartProps extends VictoryChartProps {
    * The style prop defines the style of the component. The style prop should be given as an object with styles defined
    * for data, labels and parent. Any valid svg styles are supported, but width, height, and padding should be specified
    * via props as they determine relative layout for components in Chart.
+   *
+   * @propType { parent: object, background: object }
+   * @propType { parent: object, background: object }
    */
   style?: Pick<VictoryStyleInterface, 'parent'> & { background?: VictoryStyleObject };
   /**
    * The theme prop specifies a theme to use for determining styles and layout properties for a component. Any styles or
    * props defined in theme may be overwritten by props specified on the component instance.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**

--- a/packages/react-charts/src/components/ChartArea/ChartArea.tsx
+++ b/packages/react-charts/src/components/ChartArea/ChartArea.tsx
@@ -35,14 +35,12 @@ export enum ChartAreaSortOrder {
  */
 export interface ChartAreaProps extends VictoryAreaProps {
   /**
-   * type: boolean || object
-   *
    * The animate prop specifies props for VictoryAnimation to use.
    * The animate prop should also be used to specify enter and exit
    * transition configurations with the `onExit` and `onEnter` namespaces respectively.
    *
-   * @example
-   * {duration: 500, onExit: () => {}, onEnter: {duration: 500, before: () => ({y: 0})})}
+   * @propType boolean | object
+   * @example {duration: 500, onExit: () => {}, onEnter: {duration: 500, before: () => ({y: 0})})}
    */
   animate?: boolean | AnimatePropTypeInterface;
   /**
@@ -51,6 +49,7 @@ export interface ChartAreaProps extends VictoryAreaProps {
    * these arrays of values specified for x and y. If this prop is not set,
    * categorical data will be plotted in the order it was given in the data array
    *
+   * @propType string[] | { x: string[], y: string[] }
    * @example ["dogs", "cats", "mice"]
    */
   categories?: CategoryPropType;
@@ -76,7 +75,9 @@ export interface ChartAreaProps extends VictoryAreaProps {
    * Each data point may be any format you wish (depending on the `x` and `y` accessor props),
    * but by default, an object with x and y properties is expected.
    *
-   * @example [{x: 1, y: 2}, {x: 2, y: 3}], [[1, 2], [2, 3]],
+   * @example
+   *
+   * [{x: 1, y: 2}, {x: 2, y: 3}], [[1, 2], [2, 3]],
    * [[{x: "a", y: 1}, {x: "b", y: 2}], [{x: "a", y: 2}, {x: "b", y: 3}]]
    */
   data?: any[];
@@ -97,7 +98,10 @@ export interface ChartAreaProps extends VictoryAreaProps {
    * If this prop is not provided, a domain will be calculated from data, or other
    * available information.
    *
-   * @example [-1, 1], {x: [0, 100], y: [0, 1]}
+   * @propType number[] | { x: number[], y: number[] }
+   * @example [low, high], { x: [low, high], y: [low, high] }
+   *
+   * [-1, 1], {x: [0, 100], y: [0, 1]}
    */
   domain?: DomainPropType;
   /**
@@ -105,11 +109,18 @@ export interface ChartAreaProps extends VictoryAreaProps {
    * beginning and end of a domain. This prop is useful for explicitly spacing ticks farther
    * from the origin to prevent crowding. This prop should be given as an object with
    * numbers specified for x and y.
+   *
+   * @propType number | number[] | { x: number[], y: number[] }
+   * @example [left, right], { x: [left, right], y: [bottom, top] }
+   *
+   * {x: [10, -10], y: 5}
    */
   domainPadding?: DomainPaddingPropType;
   /**
    * Similar to data accessor props `x` and `y`, this prop may be used to functionally
    * assign eventKeys to data
+   *
+   * @propType number | string | Function | string[] | number[]
    */
   eventKey?: string[] | number[] | StringOrNumberOrCallback;
   /**
@@ -127,6 +138,7 @@ export interface ChartAreaProps extends VictoryAreaProps {
    * element (i.e. an area), and the object returned from the mutation function
    * will override the props of the selected element via object assignment.
    *
+   * @propType object[]
    * @example
    * events={[
    *   {
@@ -153,6 +165,8 @@ export interface ChartAreaProps extends VictoryAreaProps {
   events?: EventPropTypeInterface<VictoryAreaTTargetType, string | number>[];
   /**
    * ChartArea uses the standard externalEventMutations prop.
+   *
+   * @propType object[]
    */
   externalEventMutations?: EventCallbackInterface<string | string[], StringOrNumberOrList>[];
   /**
@@ -173,7 +187,12 @@ export interface ChartAreaProps extends VictoryAreaProps {
    */
   horizontal?: boolean;
   /**
-   * The interpolation prop determines how data points should be connected when plotting a line
+   * The interpolation prop determines how data points should be connected when plotting a line.
+   * Polar area charts may use the following interpolation options: "basis", "cardinal", "catmullRom", "linear".
+   * Cartesian area charts may use the following interpolation options: "basis", "cardinal", "catmullRom", "linear",
+   * "monotoneX", "monotoneY", "natural", "step", "stepAfter", "stepBefore".
+   *
+   * @propType string | Function
    */
   interpolation?: InterpolationPropType;
   /**
@@ -207,7 +226,7 @@ export interface ChartAreaProps extends VictoryAreaProps {
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
-   * examples:
+   * @example
    *
    * maxDomain={0}
    * maxDomain={{ y: 0 }}
@@ -222,7 +241,7 @@ export interface ChartAreaProps extends VictoryAreaProps {
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
-   * examples:
+   * @example
    *
    * minDomain={0}
    * minDomain={{ y: 0 }}
@@ -235,7 +254,9 @@ export interface ChartAreaProps extends VictoryAreaProps {
   /**
    * Victory components will pass an origin prop is to define the center point in svg coordinates for polar charts.
    *
-   * **This prop should not be set manually.**
+   * Note: It will not typically be necessary to set an origin prop manually
+   *
+   * @propType { x: number, y: number }
    */
   origin?: OriginType;
   /**
@@ -243,6 +264,8 @@ export interface ChartAreaProps extends VictoryAreaProps {
    * the edge of the chart and any rendered child components. This prop can be given
    * as a number or as an object with padding specified for top, bottom, left
    * and right.
+   *
+   * @propType number | { top: number, bottom: number, left: number, right: number }
    */
   padding?: PaddingProps;
   /**
@@ -257,7 +280,8 @@ export interface ChartAreaProps extends VictoryAreaProps {
    * chart must share the same range, so setting this prop on children nested within Chart or
    * ChartGroup will have no effect. This prop is usually not set manually.
    *
-   * examples:
+   * @propType number[] | { x: number[], y: number[] }
+   * @example [low, high] | { x: [low, high], y: [low, high] }
    *
    * Cartesian: range={{ x: [50, 250], y: [50, 250] }}
    * Polar: range={{ x: [0, 360], y: [0, 250] }}
@@ -273,6 +297,7 @@ export interface ChartAreaProps extends VictoryAreaProps {
    * given as a string specifying a supported scale ("linear", "time", "log", "sqrt"),
    * as a d3 scale function, or as an object with scales specified for x and y
    *
+   * @propType string | { x: string, y: string }
    * @example d3Scale.time(), {x: "linear", y: "log"}
    */
   scale?:
@@ -285,7 +310,9 @@ export interface ChartAreaProps extends VictoryAreaProps {
   /**
    * The sharedEvents prop is used internally to coordinate events between components.
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   sharedEvents?: { events: any[]; getEventState: Function };
   /**
@@ -300,7 +327,7 @@ export interface ChartAreaProps extends VictoryAreaProps {
    * value refers to the dependent variable. This may cause confusion in horizontal charts, as the independent variable
    * will corresponds to the y axis.
    *
-   * examples:
+   * @example
    *
    * singleQuadrantDomainPadding={false}
    * singleQuadrantDomainPadding={{ x: false }}
@@ -310,10 +337,14 @@ export interface ChartAreaProps extends VictoryAreaProps {
    * Use the sortKey prop to indicate how data should be sorted. This prop
    * is given directly to the lodash sortBy function to be executed on the
    * final dataset.
+   *
+   * @propType number | string | Function | string[]
    */
   sortKey?: DataGetterPropType;
   /**
    * The sortOrder prop specifies whether sorted data should be returned in 'ascending' or 'descending' order.
+   *
+   * @propType string
    */
   sortOrder?: SortOrderPropType;
   /**
@@ -328,6 +359,7 @@ export interface ChartAreaProps extends VictoryAreaProps {
    * width, and padding props, as they are used to calculate the alignment of
    * components within chart.
    *
+   * @propType { parent: object, data: object, labels: object }
    * @example {data: {fill: "red"}, labels: {fontSize: 12}}
    */
   style?: VictoryStyleInterface;
@@ -337,6 +369,8 @@ export interface ChartAreaProps extends VictoryAreaProps {
    * When using ChartArea as a solo component, implement the theme directly on
    * ChartArea. If you are wrapping ChartArea in ChartChart or ChartGroup,
    * please call the theme on the outermost wrapper component instead.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**
@@ -369,6 +403,7 @@ export interface ChartAreaProps extends VictoryAreaProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'x', 'x.value.nested.1.thing', 'x[2].also.nested', null, d => Math.sin(d)
    */
   x?: DataGetterPropType;
@@ -381,6 +416,7 @@ export interface ChartAreaProps extends VictoryAreaProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'y', 'y.value.nested.1.thing', 'y[2].also.nested', null, d => Math.sin(d)
    */
   y?: DataGetterPropType;
@@ -389,6 +425,7 @@ export interface ChartAreaProps extends VictoryAreaProps {
    * This prop is useful for defining custom baselines for components like ChartArea.
    * This prop may be given in a variety of formats.
    *
+   * @propType number | string | Function | string[]
    * @example 'last_quarter_profit', () => 10, 1, 'employees.salary', ["employees", "salary"]
    */
   y0?: DataGetterPropType;

--- a/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
+++ b/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
@@ -29,8 +29,8 @@ export interface ChartAxisProps extends VictoryAxisProps {
    * The animate prop should also be used to specify enter and exit
    * transition configurations with the `onExit` and `onEnter` namespaces respectively.
    *
-   * @example
-   * {duration: 500, onExit: () => {}, onEnter: {duration: 500, before: () => ({y: 0})})}
+   * @propType boolean | object
+   * @example {duration: 500, onExit: () => {}, onEnter: {duration: 500, before: () => ({y: 0})})}
    */
   animate?: boolean | AnimatePropTypeInterface;
   /**
@@ -88,7 +88,10 @@ export interface ChartAxisProps extends VictoryAxisProps {
    * given as a array of the minimum and maximum expected values for your axis.
    * If this value is not given it will be calculated based on the scale or tickValues.
    *
-   * @example [-1, 1]
+   * @propType number[] | { x: number[], y: number[] }
+   * @example [low, high], { x: [low, high], y: [low, high] }
+   *
+   * [-1, 1], {x: [0, 100], y: [0, 1]}
    */
   domain?: DomainPropType;
   /**
@@ -96,6 +99,11 @@ export interface ChartAxisProps extends VictoryAxisProps {
    * beginning and end of a domain. This prop is useful for explicitly spacing ticks farther
    * from the origin to prevent crowding. This prop should be given as an object with
    * numbers specified for x and y.
+   *
+   * @propType number | number[] | { x: number[], y: number[] }
+   * @example [left, right], { x: [left, right], y: [bottom, top] }
+   *
+   * {x: [10, -10], y: 5}
    */
   domainPadding?: DomainPaddingPropType;
   /**
@@ -114,6 +122,7 @@ export interface ChartAxisProps extends VictoryAxisProps {
    * element (i.e. a single tick), and the object returned from the mutation function
    * will override the props of the selected element via object assignment.
    *
+   * @propType object[]
    * @example
    * events={[
    *   {
@@ -141,6 +150,8 @@ export interface ChartAxisProps extends VictoryAxisProps {
   events?: EventPropTypeInterface<VictoryAxisTTargetType, number | string>[];
   /**
    * ChartAxis uses the standard externalEventMutations prop.
+   *
+   * @propType object[]
    */
   externalEventMutations?: EventCallbackInterface<string | string[], StringOrNumberOrList>[];
   /**
@@ -197,7 +208,7 @@ export interface ChartAxisProps extends VictoryAxisProps {
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
-   * examples:
+   * @example
    *
    * maxDomain={0}
    * maxDomain={{ y: 0 }}
@@ -212,7 +223,7 @@ export interface ChartAxisProps extends VictoryAxisProps {
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
-   * examples:
+   * @example
    *
    * minDomain={0}
    * minDomain={{ y: 0 }}
@@ -237,6 +248,8 @@ export interface ChartAxisProps extends VictoryAxisProps {
   /**
    * The orientation prop specifies the position and orientation of your axis.
    * Valid values are 'top', 'bottom', 'left' and 'right'.
+   *
+   * @propType string
    */
   orientation?: OrientationTypes;
   /**
@@ -244,6 +257,8 @@ export interface ChartAxisProps extends VictoryAxisProps {
    * the edge of the chart and any rendered child components. This prop can be given
    * as a number or as an object with padding specified for top, bottom, left
    * and right.
+   *
+   * @propType number | { top: number, bottom: number, left: number, right: number }
    */
   padding?: PaddingProps;
   /**
@@ -254,7 +269,8 @@ export interface ChartAxisProps extends VictoryAxisProps {
    * chart must share the same range, so setting this prop on children nested within Chart, ChartStack, or
    * ChartGroup will have no effect. This prop is usually not set manually.
    *
-   * examples:
+   * @propType number[] | { x: number[], y: number[] }
+   * @example [low, high] | { x: [low, high], y: [low, high] }
    *
    * Cartesian: range={{ x: [50, 250], y: [50, 250] }}
    * Polar: range={{ x: [0, 360], y: [0, 250] }}
@@ -265,6 +281,7 @@ export interface ChartAxisProps extends VictoryAxisProps {
    * given as a string specifying a supported scale ("linear", "time", "log", "sqrt"),
    * as a d3 scale function, or as an object with scales specified for x and y
    *
+   * @propType string | { x: string, y: string }
    * @example d3Scale.time(), {x: "linear", y: "log"}
    */
   scale?:
@@ -277,7 +294,9 @@ export interface ChartAxisProps extends VictoryAxisProps {
   /**
    * The sharedEvents prop is used internally to coordinate events between components.
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   sharedEvents?: { events: any[]; getEventState: Function };
   /**
@@ -296,7 +315,7 @@ export interface ChartAxisProps extends VictoryAxisProps {
    * value refers to the dependent variable. This may cause confusion in horizontal charts, as the independent variable
    * will corresponds to the y axis.
    *
-   * examples:
+   * @example
    *
    * singleQuadrantDomainPadding={false}
    * singleQuadrantDomainPadding={{ x: false }}
@@ -319,7 +338,9 @@ export interface ChartAxisProps extends VictoryAxisProps {
    * <svg> element with standalone={false} parent styles will be applied to the enclosing <g> tag.
    * Many styles that can be applied to a parent <svg> will not be expressed when applied to a <g>.
    *
-   * note: custom angle and verticalAnchor properties may be included in labels styles.
+   * Note: custom angle and verticalAnchor properties may be included in labels styles.
+   *
+   * @propType { axis: object, axisLabel: object, grid: object, ticks: object, tickLabels: object }
    */
   style?: {
     parent?: {
@@ -347,6 +368,8 @@ export interface ChartAxisProps extends VictoryAxisProps {
    * When using ChartAxis as a solo component, implement the theme directly on
    * ChartAxis. If you are wrapping ChartAxis in ChartChart or ChartGroup,
    * please call the theme on the outermost wrapper component instead.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**

--- a/packages/react-charts/src/components/ChartBar/ChartBar.tsx
+++ b/packages/react-charts/src/components/ChartBar/ChartBar.tsx
@@ -33,6 +33,8 @@ export interface ChartBarProps extends VictoryBarProps {
    * The alignment prop specifies how bars should be aligned relative to their data points.
    * This prop may be given as “start”, “middle” or “end”. When this prop is not specified,
    * bars will have “middle” alignment relative to their data points.
+   *
+   * @propType string
    */
   alignment?: VictoryBarAlignmentType;
   /**
@@ -40,8 +42,8 @@ export interface ChartBarProps extends VictoryBarProps {
    * The animate prop should also be used to specify enter and exit
    * transition configurations with the `onExit` and `onEnter` namespaces respectively.
    *
-   * @example
-   * {duration: 500, onExit: () => {}, onEnter: {duration: 500, before: () => ({y: 0})})}
+   * @propType boolean | object
+   * @example {duration: 500, onExit: () => {}, onEnter: {duration: 500, before: () => ({y: 0})})}
    */
   animate?: boolean | AnimatePropTypeInterface;
   /**
@@ -57,6 +59,8 @@ export interface ChartBarProps extends VictoryBarProps {
    * a function, it will be evaluated with the arguments datum, and active. When this value
    * is not given, a default value will be calculated based on the overall dimensions of
    * the chart, and the number of bars.
+   *
+   * @propType number | Function
    */
   barWidth?: NumberOrCallback;
   /**
@@ -65,6 +69,7 @@ export interface ChartBarProps extends VictoryBarProps {
    * these arrays of values specified for x and y. If this prop is not set,
    * categorical data will be plotted in the order it was given in the data array
    *
+   * @propType string[] | { x: string[], y: string[] }
    * @example ["dogs", "cats", "mice"]
    */
   categories?: CategoryPropType;
@@ -88,6 +93,9 @@ export interface ChartBarProps extends VictoryBarProps {
    * The cornerRadius prop specifies a radius to apply to each bar.
    * If this prop is given as a single number, the radius will only be applied to the top of each bar.
    * When this prop is given as a function, it will be evaluated with the arguments datum, and active.
+   *
+   * @propType Function | number | { top, bottom, topLeft, topRight, bottomLeft, bottomRight }
+   * @example {topLeft: ({ datum }) => datum.x * 4}
    */
   cornerRadius?:
     | NumberOrCallback
@@ -105,7 +113,9 @@ export interface ChartBarProps extends VictoryBarProps {
    * Each data point may be any format you wish (depending on the `x` and `y` accessor props),
    * but by default, an object with x and y properties is expected.
    *
-   * @example [{x: 1, y: 2}, {x: 2, y: 3}], [[1, 2], [2, 3]],
+   * @example
+   *
+   * [{x: 1, y: 2}, {x: 2, y: 3}], [[1, 2], [2, 3]],
    * [[{x: "a", y: 1}, {x: "b", y: 2}], [{x: "a", y: 2}, {x: "b", y: 3}]]
    */
   data?: any[];
@@ -126,7 +136,10 @@ export interface ChartBarProps extends VictoryBarProps {
    * If this prop is not provided, a domain will be calculated from data, or other
    * available information.
    *
-   * @example [-1, 1], {x: [0, 100], y: [0, 1]}
+   * @propType number[] | { x: number[], y: number[] }
+   * @example [low, high], { x: [low, high], y: [low, high] }
+   *
+   * [-1, 1], {x: [0, 100], y: [0, 1]}
    */
   domain?: DomainPropType;
   /**
@@ -134,11 +147,18 @@ export interface ChartBarProps extends VictoryBarProps {
    * beginning and end of a domain. This prop is useful for explicitly spacing ticks farther
    * from the origin to prevent crowding. This prop should be given as an object with
    * numbers specified for x and y.
+   *
+   * @propType number | number[] | { x: number[], y: number[] }
+   * @example [left, right], { x: [left, right], y: [bottom, top] }
+   *
+   * {x: [10, -10], y: 5}
    */
   domainPadding?: DomainPaddingPropType;
   /**
    * Similar to data accessor props `x` and `y`, this prop may be used to functionally
    * assign eventKeys to data
+   *
+   * @propType number | string | Function
    */
   eventKey?: StringOrNumberOrCallback;
   /**
@@ -156,6 +176,7 @@ export interface ChartBarProps extends VictoryBarProps {
    * element (i.e. a single bar), and the object returned from the mutation function
    * will override the props of the selected element via object assignment.
    *
+   * @propType object[]
    * @example
    * events={[
    *   {
@@ -185,6 +206,8 @@ export interface ChartBarProps extends VictoryBarProps {
   events?: EventPropTypeInterface<VictoryBarTTargetType, number | string | number[] | string[]>[];
   /**
    * ChartBar uses the standard externalEventMutations prop.
+   *
+   * @propType object[]
    */
   externalEventMutations?: EventCallbackInterface<string | string[], StringOrNumberOrList>[];
   /**
@@ -235,7 +258,7 @@ export interface ChartBarProps extends VictoryBarProps {
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
-   * examples:
+   * @example
    *
    * maxDomain={0}
    * maxDomain={{ y: 0 }}
@@ -250,7 +273,7 @@ export interface ChartBarProps extends VictoryBarProps {
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
-   * examples:
+   * @example
    *
    * minDomain={0}
    * minDomain={{ y: 0 }}
@@ -263,7 +286,9 @@ export interface ChartBarProps extends VictoryBarProps {
   /**
    * Victory components will pass an origin prop is to define the center point in svg coordinates for polar charts.
    *
-   * **This prop should not be set manually.**
+   * Note: It will not typically be necessary to set an origin prop manually
+   *
+   * @propType { x: number, y: number }
    */
   origin?: OriginType;
   /**
@@ -271,12 +296,16 @@ export interface ChartBarProps extends VictoryBarProps {
    * the edge of the chart and any rendered child components. This prop can be given
    * as a number or as an object with padding specified for top, bottom, left
    * and right.
+   *
+   * @propType number | { top: number, bottom: number, left: number, right: number }
    */
   padding?: PaddingProps;
   /**
    * Victory components can pass a boolean polar prop to specify whether a label is part of a polar chart.
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   polar?: boolean;
   /**
@@ -287,7 +316,8 @@ export interface ChartBarProps extends VictoryBarProps {
    * chart must share the same range, so setting this prop on children nested within Chart or
    * ChartGroup will have no effect. This prop is usually not set manually.
    *
-   * examples:
+   * @propType number[] | { x: number[], y: number[] }
+   * @example [low, high] | { x: [low, high], y: [low, high] }
    *
    * Cartesian: range={{ x: [50, 250], y: [50, 250] }}
    * Polar: range={{ x: [0, 360], y: [0, 250] }}
@@ -303,6 +333,7 @@ export interface ChartBarProps extends VictoryBarProps {
    * given as a string specifying a supported scale ("linear", "time", "log", "sqrt"),
    * as a d3 scale function, or as an object with scales specified for x and y
    *
+   * @propType string | { x: string, y: string }
    * @example d3Scale.time(), {x: "linear", y: "log"}
    */
   scale?:
@@ -315,7 +346,9 @@ export interface ChartBarProps extends VictoryBarProps {
   /**
    * The sharedEvents prop is used internally to coordinate events between components.
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   sharedEvents?: { events: any[]; getEventState: Function };
   /**
@@ -330,7 +363,7 @@ export interface ChartBarProps extends VictoryBarProps {
    * value refers to the dependent variable. This may cause confusion in horizontal charts, as the independent variable
    * will corresponds to the y axis.
    *
-   * examples:
+   * @example
    *
    * singleQuadrantDomainPadding={false}
    * singleQuadrantDomainPadding={{ x: false }}
@@ -340,10 +373,14 @@ export interface ChartBarProps extends VictoryBarProps {
    * Use the sortKey prop to indicate how data should be sorted. This prop
    * is given directly to the lodash sortBy function to be executed on the
    * final dataset.
+   *
+   * @propType number | string | Function | string[]
    */
   sortKey?: DataGetterPropType;
   /**
    * The sortOrder prop specifies whether sorted data should be returned in 'ascending' or 'descending' order.
+   *
+   * @propType string
    */
   sortOrder?: SortOrderPropType;
   /**
@@ -358,6 +395,7 @@ export interface ChartBarProps extends VictoryBarProps {
    * width, and padding props, as they are used to calculate the alignment of
    * components within chart.
    *
+   * @propType { parent: object, data: object, labels: object }
    * @example {data: {fill: "red"}, labels: {fontSize: 12}}
    */
   style?: VictoryStyleInterface;
@@ -367,6 +405,8 @@ export interface ChartBarProps extends VictoryBarProps {
    * When using ChartBar as a solo component, implement the theme directly on
    * ChartBar. If you are wrapping ChartBar in ChartChart or ChartGroup,
    * please call the theme on the outermost wrapper component instead.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**
@@ -399,6 +439,7 @@ export interface ChartBarProps extends VictoryBarProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'x', 'x.value.nested.1.thing', 'x[2].also.nested', null, d => Math.sin(d)
    */
   x?: DataGetterPropType;
@@ -411,6 +452,7 @@ export interface ChartBarProps extends VictoryBarProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'y', 'y.value.nested.1.thing', 'y[2].also.nested', null, d => Math.sin(d)
    */
   y?: DataGetterPropType;
@@ -419,6 +461,7 @@ export interface ChartBarProps extends VictoryBarProps {
    * This prop is useful for defining custom baselines for components like ChartBar.
    * This prop may be given in a variety of formats.
    *
+   * @propType number | string | Function | string[]
    * @example 'last_quarter_profit', () => 10, 1, 'employees.salary', ["employees", "salary"]
    */
   y0?: DataGetterPropType;

--- a/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
@@ -81,6 +81,7 @@ export interface ChartBulletProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'y', 'y.value.nested.1.thing', 'y[2].also.nested', null, d => Math.sin(d)
    */
   comparativeErrorMeasureDataY?: DataGetterPropType;
@@ -120,6 +121,7 @@ export interface ChartBulletProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'y', 'y.value.nested.1.thing', 'y[2].also.nested', null, d => Math.sin(d)
    */
   comparativeWarningMeasureDataY?: DataGetterPropType;
@@ -154,9 +156,12 @@ export interface ChartBulletProps {
    * If this prop is not provided, a domain will be calculated from data, or other
    * available information.
    *
-   * @example {x: [0, 2], y: [0, 100]}
-   *
    * Note: The x domain is expected to be `x: [0, 2]` in order to position all measures properly
+   *
+   * @propType number[] | { x: number[], y: number[] }
+   * @example [low, high], { x: [low, high], y: [low, high] }
+   *
+   * {x: [0, 2], y: [0, 100]}
    */
   domain?: DomainPropType;
   /**
@@ -244,7 +249,7 @@ export interface ChartBulletProps {
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
-   * examples:
+   * @example
    *
    * maxDomain={0}
    * maxDomain={{ y: 0 }}
@@ -261,7 +266,7 @@ export interface ChartBulletProps {
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
-   * examples:
+   * @example
    *
    * minDomain={0}
    * minDomain={{ y: 0 }}
@@ -277,6 +282,8 @@ export interface ChartBulletProps {
    *
    * Note: The underlying bullet chart is a different size than height and width. For a horizontal chart, left and right
    * padding may need to be applied at (approx) 2 to 1 scale.
+   *
+   * @propType number | { top: number, bottom: number, left: number, right: number }
    */
   padding?: PaddingProps;
   /**
@@ -301,6 +308,7 @@ export interface ChartBulletProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'y', 'y.value.nested.1.thing', 'y[2].also.nested', null, d => Math.sin(d)
    */
   primaryDotMeasureDataY?: DataGetterPropType;
@@ -340,6 +348,7 @@ export interface ChartBulletProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'y', 'y.value.nested.1.thing', 'y[2].also.nested', null, d => Math.sin(d)
    */
   primarySegmentedMeasureDataY?: DataGetterPropType;
@@ -379,6 +388,7 @@ export interface ChartBulletProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'y', 'y.value.nested.1.thing', 'y[2].also.nested', null, d => Math.sin(d)
    */
   qualitativeRangeDataY?: DataGetterPropType;
@@ -387,6 +397,7 @@ export interface ChartBulletProps {
    * This prop is useful for defining custom baselines for components like ChartBar.
    * This prop may be given in a variety of formats.
    *
+   * @propType number | string | Function | string[]
    * @example 'last_quarter_profit', () => 10, 1, 'employees.salary', ["employees", "salary"]
    */
   qualitativeRangeDataY0?: DataGetterPropType;
@@ -417,6 +428,8 @@ export interface ChartBulletProps {
   /**
    * The theme prop specifies a theme to use for determining styles and layout properties for a component. Any styles or
    * props defined in theme may be overwritten by props specified on the component instance.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletComparativeErrorMeasure.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletComparativeErrorMeasure.tsx
@@ -38,6 +38,8 @@ export interface ChartBulletComparativeErrorMeasureProps {
    * a function, it will be evaluated with the arguments datum, and active. When this value
    * is not given, a default value will be calculated based on the overall dimensions of
    * the chart, and the number of bars.
+   *
+   * @propType number | Function
    */
   barWidth?: NumberOrCallback;
   /**
@@ -62,9 +64,12 @@ export interface ChartBulletComparativeErrorMeasureProps {
    * If this prop is not provided, a domain will be calculated from data, or other
    * available information.
    *
-   * @example {x: [0, 2], y: [0, 100]}
-   *
    * Note: The x domain is expected to be `x: [0, 2]` in order to position all measures properly
+   *
+   * @propType number[] | { x: number[], y: number[] }
+   * @example [low, high], { x: [low, high], y: [low, high] }
+   *
+   * {x: [0, 2], y: [0, 100]}
    */
   domain?: DomainPropType;
   /**
@@ -109,6 +114,8 @@ export interface ChartBulletComparativeErrorMeasureProps {
    * the edge of the chart and any rendered child components. This prop can be given
    * as a number or as an object with padding specified for top, bottom, left
    * and right.
+   *
+   * @propType number | { top: number, bottom: number, left: number, right: number }
    */
   padding?: PaddingProps;
   /**
@@ -123,6 +130,8 @@ export interface ChartBulletComparativeErrorMeasureProps {
    * When using ChartLine as a solo component, implement the theme directly on
    * ChartLine. If you are wrapping ChartLine in ChartChart or ChartGroup,
    * please call the theme on the outermost wrapper component instead.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**
@@ -155,6 +164,7 @@ export interface ChartBulletComparativeErrorMeasureProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'y', 'y.value.nested.1.thing', 'y[2].also.nested', null, d => Math.sin(d)
    */
   y?: DataGetterPropType;

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletComparativeMeasure.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletComparativeMeasure.tsx
@@ -40,6 +40,8 @@ export interface ChartBulletComparativeMeasureProps {
    * a function, it will be evaluated with the arguments datum, and active. When this value
    * is not given, a default value will be calculated based on the overall dimensions of
    * the chart, and the number of bars.
+   *
+   * @propType number | Function
    */
   barWidth?: NumberOrCallback;
   /**
@@ -64,9 +66,12 @@ export interface ChartBulletComparativeMeasureProps {
    * If this prop is not provided, a domain will be calculated from data, or other
    * available information.
    *
-   * @example {x: [0, 2], y: [0, 100]}
-   *
    * Note: The x domain is expected to be `x: [0, 2]` in order to position all measures properly
+   *
+   * @propType number[] | { x: number[], y: number[] }
+   * @example [low, high], { x: [low, high], y: [low, high] }
+   *
+   * {x: [0, 2], y: [0, 100]}
    */
   domain?: DomainPropType;
   /**
@@ -111,6 +116,8 @@ export interface ChartBulletComparativeMeasureProps {
    * the edge of the chart and any rendered child components. This prop can be given
    * as a number or as an object with padding specified for top, bottom, left
    * and right.
+   *
+   * @propType number | { top: number, bottom: number, left: number, right: number }
    */
   padding?: PaddingProps;
   /**
@@ -125,6 +132,8 @@ export interface ChartBulletComparativeMeasureProps {
    * When using ChartLine as a solo component, implement the theme directly on
    * ChartLine. If you are wrapping ChartLine in ChartChart or ChartGroup,
    * please call the theme on the outermost wrapper component instead.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**
@@ -157,6 +166,7 @@ export interface ChartBulletComparativeMeasureProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'y', 'y.value.nested.1.thing', 'y[2].also.nested', null, d => Math.sin(d)
    */
   y?: DataGetterPropType;

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletComparativeWarningMeasure.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletComparativeWarningMeasure.tsx
@@ -38,6 +38,8 @@ export interface ChartBulletComparativeWarningMeasureProps {
    * a function, it will be evaluated with the arguments datum, and active. When this value
    * is not given, a default value will be calculated based on the overall dimensions of
    * the chart, and the number of bars.
+   *
+   * @propType number | Function
    */
   barWidth?: NumberOrCallback;
   /**
@@ -62,9 +64,12 @@ export interface ChartBulletComparativeWarningMeasureProps {
    * If this prop is not provided, a domain will be calculated from data, or other
    * available information.
    *
-   * @example {x: [0, 2], y: [0, 100]}
-   *
    * Note: The x domain is expected to be `x: [0, 2]` in order to position all measures properly
+   *
+   * @propType number[] | { x: number[], y: number[] }
+   * @example [low, high], { x: [low, high], y: [low, high] }
+   *
+   * {x: [0, 2], y: [0, 100]}
    */
   domain?: DomainPropType;
   /**
@@ -109,6 +114,8 @@ export interface ChartBulletComparativeWarningMeasureProps {
    * the edge of the chart and any rendered child components. This prop can be given
    * as a number or as an object with padding specified for top, bottom, left
    * and right.
+   *
+   * @propType number | { top: number, bottom: number, left: number, right: number }
    */
   padding?: PaddingProps;
   /**
@@ -123,6 +130,8 @@ export interface ChartBulletComparativeWarningMeasureProps {
    * When using ChartLine as a solo component, implement the theme directly on
    * ChartLine. If you are wrapping ChartLine in ChartChart or ChartGroup,
    * please call the theme on the outermost wrapper component instead.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**
@@ -155,6 +164,7 @@ export interface ChartBulletComparativeWarningMeasureProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'y', 'y.value.nested.1.thing', 'y[2].also.nested', null, d => Math.sin(d)
    */
   y?: DataGetterPropType;

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletGroupTitle.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletGroupTitle.tsx
@@ -34,6 +34,8 @@ export interface ChartBulletGroupTitleProps {
    * This is necessary because of SVG, which (a) positions the *bottom* of the text at `y`, and (b) has no notion of
    * line height. The value should ideally use the same units as `lineHeight` and `dy`, preferably ems. If given a
    * unitless number, it is assumed to be ems.
+   *
+   * @propType number | string | Function
    */
   capHeight?: StringOrNumberOrCallback;
   /**
@@ -52,6 +54,8 @@ export interface ChartBulletGroupTitleProps {
    * and right.
    *
    * Note: The bottom padding property is unused
+   *
+   * @propType number | { top: number, bottom: number, left: number, right: number }
    */
   padding?: PaddingProps;
   /**
@@ -76,6 +80,8 @@ export interface ChartBulletGroupTitleProps {
    * When using ChartLine as a solo component, implement the theme directly on
    * ChartLine. If you are wrapping ChartLine in ChartChart or ChartGroup,
    * please call the theme on the outermost wrapper component instead.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletPrimaryDotMeasure.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletPrimaryDotMeasure.tsx
@@ -56,9 +56,12 @@ export interface ChartBulletPrimaryDotMeasureProps {
    * If this prop is not provided, a domain will be calculated from data, or other
    * available information.
    *
-   * @example {x: [0, 2], y: [0, 100]}
-   *
    * Note: The x domain is expected to be `x: [0, 2]` in order to position all measures properly
+   *
+   * @propType number[] | { x: number[], y: number[] }
+   * @example [low, high], { x: [low, high], y: [low, high] }
+   *
+   * {x: [0, 2], y: [0, 100]}
    */
   domain?: DomainPropType;
   /**
@@ -107,6 +110,8 @@ export interface ChartBulletPrimaryDotMeasureProps {
    * the edge of the chart and any rendered child components. This prop can be given
    * as a number or as an object with padding specified for top, bottom, left
    * and right.
+   *
+   * @propType number | { top: number, bottom: number, left: number, right: number }
    */
   padding?: PaddingProps;
   /**
@@ -125,6 +130,8 @@ export interface ChartBulletPrimaryDotMeasureProps {
    * When using ChartScatter as a solo component, implement the theme directly on
    * ChartScatter. If you are wrapping ChartScatter in ChartChart or ChartGroup,
    * please call the theme on the outermost wrapper component instead.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**
@@ -157,6 +164,7 @@ export interface ChartBulletPrimaryDotMeasureProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'y', 'y.value.nested.1.thing', 'y[2].also.nested', null, d => Math.sin(d)
    */
   y?: DataGetterPropType;
@@ -165,6 +173,7 @@ export interface ChartBulletPrimaryDotMeasureProps {
    * This prop is useful for defining custom baselines for components like ChartScatter.
    * This prop may be given in a variety of formats.
    *
+   * @propType number | string | Function | string[]
    * @example 'last_quarter_profit', () => 10, 1, 'employees.salary', ["employees", "salary"]
    */
   y0?: DataGetterPropType;

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletPrimarySegmentedMeasure.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletPrimarySegmentedMeasure.tsx
@@ -40,6 +40,8 @@ export interface ChartBulletPrimarySegmentedMeasureProps {
    * a function, it will be evaluated with the arguments datum, and active. When this value
    * is not given, a default value will be calculated based on the overall dimensions of
    * the chart, and the number of bars.
+   *
+   * @propType number | Function
    */
   barWidth?: NumberOrCallback;
   /**
@@ -64,9 +66,12 @@ export interface ChartBulletPrimarySegmentedMeasureProps {
    * If this prop is not provided, a domain will be calculated from data, or other
    * available information.
    *
-   * @example {x: [0, 2], y: [0, 100]}
-   *
    * Note: The x domain is expected to be `x: [0, 2]` in order to position all measures properly
+   *
+   * @propType number[] | { x: number[], y: number[] }
+   * @example [low, high], { x: [low, high], y: [low, high] }
+   *
+   * {x: [0, 2], y: [0, 100]}
    */
   domain?: DomainPropType;
   /**
@@ -116,6 +121,8 @@ export interface ChartBulletPrimarySegmentedMeasureProps {
    * When using ChartBar as a solo component, implement the theme directly on
    * ChartBar. If you are wrapping ChartBar in ChartChart or ChartGroup,
    * please call the theme on the outermost wrapper component instead.
+   *
+   * @propType object
    */
   negativeMeasureTheme?: ChartThemeDefinition;
   /**
@@ -123,6 +130,8 @@ export interface ChartBulletPrimarySegmentedMeasureProps {
    * the edge of the chart and any rendered child components. This prop can be given
    * as a number or as an object with padding specified for top, bottom, left
    * and right.
+   *
+   * @propType number | { top: number, bottom: number, left: number, right: number }
    */
   padding?: PaddingProps;
   /**
@@ -137,6 +146,8 @@ export interface ChartBulletPrimarySegmentedMeasureProps {
    * When using ChartBar as a solo component, implement the theme directly on
    * ChartBar. If you are wrapping ChartBar in ChartChart or ChartGroup,
    * please call the theme on the outermost wrapper component instead.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**
@@ -169,6 +180,7 @@ export interface ChartBulletPrimarySegmentedMeasureProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'y', 'y.value.nested.1.thing', 'y[2].also.nested', null, d => Math.sin(d)
    */
   y?: DataGetterPropType;
@@ -177,6 +189,7 @@ export interface ChartBulletPrimarySegmentedMeasureProps {
    * This prop is useful for defining custom baselines for components like ChartBar.
    * This prop may be given in a variety of formats.
    *
+   * @propType number | string | Function | string[]
    * @example 'last_quarter_profit', () => 10, 1, 'employees.salary', ["employees", "salary"]
    */
   y0?: DataGetterPropType;

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletQualitativeRange.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletQualitativeRange.tsx
@@ -40,6 +40,8 @@ export interface ChartBulletQualitativeRangeProps {
    * a function, it will be evaluated with the arguments datum, and active. When this value
    * is not given, a default value will be calculated based on the overall dimensions of
    * the chart, and the number of bars.
+   *
+   * @propType number | Function
    */
   barWidth?: NumberOrCallback;
   /**
@@ -64,9 +66,12 @@ export interface ChartBulletQualitativeRangeProps {
    * If this prop is not provided, a domain will be calculated from data, or other
    * available information.
    *
-   * @example {x: [0, 2], y: [0, 100]}
-   *
    * Note: The x domain is expected to be `x: [0, 2]` in order to position all measures properly
+   *
+   * @propType number[] | { x: number[], y: number[] }
+   * @example [low, high], { x: [low, high], y: [low, high] }
+   *
+   * {x: [0, 2], y: [0, 100]}
    */
   domain?: DomainPropType;
   /**
@@ -115,6 +120,8 @@ export interface ChartBulletQualitativeRangeProps {
    * the edge of the chart and any rendered child components. This prop can be given
    * as a number or as an object with padding specified for top, bottom, left
    * and right.
+   *
+   * @propType number | { top: number, bottom: number, left: number, right: number }
    */
   padding?: PaddingProps;
   /**
@@ -129,6 +136,8 @@ export interface ChartBulletQualitativeRangeProps {
    * When using ChartBar as a solo component, implement the theme directly on
    * ChartBar. If you are wrapping ChartBar in ChartChart or ChartGroup,
    * please call the theme on the outermost wrapper component instead.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**
@@ -161,6 +170,7 @@ export interface ChartBulletQualitativeRangeProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'y', 'y.value.nested.1.thing', 'y[2].also.nested', null, d => Math.sin(d)
    */
   y?: DataGetterPropType;
@@ -169,6 +179,7 @@ export interface ChartBulletQualitativeRangeProps {
    * This prop is useful for defining custom baselines for components like ChartBar.
    * This prop may be given in a variety of formats.
    *
+   * @propType number | string | Function | string[]
    * @example 'last_quarter_profit', () => 10, 1, 'employees.salary', ["employees", "salary"]
    */
   y0?: DataGetterPropType;

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletTitle.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletTitle.tsx
@@ -29,6 +29,8 @@ export interface ChartBulletTitleProps {
    * This is necessary because of SVG, which (a) positions the *bottom* of the text at `y`, and (b) has no notion of
    * line height. The value should ideally use the same units as `lineHeight` and `dy`, preferably ems. If given a
    * unitless number, it is assumed to be ems.
+   *
+   * @propType number | string | Function
    */
   capHeight?: StringOrNumberOrCallback;
   /**
@@ -54,6 +56,8 @@ export interface ChartBulletTitleProps {
    *
    * Note: The underlying bullet chart is a different size than height and width. For a horizontal chart, left and right
    * padding may need to be applied at (approx) 2 to 1 scale.
+   *
+   * @propType number | { top: number, bottom: number, left: number, right: number }
    */
   padding?: PaddingProps;
   /**
@@ -78,6 +82,8 @@ export interface ChartBulletTitleProps {
    * When using ChartLine as a solo component, implement the theme directly on
    * ChartLine. If you are wrapping ChartLine in ChartChart or ChartGroup,
    * please call the theme on the outermost wrapper component instead.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**

--- a/packages/react-charts/src/components/ChartContainer/ChartContainer.tsx
+++ b/packages/react-charts/src/components/ChartContainer/ChartContainer.tsx
@@ -13,8 +13,6 @@ export interface ChartContainerProps extends VictoryContainerProps {
   /**
    * The children prop specifies the child or children that will be rendered within the container. It will be set by
    * whatever Victory component is rendering the container.
-   *
-   * **This prop should not be set manually.**
    */
   children?: React.ReactElement | React.ReactElement[];
   /**
@@ -49,7 +47,7 @@ export interface ChartContainerProps extends VictoryContainerProps {
    * applicable. Use the invert method to convert event coordinate information to
    * data. `scale.x.invert(evt.offsetX)`.
    *
-   * @example {{ onClick: (evt) => alert(`x: ${evt.clientX}, y: ${evt.clientY}`)}}
+   * @example {onClick: (evt) => alert(`x: ${evt.clientX}, y: ${evt.clientY}`)}
    */
   events?: React.DOMAttributes<any>;
   /**
@@ -65,13 +63,17 @@ export interface ChartContainerProps extends VictoryContainerProps {
   /**
    * Victory components will pass an origin prop is to define the center point in svg coordinates for polar charts.
    *
-   * **This prop should not be set manually.**
+   * Note: It will not typically be necessary to set an origin prop manually
+   *
+   * @propType { x: number, y: number }
    */
   origin?: OriginType;
   /**
    * Victory components can pass a boolean polar prop to specify whether a label is part of a polar chart.
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   polar?: boolean;
   /**
@@ -109,6 +111,8 @@ export interface ChartContainerProps extends VictoryContainerProps {
   /**
    * The theme prop specifies a theme to use for determining styles and layout properties for a component. Any styles or
    * props defined in theme may be overwritten by props specified on the component instance.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**

--- a/packages/react-charts/src/components/ChartCursorContainer/ChartCursorContainer.tsx
+++ b/packages/react-charts/src/components/ChartCursorContainer/ChartCursorContainer.tsx
@@ -15,7 +15,9 @@ export interface ChartCursorContainerProps extends VictoryCursorContainerProps {
    * he children prop specifies the child or children that will be rendered within the container. It will be set by
    * whatever Victory component is rendering the container.
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   children?: React.ReactElement | React.ReactElement[];
   /**
@@ -43,6 +45,7 @@ export interface ChartCursorContainerProps extends VictoryCursorContainerProps {
    * The cursorLabel prop defines the label that will appear next to the cursor. A label will only appear if cursorLabel
    * is set. This prop should be given as a function of a point (an Object with x and y properties).
    *
+   * @propType Function
    * example: cursorLabel={(point) => point.x}
    */
   cursorLabel?: (point: CoordinatesPropType) => any | void;
@@ -55,6 +58,8 @@ export interface ChartCursorContainerProps extends VictoryCursorContainerProps {
   /**
    * The cursorLabelOffset prop determines the pixel offset of the cursor label from the cursor point. This prop should
    * be an Object with x and y properties, or a number to be used for both dimensions.
+   *
+   * @propType number | { x: number, y: number }
    */
   cursorLabelOffset?: number | CoordinatesPropType;
   /**
@@ -62,7 +67,8 @@ export interface ChartCursorContainerProps extends VictoryCursorContainerProps {
    * displayed, use the defaultCursorValue prop to set the default value. The prop should be a point (an Object with x
    * and y properties) for 2-dimensional cursors, or a number for 1-dimensional cursors.
    *
-   * examples: defaultCursorValue={{x: 1, y: 1}}, defaultCursorValue={0}
+   * @propType number | { x: number, y: number }
+   * @example defaultCursorValue={{x: 1, y: 1}}, defaultCursorValue={0}
    */
   defaultCursorValue?: number | CoordinatesPropType;
   /**
@@ -86,7 +92,7 @@ export interface ChartCursorContainerProps extends VictoryCursorContainerProps {
    * applicable. Use the invert method to convert event coordinate information to
    * data. `scale.x.invert(evt.offsetX)`.
    *
-   * @example {{ onClick: (evt) => alert(`x: ${evt.clientX}, y: ${evt.clientY}`)}}
+   * @example {onClick: (evt) => alert(`x: ${evt.clientX}, y: ${evt.clientY}`)}
    */
   events?: React.DOMAttributes<any>;
   /**
@@ -104,19 +110,24 @@ export interface ChartCursorContainerProps extends VictoryCursorContainerProps {
    * called with value (the updated cursor value) and props (the props used by ChartCursorContainer). A common use for
    * onCursorChange is to save the cursor value to state and use it in another part of the view.
    *
+   * @propType Function
    * example: onCursorChange={(value, props) => this.setState({cursorValue: value})}
    */
   onCursorChange?: (value: CoordinatesPropType, props: VictoryCursorContainerProps) => void;
   /**
    * Victory components will pass an origin prop is to define the center point in svg coordinates for polar charts.
    *
-   * **This prop should not be set manually.**
+   * Note: It will not typically be necessary to set an origin prop manually
+   *
+   * @propType { x: number, y: number }
    */
   origin?: OriginType;
   /**
    * Victory components can pass a boolean polar prop to specify whether a label is part of a polar chart.
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   polar?: boolean;
   /**
@@ -156,6 +167,8 @@ export interface ChartCursorContainerProps extends VictoryCursorContainerProps {
   /**
    * The theme prop specifies a theme to use for determining styles and layout properties for a component. Any styles or
    * props defined in theme may be overwritten by props specified on the component instance.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**

--- a/packages/react-charts/src/components/ChartCursorTooltip/ChartCursorTooltip.tsx
+++ b/packages/react-charts/src/components/ChartCursorTooltip/ChartCursorTooltip.tsx
@@ -47,6 +47,8 @@ export interface ChartCursorTooltipProps extends ChartTooltipProps {
    * pointer. This prop should be given as an object of x and y, where each is either a numeric offset value or a
    * function that returns a numeric value. When this prop is set, non-zero pointerLength values will no longer be
    * respected.
+   *
+   * @propType { x: number | Function, y: number | Function }
    */
   centerOffset?: {
     x?: NumberOrCallback;
@@ -61,6 +63,8 @@ export interface ChartCursorTooltipProps extends ChartTooltipProps {
   /**
    * The cornerRadius prop determines corner radius of the flyout container. This prop may be given as a positive number
    * or a function of datum.
+   *
+   * @propType number | Function
    */
   cornerRadius?: NumberOrCallback;
   /**
@@ -75,17 +79,23 @@ export interface ChartCursorTooltipProps extends ChartTooltipProps {
   datum?: {};
   /**
    * The dx prop defines a horizontal shift from the x coordinate.
+   *
+   * @propType number | Function
    */
   dx?: NumberOrCallback;
   /**
    * The dy prop defines a vertical shift from the y coordinate.
+   *
+   * @propType number | Function
    */
   dy?: NumberOrCallback;
   /**
    * The events prop attaches arbitrary event handlers to the label component. This prop should be given as an object of
    * event names and corresponding event handlers. When events are provided via Victory’s event system, event handlers
    * will be called with the event, the props of the component is attached to, and an eventKey.
-   * Examples: events={{onClick: (evt) => alert("x: " + evt.clientX)}}
+   *
+   * @propType object
+   * @example events={{onClick: (evt) => alert("x: " + evt.clientX)}}
    */
   events?: { [key: string]: (event: React.SyntheticEvent<any>) => void };
   /**
@@ -95,24 +105,31 @@ export interface ChartCursorTooltipProps extends ChartTooltipProps {
    * Any of these props may be overridden by passing in props to the supplied component, or modified or ignored within
    * the custom component itself. If flyoutComponent is omitted, a default Flyout component will be created with props
    * described above.
-   * Examples: flyoutComponent={<Flyout x={50} y={50}/>}, flyoutComponent={<MyCustomFlyout/>}
+   *
+   * @example flyoutComponent={<Flyout x={50} y={50}/>}, flyoutComponent={<MyCustomFlyout/>}
    */
   flyoutComponent?: React.ReactElement<any>;
   /**
    * The flyoutHeight prop defines the height of the tooltip flyout. This prop may be given as a positive number or a function
    * of datum. If this prop is not set, height will be determined based on an approximate text size calculated from the
    * text and style props provided to ChartTooltip.
+   *
+   * @propType number | Function
    */
   flyoutHeight?: NumberOrCallback;
   /**
    * The style prop applies SVG style properties to the rendered flyout container. These props will be passed to the
    * flyoutComponent.
+   *
+   * @propType object
    */
   flyoutStyle?: VictoryStyleObject;
   /**
    * The flyoutWidth prop defines the width of the tooltip flyout. This prop may be given as a positive number or a
    * function of datum. If this prop is not set, flyoutWidth will be determined based on an approximate text size
    * calculated from the text and style props provided to VictoryTooltip.
+   *
+   * @propType number | Function
    */
   flyoutWidth?: NumberOrCallback;
   /**
@@ -125,7 +142,9 @@ export interface ChartCursorTooltipProps extends ChartTooltipProps {
    * parents of ChartCursorTooltip, and should not be set manually. In versions before ^33.0.0 this prop referred to
    * the height of the tooltip flyout. Please use flyoutHeight instead
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   height?: number;
   /**
@@ -144,12 +163,15 @@ export interface ChartCursorTooltipProps extends ChartTooltipProps {
    * verticalAnchor, textAnchor, style, text, and events. Any of these props may be overridden by passing in props to
    * the supplied component, or modified or ignored within the custom component itself. If labelComponent is omitted, a
    * new ChartLabel will be created with the props described above.
-   * Examples: labelComponent={<ChartLabel dy={20}/>}, labelComponent={<MyCustomLabel/>}
+   *
+   * @example labelComponent={<ChartLabel dy={20}/>}, labelComponent={<MyCustomLabel/>}
    */
   labelComponent?: React.ReactElement<any>;
   /**
    * Defines how the labelComponent text is horizontally positioned relative to its `x` and `y` coordinates. Valid
    * values are 'start' (default), 'middle', 'end', and 'inherit'. Note that this overrides the style prop.
+   *
+   * @propType string | Function
    */
   labelTextAnchor?: TextAnchorType | (() => TextAnchorType);
   /**
@@ -157,22 +179,30 @@ export interface ChartCursorTooltipProps extends ChartTooltipProps {
    * This prop can be given as “top”, “bottom”, “left”, “right”, or as a function of datum that returns one of these
    * values. If this prop is not provided it will be determined from the sign of the datum, and the value of the
    * horizontal prop.
+   *
+   * @propType string | Function
    */
   orientation?: OrientationOrCallback;
   /**
    * The pointerLength prop determines the length of the triangular pointer extending from the flyout. This prop may be
    * given as a positive number or a function of datum.
+   *
+   * @propType number | Function
    */
   pointerLength?: NumberOrCallback;
   /**
    * This prop determines which side of the tooltip flyout the pointer should originate on. When this prop is not set,
    * it will be determined based on the overall orientation of the flyout in relation to its data point, and any center
    * or centerOffset values. Valid values are 'top', 'bottom', 'left' and 'right.
+   *
+   * @propType string | Function
    */
   pointerOrientation?: OrientationOrCallback;
   /**
    * The pointerWidth prop determines the width of the base of the triangular pointer extending from
    * the flyout. This prop may be given as a positive number or a function of datum.
+   *
+   * @propType number | Function
    */
   pointerWidth?: NumberOrCallback;
   /**
@@ -193,11 +223,15 @@ export interface ChartCursorTooltipProps extends ChartTooltipProps {
    * The text prop defines the text ChartTooltip will render. The text prop may be given as a string, number, or
    * function of datum. When ChartLabel is used as the labelComponent, strings may include newline characters, which
    * ChartLabel will split in to separate <tspan/> elements.
+   *
+   * @propType number | string | Function | string[] | number[]
    */
   text?: StringOrNumberOrCallback | string[] | number[];
   /**
    * The theme prop specifies a theme to use for determining styles and layout properties for a component. Any styles or
    * props defined in theme may be overwritten by props specified on the component instance.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**
@@ -221,7 +255,9 @@ export interface ChartCursorTooltipProps extends ChartTooltipProps {
    * parents of ChartCursorTooltip, and should not be set manually. In versions before ^33.0.0 this prop referred to the
    * width of the tooltip flyout. Please use flyoutWidth instead
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   width?: number;
   /**

--- a/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -68,8 +68,8 @@ export interface ChartDonutProps extends ChartPieProps {
    * The animate prop should also be used to specify enter and exit
    * transition configurations with the `onExit` and `onEnter` namespaces respectively.
    *
-   * @example
-   * {duration: 500, onExit: () => {}, onEnter: {duration: 500, before: () => ({y: 0})})}
+   * @propType boolean | object
+   * @example {duration: 500, onExit: () => {}, onEnter: {duration: 500, before: () => ({y: 0})})}
    */
   animate?: boolean | AnimatePropTypeInterface;
   /**
@@ -91,6 +91,8 @@ export interface ChartDonutProps extends ChartPieProps {
    * This is necessary because of SVG, which (a) positions the *bottom* of the text at `y`, and (b) has no notion of
    * line height. The value should ideally use the same units as `lineHeight` and `dy`, preferably ems. If given a
    * unitless number, it is assumed to be ems.
+   *
+   * @propType number | string | Function
    */
   capHeight?: StringOrNumberOrCallback;
   /**
@@ -99,6 +101,7 @@ export interface ChartDonutProps extends ChartPieProps {
    * these arrays of values specified for x and y. If this prop is not set,
    * categorical data will be plotted in the order it was given in the data array
    *
+   * @propType string[] | { x: string[], y: string[] }
    * @example ["dogs", "cats", "mice"]
    */
   categories?: CategoryPropType;
@@ -134,6 +137,8 @@ export interface ChartDonutProps extends ChartPieProps {
   containerComponent?: React.ReactElement<any>;
   /**
    * Set the cornerRadius for every dataComponent (Slice by default) within ChartDonut
+   *
+   * @propType number | Function
    */
   cornerRadius?: SliceNumberOrCallback<SliceProps, 'cornerRadius'>;
   /**
@@ -144,7 +149,9 @@ export interface ChartDonutProps extends ChartPieProps {
    * Each data point may be any format you wish (depending on the `x` and `y` accessor props),
    * but by default, an object with x and y properties is expected.
    *
-   * @example [{x: 1, y: 2}, {x: 2, y: 3}], [[1, 2], [2, 3]],
+   * @example
+   *
+   * [{x: 1, y: 2}, {x: 2, y: 3}], [[1, 2], [2, 3]],
    * [[{x: "a", y: 1}, {x: "b", y: 2}], [{x: "a", y: 2}, {x: "b", y: 3}]]
    */
   data?: any[];
@@ -166,6 +173,8 @@ export interface ChartDonutProps extends ChartPieProps {
   /**
    * Similar to data accessor props `x` and `y`, this prop may be used to functionally
    * assign eventKeys to data
+   *
+   * @propType number | string | Function
    */
   eventKey?: StringOrNumberOrCallback;
   /**
@@ -183,6 +192,7 @@ export interface ChartDonutProps extends ChartPieProps {
    * element (i.e. a single bar), and the object returned from the mutation function
    * will override the props of the selected element via object assignment.
    *
+   * @propType object[]
    * @example
    * events={[
    *   {
@@ -212,6 +222,8 @@ export interface ChartDonutProps extends ChartPieProps {
   events?: EventPropTypeInterface<'data' | 'labels' | 'parent', StringOrNumberOrCallback | string[] | number[]>[];
   /**
    * ChartDonut uses the standard externalEventMutations prop.
+   *
+   * @propType object[]
    */
   externalEventMutations?: EventCallbackInterface<string | string[], StringOrNumberOrList>[];
   /**
@@ -240,6 +252,8 @@ export interface ChartDonutProps extends ChartPieProps {
   /**
    * When creating a donut chart, this prop determines the number of pixels between
    * the center of the chart and the inner edge.
+   *
+   * @propType number | Function
    */
   innerRadius?: NumberOrCallback;
   /**
@@ -257,11 +271,15 @@ export interface ChartDonutProps extends ChartPieProps {
   /**
    * The labelPosition prop specifies the angular position of each label relative to its corresponding slice.
    * When this prop is not given, the label will be positioned at the centroid of each slice.
+   *
+   * @propType string | Function
    */
   labelPosition?: VictorySliceLabelPositionType | ((props: SliceProps) => VictorySliceLabelPositionType);
   /**
    * The labelRadius prop defines the radius of the arc that will be used for positioning each slice label.
    * If this prop is not set, the label radius will default to the radius of the pie + label padding.
+   *
+   * @propType number | Function
    */
   labelRadius?: number | ((props: SliceProps) => number);
   /**
@@ -326,12 +344,16 @@ export interface ChartDonutProps extends ChartPieProps {
   /**
    * Victory components will pass an origin prop is to define the center point in svg coordinates for polar charts.
    *
-   * **This prop should not be set manually.**
+   * Note: It will not typically be necessary to set an origin prop manually
+   *
+   * @propType { x: number, y: number }
    */
   origin?: OriginType;
   /**
    * The padAngle prop determines the amount of separation between adjacent data slices
    * in number of degrees
+   *
+   * @propType number | Function
    */
   padAngle?: NumberOrCallback;
   /**
@@ -339,27 +361,37 @@ export interface ChartDonutProps extends ChartPieProps {
    * the edge of the chart and any rendered child components. This prop can be given
    * as a number or as an object with padding specified for top, bottom, left
    * and right.
+   *
+   * @propType number | { top: number, bottom: number, left: number, right: number }
    */
   padding?: PaddingProps;
   /**
    * Specifies the radius of the chart. If this property is not provided it is computed
    * from width, height, and padding props
+   *
+   * @propType number | Function
    */
   radius?: NumberOrCallback;
   /**
    * The sharedEvents prop is used internally to coordinate events between components.
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   sharedEvents?: { events: any[]; getEventState: Function };
   /**
    * Use the sortKey prop to indicate how data should be sorted. This prop
    * is given directly to the lodash sortBy function to be executed on the
    * final dataset.
+   *
+   * @propType number | string | Function | string[]
    */
   sortKey?: DataGetterPropType;
   /**
    * The sortOrder prop specifies whether sorted data should be returned in 'ascending' or 'descending' order.
+   *
+   * @propType string
    */
   sortOrder?: SortOrderPropType;
   /**
@@ -378,6 +410,7 @@ export interface ChartDonutProps extends ChartPieProps {
    * so valid Radium style objects should work for this prop. Height, width, and
    * padding should be specified via the height, width, and padding props.
    *
+   * @propType { parent: object, data: object, labels: object }
    * @example {data: {stroke: "black"}, label: {fontSize: 10}}
    */
   style?: VictoryStyleInterface;
@@ -411,6 +444,8 @@ export interface ChartDonutProps extends ChartPieProps {
    * When using ChartDonut as a solo component, implement the theme directly on
    * ChartDonut. If you are wrapping ChartDonut in ChartChart or ChartGroup,
    * please call the theme on the outermost wrapper component instead.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**
@@ -487,6 +522,7 @@ export interface ChartDonutProps extends ChartPieProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'x', 'x.value.nested.1.thing', 'x[2].also.nested', null, d => Math.sin(d)
    */
   x?: DataGetterPropType;
@@ -499,6 +535,7 @@ export interface ChartDonutProps extends ChartPieProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'y', 'y.value.nested.1.thing', 'y[2].also.nested', null, d => Math.sin(d)
    */
   y?: DataGetterPropType;

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
@@ -67,6 +67,7 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    * The animate prop should also be used to specify enter and exit
    * transition configurations with the `onExit` and `onEnter` namespaces respectively.
    *
+   * @propType boolean | object
    * @example
    * {duration: 500, onExit: () => {}, onEnter: {duration: 500, before: () => ({y: 0})})}
    */
@@ -91,11 +92,16 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    * these arrays of values specified for x and y. If this prop is not set,
    * categorical data will be plotted in the order it was given in the data array
    *
+   * @propType string[] | { x: string[], y: string[] }
    * @example ["dogs", "cats", "mice"]
    */
   categories?: CategoryPropType;
   /**
    * The utilization donut chart to render with the threshold donut chart
+   *
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   children?: React.ReactElement<any>;
   /**
@@ -130,6 +136,8 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
   containerComponent?: React.ReactElement<any>;
   /**
    * Set the cornerRadius for every dataComponent (Slice by default) within ChartDonutThreshold
+   *
+   * @propType number | Function
    */
   cornerRadius?: SliceNumberOrCallback<SliceProps, 'cornerRadius'>;
   /**
@@ -175,6 +183,8 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
   /**
    * Similar to data accessor props `x` and `y`, this prop may be used to functionally
    * assign eventKeys to data
+   *
+   * @propType number | string | Function
    */
   eventKey?: StringOrNumberOrCallback;
   /**
@@ -192,6 +202,7 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    * element (i.e. a single bar), and the object returned from the mutation function
    * will override the props of the selected element via object assignment.
    *
+   * @propType object[]
    * @example
    * events={[
    *   {
@@ -221,6 +232,8 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
   events?: EventPropTypeInterface<'data' | 'labels' | 'parent', StringOrNumberOrCallback | string[] | number[]>[];
   /**
    * ChartDonutThreshold uses the standard externalEventMutations prop.
+   *
+   * @propType object[]
    */
   externalEventMutations?: EventCallbackInterface<string | string[], StringOrNumberOrList>[];
   /**
@@ -241,6 +254,8 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
   /**
    * When creating a donut chart, this prop determines the number of pixels between
    * the center of the chart and the inner edge.
+   *
+   * @propType number | Function
    */
   innerRadius?: NumberOrCallback;
   /**
@@ -250,6 +265,8 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
   /**
    * The labelRadius prop defines the radius of the arc that will be used for positioning each slice label.
    * If this prop is not set, the label radius will default to the radius of the pie + label padding.
+   *
+   * @propType number | Function
    */
   labelRadius?: number | ((props: SliceProps) => number);
   /**
@@ -269,12 +286,16 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
   /**
    * Victory components will pass an origin prop is to define the center point in svg coordinates for polar charts.
    *
-   * **This prop should not be set manually.**
+   * Note: It will not typically be necessary to set an origin prop manually
+   *
+   * @propType { x: number, y: number }
    */
   origin?: OriginType;
   /**
    * The padAngle prop determines the amount of separation between adjacent data slices
    * in number of degrees
+   *
+   * @propType number | Function
    */
   padAngle?: NumberOrCallback;
   /**
@@ -282,17 +303,23 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    * the edge of the chart and any rendered child components. This prop can be given
    * as a number or as an object with padding specified for top, bottom, left
    * and right.
+   *
+   * @propType number | { top: number, bottom: number, left: number, right: number }
    */
   padding?: PaddingProps;
   /**
    * Specifies the radius of the chart. If this property is not provided it is computed
    * from width, height, and padding props
+   *
+   * @propType number | Function
    */
   radius?: NumberOrCallback;
   /**
    * The sharedEvents prop is used internally to coordinate events between components.
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   sharedEvents?: { events: any[]; getEventState: Function };
   /**
@@ -303,10 +330,14 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    * Use the sortKey prop to indicate how data should be sorted. This prop
    * is given directly to the lodash sortBy function to be executed on the
    * final dataset.
+   *
+   * @propType number | string | Function | string[]
    */
   sortKey?: DataGetterPropType;
   /**
    * The sortOrder prop specifies whether sorted data should be returned in 'ascending' or 'descending' order.
+   *
+   * @propType string
    */
   sortOrder?: SortOrderPropType;
   /**
@@ -325,6 +356,7 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    * so valid Radium style objects should work for this prop. Height, width, and
    * padding should be specified via the height, width, and padding props.
    *
+   * @propType { parent: object, data: object, labels: object }
    * @example {data: {stroke: "black"}, label: {fontSize: 10}}
    */
   style?: VictoryStyleInterface;
@@ -342,6 +374,8 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    * When using ChartDonutThreshold as a solo component, implement the theme directly on
    * ChartDonutThreshold. If you are wrapping ChartDonutThreshold in ChartChart or ChartGroup,
    * please call the theme on the outermost wrapper component instead.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**
@@ -382,6 +416,7 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'x', 'x.value.nested.1.thing', 'x[2].also.nested', null, d => Math.sin(d)
    */
   x?: DataGetterPropType;
@@ -394,6 +429,7 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'y', 'y.value.nested.1.thing', 'y[2].also.nested', null, d => Math.sin(d)
    */
   y?: DataGetterPropType;

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
@@ -66,6 +66,7 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    * The animate prop should also be used to specify enter and exit
    * transition configurations with the `onExit` and `onEnter` namespaces respectively.
    *
+   * @propType boolean | object
    * @example
    * {duration: 500, onExit: () => {}, onEnter: {duration: 500, before: () => ({y: 0})})}
    */
@@ -89,6 +90,8 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    * This is necessary because of SVG, which (a) positions the *bottom* of the text at `y`, and (b) has no notion of
    * line height. The value should ideally use the same units as `lineHeight` and `dy`, preferably ems. If given a
    * unitless number, it is assumed to be ems.
+   *
+   * @propType number | string | Function
    */
   capHeight?: StringOrNumberOrCallback;
   /**
@@ -97,6 +100,7 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    * these arrays of values specified for x and y. If this prop is not set,
    * categorical data will be plotted in the order it was given in the data array
    *
+   * @propType string[] | { x: string[], y: string[] }
    * @example ["dogs", "cats", "mice"]
    */
   categories?: CategoryPropType;
@@ -132,6 +136,8 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
   containerComponent?: React.ReactElement<any>;
   /**
    * Set the cornerRadius for every dataComponent (Slice by default) within ChartDonutUtilization
+   *
+   * @propType number | Function
    */
   cornerRadius?: SliceNumberOrCallback<SliceProps, 'cornerRadius'>;
   /**
@@ -177,6 +183,8 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
   /**
    * Similar to data accessor props `x` and `y`, this prop may be used to functionally
    * assign eventKeys to data
+   *
+   * @propType number | string | Function
    */
   eventKey?: StringOrNumberOrCallback;
   /**
@@ -194,6 +202,7 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    * element (i.e. a single bar), and the object returned from the mutation function
    * will override the props of the selected element via object assignment.
    *
+   * @propType object[]
    * @example
    * events={[
    *   {
@@ -224,6 +233,8 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
 
   /**
    * ChartDonutUtilization uses the standard externalEventMutations prop.
+   *
+   * @propType object[]
    */
   externalEventMutations?: EventCallbackInterface<string | string[], StringOrNumberOrList>[];
   /**
@@ -245,6 +256,8 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
   /**
    * When creating a donut chart, this prop determines the number of pixels between
    * the center of the chart and the inner edge.
+   *
+   * @propType number | Function
    */
   innerRadius?: NumberOrCallback;
   /**
@@ -275,7 +288,10 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
   labelComponent?: React.ReactElement<any>;
   /**
    * The labelPosition prop specifies the angular position of each label relative to its corresponding slice.
-   * When this prop is not given, the label will be positioned at the centroid of each slice.
+   * This prop should be given as "startAngle", "endAngle", "centroid", or as a function that returns one of these
+   * values. When this prop is not given, the label will be positioned at the centroid of each slice.
+   *
+   * @propType string | Function
    */
   labelPosition?: VictorySliceLabelPositionType | ((props: SliceProps) => VictorySliceLabelPositionType);
   /**
@@ -319,6 +335,8 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
   /**
    * The labelRadius prop defines the radius of the arc that will be used for positioning each slice label.
    * If this prop is not set, the label radius will default to the radius of the pie + label padding.
+   *
+   * @propType number | Function
    */
   labelRadius?: number | ((props: SliceProps) => number);
   /**
@@ -338,12 +356,16 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
   /**
    * Victory components will pass an origin prop is to define the center point in svg coordinates for polar charts.
    *
-   * **This prop should not be set manually.**
+   * Note: It will not typically be necessary to set an origin prop manually
+   *
+   * @propType { x: number, y: number }
    */
   origin?: OriginType;
   /**
    * The padAngle prop determines the amount of separation between adjacent data slices
    * in number of degrees
+   *
+   * @propType number | Function
    */
   padAngle?: NumberOrCallback;
   /**
@@ -351,33 +373,45 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    * the edge of the chart and any rendered child components. This prop can be given
    * as a number or as an object with padding specified for top, bottom, left
    * and right.
+   *
+   * @propType number | { top: number, bottom: number, left: number, right: number }
    */
   padding?: PaddingProps;
   /**
    * Specifies the radius of the chart. If this property is not provided it is computed
    * from width, height, and padding props
+   *
+   * @propType number | Function
    */
   radius?: NumberOrCallback;
   /**
    * The sharedEvents prop is used internally to coordinate events between components.
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   sharedEvents?: { events: any[]; getEventState: Function };
   /**
    * This will show the static, unused portion of the donut chart.
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   showStatic?: boolean;
   /**
    * Use the sortKey prop to indicate how data should be sorted. This prop
    * is given directly to the lodash sortBy function to be executed on the
    * final dataset.
+   *
+   * @propType number | string | Function | string[]
    */
   sortKey?: DataGetterPropType;
   /**
    * The sortOrder prop specifies whether sorted data should be returned in 'ascending' or 'descending' order.
+   *
+   * @propType string
    */
   sortOrder?: SortOrderPropType;
   /**
@@ -396,6 +430,7 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    * so valid Radium style objects should work for this prop. Height, width, and
    * padding should be specified via the height, width, and padding props.
    *
+   * @propType { parent: object, data: object, labels: object }
    * @example {data: {stroke: "black"}, label: {fontSize: 10}}
    */
   style?: VictoryStyleInterface;
@@ -429,6 +464,8 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    * When using ChartDonutUtilization as a solo component, implement the theme directly on
    * ChartDonutUtilization. If you are wrapping ChartDonutUtilization in ChartChart, ChartGroup, or ChartThreshold
    * please call the theme on the outermost wrapper component instead.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**
@@ -512,6 +549,7 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'x', 'x.value.nested.1.thing', 'x[2].also.nested', null, d => Math.sin(d)
    */
   x?: DataGetterPropType;
@@ -524,6 +562,7 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'y', 'y.value.nested.1.thing', 'y[2].also.nested', null, d => Math.sin(d)
    */
   y?: DataGetterPropType;

--- a/packages/react-charts/src/components/ChartGroup/ChartGroup.tsx
+++ b/packages/react-charts/src/components/ChartGroup/ChartGroup.tsx
@@ -38,6 +38,7 @@ export interface ChartGroupProps extends VictoryGroupProps {
    * The animate prop should also be used to specify enter and exit
    * transition configurations with the `onExit` and `onEnter` namespaces respectively.
    *
+   * @propType boolean | object
    * @example
    * {duration: 500, onExit: () => {}, onEnter: {duration: 500, before: () => ({y: 0})})}
    */
@@ -62,6 +63,7 @@ export interface ChartGroupProps extends VictoryGroupProps {
    * these arrays of values specified for x and y. If this prop is not set,
    * categorical data will be plotted in the order it was given in the data array
    *
+   * @propType string[] | { x: string[], y: string[] }
    * @example ["dogs", "cats", "mice"]
    */
   categories?: CategoryPropType;
@@ -115,7 +117,10 @@ export interface ChartGroupProps extends VictoryGroupProps {
    * If this prop is not provided, a domain will be calculated from data, or other
    * available information.
    *
-   * @example [-1, 1], {x: [0, 100], y: [0, 1]}
+   * @propType number[] | { x: number[], y: number[] }
+   * @example [low, high], { x: [low, high], y: [low, high] }
+   *
+   * [-1, 1], {x: [0, 100], y: [0, 1]}
    */
   domain?: DomainPropType;
   /**
@@ -123,11 +128,18 @@ export interface ChartGroupProps extends VictoryGroupProps {
    * beginning and end of a domain. This prop is useful for explicitly spacing ticks farther
    * from the origin to prevent crowding. This prop should be given as an object with
    * numbers specified for x and y.
+   *
+   * @propType number | number[] | { x: number[], y: number[] }
+   * @example [left, right], { x: [left, right], y: [bottom, top] }
+   *
+   * {x: [10, -10], y: 5}
    */
   domainPadding?: DomainPaddingPropType;
   /**
    * Similar to data accessor props `x` and `y`, this prop may be used to functionally
    * assign eventKeys to data
+   *
+   * @propType number | string | Function
    */
   eventKey?: StringOrNumberOrCallback;
   /**
@@ -145,6 +157,7 @@ export interface ChartGroupProps extends VictoryGroupProps {
    * element (i.e. an area), and the object returned from the mutation function
    * will override the props of the selected element via object assignment.
    *
+   * @propType object[]
    * @example
    * events={[
    *   {
@@ -171,6 +184,8 @@ export interface ChartGroupProps extends VictoryGroupProps {
   events?: EventPropTypeInterface<VictoryGroupTTargetType, StringOrNumberOrCallback>[];
   /**
    * ChartGroup uses the standard externalEventMutations prop.
+   *
+   * @propType object[]
    */
   externalEventMutations?: EventCallbackInterface<string | string[], StringOrNumberOrList>[];
   /**
@@ -221,7 +236,7 @@ export interface ChartGroupProps extends VictoryGroupProps {
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
-   * examples:
+   * @example
    *
    * maxDomain={0}
    * maxDomain={{ y: 0 }}
@@ -236,7 +251,7 @@ export interface ChartGroupProps extends VictoryGroupProps {
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
-   * examples:
+   * @example
    *
    * minDomain={0}
    * minDomain={{ y: 0 }}
@@ -255,6 +270,10 @@ export interface ChartGroupProps extends VictoryGroupProps {
   offset?: number;
   /**
    * Victory components will pass an origin prop is to define the center point in svg coordinates for polar charts.
+   *
+   * Note: It will not typically be necessary to set an origin prop manually
+   *
+   * @propType { x: number, y: number }
    */
   origin?: OriginType;
   /**
@@ -262,6 +281,8 @@ export interface ChartGroupProps extends VictoryGroupProps {
    * the edge of the chart and any rendered child components. This prop can be given
    * as a number or as an object with padding specified for top, bottom, left
    * and right.
+   *
+   * @propType number | { top: number, bottom: number, left: number, right: number }
    */
   padding?: PaddingProps;
   /**
@@ -276,7 +297,8 @@ export interface ChartGroupProps extends VictoryGroupProps {
    * chart must share the same range, so setting this prop on children nested within Chart,
    * ChartGroup will have no effect. This prop is usually not set manually.
    *
-   * examples:
+   * @propType number[] | { x: number[], y: number[] }
+   * @example [low, high] | { x: [low, high], y: [low, high] }
    *
    * Cartesian: range={{ x: [50, 250], y: [50, 250] }}
    * Polar: range={{ x: [0, 360], y: [0, 250] }}
@@ -292,6 +314,7 @@ export interface ChartGroupProps extends VictoryGroupProps {
    * given as a string specifying a supported scale ("linear", "time", "log", "sqrt"),
    * as a d3 scale function, or as an object with scales specified for x and y
    *
+   * @propType string | { x: string, y: string }
    * @example d3Scale.time(), {x: "linear", y: "log"}
    */
   scale?:
@@ -304,7 +327,9 @@ export interface ChartGroupProps extends VictoryGroupProps {
   /**
    * The sharedEvents prop is used internally to coordinate events between components.
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   sharedEvents?: { events: any[]; getEventState: Function };
   /**
@@ -319,7 +344,7 @@ export interface ChartGroupProps extends VictoryGroupProps {
    * value refers to the dependent variable. This may cause confusion in horizontal charts, as the independent variable
    * will corresponds to the y axis.
    *
-   * examples:
+   * @example
    *
    * singleQuadrantDomainPadding={false}
    * singleQuadrantDomainPadding={{ x: false }}
@@ -329,10 +354,14 @@ export interface ChartGroupProps extends VictoryGroupProps {
    * Use the sortKey prop to indicate how data should be sorted. This prop
    * is given directly to the lodash sortBy function to be executed on the
    * final dataset.
+   *
+   * @propType number | string | Function | string[]
    */
   sortKey?: DataGetterPropType;
   /**
    * The sortOrder prop specifies whether sorted data should be returned in 'ascending' or 'descending' order.
+   *
+   * @propType string
    */
   sortOrder?: SortOrderPropType;
   /**
@@ -347,12 +376,15 @@ export interface ChartGroupProps extends VictoryGroupProps {
    * width, and padding props, as they are used to calculate the alignment of
    * components within chart.
    *
+   * @propType { parent: object, data: object, labels: object }
    * @example {data: {fill: "red"}, labels: {fontSize: 12}}
    */
   style?: VictoryStyleInterface;
   /**
    * The theme prop specifies a theme to use for determining styles and layout properties for a component. Any styles or
    * props defined in theme may be overwritten by props specified on the component instance.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**
@@ -385,6 +417,7 @@ export interface ChartGroupProps extends VictoryGroupProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'x', 'x.value.nested.1.thing', 'x[2].also.nested', null, d => Math.sin(d)
    */
   x?: DataGetterPropType;
@@ -397,6 +430,7 @@ export interface ChartGroupProps extends VictoryGroupProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'y', 'y.value.nested.1.thing', 'y[2].also.nested', null, d => Math.sin(d)
    */
   y?: DataGetterPropType;
@@ -405,6 +439,7 @@ export interface ChartGroupProps extends VictoryGroupProps {
    * This prop is useful for defining custom baselines for components like ChartBar or ChartArea.
    * This prop may be given in a variety of formats.
    *
+   * @propType number | string | Function | string[]
    * @example 'last_quarter_profit', () => 10, 1, 'employees.salary', ["employees", "salary"]
    */
   y0?: DataGetterPropType;

--- a/packages/react-charts/src/components/ChartLabel/ChartLabel.tsx
+++ b/packages/react-charts/src/components/ChartLabel/ChartLabel.tsx
@@ -43,11 +43,18 @@ export interface ChartLabelProps extends VictoryLabelProps {
    * This is necessary because of SVG, which (a) positions the *bottom* of the text at `y`, and (b) has no notion of
    * line height. The value should ideally use the same units as `lineHeight` and `dy`, preferably ems. If given a
    * unitless number, it is assumed to be ems.
+   *
+   * @propType number | string | Function
    */
   capHeight?: StringOrNumberOrCallback;
   /**
    * The children of this component define the content of the label. This makes using the component similar to normal
    * HTML spans or labels. strings, numbers, and functions of data / value are supported.
+   *
+   * Note: This prop should not be set manually.
+   *
+   * @propType number | string | Function
+   * @hide
    */
   children?: StringOrNumberOrCallback;
   /**
@@ -75,11 +82,15 @@ export interface ChartLabelProps extends VictoryLabelProps {
   direction?: 'rtl' | 'ltr' | 'inherit';
   /**
    * The dx prop defines a horizontal shift from the `x` coordinate.
+   *
+   * @propType number | string | Function
    */
   dx?: StringOrNumberOrCallback;
   /**
    * The dy prop defines a vertical shift from the `y` coordinate. Since this component already accounts for
    * `capHeight`, `lineHeight`, and `verticalAnchor`, this will usually not be necessary.
+   *
+   * @propType number | string | Function
    */
   dy?: StringOrNumberOrCallback;
   /**
@@ -88,7 +99,11 @@ export interface ChartLabelProps extends VictoryLabelProps {
    */
   events?: React.DOMAttributes<any>;
   /**
-   * The index prop represents the index of the datum in the data array. This prop should not be set manually.
+   * The index prop represents the index of the datum in the data array.
+   *
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   index?: string | number;
   /**
@@ -102,6 +117,8 @@ export interface ChartLabelProps extends VictoryLabelProps {
    * charts, where it may be desireable to position a label either parallel or perpendicular to its corresponding angle.
    * When this prop is not set, perpendicular label placement will be used for polar charts, and vertical label
    * placement will be used for cartesian charts.
+   *
+   * @propType string
    */
   labelPlacement?: LabelOrientationType;
   /**
@@ -110,18 +127,24 @@ export interface ChartLabelProps extends VictoryLabelProps {
    * but the result is similar: a roughly equal amount of extra space is distributed above and below the line of text.
    * The value should ideally use the same units as `capHeight` and `dy`, preferably ems.
    * If given a unitless number, it is assumed to be ems.
+   *
+   * @propType number | string | Function
    */
   lineHeight?: StringOrNumberOrCallback;
   /**
    * Victory components will pass an origin prop is to define the center point in svg coordinates for polar charts.
    *
-   * **This prop should not be set manually.**
+   * Note: It will not typically be necessary to set an origin prop manually
+   *
+   * @propType { x: number, y: number }
    */
   origin?: OriginType;
   /**
    * Victory components can pass a boolean polar prop to specify whether a label is part of a polar chart.
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   polar?: boolean;
   /**
@@ -131,7 +154,11 @@ export interface ChartLabelProps extends VictoryLabelProps {
   renderInPortal?: boolean;
   /**
    * Victory components can pass a scale prop to their label component. This can be used to calculate the position of
-   * label elements from datum. This prop should not be set manually.
+   * label elements from datum.
+   *
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   scale?: { x?: any; y?: any };
   /**
@@ -143,11 +170,15 @@ export interface ChartLabelProps extends VictoryLabelProps {
    * of datum, or an array of any of these. Strings may include newline characters, which ChartLabel will split into
    * separate <tspan/> elements. When text is given as an array, separate <tspan/> elements will be created for each
    * element in the array.
+   *
+   * @propType number | string | Function | string[]
    */
   text?: string[] | StringOrNumberOrCallback;
   /**
    * The textAnchor prop defines how the text is horizontally positioned relative to the given `x` and `y` coordinates.
    * Options are "start", "middle" and "end". Note that this overrides the style prop.
+   *
+   * @propType string | Function
    */
   textAnchor?: TextAnchorType | (() => TextAnchorType);
   /**
@@ -158,13 +189,17 @@ export interface ChartLabelProps extends VictoryLabelProps {
   /**
    * The verticalAnchor prop defines how the text is vertically positioned relative to the given `x` and `y`
    * coordinates. Options are "start", "middle" and "end".
+   *
+   * @propType string
    */
   verticalAnchor?: VerticalAnchorType | (() => VerticalAnchorType);
   /**
    * This props refers to the width of the svg that VictoryLabel is rendered within. This prop is passed from parents
    * of VictoryLabel.
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   width?: number;
   /**

--- a/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
+++ b/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
@@ -8,8 +8,8 @@ import {
   PaddingProps,
   StringOrNumberOrCallback,
   StringOrNumberOrList,
-  VictoryStyleInterface,
-  VictoryStyleObject
+  VictoryLabelStyleObject,
+  VictoryStyleInterface
 } from 'victory-core';
 import {
   VictoryLegend,
@@ -63,6 +63,8 @@ export interface ChartLegendProps extends VictoryLegendProps {
    * a number, or asanobject with values specified for top, bottom, left, and right.
    * Please note that the default width and height calculated for the border
    * component is based on approximated text measurements, so padding may need to be adjusted.
+   *
+   * @propType number | { top: number, bottom: number, left: number, right: number }
    */
   borderPadding?: PaddingProps;
   /**
@@ -123,14 +125,20 @@ export interface ChartLegendProps extends VictoryLegendProps {
   /**
    * ChartLegend uses the standard eventKey prop to specify how event targets
    * are addressed. This prop is not commonly used.
+   *
+   * @propType number | string | Function | string[]
    */
   eventKey?: StringOrNumberOrCallback | string[];
   /**
    * ChartLegend uses the standard events prop.
+   *
+   * @propType object[]
    */
   events?: EventPropTypeInterface<VictoryLegendTTargetType, StringOrNumberOrCallback>[];
   /**
    * ChartLegend uses the standard externalEventMutations prop.
+   *
+   * @propType object[]
    */
   externalEventMutations?: EventCallbackInterface<string | string[], StringOrNumberOrList>[];
   /**
@@ -180,6 +188,8 @@ export interface ChartLegendProps extends VictoryLegendProps {
    * and text-wrapping is not currently supported, so "vertical"
    * orientation is both the default setting and recommended for
    * displaying many series of data.
+   *
+   * @propType string
    */
   orientation?: VictoryLegendOrientationType;
   /**
@@ -187,6 +197,8 @@ export interface ChartLegendProps extends VictoryLegendProps {
    * the edge of the chart and any rendered child components. This prop can be given
    * as a number or as an object with padding specified for top, bottom, left
    * and right.
+   *
+   * @propType number | { top: number, bottom: number, left: number, right: number }
    */
   padding?: PaddingProps;
   /**
@@ -203,12 +215,17 @@ export interface ChartLegendProps extends VictoryLegendProps {
    * This prop may be given as a number, or as an object with values
    * specified for “top” and “bottom” gutters. To set spacing between columns,
    * use the gutter prop.
+   *
+   * @propType number | { top: number, bottom: number }
+   * @example { top: 0, bottom: 10 }
    */
   rowGutter?: number | Omit<BlockProps, 'left' | 'right'>;
   /**
    * The sharedEvents prop is used internally to coordinate events between components.
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   sharedEvents?: { events: any[]; getEventState: Function };
   /**
@@ -222,9 +239,10 @@ export interface ChartLegendProps extends VictoryLegendProps {
    * so valid Radium style objects should work for this prop. Height, width, and
    * padding should be specified via the height, width, and padding props.
    *
+   * @propType { border: object, data: object, labels: object, parent: object, title: object }
    * @example {data: {stroke: "black"}, label: {fontSize: 10}}
    */
-  style?: VictoryStyleInterface & { title?: VictoryStyleObject };
+  style?: VictoryStyleInterface & { title?: VictoryLabelStyleObject | VictoryLabelStyleObject[] };
   /**
    * The symbolSpacer prop defines the number of pixels between data
    * components and label components.
@@ -236,6 +254,8 @@ export interface ChartLegendProps extends VictoryLegendProps {
    * When using ChartLegend as a solo component, implement the theme directly on
    * ChartLegend. If you are wrapping ChartLegend in ChartChart or
    * ChartGroup, please call the theme on the outermost wrapper component instead.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**
@@ -273,6 +293,8 @@ export interface ChartLegendProps extends VictoryLegendProps {
    * The titleOrientation prop specifies where the a title should be rendered
    * in relation to the rest of the legend. Possible values
    * for this prop are “top”, “bottom”, “left”, and “right”.
+   *
+   * @propType string
    */
   titleOrientation?: OrientationTypes;
   /**

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
@@ -40,7 +40,9 @@ export interface ChartLegendTooltipProps extends ChartCursorTooltipProps {
   /**
    * The activePoints prop specifies the active data
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   activePoints?: any[];
   /**
@@ -60,6 +62,8 @@ export interface ChartLegendTooltipProps extends ChartCursorTooltipProps {
    * pointer. This prop should be given as an object of x and y, where each is either a numeric offset value or a
    * function that returns a numeric value. When this prop is set, non-zero pointerLength values will no longer be
    * respected.
+   *
+   * @propType { x: number | Function, y: number | Function }
    */
   centerOffset?: {
     x?: NumberOrCallback;
@@ -74,6 +78,8 @@ export interface ChartLegendTooltipProps extends ChartCursorTooltipProps {
   /**
    * The cornerRadius prop determines corner radius of the flyout container. This prop may be given as a positive number
    * or a function of datum.
+   *
+   * @propType number | Function
    */
   cornerRadius?: NumberOrCallback;
   /**
@@ -88,17 +94,23 @@ export interface ChartLegendTooltipProps extends ChartCursorTooltipProps {
   datum?: {};
   /**
    * The dx prop defines a horizontal shift from the x coordinate.
+   *
+   * @propType number | Function
    */
   dx?: NumberOrCallback;
   /**
    * The dy prop defines a vertical shift from the y coordinate.
+   *
+   * @propType number | Function
    */
   dy?: NumberOrCallback;
   /**
    * The events prop attaches arbitrary event handlers to the label component. This prop should be given as an object of
    * event names and corresponding event handlers. When events are provided via Victory’s event system, event handlers
    * will be called with the event, the props of the component is attached to, and an eventKey.
-   * Examples: events={{onClick: (evt) => alert("x: " + evt.clientX)}}
+   *
+   * @propType object
+   * @example events={{onClick: (evt) => alert("x: " + evt.clientX)}}
    */
   events?: { [key: string]: (event: React.SyntheticEvent<any>) => void };
   /**
@@ -108,24 +120,31 @@ export interface ChartLegendTooltipProps extends ChartCursorTooltipProps {
    * Any of these props may be overridden by passing in props to the supplied component, or modified or ignored within
    * the custom component itself. If flyoutComponent is omitted, a default Flyout component will be created with props
    * described above.
-   * Examples: flyoutComponent={<Flyout x={50} y={50}/>}, flyoutComponent={<MyCustomFlyout/>}
+   *
+   * @example flyoutComponent={<Flyout x={50} y={50}/>}, flyoutComponent={<MyCustomFlyout/>}
    */
   flyoutComponent?: React.ReactElement<any>;
   /**
    * The flyoutHeight prop defines the height of the tooltip flyout. This prop may be given as a positive number or a function
    * of datum. If this prop is not set, height will be determined based on an approximate text size calculated from the
    * text and style props provided to ChartTooltip.
+   *
+   * @propType number | Function
    */
   flyoutHeight?: NumberOrCallback;
   /**
    * The style prop applies SVG style properties to the rendered flyout container. These props will be passed to the
    * flyoutComponent.
+   *
+   * @propType number | Function
    */
   flyoutStyle?: VictoryStyleObject;
   /**
    * The flyoutWidth prop defines the width of the tooltip flyout. This prop may be given as a positive number or a
    * function of datum. If this prop is not set, flyoutWidth will be determined based on an approximate text size
    * calculated from the text and style props provided to VictoryTooltip.
+   *
+   * @propType number | Function
    */
   flyoutWidth?: NumberOrCallback;
   /**
@@ -138,7 +157,9 @@ export interface ChartLegendTooltipProps extends ChartCursorTooltipProps {
    * parents of ChartLegendTooltip, and should not be set manually. In versions before ^33.0.0 this prop referred to
    * the height of the tooltip flyout. Please use flyoutHeight instead
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   height?: number;
   /**
@@ -162,12 +183,15 @@ export interface ChartLegendTooltipProps extends ChartCursorTooltipProps {
    * verticalAnchor, textAnchor, style, text, and events. Any of these props may be overridden by passing in props to
    * the supplied component, or modified or ignored within the custom component itself. If labelComponent is omitted, a
    * new ChartLabel will be created with the props described above.
-   * Examples: labelComponent={<ChartLabel dy={20}/>}, labelComponent={<MyCustomLabel/>}
+   *
+   * @example labelComponent={<ChartLabel dy={20}/>}, labelComponent={<MyCustomLabel/>}
    */
   labelComponent?: React.ReactElement<any>;
   /**
    * Defines how the labelComponent text is horizontally positioned relative to its `x` and `y` coordinates. Valid
    * values are 'start', 'middle', 'end', and 'inherit'.
+   *
+   * @propType string | Function
    */
   labelTextAnchor?: TextAnchorType | (() => TextAnchorType);
   /**
@@ -176,8 +200,10 @@ export interface ChartLegendTooltipProps extends ChartCursorTooltipProps {
    *
    * The data prop must be given as an array.
    *
-   * @example legendData={[{ name: `GBps capacity - 45%` }, { name: 'Unused' }]}
-   * @example legendData={[{ childName: `cats`, name: `Total cats` }, { childName: `dogs`, name: 'Total dogs' }]}
+   * @example
+   *
+   * legendData={[{ name: `GBps capacity - 45%` }, { name: 'Unused' }]}
+   * legendData={[{ childName: `cats`, name: `Total cats` }, { childName: `dogs`, name: 'Total dogs' }]}
    */
   legendData?: {
     childName?: string;
@@ -195,22 +221,30 @@ export interface ChartLegendTooltipProps extends ChartCursorTooltipProps {
    * This prop can be given as “top”, “bottom”, “left”, “right”, or as a function of datum that returns one of these
    * values. If this prop is not provided it will be determined from the sign of the datum, and the value of the
    * horizontal prop.
+   *
+   * @propType string | Function
    */
   orientation?: OrientationOrCallback;
   /**
    * The pointerLength prop determines the length of the triangular pointer extending from the flyout. This prop may be
    * given as a positive number or a function of datum.
+   *
+   * @propType number | Function
    */
   pointerLength?: NumberOrCallback;
   /**
    * This prop determines which side of the tooltip flyout the pointer should originate on. When this prop is not set,
    * it will be determined based on the overall orientation of the flyout in relation to its data point, and any center
    * or centerOffset values. Valid values are 'top', 'bottom', 'left' and 'right.
+   *
+   * @propType string | Function
    */
   pointerOrientation?: OrientationOrCallback;
   /**
    * The pointerWidth prop determines the width of the base of the triangular pointer extending from
    * the flyout. This prop may be given as a positive number or a function of datum.
+   *
+   * @propType number | Function
    */
   pointerWidth?: NumberOrCallback;
   /**
@@ -226,11 +260,15 @@ export interface ChartLegendTooltipProps extends ChartCursorTooltipProps {
    * The text prop defines the text ChartTooltip will render. The text prop may be given as a string, number, or
    * function of datum. When ChartLabel is used as the labelComponent, strings may include newline characters, which
    * ChartLabel will split in to separate <tspan/> elements.
+   *
+   * @propType number | string | Function | string[] | number[]
    */
   text?: StringOrNumberOrCallback | string[] | number[];
   /**
    * The theme prop specifies a theme to use for determining styles and layout properties for a component. Any styles or
    * props defined in theme may be overwritten by props specified on the component instance.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**
@@ -261,7 +299,9 @@ export interface ChartLegendTooltipProps extends ChartCursorTooltipProps {
    * parents of ChartLegendTooltip, and should not be set manually. In versions before ^33.0.0 this prop referred to the
    * width of the tooltip flyout. Please use flyoutWidth instead
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   width?: number;
   /**

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipContent.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipContent.tsx
@@ -22,7 +22,9 @@ export interface ChartLegendTooltipContentProps {
   /**
    * The activePoints prop specifies the active data
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   activePoints?: any[];
   /**
@@ -40,22 +42,30 @@ export interface ChartLegendTooltipContentProps {
   datum?: {};
   /**
    * The dx prop defines a horizontal shift from the x coordinate.
+   *
+   * @propType number | Function
    */
   dx?: NumberOrCallback;
   /**
    * The dy prop defines a horizontal shift from the y coordinate.
+   *
+   * @propType number | Function
    */
   dy?: NumberOrCallback;
   /**
    * The flyoutHeight prop defines the height of the tooltip flyout. This prop may be given as a positive number or a function
    * of datum. If this prop is not set, height will be determined based on an approximate text size calculated from the
    * text and style props provided to ChartTooltip.
+   *
+   * @propType number | Function
    */
   flyoutHeight?: NumberOrCallback;
   /**
    * The flyoutWidth prop defines the width of the tooltip flyout. This prop may be given as a positive number or a
    * function of datum. If this prop is not set, flyoutWidth will be determined based on an approximate text size
    * calculated from the text and style props provided to VictoryTooltip.
+   *
+   * @propType number | Function
    */
   flyoutWidth?: NumberOrCallback;
   /**
@@ -90,8 +100,10 @@ export interface ChartLegendTooltipContentProps {
    *
    * The data prop must be given as an array.
    *
-   * @example legendData={[{ name: `GBps capacity - 45%` }, { name: 'Unused' }]}
-   * @example legendData={[{ childName: `cats`, name: `Total cats` }, { childName: `dogs`, name: 'Total dogs' }]}
+   * @example
+   *
+   * legendData={[{ name: `GBps capacity - 45%` }, { name: 'Unused' }]}
+   * legendData={[{ childName: `cats`, name: `Total cats` }, { childName: `dogs`, name: 'Total dogs' }]}
    */
   legendData?: {
     childName?: string;
@@ -108,6 +120,8 @@ export interface ChartLegendTooltipContentProps {
    * The text prop defines the text ChartTooltip will render. The text prop may be given as a string, number, or
    * function of datum. When ChartLabel is used as the labelComponent, strings may include newline characters, which
    * ChartLabel will split in to separate <tspan/> elements.
+   *
+   * @propType number | string | Function | string[] | number[]
    */
   text?: StringOrNumberOrCallback | string[] | number[];
   /**
@@ -116,6 +130,8 @@ export interface ChartLegendTooltipContentProps {
    * When using ChartLegend as a solo component, implement the theme directly on
    * ChartLegend. If you are wrapping ChartLegend in ChartChart or
    * ChartGroup, please call the theme on the outermost wrapper component instead.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipLabel.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipLabel.tsx
@@ -33,11 +33,18 @@ export interface ChartLegendLabelProps extends VictoryLabelProps {
    * This is necessary because of SVG, which (a) positions the *bottom* of the text at `y`, and (b) has no notion of
    * line height. The value should ideally use the same units as `lineHeight` and `dy`, preferably ems. If given a
    * unitless number, it is assumed to be ems.
+   *
+   * @propType number | string | Function
    */
   capHeight?: StringOrNumberOrCallback;
   /**
    * The children of this component define the content of the label. This makes using the component similar to normal
    * HTML spans or labels. strings, numbers, and functions of data / value are supported.
+   *
+   * Note: This prop should not be set manually.
+   *
+   * @propType number | string | Function
+   * @hide
    */
   children?: StringOrNumberOrCallback;
   /**
@@ -65,11 +72,15 @@ export interface ChartLegendLabelProps extends VictoryLabelProps {
   direction?: 'rtl' | 'ltr' | 'inherit';
   /**
    * The dx prop defines a horizontal shift from the `x` coordinate.
+   *
+   * @propType number | string | Function
    */
   dx?: StringOrNumberOrCallback;
   /**
    * The dy prop defines a vertical shift from the `y` coordinate. Since this component already accounts for
    * `capHeight`, `lineHeight`, and `verticalAnchor`, this will usually not be necessary.
+   *
+   * @propType number | string | Function
    */
   dy?: StringOrNumberOrCallback;
   /**
@@ -78,7 +89,11 @@ export interface ChartLegendLabelProps extends VictoryLabelProps {
    */
   events?: React.DOMAttributes<any>;
   /**
-   * The index prop represents the index of the datum in the data array. This prop should not be set manually.
+   * The index prop represents the index of the datum in the data array.
+   *
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   index?: string | number;
   /**
@@ -92,6 +107,8 @@ export interface ChartLegendLabelProps extends VictoryLabelProps {
    * charts, where it may be desireable to position a label either parallel or perpendicular to its corresponding angle.
    * When this prop is not set, perpendicular label placement will be used for polar charts, and vertical label
    * placement will be used for cartesian charts.
+   *
+   * @propType string
    */
   labelPlacement?: LabelOrientationType;
   /**
@@ -118,18 +135,24 @@ export interface ChartLegendLabelProps extends VictoryLabelProps {
    * but the result is similar: a roughly equal amount of extra space is distributed above and below the line of text.
    * The value should ideally use the same units as `capHeight` and `dy`, preferably ems.
    * If given a unitless number, it is assumed to be ems.
+   *
+   * @propType number | string | Function
    */
   lineHeight?: StringOrNumberOrCallback;
   /**
    * Victory components will pass an origin prop is to define the center point in svg coordinates for polar charts.
    *
-   * **This prop should not be set manually.**
+   * Note: It will not typically be necessary to set an origin prop manually
+   *
+   * @propType { x: number, y: number }
    */
   origin?: OriginType;
   /**
    * Victory components can pass a boolean polar prop to specify whether a label is part of a polar chart.
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   polar?: boolean;
   /**
@@ -139,7 +162,11 @@ export interface ChartLegendLabelProps extends VictoryLabelProps {
   renderInPortal?: boolean;
   /**
    * Victory components can pass a scale prop to their label component. This can be used to calculate the position of
-   * label elements from datum. This prop should not be set manually.
+   * label elements from datum.
+   *
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   scale?: { x?: any; y?: any };
   /**
@@ -151,11 +178,15 @@ export interface ChartLegendLabelProps extends VictoryLabelProps {
    * of datum, or an array of any of these. Strings may include newline characters, which ChartLabel will split into
    * separate <tspan/> elements. When text is given as an array, separate <tspan/> elements will be created for each
    * element in the array.
+   *
+   * @propType number | string | Function | string[]
    */
   text?: string[] | StringOrNumberOrCallback;
   /**
    * The textAnchor prop defines how the text is horizontally positioned relative to the given `x` and `y` coordinates.
    * Options are "start", "middle" and "end". Note that this overrides the style prop.
+   *
+   * @propType string | Function
    */
   textAnchor?: TextAnchorType | (() => TextAnchorType);
   /**
@@ -166,13 +197,17 @@ export interface ChartLegendLabelProps extends VictoryLabelProps {
   /**
    * The verticalAnchor prop defines how the text is vertically positioned relative to the given `x` and `y`
    * coordinates. Options are "start", "middle" and "end".
+   *
+   * @propType string
    */
   verticalAnchor?: VerticalAnchorType | (() => VerticalAnchorType);
   /**
    * This props refers to the width of the svg that VictoryLabel is rendered within. This prop is passed from parents
    * of VictoryLabel.
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   width?: number;
   /**

--- a/packages/react-charts/src/components/ChartLine/ChartLine.tsx
+++ b/packages/react-charts/src/components/ChartLine/ChartLine.tsx
@@ -39,6 +39,7 @@ export interface ChartLineProps extends VictoryLineProps {
    * The animate prop should also be used to specify enter and exit
    * transition configurations with the `onExit` and `onEnter` namespaces respectively.
    *
+   * @propType boolean | object
    * @example
    * {duration: 500, onExit: () => {}, onEnter: {duration: 500, before: () => ({y: 0})})}
    */
@@ -49,6 +50,7 @@ export interface ChartLineProps extends VictoryLineProps {
    * these arrays of values specified for x and y. If this prop is not set,
    * categorical data will be plotted in the order it was given in the data array
    *
+   * @propType string[] | { x: string[], y: string[] }
    * @example ["dogs", "cats", "mice"]
    */
   categories?: CategoryPropType;
@@ -95,7 +97,10 @@ export interface ChartLineProps extends VictoryLineProps {
    * If this prop is not provided, a domain will be calculated from data, or other
    * available information.
    *
-   * @example [-1, 1], {x: [0, 100], y: [0, 1]}
+   * @propType number[] | { x: number[], y: number[] }
+   * @example [low, high], { x: [low, high], y: [low, high] }
+   *
+   * [-1, 1], {x: [0, 100], y: [0, 1]}
    */
   domain?: DomainPropType;
   /**
@@ -103,11 +108,18 @@ export interface ChartLineProps extends VictoryLineProps {
    * beginning and end of a domain. This prop is useful for explicitly spacing ticks farther
    * from the origin to prevent crowding. This prop should be given as an object with
    * numbers specified for x and y.
+   *
+   * @propType number | number[] | { x: number[], y: number[] }
+   * @example [left, right], { x: [left, right], y: [bottom, top] }
+   *
+   * {x: [10, -10], y: 5}
    */
   domainPadding?: DomainPaddingPropType;
   /**
    * Similar to data accessor props `x` and `y`, this prop may be used to functionally
    * assign eventKeys to data
+   *
+   * @propType number | string | Function
    */
   eventKey?: StringOrNumberOrCallback;
   /**
@@ -125,6 +137,7 @@ export interface ChartLineProps extends VictoryLineProps {
    * element (i.e. a line), and the object returned from the mutation function
    * will override the props of the selected element via object assignment.
    *
+   * @propType object[]
    * @example
    * events={[
    *   {
@@ -151,6 +164,8 @@ export interface ChartLineProps extends VictoryLineProps {
   events?: EventPropTypeInterface<VictoryLineTTargetType, number | string>[];
   /**
    * ChartLine uses the standard externalEventMutations prop.
+   *
+   * @propType object[]
    */
   externalEventMutations?: EventCallbackInterface<string | string[], StringOrNumberOrList>[];
   /**
@@ -171,7 +186,12 @@ export interface ChartLineProps extends VictoryLineProps {
    */
   horizontal?: boolean;
   /**
-   * The interpolation prop determines how data points should be connected when plotting a line
+   * The interpolation prop determines how data points should be connected when plotting a line.
+   * Polar area charts may use the following interpolation options: "basis", "cardinal", "catmullRom", "linear".
+   * Cartesian area charts may use the following interpolation options: "basis", "cardinal", "catmullRom", "linear",
+   * "monotoneX", "monotoneY", "natural", "step", "stepAfter", "stepBefore".
+   *
+   * @propType string | Function
    */
   interpolation?: InterpolationPropType;
   /**
@@ -205,7 +225,7 @@ export interface ChartLineProps extends VictoryLineProps {
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
-   * examples:
+   * @example
    *
    * maxDomain={0}
    * maxDomain={{ y: 0 }}
@@ -220,7 +240,7 @@ export interface ChartLineProps extends VictoryLineProps {
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
-   * examples:
+   * @example
    *
    * minDomain={0}
    * minDomain={{ y: 0 }}
@@ -233,7 +253,9 @@ export interface ChartLineProps extends VictoryLineProps {
   /**
    * Victory components will pass an origin prop is to define the center point in svg coordinates for polar charts.
    *
-   * **This prop should not be set manually.**
+   * Note: It will not typically be necessary to set an origin prop manually
+   *
+   * @propType { x: number, y: number }
    */
   origin?: OriginType;
   /**
@@ -241,12 +263,16 @@ export interface ChartLineProps extends VictoryLineProps {
    * the edge of the chart and any rendered child components. This prop can be given
    * as a number or as an object with padding specified for top, bottom, left
    * and right.
+   *
+   * @propType number | { top: number, bottom: number, left: number, right: number }
    */
   padding?: PaddingProps;
   /**
    * Victory components can pass a boolean polar prop to specify whether a label is part of a polar chart.
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   polar?: boolean;
   /**
@@ -257,7 +283,8 @@ export interface ChartLineProps extends VictoryLineProps {
    * chart must share the same range, so setting this prop on children nested within Chart or
    * ChartGroup will have no effect. This prop is usually not set manually.
    *
-   * examples:
+   * @propType number[] | { x: number[], y: number[] }
+   * @example [low, high] | { x: [low, high], y: [low, high] }
    *
    * Cartesian: range={{ x: [50, 250], y: [50, 250] }}
    * Polar: range={{ x: [0, 360], y: [0, 250] }}
@@ -273,6 +300,7 @@ export interface ChartLineProps extends VictoryLineProps {
    * given as a string specifying a supported scale ("linear", "time", "log", "sqrt"),
    * as a d3 scale function, or as an object with scales specified for x and y
    *
+   * @propType string | { x: string, y: string }
    * @example d3Scale.time(), {x: "linear", y: "log"}
    */
   scale?:
@@ -285,7 +313,9 @@ export interface ChartLineProps extends VictoryLineProps {
   /**
    * The sharedEvents prop is used internally to coordinate events between components.
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   sharedEvents?: { events: any[]; getEventState: Function };
   /**
@@ -300,7 +330,7 @@ export interface ChartLineProps extends VictoryLineProps {
    * value refers to the dependent variable. This may cause confusion in horizontal charts, as the independent variable
    * will corresponds to the y axis.
    *
-   * examples:
+   * @example
    *
    * singleQuadrantDomainPadding={false}
    * singleQuadrantDomainPadding={{ x: false }}
@@ -314,6 +344,8 @@ export interface ChartLineProps extends VictoryLineProps {
   sortKey?: string | string[] | Function;
   /**
    * The sortOrder prop specifies whether sorted data should be returned in 'ascending' or 'descending' order.
+   *
+   * @propType string
    */
   sortOrder?: SortOrderPropType;
   /**
@@ -328,6 +360,7 @@ export interface ChartLineProps extends VictoryLineProps {
    * width, and padding props, as they are used to calculate the alignment of
    * components within chart.
    *
+   * @propType { parent: object, data: object, labels: object }
    * @example {data: {fill: "red"}, labels: {fontSize: 12}}
    */
   style?: VictoryStyleInterface;
@@ -337,6 +370,8 @@ export interface ChartLineProps extends VictoryLineProps {
    * When using ChartLine as a solo component, implement the theme directly on
    * ChartLine. If you are wrapping ChartLine in ChartChart or ChartGroup,
    * please call the theme on the outermost wrapper component instead.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**
@@ -369,6 +404,7 @@ export interface ChartLineProps extends VictoryLineProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'x', 'x.value.nested.1.thing', 'x[2].also.nested', null, d => Math.sin(d)
    */
   x?: DataGetterPropType;
@@ -381,6 +417,7 @@ export interface ChartLineProps extends VictoryLineProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'y', 'y.value.nested.1.thing', 'y[2].also.nested', null, d => Math.sin(d)
    */
   y?: DataGetterPropType;
@@ -389,6 +426,7 @@ export interface ChartLineProps extends VictoryLineProps {
    * This prop is useful for defining custom baselines for components like ChartLine.
    * This prop may be given in a variety of formats.
    *
+   * @propType number | string | Function | string[]
    * @example 'last_quarter_profit', () => 10, 1, 'employees.salary', ["employees", "salary"]
    */
   y0?: DataGetterPropType;

--- a/packages/react-charts/src/components/ChartPie/ChartPie.tsx
+++ b/packages/react-charts/src/components/ChartPie/ChartPie.tsx
@@ -61,6 +61,7 @@ export interface ChartPieProps extends VictoryPieProps {
    * The animate prop should also be used to specify enter and exit
    * transition configurations with the `onExit` and `onEnter` namespaces respectively.
    *
+   * @propType boolean | object
    * @example
    * {duration: 500, onExit: () => {}, onEnter: {duration: 500, before: () => ({y: 0})})}
    */
@@ -85,6 +86,7 @@ export interface ChartPieProps extends VictoryPieProps {
    * these arrays of values specified for x and y. If this prop is not set,
    * categorical data will be plotted in the order it was given in the data array
    *
+   * @propType string[] | { x: string[], y: string[] }
    * @example ["dogs", "cats", "mice"]
    */
   categories?: CategoryPropType;
@@ -120,6 +122,8 @@ export interface ChartPieProps extends VictoryPieProps {
   containerComponent?: React.ReactElement<any>;
   /**
    * Set the cornerRadius for every dataComponent (Slice by default) within ChartPie
+   *
+   * @propType number | Function
    */
   cornerRadius?: SliceNumberOrCallback<SliceProps, 'cornerRadius'>;
   /**
@@ -152,6 +156,8 @@ export interface ChartPieProps extends VictoryPieProps {
   /**
    * Similar to data accessor props `x` and `y`, this prop may be used to functionally
    * assign eventKeys to data
+   *
+   * @propType number | string | Function
    */
   eventKey?: StringOrNumberOrCallback;
   /**
@@ -169,6 +175,7 @@ export interface ChartPieProps extends VictoryPieProps {
    * element (i.e. a single bar), and the object returned from the mutation function
    * will override the props of the selected element via object assignment.
    *
+   * @propType object[]
    * @example
    * events={[
    *   {
@@ -198,6 +205,8 @@ export interface ChartPieProps extends VictoryPieProps {
   events?: EventPropTypeInterface<VictorySliceTTargetType, StringOrNumberOrCallback | string[] | number[]>[];
   /**
    * ChartPie uses the standard externalEventMutations prop.
+   *
+   * @propType object[]
    */
   externalEventMutations?: EventCallbackInterface<string | string[], StringOrNumberOrList>[];
   /**
@@ -227,6 +236,8 @@ export interface ChartPieProps extends VictoryPieProps {
    * When creating a donut chart, this prop determines the number of pixels between
    * the center of the chart and the inner edge. When this prop is set to zero
    * a regular pie chart is rendered.
+   *
+   * @propType number | Function
    */
   innerRadius?: NumberOrCallback;
   /**
@@ -243,12 +254,17 @@ export interface ChartPieProps extends VictoryPieProps {
   labelComponent?: React.ReactElement<any>;
   /**
    * The labelPosition prop specifies the angular position of each label relative to its corresponding slice.
-   * When this prop is not given, the label will be positioned at the centroid of each slice.
+   * This prop should be given as "startAngle", "endAngle", "centroid", or as a function that returns one of these
+   * values. When this prop is not given, the label will be positioned at the centroid of each slice.
+   *
+   * @propType string | Function
    */
   labelPosition?: VictorySliceLabelPositionType | ((props: SliceProps) => VictorySliceLabelPositionType);
   /**
    * The labelRadius prop defines the radius of the arc that will be used for positioning each slice label.
    * If this prop is not set, the label radius will default to the radius of the pie + label padding.
+   *
+   * @propType number | Function
    */
   labelRadius?: number | ((props: SliceProps) => number);
   /**
@@ -312,11 +328,17 @@ export interface ChartPieProps extends VictoryPieProps {
   name?: string;
   /**
    * Victory components will pass an origin prop is to define the center point in svg coordinates for polar charts.
+   *
+   * Note: It will not typically be necessary to set an origin prop manually
+   *
+   * @propType { x: number, y: number }
    */
   origin?: OriginType;
   /**
    * The padAngle prop determines the amount of separation between adjacent data slices
    * in number of degrees
+   *
+   * @propType number | Function
    */
   padAngle?: NumberOrCallback;
   /**
@@ -324,26 +346,36 @@ export interface ChartPieProps extends VictoryPieProps {
    * the edge of the chart and any rendered child components. This prop can be given
    * as a number or as an object with padding specified for top, bottom, left
    * and right.
+   *
+   * @propType number | { top: number, bottom: number, left: number, right: number }
    */
   padding?: PaddingProps;
   /**
    * Specifies the radius of the chart. If this property is not provided it is computed
    * from width, height, and padding props
+   *
+   * @propType number | Function
    */
   radius?: NumberOrCallback;
   /**
    * The sharedEvents prop is used internally to coordinate events between components.
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   sharedEvents?: { events: any[]; getEventState: Function };
   /**
    * Use the sortKey prop to indicate how data should be sorted. This prop
    * is given directly to the lodash sortBy function to be executed on the final dataset.
+   *
+   * @propType number | string | Function | string[]
    */
   sortKey?: DataGetterPropType;
   /**
    * The sortOrder prop specifies whether sorted data should be returned in 'ascending' or 'descending' order.
+   *
+   * @propType string
    */
   sortOrder?: SortOrderPropType;
   /**
@@ -362,6 +394,7 @@ export interface ChartPieProps extends VictoryPieProps {
    * so valid Radium style objects should work for this prop. Height, width, and
    * padding should be specified via the height, width, and padding props.
    *
+   * @propType { parent: object, data: object, labels: object }
    * @example {data: {stroke: "black"}, label: {fontSize: 10}}
    */
   style?: VictoryStyleInterface;
@@ -371,6 +404,8 @@ export interface ChartPieProps extends VictoryPieProps {
    * When using ChartPie as a solo component, implement the theme directly on
    * ChartPie. If you are wrapping ChartPie in ChartChart or ChartGroup,
    * please call the theme on the outermost wrapper component instead.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**
@@ -407,6 +442,7 @@ export interface ChartPieProps extends VictoryPieProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'x', 'x.value.nested.1.thing', 'x[2].also.nested', null, d => Math.sin(d)
    */
   x?: DataGetterPropType;
@@ -419,6 +455,7 @@ export interface ChartPieProps extends VictoryPieProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'y', 'y.value.nested.1.thing', 'y[2].also.nested', null, d => Math.sin(d)
    */
   y?: DataGetterPropType;

--- a/packages/react-charts/src/components/ChartScatter/ChartScatter.tsx
+++ b/packages/react-charts/src/components/ChartScatter/ChartScatter.tsx
@@ -39,6 +39,7 @@ export interface ChartScatterProps extends VictoryScatterProps {
    * The animate prop should also be used to specify enter and exit
    * transition configurations with the `onExit` and `onEnter` namespaces respectively.
    *
+   * @propType boolean | object
    * @example
    * {duration: 500, onExit: () => {}, onEnter: {duration: 500, before: () => ({y: 0})})}
    */
@@ -54,6 +55,7 @@ export interface ChartScatterProps extends VictoryScatterProps {
    * these arrays of values specified for x and y. If this prop is not set,
    * categorical data will be plotted in the order it was given in the data array
    *
+   * @propType string[] | { x: string[], y: string[] }
    * @example ["dogs", "cats", "mice"]
    */
   categories?: CategoryPropType;
@@ -100,7 +102,10 @@ export interface ChartScatterProps extends VictoryScatterProps {
    * If this prop is not provided, a domain will be calculated from data, or other
    * available information.
    *
-   * @example [-1, 1], {x: [0, 100], y: [0, 1]}
+   * @propType number[] | { x: number[], y: number[] }
+   * @example [low, high], { x: [low, high], y: [low, high] }
+   *
+   * [-1, 1], {x: [0, 100], y: [0, 1]}
    */
   domain?: DomainPropType;
   /**
@@ -108,11 +113,18 @@ export interface ChartScatterProps extends VictoryScatterProps {
    * beginning and end of a domain. This prop is useful for explicitly spacing ticks farther
    * from the origin to prevent crowding. This prop should be given as an object with
    * numbers specified for x and y.
+   *
+   * @propType number | number[] | { x: number[], y: number[] }
+   * @example [left, right], { x: [left, right], y: [bottom, top] }
+   *
+   * {x: [10, -10], y: 5}
    */
   domainPadding?: DomainPaddingPropType;
   /**
    * Similar to data accessor props `x` and `y`, this prop may be used to functionally
    * assign eventKeys to data
+   *
+   * @propType number | string | Function
    */
   eventKey?: StringOrNumberOrCallback;
   /**
@@ -130,6 +142,7 @@ export interface ChartScatterProps extends VictoryScatterProps {
    * element (i.e. a line), and the object returned from the mutation function
    * will override the props of the selected element via object assignment.
    *
+   * @propType object[]
    * @example
    * events={[
    *   {
@@ -156,6 +169,8 @@ export interface ChartScatterProps extends VictoryScatterProps {
   events?: EventPropTypeInterface<VictoryScatterTTargetType, StringOrNumberOrCallback>[];
   /**
    * ChartScatter uses the standard externalEventMutations prop.
+   *
+   * @propType object[]
    */
   externalEventMutations?: EventCallbackInterface<string | string[], StringOrNumberOrList>[];
   /**
@@ -210,7 +225,7 @@ export interface ChartScatterProps extends VictoryScatterProps {
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
-   * examples:
+   * @example
    *
    * maxDomain={0}
    * maxDomain={{ y: 0 }}
@@ -229,7 +244,7 @@ export interface ChartScatterProps extends VictoryScatterProps {
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
-   * examples:
+   * @example
    *
    * minDomain={0}
    * minDomain={{ y: 0 }}
@@ -242,7 +257,9 @@ export interface ChartScatterProps extends VictoryScatterProps {
   /**
    * Victory components will pass an origin prop is to define the center point in svg coordinates for polar charts.
    *
-   * **This prop should not be set manually.**
+   * Note: It will not typically be necessary to set an origin prop manually
+   *
+   * @propType { x: number, y: number }
    */
   origin?: OriginType;
   /**
@@ -250,12 +267,16 @@ export interface ChartScatterProps extends VictoryScatterProps {
    * the edge of the chart and any rendered child components. This prop can be given
    * as a number or as an object with padding specified for top, bottom, left
    * and right.
+   *
+   * @propType number | { top: number, bottom: number, left: number, right: number }
    */
   padding?: PaddingProps;
   /**
    * Victory components can pass a boolean polar prop to specify whether a label is part of a polar chart.
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   polar?: boolean;
   /**
@@ -266,7 +287,8 @@ export interface ChartScatterProps extends VictoryScatterProps {
    * chart must share the same range, so setting this prop on children nested within Chart or
    * ChartGroup will have no effect. This prop is usually not set manually.
    *
-   * examples:
+   * @propType number[] | { x: number[], y: number[] }
+   * @example [low, high] | { x: [low, high], y: [low, high] }
    *
    * Cartesian: range={{ x: [50, 250], y: [50, 250] }}
    * Polar: range={{ x: [0, 360], y: [0, 250] }}
@@ -282,6 +304,7 @@ export interface ChartScatterProps extends VictoryScatterProps {
    * given as a string specifying a supported scale ("linear", "time", "log", "sqrt"),
    * as a d3 scale function, or as an object with scales specified for x and y
    *
+   * @propType string | { x: string, y: string }
    * @example d3Scale.time(), {x: "linear", y: "log"}
    */
   scale?:
@@ -294,7 +317,9 @@ export interface ChartScatterProps extends VictoryScatterProps {
   /**
    * The sharedEvents prop is used internally to coordinate events between components.
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   sharedEvents?: { events: any[]; getEventState: Function };
   /**
@@ -309,7 +334,7 @@ export interface ChartScatterProps extends VictoryScatterProps {
    * value refers to the dependent variable. This may cause confusion in horizontal charts, as the independent variable
    * will corresponds to the y axis.
    *
-   * examples:
+   * @example
    *
    * singleQuadrantDomainPadding={false}
    * singleQuadrantDomainPadding={{ x: false }}
@@ -323,10 +348,14 @@ export interface ChartScatterProps extends VictoryScatterProps {
    * Use the sortKey prop to indicate how data should be sorted. This prop
    * is given directly to the lodash sortBy function to be executed on the
    * final dataset.
+   *
+   * @propType number | string | Function | string[]
    */
   sortKey?: DataGetterPropType;
   /**
    * The sortOrder prop specifies whether sorted data should be returned in 'ascending' or 'descending' order.
+   *
+   * @propType string
    */
   sortOrder?: SortOrderPropType;
   /**
@@ -341,11 +370,15 @@ export interface ChartScatterProps extends VictoryScatterProps {
    * width, and padding props, as they are used to calculate the alignment of
    * components within chart.
    *
+   * @propType { parent: object, data: object, labels: object }
    * @example {data: {fill: "red"}, labels: {fontSize: 12}}
    */
   style?: VictoryStyleInterface;
   /**
-   * The symbol prop determines which symbol should be drawn to represent data points.
+   * The symbol prop determines which symbol should be drawn to represent data points. Options are: "circle", "cross",
+   * "diamond", "plus", "minus", "square", "star", "triangleDown", "triangleUp".
+   *
+   * @propType string | Function
    */
   symbol?: ScatterSymbolType | ((data: any) => ScatterSymbolType);
   /**
@@ -354,6 +387,8 @@ export interface ChartScatterProps extends VictoryScatterProps {
    * When using ChartScatter as a solo component, implement the theme directly on
    * ChartScatter. If you are wrapping ChartScatter in ChartChart or ChartGroup,
    * please call the theme on the outermost wrapper component instead.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**
@@ -386,6 +421,7 @@ export interface ChartScatterProps extends VictoryScatterProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'x', 'x.value.nested.1.thing', 'x[2].also.nested', null, d => Math.sin(d)
    */
   x?: DataGetterPropType;
@@ -398,6 +434,7 @@ export interface ChartScatterProps extends VictoryScatterProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'y', 'y.value.nested.1.thing', 'y[2].also.nested', null, d => Math.sin(d)
    */
   y?: DataGetterPropType;
@@ -406,6 +443,7 @@ export interface ChartScatterProps extends VictoryScatterProps {
    * This prop is useful for defining custom baselines for components like ChartScatter.
    * This prop may be given in a variety of formats.
    *
+   * @propType number | string | Function | string[]
    * @example 'last_quarter_profit', () => 10, 1, 'employees.salary', ["employees", "salary"]
    */
   y0?: DataGetterPropType;

--- a/packages/react-charts/src/components/ChartStack/ChartStack.tsx
+++ b/packages/react-charts/src/components/ChartStack/ChartStack.tsx
@@ -31,6 +31,7 @@ export interface ChartStackProps extends VictoryStackProps {
    * The animate prop should also be used to specify enter and exit
    * transition configurations with the `onExit` and `onEnter` namespaces respectively.
    *
+   * @propType boolean | object
    * @example
    * {duration: 500, onExit: () => {}, onEnter: {duration: 500, before: () => ({y: 0})})}
    */
@@ -57,6 +58,7 @@ export interface ChartStackProps extends VictoryStackProps {
    * its the children. If this prop is not set, any categories on child component
    * or catigorical data, will be merged to create a shared set of categories.
    *
+   * @propType string[] | { x: string[], y: string[] }
    * @example ["dogs", "cats", "mice"]
    */
   categories?: CategoryPropType;
@@ -98,7 +100,10 @@ export interface ChartStackProps extends VictoryStackProps {
    * If this prop is not provided, a domain will be calculated from data, or other
    * available information.
    *
-   * @example [-1, 1], {x: [0, 100], y: [0, 1]}
+   * @propType number[] | { x: number[], y: number[] }
+   * @example [low, high], { x: [low, high], y: [low, high] }
+   *
+   * [-1, 1], {x: [0, 100], y: [0, 1]}
    */
   domain?: DomainPropType;
   /**
@@ -106,11 +111,18 @@ export interface ChartStackProps extends VictoryStackProps {
    * beginning and end of a domain. This prop is useful for explicitly spacing ticks farther
    * from the origin to prevent crowding. This prop should be given as an object with
    * numbers specified for x and y.
+   *
+   * @propType number | number[] | { x: number[], y: number[] }
+   * @example [left, right], { x: [left, right], y: [bottom, top] }
+   *
+   * {x: [10, -10], y: 5}
    */
   domainPadding?: DomainPaddingPropType;
   /**
    * Similar to data accessor props `x` and `y`, this prop may be used to functionally
    * assign eventKeys to data
+   *
+   * @propType number | string | Function
    */
   eventKey?: StringOrNumberOrCallback;
   /**
@@ -129,6 +141,7 @@ export interface ChartStackProps extends VictoryStackProps {
    * element (i.e. a single bar), and the object returned from the mutation function
    * will override the props of the selected element via object assignment.
    *
+   * @propType object[]
    * @example
    * events={[
    *   {
@@ -158,6 +171,8 @@ export interface ChartStackProps extends VictoryStackProps {
   events?: EventPropTypeInterface<VictoryStackTTargetType, StringOrNumberOrCallback>[];
   /**
    * ChartStack uses the standard externalEventMutations prop.
+   *
+   * @propType object[]
    */
   externalEventMutations?: EventCallbackInterface<string | string[], StringOrNumberOrList>[];
   /**
@@ -208,7 +223,7 @@ export interface ChartStackProps extends VictoryStackProps {
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
-   * examples:
+   * @example
    *
    * maxDomain={0}
    * maxDomain={{ y: 0 }}
@@ -223,7 +238,7 @@ export interface ChartStackProps extends VictoryStackProps {
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
-   * examples:
+   * @example
    *
    * minDomain={0}
    * minDomain={{ y: 0 }}
@@ -236,7 +251,9 @@ export interface ChartStackProps extends VictoryStackProps {
   /**
    * Victory components will pass an origin prop is to define the center point in svg coordinates for polar charts.
    *
-   * **This prop should not be set manually.**
+   * Note: It will not typically be necessary to set an origin prop manually
+   *
+   * @propType { x: number, y: number }
    */
   origin?: OriginType;
   /**
@@ -244,12 +261,16 @@ export interface ChartStackProps extends VictoryStackProps {
    * the edge of the chart and any rendered child components. This prop can be given
    * as a number or as an object with padding specified for top, bottom, left
    * and right.
+   *
+   * @propType number | { top: number, bottom: number, left: number, right: number }
    */
   padding?: PaddingProps;
   /**
    * Victory components can pass a boolean polar prop to specify whether a label is part of a polar chart.
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   polar?: boolean;
   /**
@@ -260,7 +281,8 @@ export interface ChartStackProps extends VictoryStackProps {
    * chart must share the same range, so setting this prop on children nested within Chart or
    * ChartGroup will have no effect. This prop is usually not set manually.
    *
-   * examples:
+   * @propType number[] | { x: number[], y: number[] }
+   * @example [low, high] | { x: [low, high], y: [low, high] }
    *
    * Cartesian: range={{ x: [50, 250], y: [50, 250] }}
    * Polar: range={{ x: [0, 360], y: [0, 250] }}
@@ -271,6 +293,7 @@ export interface ChartStackProps extends VictoryStackProps {
    * given as a string specifying a supported scale ("linear", "time", "log", "sqrt"),
    * as a d3 scale function, or as an object with scales specified for x and y
    *
+   * @propType string | { x: string, y: string }
    * @example d3Scale.time(), {x: "linear", y: "log"}
    */
   scale?:
@@ -283,7 +306,9 @@ export interface ChartStackProps extends VictoryStackProps {
   /**
    * The sharedEvents prop is used internally to coordinate events between components.
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   sharedEvents?: { events: any[]; getEventState: Function };
   /**
@@ -298,7 +323,7 @@ export interface ChartStackProps extends VictoryStackProps {
    * value refers to the dependent variable. This may cause confusion in horizontal charts, as the independent variable
    * will corresponds to the y axis.
    *
-   * examples:
+   * @example
    *
    * singleQuadrantDomainPadding={false}
    * singleQuadrantDomainPadding={{ x: false }}
@@ -313,6 +338,8 @@ export interface ChartStackProps extends VictoryStackProps {
   /**
    * The style prop specifies styles for your grouped chart. These styles will be
    * applied to all grouped children
+   *
+   * @propType { parent: object, data: object, labels: object }
    */
   style?: VictoryStyleInterface;
   /**
@@ -321,6 +348,8 @@ export interface ChartStackProps extends VictoryStackProps {
    * When using ChartArea as a solo component, implement the theme directly on
    * ChartArea. If you are wrapping ChartArea in ChartChart or ChartGroup,
    * please call the theme on the outermost wrapper component instead.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**

--- a/packages/react-charts/src/components/ChartThreshold/ChartThreshold.tsx
+++ b/packages/react-charts/src/components/ChartThreshold/ChartThreshold.tsx
@@ -35,6 +35,7 @@ export interface ChartThresholdProps extends VictoryLineProps {
    * The animate prop should also be used to specify enter and exit
    * transition configurations with the `onExit` and `onEnter` namespaces respectively.
    *
+   * @propType boolean | object
    * @example
    * {duration: 500, onExit: () => {}, onEnter: {duration: 500, before: () => ({y: 0})})}
    */
@@ -45,6 +46,7 @@ export interface ChartThresholdProps extends VictoryLineProps {
    * these arrays of values specified for x and y. If this prop is not set,
    * categorical data will be plotted in the order it was given in the data array
    *
+   * @propType string[] | { x: string[], y: string[] }
    * @example ["dogs", "cats", "mice"]
    */
   categories?: CategoryPropType;
@@ -91,7 +93,10 @@ export interface ChartThresholdProps extends VictoryLineProps {
    * If this prop is not provided, a domain will be calculated from data, or other
    * available information.
    *
-   * @example [-1, 1], {x: [0, 100], y: [0, 1]}
+   * @propType number[] | { x: number[], y: number[] }
+   * @example [low, high], { x: [low, high], y: [low, high] }
+   *
+   * [-1, 1], {x: [0, 100], y: [0, 1]}
    */
   domain?: DomainPropType;
   /**
@@ -99,11 +104,18 @@ export interface ChartThresholdProps extends VictoryLineProps {
    * beginning and end of a domain. This prop is useful for explicitly spacing ticks farther
    * from the origin to prevent crowding. This prop should be given as an object with
    * numbers specified for x and y.
+   *
+   * @propType number | number[] | { x: number[], y: [number, number] }
+   * @example [left, right], { x: [left, right], y: [bottom, top] }
+   *
+   * {x: [10, -10], y: 5}
    */
   domainPadding?: DomainPaddingPropType;
   /**
    * Similar to data accessor props `x` and `y`, this prop may be used to functionally
    * assign eventKeys to data
+   *
+   * @propType number | string | Function
    */
   eventKey?: StringOrNumberOrCallback;
   /**
@@ -121,6 +133,7 @@ export interface ChartThresholdProps extends VictoryLineProps {
    * element (i.e. a line), and the object returned from the mutation function
    * will override the props of the selected element via object assignment.
    *
+   * @propType object[]
    * @example
    * events={[
    *   {
@@ -147,6 +160,8 @@ export interface ChartThresholdProps extends VictoryLineProps {
   events?: EventPropTypeInterface<VictoryLineTTargetType, number | string>[];
   /**
    * ChartLine uses the standard externalEventMutations prop.
+   *
+   * @propType object[]
    */
   externalEventMutations?: EventCallbackInterface<string | string[], StringOrNumberOrList>[];
   /**
@@ -167,7 +182,12 @@ export interface ChartThresholdProps extends VictoryLineProps {
    */
   horizontal?: boolean;
   /**
-   * The interpolation prop determines how data points should be connected when plotting a line
+   * The interpolation prop determines how data points should be connected when plotting a line.
+   * Polar area charts may use the following interpolation options: "basis", "cardinal", "catmullRom", "linear".
+   * Cartesian area charts may use the following interpolation options: "basis", "cardinal", "catmullRom", "linear",
+   * "monotoneX", "monotoneY", "natural", "step", "stepAfter", "stepBefore".
+   *
+   * @propType string | Function
    */
   interpolation?: InterpolationPropType;
   /**
@@ -201,7 +221,7 @@ export interface ChartThresholdProps extends VictoryLineProps {
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
-   * examples:
+   * @example
    *
    * maxDomain={0}
    * maxDomain={{ y: 0 }}
@@ -216,7 +236,7 @@ export interface ChartThresholdProps extends VictoryLineProps {
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
-   * examples:
+   * @example
    *
    * minDomain={0}
    * minDomain={{ y: 0 }}
@@ -229,7 +249,9 @@ export interface ChartThresholdProps extends VictoryLineProps {
   /**
    * Victory components will pass an origin prop is to define the center point in svg coordinates for polar charts.
    *
-   * **This prop should not be set manually.**
+   * Note: It will not typically be necessary to set an origin prop manually
+   *
+   * @propType { x: number, y: number }
    */
   origin?: OriginType;
   /**
@@ -237,12 +259,16 @@ export interface ChartThresholdProps extends VictoryLineProps {
    * the edge of the chart and any rendered child components. This prop can be given
    * as a number or as an object with padding specified for top, bottom, left
    * and right.
+   *
+   * @propType number | { top: number, bottom: number, left: number, right: number }
    */
   padding?: PaddingProps;
   /**
    * Victory components can pass a boolean polar prop to specify whether a label is part of a polar chart.
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   polar?: boolean;
   /**
@@ -253,7 +279,8 @@ export interface ChartThresholdProps extends VictoryLineProps {
    * chart must share the same range, so setting this prop on children nested within Chart or
    * ChartGroup will have no effect. This prop is usually not set manually.
    *
-   * examples:
+   * @propType [number, number] | { x: [number, number], y: [number, number] }
+   * @example [low, high] | { x: [low, high], y: [low, high] }
    *
    * Cartesian: range={{ x: [50, 250], y: [50, 250] }}
    * Polar: range={{ x: [0, 360], y: [0, 250] }}
@@ -269,6 +296,7 @@ export interface ChartThresholdProps extends VictoryLineProps {
    * given as a string specifying a supported scale ("linear", "time", "log", "sqrt"),
    * as a d3 scale function, or as an object with scales specified for x and y
    *
+   * @propType string | { x: string, y: string }
    * @example d3Scale.time(), {x: "linear", y: "log"}
    */
   scale?:
@@ -281,7 +309,9 @@ export interface ChartThresholdProps extends VictoryLineProps {
   /**
    * The sharedEvents prop is used internally to coordinate events between components.
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   sharedEvents?: { events: any[]; getEventState: Function };
   /**
@@ -296,7 +326,7 @@ export interface ChartThresholdProps extends VictoryLineProps {
    * value refers to the dependent variable. This may cause confusion in horizontal charts, as the independent variable
    * will corresponds to the y axis.
    *
-   * examples:
+   * @example
    *
    * singleQuadrantDomainPadding={false}
    * singleQuadrantDomainPadding={{ x: false }}
@@ -310,6 +340,8 @@ export interface ChartThresholdProps extends VictoryLineProps {
   sortKey?: string | string[] | Function;
   /**
    * The sortOrder prop specifies whether sorted data should be returned in 'ascending' or 'descending' order.
+   *
+   * @propType string
    */
   sortOrder?: SortOrderPropType;
   /**
@@ -324,6 +356,7 @@ export interface ChartThresholdProps extends VictoryLineProps {
    * width, and padding props, as they are used to calculate the alignment of
    * components within chart.
    *
+   * @propType { parent: object, data: object, labels: object }
    * @example {data: {fill: "red"}, labels: {fontSize: 12}}
    */
   style?: VictoryStyleInterface;
@@ -333,6 +366,8 @@ export interface ChartThresholdProps extends VictoryLineProps {
    * When using ChartLine as a solo component, implement the theme directly on
    * ChartLine. If you are wrapping ChartLine in ChartChart or ChartGroup,
    * please call the theme on the outermost wrapper component instead.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**
@@ -365,6 +400,7 @@ export interface ChartThresholdProps extends VictoryLineProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'x', 'x.value.nested.1.thing', 'x[2].also.nested', null, d => Math.sin(d)
    */
   x?: DataGetterPropType;
@@ -377,6 +413,7 @@ export interface ChartThresholdProps extends VictoryLineProps {
    * it will be used as a nested object property path (for details see Lodash docs for _.get).
    * If `null` or `undefined`, the data value will be used as is (identity function/pass-through).
    *
+   * @propType number | string | Function | string[]
    * @example 0, 'y', 'y.value.nested.1.thing', 'y[2].also.nested', null, d => Math.sin(d)
    */
   y?: DataGetterPropType;
@@ -385,6 +422,7 @@ export interface ChartThresholdProps extends VictoryLineProps {
    * This prop is useful for defining custom baselines for components like ChartLine.
    * This prop may be given in a variety of formats.
    *
+   * @propType number | string | Function | string[]
    * @example 'last_quarter_profit', () => 10, 1, 'employees.salary', ["employees", "salary"]
    */
   y0?: DataGetterPropType;

--- a/packages/react-charts/src/components/ChartTooltip/ChartTooltip.tsx
+++ b/packages/react-charts/src/components/ChartTooltip/ChartTooltip.tsx
@@ -43,6 +43,8 @@ export interface ChartTooltipProps extends VictoryTooltipProps {
    * pointer. This prop should be given as an object of x and y, where each is either a numeric offset value or a
    * function that returns a numeric value. When this prop is set, non-zero pointerLength values will no longer be
    * respected.
+   *
+   * @propType { x: number | Function, y: number | Function }
    */
   centerOffset?: {
     x?: NumberOrCallback;
@@ -57,6 +59,8 @@ export interface ChartTooltipProps extends VictoryTooltipProps {
   /**
    * The cornerRadius prop determines corner radius of the flyout container. This prop may be given as a positive number
    * or a function of datum.
+   *
+   * @propType number | Function
    */
   cornerRadius?: NumberOrCallback;
   /**
@@ -71,17 +75,23 @@ export interface ChartTooltipProps extends VictoryTooltipProps {
   datum?: {};
   /**
    * The dx prop defines a horizontal shift from the x coordinate.
+   *
+   * @propType number | Function
    */
   dx?: NumberOrCallback;
   /**
    * The dy prop defines a vertical shift from the y coordinate.
+   *
+   * @propType number | Function
    */
   dy?: NumberOrCallback;
   /**
    * The events prop attaches arbitrary event handlers to the label component. This prop should be given as an object of
    * event names and corresponding event handlers. When events are provided via Victory’s event system, event handlers
    * will be called with the event, the props of the component is attached to, and an eventKey.
-   * Examples: events={{onClick: (evt) => alert("x: " + evt.clientX)}}
+   *
+   * @propType object
+   * @example events={{onClick: (evt) => alert("x: " + evt.clientX)}}
    */
   events?: { [key: string]: (event: React.SyntheticEvent<any>) => void };
   /**
@@ -91,24 +101,31 @@ export interface ChartTooltipProps extends VictoryTooltipProps {
    * Any of these props may be overridden by passing in props to the supplied component, or modified or ignored within
    * the custom component itself. If flyoutComponent is omitted, a default Flyout component will be created with props
    * described above.
-   * Examples: flyoutComponent={<Flyout x={50} y={50}/>}, flyoutComponent={<MyCustomFlyout/>}
+   *
+   * @example flyoutComponent={<Flyout x={50} y={50}/>}, flyoutComponent={<MyCustomFlyout/>}
    */
   flyoutComponent?: React.ReactElement<any>;
   /**
    * The flyoutHeight prop defines the height of the tooltip flyout. This prop may be given as a positive number or a function
    * of datum. If this prop is not set, height will be determined based on an approximate text size calculated from the
    * text and style props provided to ChartTooltip.
+   *
+   * @propType number | Function
    */
   flyoutHeight?: NumberOrCallback;
   /**
    * The style prop applies SVG style properties to the rendered flyout container. These props will be passed to the
    * flyoutComponent.
+   *
+   * @propType number | Function
    */
   flyoutStyle?: VictoryStyleObject;
   /**
    * The flyoutWidth prop defines the width of the tooltip flyout. This prop may be given as a positive number or a
    * function of datum. If this prop is not set, flyoutWidth will be determined based on an approximate text size
    * calculated from the text and style props provided to VictoryTooltip.
+   *
+   * @propType number | Function
    */
   flyoutWidth?: NumberOrCallback;
   /**
@@ -121,7 +138,9 @@ export interface ChartTooltipProps extends VictoryTooltipProps {
    * of ChartTooltip, and should not be set manually. In versions before ^33.0.0 this prop referred to the height of the
    * tooltip flyout. Please use flyoutHeight instead
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   height?: number;
   /**
@@ -140,12 +159,15 @@ export interface ChartTooltipProps extends VictoryTooltipProps {
    * verticalAnchor, textAnchor, style, text, and events. Any of these props may be overridden by passing in props to
    * the supplied component, or modified or ignored within the custom component itself. If labelComponent is omitted, a
    * new ChartLabel will be created with the props described above.
-   * Examples: labelComponent={<ChartLabel dy={20}/>}, labelComponent={<MyCustomLabel/>}
+   *
+   * @example labelComponent={<ChartLabel dy={20}/>}, labelComponent={<MyCustomLabel/>}
    */
   labelComponent?: React.ReactElement<any>;
   /**
    * Defines how the labelComponent text is horizontally positioned relative to its `x` and `y` coordinates. Valid
    * values are 'start', 'middle', 'end', and 'inherit'.
+   *
+   * @propType string | Function
    */
   labelTextAnchor?: TextAnchorType | (() => TextAnchorType);
   /**
@@ -153,22 +175,30 @@ export interface ChartTooltipProps extends VictoryTooltipProps {
    * This prop can be given as “top”, “bottom”, “left”, “right”, or as a function of datum that returns one of these
    * values. If this prop is not provided it will be determined from the sign of the datum, and the value of the
    * horizontal prop.
+   *
+   * @propType string | Function
    */
   orientation?: OrientationOrCallback;
   /**
    * The pointerLength prop determines the length of the triangular pointer extending from the flyout. This prop may be
    * given as a positive number or a function of datum.
+   *
+   * @propType number | Function
    */
   pointerLength?: NumberOrCallback;
   /**
    * This prop determines which side of the tooltip flyout the pointer should originate on. When this prop is not set,
    * it will be determined based on the overall orientation of the flyout in relation to its data point, and any center
    * or centerOffset values. Valid values are 'top', 'bottom', 'left' and 'right.
+   *
+   * @propType string | Function
    */
   pointerOrientation?: OrientationTypes | ((...args: any[]) => OrientationTypes);
   /**
    * The pointerWidth prop determines the width of the base of the triangular pointer extending from
    * the flyout. This prop may be given as a positive number or a function of datum.
+   *
+   * @propType number | Function
    */
   pointerWidth?: NumberOrCallback;
   /**
@@ -184,11 +214,15 @@ export interface ChartTooltipProps extends VictoryTooltipProps {
    * The text prop defines the text ChartTooltip will render. The text prop may be given as a string, number, or
    * function of datum. When ChartLabel is used as the labelComponent, strings may include newline characters, which
    * ChartLabel will split in to separate <tspan/> elements.
+   *
+   * @propType number | string | Function | string[] | number[]
    */
   text?: StringOrNumberOrCallback | string[] | number[];
   /**
    * The theme prop specifies a theme to use for determining styles and layout properties for a component. Any styles or
    * props defined in theme may be overwritten by props specified on the component instance.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**
@@ -212,7 +246,9 @@ export interface ChartTooltipProps extends VictoryTooltipProps {
    * of ChartTooltip, and should not be set manually. In versions before ^33.0.0 this prop referred to the width of the
    * tooltip flyout. Please use flyoutWidth instead
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   width?: number;
   /**

--- a/packages/react-charts/src/components/ChartVoronoiContainer/ChartVoronoiContainer.tsx
+++ b/packages/react-charts/src/components/ChartVoronoiContainer/ChartVoronoiContainer.tsx
@@ -35,7 +35,9 @@ export interface ChartVoronoiContainerProps extends VictoryVoronoiContainerProps
    * he children prop specifies the child or children that will be rendered within the container. It will be set by
    * whatever Victory component is rendering the container.
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   children?: React.ReactElement | React.ReactElement[];
   /**
@@ -74,7 +76,7 @@ export interface ChartVoronoiContainerProps extends VictoryVoronoiContainerProps
    * applicable. Use the invert method to convert event coordinate information to
    * data. `scale.x.invert(evt.offsetX)`.
    *
-   * @example {{ onClick: (evt) => alert(`x: ${evt.clientX}, y: ${evt.clientY}`)}}
+   * @example {onClick: (evt) => alert(`x: ${evt.clientX}, y: ${evt.clientY}`)}
    */
   events?: React.DOMAttributes<any>;
   /**
@@ -110,24 +112,32 @@ export interface ChartVoronoiContainerProps extends VictoryVoronoiContainerProps
    * The onActivated prop accepts a function to be called whenever new data points are activated.
    * The function is called with the parameters points (an array of active data objects) and props
    * (the props used by ChartVoronoiContainer).
+   *
+   * @propType Function
    */
   onActivated?: (points: any[], props: VictoryVoronoiContainerProps) => void;
   /**
    * The onDeactivated prop accepts a function to be called whenever points are deactivated. The
    * function is called with the parameters points (an array of the newly-deactivated data objects)
    * and props (the props used by ChartVoronoiContainer).
+   *
+   * @propType Function
    */
   onDeactivated?: (points: any[], props: VictoryVoronoiContainerProps) => void;
   /**
    * Victory components will pass an origin prop is to define the center point in svg coordinates for polar charts.
    *
-   * **This prop should not be set manually.**
+   * Note: It will not typically be necessary to set an origin prop manually
+   *
+   * @propType { x: number, y: number }
    */
   origin?: OriginType;
   /**
    * Victory components can pass a boolean polar prop to specify whether a label is part of a polar chart.
    *
-   * **This prop should not be set manually.**
+   * Note: This prop should not be set manually.
+   *
+   * @hide
    */
   polar?: boolean;
   /**
@@ -172,6 +182,8 @@ export interface ChartVoronoiContainerProps extends VictoryVoronoiContainerProps
   /**
    * The theme prop specifies a theme to use for determining styles and layout properties for a component. Any styles or
    * props defined in theme may be overwritten by props specified on the component instance.
+   *
+   * @propType object
    */
   theme?: ChartThemeDefinition;
   /**


### PR DESCRIPTION
The example docs for react-charts currently show Victory's complex object types. For example, the `ChartArea` component shows `AnimatePropTypeInterface` as the `animate` prop type. However, the Victory docs show the `animate` type as `type: boolean | object`.

This change adds `@propType` annotations in order to replace Victory's complex object types, shown in the example docs, with something more readable.

Fixes https://github.com/patternfly/patternfly-react/issues/2139

Before
<img width="408" alt="Screen Shot 2021-01-07 at 2 53 49 PM" src="https://user-images.githubusercontent.com/17481322/103938413-2c489d80-50f8-11eb-94c6-21fdf78b0c01.png">

After
<img width="409" alt="Screen Shot 2021-01-07 at 2 53 13 PM" src="https://user-images.githubusercontent.com/17481322/103938430-32d71500-50f8-11eb-9c39-951ecd649bdf.png">


