### PR TITLE
fix(drawer): fix dragging problem on iframe when resizing drawer

### DIFF
--- a/packages/react-core/src/components/Drawer/DrawerPanelContent.tsx
+++ b/packages/react-core/src/components/Drawer/DrawerPanelContent.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/Drawer/drawer';
+import '@patternfly/react-styles/css/components/Drawer/DrawerIframe';
 import { css } from '@patternfly/react-styles';
 import { DrawerContext } from './Drawer';
 import { formatBreakpointMods } from '../../helpers/util';
@@ -55,6 +56,7 @@ export const DrawerPanelContent: React.FunctionComponent<DrawerPanelContentProps
     e.preventDefault();
     document.addEventListener('mousemove', callbackMouseMove);
     document.addEventListener('mouseup', callbackMouseUp);
+    panel.current.parentElement.classList.add('pf-m-drawer-resizing');
     isResizing = true;
   };
 
@@ -98,6 +100,7 @@ export const DrawerPanelContent: React.FunctionComponent<DrawerPanelContentProps
     if (!isResizing) {
       return;
     }
+    panel.current.parentElement.classList.remove('pf-m-drawer-resizing');
     isResizing = false;
     document.removeEventListener('mousemove', callbackMouseMove);
     document.removeEventListener('mouseup', callbackMouseUp);

--- a/packages/react-docs/patternfly-docs.css.js
+++ b/packages/react-docs/patternfly-docs.css.js
@@ -5,6 +5,7 @@ import '@patternfly/react-styles/src/css/components/Topology/topology-side-bar.c
 import '@patternfly/react-styles/src/css/components/Topology/topology-view.css';
 import '@patternfly/react-styles/src/css/layouts/Toolbar/toolbar.css';
 import '@patternfly/react-styles/src/css/components/Popper/Popper.css';
+import '@patternfly/react-styles/src/css/components/Drawer/DrawerIframe.css';
 
 import '@patternfly/react-styles/src/css/components/Consoles/AccessConsoles.css';
 import '@patternfly/react-styles/src/css/components/Consoles/DesktopViewer.css';

--- a/packages/react-styles/src/css/components/Drawer/DrawerIframe.css
+++ b/packages/react-styles/src/css/components/Drawer/DrawerIframe.css
@@ -1,0 +1,3 @@
+.pf-m-drawer-resizing iframe {
+  pointer-events: none !important;
+}

--- a/packages/react-styles/src/css/components/Drawer/DrawerIframe.css
+++ b/packages/react-styles/src/css/components/Drawer/DrawerIframe.css
@@ -1,3 +1,7 @@
-.pf-m-drawer-resizing iframe {
+.pf-m-drawer-resizing {
   pointer-events: none !important;
+}
+
+.pf-m-drawer-resizing .pf-c-drawer__splitter {
+  pointer-events: auto !important;
 }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5279 
Add a new class set all the iframe in that class to `pointer-events: none`. When dragging happens, add that class to the drawer and remove that class when dragging ends.
