### PR TITLE
feat(Drawer): update transitions and content mounting

### DIFF
--- a/packages/react-core/src/components/Drawer/Drawer.tsx
+++ b/packages/react-core/src/components/Drawer/Drawer.tsx
@@ -24,16 +24,18 @@ export interface DrawerContextProps {
   isStatic: boolean;
   onExpand?: () => void;
   position?: string;
+  drawerRef?: React.RefObject<HTMLDivElement>;
 }
 
 export const DrawerContext = React.createContext<Partial<DrawerContextProps>>({
   isExpanded: false,
   isStatic: false,
   onExpand: () => {},
-  position: 'right'
+  position: 'right',
+  drawerRef: null
 });
 
-export const Drawer: React.SFC<DrawerProps> = ({
+export const Drawer: React.FunctionComponent<DrawerProps> = ({
   className = '',
   children,
   isExpanded = false,
@@ -42,22 +44,26 @@ export const Drawer: React.SFC<DrawerProps> = ({
   position = 'right',
   onExpand = () => {},
   ...props
-}: DrawerProps) => (
-  <DrawerContext.Provider value={{ isExpanded, isStatic, onExpand, position }}>
-    <div
-      className={css(
-        styles.drawer,
-        isExpanded && styles.modifiers.expanded,
-        isInline && styles.modifiers.inline,
-        isStatic && styles.modifiers.static,
-        position === 'left' && styles.modifiers.panelLeft,
-        position === 'bottom' && styles.modifiers.panelBottom,
-        className
-      )}
-      {...props}
-    >
-      {children}
-    </div>
-  </DrawerContext.Provider>
-);
+}: DrawerProps) => {
+  const drawerRef = React.useRef<HTMLDivElement>();
+  return (
+    <DrawerContext.Provider value={{ isExpanded, isStatic, onExpand, position, drawerRef }}>
+      <div
+        className={css(
+          styles.drawer,
+          isExpanded && styles.modifiers.expanded,
+          isInline && styles.modifiers.inline,
+          isStatic && styles.modifiers.static,
+          position === 'left' && styles.modifiers.panelLeft,
+          position === 'bottom' && styles.modifiers.panelBottom,
+          className
+        )}
+        ref={drawerRef}
+        {...props}
+      >
+        {children}
+      </div>
+    </DrawerContext.Provider>
+  );
+};
 Drawer.displayName = 'Drawer';

--- a/packages/react-core/src/components/Drawer/__tests__/Generated/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/react-core/src/components/Drawer/__tests__/Generated/__snapshots__/Drawer.test.tsx.snap
@@ -4,6 +4,9 @@ exports[`Drawer should match snapshot (auto-generated) 1`] = `
 <ContextProvider
   value={
     Object {
+      "drawerRef": Object {
+        "current": undefined,
+      },
       "isExpanded": false,
       "isStatic": false,
       "onExpand": [Function],

--- a/packages/react-docs/patternfly-docs.css.js
+++ b/packages/react-docs/patternfly-docs.css.js
@@ -5,7 +5,6 @@ import '@patternfly/react-styles/src/css/components/Topology/topology-side-bar.c
 import '@patternfly/react-styles/src/css/components/Topology/topology-view.css';
 import '@patternfly/react-styles/src/css/layouts/Toolbar/toolbar.css';
 import '@patternfly/react-styles/src/css/components/Popper/Popper.css';
-import '@patternfly/react-styles/src/css/components/Drawer/DrawerIframe.css';
 
 import '@patternfly/react-styles/src/css/components/Consoles/AccessConsoles.css';
 import '@patternfly/react-styles/src/css/components/Consoles/DesktopViewer.css';

--- a/packages/react-styles/src/css/components/Drawer/DrawerIframe.css
+++ b/packages/react-styles/src/css/components/Drawer/DrawerIframe.css
@@ -1,7 +1,0 @@
-.pf-m-drawer-resizing {
-  pointer-events: none !important;
-}
-
-.pf-m-drawer-resizing .pf-c-drawer__splitter {
-  pointer-events: auto !important;
-}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5419 , #5418 , #5412

Removes the transition from the style object on the panel and adds in the new CSS class to handle the property. 
Updates the local CSS class for iframes to the new core side CSS class.
Panel content will now unmount after the transition to close ends, and re-mount when the panel opens. This solves the splitter being in the tab order because it no longer exists when closed.