### PR TITLE
fix(Drawer): stop panel content unmounting before collapse

### DIFF
--- a/packages/react-core/src/components/Drawer/DrawerPanelContent.tsx
+++ b/packages/react-core/src/components/Drawer/DrawerPanelContent.tsx
@@ -186,25 +186,23 @@ export const DrawerPanelContent: React.FunctionComponent<DrawerPanelContentProps
       hidden={hidden}
       {...props}
     >
-      {!hidden && (
-        <React.Fragment>
-          {isResizable && (
-            <div
-              className={css(styles.drawerSplitter, position !== 'bottom' && styles.modifiers.vertical)}
-              role="separator"
-              tabIndex={0}
-              aria-orientation={position === 'bottom' ? 'horizontal' : 'vertical'}
-              aria-label={resizeAriaLabel}
-              aria-describedby={resizeAriaDescribedBy}
-              onMouseDown={handleMousedown}
-              onKeyDown={handleKeys}
-            >
-              <div className={css(styles.drawerSplitterHandle)} aria-hidden></div>
-            </div>
-          )}
-          {children}
-        </React.Fragment>
-      )}
+      <React.Fragment>
+        {isResizable && (
+          <div
+            className={css(styles.drawerSplitter, position !== 'bottom' && styles.modifiers.vertical)}
+            role="separator"
+            tabIndex={0}
+            aria-orientation={position === 'bottom' ? 'horizontal' : 'vertical'}
+            aria-label={resizeAriaLabel}
+            aria-describedby={resizeAriaDescribedBy}
+            onMouseDown={handleMousedown}
+            onKeyDown={handleKeys}
+          >
+            <div className={css(styles.drawerSplitterHandle)} aria-hidden></div>
+          </div>
+        )}
+        {children}
+      </React.Fragment>
     </div>
   );
 };

--- a/packages/react-core/src/components/Drawer/__tests__/Generated/__snapshots__/DrawerPanelContent.test.tsx.snap
+++ b/packages/react-core/src/components/Drawer/__tests__/Generated/__snapshots__/DrawerPanelContent.test.tsx.snap
@@ -6,5 +6,9 @@ exports[`DrawerPanelContent should match snapshot (auto-generated) 1`] = `
   hasNoPadding={false}
   hidden={true}
   onTransitionEnd={[Function]}
-/>
+>
+  <div>
+    ReactNode
+  </div>
+</div>
 `;

--- a/packages/react-core/src/components/Drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/react-core/src/components/Drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`Drawer expands from bottom 1`] = `
                                   aria-disabled={false}
                                   aria-label="Close drawer panel"
                                   className="pf-c-button pf-m-plain"
-                                  data-ouia-component-id="OUIA-Generated-Button-plain-4"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-6"
                                   data-ouia-component-type="PF4/Button"
                                   data-ouia-safe={true}
                                   disabled={false}
@@ -229,7 +229,7 @@ exports[`Drawer has resizable css 1`] = `
                                   aria-disabled={false}
                                   aria-label="Close drawer panel"
                                   className="pf-c-button pf-m-plain"
-                                  data-ouia-component-id="OUIA-Generated-Button-plain-5"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-7"
                                   data-ouia-component-type="PF4/Button"
                                   data-ouia-safe={true}
                                   disabled={false}
@@ -331,7 +331,87 @@ exports[`Drawer isExpanded = false and isInline = false and isStatic = false 1`]
               className="pf-c-drawer__panel"
               hidden={true}
               onTransitionEnd={[Function]}
