### PR TITLE
fix(timepicker): fix issue when clicking dropdown menu does not trigger onchange function

### DIFF
--- a/packages/react-core/src/components/TimePicker/TimeOption.tsx
+++ b/packages/react-core/src/components/TimePicker/TimeOption.tsx
@@ -14,7 +14,7 @@ export interface TimeOptionProps extends Omit<React.HTMLProps<HTMLLIElement>, 'o
   /** Flag forcing the focused state */
   isFocused?: boolean;
   /** Optional callback for click event */
-  onSelect?: (value: string, index: number) => void;
+  onSelect?: (value: string, event: React.MouseEvent) => void;
   /** ID of the item. Required for tracking favorites */
   id?: string;
 }
@@ -22,7 +22,6 @@ export interface TimeOptionProps extends Omit<React.HTMLProps<HTMLLIElement>, 'o
 export const TimeOption: React.FunctionComponent<TimeOptionProps> = ({
   className = '',
   value = '',
-  index = 0,
   onSelect = () => {},
   children,
   id,
@@ -36,8 +35,8 @@ export const TimeOption: React.FunctionComponent<TimeOptionProps> = ({
   >
     <button
       className={css(styles.selectMenuItem)}
-      onClick={() => {
-        onSelect(value, index);
+      onClick={event => {
+        onSelect(value, event);
       }}
       role="option"
       type="button"

--- a/packages/react-core/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react-core/src/components/TimePicker/TimePicker.tsx
@@ -135,7 +135,7 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
           this.onToggle(false);
         } else if (event.key === KeyTypes.Enter) {
           if (focusedIndex !== null) {
-            this.onSelect((this.getOptions()[focusedIndex] as HTMLElement).innerText, focusedIndex);
+            this.onSelect((this.getOptions()[focusedIndex] as HTMLElement).innerText, event as any);
             event.stopPropagation();
           } else {
             this.onToggle(false);
@@ -180,8 +180,7 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
       }
       this.scrollToIndex(nextIndex);
       return {
-        focusedIndex: nextIndex,
-        time: this.getOptions()[nextIndex].innerText
+        focusedIndex: nextIndex
       };
     });
   };
@@ -264,16 +263,15 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
     });
   };
 
-  onSelect = (selection: string, index: number) => {
+  onSelect = (selection: string, event: React.MouseEvent | React.KeyboardEvent) => {
     const { timeRegex } = this.state;
     const { delimiter, is24Hour } = this.props;
     const time = parseTime(selection, timeRegex, delimiter, !is24Hour);
+    if (time !== this.state.time) {
+      this.onInputChange(time, event);
+    }
     this.setState({
-      time,
-      isInvalid: !validateTime(time, timeRegex, delimiter, !is24Hour),
-      isOpen: false,
-      focusedIndex: index,
-      scrollIndex: index
+      isOpen: false
     });
   };
 
@@ -284,7 +282,10 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
     e.stopPropagation();
   };
 
-  onInputChange = (time: string, event: React.FormEvent<HTMLInputElement>) => {
+  onInputChange = (
+    time: string,
+    event?: React.FormEvent<HTMLInputElement> | React.MouseEvent | React.KeyboardEvent
+  ) => {
     if (this.props.onChange) {
       this.props.onChange(time, event);
     }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5398

**Reason**: The `onChange` function is only called in `onInputChange` function, which is only triggered when users input something. However, in `onSelect` function, we don't use `onChange` function.

To optimize the code structure, I called `onInputChange` function inside `onSelect` function because they did almost the same thing, and I removed those unused props and redundant setState functions. It works for both mouse events and keyboard events.