### PR TITLE
bug(codeeditor) Displays empty state if one is supplied 🥳

### DIFF
--- a/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
@@ -427,7 +427,7 @@ export class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState
 
           return (
             <div className={css(styles.codeEditor, isReadOnly && styles.modifiers.readOnly, className)}>
-              {isUploadEnabled ? (
+              {isUploadEnabled || providedEmptyState ? (
                 <div
                   {...getRootProps({
                     onClick: event => event.preventDefault() // Prevents clicking TextArea from opening file dialog
@@ -437,7 +437,7 @@ export class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState
                   {editorHeader}
                   <div className={css(styles.codeEditorMain)}>
                     <input {...getInputProps()} /* hidden, necessary for react-dropzone */ />
-                    {showEmptyState && !value ? emptyState : editor}
+                    {(showEmptyState || providedEmptyState) && !value ? emptyState : editor}
                   </div>
                 </div>
               ) : (


### PR DESCRIPTION
no issue, cuz this was a quick n easy one, presently , users supplying empty states dont see em CUZ they're hidden by that showEmptyState toggle 

now ya'll see one if its provided

#### this is what we wanta see 💩 
![Screen Shot 2021-02-02 at 4 11 07 PM](https://user-images.githubusercontent.com/6640236/106663120-477cc080-6571-11eb-869c-4b5d091ac1fd.png)

