### PR TITLE
fix(selectmenu): don't use focus trap when no tabbable children

### DIFF
--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -743,6 +743,16 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
                   this.handleMenuKeys(0, 0, 'left');
                 } else if (event.key === KeyTypes.ArrowRight) {
                   this.handleMenuKeys(0, 0, 'right');
+                } else if (event.key === KeyTypes.Tab && variant === SelectVariant.checkbox) {
+                  // More modal-like experience for checkboxes
+                  // Let SelectOption handle this
+                  if (event.shiftKey) {
+                    this.handleMenuKeys(0, 0, 'up');
+                  } else {
+                    this.handleMenuKeys(0, 0, 'down');
+                  }
+                  event.stopPropagation();
+                  event.preventDefault();
                 }
               }}
               ref={this.filterRef}

--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -780,7 +780,8 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
           variantProps = {
             checked: selections,
             isGrouped,
-            hasInlineFilter
+            hasInlineFilter,
+            openedOnEnter
           };
           variantChildren = filterWithChildren;
           break;

--- a/packages/react-core/src/components/Select/SelectMenu.tsx
+++ b/packages/react-core/src/components/Select/SelectMenu.tsx
@@ -6,7 +6,6 @@ import { SelectOptionObject, SelectOption } from './SelectOption';
 import { SelectConsumer, SelectVariant } from './selectConstants';
 import { PickOptional } from '../../helpers/typeUtils';
 
-import { FocusTrap } from '../../helpers';
 import { SelectGroup } from './SelectGroup';
 import { Divider } from '../Divider/Divider';
 
@@ -227,26 +226,24 @@ class SelectMenuWithRef extends React.Component<SelectMenuProps> {
                 </div>
               ))}
             {variant === SelectVariant.checkbox && !isCustomContent && React.Children.count(children) > 0 && (
-              <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true, preventScroll: true }}>
-                <div
-                  ref={innerRef}
-                  className={css(styles.selectMenu, className)}
-                  {...(maxHeight && { style: { maxHeight, overflow: 'auto' } })}
+              <div
+                ref={innerRef}
+                className={css(styles.selectMenu, className)}
+                {...(maxHeight && { style: { maxHeight, overflow: 'auto' } })}
+              >
+                <fieldset
+                  {...props}
+                  aria-label={ariaLabel}
+                  aria-labelledby={(!ariaLabel && ariaLabelledBy) || null}
+                  className={css(formStyles.formFieldset)}
                 >
-                  <fieldset
-                    {...props}
-                    aria-label={ariaLabel}
-                    aria-labelledby={(!ariaLabel && ariaLabelledBy) || null}
-                    className={css(formStyles.formFieldset)}
-                  >
-                    {hasInlineFilter && [
-                      (children as React.ReactElement[]).shift(),
-                      ...this.extendCheckboxChildren(children as React.ReactElement[])
-                    ]}
-                    {!hasInlineFilter && this.extendCheckboxChildren(children as React.ReactElement[])}
-                  </fieldset>
-                </div>
-              </FocusTrap>
+                  {hasInlineFilter && [
+                    (children as React.ReactElement[]).shift(),
+                    ...this.extendCheckboxChildren(children as React.ReactElement[])
+                  ]}
+                  {!hasInlineFilter && this.extendCheckboxChildren(children as React.ReactElement[])}
+                </fieldset>
+              </div>
             )}
             {variant === SelectVariant.checkbox && !isCustomContent && React.Children.count(children) === 0 && (
               <div

--- a/packages/react-core/src/components/Select/SelectOption.tsx
+++ b/packages/react-core/src/components/Select/SelectOption.tsx
@@ -101,10 +101,20 @@ export class SelectOption extends React.Component<SelectOptionProps> {
     );
   }
 
-  onKeyDown = (event: React.KeyboardEvent, innerIndex: number, onEnter?: any) => {
+  onKeyDown = (event: React.KeyboardEvent, innerIndex: number, onEnter?: any, isCheckbox?: boolean) => {
     const { index, keyHandler } = this.props;
     if (event.key === KeyTypes.Tab) {
-      keyHandler(index, innerIndex, 'tab');
+      // More modal-like experience for checkboxes
+      if (isCheckbox) {
+        if (event.shiftKey) {
+          keyHandler(index, innerIndex, 'up');
+        } else {
+          keyHandler(index, innerIndex, 'down');
+        }
+        event.stopPropagation();
+      } else {
+        keyHandler(index, innerIndex, 'tab');
+      }
     }
     event.preventDefault();
     if (event.key === KeyTypes.ArrowUp) {
@@ -120,9 +130,6 @@ export class SelectOption extends React.Component<SelectOptionProps> {
         onEnter();
       } else {
         this.ref.current.click();
-        if (this.context.variant === SelectVariant.checkbox) {
-          this.ref.current.focus();
-        }
       }
     }
   };
@@ -169,7 +176,7 @@ export class SelectOption extends React.Component<SelectOptionProps> {
           onFavorite(generatedId.replace('favorite-', ''), isFavorite);
         }}
         onKeyDown={event => {
-          this.onKeyDown(event, 1, () => onFavorite(generatedId.replace('favorite-', ''), isFavorite));
+          this.onKeyDown(event, 1, () => onFavorite(generatedId.replace('favorite-', '')));
         }}
         ref={this.favoriteRef}
       >
@@ -257,7 +264,7 @@ export class SelectOption extends React.Component<SelectOptionProps> {
                   className
                 )}
                 onKeyDown={(event: React.KeyboardEvent) => {
-                  this.onKeyDown(event, 0);
+                  this.onKeyDown(event, 0, undefined, true);
                 }}
               >
                 <input
