### PR TITLE
feat(Drawer): add resize callback

### DIFF
--- a/packages/react-core/src/components/Drawer/DrawerPanelContent.tsx
+++ b/packages/react-core/src/components/Drawer/DrawerPanelContent.tsx
@@ -7,12 +7,16 @@ import { formatBreakpointMods } from '../../helpers/util';
 export interface DrawerPanelContentProps extends React.HTMLProps<HTMLDivElement> {
   /** Additional classes added to the drawer. */
   className?: string;
+  /** ID of the drawer panel */
+  id?: string;
   /** Content to be rendered in the drawer panel. */
   children?: React.ReactNode;
   /** Flag indicating that the drawer panel should not have a border. */
   hasNoBorder?: boolean;
   /** Flag indicating that the drawer panel should be resizable. */
   isResizable?: boolean;
+  /** Callback for resize end. */
+  onResize?: (width: number, id: string) => void;
   /** The minimum size of a resizable drawer, in pixels. Defaults to the starting width of the drawer. */
   minSize?: number;
   /** The maximum size of a resizable drawer, in pixels. Defaults to the max width of the parent container. */
@@ -36,9 +40,11 @@ let newSize: number = 0;
 
 export const DrawerPanelContent: React.FunctionComponent<DrawerPanelContentProps> = ({
   className = '',
+  id,
   children,
   hasNoBorder = false,
   isResizable = false,
+  onResize,
   minSize,
   maxSize,
   increment = 5,
@@ -49,6 +55,7 @@ export const DrawerPanelContent: React.FunctionComponent<DrawerPanelContentProps
 }: DrawerPanelContentProps) => {
   const panel = React.useRef<HTMLDivElement>();
   const { position, isExpanded, isStatic, onExpand } = React.useContext(DrawerContext);
+  let currWidth: number = 0;
 
   const handleMousedown = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -86,6 +93,7 @@ export const DrawerPanelContent: React.FunctionComponent<DrawerPanelContentProps
       } else {
         panel.current.style.setProperty('--pf-c-drawer__panel--FlexBasis', (newSize / max) * 100 + '%');
       }
+      currWidth = newSize;
     }
   };
 
@@ -94,6 +102,7 @@ export const DrawerPanelContent: React.FunctionComponent<DrawerPanelContentProps
       return;
     }
     isResizing = false;
+    onResize && onResize(currWidth, id);
     document.removeEventListener('mousemove', callbackMouseMove);
     document.removeEventListener('mouseup', callbackMouseUp);
   };
@@ -124,6 +133,7 @@ export const DrawerPanelContent: React.FunctionComponent<DrawerPanelContentProps
         isResizing = true;
       } else {
         isResizing = false;
+        onResize && onResize(currWidth, id);
       }
       const panelRect = panel.current.getBoundingClientRect();
       newSize = position === 'bottom' ? panelRect.height : panelRect.width;
@@ -154,12 +164,14 @@ export const DrawerPanelContent: React.FunctionComponent<DrawerPanelContentProps
         } else {
           panel.current.style.setProperty('--pf-c-drawer__panel--FlexBasis', (newSize / max) * 100 + '%');
         }