-            />
+            >
+              <DrawerHead>
+                <DrawerPanelBody
+                  hasNoPadding={false}
+                >
+                  <div
+                    className="pf-c-drawer__body"
+                  >
+                    <div
+                      className="pf-c-drawer__head"
+                    >
+                      <span>
+                        drawer-panel
+                      </span>
+                      <DrawerActions>
+                        <div
+                          className="pf-c-drawer__actions"
+                        >
+                          <DrawerCloseButton>
+                            <div
+                              className="pf-c-drawer__close"
+                            >
+                              <Button
+                                aria-label="Close drawer panel"
+                                onClick={[Function]}
+                                variant="plain"
+                              >
+                                <button
+                                  aria-disabled={false}
+                                  aria-label="Close drawer panel"
+                                  className="pf-c-button pf-m-plain"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-2"
+                                  data-ouia-component-type="PF4/Button"
+                                  data-ouia-safe={true}
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  role={null}
+                                  type="button"
+                                >
+                                  <TimesIcon
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 352 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                      />
+                                    </svg>
+                                  </TimesIcon>
+                                </button>
+                              </Button>
+                            </div>
+                          </DrawerCloseButton>
+                        </div>
+                      </DrawerActions>
+                    </div>
+                  </div>
+                </DrawerPanelBody>
+              </DrawerHead>
+              <DrawerPanelBody>
+                <div
+                  className="pf-c-drawer__body"
+                >
+                  drawer-panel
+                </div>
+              </DrawerPanelBody>
+            </div>
           </DrawerPanelContent>
         </div>
       </DrawerMain>
@@ -384,7 +464,87 @@ exports[`Drawer isExpanded = false and isInline = true and isStatic = false 1`] 
               className="pf-c-drawer__panel"
               hidden={true}
               onTransitionEnd={[Function]}
-            />
+            >
+              <DrawerHead>
+                <DrawerPanelBody
+                  hasNoPadding={false}
+                >
+                  <div
+                    className="pf-c-drawer__body"
+                  >
+                    <div
+                      className="pf-c-drawer__head"
+                    >
+                      <span>
+                        drawer-panel
+                      </span>
+                      <DrawerActions>
+                        <div
+                          className="pf-c-drawer__actions"
+                        >
+                          <DrawerCloseButton>
+                            <div
+                              className="pf-c-drawer__close"
+                            >
+                              <Button
+                                aria-label="Close drawer panel"
+                                onClick={[Function]}
+                                variant="plain"
+                              >
+                                <button
+                                  aria-disabled={false}
+                                  aria-label="Close drawer panel"
+                                  className="pf-c-button pf-m-plain"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-4"
+                                  data-ouia-component-type="PF4/Button"
+                                  data-ouia-safe={true}
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  role={null}
+                                  type="button"
+                                >
+                                  <TimesIcon
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 352 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                      />
+                                    </svg>
+                                  </TimesIcon>
+                                </button>
+                              </Button>
+                            </div>
+                          </DrawerCloseButton>
+                        </div>
+                      </DrawerActions>
+                    </div>
+                  </div>
+                </DrawerPanelBody>
+              </DrawerHead>
+              <DrawerPanelBody>
+                <div
+                  className="pf-c-drawer__body"
+                >
+                  drawer-panel
+                </div>
+              </DrawerPanelBody>
+            </div>
           </DrawerPanelContent>
         </div>
       </DrawerMain>
@@ -601,7 +761,7 @@ exports[`Drawer isExpanded = true and isInline = false and isStatic = true 1`] =
                                   aria-disabled={false}
                                   aria-label="Close drawer panel"
                                   className="pf-c-button pf-m-plain"
-                                  data-ouia-component-id="OUIA-Generated-Button-plain-3"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-5"
                                   data-ouia-component-type="PF4/Button"
                                   data-ouia-safe={true}
                                   disabled={false}
@@ -734,7 +894,7 @@ exports[`Drawer isExpanded = true and isInline = true and isStatic = false 1`] =
                                   aria-disabled={false}
                                   aria-label="Close drawer panel"
                                   className="pf-c-button pf-m-plain"
-                                  data-ouia-component-id="OUIA-Generated-Button-plain-2"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-3"
                                   data-ouia-component-type="PF4/Button"
                                   data-ouia-safe={true}
                                   disabled={false}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5290

Removes the extra logic to not render the content when a panel is hidden. The panel is already hidden via the `hidden` attribute so the content should not have to also be un-rendered.