@@ -293,7 +300,9 @@ export class SelectOption extends React.Component<SelectOptionProps> {
                   role="option"
                   aria-selected={isSelected || null}
                   ref={this.ref}
-                  onKeyDown={this.onKeyDown}
+                  onKeyDown={(event: React.KeyboardEvent) => {
+                    this.onKeyDown(event, 0, undefined, true);
+                  }}
                   type="button"
                 >
                   {children || value.toString()}

--- a/packages/react-core/src/components/Select/SelectToggle.tsx
+++ b/packages/react-core/src/components/Select/SelectToggle.tsx
@@ -144,7 +144,6 @@ export class SelectToggle extends React.Component<SelectToggleProps> {
     if (
       variant === SelectVariant.typeahead ||
       variant === SelectVariant.typeaheadMulti ||
-      (event.key === KeyTypes.Tab && variant === SelectVariant.checkbox) ||
       (event.key === KeyTypes.Tab && !isOpen) ||
       (event.key !== KeyTypes.Enter && event.key !== KeyTypes.Space)
     ) {

--- a/packages/react-core/src/components/Select/SelectToggle.tsx
+++ b/packages/react-core/src/components/Select/SelectToggle.tsx
@@ -101,9 +101,6 @@ export class SelectToggle extends React.Component<SelectToggleProps> {
 
   handleGlobalKeys = (event: KeyboardEvent) => {
     const { parentRef, menuRef, isOpen, variant, onToggle, onClose } = this.props;
-    if (event.key === KeyTypes.Tab && variant === SelectVariant.checkbox) {
-      return;
-    }
     const escFromToggle = parentRef && parentRef.current && parentRef.current.contains(event.target as Node);
     const escFromWithinMenu =
       menuRef && menuRef.current && menuRef.current.contains && menuRef.current.contains(event.target as Node);

--- a/packages/react-core/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/packages/react-core/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
@@ -261,160 +261,158 @@ exports[`checkbox select renders checkbox select groups successfully 1`] = `
                   </svg>
                 </span>
               </button>
-              <div>
-                <div
-                  class="pf-c-select__menu"
+              <div
+                class="pf-c-select__menu"
+              >
+                <fieldset
+                  aria-label=""
+                  class="pf-c-form__fieldset"
                 >
-                  <fieldset
-                    aria-label=""
-                    class="pf-c-form__fieldset"
+                  <div
+                    class="pf-c-select__menu-group"
                   >
                     <div
-                      class="pf-c-select__menu-group"
+                      aria-hidden="true"
+                      class="pf-c-select__menu-group-title"
+                      id="group-1"
                     >
-                      <div
-                        aria-hidden="true"
-                        class="pf-c-select__menu-group-title"
-                        id="group-1"
-                      >
-                        group 1
-                      </div>
-                      <fieldset
-                        aria-labelledby="group-1"
-                        class="pf-c-select__menu-fieldset"
-                      >
-                        <label
-                          class="pf-c-check pf-c-select__menu-item"
-                        >
-                          <input
-                            class="pf-c-check__input"
-                            id="pf-random-id-15-Mr"
-                            type="checkbox"
-                          />
-                          <span
-                            class="pf-c-check__label"
-                          >
-                            Mr
-                          </span>
-                        </label>
-                        <label
-                          class="pf-c-check pf-c-select__menu-item"
-                        >
-                          <input
-                            class="pf-c-check__input"
-                            id="pf-random-id-15-Mrs"
-                            type="checkbox"
-                          />
-                          <span
-                            class="pf-c-check__label"
-                          >
-                            Mrs
-                          </span>
-                        </label>
-                        <label
-                          class="pf-c-check pf-c-select__menu-item"
-                        >
-                          <input
-                            class="pf-c-check__input"
-                            id="pf-random-id-15-Ms"
-                            type="checkbox"
-                          />
-                          <span
-                            class="pf-c-check__label"
-                          >
-                            Ms
-                          </span>
-                        </label>
-                        <label
-                          class="pf-c-check pf-c-select__menu-item"
-                        >
-                          <input
-                            class="pf-c-check__input"
-                            id="pf-random-id-15-Other"
-                            type="checkbox"
-                          />
-                          <span
-                            class="pf-c-check__label"
-                          >
-                            Other
-                          </span>
-                        </label>
-                      </fieldset>
+                      group 1
                     </div>
+                    <fieldset
+                      aria-labelledby="group-1"
+                      class="pf-c-select__menu-fieldset"
+                    >
+                      <label
+                        class="pf-c-check pf-c-select__menu-item"
+                      >
+                        <input
+                          class="pf-c-check__input"
+                          id="pf-random-id-15-Mr"
+                          type="checkbox"
+                        />
+                        <span
+                          class="pf-c-check__label"
+                        >
+                          Mr
+                        </span>
+                      </label>
+                      <label
+                        class="pf-c-check pf-c-select__menu-item"
+                      >
+                        <input
+                          class="pf-c-check__input"
+                          id="pf-random-id-15-Mrs"
+                          type="checkbox"
+                        />
+                        <span
+                          class="pf-c-check__label"
+                        >
+                          Mrs
+                        </span>
+                      </label>
+                      <label
+                        class="pf-c-check pf-c-select__menu-item"
+                      >
+                        <input
+                          class="pf-c-check__input"
+                          id="pf-random-id-15-Ms"
+                          type="checkbox"
+                        />
+                        <span
+                          class="pf-c-check__label"
+                        >
+                          Ms
+                        </span>
+                      </label>
+                      <label
+                        class="pf-c-check pf-c-select__menu-item"
+                      >
+                        <input
+                          class="pf-c-check__input"
+                          id="pf-random-id-15-Other"
+                          type="checkbox"
+                        />
+                        <span
+                          class="pf-c-check__label"
+                        >
+                          Other
+                        </span>
+                      </label>
+                    </fieldset>
+                  </div>
+                  <div
+                    class="pf-c-select__menu-group"
+                  >
                     <div
-                      class="pf-c-select__menu-group"
+                      aria-hidden="true"
+                      class="pf-c-select__menu-group-title"
+                      id="group-2"
                     >
-                      <div
-                        aria-hidden="true"
-                        class="pf-c-select__menu-group-title"
-                        id="group-2"
-                      >
-                        group 2
-                      </div>
-                      <fieldset
-                        aria-labelledby="group-2"
-                        class="pf-c-select__menu-fieldset"
-                      >
-                        <label
-                          class="pf-c-check pf-c-select__menu-item"
-                        >
-                          <input
-                            class="pf-c-check__input"
-                            id="pf-random-id-15-Mr"
-                            type="checkbox"
-                          />
-                          <span
-                            class="pf-c-check__label"
-                          >
-                            Mr
-                          </span>
-                        </label>
-                        <label
-                          class="pf-c-check pf-c-select__menu-item"
-                        >
-                          <input
-                            class="pf-c-check__input"
-                            id="pf-random-id-15-Mrs"
-                            type="checkbox"
-                          />
-                          <span
-                            class="pf-c-check__label"
-                          >
-                            Mrs
-                          </span>
-                        </label>
-                        <label
-                          class="pf-c-check pf-c-select__menu-item"
-                        >
-                          <input
-                            class="pf-c-check__input"
-                            id="pf-random-id-15-Ms"
-                            type="checkbox"
-                          />
-                          <span
-                            class="pf-c-check__label"
-                          >
-                            Ms
-                          </span>
-                        </label>
-                        <label
-                          class="pf-c-check pf-c-select__menu-item"
-                        >
-                          <input
-                            class="pf-c-check__input"
-                            id="pf-random-id-15-Other"
-                            type="checkbox"
-                          />
-                          <span
-                            class="pf-c-check__label"
-                          >
-                            Other
-                          </span>
-                        </label>
-                      </fieldset>
+                      group 2
                     </div>
-                  </fieldset>
-                </div>
+                    <fieldset
+                      aria-labelledby="group-2"
+                      class="pf-c-select__menu-fieldset"
+                    >
+                      <label
+                        class="pf-c-check pf-c-select__menu-item"
+                      >
+                        <input
+                          class="pf-c-check__input"
+                          id="pf-random-id-15-Mr"
+                          type="checkbox"
+                        />
+                        <span
+                          class="pf-c-check__label"
+                        >
+                          Mr
+                        </span>
+                      </label>
+                      <label
+                        class="pf-c-check pf-c-select__menu-item"
+                      >
+                        <input
+                          class="pf-c-check__input"
+                          id="pf-random-id-15-Mrs"
+                          type="checkbox"
+                        />
+                        <span
+                          class="pf-c-check__label"
+                        >
+                          Mrs
+                        </span>
+                      </label>
+                      <label
+                        class="pf-c-check pf-c-select__menu-item"
+                      >
+                        <input
+                          class="pf-c-check__input"
+                          id="pf-random-id-15-Ms"
+                          type="checkbox"
+                        />
+                        <span
+                          class="pf-c-check__label"
+                        >
+                          Ms
+                        </span>
+                      </label>
+                      <label
+                        class="pf-c-check pf-c-select__menu-item"
+                      >
+                        <input
+                          class="pf-c-check__input"
+                          id="pf-random-id-15-Other"
+                          type="checkbox"
+                        />
+                        <span
+                          class="pf-c-check__label"
+                        >
+                          Other
+                        </span>
+                      </label>
+                    </fieldset>
+                  </div>
+                </fieldset>
               </div>
             </div>,
           }
@@ -653,370 +651,356 @@ exports[`checkbox select renders checkbox select groups successfully 1`] = `
           selected={Array []}
           sendRef={[Function]}
         >
-          <FocusTrap
-            active={true}
-            focusTrapOptions={
-              Object {
-                "clickOutsideDeactivates": true,
-                "preventScroll": true,
-              }
-            }
-            paused={false}
-            preventScrollOnDeactivate={false}
+          <div
+            className="pf-c-select__menu"
           >
-            <div>
-              <div
-                className="pf-c-select__menu"
+            <fieldset
+              aria-label=""
+              aria-labelledby={null}
+              className="pf-c-form__fieldset"
+            >
+              <SelectGroup
+                key=".0"
+                label="group 1"
+                titleId="group-1"
               >
-                <fieldset
-                  aria-label=""
-                  aria-labelledby={null}
-                  className="pf-c-form__fieldset"
+                <div
+                  className="pf-c-select__menu-group"
                 >
-                  <SelectGroup
-                    key=".0"
-                    label="group 1"
-                    titleId="group-1"
+                  <div
+                    aria-hidden={true}
+                    className="pf-c-select__menu-group-title"
+                    id="group-1"
                   >
-                    <div
-                      className="pf-c-select__menu-group"
-                    >
-                      <div
-                        aria-hidden={true}
-                        className="pf-c-select__menu-group-title"
-                        id="group-1"
-                      >
-                        group 1
-                      </div>
-                      <fieldset
-                        aria-labelledby="group-1"
-                        className="pf-c-select__menu-fieldset"
-                      >
-                        <SelectOption
-                          className=""
-                          component="button"
-                          id="option-1"
-                          index={0}
-                          inputId=""
-                          isChecked={false}
-                          isDisabled={false}
-                          isFavorite={null}
-                          isNoResultsOption={false}
-                          isPlaceholder={false}
-                          isSelected={false}
-                          key=".$00"
-                          keyHandler={[Function]}
-                          onClick={[Function]}
-                          sendRef={[Function]}
-                          value="Mr"
-                        >
-                          <label
-                            className="pf-c-check pf-c-select__menu-item"
-                            onKeyDown={[Function]}
-                          >
-                            <input
-                              checked={false}
-                              className="pf-c-check__input"
-                              disabled={false}
-                              id="pf-random-id-15-Mr"
-                              onChange={[Function]}
-                              type="checkbox"
-                            />
-                            <span
-                              className="pf-c-check__label"
-                            >
-                              Mr
-                            </span>
-                          </label>
-                        </SelectOption>
-                        <SelectOption
-                          className=""
-                          component="button"
-                          id="option-2"
-                          index={1}
-                          inputId=""
-                          isChecked={false}
-                          isDisabled={false}
-                          isFavorite={null}
-                          isNoResultsOption={false}
-                          isPlaceholder={false}
-                          isSelected={false}
-                          key=".$01"
-                          keyHandler={[Function]}
-                          onClick={[Function]}
-                          sendRef={[Function]}
-                          value="Mrs"
-                        >
-                          <label
-                            className="pf-c-check pf-c-select__menu-item"
-                            onKeyDown={[Function]}
-                          >
-                            <input
-                              checked={false}
-                              className="pf-c-check__input"
-                              disabled={false}
-                              id="pf-random-id-15-Mrs"
-                              onChange={[Function]}
-                              type="checkbox"
-                            />
-                            <span
-                              className="pf-c-check__label"
-                            >
-                              Mrs
-                            </span>
-                          </label>
-                        </SelectOption>
-                        <SelectOption
-                          className=""
-                          component="button"
-                          id="option-3"
-                          index={2}
-                          inputId=""
-                          isChecked={false}
-                          isDisabled={false}
-                          isFavorite={null}
-                          isNoResultsOption={false}
-                          isPlaceholder={false}
-                          isSelected={false}
-                          key=".$02"
-                          keyHandler={[Function]}
-                          onClick={[Function]}
-                          sendRef={[Function]}
-                          value="Ms"
-                        >
-                          <label
-                            className="pf-c-check pf-c-select__menu-item"
-                            onKeyDown={[Function]}
-                          >
-                            <input
-                              checked={false}
-                              className="pf-c-check__input"
-                              disabled={false}
-                              id="pf-random-id-15-Ms"
-                              onChange={[Function]}
-                              type="checkbox"
-                            />
-                            <span
-                              className="pf-c-check__label"
-                            >
-                              Ms
-                            </span>
-                          </label>
-                        </SelectOption>
-                        <SelectOption
-                          className=""
-                          component="button"
-                          id="option-4"
-                          index={3}
-                          inputId=""
-                          isChecked={false}
-                          isDisabled={false}
-                          isFavorite={null}
-                          isNoResultsOption={false}
-                          isPlaceholder={false}
-                          isSelected={false}
-                          key=".$03"
-                          keyHandler={[Function]}
-                          onClick={[Function]}
-                          sendRef={[Function]}
-                          value="Other"
-                        >
-                          <label
-                            className="pf-c-check pf-c-select__menu-item"
-                            onKeyDown={[Function]}
-                          >
-                            <input
-                              checked={false}
-                              className="pf-c-check__input"
-                              disabled={false}
-                              id="pf-random-id-15-Other"
-                              onChange={[Function]}
-                              type="checkbox"
-                            />
-                            <span
-                              className="pf-c-check__label"
-                            >
-                              Other
-                            </span>
-                          </label>
-                        </SelectOption>
-                      </fieldset>
-                    </div>
-                  </SelectGroup>
-                  <SelectGroup
-                    key=".1"
-                    label="group 2"
-                    titleId="group-2"
+                    group 1
+                  </div>
+                  <fieldset
+                    aria-labelledby="group-1"
+                    className="pf-c-select__menu-fieldset"
                   >
-                    <div
-                      className="pf-c-select__menu-group"
+                    <SelectOption
+                      className=""
+                      component="button"
+                      id="option-1"
+                      index={0}
+                      inputId=""
+                      isChecked={false}
+                      isDisabled={false}
+                      isFavorite={null}
+                      isNoResultsOption={false}
+                      isPlaceholder={false}
+                      isSelected={false}
+                      key=".$00"
+                      keyHandler={[Function]}
+                      onClick={[Function]}
+                      sendRef={[Function]}
+                      value="Mr"
                     >
-                      <div
-                        aria-hidden={true}
-                        className="pf-c-select__menu-group-title"
-                        id="group-2"
+                      <label
+                        className="pf-c-check pf-c-select__menu-item"
+                        onKeyDown={[Function]}
                       >
-                        group 2
-                      </div>
-                      <fieldset
-                        aria-labelledby="group-2"
-                        className="pf-c-select__menu-fieldset"
+                        <input
+                          checked={false}
+                          className="pf-c-check__input"
+                          disabled={false}
+                          id="pf-random-id-15-Mr"
+                          onChange={[Function]}
+                          type="checkbox"
+                        />
+                        <span
+                          className="pf-c-check__label"
+                        >
+                          Mr
+                        </span>
+                      </label>
+                    </SelectOption>
+                    <SelectOption
+                      className=""
+                      component="button"
+                      id="option-2"
+                      index={1}
+                      inputId=""
+                      isChecked={false}
+                      isDisabled={false}
+                      isFavorite={null}
+                      isNoResultsOption={false}
+                      isPlaceholder={false}
+                      isSelected={false}
+                      key=".$01"
+                      keyHandler={[Function]}
+                      onClick={[Function]}
+                      sendRef={[Function]}
+                      value="Mrs"
+                    >
+                      <label
+                        className="pf-c-check pf-c-select__menu-item"
+                        onKeyDown={[Function]}
                       >
-                        <SelectOption
-                          className=""
-                          component="button"
-                          id="option-1"
-                          index={4}
-                          inputId=""
-                          isChecked={false}
-                          isDisabled={false}
-                          isFavorite={null}
-                          isNoResultsOption={false}
-                          isPlaceholder={false}
-                          isSelected={false}
-                          key=".$00"
-                          keyHandler={[Function]}
-                          onClick={[Function]}
-                          sendRef={[Function]}
-                          value="Mr"
+                        <input
+                          checked={false}
+                          className="pf-c-check__input"
+                          disabled={false}
+                          id="pf-random-id-15-Mrs"
+                          onChange={[Function]}
+                          type="checkbox"
+                        />
+                        <span
+                          className="pf-c-check__label"
                         >
-                          <label
-                            className="pf-c-check pf-c-select__menu-item"
-                            onKeyDown={[Function]}
-                          >
-                            <input
-                              checked={false}
-                              className="pf-c-check__input"
-                              disabled={false}
-                              id="pf-random-id-15-Mr"
-                              onChange={[Function]}
-                              type="checkbox"
-                            />
-                            <span
-                              className="pf-c-check__label"
-                            >
-                              Mr
-                            </span>
-                          </label>
-                        </SelectOption>
-                        <SelectOption
-                          className=""
-                          component="button"
-                          id="option-2"
-                          index={5}
-                          inputId=""
-                          isChecked={false}
-                          isDisabled={false}
-                          isFavorite={null}
-                          isNoResultsOption={false}
-                          isPlaceholder={false}
-                          isSelected={false}
-                          key=".$01"
-                          keyHandler={[Function]}
-                          onClick={[Function]}
-                          sendRef={[Function]}
-                          value="Mrs"
+                          Mrs
+                        </span>
+                      </label>
+                    </SelectOption>
+                    <SelectOption
+                      className=""
+                      component="button"
+                      id="option-3"
+                      index={2}
+                      inputId=""
+                      isChecked={false}
+                      isDisabled={false}
+                      isFavorite={null}
+                      isNoResultsOption={false}
+                      isPlaceholder={false}
+                      isSelected={false}
+                      key=".$02"
+                      keyHandler={[Function]}
+                      onClick={[Function]}
+                      sendRef={[Function]}
+                      value="Ms"
+                    >
+                      <label
+                        className="pf-c-check pf-c-select__menu-item"
+                        onKeyDown={[Function]}
+                      >
+                        <input
+                          checked={false}
+                          className="pf-c-check__input"
+                          disabled={false}
+                          id="pf-random-id-15-Ms"
+                          onChange={[Function]}
+                          type="checkbox"
+                        />
+                        <span
+                          className="pf-c-check__label"
                         >
-                          <label
-                            className="pf-c-check pf-c-select__menu-item"
-                            onKeyDown={[Function]}
-                          >
-                            <input
-                              checked={false}
-                              className="pf-c-check__input"
-                              disabled={false}
-                              id="pf-random-id-15-Mrs"
-                              onChange={[Function]}
-                              type="checkbox"
-                            />
-                            <span
-                              className="pf-c-check__label"
-                            >
-                              Mrs
-                            </span>
-                          </label>
-                        </SelectOption>
-                        <SelectOption
-                          className=""
-                          component="button"
-                          id="option-3"
-                          index={6}
-                          inputId=""
-                          isChecked={false}
-                          isDisabled={false}
-                          isFavorite={null}
-                          isNoResultsOption={false}
-                          isPlaceholder={false}
-                          isSelected={false}
-                          key=".$02"
-                          keyHandler={[Function]}
-                          onClick={[Function]}
-                          sendRef={[Function]}
-                          value="Ms"
+                          Ms
+                        </span>
+                      </label>
+                    </SelectOption>
+                    <SelectOption
+                      className=""
+                      component="button"
+                      id="option-4"
+                      index={3}
+                      inputId=""
+                      isChecked={false}
+                      isDisabled={false}
+                      isFavorite={null}
+                      isNoResultsOption={false}
+                      isPlaceholder={false}
+                      isSelected={false}
+                      key=".$03"
+                      keyHandler={[Function]}
+                      onClick={[Function]}
+                      sendRef={[Function]}
+                      value="Other"
+                    >
+                      <label
+                        className="pf-c-check pf-c-select__menu-item"
+                        onKeyDown={[Function]}
+                      >
+                        <input
+                          checked={false}
+                          className="pf-c-check__input"
+                          disabled={false}
+                          id="pf-random-id-15-Other"
+                          onChange={[Function]}
+                          type="checkbox"
+                        />
+                        <span
+                          className="pf-c-check__label"
                         >
-                          <label
-                            className="pf-c-check pf-c-select__menu-item"
-                            onKeyDown={[Function]}
-                          >
-                            <input
-                              checked={false}
-                              className="pf-c-check__input"
-                              disabled={false}
-                              id="pf-random-id-15-Ms"
-                              onChange={[Function]}
-                              type="checkbox"
-                            />
-                            <span
-                              className="pf-c-check__label"
-                            >
-                              Ms
-                            </span>
-                          </label>
-                        </SelectOption>
-                        <SelectOption
-                          className=""
-                          component="button"
-                          id="option-4"
-                          index={7}
-                          inputId=""
-                          isChecked={false}
-                          isDisabled={false}
-                          isFavorite={null}
-                          isNoResultsOption={false}
-                          isPlaceholder={false}
-                          isSelected={false}
-                          key=".$03"
-                          keyHandler={[Function]}
-                          onClick={[Function]}
-                          sendRef={[Function]}
-                          value="Other"
+                          Other
+                        </span>
+                      </label>
+                    </SelectOption>
+                  </fieldset>
+                </div>
+              </SelectGroup>
+              <SelectGroup
+                key=".1"
+                label="group 2"
+                titleId="group-2"
+              >
+                <div
+                  className="pf-c-select__menu-group"
+                >
+                  <div
+                    aria-hidden={true}
+                    className="pf-c-select__menu-group-title"
+                    id="group-2"
+                  >
+                    group 2
+                  </div>
+                  <fieldset
+                    aria-labelledby="group-2"
+                    className="pf-c-select__menu-fieldset"
+                  >
+                    <SelectOption
+                      className=""
+                      component="button"
+                      id="option-1"
+                      index={4}
+                      inputId=""
+                      isChecked={false}
+                      isDisabled={false}
+                      isFavorite={null}
+                      isNoResultsOption={false}
+                      isPlaceholder={false}
+                      isSelected={false}
+                      key=".$00"
+                      keyHandler={[Function]}
+                      onClick={[Function]}
+                      sendRef={[Function]}
+                      value="Mr"
+                    >
+                      <label
+                        className="pf-c-check pf-c-select__menu-item"
+                        onKeyDown={[Function]}
+                      >
+                        <input
+                          checked={false}
+                          className="pf-c-check__input"
+                          disabled={false}
+                          id="pf-random-id-15-Mr"
+                          onChange={[Function]}
+                          type="checkbox"
+                        />
+                        <span
+                          className="pf-c-check__label"
                         >
-                          <label
-                            className="pf-c-check pf-c-select__menu-item"
-                            onKeyDown={[Function]}
-                          >
-                            <input
-                              checked={false}
-                              className="pf-c-check__input"
-                              disabled={false}
-                              id="pf-random-id-15-Other"
-                              onChange={[Function]}
-                              type="checkbox"
-                            />
-                            <span
-                              className="pf-c-check__label"
-                            >
-                              Other
-                            </span>
-                          </label>
-                        </SelectOption>
-                      </fieldset>
-                    </div>
-                  </SelectGroup>
-                </fieldset>
-              </div>
-            </div>
-          </FocusTrap>
+                          Mr
+                        </span>
+                      </label>
+                    </SelectOption>
+                    <SelectOption
+                      className=""
+                      component="button"
+                      id="option-2"
+                      index={5}
+                      inputId=""
+                      isChecked={false}
+                      isDisabled={false}
+                      isFavorite={null}
+                      isNoResultsOption={false}
+                      isPlaceholder={false}
+                      isSelected={false}
+                      key=".$01"
+                      keyHandler={[Function]}
+                      onClick={[Function]}
+                      sendRef={[Function]}
+                      value="Mrs"
+                    >
+                      <label
+                        className="pf-c-check pf-c-select__menu-item"
+                        onKeyDown={[Function]}
+                      >
+                        <input
+                          checked={false}
+                          className="pf-c-check__input"
+                          disabled={false}
+                          id="pf-random-id-15-Mrs"
+                          onChange={[Function]}
+                          type="checkbox"
+                        />
+                        <span
+                          className="pf-c-check__label"
+                        >
+                          Mrs
+                        </span>
+                      </label>
+                    </SelectOption>
+                    <SelectOption
+                      className=""
+                      component="button"
+                      id="option-3"
+                      index={6}
+                      inputId=""
+                      isChecked={false}
+                      isDisabled={false}
+                      isFavorite={null}
+                      isNoResultsOption={false}
+                      isPlaceholder={false}
+                      isSelected={false}
+                      key=".$02"
+                      keyHandler={[Function]}
+                      onClick={[Function]}
+                      sendRef={[Function]}
+                      value="Ms"
+                    >
+                      <label
+                        className="pf-c-check pf-c-select__menu-item"
+                        onKeyDown={[Function]}
+                      >
+                        <input
+                          checked={false}
+                          className="pf-c-check__input"
+                          disabled={false}
+                          id="pf-random-id-15-Ms"
+                          onChange={[Function]}
+                          type="checkbox"
+                        />
+                        <span
+                          className="pf-c-check__label"
+                        >
+                          Ms
+                        </span>
+                      </label>
+                    </SelectOption>
+                    <SelectOption
+                      className=""
+                      component="button"
+                      id="option-4"
+                      index={7}
+                      inputId=""
+                      isChecked={false}
+                      isDisabled={false}
+                      isFavorite={null}
+                      isNoResultsOption={false}
+                      isPlaceholder={false}
+                      isSelected={false}
+                      key=".$03"
+                      keyHandler={[Function]}
+                      onClick={[Function]}
+                      sendRef={[Function]}
+                      value="Other"
+                    >
+                      <label
+                        className="pf-c-check pf-c-select__menu-item"
+                        onKeyDown={[Function]}
+                      >
+                        <input
+                          checked={false}
+                          className="pf-c-check__input"
+                          disabled={false}
+                          id="pf-random-id-15-Other"
+                          onChange={[Function]}
+                          type="checkbox"
+                        />
+                        <span
+                          className="pf-c-check__label"
+                        >
+                          Other
+                        </span>
+                      </label>
+                    </SelectOption>
+                  </fieldset>
+                </div>
+              </SelectGroup>
+            </fieldset>
+          </div>
         </SelectMenu>
       </ForwardRef>
     </div>
@@ -1758,72 +1742,70 @@ exports[`checkbox select renders expanded successfully 1`] = `
                   </svg>
                 </span>
               </button>
-              <div>
-                <div
-                  class="pf-c-select__menu"
+              <div
+                class="pf-c-select__menu"
+              >
+                <fieldset
+                  aria-label=""
+                  class="pf-c-form__fieldset"
                 >
-                  <fieldset
-                    aria-label=""
-                    class="pf-c-form__fieldset"
+                  <label
+                    class="pf-c-check pf-c-select__menu-item"
                   >
-                    <label
-                      class="pf-c-check pf-c-select__menu-item"
+                    <input
+                      class="pf-c-check__input"
+                      id="pf-random-id-11-Mr"
+                      type="checkbox"
+                    />
+                    <span
+                      class="pf-c-check__label"
                     >
-                      <input
-                        class="pf-c-check__input"
-                        id="pf-random-id-11-Mr"
-                        type="checkbox"
-                      />
-                      <span
-                        class="pf-c-check__label"
-                      >
-                        Mr
-                      </span>
-                    </label>
-                    <label
-                      class="pf-c-check pf-c-select__menu-item"
+                      Mr
+                    </span>
+                  </label>
+                  <label
+                    class="pf-c-check pf-c-select__menu-item"
+                  >
+                    <input
+                      class="pf-c-check__input"
+                      id="pf-random-id-11-Mrs"
+                      type="checkbox"
+                    />
+                    <span
+                      class="pf-c-check__label"
                     >
-                      <input
-                        class="pf-c-check__input"
-                        id="pf-random-id-11-Mrs"
-                        type="checkbox"
-                      />
-                      <span
-                        class="pf-c-check__label"
-                      >
-                        Mrs
-                      </span>
-                    </label>
-                    <label
-                      class="pf-c-check pf-c-select__menu-item"
+                      Mrs
+                    </span>
+                  </label>
+                  <label
+                    class="pf-c-check pf-c-select__menu-item"
+                  >
+                    <input
+                      class="pf-c-check__input"
+                      id="pf-random-id-11-Ms"
+                      type="checkbox"
+                    />
+                    <span
+                      class="pf-c-check__label"
                     >
-                      <input
-                        class="pf-c-check__input"
-                        id="pf-random-id-11-Ms"
-                        type="checkbox"
-                      />
-                      <span
-                        class="pf-c-check__label"
-                      >
-                        Ms
-                      </span>
-                    </label>
-                    <label
-                      class="pf-c-check pf-c-select__menu-item"
+                      Ms
+                    </span>
+                  </label>
+                  <label
+                    class="pf-c-check pf-c-select__menu-item"
+                  >
+                    <input
+                      class="pf-c-check__input"
+                      id="pf-random-id-11-Other"
+                      type="checkbox"
+                    />
+                    <span
+                      class="pf-c-check__label"
                     >
-                      <input
-                        class="pf-c-check__input"
-                        id="pf-random-id-11-Other"
-                        type="checkbox"
-                      />
-                      <span
-                        class="pf-c-check__label"
-                      >
-                        Other
-                      </span>
-                    </label>
-                  </fieldset>
-                </div>
+                      Other
+                    </span>
+                  </label>
+                </fieldset>
               </div>
             </div>,
           }
@@ -1974,178 +1956,164 @@ exports[`checkbox select renders expanded successfully 1`] = `
           selected={Array []}
           sendRef={[Function]}
         >
-          <FocusTrap
-            active={true}
-            focusTrapOptions={
-              Object {
-                "clickOutsideDeactivates": true,
-                "preventScroll": true,
-              }
-            }
-            paused={false}
-            preventScrollOnDeactivate={false}
+          <div
+            className="pf-c-select__menu"
           >
-            <div>
-              <div
-                className="pf-c-select__menu"
+            <fieldset
+              aria-label=""
+              aria-labelledby={null}
+              className="pf-c-form__fieldset"
+            >
+              <SelectOption
+                className=""
+                component="button"
+                id="option-1"
+                index={0}
+                inputId=""
+                isChecked={false}
+                isDisabled={false}
+                isFavorite={null}
+                isNoResultsOption={false}
+                isPlaceholder={false}
+                isSelected={false}
+                key=".$00"
+                keyHandler={[Function]}
+                onClick={[Function]}
+                sendRef={[Function]}
+                value="Mr"
               >
-                <fieldset
-                  aria-label=""
-                  aria-labelledby={null}
-                  className="pf-c-form__fieldset"
+                <label
+                  className="pf-c-check pf-c-select__menu-item"
+                  onKeyDown={[Function]}
                 >
-                  <SelectOption
-                    className=""
-                    component="button"
-                    id="option-1"
-                    index={0}
-                    inputId=""
-                    isChecked={false}
-                    isDisabled={false}
-                    isFavorite={null}
-                    isNoResultsOption={false}
-                    isPlaceholder={false}
-                    isSelected={false}
-                    key=".$00"
-                    keyHandler={[Function]}
-                    onClick={[Function]}
-                    sendRef={[Function]}
-                    value="Mr"
+                  <input
+                    checked={false}
+                    className="pf-c-check__input"
+                    disabled={false}
+                    id="pf-random-id-11-Mr"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  <span
+                    className="pf-c-check__label"
                   >
-                    <label
-                      className="pf-c-check pf-c-select__menu-item"
-                      onKeyDown={[Function]}
-                    >
-                      <input
-                        checked={false}
-                        className="pf-c-check__input"
-                        disabled={false}
-                        id="pf-random-id-11-Mr"
-                        onChange={[Function]}
-                        type="checkbox"
-                      />
-                      <span
-                        className="pf-c-check__label"
-                      >
-                        Mr
-                      </span>
-                    </label>
-                  </SelectOption>
-                  <SelectOption
-                    className=""
-                    component="button"
-                    id="option-2"
-                    index={1}
-                    inputId=""
-                    isChecked={false}
-                    isDisabled={false}
-                    isFavorite={null}
-                    isNoResultsOption={false}
-                    isPlaceholder={false}
-                    isSelected={false}
-                    key=".$01"
-                    keyHandler={[Function]}
-                    onClick={[Function]}
-                    sendRef={[Function]}
-                    value="Mrs"
+                    Mr
+                  </span>
+                </label>
+              </SelectOption>
+              <SelectOption
+                className=""
+                component="button"
+                id="option-2"
+                index={1}
+                inputId=""
+                isChecked={false}
+                isDisabled={false}
+                isFavorite={null}
+                isNoResultsOption={false}
+                isPlaceholder={false}
+                isSelected={false}
+                key=".$01"
+                keyHandler={[Function]}
+                onClick={[Function]}
+                sendRef={[Function]}
+                value="Mrs"
+              >
+                <label
+                  className="pf-c-check pf-c-select__menu-item"
+                  onKeyDown={[Function]}
+                >
+                  <input
+                    checked={false}
+                    className="pf-c-check__input"
+                    disabled={false}
+                    id="pf-random-id-11-Mrs"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  <span
+                    className="pf-c-check__label"
                   >
-                    <label
-                      className="pf-c-check pf-c-select__menu-item"
-                      onKeyDown={[Function]}
-                    >
-                      <input
-                        checked={false}
-                        className="pf-c-check__input"
-                        disabled={false}
-                        id="pf-random-id-11-Mrs"
-                        onChange={[Function]}
-                        type="checkbox"
-                      />
-                      <span
-                        className="pf-c-check__label"
-                      >
-                        Mrs
-                      </span>
-                    </label>
-                  </SelectOption>
-                  <SelectOption
-                    className=""
-                    component="button"
-                    id="option-3"
-                    index={2}
-                    inputId=""
-                    isChecked={false}
-                    isDisabled={false}
-                    isFavorite={null}
-                    isNoResultsOption={false}
-                    isPlaceholder={false}
-                    isSelected={false}
-                    key=".$02"
-                    keyHandler={[Function]}
-                    onClick={[Function]}
-                    sendRef={[Function]}
-                    value="Ms"
+                    Mrs
+                  </span>
+                </label>
+              </SelectOption>
+              <SelectOption
+                className=""
+                component="button"
+                id="option-3"
+                index={2}
+                inputId=""
+                isChecked={false}
+                isDisabled={false}
+                isFavorite={null}
+                isNoResultsOption={false}
+                isPlaceholder={false}
+                isSelected={false}
+                key=".$02"
+                keyHandler={[Function]}
+                onClick={[Function]}
+                sendRef={[Function]}
+                value="Ms"
+              >
+                <label
+                  className="pf-c-check pf-c-select__menu-item"
+                  onKeyDown={[Function]}
+                >
+                  <input
+                    checked={false}
+                    className="pf-c-check__input"
+                    disabled={false}
+                    id="pf-random-id-11-Ms"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  <span
+                    className="pf-c-check__label"
                   >
-                    <label
-                      className="pf-c-check pf-c-select__menu-item"
-                      onKeyDown={[Function]}
-                    >
-                      <input
-                        checked={false}
-                        className="pf-c-check__input"
-                        disabled={false}
-                        id="pf-random-id-11-Ms"
-                        onChange={[Function]}
-                        type="checkbox"
-                      />
-                      <span
-                        className="pf-c-check__label"
-                      >
-                        Ms
-                      </span>
-                    </label>
-                  </SelectOption>
-                  <SelectOption
-                    className=""
-                    component="button"
-                    id="option-4"
-                    index={3}
-                    inputId=""
-                    isChecked={false}
-                    isDisabled={false}
-                    isFavorite={null}
-                    isNoResultsOption={false}
-                    isPlaceholder={false}
-                    isSelected={false}
-                    key=".$03"
-                    keyHandler={[Function]}
-                    onClick={[Function]}
-                    sendRef={[Function]}
-                    value="Other"
+                    Ms
+                  </span>
+                </label>
+              </SelectOption>
+              <SelectOption
+                className=""
+                component="button"
+                id="option-4"
+                index={3}
+                inputId=""
+                isChecked={false}
+                isDisabled={false}
+                isFavorite={null}
+                isNoResultsOption={false}
+                isPlaceholder={false}
+                isSelected={false}
+                key=".$03"
+                keyHandler={[Function]}
+                onClick={[Function]}
+                sendRef={[Function]}
+                value="Other"
+              >
+                <label
+                  className="pf-c-check pf-c-select__menu-item"
+                  onKeyDown={[Function]}
+                >
+                  <input
+                    checked={false}
+                    className="pf-c-check__input"
+                    disabled={false}
+                    id="pf-random-id-11-Other"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  <span
+                    className="pf-c-check__label"
                   >
-                    <label
-                      className="pf-c-check pf-c-select__menu-item"
-                      onKeyDown={[Function]}
-                    >
-                      <input
-                        checked={false}
-                        className="pf-c-check__input"
-                        disabled={false}
-                        id="pf-random-id-11-Other"
-                        onChange={[Function]}
-                        type="checkbox"
-                      />
-                      <span
-                        className="pf-c-check__label"
-                      >
-                        Other
-                      </span>
-                    </label>
-                  </SelectOption>
-                </fieldset>
-              </div>
-            </div>
-          </FocusTrap>
+                    Other
+                  </span>
+                </label>
+              </SelectOption>
+            </fieldset>
+          </div>
         </SelectMenu>
       </ForwardRef>
     </div>
@@ -2312,58 +2280,56 @@ exports[`checkbox select renders expanded successfully with custom objects 1`] =
                   </svg>
                 </span>
               </button>
-              <div>
-                <div
-                  class="pf-c-select__menu"
+              <div
+                class="pf-c-select__menu"
+              >
+                <fieldset
+                  aria-label=""
+                  class="pf-c-form__fieldset"
                 >
-                  <fieldset
-                    aria-label=""
-                    class="pf-c-form__fieldset"
+                  <label
+                    class="pf-c-check pf-c-select__menu-item"
                   >
-                    <label
-                      class="pf-c-check pf-c-select__menu-item"
+                    <input
+                      class="pf-c-check__input"
+                      id="pf-random-id-14-Mr: User One"
+                      type="checkbox"
+                    />
+                    <span
+                      class="pf-c-check__label"
                     >
-                      <input
-                        class="pf-c-check__input"
-                        id="pf-random-id-14-Mr: User One"
-                        type="checkbox"
-                      />
-                      <span
-                        class="pf-c-check__label"
-                      >
-                        Mr: User One
-                      </span>
-                    </label>
-                    <label
-                      class="pf-c-check pf-c-select__menu-item"
+                      Mr: User One
+                    </span>
+                  </label>
+                  <label
+                    class="pf-c-check pf-c-select__menu-item"
+                  >
+                    <input
+                      class="pf-c-check__input"
+                      id="pf-random-id-14-Mrs: New User"
+                      type="checkbox"
+                    />
+                    <span
+                      class="pf-c-check__label"
                     >
-                      <input
-                        class="pf-c-check__input"
-                        id="pf-random-id-14-Mrs: New User"
-                        type="checkbox"
-                      />
-                      <span
-                        class="pf-c-check__label"
-                      >
-                        Mrs: New User
-                      </span>
-                    </label>
-                    <label
-                      class="pf-c-check pf-c-select__menu-item"
+                      Mrs: New User
+                    </span>
+                  </label>
+                  <label
+                    class="pf-c-check pf-c-select__menu-item"
+                  >
+                    <input
+                      class="pf-c-check__input"
+                      id="pf-random-id-14-Ms: Test Three"
+                      type="checkbox"
+                    />
+                    <span
+                      class="pf-c-check__label"
                     >
-                      <input
-                        class="pf-c-check__input"
-                        id="pf-random-id-14-Ms: Test Three"
-                        type="checkbox"
-                      />
-                      <span
-                        class="pf-c-check__label"
-                      >
-                        Ms: Test Three
-                      </span>
-                    </label>
-                  </fieldset>
-                </div>
+                      Ms: Test Three
+                    </span>
+                  </label>
+                </fieldset>
               </div>
             </div>,
           }
@@ -2500,165 +2466,151 @@ exports[`checkbox select renders expanded successfully with custom objects 1`] =
           selected={Array []}
           sendRef={[Function]}
         >
-          <FocusTrap
-            active={true}
-            focusTrapOptions={
-              Object {
-                "clickOutsideDeactivates": true,
-                "preventScroll": true,
-              }
-            }
-            paused={false}
-            preventScrollOnDeactivate={false}
+          <div
+            className="pf-c-select__menu"
           >
-            <div>
-              <div
-                className="pf-c-select__menu"
+            <fieldset
+              aria-label=""
+              aria-labelledby={null}
+              className="pf-c-form__fieldset"
+            >
+              <SelectOption
+                className=""
+                component="button"
+                id="option-1"
+                index={0}
+                inputId=""
+                isChecked={false}
+                isDisabled={false}
+                isFavorite={null}
+                isNoResultsOption={false}
+                isPlaceholder={false}
+                isSelected={false}
+                key=".$0"
+                keyHandler={[Function]}
+                onClick={[Function]}
+                sendRef={[Function]}
+                value={
+                  User {
+                    "compareTo": [Function],
+                    "firstName": "User",
+                    "lastName": "One",
+                    "title": "Mr",
+                    "toString": [Function],
+                  }
+                }
               >
-                <fieldset
-                  aria-label=""
-                  aria-labelledby={null}
-                  className="pf-c-form__fieldset"
+                <label
+                  className="pf-c-check pf-c-select__menu-item"
+                  onKeyDown={[Function]}
                 >
-                  <SelectOption
-                    className=""
-                    component="button"
-                    id="option-1"
-                    index={0}
-                    inputId=""
-                    isChecked={false}
-                    isDisabled={false}
-                    isFavorite={null}
-                    isNoResultsOption={false}
-                    isPlaceholder={false}
-                    isSelected={false}
-                    key=".$0"
-                    keyHandler={[Function]}
-                    onClick={[Function]}
-                    sendRef={[Function]}
-                    value={
-                      User {
-                        "compareTo": [Function],
-                        "firstName": "User",
-                        "lastName": "One",
-                        "title": "Mr",
-                        "toString": [Function],
-                      }
-                    }
+                  <input
+                    checked={false}
+                    className="pf-c-check__input"
+                    disabled={false}
+                    id="pf-random-id-14-Mr: User One"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  <span
+                    className="pf-c-check__label"
                   >
-                    <label
-                      className="pf-c-check pf-c-select__menu-item"
-                      onKeyDown={[Function]}
-                    >
-                      <input
-                        checked={false}
-                        className="pf-c-check__input"
-                        disabled={false}
-                        id="pf-random-id-14-Mr: User One"
-                        onChange={[Function]}
-                        type="checkbox"
-                      />
-                      <span
-                        className="pf-c-check__label"
-                      >
-                        Mr: User One
-                      </span>
-                    </label>
-                  </SelectOption>
-                  <SelectOption
-                    className=""
-                    component="button"
-                    id="option-2"
-                    index={1}
-                    inputId=""
-                    isChecked={false}
-                    isDisabled={false}
-                    isFavorite={null}
-                    isNoResultsOption={false}
-                    isPlaceholder={false}
-                    isSelected={false}
-                    key=".$1"
-                    keyHandler={[Function]}
-                    onClick={[Function]}
-                    sendRef={[Function]}
-                    value={
-                      User {
-                        "compareTo": [Function],
-                        "firstName": "New",
-                        "lastName": "User",
-                        "title": "Mrs",
-                        "toString": [Function],
-                      }
-                    }
+                    Mr: User One
+                  </span>
+                </label>
+              </SelectOption>
+              <SelectOption
+                className=""
+                component="button"
+                id="option-2"
+                index={1}
+                inputId=""
+                isChecked={false}
+                isDisabled={false}
+                isFavorite={null}
+                isNoResultsOption={false}
+                isPlaceholder={false}
+                isSelected={false}
+                key=".$1"
+                keyHandler={[Function]}
+                onClick={[Function]}
+                sendRef={[Function]}
+                value={
+                  User {
+                    "compareTo": [Function],
+                    "firstName": "New",
+                    "lastName": "User",
+                    "title": "Mrs",
+                    "toString": [Function],
+                  }
+                }
+              >
+                <label
+                  className="pf-c-check pf-c-select__menu-item"
+                  onKeyDown={[Function]}
+                >
+                  <input
+                    checked={false}
+                    className="pf-c-check__input"
+                    disabled={false}
+                    id="pf-random-id-14-Mrs: New User"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  <span
+                    className="pf-c-check__label"
                   >
-                    <label
-                      className="pf-c-check pf-c-select__menu-item"
-                      onKeyDown={[Function]}
-                    >
-                      <input
-                        checked={false}
-                        className="pf-c-check__input"
-                        disabled={false}
-                        id="pf-random-id-14-Mrs: New User"
-                        onChange={[Function]}
-                        type="checkbox"
-                      />
-                      <span
-                        className="pf-c-check__label"
-                      >
-                        Mrs: New User
-                      </span>
-                    </label>
-                  </SelectOption>
-                  <SelectOption
-                    className=""
-                    component="button"
-                    id="option-3"
-                    index={2}
-                    inputId=""
-                    isChecked={false}
-                    isDisabled={false}
-                    isFavorite={null}
-                    isNoResultsOption={false}
-                    isPlaceholder={false}
-                    isSelected={false}
-                    key=".$2"
-                    keyHandler={[Function]}
-                    onClick={[Function]}
-                    sendRef={[Function]}
-                    value={
-                      User {
-                        "compareTo": [Function],
-                        "firstName": "Test",
-                        "lastName": "Three",
-                        "title": "Ms",
-                        "toString": [Function],
-                      }
-                    }
+                    Mrs: New User
+                  </span>
+                </label>
+              </SelectOption>
+              <SelectOption
+                className=""
+                component="button"
+                id="option-3"
+                index={2}
+                inputId=""
+                isChecked={false}
+                isDisabled={false}
+                isFavorite={null}
+                isNoResultsOption={false}
+                isPlaceholder={false}
+                isSelected={false}
+                key=".$2"
+                keyHandler={[Function]}
+                onClick={[Function]}
+                sendRef={[Function]}
+                value={
+                  User {
+                    "compareTo": [Function],
+                    "firstName": "Test",
+                    "lastName": "Three",
+                    "title": "Ms",
+                    "toString": [Function],
+                  }
+                }
+              >
+                <label
+                  className="pf-c-check pf-c-select__menu-item"
+                  onKeyDown={[Function]}
+                >
+                  <input
+                    checked={false}
+                    className="pf-c-check__input"
+                    disabled={false}
+                    id="pf-random-id-14-Ms: Test Three"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  <span
+                    className="pf-c-check__label"
                   >
-                    <label
-                      className="pf-c-check pf-c-select__menu-item"
-                      onKeyDown={[Function]}
-                    >
-                      <input
-                        checked={false}
-                        className="pf-c-check__input"
-                        disabled={false}
-                        id="pf-random-id-14-Ms: Test Three"
-                        onChange={[Function]}
-                        type="checkbox"
-                      />
-                      <span
-                        className="pf-c-check__label"
-                      >
-                        Ms: Test Three
-                      </span>
-                    </label>
-                  </SelectOption>
-                </fieldset>
-              </div>
-            </div>
-          </FocusTrap>
+                    Ms: Test Three
+                  </span>
+                </label>
+              </SelectOption>
+            </fieldset>
+          </div>
         </SelectMenu>
       </ForwardRef>
     </div>
@@ -2853,84 +2805,82 @@ exports[`checkbox select renders expanded with filtering successfully 1`] = `
                   </svg>
                 </button>
               </div>
-              <div>
-                <div
-                  class="pf-c-select__menu"
+              <div
+                class="pf-c-select__menu"
+              >
+                <fieldset
+                  aria-label=""
+                  class="pf-c-form__fieldset"
                 >
-                  <fieldset
-                    aria-label=""
-                    class="pf-c-form__fieldset"
+                  <div
+                    class="pf-c-select__menu-search"
                   >
-                    <div
-                      class="pf-c-select__menu-search"
-                    >
-                      <input
-                        autocomplete="off"
-                        class="pf-c-form-control pf-m-search"
-                        type="search"
-                      />
-                    </div>
-                    <hr
-                      class="pf-c-divider"
+                    <input
+                      autocomplete="off"
+                      class="pf-c-form-control pf-m-search"
+                      type="search"
                     />
-                    <label
-                      class="pf-c-check pf-c-select__menu-item"
+                  </div>
+                  <hr
+                    class="pf-c-divider"
+                  />
+                  <label
+                    class="pf-c-check pf-c-select__menu-item"
+                  >
+                    <input
+                      class="pf-c-check__input"
+                      id="pf-random-id-12-Mr"
+                      type="checkbox"
+                    />
+                    <span
+                      class="pf-c-check__label"
                     >
-                      <input
-                        class="pf-c-check__input"
-                        id="pf-random-id-12-Mr"
-                        type="checkbox"
-                      />
-                      <span
-                        class="pf-c-check__label"
-                      >
-                        Mr
-                      </span>
-                    </label>
-                    <label
-                      class="pf-c-check pf-c-select__menu-item"
+                      Mr
+                    </span>
+                  </label>
+                  <label
+                    class="pf-c-check pf-c-select__menu-item"
+                  >
+                    <input
+                      class="pf-c-check__input"
+                      id="pf-random-id-12-Mrs"
+                      type="checkbox"
+                    />
+                    <span
+                      class="pf-c-check__label"
                     >
-                      <input
-                        class="pf-c-check__input"
-                        id="pf-random-id-12-Mrs"
-                        type="checkbox"
-                      />
-                      <span
-                        class="pf-c-check__label"
-                      >
-                        Mrs
-                      </span>
-                    </label>
-                    <label
-                      class="pf-c-check pf-c-select__menu-item"
+                      Mrs
+                    </span>
+                  </label>
+                  <label
+                    class="pf-c-check pf-c-select__menu-item"
+                  >
+                    <input
+                      class="pf-c-check__input"
+                      id="pf-random-id-12-Ms"
+                      type="checkbox"
+                    />
+                    <span
+                      class="pf-c-check__label"
                     >
-                      <input
-                        class="pf-c-check__input"
-                        id="pf-random-id-12-Ms"
-                        type="checkbox"
-                      />
-                      <span
-                        class="pf-c-check__label"
-                      >
-                        Ms
-                      </span>
-                    </label>
-                    <label
-                      class="pf-c-check pf-c-select__menu-item"
+                      Ms
+                    </span>
+                  </label>
+                  <label
+                    class="pf-c-check pf-c-select__menu-item"
+                  >
+                    <input
+                      class="pf-c-check__input"
+                      id="pf-random-id-12-Other"
+                      type="checkbox"
+                    />
+                    <span
+                      class="pf-c-check__label"
                     >
-                      <input
-                        class="pf-c-check__input"
-                        id="pf-random-id-12-Other"
-                        type="checkbox"
-                      />
-                      <span
-                        class="pf-c-check__label"
-                      >
-                        Other
-                      </span>
-                    </label>
-                  </fieldset>
-                </div>
+                      Other
+                    </span>
+                  </label>
+                </fieldset>
               </div>
             </div>,
           }
@@ -3097,199 +3047,185 @@ exports[`checkbox select renders expanded with filtering successfully 1`] = `
           selected={Array []}
           sendRef={[Function]}
         >
-          <FocusTrap
-            active={true}
-            focusTrapOptions={
-              Object {
-                "clickOutsideDeactivates": true,
-                "preventScroll": true,
-              }
-            }
-            paused={false}
-            preventScrollOnDeactivate={false}
+          <div
+            className="pf-c-select__menu"
           >
-            <div>
+            <fieldset
+              aria-label=""
+              aria-labelledby={null}
+              className="pf-c-form__fieldset"
+            >
               <div
-                className="pf-c-select__menu"
+                className="pf-c-select__menu-search"
+                key="inline-filter"
               >
-                <fieldset
-                  aria-label=""
-                  aria-labelledby={null}
-                  className="pf-c-form__fieldset"
-                >
-                  <div
-                    className="pf-c-select__menu-search"
-                    key="inline-filter"
-                  >
-                    <input
-                      autoComplete="off"
-                      className="pf-c-form-control pf-m-search"
-                      key="inline-filter-input"
-                      onChange={[Function]}
-                      onKeyDown={[Function]}
-                      placeholder={null}
-                      type="search"
-                    />
-                  </div>
-                  <Divider
-                    key="inline-filter-divider"
-                  >
-                    <hr
-                      className="pf-c-divider"
-                    />
-                  </Divider>
-                  <SelectOption
-                    className=""
-                    component="button"
-                    id="option-1"
-                    index={1}
-                    inputId=""
-                    isChecked={false}
-                    isDisabled={false}
-                    isFavorite={null}
-                    isNoResultsOption={false}
-                    isPlaceholder={false}
-                    isSelected={false}
-                    key=".$1"
-                    keyHandler={[Function]}
-                    onClick={[Function]}
-                    sendRef={[Function]}
-                    value="Mr"
-                  >
-                    <label
-                      className="pf-c-check pf-c-select__menu-item"
-                      onKeyDown={[Function]}
-                    >
-                      <input
-                        checked={false}
-                        className="pf-c-check__input"
-                        disabled={false}
-                        id="pf-random-id-12-Mr"
-                        onChange={[Function]}
-                        type="checkbox"
-                      />
-                      <span
-                        className="pf-c-check__label"
-                      >
-                        Mr
-                      </span>
-                    </label>
-                  </SelectOption>
-                  <SelectOption
-                    className=""
-                    component="button"
-                    id="option-2"
-                    index={2}
-                    inputId=""
-                    isChecked={false}
-                    isDisabled={false}
-                    isFavorite={null}
-                    isNoResultsOption={false}
-                    isPlaceholder={false}
-                    isSelected={false}
-                    key=".$2"
-                    keyHandler={[Function]}
-                    onClick={[Function]}
-                    sendRef={[Function]}
-                    value="Mrs"
-                  >
-                    <label
-                      className="pf-c-check pf-c-select__menu-item"
-                      onKeyDown={[Function]}
-                    >
-                      <input
-                        checked={false}
-                        className="pf-c-check__input"
-                        disabled={false}
-                        id="pf-random-id-12-Mrs"
-                        onChange={[Function]}
-                        type="checkbox"
-                      />
-                      <span
-                        className="pf-c-check__label"
-                      >
-                        Mrs
-                      </span>
-                    </label>
-                  </SelectOption>
-                  <SelectOption
-                    className=""
-                    component="button"
-                    id="option-3"
-                    index={3}
-                    inputId=""
-                    isChecked={false}
-                    isDisabled={false}
-                    isFavorite={null}
-                    isNoResultsOption={false}
-                    isPlaceholder={false}
-                    isSelected={false}
-                    key=".$3"
-                    keyHandler={[Function]}
-                    onClick={[Function]}
-                    sendRef={[Function]}
-                    value="Ms"
-                  >
-                    <label
-                      className="pf-c-check pf-c-select__menu-item"
-                      onKeyDown={[Function]}
-                    >
-                      <input
-                        checked={false}
-                        className="pf-c-check__input"
-                        disabled={false}
-                        id="pf-random-id-12-Ms"
-                        onChange={[Function]}
-                        type="checkbox"
-                      />
-                      <span
-                        className="pf-c-check__label"
-                      >
-                        Ms
-                      </span>
-                    </label>
-                  </SelectOption>
-                  <SelectOption
-                    className=""
-                    component="button"
-                    id="option-4"
-                    index={4}
-                    inputId=""
-                    isChecked={false}
-                    isDisabled={false}
-                    isFavorite={null}
-                    isNoResultsOption={false}
-                    isPlaceholder={false}
-                    isSelected={false}
-                    key=".$4"
-                    keyHandler={[Function]}
-                    onClick={[Function]}
-                    sendRef={[Function]}
-                    value="Other"
-                  >
-                    <label
-                      className="pf-c-check pf-c-select__menu-item"
-                      onKeyDown={[Function]}
-                    >
-                      <input
-                        checked={false}
-                        className="pf-c-check__input"
-                        disabled={false}
-                        id="pf-random-id-12-Other"
-                        onChange={[Function]}
-                        type="checkbox"
-                      />
-                      <span
-                        className="pf-c-check__label"
-                      >
-                        Other
-                      </span>
-                    </label>
-                  </SelectOption>
-                </fieldset>
+                <input
+                  autoComplete="off"
+                  className="pf-c-form-control pf-m-search"
+                  key="inline-filter-input"
+                  onChange={[Function]}
+                  onKeyDown={[Function]}
+                  placeholder={null}
+                  type="search"
+                />
               </div>
-            </div>
-          </FocusTrap>
+              <Divider
+                key="inline-filter-divider"
+              >
+                <hr
+                  className="pf-c-divider"
+                />
+              </Divider>
+              <SelectOption
+                className=""
+                component="button"
+                id="option-1"
+                index={1}
+                inputId=""
+                isChecked={false}
+                isDisabled={false}
+                isFavorite={null}
+                isNoResultsOption={false}
+                isPlaceholder={false}
+                isSelected={false}
+                key=".$1"
+                keyHandler={[Function]}
+                onClick={[Function]}
+                sendRef={[Function]}
+                value="Mr"
+              >
+                <label
+                  className="pf-c-check pf-c-select__menu-item"
+                  onKeyDown={[Function]}
+                >
+                  <input
+                    checked={false}
+                    className="pf-c-check__input"
+                    disabled={false}
+                    id="pf-random-id-12-Mr"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  <span
+                    className="pf-c-check__label"
+                  >
+                    Mr
+                  </span>
+                </label>
+              </SelectOption>
+              <SelectOption
+                className=""
+                component="button"
+                id="option-2"
+                index={2}
+                inputId=""
+                isChecked={false}
+                isDisabled={false}
+                isFavorite={null}
+                isNoResultsOption={false}
+                isPlaceholder={false}
+                isSelected={false}
+                key=".$2"
+                keyHandler={[Function]}
+                onClick={[Function]}
+                sendRef={[Function]}
+                value="Mrs"
+              >
+                <label
+                  className="pf-c-check pf-c-select__menu-item"
+                  onKeyDown={[Function]}
+                >
+                  <input
+                    checked={false}
+                    className="pf-c-check__input"
+                    disabled={false}
+                    id="pf-random-id-12-Mrs"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  <span
+                    className="pf-c-check__label"
+                  >
+                    Mrs
+                  </span>
+                </label>
+              </SelectOption>
+              <SelectOption
+                className=""
+                component="button"
+                id="option-3"
+                index={3}
+                inputId=""
+                isChecked={false}
+                isDisabled={false}
+                isFavorite={null}
+                isNoResultsOption={false}
+                isPlaceholder={false}
+                isSelected={false}
+                key=".$3"
+                keyHandler={[Function]}
+                onClick={[Function]}
+                sendRef={[Function]}
+                value="Ms"
+              >
+                <label
+                  className="pf-c-check pf-c-select__menu-item"
+                  onKeyDown={[Function]}
+                >
+                  <input
+                    checked={false}
+                    className="pf-c-check__input"
+                    disabled={false}
+                    id="pf-random-id-12-Ms"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  <span
+                    className="pf-c-check__label"
+                  >
+                    Ms
+                  </span>
+                </label>
+              </SelectOption>
+              <SelectOption
+                className=""
+                component="button"
+                id="option-4"
+                index={4}
+                inputId=""
+                isChecked={false}
+                isDisabled={false}
+                isFavorite={null}
+                isNoResultsOption={false}
+                isPlaceholder={false}
+                isSelected={false}
+                key=".$4"
+                keyHandler={[Function]}
+                onClick={[Function]}
+                sendRef={[Function]}
+                value="Other"
+              >
+                <label
+                  className="pf-c-check pf-c-select__menu-item"
+                  onKeyDown={[Function]}
+                >
+                  <input
+                    checked={false}
+                    className="pf-c-check__input"
+                    disabled={false}
+                    id="pf-random-id-12-Other"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  <span
+                    className="pf-c-check__label"
+                  >
+                    Other
+                  </span>
+                </label>
+              </SelectOption>
+            </fieldset>
+          </div>
         </SelectMenu>
       </ForwardRef>
     </div>
@@ -3484,84 +3420,82 @@ exports[`checkbox select renders expanded with filtering successfully 2`] = `
                   </svg>
                 </button>
               </div>
-              <div>
-                <div
-                  class="pf-c-select__menu"
+              <div
+                class="pf-c-select__menu"
+              >
+                <fieldset
+                  aria-label=""
+                  class="pf-c-form__fieldset"
                 >
-                  <fieldset
-                    aria-label=""
-                    class="pf-c-form__fieldset"
+                  <div
+                    class="pf-c-select__menu-search"
                   >
-                    <div
-                      class="pf-c-select__menu-search"
-                    >
-                      <input
-                        autocomplete="off"
-                        class="pf-c-form-control pf-m-search"
-                        type="search"
-                      />
-                    </div>
-                    <hr
-                      class="pf-c-divider"
+                    <input
+                      autocomplete="off"
+                      class="pf-c-form-control pf-m-search"
+                      type="search"
                     />
-                    <label
-                      class="pf-c-check pf-c-select__menu-item"
+                  </div>
+                  <hr
+                    class="pf-c-divider"
+                  />
+                  <label
+                    class="pf-c-check pf-c-select__menu-item"
+                  >
+                    <input
+                      class="pf-c-check__input"
+                      id="pf-random-id-13-Mr"
+                      type="checkbox"
+                    />
+                    <span
+                      class="pf-c-check__label"
                     >
-                      <input
-                        class="pf-c-check__input"
-                        id="pf-random-id-13-Mr"
-                        type="checkbox"
-                      />
-                      <span
-                        class="pf-c-check__label"
-                      >
-                        Mr
-                      </span>
-                    </label>
-                    <label
-                      class="pf-c-check pf-c-select__menu-item"
+                      Mr
+                    </span>
+                  </label>
+                  <label
+                    class="pf-c-check pf-c-select__menu-item"
+                  >
+                    <input
+                      class="pf-c-check__input"
+                      id="pf-random-id-13-Mrs"
+                      type="checkbox"
+                    />
+                    <span
+                      class="pf-c-check__label"
                     >
-                      <input
-                        class="pf-c-check__input"
-                        id="pf-random-id-13-Mrs"
-                        type="checkbox"
-                      />
-                      <span
-                        class="pf-c-check__label"
-                      >
-                        Mrs
-                      </span>
-                    </label>
-                    <label
-                      class="pf-c-check pf-c-select__menu-item"
+                      Mrs
+                    </span>
+                  </label>
+                  <label
+                    class="pf-c-check pf-c-select__menu-item"
+                  >
+                    <input
+                      class="pf-c-check__input"
+                      id="pf-random-id-13-Ms"
+                      type="checkbox"
+                    />
+                    <span
+                      class="pf-c-check__label"
                     >
-                      <input
-                        class="pf-c-check__input"
-                        id="pf-random-id-13-Ms"
-                        type="checkbox"
-                      />
-                      <span
-                        class="pf-c-check__label"
-                      >
-                        Ms
-                      </span>
-                    </label>
-                    <label
-                      class="pf-c-check pf-c-select__menu-item"
+                      Ms
+                    </span>
+                  </label>
+                  <label
+                    class="pf-c-check pf-c-select__menu-item"
+                  >
+                    <input
+                      class="pf-c-check__input"
+                      id="pf-random-id-13-Other"
+                      type="checkbox"
+                    />
+                    <span
+                      class="pf-c-check__label"
                     >
-                      <input
-                        class="pf-c-check__input"
-                        id="pf-random-id-13-Other"
-                        type="checkbox"
-                      />
-                      <span
-                        class="pf-c-check__label"
-                      >
-                        Other
-                      </span>
-                    </label>
-                  </fieldset>
-                </div>
+                      Other
+                    </span>
+                  </label>
+                </fieldset>
               </div>
             </div>,
           }
@@ -3728,199 +3662,185 @@ exports[`checkbox select renders expanded with filtering successfully 2`] = `
           selected={Array []}
           sendRef={[Function]}
         >
-          <FocusTrap
-            active={true}
-            focusTrapOptions={
-              Object {
-                "clickOutsideDeactivates": true,
-                "preventScroll": true,
-              }
-            }
-            paused={false}
-            preventScrollOnDeactivate={false}
+          <div
+            className="pf-c-select__menu"
           >
-            <div>
+            <fieldset
+              aria-label=""
+              aria-labelledby={null}
+              className="pf-c-form__fieldset"
+            >
               <div
-                className="pf-c-select__menu"
+                className="pf-c-select__menu-search"
+                key="inline-filter"
               >
-                <fieldset
-                  aria-label=""
-                  aria-labelledby={null}
-                  className="pf-c-form__fieldset"
-                >
-                  <div
-                    className="pf-c-select__menu-search"
-                    key="inline-filter"
-                  >
-                    <input
-                      autoComplete="off"
-                      className="pf-c-form-control pf-m-search"
-                      key="inline-filter-input"
-                      onChange={[Function]}
-                      onKeyDown={[Function]}
-                      placeholder={null}
-                      type="search"
-                    />
-                  </div>
-                  <Divider
-                    key="inline-filter-divider"
-                  >
-                    <hr
-                      className="pf-c-divider"
-                    />
-                  </Divider>
-                  <SelectOption
-                    className=""
-                    component="button"
-                    id="option-1"
-                    index={1}
-                    inputId=""
-                    isChecked={false}
-                    isDisabled={false}
-                    isFavorite={null}
-                    isNoResultsOption={false}
-                    isPlaceholder={false}
-                    isSelected={false}
-                    key=".$1"
-                    keyHandler={[Function]}
-                    onClick={[Function]}
-                    sendRef={[Function]}
-                    value="Mr"
-                  >
-                    <label
-                      className="pf-c-check pf-c-select__menu-item"
-                      onKeyDown={[Function]}
-                    >
-                      <input
-                        checked={false}
-                        className="pf-c-check__input"
-                        disabled={false}
-                        id="pf-random-id-13-Mr"
-                        onChange={[Function]}
-                        type="checkbox"
-                      />
-                      <span
-                        className="pf-c-check__label"
-                      >
-                        Mr
-                      </span>
-                    </label>
-                  </SelectOption>
-                  <SelectOption
-                    className=""
-                    component="button"
-                    id="option-2"
-                    index={2}
-                    inputId=""
-                    isChecked={false}
-                    isDisabled={false}
-                    isFavorite={null}
-                    isNoResultsOption={false}
-                    isPlaceholder={false}
-                    isSelected={false}
-                    key=".$2"
-                    keyHandler={[Function]}
-                    onClick={[Function]}
-                    sendRef={[Function]}
-                    value="Mrs"
-                  >
-                    <label
-                      className="pf-c-check pf-c-select__menu-item"
-                      onKeyDown={[Function]}
-                    >
-                      <input
-                        checked={false}
-                        className="pf-c-check__input"
-                        disabled={false}
-                        id="pf-random-id-13-Mrs"
-                        onChange={[Function]}
-                        type="checkbox"
-                      />
-                      <span
-                        className="pf-c-check__label"
-                      >
-                        Mrs
-                      </span>
-                    </label>
-                  </SelectOption>
-                  <SelectOption
-                    className=""
-                    component="button"
-                    id="option-3"
-                    index={3}
-                    inputId=""
-                    isChecked={false}
-                    isDisabled={false}
-                    isFavorite={null}
-                    isNoResultsOption={false}
-                    isPlaceholder={false}
-                    isSelected={false}
-                    key=".$3"
-                    keyHandler={[Function]}
-                    onClick={[Function]}
-                    sendRef={[Function]}
-                    value="Ms"
-                  >
-                    <label
-                      className="pf-c-check pf-c-select__menu-item"
-                      onKeyDown={[Function]}
-                    >
-                      <input
-                        checked={false}
-                        className="pf-c-check__input"
-                        disabled={false}
-                        id="pf-random-id-13-Ms"
-                        onChange={[Function]}
-                        type="checkbox"
-                      />
-                      <span
-                        className="pf-c-check__label"
-                      >
-                        Ms
-                      </span>
-                    </label>
-                  </SelectOption>
-                  <SelectOption
-                    className=""
-                    component="button"
-                    id="option-4"
-                    index={4}
-                    inputId=""
-                    isChecked={false}
-                    isDisabled={false}
-                    isFavorite={null}
-                    isNoResultsOption={false}
-                    isPlaceholder={false}
-                    isSelected={false}
-                    key=".$4"
-                    keyHandler={[Function]}
-                    onClick={[Function]}
-                    sendRef={[Function]}
-                    value="Other"
-                  >
-                    <label
-                      className="pf-c-check pf-c-select__menu-item"
-                      onKeyDown={[Function]}
-                    >
-                      <input
-                        checked={false}
-                        className="pf-c-check__input"
-                        disabled={false}
-                        id="pf-random-id-13-Other"
-                        onChange={[Function]}
-                        type="checkbox"
-                      />
-                      <span
-                        className="pf-c-check__label"
-                      >
-                        Other
-                      </span>
-                    </label>
-                  </SelectOption>
-                </fieldset>
+                <input
+                  autoComplete="off"
+                  className="pf-c-form-control pf-m-search"
+                  key="inline-filter-input"
+                  onChange={[Function]}
+                  onKeyDown={[Function]}
+                  placeholder={null}
+                  type="search"
+                />
               </div>
-            </div>
-          </FocusTrap>
+              <Divider
+                key="inline-filter-divider"
+              >
+                <hr
+                  className="pf-c-divider"
+                />
+              </Divider>
+              <SelectOption
+                className=""
+                component="button"
+                id="option-1"
+                index={1}
+                inputId=""
+                isChecked={false}
+                isDisabled={false}
+                isFavorite={null}
+                isNoResultsOption={false}
+                isPlaceholder={false}
+                isSelected={false}
+                key=".$1"
+                keyHandler={[Function]}
+                onClick={[Function]}
+                sendRef={[Function]}
+                value="Mr"
+              >
+                <label
+                  className="pf-c-check pf-c-select__menu-item"
+                  onKeyDown={[Function]}
+                >
+                  <input
+                    checked={false}
+                    className="pf-c-check__input"
+                    disabled={false}
+                    id="pf-random-id-13-Mr"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  <span
+                    className="pf-c-check__label"
+                  >
+                    Mr
+                  </span>
+                </label>
+              </SelectOption>
+              <SelectOption
+                className=""
+                component="button"
+                id="option-2"
+                index={2}
+                inputId=""
+                isChecked={false}
+                isDisabled={false}
+                isFavorite={null}
+                isNoResultsOption={false}
+                isPlaceholder={false}
+                isSelected={false}
+                key=".$2"
+                keyHandler={[Function]}
+                onClick={[Function]}
+                sendRef={[Function]}
+                value="Mrs"
+              >
+                <label
+                  className="pf-c-check pf-c-select__menu-item"
+                  onKeyDown={[Function]}
+                >
+                  <input
+                    checked={false}
+                    className="pf-c-check__input"
+                    disabled={false}
+                    id="pf-random-id-13-Mrs"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  <span
+                    className="pf-c-check__label"
+                  >
+                    Mrs
+                  </span>
+                </label>
+              </SelectOption>
+              <SelectOption
+                className=""
+                component="button"
+                id="option-3"
+                index={3}
+                inputId=""
+                isChecked={false}
+                isDisabled={false}
+                isFavorite={null}
+                isNoResultsOption={false}
+                isPlaceholder={false}
+                isSelected={false}
+                key=".$3"
+                keyHandler={[Function]}
+                onClick={[Function]}
+                sendRef={[Function]}
+                value="Ms"
+              >
+                <label
+                  className="pf-c-check pf-c-select__menu-item"
+                  onKeyDown={[Function]}
+                >
+                  <input
+                    checked={false}
+                    className="pf-c-check__input"
+                    disabled={false}
+                    id="pf-random-id-13-Ms"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  <span
+                    className="pf-c-check__label"
+                  >
+                    Ms
+                  </span>
+                </label>
+              </SelectOption>
+              <SelectOption
+                className=""
+                component="button"
+                id="option-4"
+                index={4}
+                inputId=""
+                isChecked={false}
+                isDisabled={false}
+                isFavorite={null}
+                isNoResultsOption={false}
+                isPlaceholder={false}
+                isSelected={false}
+                key=".$4"
+                keyHandler={[Function]}
+                onClick={[Function]}
+                sendRef={[Function]}
+                value="Other"
+              >
+                <label
+                  className="pf-c-check pf-c-select__menu-item"
+                  onKeyDown={[Function]}
+                >
+                  <input
+                    checked={false}
+                    className="pf-c-check__input"
+                    disabled={false}
+                    id="pf-random-id-13-Other"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  <span
+                    className="pf-c-check__label"
+                  >
+                    Other
+                  </span>
+                </label>
+              </SelectOption>
+            </fieldset>
+          </div>
         </SelectMenu>
       </ForwardRef>
     </div>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5430

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: I'm not sure why we were using FocusTrap to begin with in this component. Please make sure I wasn't missing anything @kmcfaul !