+        currWidth = newSize;
       }
     }
   };
   const hidden = isStatic ? false : !isExpanded;
   return (
     <div
+      id={id}
       className={css(
         styles.drawerPanel,
         isResizable && styles.modifiers.resizable,

--- a/packages/react-core/src/components/Drawer/__tests__/Drawer.test.tsx
+++ b/packages/react-core/src/components/Drawer/__tests__/Drawer.test.tsx
@@ -92,3 +92,28 @@ test(`Drawer has resizable css`, () => {
   );
   expect(view).toMatchSnapshot();
 });
+
+test(`Drawer has resizable callback and id`, () => {
+  const panelContent = (
+    <DrawerPanelContent isResizable onResize={jest.fn()} id="test-id">
+      <DrawerHead>
+        <span>drawer-panel</span>
+        <DrawerActions>
+          <DrawerCloseButton />
+        </DrawerActions>
+      </DrawerHead>
+      <DrawerPanelBody>drawer-panel</DrawerPanelBody>
+    </DrawerPanelContent>
+  );
+  const drawerContent =
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.';
+
+  const view = mount(
+    <Drawer isExpanded={true} position="left">
+      <DrawerContent panelContent={panelContent}>
+        <DrawerContentBody>{drawerContent}</DrawerContentBody>
+      </DrawerContent>
+    </Drawer>
+  );
+  expect(view).toMatchSnapshot();
+});

--- a/packages/react-core/src/components/Drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/react-core/src/components/Drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -134,6 +134,164 @@ exports[`Drawer expands from bottom 1`] = `
 </Drawer>
 `;
 
+exports[`Drawer has resizable callback and id 1`] = `
+<Drawer
+  isExpanded={true}
+  position="left"
+>
+  <div
+    className="pf-c-drawer pf-m-expanded pf-m-panel-left"
+  >
+    <DrawerContent
+      panelContent={
+        <DrawerPanelContent
+          id="test-id"
+          isResizable={true}
+          onResize={[MockFunction]}
+        >
+          <DrawerHead>
+            <span>
+              drawer-panel
+            </span>
+            <DrawerActions>
+              <DrawerCloseButton />
+            </DrawerActions>
+          </DrawerHead>
+          <DrawerPanelBody>
+            drawer-panel
+          </DrawerPanelBody>
+        </DrawerPanelContent>
+      }
+    >
+      <DrawerMain>
+        <div
+          className="pf-c-drawer__main"
+        >
+          <div
+            className="pf-c-drawer__content"
+          >
+            <DrawerContentBody>
+              <div
+                className="pf-c-drawer__body"
+              >
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.
+              </div>
+            </DrawerContentBody>
+          </div>
+          <DrawerPanelContent
+            id="test-id"
+            isResizable={true}
+            onResize={[MockFunction]}
+          >
+            <div
+              className="pf-c-drawer__panel pf-m-resizable"
+              hidden={false}
+              id="test-id"
+              onTransitionEnd={[Function]}
+            >
+              <div
+                aria-describedby="Press space to begin resizing, and use the arrow keys to grow or shrink the panel. Press enter or escape to finish resizing."
+                aria-label="Resize"
+                aria-orientation="vertical"
+                className="pf-c-drawer__splitter pf-m-vertical"
+                onKeyDown={[Function]}
+                onMouseDown={[Function]}
+                role="separator"
+                tabIndex={0}
+              >
+                <div
+                  aria-hidden={true}
+                  className="pf-c-drawer__splitter-handle"
+                />
+              </div>
+              <DrawerHead>
+                <DrawerPanelBody
+                  hasNoPadding={false}
+                >
+                  <div
+                    className="pf-c-drawer__body"
+                  >
+                    <div
+                      className="pf-c-drawer__head"
+                    >
+                      <span>
+                        drawer-panel
+                      </span>
+                      <DrawerActions>
+                        <div
+                          className="pf-c-drawer__actions"
+                        >
+                          <DrawerCloseButton>
+                            <div
+                              className="pf-c-drawer__close"
+                            >
+                              <Button
+                                aria-label="Close drawer panel"
+                                onClick={[Function]}
+                                variant="plain"
+                              >
+                                <button
+                                  aria-disabled={false}
+                                  aria-label="Close drawer panel"
+                                  className="pf-c-button pf-m-plain"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-6"
+                                  data-ouia-component-type="PF4/Button"
+                                  data-ouia-safe={true}
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  role={null}
+                                  type="button"
+                                >
+                                  <TimesIcon
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 352 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                      />
+                                    </svg>
+                                  </TimesIcon>
+                                </button>
+                              </Button>
+                            </div>
+                          </DrawerCloseButton>
+                        </div>
+                      </DrawerActions>
+                    </div>
+                  </div>
+                </DrawerPanelBody>
+              </DrawerHead>
+              <DrawerPanelBody>
+                <div
+                  className="pf-c-drawer__body"
+                >
+                  drawer-panel
+                </div>
+              </DrawerPanelBody>
+            </div>
+          </DrawerPanelContent>
+        </div>
+      </DrawerMain>
+    </DrawerContent>
+  </div>
+</Drawer>
+`;
+
 exports[`Drawer has resizable css 1`] = `
 <Drawer
   isExpanded={true}

--- a/packages/react-core/src/components/Drawer/examples/Drawer.md
+++ b/packages/react-core/src/components/Drawer/examples/Drawer.md
@@ -1080,7 +1080,8 @@ class ResizableDrawer extends React.Component {
     super(props);
     this.state = {
       isExpanded: false,
-      isResizing: false
+      isResizing: false,
+      panelWidth: 200
     };
     this.drawerRef = React.createRef();
 
@@ -1095,6 +1096,15 @@ class ResizableDrawer extends React.Component {
       });
     };
 
+    this.onResize = (newWidth, id) => {
+      this.setState(
+        {
+          panelWidth: newWidth
+        },
+        () => console.log(`${id} has new width of: ${newWidth}`)
+      );
+    };
+
     this.onCloseClick = () => {
       this.setState({
         isExpanded: false
@@ -1105,7 +1115,7 @@ class ResizableDrawer extends React.Component {
   render() {
     const { isExpanded } = this.state;
     const panelContent = (
-      <DrawerPanelContent isResizable>
+      <DrawerPanelContent isResizable onResize={this.onResize} id="right-resize-panel">
         <DrawerHead>
           <span tabIndex={isExpanded ? 0 : -1} ref={this.drawerRef}>
             drawer-panel

--- a/packages/react-integration/demo-app-ts/src/components/demos/DrawerDemo/DrawerDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DrawerDemo/DrawerDemo.tsx
@@ -14,20 +14,31 @@ import {
 
 export interface DrawerDemoState {
   isExpanded: boolean;
+  panelWidth: number;
 }
 
 export class DrawerDemo extends React.Component<DrawerProps, DrawerDemoState> {
   static displayName = 'DrawerDemo';
-  constructor(props: DrawerProps) {
-    super(props);
-    this.state = {
-      isExpanded: false
-    };
-  }
+  state = {
+    isExpanded: false,
+    panelWidth: 200
+  };
+
   drawerRef = React.createRef<HTMLButtonElement>();
 
   onExpand = () => {
     this.drawerRef.current && this.drawerRef.current.focus();
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  onResize = (newWidth: number, id: string) => {
+    this.setState(
+      {
+        panelWidth: newWidth
+      },
+      // eslint-disable-next-line no-console
+      () => console.log(`${id} has new width: ${newWidth}`)
+    );
   };
 
   onClick = () => {
@@ -55,6 +66,8 @@ export class DrawerDemo extends React.Component<DrawerProps, DrawerDemoState> {
         }}
         isResizable
         increment={50}
+        onResize={this.onResize}
+        id="panel"
       >
         <DrawerHead>
           <span ref={this.drawerRef} tabIndex={isExpanded ? 0 : -1}>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5282

Adds `onResize` callback which will return the new size of the drawer after resizing as well as the ID of the panel (if it was given). Adds prop description for `id`.

Combined with #5313 a user may store a predetermined width and pass it with `defaultSize` to set the width of the panel when first opened. Using the `onResize` callback, this width may be updated and persisted if the page is refreshed. Or the width may remain the same to reset the panel width.
