### PR TITLE
fix(datepicker): don't rely on toISOString

### DIFF
--- a/packages/react-core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-core/src/components/DatePicker/DatePicker.tsx
@@ -41,7 +41,11 @@ export interface DatePickerProps
   validators?: ((date: Date) => string)[];
 }
 
-export const yyyyMMddFormat = (date: Date) => `${date.getFullYear()}-${(date.getMonth() + 1).toString().padStart(2, '0')}-${date.getDate().toString().padStart(2, '0')}`;
+export const yyyyMMddFormat = (date: Date) =>
+  `${date.getFullYear()}-${(date.getMonth() + 1).toString().padStart(2, '0')}-${date
+    .getDate()
+    .toString()
+    .padStart(2, '0')}`;
 
 export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
   className,

--- a/packages/react-core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-core/src/components/DatePicker/DatePicker.tsx
@@ -41,10 +41,12 @@ export interface DatePickerProps
   validators?: ((date: Date) => string)[];
 }
 
+export const yyyyMMddFormat = (date: Date) => `${date.getFullYear()}-${(date.getMonth() + 1).toString().padStart(2, '0')}-${date.getDate().toString().padStart(2, '0')}`;
+
 export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
   className,
   locale = undefined,
-  dateFormat = (date: Date) => date.toISOString().substring(0, 10),
+  dateFormat = yyyyMMddFormat,
   dateParse = (val: string) => new Date(`${val}T00:00:00`),
   isDisabled = false,
   placeholder = 'yyyy-MM-dd',

--- a/packages/react-core/src/demos/DatePicker.md
+++ b/packages/react-core/src/demos/DatePicker.md
@@ -10,7 +10,7 @@ section: components
 Intended to be used as a filter. After selecting a start date the next day is automatically selected.
 
 ```js
-import { Split, SplitItem, DatePicker, isValidDate } from '@patternfly/react-core';
+import { Split, SplitItem, DatePicker, isValidDate, yyyyMMddFormat } from '@patternfly/react-core';
 
 DateRangePicker = () => {
   const [from, setFrom] = React.useState();
@@ -21,7 +21,7 @@ DateRangePicker = () => {
     setFrom(new Date(date));
     if (isValidDate(date)) {
       date.setDate(date.getDate() + 1);
-      setTo(date.toISOString().substring(0, 10));
+      setTo(yyyyMMddFormat(date));
     }
     else {
       setTo('');


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5368

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: Looks like when I originally implemented this I missed some pitfalls of `toISOString`, namely [timezones.](https://stackoverflow.com/questions/23593052/format-javascript-date-as-yyyy-mm-dd)
