### PR TITLE
Bar chart remains muted with interactive legend

### DIFF
--- a/packages/react-charts/src/components/ChartUtils/chart-interactive-legend.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-interactive-legend.ts
@@ -8,6 +8,7 @@ interface ChartInteractiveLegendInterface {
   // [ area-1, area-2, area-3 ]
   // [ [area-1, scatter-1], [area-2, scatter-2], [area-3, scatter-3] ]
   chartNames: [string | string[]];
+  isDataHidden?: (data: any) => boolean; // Returns true if given data is hidden -- helpful when bar charts are hidden
   isHidden?: (index: number) => boolean; // Returns true if given index, associated with the legend item, is hidden
   legendName: string; // The name property associated with the legend
   onLegendClick?: (props: any) => void; // Called when legend item is clicked
@@ -67,6 +68,7 @@ export const getInteractiveLegendItemStyles = (hidden = false) =>
 // Returns targeted events for legend 'data' or 'labels'
 const getInteractiveLegendTargetEvents = ({
   chartNames,
+  isDataHidden = () => false,
   isHidden = () => false,
   legendName,
   onLegendClick = () => null,
@@ -110,16 +112,19 @@ const getInteractiveLegendTargetEvents = ({
                   target: 'data',
                   eventKey: 'all',
                   mutation: (props: any) =>
-                    ({
-                      style: {
-                        ...props.style,
-                        opacity: chart_area_Opacity.value
-                      }
-                    } as any)
+                    isDataHidden(props.data)
+                      ? null
+                      : ({
+                          // Skip if hidden
+                          style: {
+                            ...props.style,
+                            opacity: chart_area_Opacity.value
+                          }
+                        } as any)
                 },
                 {
                   // Mute all legend item symbols, except the symbol associated with this event
-                  childName: 'legend',
+                  childName: legendName,
                   target: 'data',
                   eventKey: legendItems,
                   mutation: (props: any) =>
@@ -135,7 +140,7 @@ const getInteractiveLegendTargetEvents = ({
                 },
                 {
                   // Mute all legend item labels, except the label associated with this event
-                  childName: 'legend',
+                  childName: legendName,
                   target: 'labels',
                   eventKey: legendItems,
                   mutation: (props: any) => {
@@ -155,7 +160,7 @@ const getInteractiveLegendTargetEvents = ({
         onMouseOut: () => [
           {
             // Restore all data series associated with this event
-            childName: childNames,
+            childName: 'all',
             target: 'data',
             eventKey: 'all',
             mutation: () => null as any


### PR DESCRIPTION
When hovering over an interactive legend item, all other datasets in the chart are muted (i.e., an opacity is applied to make them look slightly grayed out). When the cursor moves away from the legend item, the muted styles are removed. This works fine with line and area charts, but there is a problem with bar charts. It's more of an edge case, but under certain conditions, bars may remain muted.

Fixes https://github.com/patternfly/patternfly-react/issues/5377

Cost Management
![capture-good](https://user-images.githubusercontent.com/17481322/105927714-8ad7ac00-6012-11eb-9823-1544c505ea74.gif)
