### PR TITLE
feat(Modal): support disabling the 'Close' button on the modal header

### DIFF
--- a/packages/react-core/src/components/Modal/Modal.tsx
+++ b/packages/react-core/src/components/Modal/Modal.tsx
@@ -31,6 +31,9 @@ export interface ModalProps extends React.HTMLProps<HTMLDivElement>, OUIAProps {
   'aria-label'?: string;
   /** Id to use for Modal Box descriptor */
   'aria-describedby'?: string;
+  /** Flag to disable the close button in the header area of the modal.
+   * When set pressing of the Escape key will not close the modal either */
+  isCloseDisabled?: boolean;
   /** Flag to show the close button in the header area of the modal */
   showClose?: boolean;
   /** Custom footer */
@@ -87,6 +90,7 @@ export class Modal extends React.Component<ModalProps, ModalState> {
     titleIconVariant: null,
     titleLabel: '',
     'aria-label': '',
+    isCloseDisabled: false,
     showClose: true,
     'aria-describedby': '',
     'aria-labelledby': '',
@@ -116,7 +120,7 @@ export class Modal extends React.Component<ModalProps, ModalState> {
 
   handleEscKeyClick = (event: KeyboardEvent): void => {
     const { onEscapePress } = this.props;
-    if (event.keyCode === KEY_CODES.ESCAPE_KEY && this.props.isOpen) {
+    if (event.keyCode === KEY_CODES.ESCAPE_KEY && this.props.isOpen && !this.props.isCloseDisabled) {
       onEscapePress ? onEscapePress(event) : this.props.onClose();
     }
   };

--- a/packages/react-core/src/components/Modal/ModalBoxCloseButton.tsx
+++ b/packages/react-core/src/components/Modal/ModalBoxCloseButton.tsx
@@ -7,14 +7,17 @@ export interface ModalBoxCloseButtonProps {
   className?: string;
   /** A callback for when the close button is clicked */
   onClose?: () => void;
+  /** Adds disabled styling and disables the button using the disabled html attribute */
+  isDisabled?: boolean;
 }
 
 export const ModalBoxCloseButton: React.FunctionComponent<ModalBoxCloseButtonProps> = ({
   className = '',
   onClose = () => undefined as any,
+  isDisabled = false,
   ...props
 }: ModalBoxCloseButtonProps) => (
-  <Button className={className} variant="plain" onClick={onClose} aria-label="Close" {...props}>
+  <Button className={className} variant="plain" onClick={onClose} aria-label="Close" isDisabled={isDisabled} {...props}>
     <TimesIcon />
   </Button>
 );

--- a/packages/react-core/src/components/Modal/ModalContent.tsx
+++ b/packages/react-core/src/components/Modal/ModalContent.tsx
@@ -47,6 +47,9 @@ export interface ModalContentProps extends OUIAProps {
   'aria-label'?: string;
   /** Id of Modal Box description */
   'aria-describedby'?: string;
+  /** Flag to disable the close button in the header area of the modal.
+   * When set pressing of the Escape key will not close the modal either */
+  isCloseDisabled?: boolean;
   /** Flag to show the close button in the header area of the modal */
   showClose?: boolean;
   /** Default width of the content. */
@@ -82,6 +85,7 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
   'aria-label': ariaLabel = '',
   'aria-describedby': ariaDescribedby,
   'aria-labelledby': ariaLabelledby,
+  isCloseDisabled = false,
   showClose = true,
   footer = null,
   actions = [],
@@ -162,7 +166,7 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
       aria-describedby={ariaDescribedby || (hasNoBodyWrapper ? null : descriptorId)}
       {...getOUIAProps(ModalContent.displayName, ouiaId, ouiaSafe)}
     >
-      {showClose && <ModalBoxCloseButton onClose={onClose} />}
+      {showClose && <ModalBoxCloseButton onClose={onClose} isDisabled={isCloseDisabled} />}
       {modalBoxHeader}
       {modalBody}
       {modalBoxFooter}

--- a/packages/react-core/src/components/Modal/__tests__/Generated/__snapshots__/Modal.test.tsx.snap
+++ b/packages/react-core/src/components/Modal/__tests__/Generated/__snapshots__/Modal.test.tsx.snap
@@ -30,6 +30,7 @@ exports[`Modal should match snapshot (auto-generated) 1`] = `
       </div>
     }
     id="string"
+    isCloseDisabled={false}
     isOpen={false}
     labelId="pf-modal-part-1"
     onClose={[Function]}

--- a/packages/react-core/src/components/Modal/__tests__/Generated/__snapshots__/ModalBoxCloseButton.test.tsx.snap
+++ b/packages/react-core/src/components/Modal/__tests__/Generated/__snapshots__/ModalBoxCloseButton.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`ModalBoxCloseButton should match snapshot (auto-generated) 1`] = `
 <Button
   aria-label="Close"
   className="''"
+  isDisabled={false}
   onClick={[Function]}
   variant="plain"
 >

--- a/packages/react-core/src/components/Modal/__tests__/__snapshots__/ModalBoxCloseButton.test.tsx.snap
+++ b/packages/react-core/src/components/Modal/__tests__/__snapshots__/ModalBoxCloseButton.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`ModalBoxCloseButton Test 1`] = `
 <Button
   aria-label="Close"
   className="test-box-close-button-class"
+  isDisabled={false}
   onClick={[MockFunction]}
   variant="plain"
 >

--- a/packages/react-core/src/components/Modal/__tests__/__snapshots__/ModalContent.test.tsx.snap
+++ b/packages/react-core/src/components/Modal/__tests__/__snapshots__/ModalContent.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`Modal Content Test description 1`] = `
       variant="default"
     >
       <ModalBoxCloseButton
+        isDisabled={false}
         onClose={[Function]}
       />
       <ModalBoxHeader
@@ -70,6 +71,7 @@ exports[`Modal Content Test isOpen 1`] = `
       variant="default"
     >
       <ModalBoxCloseButton
+        isDisabled={false}
         onClose={[Function]}
       />
       <ModalBoxHeader
@@ -112,6 +114,7 @@ exports[`Modal Content Test only body 1`] = `
       variant="default"
     >
       <ModalBoxCloseButton
+        isDisabled={false}
         onClose={[Function]}
       />
       <ModalBoxHeader
@@ -154,6 +157,7 @@ exports[`Modal Content Test with footer 1`] = `
       variant="default"
     >
       <ModalBoxCloseButton
+        isDisabled={false}
         onClose={[Function]}
       />
       <ModalBoxHeader
@@ -199,6 +203,7 @@ exports[`Modal Content Test with onclose 1`] = `
       variant="default"
     >
       <ModalBoxCloseButton
+        isDisabled={false}
         onClose={[Function]}
       />
       <ModalBoxHeader
@@ -246,6 +251,7 @@ exports[`Modal Content test without footer 1`] = `
       variant="default"
     >
       <ModalBoxCloseButton
+        isDisabled={false}
         onClose={[Function]}
       />
       <ModalBoxHeader
@@ -288,6 +294,7 @@ exports[`Modal Test with custom footer 1`] = `
       variant="default"
     >
       <ModalBoxCloseButton
+        isDisabled={false}
         onClose={[Function]}
       />
       <ModalBoxHeader
@@ -339,6 +346,7 @@ exports[`Modal Test with custom header 1`] = `
       variant="default"
     >
       <ModalBoxCloseButton
+        isDisabled={false}
         onClose={[Function]}
       />
       <ModalBoxHeader

--- a/packages/react-core/src/components/Modal/examples/Modal.md
+++ b/packages/react-core/src/components/Modal/examples/Modal.md
@@ -863,3 +863,54 @@ class HelpModal extends React.Component {
   }
 }
 ```
+
+### Disabled Close
+
+```js
+import React from 'react';
+import { Modal, Button } from '@patternfly/react-core';
+
+class SimpleModal extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isModalOpen: false,
+
+    };
+    this.handleModalToggle = () => {
+      this.setState(({ isModalOpen }) => ({
+        isModalOpen: !isModalOpen
+      }));
+    };
+  }
+
+  render() {
+    const { isModalOpen } = this.state;
+
+    return (
+      <React.Fragment>
+        <Button variant="primary" onClick={this.handleModalToggle}>
+          Show Modal
+        </Button>
+        <Modal
+          title="Simple modal header"
+          isOpen={isModalOpen}
+          isCloseDisabled
+          onClose={this.handleModalToggle}
+          actions={[
+            <Button key="confirm" variant="primary" onClick={this.handleModalToggle}>
+              Confirm
+            </Button>,
+            <Button key="cancel" variant="link" onClick={this.handleModalToggle}>
+              Cancel
+            </Button>
+          ]}
+        >
+        In real world scenarios one would probably want to disable both Cancel and [x] button at the same time,
+        ex. when an non-cancellable operation is in progress after submitting the modal.
+        </Modal>
+      </React.Fragment>
+    );
+  }
+}
+```

--- a/packages/react-core/src/components/Wizard/__tests__/Generated/__snapshots__/Wizard.test.tsx.snap
+++ b/packages/react-core/src/components/Wizard/__tests__/Generated/__snapshots__/Wizard.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`Wizard should match snapshot (auto-generated) 1`] = `
   aria-labelledby="string"
   className=""
   hasNoBodyWrapper={true}
+  isCloseDisabled={false}
   isOpen={true}
   onClose={[Function]}
   ouiaSafe={true}


### PR DESCRIPTION
When onCloseDisabled is set the modal can't be closed using Escape key
either.

Fixes #5210
Closes #5359