### PR TITLE
feat(TreeView): add keyboard interaction

### DIFF
--- a/packages/react-core/src/components/TreeView/TreeView.tsx
+++ b/packages/react-core/src/components/TreeView/TreeView.tsx
@@ -120,7 +120,17 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
       ))}
     </TreeViewList>
   );
-  return <>{parentItem ? treeViewList : <TreeViewRoot {...props}>{treeViewList}</TreeViewRoot>}</>;
+  return (
+    <>
+      {parentItem ? (
+        treeViewList
+      ) : (
+        <TreeViewRoot hasChecks={hasChecks} {...props}>
+          {treeViewList}
+        </TreeViewRoot>
+      )}
+    </>
+  );
 };
 
 TreeView.displayName = 'TreeView';

--- a/packages/react-core/src/components/TreeView/TreeView.tsx
+++ b/packages/react-core/src/components/TreeView/TreeView.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { css } from '@patternfly/react-styles';
-import styles from '@patternfly/react-styles/css/components/TreeView/tree-view';
 import { TreeViewList } from './TreeViewList';
 import { TreeViewListItem } from './TreeViewListItem';
+import { TreeViewRoot } from './TreeViewRoot';
 
 export interface TreeViewDataItem {
   /** Internal content of a tree view item */
@@ -121,17 +120,7 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
       ))}
     </TreeViewList>
   );
-  return (
-    <>
-      {parentItem ? (
-        treeViewList
-      ) : (
-        <div className={css(styles.treeView)} {...props}>
-          {treeViewList}
-        </div>
-      )}
-    </>
-  );
+  return <>{parentItem ? treeViewList : <TreeViewRoot {...props}>{treeViewList}</TreeViewRoot>}</>;
 };
 
 TreeView.displayName = 'TreeView';

--- a/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
+++ b/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
@@ -76,8 +76,8 @@ export const TreeViewListItem: React.FunctionComponent<TreeViewListItemProps> = 
       id={id}
       className={css(styles.treeViewListItem, isExpanded && styles.modifiers.expanded)}
       {...(isExpanded && { 'aria-expanded': 'true' })}
-      role="treeitem"
-      tabIndex={0}
+      role={children ? 'treeitem' : 'none'}
+      tabIndex={-1}
     >
       <div className={css(styles.treeViewContent)}>
         <GenerateId prefix="checkbox-id">
@@ -100,6 +100,8 @@ export const TreeViewListItem: React.FunctionComponent<TreeViewListItemProps> = 
                   onSelect && onSelect(evt, itemData, parentItem);
                 }
               }}
+              {...(!children && { role: 'treeitem' })}
+              tabIndex={-1}
             >
               {children && (
                 <ToggleComponent
@@ -110,6 +112,7 @@ export const TreeViewListItem: React.FunctionComponent<TreeViewListItemProps> = 
                     }
                   }}
                   {...(hasCheck && { 'aria-labelledby': `label-${randomId}` })}
+                  tabIndex={-1}
                 >
                   <span className={css(styles.treeViewNodeToggleIcon)}>
                     <AngleRightIcon aria-hidden="true" />
@@ -125,6 +128,7 @@ export const TreeViewListItem: React.FunctionComponent<TreeViewListItemProps> = 
                     ref={elem => elem && (elem.indeterminate = checkProps.checked === null)}
                     {...checkProps}
                     id={randomId}
+                    tabIndex={-1}
                   />
                 </span>
               )}

--- a/packages/react-core/src/components/TreeView/TreeViewRoot.tsx
+++ b/packages/react-core/src/components/TreeView/TreeViewRoot.tsx
@@ -20,7 +20,9 @@ export class TreeViewRoot extends React.Component<TreeViewRootProps> {
   }
 
   handleKeys = (event: KeyboardEvent) => {
-    event.stopImmediatePropagation();
+    if (this.treeRef.current !== (event.target as HTMLElement).closest('.pf-c-tree-view')) {
+      return;
+    }
     const activeElement = document.activeElement;
     const key = event.key;
     let moveFocus = false;

--- a/packages/react-core/src/components/TreeView/TreeViewRoot.tsx
+++ b/packages/react-core/src/components/TreeView/TreeViewRoot.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react';
+import { css } from '@patternfly/react-styles';
+import styles from '@patternfly/react-styles/css/components/TreeView/tree-view';
+
+export interface TreeViewRootProps {
+  /** Child nodes of the tree view */
+  children: React.ReactNode;
+}
+
+export class TreeViewRoot extends React.Component<TreeViewRootProps> {
+  displayName = 'TreeViewRoot';
+  private treeRef = React.createRef<HTMLDivElement>();
+
+  componentDidMount() {
+    window.addEventListener('keydown', this.handleKeys);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('keydown', this.handleKeys);
+  }
+
+  handleKeys = (event: KeyboardEvent) => {
+    event.stopImmediatePropagation();
+    const activeElement = document.activeElement;
+    const key = event.key;
+    let moveFocus = false;
+    let currentIndex = -1;
+    const treeItems = Array.from(this.treeRef.current.getElementsByClassName('pf-c-tree-view__node'));
+
+    if (key === 'Space') {
+      (document.activeElement as HTMLElement).click();
+      event.preventDefault();
+    }
+
+    if (['ArrowUp', 'ArrowDown'].includes(key)) {
+      treeItems.forEach((treeItem, index) => {
+        if (activeElement === treeItem) {
+          const increment = key === 'ArrowUp' ? -1 : 1;
+          currentIndex = index + increment;
+          while (
+            currentIndex < treeItems.length &&
+            currentIndex >= 0 &&
+            treeItems[currentIndex].classList.contains('pf-m-disabled')
+          ) {
+            currentIndex = currentIndex + increment;
+          }
+          moveFocus = true;
+          event.preventDefault();
+        }
+      });
+
+      if (moveFocus && treeItems[currentIndex]) {
+        (treeItems[currentIndex] as HTMLElement).focus();
+      }
+    }
+
+    if (['ArrowLeft', 'ArrowRight'].includes(key)) {
+      const isExpandable = activeElement.firstElementChild.classList.contains('pf-c-tree-view__node-toggle');
+      const isExpanded = activeElement.closest('li').classList.contains('pf-m-expanded');
+      if (key === 'ArrowLeft') {
+        if (isExpandable && isExpanded) {
+          (activeElement as HTMLElement).click();
+        } else {
+          const parentList = activeElement.closest('ul').parentElement;
+          if (parentList.tagName !== 'DIV') {
+            const parentButton = parentList.querySelector('button');
+            parentButton.focus();
+            (parentButton as HTMLElement).click();
+          }
+        }
+      } else {
+        if (isExpandable && !isExpanded) {
+          (activeElement as HTMLElement).click();
+          activeElement
+            .closest('li')
+            .querySelector('ul > li')
+            .querySelector('button')
+            .focus();
+        }
+      }
+      event.preventDefault();
+    }
+  };
+
+  render() {
+    const { children, ...props } = this.props;
+    return (
+      <div className={css(styles.treeView)} ref={this.treeRef} {...props}>
+        {children}
+      </div>
+    );
+  }
+}

--- a/packages/react-core/src/components/TreeView/__tests__/__snapshots__/TreeView.test.tsx.snap
+++ b/packages/react-core/src/components/TreeView/__tests__/__snapshots__/TreeView.test.tsx.snap
@@ -121,7 +121,9 @@ exports[`tree view renders active successfully 1`] = `
   }
   onSelect={[MockFunction]}
 >
-  <TreeViewRoot>
+  <TreeViewRoot
+    hasChecks={false}
+  >
     <div
       className="pf-c-tree-view"
     >
@@ -1173,7 +1175,9 @@ exports[`tree view renders badges successfully 1`] = `
   hasBadges={true}
   onSelect={[MockFunction]}
 >
-  <TreeViewRoot>
+  <TreeViewRoot
+    hasChecks={false}
+  >
     <div
       className="pf-c-tree-view"
     >
@@ -2284,7 +2288,9 @@ exports[`tree view renders basic successfully 1`] = `
   }
   onSelect={[MockFunction]}
 >
-  <TreeViewRoot>
+  <TreeViewRoot
+    hasChecks={false}
+  >
     <div
       className="pf-c-tree-view"
     >
@@ -3210,7 +3216,9 @@ exports[`tree view renders checkboxes successfully 1`] = `
   hasChecks={true}
   onSelect={[MockFunction]}
 >
-  <TreeViewRoot>
+  <TreeViewRoot
+    hasChecks={true}
+  >
     <div
       className="pf-c-tree-view"
     >
@@ -4359,7 +4367,9 @@ exports[`tree view renders icons successfully 1`] = `
   }
   onSelect={[MockFunction]}
 >
-  <TreeViewRoot>
+  <TreeViewRoot
+    hasChecks={false}
+  >
     <div
       className="pf-c-tree-view"
     >
@@ -5700,7 +5710,9 @@ exports[`tree view renders individual flag options successfully 1`] = `
   }
   onSelect={[MockFunction]}
 >
-  <TreeViewRoot>
+  <TreeViewRoot
+    hasChecks={false}
+  >
     <div
       className="pf-c-tree-view"
     >
@@ -6965,7 +6977,9 @@ exports[`tree view renders search successfully 1`] = `
     }
   }
 >
-  <TreeViewRoot>
+  <TreeViewRoot
+    hasChecks={false}
+  >
     <div
       className="pf-c-tree-view"
     >

--- a/packages/react-core/src/components/TreeView/__tests__/__snapshots__/TreeView.test.tsx.snap
+++ b/packages/react-core/src/components/TreeView/__tests__/__snapshots__/TreeView.test.tsx.snap
@@ -121,43 +121,20 @@ exports[`tree view renders active successfully 1`] = `
   }
   onSelect={[MockFunction]}
 >
-  <div
-    className="pf-c-tree-view"
-  >
-    <TreeViewList
-      isNested={false}
+  <TreeViewRoot>
+    <div
+      className="pf-c-tree-view"
     >
-      <ul
-        className="pf-c-tree-view__list"
-        role="tree"
+      <TreeViewList
+        isNested={false}
       >
-        <TreeViewListItem
-          activeItems={
-            Array [
-              Object {
-                "children": Array [
-                  Object {
-                    "id": "App1Settings",
-                    "name": "Settings",
-                  },
-                  Object {
-                    "id": "App1Current",
-                    "name": "Current",
-                  },
-                ],
-                "id": "App1",
-                "name": "Application 1",
-              },
-            ]
-          }
-          compareItems={[Function]}
-          defaultExpanded={true}
-          hasBadge={false}
-          hasCheck={false}
-          id="AppLaunch"
-          itemData={
-            Object {
-              "children": Array [
+        <ul
+          className="pf-c-tree-view__list"
+          role="tree"
+        >
+          <TreeViewListItem
+            activeItems={
+              Array [
                 Object {
                   "children": Array [
                     Object {
@@ -172,124 +149,16 @@ exports[`tree view renders active successfully 1`] = `
                   "id": "App1",
                   "name": "Application 1",
                 },
-                Object {
-                  "children": Array [
-                    Object {
-                      "id": "App2Settings",
-                      "name": "Settings",
-                    },
-                    Object {
-                      "children": Array [
-                        Object {
-                          "id": "LoadApp1",
-                          "name": "Loading App 1",
-                        },
-                        Object {
-                          "id": "LoadApp2",
-                          "name": "Loading App 2",
-                        },
-                        Object {
-                          "id": "LoadApp3",
-                          "name": "Loading App 3",
-                        },
-                      ],
-                      "id": "App2Loader",
-                      "name": "Loader",
-                    },
-                  ],
-                  "id": "App2",
-                  "name": "Application 2",
-                },
-              ],
-              "defaultExpanded": true,
-              "id": "AppLaunch",
-              "name": "ApplicationLauncher",
+              ]
             }
-          }
-          key="ApplicationLauncher"
-          name="ApplicationLauncher"
-          onSelect={[MockFunction]}
-        >
-          <li
-            aria-expanded="true"
-            className="pf-c-tree-view__list-item pf-m-expanded"
+            compareItems={[Function]}
+            defaultExpanded={true}
+            hasBadge={false}
+            hasCheck={false}
             id="AppLaunch"
-            role="treeitem"
-            tabIndex={0}
-          >
-            <div
-              className="pf-c-tree-view__content"
-            >
-              <GenerateId
-                prefix="checkbox-id"
-              >
-                <button
-                  className="pf-c-tree-view__node"
-                  onClick={[Function]}
-                >
-                  <div
-                    className="pf-c-tree-view__node-toggle"
-                    onClick={[Function]}
-                  >
-                    <span
-                      className="pf-c-tree-view__node-toggle-icon"
-                    >
-                      <AngleRightIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </AngleRightIcon>
-                    </span>
-                  </div>
-                  <span
-                    className="pf-c-tree-view__node-text"
-                  >
-                    ApplicationLauncher
-                  </span>
-                </button>
-              </GenerateId>
-            </div>
-            <TreeView
-              activeItems={
-                Array [
-                  Object {
-                    "children": Array [
-                      Object {
-                        "id": "App1Settings",
-                        "name": "Settings",
-                      },
-                      Object {
-                        "id": "App1Current",
-                        "name": "Current",
-                      },
-                    ],
-                    "id": "App1",
-                    "name": "Application 1",
-                  },
-                ]
-              }
-              data={
-                Array [
+            itemData={
+              Object {
+                "children": Array [
                   Object {
                     "children": Array [
                       Object {
@@ -332,16 +201,96 @@ exports[`tree view renders active successfully 1`] = `
                     "id": "App2",
                     "name": "Application 2",
                   },
-                ]
+                ],
+                "defaultExpanded": true,
+                "id": "AppLaunch",
+                "name": "ApplicationLauncher",
               }
-              defaultAllExpanded={false}
-              hasBadges={false}
-              hasChecks={false}
-              isNested={true}
-              onSelect={[MockFunction]}
-              parentItem={
-                Object {
-                  "children": Array [
+            }
+            key="ApplicationLauncher"
+            name="ApplicationLauncher"
+            onSelect={[MockFunction]}
+          >
+            <li
+              aria-expanded="true"
+              className="pf-c-tree-view__list-item pf-m-expanded"
+              id="AppLaunch"
+              role="treeitem"
+              tabIndex={0}
+            >
+              <div
+                className="pf-c-tree-view__content"
+              >
+                <GenerateId
+                  prefix="checkbox-id"
+                >
+                  <button
+                    className="pf-c-tree-view__node"
+                    onClick={[Function]}
+                  >
+                    <div
+                      className="pf-c-tree-view__node-toggle"
+                      onClick={[Function]}
+                    >
+                      <span
+                        className="pf-c-tree-view__node-toggle-icon"
+                      >
+                        <AngleRightIcon
+                          aria-hidden="true"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </AngleRightIcon>
+                      </span>
+                    </div>
+                    <span
+                      className="pf-c-tree-view__node-text"
+                    >
+                      ApplicationLauncher
+                    </span>
+                  </button>
+                </GenerateId>
+              </div>
+              <TreeView
+                activeItems={
+                  Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": "App1Settings",
+                          "name": "Settings",
+                        },
+                        Object {
+                          "id": "App1Current",
+                          "name": "Current",
+                        },
+                      ],
+                      "id": "App1",
+                      "name": "Application 1",
+                    },
+                  ]
+                }
+                data={
+                  Array [
                     Object {
                       "children": Array [
                         Object {
@@ -384,45 +333,16 @@ exports[`tree view renders active successfully 1`] = `
                       "id": "App2",
                       "name": "Application 2",
                     },
-                  ],
-                  "defaultExpanded": true,
-                  "id": "AppLaunch",
-                  "name": "ApplicationLauncher",
+                  ]
                 }
-              }
-            >
-              <TreeViewList
+                defaultAllExpanded={false}
+                hasBadges={false}
+                hasChecks={false}
                 isNested={true}
-              >
-                <ul
-                  className="pf-c-tree-view__list"
-                  role="group"
-                >
-                  <TreeViewListItem
-                    activeItems={
-                      Array [
-                        Object {
-                          "children": Array [
-                            Object {
-                              "id": "App1Settings",
-                              "name": "Settings",
-                            },
-                            Object {
-                              "id": "App1Current",
-                              "name": "Current",
-                            },
-                          ],
-                          "id": "App1",
-                          "name": "Application 1",
-                        },
-                      ]
-                    }
-                    compareItems={[Function]}
-                    defaultExpanded={false}
-                    hasBadge={false}
-                    hasCheck={false}
-                    id="App1"
-                    itemData={
+                onSelect={[MockFunction]}
+                parentItem={
+                  Object {
+                    "children": Array [
                       Object {
                         "children": Array [
                           Object {
@@ -436,148 +356,7 @@ exports[`tree view renders active successfully 1`] = `
                         ],
                         "id": "App1",
                         "name": "Application 1",
-                      }
-                    }
-                    key="Application 1"
-                    name="Application 1"
-                    onSelect={[MockFunction]}
-                    parentItem={
-                      Object {
-                        "children": Array [
-                          Object {
-                            "children": Array [
-                              Object {
-                                "id": "App1Settings",
-                                "name": "Settings",
-                              },
-                              Object {
-                                "id": "App1Current",
-                                "name": "Current",
-                              },
-                            ],
-                            "id": "App1",
-                            "name": "Application 1",
-                          },
-                          Object {
-                            "children": Array [
-                              Object {
-                                "id": "App2Settings",
-                                "name": "Settings",
-                              },
-                              Object {
-                                "children": Array [
-                                  Object {
-                                    "id": "LoadApp1",
-                                    "name": "Loading App 1",
-                                  },
-                                  Object {
-                                    "id": "LoadApp2",
-                                    "name": "Loading App 2",
-                                  },
-                                  Object {
-                                    "id": "LoadApp3",
-                                    "name": "Loading App 3",
-                                  },
-                                ],
-                                "id": "App2Loader",
-                                "name": "Loader",
-                              },
-                            ],
-                            "id": "App2",
-                            "name": "Application 2",
-                          },
-                        ],
-                        "defaultExpanded": true,
-                        "id": "AppLaunch",
-                        "name": "ApplicationLauncher",
-                      }
-                    }
-                  >
-                    <li
-                      className="pf-c-tree-view__list-item"
-                      id="App1"
-                      role="treeitem"
-                      tabIndex={0}
-                    >
-                      <div
-                        className="pf-c-tree-view__content"
-                      >
-                        <GenerateId
-                          prefix="checkbox-id"
-                        >
-                          <button
-                            className="pf-c-tree-view__node"
-                            onClick={[Function]}
-                          >
-                            <div
-                              className="pf-c-tree-view__node-toggle"
-                              onClick={[Function]}
-                            >
-                              <span
-                                className="pf-c-tree-view__node-toggle-icon"
-                              >
-                                <AngleRightIcon
-                                  aria-hidden="true"
-                                  color="currentColor"
-                                  noVerticalAlign={false}
-                                  size="sm"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-labelledby={null}
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    style={
-                                      Object {
-                                        "verticalAlign": "-0.125em",
-                                      }
-                                    }
-                                    viewBox="0 0 256 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                    />
-                                  </svg>
-                                </AngleRightIcon>
-                              </span>
-                            </div>
-                            <span
-                              className="pf-c-tree-view__node-text"
-                            >
-                              Application 1
-                            </span>
-                          </button>
-                        </GenerateId>
-                      </div>
-                    </li>
-                  </TreeViewListItem>
-                  <TreeViewListItem
-                    activeItems={
-                      Array [
-                        Object {
-                          "children": Array [
-                            Object {
-                              "id": "App1Settings",
-                              "name": "Settings",
-                            },
-                            Object {
-                              "id": "App1Current",
-                              "name": "Current",
-                            },
-                          ],
-                          "id": "App1",
-                          "name": "Application 1",
-                        },
-                      ]
-                    }
-                    compareItems={[Function]}
-                    defaultExpanded={false}
-                    hasBadge={false}
-                    hasCheck={false}
-                    id="App2"
-                    itemData={
+                      },
                       Object {
                         "children": Array [
                           Object {
@@ -605,14 +384,24 @@ exports[`tree view renders active successfully 1`] = `
                         ],
                         "id": "App2",
                         "name": "Application 2",
-                      }
-                    }
-                    key="Application 2"
-                    name="Application 2"
-                    onSelect={[MockFunction]}
-                    parentItem={
-                      Object {
-                        "children": Array [
+                      },
+                    ],
+                    "defaultExpanded": true,
+                    "id": "AppLaunch",
+                    "name": "ApplicationLauncher",
+                  }
+                }
+              >
+                <TreeViewList
+                  isNested={true}
+                >
+                  <ul
+                    className="pf-c-tree-view__list"
+                    role="group"
+                  >
+                    <TreeViewListItem
+                      activeItems={
+                        Array [
                           Object {
                             "children": Array [
                               Object {
@@ -627,425 +416,638 @@ exports[`tree view renders active successfully 1`] = `
                             "id": "App1",
                             "name": "Application 1",
                           },
+                        ]
+                      }
+                      compareItems={[Function]}
+                      defaultExpanded={false}
+                      hasBadge={false}
+                      hasCheck={false}
+                      id="App1"
+                      itemData={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "id": "App1Settings",
+                              "name": "Settings",
+                            },
+                            Object {
+                              "id": "App1Current",
+                              "name": "Current",
+                            },
+                          ],
+                          "id": "App1",
+                          "name": "Application 1",
+                        }
+                      }
+                      key="Application 1"
+                      name="Application 1"
+                      onSelect={[MockFunction]}
+                      parentItem={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "App1Settings",
+                                  "name": "Settings",
+                                },
+                                Object {
+                                  "id": "App1Current",
+                                  "name": "Current",
+                                },
+                              ],
+                              "id": "App1",
+                              "name": "Application 1",
+                            },
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "App2Settings",
+                                  "name": "Settings",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "id": "LoadApp1",
+                                      "name": "Loading App 1",
+                                    },
+                                    Object {
+                                      "id": "LoadApp2",
+                                      "name": "Loading App 2",
+                                    },
+                                    Object {
+                                      "id": "LoadApp3",
+                                      "name": "Loading App 3",
+                                    },
+                                  ],
+                                  "id": "App2Loader",
+                                  "name": "Loader",
+                                },
+                              ],
+                              "id": "App2",
+                              "name": "Application 2",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "id": "AppLaunch",
+                          "name": "ApplicationLauncher",
+                        }
+                      }
+                    >
+                      <li
+                        className="pf-c-tree-view__list-item"
+                        id="App1"
+                        role="treeitem"
+                        tabIndex={0}
+                      >
+                        <div
+                          className="pf-c-tree-view__content"
+                        >
+                          <GenerateId
+                            prefix="checkbox-id"
+                          >
+                            <button
+                              className="pf-c-tree-view__node"
+                              onClick={[Function]}
+                            >
+                              <div
+                                className="pf-c-tree-view__node-toggle"
+                                onClick={[Function]}
+                              >
+                                <span
+                                  className="pf-c-tree-view__node-toggle-icon"
+                                >
+                                  <AngleRightIcon
+                                    aria-hidden="true"
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                      />
+                                    </svg>
+                                  </AngleRightIcon>
+                                </span>
+                              </div>
+                              <span
+                                className="pf-c-tree-view__node-text"
+                              >
+                                Application 1
+                              </span>
+                            </button>
+                          </GenerateId>
+                        </div>
+                      </li>
+                    </TreeViewListItem>
+                    <TreeViewListItem
+                      activeItems={
+                        Array [
                           Object {
                             "children": Array [
                               Object {
-                                "id": "App2Settings",
+                                "id": "App1Settings",
                                 "name": "Settings",
                               },
                               Object {
-                                "children": Array [
-                                  Object {
-                                    "id": "LoadApp1",
-                                    "name": "Loading App 1",
-                                  },
-                                  Object {
-                                    "id": "LoadApp2",
-                                    "name": "Loading App 2",
-                                  },
-                                  Object {
-                                    "id": "LoadApp3",
-                                    "name": "Loading App 3",
-                                  },
-                                ],
-                                "id": "App2Loader",
-                                "name": "Loader",
+                                "id": "App1Current",
+                                "name": "Current",
                               },
                             ],
-                            "id": "App2",
-                            "name": "Application 2",
+                            "id": "App1",
+                            "name": "Application 1",
                           },
-                        ],
-                        "defaultExpanded": true,
-                        "id": "AppLaunch",
-                        "name": "ApplicationLauncher",
+                        ]
                       }
-                    }
-                  >
-                    <li
-                      className="pf-c-tree-view__list-item"
+                      compareItems={[Function]}
+                      defaultExpanded={false}
+                      hasBadge={false}
+                      hasCheck={false}
                       id="App2"
-                      role="treeitem"
-                      tabIndex={0}
+                      itemData={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "id": "App2Settings",
+                              "name": "Settings",
+                            },
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "LoadApp1",
+                                  "name": "Loading App 1",
+                                },
+                                Object {
+                                  "id": "LoadApp2",
+                                  "name": "Loading App 2",
+                                },
+                                Object {
+                                  "id": "LoadApp3",
+                                  "name": "Loading App 3",
+                                },
+                              ],
+                              "id": "App2Loader",
+                              "name": "Loader",
+                            },
+                          ],
+                          "id": "App2",
+                          "name": "Application 2",
+                        }
+                      }
+                      key="Application 2"
+                      name="Application 2"
+                      onSelect={[MockFunction]}
+                      parentItem={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "App1Settings",
+                                  "name": "Settings",
+                                },
+                                Object {
+                                  "id": "App1Current",
+                                  "name": "Current",
+                                },
+                              ],
+                              "id": "App1",
+                              "name": "Application 1",
+                            },
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "App2Settings",
+                                  "name": "Settings",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "id": "LoadApp1",
+                                      "name": "Loading App 1",
+                                    },
+                                    Object {
+                                      "id": "LoadApp2",
+                                      "name": "Loading App 2",
+                                    },
+                                    Object {
+                                      "id": "LoadApp3",
+                                      "name": "Loading App 3",
+                                    },
+                                  ],
+                                  "id": "App2Loader",
+                                  "name": "Loader",
+                                },
+                              ],
+                              "id": "App2",
+                              "name": "Application 2",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "id": "AppLaunch",
+                          "name": "ApplicationLauncher",
+                        }
+                      }
                     >
-                      <div
-                        className="pf-c-tree-view__content"
+                      <li
+                        className="pf-c-tree-view__list-item"
+                        id="App2"
+                        role="treeitem"
+                        tabIndex={0}
                       >
-                        <GenerateId
-                          prefix="checkbox-id"
+                        <div
+                          className="pf-c-tree-view__content"
                         >
-                          <button
-                            className="pf-c-tree-view__node"
-                            onClick={[Function]}
+                          <GenerateId
+                            prefix="checkbox-id"
                           >
-                            <div
-                              className="pf-c-tree-view__node-toggle"
+                            <button
+                              className="pf-c-tree-view__node"
                               onClick={[Function]}
                             >
-                              <span
-                                className="pf-c-tree-view__node-toggle-icon"
+                              <div
+                                className="pf-c-tree-view__node-toggle"
+                                onClick={[Function]}
                               >
-                                <AngleRightIcon
-                                  aria-hidden="true"
-                                  color="currentColor"
-                                  noVerticalAlign={false}
-                                  size="sm"
+                                <span
+                                  className="pf-c-tree-view__node-toggle-icon"
                                 >
-                                  <svg
+                                  <AngleRightIcon
                                     aria-hidden="true"
-                                    aria-labelledby={null}
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    style={
-                                      Object {
-                                        "verticalAlign": "-0.125em",
-                                      }
-                                    }
-                                    viewBox="0 0 256 512"
-                                    width="1em"
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
                                   >
-                                    <path
-                                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                    />
-                                  </svg>
-                                </AngleRightIcon>
+                                    <svg
+                                      aria-hidden="true"
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                      />
+                                    </svg>
+                                  </AngleRightIcon>
+                                </span>
+                              </div>
+                              <span
+                                className="pf-c-tree-view__node-text"
+                              >
+                                Application 2
                               </span>
-                            </div>
-                            <span
-                              className="pf-c-tree-view__node-text"
-                            >
-                              Application 2
-                            </span>
-                          </button>
-                        </GenerateId>
-                      </div>
-                    </li>
-                  </TreeViewListItem>
-                </ul>
-              </TreeViewList>
-            </TreeView>
-          </li>
-        </TreeViewListItem>
-        <TreeViewListItem
-          activeItems={
-            Array [
-              Object {
-                "children": Array [
-                  Object {
-                    "id": "App1Settings",
-                    "name": "Settings",
-                  },
-                  Object {
-                    "id": "App1Current",
-                    "name": "Current",
-                  },
-                ],
-                "id": "App1",
-                "name": "Application 1",
-              },
-            ]
-          }
-          compareItems={[Function]}
-          defaultExpanded={false}
-          hasBadge={false}
-          hasCheck={false}
-          id="Cost"
-          itemData={
-            Object {
-              "children": Array [
+                            </button>
+                          </GenerateId>
+                        </div>
+                      </li>
+                    </TreeViewListItem>
+                  </ul>
+                </TreeViewList>
+              </TreeView>
+            </li>
+          </TreeViewListItem>
+          <TreeViewListItem
+            activeItems={
+              Array [
                 Object {
                   "children": Array [
                     Object {
-                      "id": "App3Settings",
+                      "id": "App1Settings",
                       "name": "Settings",
                     },
                     Object {
-                      "id": "App3Current",
+                      "id": "App1Current",
                       "name": "Current",
                     },
                   ],
-                  "id": "App3",
-                  "name": "Application 3",
+                  "id": "App1",
+                  "name": "Application 1",
                 },
-              ],
-              "id": "Cost",
-              "name": "Cost Management",
+              ]
             }
-          }
-          key="Cost Management"
-          name="Cost Management"
-          onSelect={[MockFunction]}
-        >
-          <li
-            className="pf-c-tree-view__list-item"
+            compareItems={[Function]}
+            defaultExpanded={false}
+            hasBadge={false}
+            hasCheck={false}
             id="Cost"
-            role="treeitem"
-            tabIndex={0}
-          >
-            <div
-              className="pf-c-tree-view__content"
-            >
-              <GenerateId
-                prefix="checkbox-id"
-              >
-                <button
-                  className="pf-c-tree-view__node"
-                  onClick={[Function]}
-                >
-                  <div
-                    className="pf-c-tree-view__node-toggle"
-                    onClick={[Function]}
-                  >
-                    <span
-                      className="pf-c-tree-view__node-toggle-icon"
-                    >
-                      <AngleRightIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </AngleRightIcon>
-                    </span>
-                  </div>
-                  <span
-                    className="pf-c-tree-view__node-text"
-                  >
-                    Cost Management
-                  </span>
-                </button>
-              </GenerateId>
-            </div>
-          </li>
-        </TreeViewListItem>
-        <TreeViewListItem
-          activeItems={
-            Array [
+            itemData={
               Object {
                 "children": Array [
                   Object {
-                    "id": "App1Settings",
-                    "name": "Settings",
-                  },
-                  Object {
-                    "id": "App1Current",
-                    "name": "Current",
+                    "children": Array [
+                      Object {
+                        "id": "App3Settings",
+                        "name": "Settings",
+                      },
+                      Object {
+                        "id": "App3Current",
+                        "name": "Current",
+                      },
+                    ],
+                    "id": "App3",
+                    "name": "Application 3",
                   },
                 ],
-                "id": "App1",
-                "name": "Application 1",
-              },
-            ]
-          }
-          compareItems={[Function]}
-          defaultExpanded={false}
-          hasBadge={false}
-          hasCheck={false}
-          id="Sources"
-          itemData={
-            Object {
-              "children": Array [
+                "id": "Cost",
+                "name": "Cost Management",
+              }
+            }
+            key="Cost Management"
+            name="Cost Management"
+            onSelect={[MockFunction]}
+          >
+            <li
+              className="pf-c-tree-view__list-item"
+              id="Cost"
+              role="treeitem"
+              tabIndex={0}
+            >
+              <div
+                className="pf-c-tree-view__content"
+              >
+                <GenerateId
+                  prefix="checkbox-id"
+                >
+                  <button
+                    className="pf-c-tree-view__node"
+                    onClick={[Function]}
+                  >
+                    <div
+                      className="pf-c-tree-view__node-toggle"
+                      onClick={[Function]}
+                    >
+                      <span
+                        className="pf-c-tree-view__node-toggle-icon"
+                      >
+                        <AngleRightIcon
+                          aria-hidden="true"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </AngleRightIcon>
+                      </span>
+                    </div>
+                    <span
+                      className="pf-c-tree-view__node-text"
+                    >
+                      Cost Management
+                    </span>
+                  </button>
+                </GenerateId>
+              </div>
+            </li>
+          </TreeViewListItem>
+          <TreeViewListItem
+            activeItems={
+              Array [
                 Object {
                   "children": Array [
                     Object {
-                      "id": "App4Settings",
+                      "id": "App1Settings",
                       "name": "Settings",
                     },
+                    Object {
+                      "id": "App1Current",
+                      "name": "Current",
+                    },
                   ],
-                  "id": "App4",
-                  "name": "Application 4",
+                  "id": "App1",
+                  "name": "Application 1",
                 },
-              ],
-              "id": "Sources",
-              "name": "Sources",
+              ]
             }
-          }
-          key="Sources"
-          name="Sources"
-          onSelect={[MockFunction]}
-        >
-          <li
-            className="pf-c-tree-view__list-item"
+            compareItems={[Function]}
+            defaultExpanded={false}
+            hasBadge={false}
+            hasCheck={false}
             id="Sources"
-            role="treeitem"
-            tabIndex={0}
-          >
-            <div
-              className="pf-c-tree-view__content"
-            >
-              <GenerateId
-                prefix="checkbox-id"
-              >
-                <button
-                  className="pf-c-tree-view__node"
-                  onClick={[Function]}
-                >
-                  <div
-                    className="pf-c-tree-view__node-toggle"
-                    onClick={[Function]}
-                  >
-                    <span
-                      className="pf-c-tree-view__node-toggle-icon"
-                    >
-                      <AngleRightIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </AngleRightIcon>
-                    </span>
-                  </div>
-                  <span
-                    className="pf-c-tree-view__node-text"
-                  >
-                    Sources
-                  </span>
-                </button>
-              </GenerateId>
-            </div>
-          </li>
-        </TreeViewListItem>
-        <TreeViewListItem
-          activeItems={
-            Array [
+            itemData={
               Object {
                 "children": Array [
                   Object {
-                    "id": "App1Settings",
-                    "name": "Settings",
-                  },
-                  Object {
-                    "id": "App1Current",
-                    "name": "Current",
+                    "children": Array [
+                      Object {
+                        "id": "App4Settings",
+                        "name": "Settings",
+                      },
+                    ],
+                    "id": "App4",
+                    "name": "Application 4",
                   },
                 ],
-                "id": "App1",
-                "name": "Application 1",
-              },
-            ]
-          }
-          compareItems={[Function]}
-          defaultExpanded={false}
-          hasBadge={false}
-          hasCheck={false}
-          id="Long"
-          itemData={
-            Object {
-              "children": Array [
-                Object {
-                  "id": "App5",
-                  "name": "Application 5",
-                },
-              ],
-              "id": "Long",
-              "name": "Really really really long folder name that overflows the container it is in",
+                "id": "Sources",
+                "name": "Sources",
+              }
             }
-          }
-          key="Really really really long folder name that overflows the container it is in"
-          name="Really really really long folder name that overflows the container it is in"
-          onSelect={[MockFunction]}
-        >
-          <li
-            className="pf-c-tree-view__list-item"
-            id="Long"
-            role="treeitem"
-            tabIndex={0}
+            key="Sources"
+            name="Sources"
+            onSelect={[MockFunction]}
           >
-            <div
-              className="pf-c-tree-view__content"
+            <li
+              className="pf-c-tree-view__list-item"
+              id="Sources"
+              role="treeitem"
+              tabIndex={0}
             >
-              <GenerateId
-                prefix="checkbox-id"
+              <div
+                className="pf-c-tree-view__content"
               >
-                <button
-                  className="pf-c-tree-view__node"
-                  onClick={[Function]}
+                <GenerateId
+                  prefix="checkbox-id"
                 >
-                  <div
-                    className="pf-c-tree-view__node-toggle"
+                  <button
+                    className="pf-c-tree-view__node"
                     onClick={[Function]}
                   >
-                    <span
-                      className="pf-c-tree-view__node-toggle-icon"
+                    <div
+                      className="pf-c-tree-view__node-toggle"
+                      onClick={[Function]}
                     >
-                      <AngleRightIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
+                      <span
+                        className="pf-c-tree-view__node-toggle-icon"
                       >
-                        <svg
+                        <AngleRightIcon
                           aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 256 512"
-                          width="1em"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
                         >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </AngleRightIcon>
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </AngleRightIcon>
+                      </span>
+                    </div>
+                    <span
+                      className="pf-c-tree-view__node-text"
+                    >
+                      Sources
                     </span>
-                  </div>
-                  <span
-                    className="pf-c-tree-view__node-text"
+                  </button>
+                </GenerateId>
+              </div>
+            </li>
+          </TreeViewListItem>
+          <TreeViewListItem
+            activeItems={
+              Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "id": "App1Settings",
+                      "name": "Settings",
+                    },
+                    Object {
+                      "id": "App1Current",
+                      "name": "Current",
+                    },
+                  ],
+                  "id": "App1",
+                  "name": "Application 1",
+                },
+              ]
+            }
+            compareItems={[Function]}
+            defaultExpanded={false}
+            hasBadge={false}
+            hasCheck={false}
+            id="Long"
+            itemData={
+              Object {
+                "children": Array [
+                  Object {
+                    "id": "App5",
+                    "name": "Application 5",
+                  },
+                ],
+                "id": "Long",
+                "name": "Really really really long folder name that overflows the container it is in",
+              }
+            }
+            key="Really really really long folder name that overflows the container it is in"
+            name="Really really really long folder name that overflows the container it is in"
+            onSelect={[MockFunction]}
+          >
+            <li
+              className="pf-c-tree-view__list-item"
+              id="Long"
+              role="treeitem"
+              tabIndex={0}
+            >
+              <div
+                className="pf-c-tree-view__content"
+              >
+                <GenerateId
+                  prefix="checkbox-id"
+                >
+                  <button
+                    className="pf-c-tree-view__node"
+                    onClick={[Function]}
                   >
-                    Really really really long folder name that overflows the container it is in
-                  </span>
-                </button>
-              </GenerateId>
-            </div>
-          </li>
-        </TreeViewListItem>
-      </ul>
-    </TreeViewList>
-  </div>
+                    <div
+                      className="pf-c-tree-view__node-toggle"
+                      onClick={[Function]}
+                    >
+                      <span
+                        className="pf-c-tree-view__node-toggle-icon"
+                      >
+                        <AngleRightIcon
+                          aria-hidden="true"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </AngleRightIcon>
+                      </span>
+                    </div>
+                    <span
+                      className="pf-c-tree-view__node-text"
+                    >
+                      Really really really long folder name that overflows the container it is in
+                    </span>
+                  </button>
+                </GenerateId>
+              </div>
+            </li>
+          </TreeViewListItem>
+        </ul>
+      </TreeViewList>
+    </div>
+  </TreeViewRoot>
 </TreeView>
 `;
 
@@ -1171,43 +1173,20 @@ exports[`tree view renders badges successfully 1`] = `
   hasBadges={true}
   onSelect={[MockFunction]}
 >
-  <div
-    className="pf-c-tree-view"
-  >
-    <TreeViewList
-      isNested={false}
+  <TreeViewRoot>
+    <div
+      className="pf-c-tree-view"
     >
-      <ul
-        className="pf-c-tree-view__list"
-        role="tree"
+      <TreeViewList
+        isNested={false}
       >
-        <TreeViewListItem
-          activeItems={
-            Array [
-              Object {
-                "children": Array [
-                  Object {
-                    "id": "App1Settings",
-                    "name": "Settings",
-                  },
-                  Object {
-                    "id": "App1Current",
-                    "name": "Current",
-                  },
-                ],
-                "id": "App1",
-                "name": "Application 1",
-              },
-            ]
-          }
-          compareItems={[Function]}
-          defaultExpanded={true}
-          hasBadge={true}
-          hasCheck={false}
-          id="AppLaunch"
-          itemData={
-            Object {
-              "children": Array [
+        <ul
+          className="pf-c-tree-view__list"
+          role="tree"
+        >
+          <TreeViewListItem
+            activeItems={
+              Array [
                 Object {
                   "children": Array [
                     Object {
@@ -1222,137 +1201,16 @@ exports[`tree view renders badges successfully 1`] = `
                   "id": "App1",
                   "name": "Application 1",
                 },
-                Object {
-                  "children": Array [
-                    Object {
-                      "id": "App2Settings",
-                      "name": "Settings",
-                    },
-                    Object {
-                      "children": Array [
-                        Object {
-                          "id": "LoadApp1",
-                          "name": "Loading App 1",
-                        },
-                        Object {
-                          "id": "LoadApp2",
-                          "name": "Loading App 2",
-                        },
-                        Object {
-                          "id": "LoadApp3",
-                          "name": "Loading App 3",
-                        },
-                      ],
-                      "id": "App2Loader",
-                      "name": "Loader",
-                    },
-                  ],
-                  "id": "App2",
-                  "name": "Application 2",
-                },
-              ],
-              "defaultExpanded": true,
-              "id": "AppLaunch",
-              "name": "ApplicationLauncher",
+              ]
             }
-          }
-          key="ApplicationLauncher"
-          name="ApplicationLauncher"
-          onSelect={[MockFunction]}
-        >
-          <li
-            aria-expanded="true"
-            className="pf-c-tree-view__list-item pf-m-expanded"
+            compareItems={[Function]}
+            defaultExpanded={true}
+            hasBadge={true}
+            hasCheck={false}
             id="AppLaunch"
-            role="treeitem"
-            tabIndex={0}
-          >
-            <div
-              className="pf-c-tree-view__content"
-            >
-              <GenerateId
-                prefix="checkbox-id"
-              >
-                <button
-                  className="pf-c-tree-view__node"
-                  onClick={[Function]}
-                >
-                  <div
-                    className="pf-c-tree-view__node-toggle"
-                    onClick={[Function]}
-                  >
-                    <span
-                      className="pf-c-tree-view__node-toggle-icon"
-                    >
-                      <AngleRightIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </AngleRightIcon>
-                    </span>
-                  </div>
-                  <span
-                    className="pf-c-tree-view__node-text"
-                  >
-                    ApplicationLauncher
-                  </span>
-                  <span
-                    className="pf-c-tree-view__node-count"
-                  >
-                    <Badge
-                      isRead={true}
-                    >
-                      <span
-                        className="pf-c-badge pf-m-read"
-                      >
-                        2
-                      </span>
-                    </Badge>
-                  </span>
-                </button>
-              </GenerateId>
-            </div>
-            <TreeView
-              activeItems={
-                Array [
-                  Object {
-                    "children": Array [
-                      Object {
-                        "id": "App1Settings",
-                        "name": "Settings",
-                      },
-                      Object {
-                        "id": "App1Current",
-                        "name": "Current",
-                      },
-                    ],
-                    "id": "App1",
-                    "name": "Application 1",
-                  },
-                ]
-              }
-              data={
-                Array [
+            itemData={
+              Object {
+                "children": Array [
                   Object {
                     "children": Array [
                       Object {
@@ -1395,16 +1253,109 @@ exports[`tree view renders badges successfully 1`] = `
                     "id": "App2",
                     "name": "Application 2",
                   },
-                ]
+                ],
+                "defaultExpanded": true,
+                "id": "AppLaunch",
+                "name": "ApplicationLauncher",
               }
-              defaultAllExpanded={false}
-              hasBadges={true}
-              hasChecks={false}
-              isNested={true}
-              onSelect={[MockFunction]}
-              parentItem={
-                Object {
-                  "children": Array [
+            }
+            key="ApplicationLauncher"
+            name="ApplicationLauncher"
+            onSelect={[MockFunction]}
+          >
+            <li
+              aria-expanded="true"
+              className="pf-c-tree-view__list-item pf-m-expanded"
+              id="AppLaunch"
+              role="treeitem"
+              tabIndex={0}
+            >
+              <div
+                className="pf-c-tree-view__content"
+              >
+                <GenerateId
+                  prefix="checkbox-id"
+                >
+                  <button
+                    className="pf-c-tree-view__node"
+                    onClick={[Function]}
+                  >
+                    <div
+                      className="pf-c-tree-view__node-toggle"
+                      onClick={[Function]}
+                    >
+                      <span
+                        className="pf-c-tree-view__node-toggle-icon"
+                      >
+                        <AngleRightIcon
+                          aria-hidden="true"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </AngleRightIcon>
+                      </span>
+                    </div>
+                    <span
+                      className="pf-c-tree-view__node-text"
+                    >
+                      ApplicationLauncher
+                    </span>
+                    <span
+                      className="pf-c-tree-view__node-count"
+                    >
+                      <Badge
+                        isRead={true}
+                      >
+                        <span
+                          className="pf-c-badge pf-m-read"
+                        >
+                          2
+                        </span>
+                      </Badge>
+                    </span>
+                  </button>
+                </GenerateId>
+              </div>
+              <TreeView
+                activeItems={
+                  Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": "App1Settings",
+                          "name": "Settings",
+                        },
+                        Object {
+                          "id": "App1Current",
+                          "name": "Current",
+                        },
+                      ],
+                      "id": "App1",
+                      "name": "Application 1",
+                    },
+                  ]
+                }
+                data={
+                  Array [
                     Object {
                       "children": Array [
                         Object {
@@ -1447,45 +1398,16 @@ exports[`tree view renders badges successfully 1`] = `
                       "id": "App2",
                       "name": "Application 2",
                     },
-                  ],
-                  "defaultExpanded": true,
-                  "id": "AppLaunch",
-                  "name": "ApplicationLauncher",
+                  ]
                 }
-              }
-            >
-              <TreeViewList
+                defaultAllExpanded={false}
+                hasBadges={true}
+                hasChecks={false}
                 isNested={true}
-              >
-                <ul
-                  className="pf-c-tree-view__list"
-                  role="group"
-                >
-                  <TreeViewListItem
-                    activeItems={
-                      Array [
-                        Object {
-                          "children": Array [
-                            Object {
-                              "id": "App1Settings",
-                              "name": "Settings",
-                            },
-                            Object {
-                              "id": "App1Current",
-                              "name": "Current",
-                            },
-                          ],
-                          "id": "App1",
-                          "name": "Application 1",
-                        },
-                      ]
-                    }
-                    compareItems={[Function]}
-                    defaultExpanded={false}
-                    hasBadge={true}
-                    hasCheck={false}
-                    id="App1"
-                    itemData={
+                onSelect={[MockFunction]}
+                parentItem={
+                  Object {
+                    "children": Array [
                       Object {
                         "children": Array [
                           Object {
@@ -1499,161 +1421,7 @@ exports[`tree view renders badges successfully 1`] = `
                         ],
                         "id": "App1",
                         "name": "Application 1",
-                      }
-                    }
-                    key="Application 1"
-                    name="Application 1"
-                    onSelect={[MockFunction]}
-                    parentItem={
-                      Object {
-                        "children": Array [
-                          Object {
-                            "children": Array [
-                              Object {
-                                "id": "App1Settings",
-                                "name": "Settings",
-                              },
-                              Object {
-                                "id": "App1Current",
-                                "name": "Current",
-                              },
-                            ],
-                            "id": "App1",
-                            "name": "Application 1",
-                          },
-                          Object {
-                            "children": Array [
-                              Object {
-                                "id": "App2Settings",
-                                "name": "Settings",
-                              },
-                              Object {
-                                "children": Array [
-                                  Object {
-                                    "id": "LoadApp1",
-                                    "name": "Loading App 1",
-                                  },
-                                  Object {
-                                    "id": "LoadApp2",
-                                    "name": "Loading App 2",
-                                  },
-                                  Object {
-                                    "id": "LoadApp3",
-                                    "name": "Loading App 3",
-                                  },
-                                ],
-                                "id": "App2Loader",
-                                "name": "Loader",
-                              },
-                            ],
-                            "id": "App2",
-                            "name": "Application 2",
-                          },
-                        ],
-                        "defaultExpanded": true,
-                        "id": "AppLaunch",
-                        "name": "ApplicationLauncher",
-                      }
-                    }
-                  >
-                    <li
-                      className="pf-c-tree-view__list-item"
-                      id="App1"
-                      role="treeitem"
-                      tabIndex={0}
-                    >
-                      <div
-                        className="pf-c-tree-view__content"
-                      >
-                        <GenerateId
-                          prefix="checkbox-id"
-                        >
-                          <button
-                            className="pf-c-tree-view__node"
-                            onClick={[Function]}
-                          >
-                            <div
-                              className="pf-c-tree-view__node-toggle"
-                              onClick={[Function]}
-                            >
-                              <span
-                                className="pf-c-tree-view__node-toggle-icon"
-                              >
-                                <AngleRightIcon
-                                  aria-hidden="true"
-                                  color="currentColor"
-                                  noVerticalAlign={false}
-                                  size="sm"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-labelledby={null}
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    style={
-                                      Object {
-                                        "verticalAlign": "-0.125em",
-                                      }
-                                    }
-                                    viewBox="0 0 256 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                    />
-                                  </svg>
-                                </AngleRightIcon>
-                              </span>
-                            </div>
-                            <span
-                              className="pf-c-tree-view__node-text"
-                            >
-                              Application 1
-                            </span>
-                            <span
-                              className="pf-c-tree-view__node-count"
-                            >
-                              <Badge
-                                isRead={true}
-                              >
-                                <span
-                                  className="pf-c-badge pf-m-read"
-                                >
-                                  2
-                                </span>
-                              </Badge>
-                            </span>
-                          </button>
-                        </GenerateId>
-                      </div>
-                    </li>
-                  </TreeViewListItem>
-                  <TreeViewListItem
-                    activeItems={
-                      Array [
-                        Object {
-                          "children": Array [
-                            Object {
-                              "id": "App1Settings",
-                              "name": "Settings",
-                            },
-                            Object {
-                              "id": "App1Current",
-                              "name": "Current",
-                            },
-                          ],
-                          "id": "App1",
-                          "name": "Application 1",
-                        },
-                      ]
-                    }
-                    compareItems={[Function]}
-                    defaultExpanded={false}
-                    hasBadge={true}
-                    hasCheck={false}
-                    id="App2"
-                    itemData={
+                      },
                       Object {
                         "children": Array [
                           Object {
@@ -1681,14 +1449,24 @@ exports[`tree view renders badges successfully 1`] = `
                         ],
                         "id": "App2",
                         "name": "Application 2",
-                      }
-                    }
-                    key="Application 2"
-                    name="Application 2"
-                    onSelect={[MockFunction]}
-                    parentItem={
-                      Object {
-                        "children": Array [
+                      },
+                    ],
+                    "defaultExpanded": true,
+                    "id": "AppLaunch",
+                    "name": "ApplicationLauncher",
+                  }
+                }
+              >
+                <TreeViewList
+                  isNested={true}
+                >
+                  <ul
+                    className="pf-c-tree-view__list"
+                    role="group"
+                  >
+                    <TreeViewListItem
+                      activeItems={
+                        Array [
                           Object {
                             "children": Array [
                               Object {
@@ -1703,477 +1481,703 @@ exports[`tree view renders badges successfully 1`] = `
                             "id": "App1",
                             "name": "Application 1",
                           },
+                        ]
+                      }
+                      compareItems={[Function]}
+                      defaultExpanded={false}
+                      hasBadge={true}
+                      hasCheck={false}
+                      id="App1"
+                      itemData={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "id": "App1Settings",
+                              "name": "Settings",
+                            },
+                            Object {
+                              "id": "App1Current",
+                              "name": "Current",
+                            },
+                          ],
+                          "id": "App1",
+                          "name": "Application 1",
+                        }
+                      }
+                      key="Application 1"
+                      name="Application 1"
+                      onSelect={[MockFunction]}
+                      parentItem={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "App1Settings",
+                                  "name": "Settings",
+                                },
+                                Object {
+                                  "id": "App1Current",
+                                  "name": "Current",
+                                },
+                              ],
+                              "id": "App1",
+                              "name": "Application 1",
+                            },
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "App2Settings",
+                                  "name": "Settings",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "id": "LoadApp1",
+                                      "name": "Loading App 1",
+                                    },
+                                    Object {
+                                      "id": "LoadApp2",
+                                      "name": "Loading App 2",
+                                    },
+                                    Object {
+                                      "id": "LoadApp3",
+                                      "name": "Loading App 3",
+                                    },
+                                  ],
+                                  "id": "App2Loader",
+                                  "name": "Loader",
+                                },
+                              ],
+                              "id": "App2",
+                              "name": "Application 2",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "id": "AppLaunch",
+                          "name": "ApplicationLauncher",
+                        }
+                      }
+                    >
+                      <li
+                        className="pf-c-tree-view__list-item"
+                        id="App1"
+                        role="treeitem"
+                        tabIndex={0}
+                      >
+                        <div
+                          className="pf-c-tree-view__content"
+                        >
+                          <GenerateId
+                            prefix="checkbox-id"
+                          >
+                            <button
+                              className="pf-c-tree-view__node"
+                              onClick={[Function]}
+                            >
+                              <div
+                                className="pf-c-tree-view__node-toggle"
+                                onClick={[Function]}
+                              >
+                                <span
+                                  className="pf-c-tree-view__node-toggle-icon"
+                                >
+                                  <AngleRightIcon
+                                    aria-hidden="true"
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                      />
+                                    </svg>
+                                  </AngleRightIcon>
+                                </span>
+                              </div>
+                              <span
+                                className="pf-c-tree-view__node-text"
+                              >
+                                Application 1
+                              </span>
+                              <span
+                                className="pf-c-tree-view__node-count"
+                              >
+                                <Badge
+                                  isRead={true}
+                                >
+                                  <span
+                                    className="pf-c-badge pf-m-read"
+                                  >
+                                    2
+                                  </span>
+                                </Badge>
+                              </span>
+                            </button>
+                          </GenerateId>
+                        </div>
+                      </li>
+                    </TreeViewListItem>
+                    <TreeViewListItem
+                      activeItems={
+                        Array [
                           Object {
                             "children": Array [
                               Object {
-                                "id": "App2Settings",
+                                "id": "App1Settings",
                                 "name": "Settings",
                               },
                               Object {
-                                "children": Array [
-                                  Object {
-                                    "id": "LoadApp1",
-                                    "name": "Loading App 1",
-                                  },
-                                  Object {
-                                    "id": "LoadApp2",
-                                    "name": "Loading App 2",
-                                  },
-                                  Object {
-                                    "id": "LoadApp3",
-                                    "name": "Loading App 3",
-                                  },
-                                ],
-                                "id": "App2Loader",
-                                "name": "Loader",
+                                "id": "App1Current",
+                                "name": "Current",
                               },
                             ],
-                            "id": "App2",
-                            "name": "Application 2",
+                            "id": "App1",
+                            "name": "Application 1",
                           },
-                        ],
-                        "defaultExpanded": true,
-                        "id": "AppLaunch",
-                        "name": "ApplicationLauncher",
+                        ]
                       }
-                    }
-                  >
-                    <li
-                      className="pf-c-tree-view__list-item"
+                      compareItems={[Function]}
+                      defaultExpanded={false}
+                      hasBadge={true}
+                      hasCheck={false}
                       id="App2"
-                      role="treeitem"
-                      tabIndex={0}
+                      itemData={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "id": "App2Settings",
+                              "name": "Settings",
+                            },
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "LoadApp1",
+                                  "name": "Loading App 1",
+                                },
+                                Object {
+                                  "id": "LoadApp2",
+                                  "name": "Loading App 2",
+                                },
+                                Object {
+                                  "id": "LoadApp3",
+                                  "name": "Loading App 3",
+                                },
+                              ],
+                              "id": "App2Loader",
+                              "name": "Loader",
+                            },
+                          ],
+                          "id": "App2",
+                          "name": "Application 2",
+                        }
+                      }
+                      key="Application 2"
+                      name="Application 2"
+                      onSelect={[MockFunction]}
+                      parentItem={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "App1Settings",
+                                  "name": "Settings",
+                                },
+                                Object {
+                                  "id": "App1Current",
+                                  "name": "Current",
+                                },
+                              ],
+                              "id": "App1",
+                              "name": "Application 1",
+                            },
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "App2Settings",
+                                  "name": "Settings",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "id": "LoadApp1",
+                                      "name": "Loading App 1",
+                                    },
+                                    Object {
+                                      "id": "LoadApp2",
+                                      "name": "Loading App 2",
+                                    },
+                                    Object {
+                                      "id": "LoadApp3",
+                                      "name": "Loading App 3",
+                                    },
+                                  ],
+                                  "id": "App2Loader",
+                                  "name": "Loader",
+                                },
+                              ],
+                              "id": "App2",
+                              "name": "Application 2",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "id": "AppLaunch",
+                          "name": "ApplicationLauncher",
+                        }
+                      }
                     >
-                      <div
-                        className="pf-c-tree-view__content"
+                      <li
+                        className="pf-c-tree-view__list-item"
+                        id="App2"
+                        role="treeitem"
+                        tabIndex={0}
                       >
-                        <GenerateId
-                          prefix="checkbox-id"
+                        <div
+                          className="pf-c-tree-view__content"
                         >
-                          <button
-                            className="pf-c-tree-view__node"
-                            onClick={[Function]}
+                          <GenerateId
+                            prefix="checkbox-id"
                           >
-                            <div
-                              className="pf-c-tree-view__node-toggle"
+                            <button
+                              className="pf-c-tree-view__node"
                               onClick={[Function]}
                             >
-                              <span
-                                className="pf-c-tree-view__node-toggle-icon"
-                              >
-                                <AngleRightIcon
-                                  aria-hidden="true"
-                                  color="currentColor"
-                                  noVerticalAlign={false}
-                                  size="sm"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-labelledby={null}
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    style={
-                                      Object {
-                                        "verticalAlign": "-0.125em",
-                                      }
-                                    }
-                                    viewBox="0 0 256 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                    />
-                                  </svg>
-                                </AngleRightIcon>
-                              </span>
-                            </div>
-                            <span
-                              className="pf-c-tree-view__node-text"
-                            >
-                              Application 2
-                            </span>
-                            <span
-                              className="pf-c-tree-view__node-count"
-                            >
-                              <Badge
-                                isRead={true}
+                              <div
+                                className="pf-c-tree-view__node-toggle"
+                                onClick={[Function]}
                               >
                                 <span
-                                  className="pf-c-badge pf-m-read"
+                                  className="pf-c-tree-view__node-toggle-icon"
                                 >
-                                  2
+                                  <AngleRightIcon
+                                    aria-hidden="true"
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                      />
+                                    </svg>
+                                  </AngleRightIcon>
                                 </span>
-                              </Badge>
-                            </span>
-                          </button>
-                        </GenerateId>
-                      </div>
-                    </li>
-                  </TreeViewListItem>
-                </ul>
-              </TreeViewList>
-            </TreeView>
-          </li>
-        </TreeViewListItem>
-        <TreeViewListItem
-          activeItems={
-            Array [
-              Object {
-                "children": Array [
-                  Object {
-                    "id": "App1Settings",
-                    "name": "Settings",
-                  },
-                  Object {
-                    "id": "App1Current",
-                    "name": "Current",
-                  },
-                ],
-                "id": "App1",
-                "name": "Application 1",
-              },
-            ]
-          }
-          compareItems={[Function]}
-          defaultExpanded={false}
-          hasBadge={true}
-          hasCheck={false}
-          id="Cost"
-          itemData={
-            Object {
-              "children": Array [
+                              </div>
+                              <span
+                                className="pf-c-tree-view__node-text"
+                              >
+                                Application 2
+                              </span>
+                              <span
+                                className="pf-c-tree-view__node-count"
+                              >
+                                <Badge
+                                  isRead={true}
+                                >
+                                  <span
+                                    className="pf-c-badge pf-m-read"
+                                  >
+                                    2
+                                  </span>
+                                </Badge>
+                              </span>
+                            </button>
+                          </GenerateId>
+                        </div>
+                      </li>
+                    </TreeViewListItem>
+                  </ul>
+                </TreeViewList>
+              </TreeView>
+            </li>
+          </TreeViewListItem>
+          <TreeViewListItem
+            activeItems={
+              Array [
                 Object {
                   "children": Array [
                     Object {
-                      "id": "App3Settings",
+                      "id": "App1Settings",
                       "name": "Settings",
                     },
                     Object {
-                      "id": "App3Current",
+                      "id": "App1Current",
                       "name": "Current",
                     },
                   ],
-                  "id": "App3",
-                  "name": "Application 3",
+                  "id": "App1",
+                  "name": "Application 1",
                 },
-              ],
-              "id": "Cost",
-              "name": "Cost Management",
+              ]
             }
-          }
-          key="Cost Management"
-          name="Cost Management"
-          onSelect={[MockFunction]}
-        >
-          <li
-            className="pf-c-tree-view__list-item"
+            compareItems={[Function]}
+            defaultExpanded={false}
+            hasBadge={true}
+            hasCheck={false}
             id="Cost"
-            role="treeitem"
-            tabIndex={0}
-          >
-            <div
-              className="pf-c-tree-view__content"
-            >
-              <GenerateId
-                prefix="checkbox-id"
-              >
-                <button
-                  className="pf-c-tree-view__node"
-                  onClick={[Function]}
-                >
-                  <div
-                    className="pf-c-tree-view__node-toggle"
-                    onClick={[Function]}
-                  >
-                    <span
-                      className="pf-c-tree-view__node-toggle-icon"
-                    >
-                      <AngleRightIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </AngleRightIcon>
-                    </span>
-                  </div>
-                  <span
-                    className="pf-c-tree-view__node-text"
-                  >
-                    Cost Management
-                  </span>
-                  <span
-                    className="pf-c-tree-view__node-count"
-                  >
-                    <Badge
-                      isRead={true}
-                    >
-                      <span
-                        className="pf-c-badge pf-m-read"
-                      >
-                        1
-                      </span>
-                    </Badge>
-                  </span>
-                </button>
-              </GenerateId>
-            </div>
-          </li>
-        </TreeViewListItem>
-        <TreeViewListItem
-          activeItems={
-            Array [
+            itemData={
               Object {
                 "children": Array [
                   Object {
-                    "id": "App1Settings",
-                    "name": "Settings",
-                  },
-                  Object {
-                    "id": "App1Current",
-                    "name": "Current",
+                    "children": Array [
+                      Object {
+                        "id": "App3Settings",
+                        "name": "Settings",
+                      },
+                      Object {
+                        "id": "App3Current",
+                        "name": "Current",
+                      },
+                    ],
+                    "id": "App3",
+                    "name": "Application 3",
                   },
                 ],
-                "id": "App1",
-                "name": "Application 1",
-              },
-            ]
-          }
-          compareItems={[Function]}
-          defaultExpanded={false}
-          hasBadge={true}
-          hasCheck={false}
-          id="Sources"
-          itemData={
-            Object {
-              "children": Array [
+                "id": "Cost",
+                "name": "Cost Management",
+              }
+            }
+            key="Cost Management"
+            name="Cost Management"
+            onSelect={[MockFunction]}
+          >
+            <li
+              className="pf-c-tree-view__list-item"
+              id="Cost"
+              role="treeitem"
+              tabIndex={0}
+            >
+              <div
+                className="pf-c-tree-view__content"
+              >
+                <GenerateId
+                  prefix="checkbox-id"
+                >
+                  <button
+                    className="pf-c-tree-view__node"
+                    onClick={[Function]}
+                  >
+                    <div
+                      className="pf-c-tree-view__node-toggle"
+                      onClick={[Function]}
+                    >
+                      <span
+                        className="pf-c-tree-view__node-toggle-icon"
+                      >
+                        <AngleRightIcon
+                          aria-hidden="true"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </AngleRightIcon>
+                      </span>
+                    </div>
+                    <span
+                      className="pf-c-tree-view__node-text"
+                    >
+                      Cost Management
+                    </span>
+                    <span
+                      className="pf-c-tree-view__node-count"
+                    >
+                      <Badge
+                        isRead={true}
+                      >
+                        <span
+                          className="pf-c-badge pf-m-read"
+                        >
+                          1
+                        </span>
+                      </Badge>
+                    </span>
+                  </button>
+                </GenerateId>
+              </div>
+            </li>
+          </TreeViewListItem>
+          <TreeViewListItem
+            activeItems={
+              Array [
                 Object {
                   "children": Array [
                     Object {
-                      "id": "App4Settings",
+                      "id": "App1Settings",
                       "name": "Settings",
                     },
+                    Object {
+                      "id": "App1Current",
+                      "name": "Current",
+                    },
                   ],
-                  "id": "App4",
-                  "name": "Application 4",
+                  "id": "App1",
+                  "name": "Application 1",
                 },
-              ],
-              "id": "Sources",
-              "name": "Sources",
+              ]
             }
-          }
-          key="Sources"
-          name="Sources"
-          onSelect={[MockFunction]}
-        >
-          <li
-            className="pf-c-tree-view__list-item"
+            compareItems={[Function]}
+            defaultExpanded={false}
+            hasBadge={true}
+            hasCheck={false}
             id="Sources"
-            role="treeitem"
-            tabIndex={0}
-          >
-            <div
-              className="pf-c-tree-view__content"
-            >
-              <GenerateId
-                prefix="checkbox-id"
-              >
-                <button
-                  className="pf-c-tree-view__node"
-                  onClick={[Function]}
-                >
-                  <div
-                    className="pf-c-tree-view__node-toggle"
-                    onClick={[Function]}
-                  >
-                    <span
-                      className="pf-c-tree-view__node-toggle-icon"
-                    >
-                      <AngleRightIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </AngleRightIcon>
-                    </span>
-                  </div>
-                  <span
-                    className="pf-c-tree-view__node-text"
-                  >
-                    Sources
-                  </span>
-                  <span
-                    className="pf-c-tree-view__node-count"
-                  >
-                    <Badge
-                      isRead={true}
-                    >
-                      <span
-                        className="pf-c-badge pf-m-read"
-                      >
-                        1
-                      </span>
-                    </Badge>
-                  </span>
-                </button>
-              </GenerateId>
-            </div>
-          </li>
-        </TreeViewListItem>
-        <TreeViewListItem
-          activeItems={
-            Array [
+            itemData={
               Object {
                 "children": Array [
                   Object {
-                    "id": "App1Settings",
-                    "name": "Settings",
-                  },
-                  Object {
-                    "id": "App1Current",
-                    "name": "Current",
+                    "children": Array [
+                      Object {
+                        "id": "App4Settings",
+                        "name": "Settings",
+                      },
+                    ],
+                    "id": "App4",
+                    "name": "Application 4",
                   },
                 ],
-                "id": "App1",
-                "name": "Application 1",
-              },
-            ]
-          }
-          compareItems={[Function]}
-          defaultExpanded={false}
-          hasBadge={true}
-          hasCheck={false}
-          id="Long"
-          itemData={
-            Object {
-              "children": Array [
-                Object {
-                  "id": "App5",
-                  "name": "Application 5",
-                },
-              ],
-              "id": "Long",
-              "name": "Really really really long folder name that overflows the container it is in",
+                "id": "Sources",
+                "name": "Sources",
+              }
             }
-          }
-          key="Really really really long folder name that overflows the container it is in"
-          name="Really really really long folder name that overflows the container it is in"
-          onSelect={[MockFunction]}
-        >
-          <li
-            className="pf-c-tree-view__list-item"
-            id="Long"
-            role="treeitem"
-            tabIndex={0}
+            key="Sources"
+            name="Sources"
+            onSelect={[MockFunction]}
           >
-            <div
-              className="pf-c-tree-view__content"
+            <li
+              className="pf-c-tree-view__list-item"
+              id="Sources"
+              role="treeitem"
+              tabIndex={0}
             >
-              <GenerateId
-                prefix="checkbox-id"
+              <div
+                className="pf-c-tree-view__content"
               >
-                <button
-                  className="pf-c-tree-view__node"
-                  onClick={[Function]}
+                <GenerateId
+                  prefix="checkbox-id"
                 >
-                  <div
-                    className="pf-c-tree-view__node-toggle"
+                  <button
+                    className="pf-c-tree-view__node"
                     onClick={[Function]}
                   >
-                    <span
-                      className="pf-c-tree-view__node-toggle-icon"
-                    >
-                      <AngleRightIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </AngleRightIcon>
-                    </span>
-                  </div>
-                  <span
-                    className="pf-c-tree-view__node-text"
-                  >
-                    Really really really long folder name that overflows the container it is in
-                  </span>
-                  <span
-                    className="pf-c-tree-view__node-count"
-                  >
-                    <Badge
-                      isRead={true}
+                    <div
+                      className="pf-c-tree-view__node-toggle"
+                      onClick={[Function]}
                     >
                       <span
-                        className="pf-c-badge pf-m-read"
+                        className="pf-c-tree-view__node-toggle-icon"
                       >
-                        1
+                        <AngleRightIcon
+                          aria-hidden="true"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </AngleRightIcon>
                       </span>
-                    </Badge>
-                  </span>
-                </button>
-              </GenerateId>
-            </div>
-          </li>
-        </TreeViewListItem>
-      </ul>
-    </TreeViewList>
-  </div>
+                    </div>
+                    <span
+                      className="pf-c-tree-view__node-text"
+                    >
+                      Sources
+                    </span>
+                    <span
+                      className="pf-c-tree-view__node-count"
+                    >
+                      <Badge
+                        isRead={true}
+                      >
+                        <span
+                          className="pf-c-badge pf-m-read"
+                        >
+                          1
+                        </span>
+                      </Badge>
+                    </span>
+                  </button>
+                </GenerateId>
+              </div>
+            </li>
+          </TreeViewListItem>
+          <TreeViewListItem
+            activeItems={
+              Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "id": "App1Settings",
+                      "name": "Settings",
+                    },
+                    Object {
+                      "id": "App1Current",
+                      "name": "Current",
+                    },
+                  ],
+                  "id": "App1",
+                  "name": "Application 1",
+                },
+              ]
+            }
+            compareItems={[Function]}
+            defaultExpanded={false}
+            hasBadge={true}
+            hasCheck={false}
+            id="Long"
+            itemData={
+              Object {
+                "children": Array [
+                  Object {
+                    "id": "App5",
+                    "name": "Application 5",
+                  },
+                ],
+                "id": "Long",
+                "name": "Really really really long folder name that overflows the container it is in",
+              }
+            }
+            key="Really really really long folder name that overflows the container it is in"
+            name="Really really really long folder name that overflows the container it is in"
+            onSelect={[MockFunction]}
+          >
+            <li
+              className="pf-c-tree-view__list-item"
+              id="Long"
+              role="treeitem"
+              tabIndex={0}
+            >
+              <div
+                className="pf-c-tree-view__content"
+              >
+                <GenerateId
+                  prefix="checkbox-id"
+                >
+                  <button
+                    className="pf-c-tree-view__node"
+                    onClick={[Function]}
+                  >
+                    <div
+                      className="pf-c-tree-view__node-toggle"
+                      onClick={[Function]}
+                    >
+                      <span
+                        className="pf-c-tree-view__node-toggle-icon"
+                      >
+                        <AngleRightIcon
+                          aria-hidden="true"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </AngleRightIcon>
+                      </span>
+                    </div>
+                    <span
+                      className="pf-c-tree-view__node-text"
+                    >
+                      Really really really long folder name that overflows the container it is in
+                    </span>
+                    <span
+                      className="pf-c-tree-view__node-count"
+                    >
+                      <Badge
+                        isRead={true}
+                      >
+                        <span
+                          className="pf-c-badge pf-m-read"
+                        >
+                          1
+                        </span>
+                      </Badge>
+                    </span>
+                  </button>
+                </GenerateId>
+              </div>
+            </li>
+          </TreeViewListItem>
+        </ul>
+      </TreeViewList>
+    </div>
+  </TreeViewRoot>
 </TreeView>
 `;
 
@@ -2280,139 +2284,26 @@ exports[`tree view renders basic successfully 1`] = `
   }
   onSelect={[MockFunction]}
 >
-  <div
-    className="pf-c-tree-view"
-  >
-    <TreeViewList
-      isNested={false}
+  <TreeViewRoot>
+    <div
+      className="pf-c-tree-view"
     >
-      <ul
-        className="pf-c-tree-view__list"
-        role="tree"
+      <TreeViewList
+        isNested={false}
       >
-        <TreeViewListItem
-          compareItems={[Function]}
-          defaultExpanded={true}
-          hasBadge={false}
-          hasCheck={false}
-          id="AppLaunch"
-          itemData={
-            Object {
-              "children": Array [
-                Object {
-                  "children": Array [
-                    Object {
-                      "id": "App1Settings",
-                      "name": "Settings",
-                    },
-                    Object {
-                      "id": "App1Current",
-                      "name": "Current",
-                    },
-                  ],
-                  "id": "App1",
-                  "name": "Application 1",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "id": "App2Settings",
-                      "name": "Settings",
-                    },
-                    Object {
-                      "children": Array [
-                        Object {
-                          "id": "LoadApp1",
-                          "name": "Loading App 1",
-                        },
-                        Object {
-                          "id": "LoadApp2",
-                          "name": "Loading App 2",
-                        },
-                        Object {
-                          "id": "LoadApp3",
-                          "name": "Loading App 3",
-                        },
-                      ],
-                      "id": "App2Loader",
-                      "name": "Loader",
-                    },
-                  ],
-                  "id": "App2",
-                  "name": "Application 2",
-                },
-              ],
-              "defaultExpanded": true,
-              "id": "AppLaunch",
-              "name": "ApplicationLauncher",
-            }
-          }
-          key="ApplicationLauncher"
-          name="ApplicationLauncher"
-          onSelect={[MockFunction]}
+        <ul
+          className="pf-c-tree-view__list"
+          role="tree"
         >
-          <li
-            aria-expanded="true"
-            className="pf-c-tree-view__list-item pf-m-expanded"
+          <TreeViewListItem
+            compareItems={[Function]}
+            defaultExpanded={true}
+            hasBadge={false}
+            hasCheck={false}
             id="AppLaunch"
-            role="treeitem"
-            tabIndex={0}
-          >
-            <div
-              className="pf-c-tree-view__content"
-            >
-              <GenerateId
-                prefix="checkbox-id"
-              >
-                <button
-                  className="pf-c-tree-view__node"
-                  onClick={[Function]}
-                >
-                  <div
-                    className="pf-c-tree-view__node-toggle"
-                    onClick={[Function]}
-                  >
-                    <span
-                      className="pf-c-tree-view__node-toggle-icon"
-                    >
-                      <AngleRightIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </AngleRightIcon>
-                    </span>
-                  </div>
-                  <span
-                    className="pf-c-tree-view__node-text"
-                  >
-                    ApplicationLauncher
-                  </span>
-                </button>
-              </GenerateId>
-            </div>
-            <TreeView
-              data={
-                Array [
+            itemData={
+              Object {
+                "children": Array [
                   Object {
                     "children": Array [
                       Object {
@@ -2455,16 +2346,78 @@ exports[`tree view renders basic successfully 1`] = `
                     "id": "App2",
                     "name": "Application 2",
                   },
-                ]
+                ],
+                "defaultExpanded": true,
+                "id": "AppLaunch",
+                "name": "ApplicationLauncher",
               }
-              defaultAllExpanded={false}
-              hasBadges={false}
-              hasChecks={false}
-              isNested={true}
-              onSelect={[MockFunction]}
-              parentItem={
-                Object {
-                  "children": Array [
+            }
+            key="ApplicationLauncher"
+            name="ApplicationLauncher"
+            onSelect={[MockFunction]}
+          >
+            <li
+              aria-expanded="true"
+              className="pf-c-tree-view__list-item pf-m-expanded"
+              id="AppLaunch"
+              role="treeitem"
+              tabIndex={0}
+            >
+              <div
+                className="pf-c-tree-view__content"
+              >
+                <GenerateId
+                  prefix="checkbox-id"
+                >
+                  <button
+                    className="pf-c-tree-view__node"
+                    onClick={[Function]}
+                  >
+                    <div
+                      className="pf-c-tree-view__node-toggle"
+                      onClick={[Function]}
+                    >
+                      <span
+                        className="pf-c-tree-view__node-toggle-icon"
+                      >
+                        <AngleRightIcon
+                          aria-hidden="true"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </AngleRightIcon>
+                      </span>
+                    </div>
+                    <span
+                      className="pf-c-tree-view__node-text"
+                    >
+                      ApplicationLauncher
+                    </span>
+                  </button>
+                </GenerateId>
+              </div>
+              <TreeView
+                data={
+                  Array [
                     Object {
                       "children": Array [
                         Object {
@@ -2507,27 +2460,16 @@ exports[`tree view renders basic successfully 1`] = `
                       "id": "App2",
                       "name": "Application 2",
                     },
-                  ],
-                  "defaultExpanded": true,
-                  "id": "AppLaunch",
-                  "name": "ApplicationLauncher",
+                  ]
                 }
-              }
-            >
-              <TreeViewList
+                defaultAllExpanded={false}
+                hasBadges={false}
+                hasChecks={false}
                 isNested={true}
-              >
-                <ul
-                  className="pf-c-tree-view__list"
-                  role="group"
-                >
-                  <TreeViewListItem
-                    compareItems={[Function]}
-                    defaultExpanded={false}
-                    hasBadge={false}
-                    hasCheck={false}
-                    id="App1"
-                    itemData={
+                onSelect={[MockFunction]}
+                parentItem={
+                  Object {
+                    "children": Array [
                       Object {
                         "children": Array [
                           Object {
@@ -2541,130 +2483,7 @@ exports[`tree view renders basic successfully 1`] = `
                         ],
                         "id": "App1",
                         "name": "Application 1",
-                      }
-                    }
-                    key="Application 1"
-                    name="Application 1"
-                    onSelect={[MockFunction]}
-                    parentItem={
-                      Object {
-                        "children": Array [
-                          Object {
-                            "children": Array [
-                              Object {
-                                "id": "App1Settings",
-                                "name": "Settings",
-                              },
-                              Object {
-                                "id": "App1Current",
-                                "name": "Current",
-                              },
-                            ],
-                            "id": "App1",
-                            "name": "Application 1",
-                          },
-                          Object {
-                            "children": Array [
-                              Object {
-                                "id": "App2Settings",
-                                "name": "Settings",
-                              },
-                              Object {
-                                "children": Array [
-                                  Object {
-                                    "id": "LoadApp1",
-                                    "name": "Loading App 1",
-                                  },
-                                  Object {
-                                    "id": "LoadApp2",
-                                    "name": "Loading App 2",
-                                  },
-                                  Object {
-                                    "id": "LoadApp3",
-                                    "name": "Loading App 3",
-                                  },
-                                ],
-                                "id": "App2Loader",
-                                "name": "Loader",
-                              },
-                            ],
-                            "id": "App2",
-                            "name": "Application 2",
-                          },
-                        ],
-                        "defaultExpanded": true,
-                        "id": "AppLaunch",
-                        "name": "ApplicationLauncher",
-                      }
-                    }
-                  >
-                    <li
-                      className="pf-c-tree-view__list-item"
-                      id="App1"
-                      role="treeitem"
-                      tabIndex={0}
-                    >
-                      <div
-                        className="pf-c-tree-view__content"
-                      >
-                        <GenerateId
-                          prefix="checkbox-id"
-                        >
-                          <button
-                            className="pf-c-tree-view__node"
-                            onClick={[Function]}
-                          >
-                            <div
-                              className="pf-c-tree-view__node-toggle"
-                              onClick={[Function]}
-                            >
-                              <span
-                                className="pf-c-tree-view__node-toggle-icon"
-                              >
-                                <AngleRightIcon
-                                  aria-hidden="true"
-                                  color="currentColor"
-                                  noVerticalAlign={false}
-                                  size="sm"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-labelledby={null}
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    style={
-                                      Object {
-                                        "verticalAlign": "-0.125em",
-                                      }
-                                    }
-                                    viewBox="0 0 256 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                    />
-                                  </svg>
-                                </AngleRightIcon>
-                              </span>
-                            </div>
-                            <span
-                              className="pf-c-tree-view__node-text"
-                            >
-                              Application 1
-                            </span>
-                          </button>
-                        </GenerateId>
-                      </div>
-                    </li>
-                  </TreeViewListItem>
-                  <TreeViewListItem
-                    compareItems={[Function]}
-                    defaultExpanded={false}
-                    hasBadge={false}
-                    hasCheck={false}
-                    id="App2"
-                    itemData={
+                      },
                       Object {
                         "children": Array [
                           Object {
@@ -2692,393 +2511,580 @@ exports[`tree view renders basic successfully 1`] = `
                         ],
                         "id": "App2",
                         "name": "Application 2",
-                      }
-                    }
-                    key="Application 2"
-                    name="Application 2"
-                    onSelect={[MockFunction]}
-                    parentItem={
-                      Object {
-                        "children": Array [
-                          Object {
-                            "children": Array [
-                              Object {
-                                "id": "App1Settings",
-                                "name": "Settings",
-                              },
-                              Object {
-                                "id": "App1Current",
-                                "name": "Current",
-                              },
-                            ],
-                            "id": "App1",
-                            "name": "Application 1",
-                          },
-                          Object {
-                            "children": Array [
-                              Object {
-                                "id": "App2Settings",
-                                "name": "Settings",
-                              },
-                              Object {
-                                "children": Array [
-                                  Object {
-                                    "id": "LoadApp1",
-                                    "name": "Loading App 1",
-                                  },
-                                  Object {
-                                    "id": "LoadApp2",
-                                    "name": "Loading App 2",
-                                  },
-                                  Object {
-                                    "id": "LoadApp3",
-                                    "name": "Loading App 3",
-                                  },
-                                ],
-                                "id": "App2Loader",
-                                "name": "Loader",
-                              },
-                            ],
-                            "id": "App2",
-                            "name": "Application 2",
-                          },
-                        ],
-                        "defaultExpanded": true,
-                        "id": "AppLaunch",
-                        "name": "ApplicationLauncher",
-                      }
-                    }
+                      },
+                    ],
+                    "defaultExpanded": true,
+                    "id": "AppLaunch",
+                    "name": "ApplicationLauncher",
+                  }
+                }
+              >
+                <TreeViewList
+                  isNested={true}
+                >
+                  <ul
+                    className="pf-c-tree-view__list"
+                    role="group"
                   >
-                    <li
-                      className="pf-c-tree-view__list-item"
-                      id="App2"
-                      role="treeitem"
-                      tabIndex={0}
+                    <TreeViewListItem
+                      compareItems={[Function]}
+                      defaultExpanded={false}
+                      hasBadge={false}
+                      hasCheck={false}
+                      id="App1"
+                      itemData={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "id": "App1Settings",
+                              "name": "Settings",
+                            },
+                            Object {
+                              "id": "App1Current",
+                              "name": "Current",
+                            },
+                          ],
+                          "id": "App1",
+                          "name": "Application 1",
+                        }
+                      }
+                      key="Application 1"
+                      name="Application 1"
+                      onSelect={[MockFunction]}
+                      parentItem={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "App1Settings",
+                                  "name": "Settings",
+                                },
+                                Object {
+                                  "id": "App1Current",
+                                  "name": "Current",
+                                },
+                              ],
+                              "id": "App1",
+                              "name": "Application 1",
+                            },
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "App2Settings",
+                                  "name": "Settings",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "id": "LoadApp1",
+                                      "name": "Loading App 1",
+                                    },
+                                    Object {
+                                      "id": "LoadApp2",
+                                      "name": "Loading App 2",
+                                    },
+                                    Object {
+                                      "id": "LoadApp3",
+                                      "name": "Loading App 3",
+                                    },
+                                  ],
+                                  "id": "App2Loader",
+                                  "name": "Loader",
+                                },
+                              ],
+                              "id": "App2",
+                              "name": "Application 2",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "id": "AppLaunch",
+                          "name": "ApplicationLauncher",
+                        }
+                      }
                     >
-                      <div
-                        className="pf-c-tree-view__content"
+                      <li
+                        className="pf-c-tree-view__list-item"
+                        id="App1"
+                        role="treeitem"
+                        tabIndex={0}
                       >
-                        <GenerateId
-                          prefix="checkbox-id"
+                        <div
+                          className="pf-c-tree-view__content"
                         >
-                          <button
-                            className="pf-c-tree-view__node"
-                            onClick={[Function]}
+                          <GenerateId
+                            prefix="checkbox-id"
                           >
-                            <div
-                              className="pf-c-tree-view__node-toggle"
+                            <button
+                              className="pf-c-tree-view__node"
                               onClick={[Function]}
                             >
-                              <span
-                                className="pf-c-tree-view__node-toggle-icon"
+                              <div
+                                className="pf-c-tree-view__node-toggle"
+                                onClick={[Function]}
                               >
-                                <AngleRightIcon
-                                  aria-hidden="true"
-                                  color="currentColor"
-                                  noVerticalAlign={false}
-                                  size="sm"
+                                <span
+                                  className="pf-c-tree-view__node-toggle-icon"
                                 >
-                                  <svg
+                                  <AngleRightIcon
                                     aria-hidden="true"
-                                    aria-labelledby={null}
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    style={
-                                      Object {
-                                        "verticalAlign": "-0.125em",
-                                      }
-                                    }
-                                    viewBox="0 0 256 512"
-                                    width="1em"
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
                                   >
-                                    <path
-                                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                    />
-                                  </svg>
-                                </AngleRightIcon>
+                                    <svg
+                                      aria-hidden="true"
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                      />
+                                    </svg>
+                                  </AngleRightIcon>
+                                </span>
+                              </div>
+                              <span
+                                className="pf-c-tree-view__node-text"
+                              >
+                                Application 1
                               </span>
-                            </div>
-                            <span
-                              className="pf-c-tree-view__node-text"
+                            </button>
+                          </GenerateId>
+                        </div>
+                      </li>
+                    </TreeViewListItem>
+                    <TreeViewListItem
+                      compareItems={[Function]}
+                      defaultExpanded={false}
+                      hasBadge={false}
+                      hasCheck={false}
+                      id="App2"
+                      itemData={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "id": "App2Settings",
+                              "name": "Settings",
+                            },
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "LoadApp1",
+                                  "name": "Loading App 1",
+                                },
+                                Object {
+                                  "id": "LoadApp2",
+                                  "name": "Loading App 2",
+                                },
+                                Object {
+                                  "id": "LoadApp3",
+                                  "name": "Loading App 3",
+                                },
+                              ],
+                              "id": "App2Loader",
+                              "name": "Loader",
+                            },
+                          ],
+                          "id": "App2",
+                          "name": "Application 2",
+                        }
+                      }
+                      key="Application 2"
+                      name="Application 2"
+                      onSelect={[MockFunction]}
+                      parentItem={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "App1Settings",
+                                  "name": "Settings",
+                                },
+                                Object {
+                                  "id": "App1Current",
+                                  "name": "Current",
+                                },
+                              ],
+                              "id": "App1",
+                              "name": "Application 1",
+                            },
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "App2Settings",
+                                  "name": "Settings",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "id": "LoadApp1",
+                                      "name": "Loading App 1",
+                                    },
+                                    Object {
+                                      "id": "LoadApp2",
+                                      "name": "Loading App 2",
+                                    },
+                                    Object {
+                                      "id": "LoadApp3",
+                                      "name": "Loading App 3",
+                                    },
+                                  ],
+                                  "id": "App2Loader",
+                                  "name": "Loader",
+                                },
+                              ],
+                              "id": "App2",
+                              "name": "Application 2",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "id": "AppLaunch",
+                          "name": "ApplicationLauncher",
+                        }
+                      }
+                    >
+                      <li
+                        className="pf-c-tree-view__list-item"
+                        id="App2"
+                        role="treeitem"
+                        tabIndex={0}
+                      >
+                        <div
+                          className="pf-c-tree-view__content"
+                        >
+                          <GenerateId
+                            prefix="checkbox-id"
+                          >
+                            <button
+                              className="pf-c-tree-view__node"
+                              onClick={[Function]}
                             >
-                              Application 2
-                            </span>
-                          </button>
-                        </GenerateId>
-                      </div>
-                    </li>
-                  </TreeViewListItem>
-                </ul>
-              </TreeViewList>
-            </TreeView>
-          </li>
-        </TreeViewListItem>
-        <TreeViewListItem
-          compareItems={[Function]}
-          defaultExpanded={false}
-          hasBadge={false}
-          hasCheck={false}
-          id="Cost"
-          itemData={
-            Object {
-              "children": Array [
-                Object {
-                  "children": Array [
-                    Object {
-                      "id": "App3Settings",
-                      "name": "Settings",
-                    },
-                    Object {
-                      "id": "App3Current",
-                      "name": "Current",
-                    },
-                  ],
-                  "id": "App3",
-                  "name": "Application 3",
-                },
-              ],
-              "id": "Cost",
-              "name": "Cost Management",
-            }
-          }
-          key="Cost Management"
-          name="Cost Management"
-          onSelect={[MockFunction]}
-        >
-          <li
-            className="pf-c-tree-view__list-item"
+                              <div
+                                className="pf-c-tree-view__node-toggle"
+                                onClick={[Function]}
+                              >
+                                <span
+                                  className="pf-c-tree-view__node-toggle-icon"
+                                >
+                                  <AngleRightIcon
+                                    aria-hidden="true"
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                      />
+                                    </svg>
+                                  </AngleRightIcon>
+                                </span>
+                              </div>
+                              <span
+                                className="pf-c-tree-view__node-text"
+                              >
+                                Application 2
+                              </span>
+                            </button>
+                          </GenerateId>
+                        </div>
+                      </li>
+                    </TreeViewListItem>
+                  </ul>
+                </TreeViewList>
+              </TreeView>
+            </li>
+          </TreeViewListItem>
+          <TreeViewListItem
+            compareItems={[Function]}
+            defaultExpanded={false}
+            hasBadge={false}
+            hasCheck={false}
             id="Cost"
-            role="treeitem"
-            tabIndex={0}
+            itemData={
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": "App3Settings",
+                        "name": "Settings",
+                      },
+                      Object {
+                        "id": "App3Current",
+                        "name": "Current",
+                      },
+                    ],
+                    "id": "App3",
+                    "name": "Application 3",
+                  },
+                ],
+                "id": "Cost",
+                "name": "Cost Management",
+              }
+            }
+            key="Cost Management"
+            name="Cost Management"
+            onSelect={[MockFunction]}
           >
-            <div
-              className="pf-c-tree-view__content"
+            <li
+              className="pf-c-tree-view__list-item"
+              id="Cost"
+              role="treeitem"
+              tabIndex={0}
             >
-              <GenerateId
-                prefix="checkbox-id"
+              <div
+                className="pf-c-tree-view__content"
               >
-                <button
-                  className="pf-c-tree-view__node"
-                  onClick={[Function]}
+                <GenerateId
+                  prefix="checkbox-id"
                 >
-                  <div
-                    className="pf-c-tree-view__node-toggle"
+                  <button
+                    className="pf-c-tree-view__node"
                     onClick={[Function]}
                   >
-                    <span
-                      className="pf-c-tree-view__node-toggle-icon"
+                    <div
+                      className="pf-c-tree-view__node-toggle"
+                      onClick={[Function]}
                     >
-                      <AngleRightIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
+                      <span
+                        className="pf-c-tree-view__node-toggle-icon"
                       >
-                        <svg
+                        <AngleRightIcon
                           aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 256 512"
-                          width="1em"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
                         >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </AngleRightIcon>
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </AngleRightIcon>
+                      </span>
+                    </div>
+                    <span
+                      className="pf-c-tree-view__node-text"
+                    >
+                      Cost Management
                     </span>
-                  </div>
-                  <span
-                    className="pf-c-tree-view__node-text"
-                  >
-                    Cost Management
-                  </span>
-                </button>
-              </GenerateId>
-            </div>
-          </li>
-        </TreeViewListItem>
-        <TreeViewListItem
-          compareItems={[Function]}
-          defaultExpanded={false}
-          hasBadge={false}
-          hasCheck={false}
-          id="Sources"
-          itemData={
-            Object {
-              "children": Array [
-                Object {
-                  "children": Array [
-                    Object {
-                      "id": "App4Settings",
-                      "name": "Settings",
-                    },
-                  ],
-                  "id": "App4",
-                  "name": "Application 4",
-                },
-              ],
-              "id": "Sources",
-              "name": "Sources",
-            }
-          }
-          key="Sources"
-          name="Sources"
-          onSelect={[MockFunction]}
-        >
-          <li
-            className="pf-c-tree-view__list-item"
+                  </button>
+                </GenerateId>
+              </div>
+            </li>
+          </TreeViewListItem>
+          <TreeViewListItem
+            compareItems={[Function]}
+            defaultExpanded={false}
+            hasBadge={false}
+            hasCheck={false}
             id="Sources"
-            role="treeitem"
-            tabIndex={0}
-          >
-            <div
-              className="pf-c-tree-view__content"
-            >
-              <GenerateId
-                prefix="checkbox-id"
-              >
-                <button
-                  className="pf-c-tree-view__node"
-                  onClick={[Function]}
-                >
-                  <div
-                    className="pf-c-tree-view__node-toggle"
-                    onClick={[Function]}
-                  >
-                    <span
-                      className="pf-c-tree-view__node-toggle-icon"
-                    >
-                      <AngleRightIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </AngleRightIcon>
-                    </span>
-                  </div>
-                  <span
-                    className="pf-c-tree-view__node-text"
-                  >
-                    Sources
-                  </span>
-                </button>
-              </GenerateId>
-            </div>
-          </li>
-        </TreeViewListItem>
-        <TreeViewListItem
-          compareItems={[Function]}
-          defaultExpanded={false}
-          hasBadge={false}
-          hasCheck={false}
-          id="Long"
-          itemData={
-            Object {
-              "children": Array [
-                Object {
-                  "id": "App5",
-                  "name": "Application 5",
-                },
-              ],
-              "id": "Long",
-              "name": "Really really really long folder name that overflows the container it is in",
+            itemData={
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": "App4Settings",
+                        "name": "Settings",
+                      },
+                    ],
+                    "id": "App4",
+                    "name": "Application 4",
+                  },
+                ],
+                "id": "Sources",
+                "name": "Sources",
+              }
             }
-          }
-          key="Really really really long folder name that overflows the container it is in"
-          name="Really really really long folder name that overflows the container it is in"
-          onSelect={[MockFunction]}
-        >
-          <li
-            className="pf-c-tree-view__list-item"
-            id="Long"
-            role="treeitem"
-            tabIndex={0}
+            key="Sources"
+            name="Sources"
+            onSelect={[MockFunction]}
           >
-            <div
-              className="pf-c-tree-view__content"
+            <li
+              className="pf-c-tree-view__list-item"
+              id="Sources"
+              role="treeitem"
+              tabIndex={0}
             >
-              <GenerateId
-                prefix="checkbox-id"
+              <div
+                className="pf-c-tree-view__content"
               >
-                <button
-                  className="pf-c-tree-view__node"
-                  onClick={[Function]}
+                <GenerateId
+                  prefix="checkbox-id"
                 >
-                  <div
-                    className="pf-c-tree-view__node-toggle"
+                  <button
+                    className="pf-c-tree-view__node"
                     onClick={[Function]}
                   >
-                    <span
-                      className="pf-c-tree-view__node-toggle-icon"
+                    <div
+                      className="pf-c-tree-view__node-toggle"
+                      onClick={[Function]}
                     >
-                      <AngleRightIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
+                      <span
+                        className="pf-c-tree-view__node-toggle-icon"
                       >
-                        <svg
+                        <AngleRightIcon
                           aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 256 512"
-                          width="1em"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
                         >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </AngleRightIcon>
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </AngleRightIcon>
+                      </span>
+                    </div>
+                    <span
+                      className="pf-c-tree-view__node-text"
+                    >
+                      Sources
                     </span>
-                  </div>
-                  <span
-                    className="pf-c-tree-view__node-text"
+                  </button>
+                </GenerateId>
+              </div>
+            </li>
+          </TreeViewListItem>
+          <TreeViewListItem
+            compareItems={[Function]}
+            defaultExpanded={false}
+            hasBadge={false}
+            hasCheck={false}
+            id="Long"
+            itemData={
+              Object {
+                "children": Array [
+                  Object {
+                    "id": "App5",
+                    "name": "Application 5",
+                  },
+                ],
+                "id": "Long",
+                "name": "Really really really long folder name that overflows the container it is in",
+              }
+            }
+            key="Really really really long folder name that overflows the container it is in"
+            name="Really really really long folder name that overflows the container it is in"
+            onSelect={[MockFunction]}
+          >
+            <li
+              className="pf-c-tree-view__list-item"
+              id="Long"
+              role="treeitem"
+              tabIndex={0}
+            >
+              <div
+                className="pf-c-tree-view__content"
+              >
+                <GenerateId
+                  prefix="checkbox-id"
+                >
+                  <button
+                    className="pf-c-tree-view__node"
+                    onClick={[Function]}
                   >
-                    Really really really long folder name that overflows the container it is in
-                  </span>
-                </button>
-              </GenerateId>
-            </div>
-          </li>
-        </TreeViewListItem>
-      </ul>
-    </TreeViewList>
-  </div>
+                    <div
+                      className="pf-c-tree-view__node-toggle"
+                      onClick={[Function]}
+                    >
+                      <span
+                        className="pf-c-tree-view__node-toggle-icon"
+                      >
+                        <AngleRightIcon
+                          aria-hidden="true"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </AngleRightIcon>
+                      </span>
+                    </div>
+                    <span
+                      className="pf-c-tree-view__node-text"
+                    >
+                      Really really really long folder name that overflows the container it is in
+                    </span>
+                  </button>
+                </GenerateId>
+              </div>
+            </li>
+          </TreeViewListItem>
+        </ul>
+      </TreeViewList>
+    </div>
+  </TreeViewRoot>
 </TreeView>
 `;
 
@@ -3204,43 +3210,20 @@ exports[`tree view renders checkboxes successfully 1`] = `
   hasChecks={true}
   onSelect={[MockFunction]}
 >
-  <div
-    className="pf-c-tree-view"
-  >
-    <TreeViewList
-      isNested={false}
+  <TreeViewRoot>
+    <div
+      className="pf-c-tree-view"
     >
-      <ul
-        className="pf-c-tree-view__list"
-        role="tree"
+      <TreeViewList
+        isNested={false}
       >
-        <TreeViewListItem
-          activeItems={
-            Array [
-              Object {
-                "children": Array [
-                  Object {
-                    "id": "App1Settings",
-                    "name": "Settings",
-                  },
-                  Object {
-                    "id": "App1Current",
-                    "name": "Current",
-                  },
-                ],
-                "id": "App1",
-                "name": "Application 1",
-              },
-            ]
-          }
-          compareItems={[Function]}
-          defaultExpanded={true}
-          hasBadge={false}
-          hasCheck={true}
-          id="AppLaunch"
-          itemData={
-            Object {
-              "children": Array [
+        <ul
+          className="pf-c-tree-view__list"
+          role="tree"
+        >
+          <TreeViewListItem
+            activeItems={
+              Array [
                 Object {
                   "children": Array [
                     Object {
@@ -3255,138 +3238,16 @@ exports[`tree view renders checkboxes successfully 1`] = `
                   "id": "App1",
                   "name": "Application 1",
                 },
-                Object {
-                  "children": Array [
-                    Object {
-                      "id": "App2Settings",
-                      "name": "Settings",
-                    },
-                    Object {
-                      "children": Array [
-                        Object {
-                          "id": "LoadApp1",
-                          "name": "Loading App 1",
-                        },
-                        Object {
-                          "id": "LoadApp2",
-                          "name": "Loading App 2",
-                        },
-                        Object {
-                          "id": "LoadApp3",
-                          "name": "Loading App 3",
-                        },
-                      ],
-                      "id": "App2Loader",
-                      "name": "Loader",
-                    },
-                  ],
-                  "id": "App2",
-                  "name": "Application 2",
-                },
-              ],
-              "defaultExpanded": true,
-              "id": "AppLaunch",
-              "name": "ApplicationLauncher",
+              ]
             }
-          }
-          key="ApplicationLauncher"
-          name="ApplicationLauncher"
-          onSelect={[MockFunction]}
-        >
-          <li
-            aria-expanded="true"
-            className="pf-c-tree-view__list-item pf-m-expanded"
+            compareItems={[Function]}
+            defaultExpanded={true}
+            hasBadge={false}
+            hasCheck={true}
             id="AppLaunch"
-            role="treeitem"
-            tabIndex={0}
-          >
-            <div
-              className="pf-c-tree-view__content"
-            >
-              <GenerateId
-                prefix="checkbox-id"
-              >
-                <div
-                  className="pf-c-tree-view__node"
-                  onClick={[Function]}
-                >
-                  <button
-                    aria-labelledby="label-checkbox-id18"
-                    className="pf-c-tree-view__node-toggle"
-                    onClick={[Function]}
-                  >
-                    <span
-                      className="pf-c-tree-view__node-toggle-icon"
-                    >
-                      <AngleRightIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </AngleRightIcon>
-                    </span>
-                  </button>
-                  <span
-                    className="pf-c-tree-view__node-check"
-                  >
-                    <input
-                      checked={false}
-                      id="checkbox-id18"
-                      onChange={[Function]}
-                      onClick={[Function]}
-                      type="checkbox"
-                    />
-                  </span>
-                  <label
-                    className="pf-c-tree-view__node-text"
-                    htmlFor="checkbox-id18"
-                    id="label-checkbox-id18"
-                  >
-                    ApplicationLauncher
-                  </label>
-                </div>
-              </GenerateId>
-            </div>
-            <TreeView
-              activeItems={
-                Array [
-                  Object {
-                    "children": Array [
-                      Object {
-                        "id": "App1Settings",
-                        "name": "Settings",
-                      },
-                      Object {
-                        "id": "App1Current",
-                        "name": "Current",
-                      },
-                    ],
-                    "id": "App1",
-                    "name": "Application 1",
-                  },
-                ]
-              }
-              data={
-                Array [
+            itemData={
+              Object {
+                "children": Array [
                   Object {
                     "children": Array [
                       Object {
@@ -3429,16 +3290,110 @@ exports[`tree view renders checkboxes successfully 1`] = `
                     "id": "App2",
                     "name": "Application 2",
                   },
-                ]
+                ],
+                "defaultExpanded": true,
+                "id": "AppLaunch",
+                "name": "ApplicationLauncher",
               }
-              defaultAllExpanded={false}
-              hasBadges={false}
-              hasChecks={true}
-              isNested={true}
-              onSelect={[MockFunction]}
-              parentItem={
-                Object {
-                  "children": Array [
+            }
+            key="ApplicationLauncher"
+            name="ApplicationLauncher"
+            onSelect={[MockFunction]}
+          >
+            <li
+              aria-expanded="true"
+              className="pf-c-tree-view__list-item pf-m-expanded"
+              id="AppLaunch"
+              role="treeitem"
+              tabIndex={0}
+            >
+              <div
+                className="pf-c-tree-view__content"
+              >
+                <GenerateId
+                  prefix="checkbox-id"
+                >
+                  <div
+                    className="pf-c-tree-view__node"
+                    onClick={[Function]}
+                  >
+                    <button
+                      aria-labelledby="label-checkbox-id18"
+                      className="pf-c-tree-view__node-toggle"
+                      onClick={[Function]}
+                    >
+                      <span
+                        className="pf-c-tree-view__node-toggle-icon"
+                      >
+                        <AngleRightIcon
+                          aria-hidden="true"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </AngleRightIcon>
+                      </span>
+                    </button>
+                    <span
+                      className="pf-c-tree-view__node-check"
+                    >
+                      <input
+                        checked={false}
+                        id="checkbox-id18"
+                        onChange={[Function]}
+                        onClick={[Function]}
+                        type="checkbox"
+                      />
+                    </span>
+                    <label
+                      className="pf-c-tree-view__node-text"
+                      htmlFor="checkbox-id18"
+                      id="label-checkbox-id18"
+                    >
+                      ApplicationLauncher
+                    </label>
+                  </div>
+                </GenerateId>
+              </div>
+              <TreeView
+                activeItems={
+                  Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": "App1Settings",
+                          "name": "Settings",
+                        },
+                        Object {
+                          "id": "App1Current",
+                          "name": "Current",
+                        },
+                      ],
+                      "id": "App1",
+                      "name": "Application 1",
+                    },
+                  ]
+                }
+                data={
+                  Array [
                     Object {
                       "children": Array [
                         Object {
@@ -3481,45 +3436,16 @@ exports[`tree view renders checkboxes successfully 1`] = `
                       "id": "App2",
                       "name": "Application 2",
                     },
-                  ],
-                  "defaultExpanded": true,
-                  "id": "AppLaunch",
-                  "name": "ApplicationLauncher",
+                  ]
                 }
-              }
-            >
-              <TreeViewList
+                defaultAllExpanded={false}
+                hasBadges={false}
+                hasChecks={true}
                 isNested={true}
-              >
-                <ul
-                  className="pf-c-tree-view__list"
-                  role="group"
-                >
-                  <TreeViewListItem
-                    activeItems={
-                      Array [
-                        Object {
-                          "children": Array [
-                            Object {
-                              "id": "App1Settings",
-                              "name": "Settings",
-                            },
-                            Object {
-                              "id": "App1Current",
-                              "name": "Current",
-                            },
-                          ],
-                          "id": "App1",
-                          "name": "Application 1",
-                        },
-                      ]
-                    }
-                    compareItems={[Function]}
-                    defaultExpanded={false}
-                    hasBadge={false}
-                    hasCheck={true}
-                    id="App1"
-                    itemData={
+                onSelect={[MockFunction]}
+                parentItem={
+                  Object {
+                    "children": Array [
                       Object {
                         "children": Array [
                           Object {
@@ -3533,162 +3459,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
                         ],
                         "id": "App1",
                         "name": "Application 1",
-                      }
-                    }
-                    key="Application 1"
-                    name="Application 1"
-                    onSelect={[MockFunction]}
-                    parentItem={
-                      Object {
-                        "children": Array [
-                          Object {
-                            "children": Array [
-                              Object {
-                                "id": "App1Settings",
-                                "name": "Settings",
-                              },
-                              Object {
-                                "id": "App1Current",
-                                "name": "Current",
-                              },
-                            ],
-                            "id": "App1",
-                            "name": "Application 1",
-                          },
-                          Object {
-                            "children": Array [
-                              Object {
-                                "id": "App2Settings",
-                                "name": "Settings",
-                              },
-                              Object {
-                                "children": Array [
-                                  Object {
-                                    "id": "LoadApp1",
-                                    "name": "Loading App 1",
-                                  },
-                                  Object {
-                                    "id": "LoadApp2",
-                                    "name": "Loading App 2",
-                                  },
-                                  Object {
-                                    "id": "LoadApp3",
-                                    "name": "Loading App 3",
-                                  },
-                                ],
-                                "id": "App2Loader",
-                                "name": "Loader",
-                              },
-                            ],
-                            "id": "App2",
-                            "name": "Application 2",
-                          },
-                        ],
-                        "defaultExpanded": true,
-                        "id": "AppLaunch",
-                        "name": "ApplicationLauncher",
-                      }
-                    }
-                  >
-                    <li
-                      className="pf-c-tree-view__list-item"
-                      id="App1"
-                      role="treeitem"
-                      tabIndex={0}
-                    >
-                      <div
-                        className="pf-c-tree-view__content"
-                      >
-                        <GenerateId
-                          prefix="checkbox-id"
-                        >
-                          <div
-                            className="pf-c-tree-view__node"
-                            onClick={[Function]}
-                          >
-                            <button
-                              aria-labelledby="label-checkbox-id19"
-                              className="pf-c-tree-view__node-toggle"
-                              onClick={[Function]}
-                            >
-                              <span
-                                className="pf-c-tree-view__node-toggle-icon"
-                              >
-                                <AngleRightIcon
-                                  aria-hidden="true"
-                                  color="currentColor"
-                                  noVerticalAlign={false}
-                                  size="sm"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-labelledby={null}
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    style={
-                                      Object {
-                                        "verticalAlign": "-0.125em",
-                                      }
-                                    }
-                                    viewBox="0 0 256 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                    />
-                                  </svg>
-                                </AngleRightIcon>
-                              </span>
-                            </button>
-                            <span
-                              className="pf-c-tree-view__node-check"
-                            >
-                              <input
-                                checked={false}
-                                id="checkbox-id19"
-                                onChange={[Function]}
-                                onClick={[Function]}
-                                type="checkbox"
-                              />
-                            </span>
-                            <label
-                              className="pf-c-tree-view__node-text"
-                              htmlFor="checkbox-id19"
-                              id="label-checkbox-id19"
-                            >
-                              Application 1
-                            </label>
-                          </div>
-                        </GenerateId>
-                      </div>
-                    </li>
-                  </TreeViewListItem>
-                  <TreeViewListItem
-                    activeItems={
-                      Array [
-                        Object {
-                          "children": Array [
-                            Object {
-                              "id": "App1Settings",
-                              "name": "Settings",
-                            },
-                            Object {
-                              "id": "App1Current",
-                              "name": "Current",
-                            },
-                          ],
-                          "id": "App1",
-                          "name": "Application 1",
-                        },
-                      ]
-                    }
-                    compareItems={[Function]}
-                    defaultExpanded={false}
-                    hasBadge={false}
-                    hasCheck={true}
-                    id="App2"
-                    itemData={
+                      },
                       Object {
                         "children": Array [
                           Object {
@@ -3716,14 +3487,24 @@ exports[`tree view renders checkboxes successfully 1`] = `
                         ],
                         "id": "App2",
                         "name": "Application 2",
-                      }
-                    }
-                    key="Application 2"
-                    name="Application 2"
-                    onSelect={[MockFunction]}
-                    parentItem={
-                      Object {
-                        "children": Array [
+                      },
+                    ],
+                    "defaultExpanded": true,
+                    "id": "AppLaunch",
+                    "name": "ApplicationLauncher",
+                  }
+                }
+              >
+                <TreeViewList
+                  isNested={true}
+                >
+                  <ul
+                    className="pf-c-tree-view__list"
+                    role="group"
+                  >
+                    <TreeViewListItem
+                      activeItems={
+                        Array [
                           Object {
                             "children": Array [
                               Object {
@@ -3738,481 +3519,708 @@ exports[`tree view renders checkboxes successfully 1`] = `
                             "id": "App1",
                             "name": "Application 1",
                           },
+                        ]
+                      }
+                      compareItems={[Function]}
+                      defaultExpanded={false}
+                      hasBadge={false}
+                      hasCheck={true}
+                      id="App1"
+                      itemData={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "id": "App1Settings",
+                              "name": "Settings",
+                            },
+                            Object {
+                              "id": "App1Current",
+                              "name": "Current",
+                            },
+                          ],
+                          "id": "App1",
+                          "name": "Application 1",
+                        }
+                      }
+                      key="Application 1"
+                      name="Application 1"
+                      onSelect={[MockFunction]}
+                      parentItem={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "App1Settings",
+                                  "name": "Settings",
+                                },
+                                Object {
+                                  "id": "App1Current",
+                                  "name": "Current",
+                                },
+                              ],
+                              "id": "App1",
+                              "name": "Application 1",
+                            },
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "App2Settings",
+                                  "name": "Settings",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "id": "LoadApp1",
+                                      "name": "Loading App 1",
+                                    },
+                                    Object {
+                                      "id": "LoadApp2",
+                                      "name": "Loading App 2",
+                                    },
+                                    Object {
+                                      "id": "LoadApp3",
+                                      "name": "Loading App 3",
+                                    },
+                                  ],
+                                  "id": "App2Loader",
+                                  "name": "Loader",
+                                },
+                              ],
+                              "id": "App2",
+                              "name": "Application 2",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "id": "AppLaunch",
+                          "name": "ApplicationLauncher",
+                        }
+                      }
+                    >
+                      <li
+                        className="pf-c-tree-view__list-item"
+                        id="App1"
+                        role="treeitem"
+                        tabIndex={0}
+                      >
+                        <div
+                          className="pf-c-tree-view__content"
+                        >
+                          <GenerateId
+                            prefix="checkbox-id"
+                          >
+                            <div
+                              className="pf-c-tree-view__node"
+                              onClick={[Function]}
+                            >
+                              <button
+                                aria-labelledby="label-checkbox-id19"
+                                className="pf-c-tree-view__node-toggle"
+                                onClick={[Function]}
+                              >
+                                <span
+                                  className="pf-c-tree-view__node-toggle-icon"
+                                >
+                                  <AngleRightIcon
+                                    aria-hidden="true"
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                      />
+                                    </svg>
+                                  </AngleRightIcon>
+                                </span>
+                              </button>
+                              <span
+                                className="pf-c-tree-view__node-check"
+                              >
+                                <input
+                                  checked={false}
+                                  id="checkbox-id19"
+                                  onChange={[Function]}
+                                  onClick={[Function]}
+                                  type="checkbox"
+                                />
+                              </span>
+                              <label
+                                className="pf-c-tree-view__node-text"
+                                htmlFor="checkbox-id19"
+                                id="label-checkbox-id19"
+                              >
+                                Application 1
+                              </label>
+                            </div>
+                          </GenerateId>
+                        </div>
+                      </li>
+                    </TreeViewListItem>
+                    <TreeViewListItem
+                      activeItems={
+                        Array [
                           Object {
                             "children": Array [
                               Object {
-                                "id": "App2Settings",
+                                "id": "App1Settings",
                                 "name": "Settings",
                               },
                               Object {
-                                "children": Array [
-                                  Object {
-                                    "id": "LoadApp1",
-                                    "name": "Loading App 1",
-                                  },
-                                  Object {
-                                    "id": "LoadApp2",
-                                    "name": "Loading App 2",
-                                  },
-                                  Object {
-                                    "id": "LoadApp3",
-                                    "name": "Loading App 3",
-                                  },
-                                ],
-                                "id": "App2Loader",
-                                "name": "Loader",
+                                "id": "App1Current",
+                                "name": "Current",
                               },
                             ],
-                            "id": "App2",
-                            "name": "Application 2",
+                            "id": "App1",
+                            "name": "Application 1",
                           },
-                        ],
-                        "defaultExpanded": true,
-                        "id": "AppLaunch",
-                        "name": "ApplicationLauncher",
+                        ]
                       }
-                    }
-                  >
-                    <li
-                      className="pf-c-tree-view__list-item"
+                      compareItems={[Function]}
+                      defaultExpanded={false}
+                      hasBadge={false}
+                      hasCheck={true}
                       id="App2"
-                      role="treeitem"
-                      tabIndex={0}
+                      itemData={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "id": "App2Settings",
+                              "name": "Settings",
+                            },
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "LoadApp1",
+                                  "name": "Loading App 1",
+                                },
+                                Object {
+                                  "id": "LoadApp2",
+                                  "name": "Loading App 2",
+                                },
+                                Object {
+                                  "id": "LoadApp3",
+                                  "name": "Loading App 3",
+                                },
+                              ],
+                              "id": "App2Loader",
+                              "name": "Loader",
+                            },
+                          ],
+                          "id": "App2",
+                          "name": "Application 2",
+                        }
+                      }
+                      key="Application 2"
+                      name="Application 2"
+                      onSelect={[MockFunction]}
+                      parentItem={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "App1Settings",
+                                  "name": "Settings",
+                                },
+                                Object {
+                                  "id": "App1Current",
+                                  "name": "Current",
+                                },
+                              ],
+                              "id": "App1",
+                              "name": "Application 1",
+                            },
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "App2Settings",
+                                  "name": "Settings",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "id": "LoadApp1",
+                                      "name": "Loading App 1",
+                                    },
+                                    Object {
+                                      "id": "LoadApp2",
+                                      "name": "Loading App 2",
+                                    },
+                                    Object {
+                                      "id": "LoadApp3",
+                                      "name": "Loading App 3",
+                                    },
+                                  ],
+                                  "id": "App2Loader",
+                                  "name": "Loader",
+                                },
+                              ],
+                              "id": "App2",
+                              "name": "Application 2",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "id": "AppLaunch",
+                          "name": "ApplicationLauncher",
+                        }
+                      }
                     >
-                      <div
-                        className="pf-c-tree-view__content"
+                      <li
+                        className="pf-c-tree-view__list-item"
+                        id="App2"
+                        role="treeitem"
+                        tabIndex={0}
                       >
-                        <GenerateId
-                          prefix="checkbox-id"
+                        <div
+                          className="pf-c-tree-view__content"
                         >
-                          <div
-                            className="pf-c-tree-view__node"
-                            onClick={[Function]}
+                          <GenerateId
+                            prefix="checkbox-id"
                           >
-                            <button
-                              aria-labelledby="label-checkbox-id20"
-                              className="pf-c-tree-view__node-toggle"
+                            <div
+                              className="pf-c-tree-view__node"
                               onClick={[Function]}
                             >
-                              <span
-                                className="pf-c-tree-view__node-toggle-icon"
-                              >
-                                <AngleRightIcon
-                                  aria-hidden="true"
-                                  color="currentColor"
-                                  noVerticalAlign={false}
-                                  size="sm"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-labelledby={null}
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    style={
-                                      Object {
-                                        "verticalAlign": "-0.125em",
-                                      }
-                                    }
-                                    viewBox="0 0 256 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                    />
-                                  </svg>
-                                </AngleRightIcon>
-                              </span>
-                            </button>
-                            <span
-                              className="pf-c-tree-view__node-check"
-                            >
-                              <input
-                                checked={false}
-                                id="checkbox-id20"
-                                onChange={[Function]}
+                              <button
+                                aria-labelledby="label-checkbox-id20"
+                                className="pf-c-tree-view__node-toggle"
                                 onClick={[Function]}
-                                type="checkbox"
-                              />
-                            </span>
-                            <label
-                              className="pf-c-tree-view__node-text"
-                              htmlFor="checkbox-id20"
-                              id="label-checkbox-id20"
-                            >
-                              Application 2
-                            </label>
-                          </div>
-                        </GenerateId>
-                      </div>
-                    </li>
-                  </TreeViewListItem>
-                </ul>
-              </TreeViewList>
-            </TreeView>
-          </li>
-        </TreeViewListItem>
-        <TreeViewListItem
-          activeItems={
-            Array [
-              Object {
-                "children": Array [
-                  Object {
-                    "id": "App1Settings",
-                    "name": "Settings",
-                  },
-                  Object {
-                    "id": "App1Current",
-                    "name": "Current",
-                  },
-                ],
-                "id": "App1",
-                "name": "Application 1",
-              },
-            ]
-          }
-          compareItems={[Function]}
-          defaultExpanded={false}
-          hasBadge={false}
-          hasCheck={true}
-          id="Cost"
-          itemData={
-            Object {
-              "children": Array [
+                              >
+                                <span
+                                  className="pf-c-tree-view__node-toggle-icon"
+                                >
+                                  <AngleRightIcon
+                                    aria-hidden="true"
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                      />
+                                    </svg>
+                                  </AngleRightIcon>
+                                </span>
+                              </button>
+                              <span
+                                className="pf-c-tree-view__node-check"
+                              >
+                                <input
+                                  checked={false}
+                                  id="checkbox-id20"
+                                  onChange={[Function]}
+                                  onClick={[Function]}
+                                  type="checkbox"
+                                />
+                              </span>
+                              <label
+                                className="pf-c-tree-view__node-text"
+                                htmlFor="checkbox-id20"
+                                id="label-checkbox-id20"
+                              >
+                                Application 2
+                              </label>
+                            </div>
+                          </GenerateId>
+                        </div>
+                      </li>
+                    </TreeViewListItem>
+                  </ul>
+                </TreeViewList>
+              </TreeView>
+            </li>
+          </TreeViewListItem>
+          <TreeViewListItem
+            activeItems={
+              Array [
                 Object {
                   "children": Array [
                     Object {
-                      "id": "App3Settings",
+                      "id": "App1Settings",
                       "name": "Settings",
                     },
                     Object {
-                      "id": "App3Current",
+                      "id": "App1Current",
                       "name": "Current",
                     },
                   ],
-                  "id": "App3",
-                  "name": "Application 3",
+                  "id": "App1",
+                  "name": "Application 1",
                 },
-              ],
-              "id": "Cost",
-              "name": "Cost Management",
+              ]
             }
-          }
-          key="Cost Management"
-          name="Cost Management"
-          onSelect={[MockFunction]}
-        >
-          <li
-            className="pf-c-tree-view__list-item"
+            compareItems={[Function]}
+            defaultExpanded={false}
+            hasBadge={false}
+            hasCheck={true}
             id="Cost"
-            role="treeitem"
-            tabIndex={0}
-          >
-            <div
-              className="pf-c-tree-view__content"
-            >
-              <GenerateId
-                prefix="checkbox-id"
-              >
-                <div
-                  className="pf-c-tree-view__node"
-                  onClick={[Function]}
-                >
-                  <button
-                    aria-labelledby="label-checkbox-id21"
-                    className="pf-c-tree-view__node-toggle"
-                    onClick={[Function]}
-                  >
-                    <span
-                      className="pf-c-tree-view__node-toggle-icon"
-                    >
-                      <AngleRightIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </AngleRightIcon>
-                    </span>
-                  </button>
-                  <span
-                    className="pf-c-tree-view__node-check"
-                  >
-                    <input
-                      checked={false}
-                      id="checkbox-id21"
-                      onChange={[Function]}
-                      onClick={[Function]}
-                      type="checkbox"
-                    />
-                  </span>
-                  <label
-                    className="pf-c-tree-view__node-text"
-                    htmlFor="checkbox-id21"
-                    id="label-checkbox-id21"
-                  >
-                    Cost Management
-                  </label>
-                </div>
-              </GenerateId>
-            </div>
-          </li>
-        </TreeViewListItem>
-        <TreeViewListItem
-          activeItems={
-            Array [
+            itemData={
               Object {
                 "children": Array [
                   Object {
-                    "id": "App1Settings",
-                    "name": "Settings",
-                  },
-                  Object {
-                    "id": "App1Current",
-                    "name": "Current",
+                    "children": Array [
+                      Object {
+                        "id": "App3Settings",
+                        "name": "Settings",
+                      },
+                      Object {
+                        "id": "App3Current",
+                        "name": "Current",
+                      },
+                    ],
+                    "id": "App3",
+                    "name": "Application 3",
                   },
                 ],
-                "id": "App1",
-                "name": "Application 1",
-              },
-            ]
-          }
-          compareItems={[Function]}
-          defaultExpanded={false}
-          hasBadge={false}
-          hasCheck={true}
-          id="Sources"
-          itemData={
-            Object {
-              "children": Array [
+                "id": "Cost",
+                "name": "Cost Management",
+              }
+            }
+            key="Cost Management"
+            name="Cost Management"
+            onSelect={[MockFunction]}
+          >
+            <li
+              className="pf-c-tree-view__list-item"
+              id="Cost"
+              role="treeitem"
+              tabIndex={0}
+            >
+              <div
+                className="pf-c-tree-view__content"
+              >
+                <GenerateId
+                  prefix="checkbox-id"
+                >
+                  <div
+                    className="pf-c-tree-view__node"
+                    onClick={[Function]}
+                  >
+                    <button
+                      aria-labelledby="label-checkbox-id21"
+                      className="pf-c-tree-view__node-toggle"
+                      onClick={[Function]}
+                    >
+                      <span
+                        className="pf-c-tree-view__node-toggle-icon"
+                      >
+                        <AngleRightIcon
+                          aria-hidden="true"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </AngleRightIcon>
+                      </span>
+                    </button>
+                    <span
+                      className="pf-c-tree-view__node-check"
+                    >
+                      <input
+                        checked={false}
+                        id="checkbox-id21"
+                        onChange={[Function]}
+                        onClick={[Function]}
+                        type="checkbox"
+                      />
+                    </span>
+                    <label
+                      className="pf-c-tree-view__node-text"
+                      htmlFor="checkbox-id21"
+                      id="label-checkbox-id21"
+                    >
+                      Cost Management
+                    </label>
+                  </div>
+                </GenerateId>
+              </div>
+            </li>
+          </TreeViewListItem>
+          <TreeViewListItem
+            activeItems={
+              Array [
                 Object {
                   "children": Array [
                     Object {
-                      "id": "App4Settings",
+                      "id": "App1Settings",
                       "name": "Settings",
                     },
+                    Object {
+                      "id": "App1Current",
+                      "name": "Current",
+                    },
                   ],
-                  "id": "App4",
-                  "name": "Application 4",
+                  "id": "App1",
+                  "name": "Application 1",
                 },
-              ],
-              "id": "Sources",
-              "name": "Sources",
+              ]
             }
-          }
-          key="Sources"
-          name="Sources"
-          onSelect={[MockFunction]}
-        >
-          <li
-            className="pf-c-tree-view__list-item"
+            compareItems={[Function]}
+            defaultExpanded={false}
+            hasBadge={false}
+            hasCheck={true}
             id="Sources"
-            role="treeitem"
-            tabIndex={0}
-          >
-            <div
-              className="pf-c-tree-view__content"
-            >
-              <GenerateId
-                prefix="checkbox-id"
-              >
-                <div
-                  className="pf-c-tree-view__node"
-                  onClick={[Function]}
-                >
-                  <button
-                    aria-labelledby="label-checkbox-id22"
-                    className="pf-c-tree-view__node-toggle"
-                    onClick={[Function]}
-                  >
-                    <span
-                      className="pf-c-tree-view__node-toggle-icon"
-                    >
-                      <AngleRightIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </AngleRightIcon>
-                    </span>
-                  </button>
-                  <span
-                    className="pf-c-tree-view__node-check"
-                  >
-                    <input
-                      checked={false}
-                      id="checkbox-id22"
-                      onChange={[Function]}
-                      onClick={[Function]}
-                      type="checkbox"
-                    />
-                  </span>
-                  <label
-                    className="pf-c-tree-view__node-text"
-                    htmlFor="checkbox-id22"
-                    id="label-checkbox-id22"
-                  >
-                    Sources
-                  </label>
-                </div>
-              </GenerateId>
-            </div>
-          </li>
-        </TreeViewListItem>
-        <TreeViewListItem
-          activeItems={
-            Array [
+            itemData={
               Object {
                 "children": Array [
                   Object {
-                    "id": "App1Settings",
-                    "name": "Settings",
-                  },
-                  Object {
-                    "id": "App1Current",
-                    "name": "Current",
+                    "children": Array [
+                      Object {
+                        "id": "App4Settings",
+                        "name": "Settings",
+                      },
+                    ],
+                    "id": "App4",
+                    "name": "Application 4",
                   },
                 ],
-                "id": "App1",
-                "name": "Application 1",
-              },
-            ]
-          }
-          compareItems={[Function]}
-          defaultExpanded={false}
-          hasBadge={false}
-          hasCheck={true}
-          id="Long"
-          itemData={
-            Object {
-              "children": Array [
-                Object {
-                  "id": "App5",
-                  "name": "Application 5",
-                },
-              ],
-              "id": "Long",
-              "name": "Really really really long folder name that overflows the container it is in",
+                "id": "Sources",
+                "name": "Sources",
+              }
             }
-          }
-          key="Really really really long folder name that overflows the container it is in"
-          name="Really really really long folder name that overflows the container it is in"
-          onSelect={[MockFunction]}
-        >
-          <li
-            className="pf-c-tree-view__list-item"
-            id="Long"
-            role="treeitem"
-            tabIndex={0}
+            key="Sources"
+            name="Sources"
+            onSelect={[MockFunction]}
           >
-            <div
-              className="pf-c-tree-view__content"
+            <li
+              className="pf-c-tree-view__list-item"
+              id="Sources"
+              role="treeitem"
+              tabIndex={0}
             >
-              <GenerateId
-                prefix="checkbox-id"
+              <div
+                className="pf-c-tree-view__content"
               >
-                <div
-                  className="pf-c-tree-view__node"
-                  onClick={[Function]}
+                <GenerateId
+                  prefix="checkbox-id"
                 >
-                  <button
-                    aria-labelledby="label-checkbox-id23"
-                    className="pf-c-tree-view__node-toggle"
+                  <div
+                    className="pf-c-tree-view__node"
                     onClick={[Function]}
                   >
-                    <span
-                      className="pf-c-tree-view__node-toggle-icon"
-                    >
-                      <AngleRightIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </AngleRightIcon>
-                    </span>
-                  </button>
-                  <span
-                    className="pf-c-tree-view__node-check"
-                  >
-                    <input
-                      checked={false}
-                      id="checkbox-id23"
-                      onChange={[Function]}
+                    <button
+                      aria-labelledby="label-checkbox-id22"
+                      className="pf-c-tree-view__node-toggle"
                       onClick={[Function]}
-                      type="checkbox"
-                    />
-                  </span>
-                  <label
-                    className="pf-c-tree-view__node-text"
-                    htmlFor="checkbox-id23"
-                    id="label-checkbox-id23"
+                    >
+                      <span
+                        className="pf-c-tree-view__node-toggle-icon"
+                      >
+                        <AngleRightIcon
+                          aria-hidden="true"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </AngleRightIcon>
+                      </span>
+                    </button>
+                    <span
+                      className="pf-c-tree-view__node-check"
+                    >
+                      <input
+                        checked={false}
+                        id="checkbox-id22"
+                        onChange={[Function]}
+                        onClick={[Function]}
+                        type="checkbox"
+                      />
+                    </span>
+                    <label
+                      className="pf-c-tree-view__node-text"
+                      htmlFor="checkbox-id22"
+                      id="label-checkbox-id22"
+                    >
+                      Sources
+                    </label>
+                  </div>
+                </GenerateId>
+              </div>
+            </li>
+          </TreeViewListItem>
+          <TreeViewListItem
+            activeItems={
+              Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "id": "App1Settings",
+                      "name": "Settings",
+                    },
+                    Object {
+                      "id": "App1Current",
+                      "name": "Current",
+                    },
+                  ],
+                  "id": "App1",
+                  "name": "Application 1",
+                },
+              ]
+            }
+            compareItems={[Function]}
+            defaultExpanded={false}
+            hasBadge={false}
+            hasCheck={true}
+            id="Long"
+            itemData={
+              Object {
+                "children": Array [
+                  Object {
+                    "id": "App5",
+                    "name": "Application 5",
+                  },
+                ],
+                "id": "Long",
+                "name": "Really really really long folder name that overflows the container it is in",
+              }
+            }
+            key="Really really really long folder name that overflows the container it is in"
+            name="Really really really long folder name that overflows the container it is in"
+            onSelect={[MockFunction]}
+          >
+            <li
+              className="pf-c-tree-view__list-item"
+              id="Long"
+              role="treeitem"
+              tabIndex={0}
+            >
+              <div
+                className="pf-c-tree-view__content"
+              >
+                <GenerateId
+                  prefix="checkbox-id"
+                >
+                  <div
+                    className="pf-c-tree-view__node"
+                    onClick={[Function]}
                   >
-                    Really really really long folder name that overflows the container it is in
-                  </label>
-                </div>
-              </GenerateId>
-            </div>
-          </li>
-        </TreeViewListItem>
-      </ul>
-    </TreeViewList>
-  </div>
+                    <button
+                      aria-labelledby="label-checkbox-id23"
+                      className="pf-c-tree-view__node-toggle"
+                      onClick={[Function]}
+                    >
+                      <span
+                        className="pf-c-tree-view__node-toggle-icon"
+                      >
+                        <AngleRightIcon
+                          aria-hidden="true"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </AngleRightIcon>
+                      </span>
+                    </button>
+                    <span
+                      className="pf-c-tree-view__node-check"
+                    >
+                      <input
+                        checked={false}
+                        id="checkbox-id23"
+                        onChange={[Function]}
+                        onClick={[Function]}
+                        type="checkbox"
+                      />
+                    </span>
+                    <label
+                      className="pf-c-tree-view__node-text"
+                      htmlFor="checkbox-id23"
+                      id="label-checkbox-id23"
+                    >
+                      Really really really long folder name that overflows the container it is in
+                    </label>
+                  </div>
+                </GenerateId>
+              </div>
+            </li>
+          </TreeViewListItem>
+        </ul>
+      </TreeViewList>
+    </div>
+  </TreeViewRoot>
 </TreeView>
 `;
 
@@ -4351,57 +4359,20 @@ exports[`tree view renders icons successfully 1`] = `
   }
   onSelect={[MockFunction]}
 >
-  <div
-    className="pf-c-tree-view"
-  >
-    <TreeViewList
-      isNested={false}
+  <TreeViewRoot>
+    <div
+      className="pf-c-tree-view"
     >
-      <ul
-        className="pf-c-tree-view__list"
-        role="tree"
+      <TreeViewList
+        isNested={false}
       >
-        <TreeViewListItem
-          activeItems={
-            Array [
-              Object {
-                "children": Array [
-                  Object {
-                    "id": "App1Settings",
-                    "name": "Settings",
-                  },
-                  Object {
-                    "id": "App1Current",
-                    "name": "Current",
-                  },
-                ],
-                "id": "App1",
-                "name": "Application 1",
-              },
-            ]
-          }
-          compareItems={[Function]}
-          defaultExpanded={true}
-          expandedIcon={
-            <FolderOpenIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
-            />
-          }
-          hasBadge={false}
-          hasCheck={false}
-          icon={
-            <FolderIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
-            />
-          }
-          id="AppLaunch"
-          itemData={
-            Object {
-              "children": Array [
+        <ul
+          className="pf-c-tree-view__list"
+          role="tree"
+        >
+          <TreeViewListItem
+            activeItems={
+              Array [
                 Object {
                   "children": Array [
                     Object {
@@ -4416,152 +4387,30 @@ exports[`tree view renders icons successfully 1`] = `
                   "id": "App1",
                   "name": "Application 1",
                 },
-                Object {
-                  "children": Array [
-                    Object {
-                      "id": "App2Settings",
-                      "name": "Settings",
-                    },
-                    Object {
-                      "children": Array [
-                        Object {
-                          "id": "LoadApp1",
-                          "name": "Loading App 1",
-                        },
-                        Object {
-                          "id": "LoadApp2",
-                          "name": "Loading App 2",
-                        },
-                        Object {
-                          "id": "LoadApp3",
-                          "name": "Loading App 3",
-                        },
-                      ],
-                      "id": "App2Loader",
-                      "name": "Loader",
-                    },
-                  ],
-                  "id": "App2",
-                  "name": "Application 2",
-                },
-              ],
-              "defaultExpanded": true,
-              "id": "AppLaunch",
-              "name": "ApplicationLauncher",
+              ]
             }
-          }
-          key="ApplicationLauncher"
-          name="ApplicationLauncher"
-          onSelect={[MockFunction]}
-        >
-          <li
-            aria-expanded="true"
-            className="pf-c-tree-view__list-item pf-m-expanded"
+            compareItems={[Function]}
+            defaultExpanded={true}
+            expandedIcon={
+              <FolderOpenIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
+              />
+            }
+            hasBadge={false}
+            hasCheck={false}
+            icon={
+              <FolderIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
+              />
+            }
             id="AppLaunch"
-            role="treeitem"
-            tabIndex={0}
-          >
-            <div
-              className="pf-c-tree-view__content"
-            >
-              <GenerateId
-                prefix="checkbox-id"
-              >
-                <button
-                  className="pf-c-tree-view__node"
-                  onClick={[Function]}
-                >
-                  <div
-                    className="pf-c-tree-view__node-toggle"
-                    onClick={[Function]}
-                  >
-                    <span
-                      className="pf-c-tree-view__node-toggle-icon"
-                    >
-                      <AngleRightIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </AngleRightIcon>
-                    </span>
-                  </div>
-                  <span
-                    className="pf-c-tree-view__node-icon"
-                  >
-                    <FolderOpenIcon
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="sm"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        aria-labelledby={null}
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style={
-                          Object {
-                            "verticalAlign": "-0.125em",
-                          }
-                        }
-                        viewBox="0 0 576 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M572.694 292.093L500.27 416.248A63.997 63.997 0 0 1 444.989 448H45.025c-18.523 0-30.064-20.093-20.731-36.093l72.424-124.155A64 64 0 0 1 152 256h399.964c18.523 0 30.064 20.093 20.73 36.093zM152 224h328v-48c0-26.51-21.49-48-48-48H272l-64-64H48C21.49 64 0 85.49 0 112v278.046l69.077-118.418C86.214 242.25 117.989 224 152 224z"
-                        />
-                      </svg>
-                    </FolderOpenIcon>
-                  </span>
-                  <span
-                    className="pf-c-tree-view__node-text"
-                  >
-                    ApplicationLauncher
-                  </span>
-                </button>
-              </GenerateId>
-            </div>
-            <TreeView
-              activeItems={
-                Array [
-                  Object {
-                    "children": Array [
-                      Object {
-                        "id": "App1Settings",
-                        "name": "Settings",
-                      },
-                      Object {
-                        "id": "App1Current",
-                        "name": "Current",
-                      },
-                    ],
-                    "id": "App1",
-                    "name": "Application 1",
-                  },
-                ]
-              }
-              data={
-                Array [
+            itemData={
+              Object {
+                "children": Array [
                   Object {
                     "children": Array [
                       Object {
@@ -4604,30 +4453,124 @@ exports[`tree view renders icons successfully 1`] = `
                     "id": "App2",
                     "name": "Application 2",
                   },
-                ]
+                ],
+                "defaultExpanded": true,
+                "id": "AppLaunch",
+                "name": "ApplicationLauncher",
               }
-              defaultAllExpanded={false}
-              expandedIcon={
-                <FolderOpenIcon
-                  color="currentColor"
-                  noVerticalAlign={false}
-                  size="sm"
-                />
-              }
-              hasBadges={false}
-              hasChecks={false}
-              icon={
-                <FolderIcon
-                  color="currentColor"
-                  noVerticalAlign={false}
-                  size="sm"
-                />
-              }
-              isNested={true}
-              onSelect={[MockFunction]}
-              parentItem={
-                Object {
-                  "children": Array [
+            }
+            key="ApplicationLauncher"
+            name="ApplicationLauncher"
+            onSelect={[MockFunction]}
+          >
+            <li
+              aria-expanded="true"
+              className="pf-c-tree-view__list-item pf-m-expanded"
+              id="AppLaunch"
+              role="treeitem"
+              tabIndex={0}
+            >
+              <div
+                className="pf-c-tree-view__content"
+              >
+                <GenerateId
+                  prefix="checkbox-id"
+                >
+                  <button
+                    className="pf-c-tree-view__node"
+                    onClick={[Function]}
+                  >
+                    <div
+                      className="pf-c-tree-view__node-toggle"
+                      onClick={[Function]}
+                    >
+                      <span
+                        className="pf-c-tree-view__node-toggle-icon"
+                      >
+                        <AngleRightIcon
+                          aria-hidden="true"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </AngleRightIcon>
+                      </span>
+                    </div>
+                    <span
+                      className="pf-c-tree-view__node-icon"
+                    >
+                      <FolderOpenIcon
+                        color="currentColor"
+                        noVerticalAlign={false}
+                        size="sm"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          aria-labelledby={null}
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style={
+                            Object {
+                              "verticalAlign": "-0.125em",
+                            }
+                          }
+                          viewBox="0 0 576 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M572.694 292.093L500.27 416.248A63.997 63.997 0 0 1 444.989 448H45.025c-18.523 0-30.064-20.093-20.731-36.093l72.424-124.155A64 64 0 0 1 152 256h399.964c18.523 0 30.064 20.093 20.73 36.093zM152 224h328v-48c0-26.51-21.49-48-48-48H272l-64-64H48C21.49 64 0 85.49 0 112v278.046l69.077-118.418C86.214 242.25 117.989 224 152 224z"
+                          />
+                        </svg>
+                      </FolderOpenIcon>
+                    </span>
+                    <span
+                      className="pf-c-tree-view__node-text"
+                    >
+                      ApplicationLauncher
+                    </span>
+                  </button>
+                </GenerateId>
+              </div>
+              <TreeView
+                activeItems={
+                  Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": "App1Settings",
+                          "name": "Settings",
+                        },
+                        Object {
+                          "id": "App1Current",
+                          "name": "Current",
+                        },
+                      ],
+                      "id": "App1",
+                      "name": "Application 1",
+                    },
+                  ]
+                }
+                data={
+                  Array [
                     Object {
                       "children": Array [
                         Object {
@@ -4670,59 +4613,30 @@ exports[`tree view renders icons successfully 1`] = `
                       "id": "App2",
                       "name": "Application 2",
                     },
-                  ],
-                  "defaultExpanded": true,
-                  "id": "AppLaunch",
-                  "name": "ApplicationLauncher",
+                  ]
                 }
-              }
-            >
-              <TreeViewList
+                defaultAllExpanded={false}
+                expandedIcon={
+                  <FolderOpenIcon
+                    color="currentColor"
+                    noVerticalAlign={false}
+                    size="sm"
+                  />
+                }
+                hasBadges={false}
+                hasChecks={false}
+                icon={
+                  <FolderIcon
+                    color="currentColor"
+                    noVerticalAlign={false}
+                    size="sm"
+                  />
+                }
                 isNested={true}
-              >
-                <ul
-                  className="pf-c-tree-view__list"
-                  role="group"
-                >
-                  <TreeViewListItem
-                    activeItems={
-                      Array [
-                        Object {
-                          "children": Array [
-                            Object {
-                              "id": "App1Settings",
-                              "name": "Settings",
-                            },
-                            Object {
-                              "id": "App1Current",
-                              "name": "Current",
-                            },
-                          ],
-                          "id": "App1",
-                          "name": "Application 1",
-                        },
-                      ]
-                    }
-                    compareItems={[Function]}
-                    defaultExpanded={false}
-                    expandedIcon={
-                      <FolderOpenIcon
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
-                      />
-                    }
-                    hasBadge={false}
-                    hasCheck={false}
-                    icon={
-                      <FolderIcon
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
-                      />
-                    }
-                    id="App1"
-                    itemData={
+                onSelect={[MockFunction]}
+                parentItem={
+                  Object {
+                    "children": Array [
                       Object {
                         "children": Array [
                           Object {
@@ -4736,190 +4650,7 @@ exports[`tree view renders icons successfully 1`] = `
                         ],
                         "id": "App1",
                         "name": "Application 1",
-                      }
-                    }
-                    key="Application 1"
-                    name="Application 1"
-                    onSelect={[MockFunction]}
-                    parentItem={
-                      Object {
-                        "children": Array [
-                          Object {
-                            "children": Array [
-                              Object {
-                                "id": "App1Settings",
-                                "name": "Settings",
-                              },
-                              Object {
-                                "id": "App1Current",
-                                "name": "Current",
-                              },
-                            ],
-                            "id": "App1",
-                            "name": "Application 1",
-                          },
-                          Object {
-                            "children": Array [
-                              Object {
-                                "id": "App2Settings",
-                                "name": "Settings",
-                              },
-                              Object {
-                                "children": Array [
-                                  Object {
-                                    "id": "LoadApp1",
-                                    "name": "Loading App 1",
-                                  },
-                                  Object {
-                                    "id": "LoadApp2",
-                                    "name": "Loading App 2",
-                                  },
-                                  Object {
-                                    "id": "LoadApp3",
-                                    "name": "Loading App 3",
-                                  },
-                                ],
-                                "id": "App2Loader",
-                                "name": "Loader",
-                              },
-                            ],
-                            "id": "App2",
-                            "name": "Application 2",
-                          },
-                        ],
-                        "defaultExpanded": true,
-                        "id": "AppLaunch",
-                        "name": "ApplicationLauncher",
-                      }
-                    }
-                  >
-                    <li
-                      className="pf-c-tree-view__list-item"
-                      id="App1"
-                      role="treeitem"
-                      tabIndex={0}
-                    >
-                      <div
-                        className="pf-c-tree-view__content"
-                      >
-                        <GenerateId
-                          prefix="checkbox-id"
-                        >
-                          <button
-                            className="pf-c-tree-view__node"
-                            onClick={[Function]}
-                          >
-                            <div
-                              className="pf-c-tree-view__node-toggle"
-                              onClick={[Function]}
-                            >
-                              <span
-                                className="pf-c-tree-view__node-toggle-icon"
-                              >
-                                <AngleRightIcon
-                                  aria-hidden="true"
-                                  color="currentColor"
-                                  noVerticalAlign={false}
-                                  size="sm"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-labelledby={null}
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    style={
-                                      Object {
-                                        "verticalAlign": "-0.125em",
-                                      }
-                                    }
-                                    viewBox="0 0 256 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                    />
-                                  </svg>
-                                </AngleRightIcon>
-                              </span>
-                            </div>
-                            <span
-                              className="pf-c-tree-view__node-icon"
-                            >
-                              <FolderIcon
-                                color="currentColor"
-                                noVerticalAlign={false}
-                                size="sm"
-                              >
-                                <svg
-                                  aria-hidden={true}
-                                  aria-labelledby={null}
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  style={
-                                    Object {
-                                      "verticalAlign": "-0.125em",
-                                    }
-                                  }
-                                  viewBox="0 0 512 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M464 128H272l-64-64H48C21.49 64 0 85.49 0 112v288c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V176c0-26.51-21.49-48-48-48z"
-                                  />
-                                </svg>
-                              </FolderIcon>
-                            </span>
-                            <span
-                              className="pf-c-tree-view__node-text"
-                            >
-                              Application 1
-                            </span>
-                          </button>
-                        </GenerateId>
-                      </div>
-                    </li>
-                  </TreeViewListItem>
-                  <TreeViewListItem
-                    activeItems={
-                      Array [
-                        Object {
-                          "children": Array [
-                            Object {
-                              "id": "App1Settings",
-                              "name": "Settings",
-                            },
-                            Object {
-                              "id": "App1Current",
-                              "name": "Current",
-                            },
-                          ],
-                          "id": "App1",
-                          "name": "Application 1",
-                        },
-                      ]
-                    }
-                    compareItems={[Function]}
-                    defaultExpanded={false}
-                    expandedIcon={
-                      <FolderOpenIcon
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
-                      />
-                    }
-                    hasBadge={false}
-                    hasCheck={false}
-                    icon={
-                      <FolderIcon
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
-                      />
-                    }
-                    id="App2"
-                    itemData={
+                      },
                       Object {
                         "children": Array [
                           Object {
@@ -4947,14 +4678,24 @@ exports[`tree view renders icons successfully 1`] = `
                         ],
                         "id": "App2",
                         "name": "Application 2",
-                      }
-                    }
-                    key="Application 2"
-                    name="Application 2"
-                    onSelect={[MockFunction]}
-                    parentItem={
-                      Object {
-                        "children": Array [
+                      },
+                    ],
+                    "defaultExpanded": true,
+                    "id": "AppLaunch",
+                    "name": "ApplicationLauncher",
+                  }
+                }
+              >
+                <TreeViewList
+                  isNested={true}
+                >
+                  <ul
+                    className="pf-c-tree-view__list"
+                    role="group"
+                  >
+                    <TreeViewListItem
+                      activeItems={
+                        Array [
                           Object {
                             "children": Array [
                               Object {
@@ -4969,72 +4710,158 @@ exports[`tree view renders icons successfully 1`] = `
                             "id": "App1",
                             "name": "Application 1",
                           },
-                          Object {
-                            "children": Array [
-                              Object {
-                                "id": "App2Settings",
-                                "name": "Settings",
-                              },
-                              Object {
-                                "children": Array [
-                                  Object {
-                                    "id": "LoadApp1",
-                                    "name": "Loading App 1",
-                                  },
-                                  Object {
-                                    "id": "LoadApp2",
-                                    "name": "Loading App 2",
-                                  },
-                                  Object {
-                                    "id": "LoadApp3",
-                                    "name": "Loading App 3",
-                                  },
-                                ],
-                                "id": "App2Loader",
-                                "name": "Loader",
-                              },
-                            ],
-                            "id": "App2",
-                            "name": "Application 2",
-                          },
-                        ],
-                        "defaultExpanded": true,
-                        "id": "AppLaunch",
-                        "name": "ApplicationLauncher",
+                        ]
                       }
-                    }
-                  >
-                    <li
-                      className="pf-c-tree-view__list-item"
-                      id="App2"
-                      role="treeitem"
-                      tabIndex={0}
+                      compareItems={[Function]}
+                      defaultExpanded={false}
+                      expandedIcon={
+                        <FolderOpenIcon
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                        />
+                      }
+                      hasBadge={false}
+                      hasCheck={false}
+                      icon={
+                        <FolderIcon
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                        />
+                      }
+                      id="App1"
+                      itemData={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "id": "App1Settings",
+                              "name": "Settings",
+                            },
+                            Object {
+                              "id": "App1Current",
+                              "name": "Current",
+                            },
+                          ],
+                          "id": "App1",
+                          "name": "Application 1",
+                        }
+                      }
+                      key="Application 1"
+                      name="Application 1"
+                      onSelect={[MockFunction]}
+                      parentItem={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "App1Settings",
+                                  "name": "Settings",
+                                },
+                                Object {
+                                  "id": "App1Current",
+                                  "name": "Current",
+                                },
+                              ],
+                              "id": "App1",
+                              "name": "Application 1",
+                            },
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "App2Settings",
+                                  "name": "Settings",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "id": "LoadApp1",
+                                      "name": "Loading App 1",
+                                    },
+                                    Object {
+                                      "id": "LoadApp2",
+                                      "name": "Loading App 2",
+                                    },
+                                    Object {
+                                      "id": "LoadApp3",
+                                      "name": "Loading App 3",
+                                    },
+                                  ],
+                                  "id": "App2Loader",
+                                  "name": "Loader",
+                                },
+                              ],
+                              "id": "App2",
+                              "name": "Application 2",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "id": "AppLaunch",
+                          "name": "ApplicationLauncher",
+                        }
+                      }
                     >
-                      <div
-                        className="pf-c-tree-view__content"
+                      <li
+                        className="pf-c-tree-view__list-item"
+                        id="App1"
+                        role="treeitem"
+                        tabIndex={0}
                       >
-                        <GenerateId
-                          prefix="checkbox-id"
+                        <div
+                          className="pf-c-tree-view__content"
                         >
-                          <button
-                            className="pf-c-tree-view__node"
-                            onClick={[Function]}
+                          <GenerateId
+                            prefix="checkbox-id"
                           >
-                            <div
-                              className="pf-c-tree-view__node-toggle"
+                            <button
+                              className="pf-c-tree-view__node"
                               onClick={[Function]}
                             >
-                              <span
-                                className="pf-c-tree-view__node-toggle-icon"
+                              <div
+                                className="pf-c-tree-view__node-toggle"
+                                onClick={[Function]}
                               >
-                                <AngleRightIcon
-                                  aria-hidden="true"
+                                <span
+                                  className="pf-c-tree-view__node-toggle-icon"
+                                >
+                                  <AngleRightIcon
+                                    aria-hidden="true"
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                      />
+                                    </svg>
+                                  </AngleRightIcon>
+                                </span>
+                              </div>
+                              <span
+                                className="pf-c-tree-view__node-icon"
+                              >
+                                <FolderIcon
                                   color="currentColor"
                                   noVerticalAlign={false}
                                   size="sm"
                                 >
                                   <svg
-                                    aria-hidden="true"
+                                    aria-hidden={true}
                                     aria-labelledby={null}
                                     fill="currentColor"
                                     height="1em"
@@ -5044,154 +4871,365 @@ exports[`tree view renders icons successfully 1`] = `
                                         "verticalAlign": "-0.125em",
                                       }
                                     }
-                                    viewBox="0 0 256 512"
+                                    viewBox="0 0 512 512"
                                     width="1em"
                                   >
                                     <path
-                                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                      d="M464 128H272l-64-64H48C21.49 64 0 85.49 0 112v288c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V176c0-26.51-21.49-48-48-48z"
                                     />
                                   </svg>
-                                </AngleRightIcon>
+                                </FolderIcon>
                               </span>
-                            </div>
-                            <span
-                              className="pf-c-tree-view__node-icon"
-                            >
-                              <FolderIcon
-                                color="currentColor"
-                                noVerticalAlign={false}
-                                size="sm"
+                              <span
+                                className="pf-c-tree-view__node-text"
                               >
-                                <svg
-                                  aria-hidden={true}
-                                  aria-labelledby={null}
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  style={
+                                Application 1
+                              </span>
+                            </button>
+                          </GenerateId>
+                        </div>
+                      </li>
+                    </TreeViewListItem>
+                    <TreeViewListItem
+                      activeItems={
+                        Array [
+                          Object {
+                            "children": Array [
+                              Object {
+                                "id": "App1Settings",
+                                "name": "Settings",
+                              },
+                              Object {
+                                "id": "App1Current",
+                                "name": "Current",
+                              },
+                            ],
+                            "id": "App1",
+                            "name": "Application 1",
+                          },
+                        ]
+                      }
+                      compareItems={[Function]}
+                      defaultExpanded={false}
+                      expandedIcon={
+                        <FolderOpenIcon
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                        />
+                      }
+                      hasBadge={false}
+                      hasCheck={false}
+                      icon={
+                        <FolderIcon
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                        />
+                      }
+                      id="App2"
+                      itemData={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "id": "App2Settings",
+                              "name": "Settings",
+                            },
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "LoadApp1",
+                                  "name": "Loading App 1",
+                                },
+                                Object {
+                                  "id": "LoadApp2",
+                                  "name": "Loading App 2",
+                                },
+                                Object {
+                                  "id": "LoadApp3",
+                                  "name": "Loading App 3",
+                                },
+                              ],
+                              "id": "App2Loader",
+                              "name": "Loader",
+                            },
+                          ],
+                          "id": "App2",
+                          "name": "Application 2",
+                        }
+                      }
+                      key="Application 2"
+                      name="Application 2"
+                      onSelect={[MockFunction]}
+                      parentItem={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "App1Settings",
+                                  "name": "Settings",
+                                },
+                                Object {
+                                  "id": "App1Current",
+                                  "name": "Current",
+                                },
+                              ],
+                              "id": "App1",
+                              "name": "Application 1",
+                            },
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "App2Settings",
+                                  "name": "Settings",
+                                },
+                                Object {
+                                  "children": Array [
                                     Object {
-                                      "verticalAlign": "-0.125em",
-                                    }
-                                  }
-                                  viewBox="0 0 512 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M464 128H272l-64-64H48C21.49 64 0 85.49 0 112v288c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V176c0-26.51-21.49-48-48-48z"
-                                  />
-                                </svg>
-                              </FolderIcon>
-                            </span>
-                            <span
-                              className="pf-c-tree-view__node-text"
+                                      "id": "LoadApp1",
+                                      "name": "Loading App 1",
+                                    },
+                                    Object {
+                                      "id": "LoadApp2",
+                                      "name": "Loading App 2",
+                                    },
+                                    Object {
+                                      "id": "LoadApp3",
+                                      "name": "Loading App 3",
+                                    },
+                                  ],
+                                  "id": "App2Loader",
+                                  "name": "Loader",
+                                },
+                              ],
+                              "id": "App2",
+                              "name": "Application 2",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "id": "AppLaunch",
+                          "name": "ApplicationLauncher",
+                        }
+                      }
+                    >
+                      <li
+                        className="pf-c-tree-view__list-item"
+                        id="App2"
+                        role="treeitem"
+                        tabIndex={0}
+                      >
+                        <div
+                          className="pf-c-tree-view__content"
+                        >
+                          <GenerateId
+                            prefix="checkbox-id"
+                          >
+                            <button
+                              className="pf-c-tree-view__node"
+                              onClick={[Function]}
                             >
-                              Application 2
-                            </span>
-                          </button>
-                        </GenerateId>
-                      </div>
-                    </li>
-                  </TreeViewListItem>
-                </ul>
-              </TreeViewList>
-            </TreeView>
-          </li>
-        </TreeViewListItem>
-        <TreeViewListItem
-          activeItems={
-            Array [
-              Object {
-                "children": Array [
-                  Object {
-                    "id": "App1Settings",
-                    "name": "Settings",
-                  },
-                  Object {
-                    "id": "App1Current",
-                    "name": "Current",
-                  },
-                ],
-                "id": "App1",
-                "name": "Application 1",
-              },
-            ]
-          }
-          compareItems={[Function]}
-          defaultExpanded={false}
-          expandedIcon={
-            <FolderOpenIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
-            />
-          }
-          hasBadge={false}
-          hasCheck={false}
-          icon={
-            <FolderIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
-            />
-          }
-          id="Cost"
-          itemData={
-            Object {
-              "children": Array [
+                              <div
+                                className="pf-c-tree-view__node-toggle"
+                                onClick={[Function]}
+                              >
+                                <span
+                                  className="pf-c-tree-view__node-toggle-icon"
+                                >
+                                  <AngleRightIcon
+                                    aria-hidden="true"
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                      />
+                                    </svg>
+                                  </AngleRightIcon>
+                                </span>
+                              </div>
+                              <span
+                                className="pf-c-tree-view__node-icon"
+                              >
+                                <FolderIcon
+                                  color="currentColor"
+                                  noVerticalAlign={false}
+                                  size="sm"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    aria-labelledby={null}
+                                    fill="currentColor"
+                                    height="1em"
+                                    role="img"
+                                    style={
+                                      Object {
+                                        "verticalAlign": "-0.125em",
+                                      }
+                                    }
+                                    viewBox="0 0 512 512"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M464 128H272l-64-64H48C21.49 64 0 85.49 0 112v288c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V176c0-26.51-21.49-48-48-48z"
+                                    />
+                                  </svg>
+                                </FolderIcon>
+                              </span>
+                              <span
+                                className="pf-c-tree-view__node-text"
+                              >
+                                Application 2
+                              </span>
+                            </button>
+                          </GenerateId>
+                        </div>
+                      </li>
+                    </TreeViewListItem>
+                  </ul>
+                </TreeViewList>
+              </TreeView>
+            </li>
+          </TreeViewListItem>
+          <TreeViewListItem
+            activeItems={
+              Array [
                 Object {
                   "children": Array [
                     Object {
-                      "id": "App3Settings",
+                      "id": "App1Settings",
                       "name": "Settings",
                     },
                     Object {
-                      "id": "App3Current",
+                      "id": "App1Current",
                       "name": "Current",
                     },
                   ],
-                  "id": "App3",
-                  "name": "Application 3",
+                  "id": "App1",
+                  "name": "Application 1",
                 },
-              ],
-              "id": "Cost",
-              "name": "Cost Management",
+              ]
             }
-          }
-          key="Cost Management"
-          name="Cost Management"
-          onSelect={[MockFunction]}
-        >
-          <li
-            className="pf-c-tree-view__list-item"
+            compareItems={[Function]}
+            defaultExpanded={false}
+            expandedIcon={
+              <FolderOpenIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
+              />
+            }
+            hasBadge={false}
+            hasCheck={false}
+            icon={
+              <FolderIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
+              />
+            }
             id="Cost"
-            role="treeitem"
-            tabIndex={0}
+            itemData={
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "id": "App3Settings",
+                        "name": "Settings",
+                      },
+                      Object {
+                        "id": "App3Current",
+                        "name": "Current",
+                      },
+                    ],
+                    "id": "App3",
+                    "name": "Application 3",
+                  },
+                ],
+                "id": "Cost",
+                "name": "Cost Management",
+              }
+            }
+            key="Cost Management"
+            name="Cost Management"
+            onSelect={[MockFunction]}
           >
-            <div
-              className="pf-c-tree-view__content"
+            <li
+              className="pf-c-tree-view__list-item"
+              id="Cost"
+              role="treeitem"
+              tabIndex={0}
             >
-              <GenerateId
-                prefix="checkbox-id"
+              <div
+                className="pf-c-tree-view__content"
               >
-                <button
-                  className="pf-c-tree-view__node"
-                  onClick={[Function]}
+                <GenerateId
+                  prefix="checkbox-id"
                 >
-                  <div
-                    className="pf-c-tree-view__node-toggle"
+                  <button
+                    className="pf-c-tree-view__node"
                     onClick={[Function]}
                   >
-                    <span
-                      className="pf-c-tree-view__node-toggle-icon"
+                    <div
+                      className="pf-c-tree-view__node-toggle"
+                      onClick={[Function]}
                     >
-                      <AngleRightIcon
-                        aria-hidden="true"
+                      <span
+                        className="pf-c-tree-view__node-toggle-icon"
+                      >
+                        <AngleRightIcon
+                          aria-hidden="true"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </AngleRightIcon>
+                      </span>
+                    </div>
+                    <span
+                      className="pf-c-tree-view__node-icon"
+                    >
+                      <FolderIcon
                         color="currentColor"
                         noVerticalAlign={false}
                         size="sm"
                       >
                         <svg
-                          aria-hidden="true"
+                          aria-hidden={true}
                           aria-labelledby={null}
                           fill="currentColor"
                           height="1em"
@@ -5201,287 +5239,145 @@ exports[`tree view renders icons successfully 1`] = `
                               "verticalAlign": "-0.125em",
                             }
                           }
-                          viewBox="0 0 256 512"
+                          viewBox="0 0 512 512"
                           width="1em"
                         >
                           <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            d="M464 128H272l-64-64H48C21.49 64 0 85.49 0 112v288c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V176c0-26.51-21.49-48-48-48z"
                           />
                         </svg>
-                      </AngleRightIcon>
+                      </FolderIcon>
                     </span>
-                  </div>
-                  <span
-                    className="pf-c-tree-view__node-icon"
-                  >
-                    <FolderIcon
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="sm"
+                    <span
+                      className="pf-c-tree-view__node-text"
                     >
-                      <svg
-                        aria-hidden={true}
-                        aria-labelledby={null}
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style={
-                          Object {
-                            "verticalAlign": "-0.125em",
-                          }
-                        }
-                        viewBox="0 0 512 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M464 128H272l-64-64H48C21.49 64 0 85.49 0 112v288c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V176c0-26.51-21.49-48-48-48z"
-                        />
-                      </svg>
-                    </FolderIcon>
-                  </span>
-                  <span
-                    className="pf-c-tree-view__node-text"
-                  >
-                    Cost Management
-                  </span>
-                </button>
-              </GenerateId>
-            </div>
-          </li>
-        </TreeViewListItem>
-        <TreeViewListItem
-          activeItems={
-            Array [
-              Object {
-                "children": Array [
-                  Object {
-                    "id": "App1Settings",
-                    "name": "Settings",
-                  },
-                  Object {
-                    "id": "App1Current",
-                    "name": "Current",
-                  },
-                ],
-                "id": "App1",
-                "name": "Application 1",
-              },
-            ]
-          }
-          compareItems={[Function]}
-          defaultExpanded={false}
-          expandedIcon={
-            <FolderOpenIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
-            />
-          }
-          hasBadge={false}
-          hasCheck={false}
-          icon={
-            <FolderIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
-            />
-          }
-          id="Sources"
-          itemData={
-            Object {
-              "children": Array [
+                      Cost Management
+                    </span>
+                  </button>
+                </GenerateId>
+              </div>
+            </li>
+          </TreeViewListItem>
+          <TreeViewListItem
+            activeItems={
+              Array [
                 Object {
                   "children": Array [
                     Object {
-                      "id": "App4Settings",
+                      "id": "App1Settings",
                       "name": "Settings",
                     },
+                    Object {
+                      "id": "App1Current",
+                      "name": "Current",
+                    },
                   ],
-                  "id": "App4",
-                  "name": "Application 4",
+                  "id": "App1",
+                  "name": "Application 1",
                 },
-              ],
-              "id": "Sources",
-              "name": "Sources",
+              ]
             }
-          }
-          key="Sources"
-          name="Sources"
-          onSelect={[MockFunction]}
-        >
-          <li
-            className="pf-c-tree-view__list-item"
+            compareItems={[Function]}
+            defaultExpanded={false}
+            expandedIcon={
+              <FolderOpenIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
+              />
+            }
+            hasBadge={false}
+            hasCheck={false}
+            icon={
+              <FolderIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
+              />
+            }
             id="Sources"
-            role="treeitem"
-            tabIndex={0}
-          >
-            <div
-              className="pf-c-tree-view__content"
-            >
-              <GenerateId
-                prefix="checkbox-id"
-              >
-                <button
-                  className="pf-c-tree-view__node"
-                  onClick={[Function]}
-                >
-                  <div
-                    className="pf-c-tree-view__node-toggle"
-                    onClick={[Function]}
-                  >
-                    <span
-                      className="pf-c-tree-view__node-toggle-icon"
-                    >
-                      <AngleRightIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </AngleRightIcon>
-                    </span>
-                  </div>
-                  <span
-                    className="pf-c-tree-view__node-icon"
-                  >
-                    <FolderIcon
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="sm"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        aria-labelledby={null}
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style={
-                          Object {
-                            "verticalAlign": "-0.125em",
-                          }
-                        }
-                        viewBox="0 0 512 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M464 128H272l-64-64H48C21.49 64 0 85.49 0 112v288c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V176c0-26.51-21.49-48-48-48z"
-                        />
-                      </svg>
-                    </FolderIcon>
-                  </span>
-                  <span
-                    className="pf-c-tree-view__node-text"
-                  >
-                    Sources
-                  </span>
-                </button>
-              </GenerateId>
-            </div>
-          </li>
-        </TreeViewListItem>
-        <TreeViewListItem
-          activeItems={
-            Array [
+            itemData={
               Object {
                 "children": Array [
                   Object {
-                    "id": "App1Settings",
-                    "name": "Settings",
-                  },
-                  Object {
-                    "id": "App1Current",
-                    "name": "Current",
+                    "children": Array [
+                      Object {
+                        "id": "App4Settings",
+                        "name": "Settings",
+                      },
+                    ],
+                    "id": "App4",
+                    "name": "Application 4",
                   },
                 ],
-                "id": "App1",
-                "name": "Application 1",
-              },
-            ]
-          }
-          compareItems={[Function]}
-          defaultExpanded={false}
-          expandedIcon={
-            <FolderOpenIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
-            />
-          }
-          hasBadge={false}
-          hasCheck={false}
-          icon={
-            <FolderIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
-            />
-          }
-          id="Long"
-          itemData={
-            Object {
-              "children": Array [
-                Object {
-                  "id": "App5",
-                  "name": "Application 5",
-                },
-              ],
-              "id": "Long",
-              "name": "Really really really long folder name that overflows the container it is in",
+                "id": "Sources",
+                "name": "Sources",
+              }
             }
-          }
-          key="Really really really long folder name that overflows the container it is in"
-          name="Really really really long folder name that overflows the container it is in"
-          onSelect={[MockFunction]}
-        >
-          <li
-            className="pf-c-tree-view__list-item"
-            id="Long"
-            role="treeitem"
-            tabIndex={0}
+            key="Sources"
+            name="Sources"
+            onSelect={[MockFunction]}
           >
-            <div
-              className="pf-c-tree-view__content"
+            <li
+              className="pf-c-tree-view__list-item"
+              id="Sources"
+              role="treeitem"
+              tabIndex={0}
             >
-              <GenerateId
-                prefix="checkbox-id"
+              <div
+                className="pf-c-tree-view__content"
               >
-                <button
-                  className="pf-c-tree-view__node"
-                  onClick={[Function]}
+                <GenerateId
+                  prefix="checkbox-id"
                 >
-                  <div
-                    className="pf-c-tree-view__node-toggle"
+                  <button
+                    className="pf-c-tree-view__node"
                     onClick={[Function]}
                   >
-                    <span
-                      className="pf-c-tree-view__node-toggle-icon"
+                    <div
+                      className="pf-c-tree-view__node-toggle"
+                      onClick={[Function]}
                     >
-                      <AngleRightIcon
-                        aria-hidden="true"
+                      <span
+                        className="pf-c-tree-view__node-toggle-icon"
+                      >
+                        <AngleRightIcon
+                          aria-hidden="true"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </AngleRightIcon>
+                      </span>
+                    </div>
+                    <span
+                      className="pf-c-tree-view__node-icon"
+                    >
+                      <FolderIcon
                         color="currentColor"
                         noVerticalAlign={false}
                         size="sm"
                       >
                         <svg
-                          aria-hidden="true"
+                          aria-hidden={true}
                           aria-labelledby={null}
                           fill="currentColor"
                           height="1em"
@@ -5491,57 +5387,171 @@ exports[`tree view renders icons successfully 1`] = `
                               "verticalAlign": "-0.125em",
                             }
                           }
-                          viewBox="0 0 256 512"
+                          viewBox="0 0 512 512"
                           width="1em"
                         >
                           <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            d="M464 128H272l-64-64H48C21.49 64 0 85.49 0 112v288c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V176c0-26.51-21.49-48-48-48z"
                           />
                         </svg>
-                      </AngleRightIcon>
+                      </FolderIcon>
                     </span>
-                  </div>
-                  <span
-                    className="pf-c-tree-view__node-icon"
-                  >
-                    <FolderIcon
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="sm"
+                    <span
+                      className="pf-c-tree-view__node-text"
                     >
-                      <svg
-                        aria-hidden={true}
-                        aria-labelledby={null}
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style={
-                          Object {
-                            "verticalAlign": "-0.125em",
-                          }
-                        }
-                        viewBox="0 0 512 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M464 128H272l-64-64H48C21.49 64 0 85.49 0 112v288c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V176c0-26.51-21.49-48-48-48z"
-                        />
-                      </svg>
-                    </FolderIcon>
-                  </span>
-                  <span
-                    className="pf-c-tree-view__node-text"
+                      Sources
+                    </span>
+                  </button>
+                </GenerateId>
+              </div>
+            </li>
+          </TreeViewListItem>
+          <TreeViewListItem
+            activeItems={
+              Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "id": "App1Settings",
+                      "name": "Settings",
+                    },
+                    Object {
+                      "id": "App1Current",
+                      "name": "Current",
+                    },
+                  ],
+                  "id": "App1",
+                  "name": "Application 1",
+                },
+              ]
+            }
+            compareItems={[Function]}
+            defaultExpanded={false}
+            expandedIcon={
+              <FolderOpenIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
+              />
+            }
+            hasBadge={false}
+            hasCheck={false}
+            icon={
+              <FolderIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
+              />
+            }
+            id="Long"
+            itemData={
+              Object {
+                "children": Array [
+                  Object {
+                    "id": "App5",
+                    "name": "Application 5",
+                  },
+                ],
+                "id": "Long",
+                "name": "Really really really long folder name that overflows the container it is in",
+              }
+            }
+            key="Really really really long folder name that overflows the container it is in"
+            name="Really really really long folder name that overflows the container it is in"
+            onSelect={[MockFunction]}
+          >
+            <li
+              className="pf-c-tree-view__list-item"
+              id="Long"
+              role="treeitem"
+              tabIndex={0}
+            >
+              <div
+                className="pf-c-tree-view__content"
+              >
+                <GenerateId
+                  prefix="checkbox-id"
+                >
+                  <button
+                    className="pf-c-tree-view__node"
+                    onClick={[Function]}
                   >
-                    Really really really long folder name that overflows the container it is in
-                  </span>
-                </button>
-              </GenerateId>
-            </div>
-          </li>
-        </TreeViewListItem>
-      </ul>
-    </TreeViewList>
-  </div>
+                    <div
+                      className="pf-c-tree-view__node-toggle"
+                      onClick={[Function]}
+                    >
+                      <span
+                        className="pf-c-tree-view__node-toggle-icon"
+                      >
+                        <AngleRightIcon
+                          aria-hidden="true"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </AngleRightIcon>
+                      </span>
+                    </div>
+                    <span
+                      className="pf-c-tree-view__node-icon"
+                    >
+                      <FolderIcon
+                        color="currentColor"
+                        noVerticalAlign={false}
+                        size="sm"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          aria-labelledby={null}
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style={
+                            Object {
+                              "verticalAlign": "-0.125em",
+                            }
+                          }
+                          viewBox="0 0 512 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M464 128H272l-64-64H48C21.49 64 0 85.49 0 112v288c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V176c0-26.51-21.49-48-48-48z"
+                          />
+                        </svg>
+                      </FolderIcon>
+                    </span>
+                    <span
+                      className="pf-c-tree-view__node-text"
+                    >
+                      Really really really long folder name that overflows the container it is in
+                    </span>
+                  </button>
+                </GenerateId>
+              </div>
+            </li>
+          </TreeViewListItem>
+        </ul>
+      </TreeViewList>
+    </div>
+  </TreeViewRoot>
 </TreeView>
 `;
 
@@ -5690,57 +5700,20 @@ exports[`tree view renders individual flag options successfully 1`] = `
   }
   onSelect={[MockFunction]}
 >
-  <div
-    className="pf-c-tree-view"
-  >
-    <TreeViewList
-      isNested={false}
+  <TreeViewRoot>
+    <div
+      className="pf-c-tree-view"
     >
-      <ul
-        className="pf-c-tree-view__list"
-        role="tree"
+      <TreeViewList
+        isNested={false}
       >
-        <TreeViewListItem
-          activeItems={
-            Array [
-              Object {
-                "children": Array [
-                  Object {
-                    "id": "App1Settings",
-                    "name": "Settings",
-                  },
-                  Object {
-                    "id": "App1Current",
-                    "name": "Current",
-                  },
-                ],
-                "id": "App1",
-                "name": "Application 1",
-              },
-            ]
-          }
-          compareItems={[Function]}
-          defaultExpanded={true}
-          expandedIcon={
-            <FolderOpenIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
-            />
-          }
-          hasBadge={false}
-          hasCheck={true}
-          icon={
-            <FolderIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
-            />
-          }
-          id="AppLaunch"
-          itemData={
-            Object {
-              "children": Array [
+        <ul
+          className="pf-c-tree-view__list"
+          role="tree"
+        >
+          <TreeViewListItem
+            activeItems={
+              Array [
                 Object {
                   "children": Array [
                     Object {
@@ -5755,179 +5728,30 @@ exports[`tree view renders individual flag options successfully 1`] = `
                   "id": "App1",
                   "name": "Application 1",
                 },
-                Object {
-                  "children": Array [
-                    Object {
-                      "hasCheck": true,
-                      "id": "App2Settings",
-                      "name": "Settings",
-                    },
-                    Object {
-                      "children": Array [
-                        Object {
-                          "id": "LoadApp1",
-                          "name": "Loading App 1",
-                        },
-                        Object {
-                          "id": "LoadApp2",
-                          "name": "Loading App 2",
-                        },
-                        Object {
-                          "id": "LoadApp3",
-                          "name": "Loading App 3",
-                        },
-                      ],
-                      "id": "App2Loader",
-                      "name": "Loader",
-                    },
-                  ],
-                  "hasBadge": true,
-                  "id": "App2",
-                  "name": "Application 2",
-                },
-              ],
-              "defaultExpanded": true,
-              "expandedIcon": <FolderOpenIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
-              />,
-              "hasCheck": true,
-              "icon": <FolderIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
-              />,
-              "id": "AppLaunch",
-              "name": "ApplicationLauncher",
+              ]
             }
-          }
-          key="ApplicationLauncher"
-          name="ApplicationLauncher"
-          onSelect={[MockFunction]}
-        >
-          <li
-            aria-expanded="true"
-            className="pf-c-tree-view__list-item pf-m-expanded"
+            compareItems={[Function]}
+            defaultExpanded={true}
+            expandedIcon={
+              <FolderOpenIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
+              />
+            }
+            hasBadge={false}
+            hasCheck={true}
+            icon={
+              <FolderIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
+              />
+            }
             id="AppLaunch"
-            role="treeitem"
-            tabIndex={0}
-          >
-            <div
-              className="pf-c-tree-view__content"
-            >
-              <GenerateId
-                prefix="checkbox-id"
-              >
-                <div
-                  className="pf-c-tree-view__node"
-                  onClick={[Function]}
-                >
-                  <button
-                    aria-labelledby="label-checkbox-id36"
-                    className="pf-c-tree-view__node-toggle"
-                    onClick={[Function]}
-                  >
-                    <span
-                      className="pf-c-tree-view__node-toggle-icon"
-                    >
-                      <AngleRightIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </AngleRightIcon>
-                    </span>
-                  </button>
-                  <span
-                    className="pf-c-tree-view__node-check"
-                  >
-                    <input
-                      checked={false}
-                      id="checkbox-id36"
-                      onChange={[Function]}
-                      onClick={[Function]}
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    className="pf-c-tree-view__node-icon"
-                  >
-                    <FolderOpenIcon
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="sm"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        aria-labelledby={null}
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style={
-                          Object {
-                            "verticalAlign": "-0.125em",
-                          }
-                        }
-                        viewBox="0 0 576 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M572.694 292.093L500.27 416.248A63.997 63.997 0 0 1 444.989 448H45.025c-18.523 0-30.064-20.093-20.731-36.093l72.424-124.155A64 64 0 0 1 152 256h399.964c18.523 0 30.064 20.093 20.73 36.093zM152 224h328v-48c0-26.51-21.49-48-48-48H272l-64-64H48C21.49 64 0 85.49 0 112v278.046l69.077-118.418C86.214 242.25 117.989 224 152 224z"
-                        />
-                      </svg>
-                    </FolderOpenIcon>
-                  </span>
-                  <label
-                    className="pf-c-tree-view__node-text"
-                    htmlFor="checkbox-id36"
-                    id="label-checkbox-id36"
-                  >
-                    ApplicationLauncher
-                  </label>
-                </div>
-              </GenerateId>
-            </div>
-            <TreeView
-              activeItems={
-                Array [
-                  Object {
-                    "children": Array [
-                      Object {
-                        "id": "App1Settings",
-                        "name": "Settings",
-                      },
-                      Object {
-                        "id": "App1Current",
-                        "name": "Current",
-                      },
-                    ],
-                    "id": "App1",
-                    "name": "Application 1",
-                  },
-                ]
-              }
-              data={
-                Array [
+            itemData={
+              Object {
+                "children": Array [
                   Object {
                     "children": Array [
                       Object {
@@ -5972,16 +5796,149 @@ exports[`tree view renders individual flag options successfully 1`] = `
                     "id": "App2",
                     "name": "Application 2",
                   },
-                ]
+                ],
+                "defaultExpanded": true,
+                "expandedIcon": <FolderOpenIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
+                />,
+                "hasCheck": true,
+                "icon": <FolderIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
+                />,
+                "id": "AppLaunch",
+                "name": "ApplicationLauncher",
               }
-              defaultAllExpanded={false}
-              hasBadges={false}
-              hasChecks={false}
-              isNested={true}
-              onSelect={[MockFunction]}
-              parentItem={
-                Object {
-                  "children": Array [
+            }
+            key="ApplicationLauncher"
+            name="ApplicationLauncher"
+            onSelect={[MockFunction]}
+          >
+            <li
+              aria-expanded="true"
+              className="pf-c-tree-view__list-item pf-m-expanded"
+              id="AppLaunch"
+              role="treeitem"
+              tabIndex={0}
+            >
+              <div
+                className="pf-c-tree-view__content"
+              >
+                <GenerateId
+                  prefix="checkbox-id"
+                >
+                  <div
+                    className="pf-c-tree-view__node"
+                    onClick={[Function]}
+                  >
+                    <button
+                      aria-labelledby="label-checkbox-id36"
+                      className="pf-c-tree-view__node-toggle"
+                      onClick={[Function]}
+                    >
+                      <span
+                        className="pf-c-tree-view__node-toggle-icon"
+                      >
+                        <AngleRightIcon
+                          aria-hidden="true"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </AngleRightIcon>
+                      </span>
+                    </button>
+                    <span
+                      className="pf-c-tree-view__node-check"
+                    >
+                      <input
+                        checked={false}
+                        id="checkbox-id36"
+                        onChange={[Function]}
+                        onClick={[Function]}
+                        type="checkbox"
+                      />
+                    </span>
+                    <span
+                      className="pf-c-tree-view__node-icon"
+                    >
+                      <FolderOpenIcon
+                        color="currentColor"
+                        noVerticalAlign={false}
+                        size="sm"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          aria-labelledby={null}
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style={
+                            Object {
+                              "verticalAlign": "-0.125em",
+                            }
+                          }
+                          viewBox="0 0 576 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M572.694 292.093L500.27 416.248A63.997 63.997 0 0 1 444.989 448H45.025c-18.523 0-30.064-20.093-20.731-36.093l72.424-124.155A64 64 0 0 1 152 256h399.964c18.523 0 30.064 20.093 20.73 36.093zM152 224h328v-48c0-26.51-21.49-48-48-48H272l-64-64H48C21.49 64 0 85.49 0 112v278.046l69.077-118.418C86.214 242.25 117.989 224 152 224z"
+                          />
+                        </svg>
+                      </FolderOpenIcon>
+                    </span>
+                    <label
+                      className="pf-c-tree-view__node-text"
+                      htmlFor="checkbox-id36"
+                      id="label-checkbox-id36"
+                    >
+                      ApplicationLauncher
+                    </label>
+                  </div>
+                </GenerateId>
+              </div>
+              <TreeView
+                activeItems={
+                  Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": "App1Settings",
+                          "name": "Settings",
+                        },
+                        Object {
+                          "id": "App1Current",
+                          "name": "Current",
+                        },
+                      ],
+                      "id": "App1",
+                      "name": "Application 1",
+                    },
+                  ]
+                }
+                data={
+                  Array [
                     Object {
                       "children": Array [
                         Object {
@@ -6026,56 +5983,16 @@ exports[`tree view renders individual flag options successfully 1`] = `
                       "id": "App2",
                       "name": "Application 2",
                     },
-                  ],
-                  "defaultExpanded": true,
-                  "expandedIcon": <FolderOpenIcon
-                    color="currentColor"
-                    noVerticalAlign={false}
-                    size="sm"
-                  />,
-                  "hasCheck": true,
-                  "icon": <FolderIcon
-                    color="currentColor"
-                    noVerticalAlign={false}
-                    size="sm"
-                  />,
-                  "id": "AppLaunch",
-                  "name": "ApplicationLauncher",
+                  ]
                 }
-              }
-            >
-              <TreeViewList
+                defaultAllExpanded={false}
+                hasBadges={false}
+                hasChecks={false}
                 isNested={true}
-              >
-                <ul
-                  className="pf-c-tree-view__list"
-                  role="group"
-                >
-                  <TreeViewListItem
-                    activeItems={
-                      Array [
-                        Object {
-                          "children": Array [
-                            Object {
-                              "id": "App1Settings",
-                              "name": "Settings",
-                            },
-                            Object {
-                              "id": "App1Current",
-                              "name": "Current",
-                            },
-                          ],
-                          "id": "App1",
-                          "name": "Application 1",
-                        },
-                      ]
-                    }
-                    compareItems={[Function]}
-                    defaultExpanded={false}
-                    hasBadge={false}
-                    hasCheck={false}
-                    id="App1"
-                    itemData={
+                onSelect={[MockFunction]}
+                parentItem={
+                  Object {
+                    "children": Array [
                       Object {
                         "children": Array [
                           Object {
@@ -6089,161 +6006,7 @@ exports[`tree view renders individual flag options successfully 1`] = `
                         ],
                         "id": "App1",
                         "name": "Application 1",
-                      }
-                    }
-                    key="Application 1"
-                    name="Application 1"
-                    onSelect={[MockFunction]}
-                    parentItem={
-                      Object {
-                        "children": Array [
-                          Object {
-                            "children": Array [
-                              Object {
-                                "id": "App1Settings",
-                                "name": "Settings",
-                              },
-                              Object {
-                                "id": "App1Current",
-                                "name": "Current",
-                              },
-                            ],
-                            "id": "App1",
-                            "name": "Application 1",
-                          },
-                          Object {
-                            "children": Array [
-                              Object {
-                                "hasCheck": true,
-                                "id": "App2Settings",
-                                "name": "Settings",
-                              },
-                              Object {
-                                "children": Array [
-                                  Object {
-                                    "id": "LoadApp1",
-                                    "name": "Loading App 1",
-                                  },
-                                  Object {
-                                    "id": "LoadApp2",
-                                    "name": "Loading App 2",
-                                  },
-                                  Object {
-                                    "id": "LoadApp3",
-                                    "name": "Loading App 3",
-                                  },
-                                ],
-                                "id": "App2Loader",
-                                "name": "Loader",
-                              },
-                            ],
-                            "hasBadge": true,
-                            "id": "App2",
-                            "name": "Application 2",
-                          },
-                        ],
-                        "defaultExpanded": true,
-                        "expandedIcon": <FolderOpenIcon
-                          color="currentColor"
-                          noVerticalAlign={false}
-                          size="sm"
-                        />,
-                        "hasCheck": true,
-                        "icon": <FolderIcon
-                          color="currentColor"
-                          noVerticalAlign={false}
-                          size="sm"
-                        />,
-                        "id": "AppLaunch",
-                        "name": "ApplicationLauncher",
-                      }
-                    }
-                  >
-                    <li
-                      className="pf-c-tree-view__list-item"
-                      id="App1"
-                      role="treeitem"
-                      tabIndex={0}
-                    >
-                      <div
-                        className="pf-c-tree-view__content"
-                      >
-                        <GenerateId
-                          prefix="checkbox-id"
-                        >
-                          <button
-                            className="pf-c-tree-view__node"
-                            onClick={[Function]}
-                          >
-                            <div
-                              className="pf-c-tree-view__node-toggle"
-                              onClick={[Function]}
-                            >
-                              <span
-                                className="pf-c-tree-view__node-toggle-icon"
-                              >
-                                <AngleRightIcon
-                                  aria-hidden="true"
-                                  color="currentColor"
-                                  noVerticalAlign={false}
-                                  size="sm"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-labelledby={null}
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    style={
-                                      Object {
-                                        "verticalAlign": "-0.125em",
-                                      }
-                                    }
-                                    viewBox="0 0 256 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                    />
-                                  </svg>
-                                </AngleRightIcon>
-                              </span>
-                            </div>
-                            <span
-                              className="pf-c-tree-view__node-text"
-                            >
-                              Application 1
-                            </span>
-                          </button>
-                        </GenerateId>
-                      </div>
-                    </li>
-                  </TreeViewListItem>
-                  <TreeViewListItem
-                    activeItems={
-                      Array [
-                        Object {
-                          "children": Array [
-                            Object {
-                              "id": "App1Settings",
-                              "name": "Settings",
-                            },
-                            Object {
-                              "id": "App1Current",
-                              "name": "Current",
-                            },
-                          ],
-                          "id": "App1",
-                          "name": "Application 1",
-                        },
-                      ]
-                    }
-                    compareItems={[Function]}
-                    defaultExpanded={false}
-                    hasBadge={true}
-                    hasCheck={false}
-                    id="App2"
-                    itemData={
+                      },
                       Object {
                         "children": Array [
                           Object {
@@ -6273,14 +6036,35 @@ exports[`tree view renders individual flag options successfully 1`] = `
                         "hasBadge": true,
                         "id": "App2",
                         "name": "Application 2",
-                      }
-                    }
-                    key="Application 2"
-                    name="Application 2"
-                    onSelect={[MockFunction]}
-                    parentItem={
-                      Object {
-                        "children": Array [
+                      },
+                    ],
+                    "defaultExpanded": true,
+                    "expandedIcon": <FolderOpenIcon
+                      color="currentColor"
+                      noVerticalAlign={false}
+                      size="sm"
+                    />,
+                    "hasCheck": true,
+                    "icon": <FolderIcon
+                      color="currentColor"
+                      noVerticalAlign={false}
+                      size="sm"
+                    />,
+                    "id": "AppLaunch",
+                    "name": "ApplicationLauncher",
+                  }
+                }
+              >
+                <TreeViewList
+                  isNested={true}
+                >
+                  <ul
+                    className="pf-c-tree-view__list"
+                    role="group"
+                  >
+                    <TreeViewListItem
+                      activeItems={
+                        Array [
                           Object {
                             "children": Array [
                               Object {
@@ -6295,171 +6079,362 @@ exports[`tree view renders individual flag options successfully 1`] = `
                             "id": "App1",
                             "name": "Application 1",
                           },
+                        ]
+                      }
+                      compareItems={[Function]}
+                      defaultExpanded={false}
+                      hasBadge={false}
+                      hasCheck={false}
+                      id="App1"
+                      itemData={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "id": "App1Settings",
+                              "name": "Settings",
+                            },
+                            Object {
+                              "id": "App1Current",
+                              "name": "Current",
+                            },
+                          ],
+                          "id": "App1",
+                          "name": "Application 1",
+                        }
+                      }
+                      key="Application 1"
+                      name="Application 1"
+                      onSelect={[MockFunction]}
+                      parentItem={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "App1Settings",
+                                  "name": "Settings",
+                                },
+                                Object {
+                                  "id": "App1Current",
+                                  "name": "Current",
+                                },
+                              ],
+                              "id": "App1",
+                              "name": "Application 1",
+                            },
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "hasCheck": true,
+                                  "id": "App2Settings",
+                                  "name": "Settings",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "id": "LoadApp1",
+                                      "name": "Loading App 1",
+                                    },
+                                    Object {
+                                      "id": "LoadApp2",
+                                      "name": "Loading App 2",
+                                    },
+                                    Object {
+                                      "id": "LoadApp3",
+                                      "name": "Loading App 3",
+                                    },
+                                  ],
+                                  "id": "App2Loader",
+                                  "name": "Loader",
+                                },
+                              ],
+                              "hasBadge": true,
+                              "id": "App2",
+                              "name": "Application 2",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "expandedIcon": <FolderOpenIcon
+                            color="currentColor"
+                            noVerticalAlign={false}
+                            size="sm"
+                          />,
+                          "hasCheck": true,
+                          "icon": <FolderIcon
+                            color="currentColor"
+                            noVerticalAlign={false}
+                            size="sm"
+                          />,
+                          "id": "AppLaunch",
+                          "name": "ApplicationLauncher",
+                        }
+                      }
+                    >
+                      <li
+                        className="pf-c-tree-view__list-item"
+                        id="App1"
+                        role="treeitem"
+                        tabIndex={0}
+                      >
+                        <div
+                          className="pf-c-tree-view__content"
+                        >
+                          <GenerateId
+                            prefix="checkbox-id"
+                          >
+                            <button
+                              className="pf-c-tree-view__node"
+                              onClick={[Function]}
+                            >
+                              <div
+                                className="pf-c-tree-view__node-toggle"
+                                onClick={[Function]}
+                              >
+                                <span
+                                  className="pf-c-tree-view__node-toggle-icon"
+                                >
+                                  <AngleRightIcon
+                                    aria-hidden="true"
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                      />
+                                    </svg>
+                                  </AngleRightIcon>
+                                </span>
+                              </div>
+                              <span
+                                className="pf-c-tree-view__node-text"
+                              >
+                                Application 1
+                              </span>
+                            </button>
+                          </GenerateId>
+                        </div>
+                      </li>
+                    </TreeViewListItem>
+                    <TreeViewListItem
+                      activeItems={
+                        Array [
                           Object {
                             "children": Array [
                               Object {
-                                "hasCheck": true,
-                                "id": "App2Settings",
+                                "id": "App1Settings",
                                 "name": "Settings",
                               },
                               Object {
-                                "children": Array [
-                                  Object {
-                                    "id": "LoadApp1",
-                                    "name": "Loading App 1",
-                                  },
-                                  Object {
-                                    "id": "LoadApp2",
-                                    "name": "Loading App 2",
-                                  },
-                                  Object {
-                                    "id": "LoadApp3",
-                                    "name": "Loading App 3",
-                                  },
-                                ],
-                                "id": "App2Loader",
-                                "name": "Loader",
+                                "id": "App1Current",
+                                "name": "Current",
                               },
                             ],
-                            "hasBadge": true,
-                            "id": "App2",
-                            "name": "Application 2",
+                            "id": "App1",
+                            "name": "Application 1",
                           },
-                        ],
-                        "defaultExpanded": true,
-                        "expandedIcon": <FolderOpenIcon
-                          color="currentColor"
-                          noVerticalAlign={false}
-                          size="sm"
-                        />,
-                        "hasCheck": true,
-                        "icon": <FolderIcon
-                          color="currentColor"
-                          noVerticalAlign={false}
-                          size="sm"
-                        />,
-                        "id": "AppLaunch",
-                        "name": "ApplicationLauncher",
+                        ]
                       }
-                    }
-                  >
-                    <li
-                      className="pf-c-tree-view__list-item"
+                      compareItems={[Function]}
+                      defaultExpanded={false}
+                      hasBadge={true}
+                      hasCheck={false}
                       id="App2"
-                      role="treeitem"
-                      tabIndex={0}
+                      itemData={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "hasCheck": true,
+                              "id": "App2Settings",
+                              "name": "Settings",
+                            },
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "LoadApp1",
+                                  "name": "Loading App 1",
+                                },
+                                Object {
+                                  "id": "LoadApp2",
+                                  "name": "Loading App 2",
+                                },
+                                Object {
+                                  "id": "LoadApp3",
+                                  "name": "Loading App 3",
+                                },
+                              ],
+                              "id": "App2Loader",
+                              "name": "Loader",
+                            },
+                          ],
+                          "hasBadge": true,
+                          "id": "App2",
+                          "name": "Application 2",
+                        }
+                      }
+                      key="Application 2"
+                      name="Application 2"
+                      onSelect={[MockFunction]}
+                      parentItem={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "App1Settings",
+                                  "name": "Settings",
+                                },
+                                Object {
+                                  "id": "App1Current",
+                                  "name": "Current",
+                                },
+                              ],
+                              "id": "App1",
+                              "name": "Application 1",
+                            },
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "hasCheck": true,
+                                  "id": "App2Settings",
+                                  "name": "Settings",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "id": "LoadApp1",
+                                      "name": "Loading App 1",
+                                    },
+                                    Object {
+                                      "id": "LoadApp2",
+                                      "name": "Loading App 2",
+                                    },
+                                    Object {
+                                      "id": "LoadApp3",
+                                      "name": "Loading App 3",
+                                    },
+                                  ],
+                                  "id": "App2Loader",
+                                  "name": "Loader",
+                                },
+                              ],
+                              "hasBadge": true,
+                              "id": "App2",
+                              "name": "Application 2",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "expandedIcon": <FolderOpenIcon
+                            color="currentColor"
+                            noVerticalAlign={false}
+                            size="sm"
+                          />,
+                          "hasCheck": true,
+                          "icon": <FolderIcon
+                            color="currentColor"
+                            noVerticalAlign={false}
+                            size="sm"
+                          />,
+                          "id": "AppLaunch",
+                          "name": "ApplicationLauncher",
+                        }
+                      }
                     >
-                      <div
-                        className="pf-c-tree-view__content"
+                      <li
+                        className="pf-c-tree-view__list-item"
+                        id="App2"
+                        role="treeitem"
+                        tabIndex={0}
                       >
-                        <GenerateId
-                          prefix="checkbox-id"
+                        <div
+                          className="pf-c-tree-view__content"
                         >
-                          <button
-                            className="pf-c-tree-view__node"
-                            onClick={[Function]}
+                          <GenerateId
+                            prefix="checkbox-id"
                           >
-                            <div
-                              className="pf-c-tree-view__node-toggle"
+                            <button
+                              className="pf-c-tree-view__node"
                               onClick={[Function]}
                             >
-                              <span
-                                className="pf-c-tree-view__node-toggle-icon"
-                              >
-                                <AngleRightIcon
-                                  aria-hidden="true"
-                                  color="currentColor"
-                                  noVerticalAlign={false}
-                                  size="sm"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-labelledby={null}
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    style={
-                                      Object {
-                                        "verticalAlign": "-0.125em",
-                                      }
-                                    }
-                                    viewBox="0 0 256 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                    />
-                                  </svg>
-                                </AngleRightIcon>
-                              </span>
-                            </div>
-                            <span
-                              className="pf-c-tree-view__node-text"
-                            >
-                              Application 2
-                            </span>
-                            <span
-                              className="pf-c-tree-view__node-count"
-                            >
-                              <Badge
-                                isRead={true}
+                              <div
+                                className="pf-c-tree-view__node-toggle"
+                                onClick={[Function]}
                               >
                                 <span
-                                  className="pf-c-badge pf-m-read"
+                                  className="pf-c-tree-view__node-toggle-icon"
                                 >
-                                  2
+                                  <AngleRightIcon
+                                    aria-hidden="true"
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                      />
+                                    </svg>
+                                  </AngleRightIcon>
                                 </span>
-                              </Badge>
-                            </span>
-                          </button>
-                        </GenerateId>
-                      </div>
-                    </li>
-                  </TreeViewListItem>
-                </ul>
-              </TreeViewList>
-            </TreeView>
-          </li>
-        </TreeViewListItem>
-        <TreeViewListItem
-          action={
-            <Button
-              aria-label="Folder action"
-              variant="plain"
-            >
-              <FolderIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
-              />
-            </Button>
-          }
-          activeItems={
-            Array [
-              Object {
-                "children": Array [
-                  Object {
-                    "id": "App1Settings",
-                    "name": "Settings",
-                  },
-                  Object {
-                    "id": "App1Current",
-                    "name": "Current",
-                  },
-                ],
-                "id": "App1",
-                "name": "Application 1",
-              },
-            ]
-          }
-          compareItems={[Function]}
-          defaultExpanded={false}
-          hasBadge={true}
-          hasCheck={false}
-          id="Cost"
-          itemData={
-            Object {
-              "action": <Button
+                              </div>
+                              <span
+                                className="pf-c-tree-view__node-text"
+                              >
+                                Application 2
+                              </span>
+                              <span
+                                className="pf-c-tree-view__node-count"
+                              >
+                                <Badge
+                                  isRead={true}
+                                >
+                                  <span
+                                    className="pf-c-badge pf-m-read"
+                                  >
+                                    2
+                                  </span>
+                                </Badge>
+                              </span>
+                            </button>
+                          </GenerateId>
+                        </div>
+                      </li>
+                    </TreeViewListItem>
+                  </ul>
+                </TreeViewList>
+              </TreeView>
+            </li>
+          </TreeViewListItem>
+          <TreeViewListItem
+            action={
+              <Button
                 aria-label="Folder action"
                 variant="plain"
               >
@@ -6468,359 +6443,396 @@ exports[`tree view renders individual flag options successfully 1`] = `
                   noVerticalAlign={false}
                   size="sm"
                 />
-              </Button>,
-              "children": Array [
+              </Button>
+            }
+            activeItems={
+              Array [
                 Object {
                   "children": Array [
                     Object {
-                      "id": "App3Settings",
+                      "id": "App1Settings",
                       "name": "Settings",
                     },
                     Object {
-                      "id": "App3Current",
+                      "id": "App1Current",
                       "name": "Current",
                     },
                   ],
-                  "id": "App3",
-                  "name": "Application 3",
+                  "id": "App1",
+                  "name": "Application 1",
                 },
-              ],
-              "hasBadge": true,
-              "id": "Cost",
-              "name": "Cost Management",
+              ]
             }
-          }
-          key="Cost Management"
-          name="Cost Management"
-          onSelect={[MockFunction]}
-        >
-          <li
-            className="pf-c-tree-view__list-item"
+            compareItems={[Function]}
+            defaultExpanded={false}
+            hasBadge={true}
+            hasCheck={false}
             id="Cost"
-            role="treeitem"
-            tabIndex={0}
-          >
-            <div
-              className="pf-c-tree-view__content"
-            >
-              <GenerateId
-                prefix="checkbox-id"
-              >
-                <button
-                  className="pf-c-tree-view__node"
-                  onClick={[Function]}
-                >
-                  <div
-                    className="pf-c-tree-view__node-toggle"
-                    onClick={[Function]}
-                  >
-                    <span
-                      className="pf-c-tree-view__node-toggle-icon"
-                    >
-                      <AngleRightIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </AngleRightIcon>
-                    </span>
-                  </div>
-                  <span
-                    className="pf-c-tree-view__node-text"
-                  >
-                    Cost Management
-                  </span>
-                  <span
-                    className="pf-c-tree-view__node-count"
-                  >
-                    <Badge
-                      isRead={true}
-                    >
-                      <span
-                        className="pf-c-badge pf-m-read"
-                      >
-                        1
-                      </span>
-                    </Badge>
-                  </span>
-                </button>
-              </GenerateId>
-              <div
-                className="pf-c-tree-view__action"
-              >
-                <Button
+            itemData={
+              Object {
+                "action": <Button
                   aria-label="Folder action"
                   variant="plain"
                 >
-                  <button
-                    aria-disabled={false}
-                    aria-label="Folder action"
-                    className="pf-c-button pf-m-plain"
-                    data-ouia-component-id="OUIA-Generated-Button-plain-1"
-                    data-ouia-component-type="PF4/Button"
-                    data-ouia-safe={true}
-                    disabled={false}
-                    role={null}
-                    type="button"
-                  >
-                    <FolderIcon
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="sm"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        aria-labelledby={null}
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style={
-                          Object {
-                            "verticalAlign": "-0.125em",
-                          }
-                        }
-                        viewBox="0 0 512 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M464 128H272l-64-64H48C21.49 64 0 85.49 0 112v288c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V176c0-26.51-21.49-48-48-48z"
-                        />
-                      </svg>
-                    </FolderIcon>
-                  </button>
-                </Button>
-              </div>
-            </div>
-          </li>
-        </TreeViewListItem>
-        <TreeViewListItem
-          activeItems={
-            Array [
-              Object {
+                  <FolderIcon
+                    color="currentColor"
+                    noVerticalAlign={false}
+                    size="sm"
+                  />
+                </Button>,
                 "children": Array [
                   Object {
-                    "id": "App1Settings",
-                    "name": "Settings",
-                  },
-                  Object {
-                    "id": "App1Current",
-                    "name": "Current",
+                    "children": Array [
+                      Object {
+                        "id": "App3Settings",
+                        "name": "Settings",
+                      },
+                      Object {
+                        "id": "App3Current",
+                        "name": "Current",
+                      },
+                    ],
+                    "id": "App3",
+                    "name": "Application 3",
                   },
                 ],
-                "id": "App1",
-                "name": "Application 1",
-              },
-            ]
-          }
-          compareItems={[Function]}
-          defaultExpanded={false}
-          hasBadge={false}
-          hasCheck={false}
-          id="Sources"
-          itemData={
-            Object {
-              "children": Array [
+                "hasBadge": true,
+                "id": "Cost",
+                "name": "Cost Management",
+              }
+            }
+            key="Cost Management"
+            name="Cost Management"
+            onSelect={[MockFunction]}
+          >
+            <li
+              className="pf-c-tree-view__list-item"
+              id="Cost"
+              role="treeitem"
+              tabIndex={0}
+            >
+              <div
+                className="pf-c-tree-view__content"
+              >
+                <GenerateId
+                  prefix="checkbox-id"
+                >
+                  <button
+                    className="pf-c-tree-view__node"
+                    onClick={[Function]}
+                  >
+                    <div
+                      className="pf-c-tree-view__node-toggle"
+                      onClick={[Function]}
+                    >
+                      <span
+                        className="pf-c-tree-view__node-toggle-icon"
+                      >
+                        <AngleRightIcon
+                          aria-hidden="true"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </AngleRightIcon>
+                      </span>
+                    </div>
+                    <span
+                      className="pf-c-tree-view__node-text"
+                    >
+                      Cost Management
+                    </span>
+                    <span
+                      className="pf-c-tree-view__node-count"
+                    >
+                      <Badge
+                        isRead={true}
+                      >
+                        <span
+                          className="pf-c-badge pf-m-read"
+                        >
+                          1
+                        </span>
+                      </Badge>
+                    </span>
+                  </button>
+                </GenerateId>
+                <div
+                  className="pf-c-tree-view__action"
+                >
+                  <Button
+                    aria-label="Folder action"
+                    variant="plain"
+                  >
+                    <button
+                      aria-disabled={false}
+                      aria-label="Folder action"
+                      className="pf-c-button pf-m-plain"
+                      data-ouia-component-id="OUIA-Generated-Button-plain-1"
+                      data-ouia-component-type="PF4/Button"
+                      data-ouia-safe={true}
+                      disabled={false}
+                      role={null}
+                      type="button"
+                    >
+                      <FolderIcon
+                        color="currentColor"
+                        noVerticalAlign={false}
+                        size="sm"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          aria-labelledby={null}
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style={
+                            Object {
+                              "verticalAlign": "-0.125em",
+                            }
+                          }
+                          viewBox="0 0 512 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M464 128H272l-64-64H48C21.49 64 0 85.49 0 112v288c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V176c0-26.51-21.49-48-48-48z"
+                          />
+                        </svg>
+                      </FolderIcon>
+                    </button>
+                  </Button>
+                </div>
+              </div>
+            </li>
+          </TreeViewListItem>
+          <TreeViewListItem
+            activeItems={
+              Array [
                 Object {
                   "children": Array [
                     Object {
-                      "id": "App4Settings",
+                      "id": "App1Settings",
                       "name": "Settings",
                     },
+                    Object {
+                      "id": "App1Current",
+                      "name": "Current",
+                    },
                   ],
-                  "id": "App4",
-                  "name": "Application 4",
+                  "id": "App1",
+                  "name": "Application 1",
                 },
-              ],
-              "id": "Sources",
-              "name": "Sources",
+              ]
             }
-          }
-          key="Sources"
-          name="Sources"
-          onSelect={[MockFunction]}
-        >
-          <li
-            className="pf-c-tree-view__list-item"
+            compareItems={[Function]}
+            defaultExpanded={false}
+            hasBadge={false}
+            hasCheck={false}
             id="Sources"
-            role="treeitem"
-            tabIndex={0}
-          >
-            <div
-              className="pf-c-tree-view__content"
-            >
-              <GenerateId
-                prefix="checkbox-id"
-              >
-                <button
-                  className="pf-c-tree-view__node"
-                  onClick={[Function]}
-                >
-                  <div
-                    className="pf-c-tree-view__node-toggle"
-                    onClick={[Function]}
-                  >
-                    <span
-                      className="pf-c-tree-view__node-toggle-icon"
-                    >
-                      <AngleRightIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </AngleRightIcon>
-                    </span>
-                  </div>
-                  <span
-                    className="pf-c-tree-view__node-text"
-                  >
-                    Sources
-                  </span>
-                </button>
-              </GenerateId>
-            </div>
-          </li>
-        </TreeViewListItem>
-        <TreeViewListItem
-          activeItems={
-            Array [
+            itemData={
               Object {
                 "children": Array [
                   Object {
-                    "id": "App1Settings",
-                    "name": "Settings",
-                  },
-                  Object {
-                    "id": "App1Current",
-                    "name": "Current",
+                    "children": Array [
+                      Object {
+                        "id": "App4Settings",
+                        "name": "Settings",
+                      },
+                    ],
+                    "id": "App4",
+                    "name": "Application 4",
                   },
                 ],
-                "id": "App1",
-                "name": "Application 1",
-              },
-            ]
-          }
-          compareItems={[Function]}
-          defaultExpanded={false}
-          hasBadge={false}
-          hasCheck={false}
-          id="Long"
-          itemData={
-            Object {
-              "children": Array [
-                Object {
-                  "id": "App5",
-                  "name": "Application 5",
-                },
-              ],
-              "id": "Long",
-              "name": "Really really really long folder name that overflows the container it is in",
+                "id": "Sources",
+                "name": "Sources",
+              }
             }
-          }
-          key="Really really really long folder name that overflows the container it is in"
-          name="Really really really long folder name that overflows the container it is in"
-          onSelect={[MockFunction]}
-        >
-          <li
-            className="pf-c-tree-view__list-item"
-            id="Long"
-            role="treeitem"
-            tabIndex={0}
+            key="Sources"
+            name="Sources"
+            onSelect={[MockFunction]}
           >
-            <div
-              className="pf-c-tree-view__content"
+            <li
+              className="pf-c-tree-view__list-item"
+              id="Sources"
+              role="treeitem"
+              tabIndex={0}
             >
-              <GenerateId
-                prefix="checkbox-id"
+              <div
+                className="pf-c-tree-view__content"
               >
-                <button
-                  className="pf-c-tree-view__node"
-                  onClick={[Function]}
+                <GenerateId
+                  prefix="checkbox-id"
                 >
-                  <div
-                    className="pf-c-tree-view__node-toggle"
+                  <button
+                    className="pf-c-tree-view__node"
                     onClick={[Function]}
                   >
-                    <span
-                      className="pf-c-tree-view__node-toggle-icon"
+                    <div
+                      className="pf-c-tree-view__node-toggle"
+                      onClick={[Function]}
                     >
-                      <AngleRightIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
+                      <span
+                        className="pf-c-tree-view__node-toggle-icon"
                       >
-                        <svg
+                        <AngleRightIcon
                           aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 256 512"
-                          width="1em"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
                         >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </AngleRightIcon>
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </AngleRightIcon>
+                      </span>
+                    </div>
+                    <span
+                      className="pf-c-tree-view__node-text"
+                    >
+                      Sources
                     </span>
-                  </div>
-                  <span
-                    className="pf-c-tree-view__node-text"
+                  </button>
+                </GenerateId>
+              </div>
+            </li>
+          </TreeViewListItem>
+          <TreeViewListItem
+            activeItems={
+              Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "id": "App1Settings",
+                      "name": "Settings",
+                    },
+                    Object {
+                      "id": "App1Current",
+                      "name": "Current",
+                    },
+                  ],
+                  "id": "App1",
+                  "name": "Application 1",
+                },
+              ]
+            }
+            compareItems={[Function]}
+            defaultExpanded={false}
+            hasBadge={false}
+            hasCheck={false}
+            id="Long"
+            itemData={
+              Object {
+                "children": Array [
+                  Object {
+                    "id": "App5",
+                    "name": "Application 5",
+                  },
+                ],
+                "id": "Long",
+                "name": "Really really really long folder name that overflows the container it is in",
+              }
+            }
+            key="Really really really long folder name that overflows the container it is in"
+            name="Really really really long folder name that overflows the container it is in"
+            onSelect={[MockFunction]}
+          >
+            <li
+              className="pf-c-tree-view__list-item"
+              id="Long"
+              role="treeitem"
+              tabIndex={0}
+            >
+              <div
+                className="pf-c-tree-view__content"
+              >
+                <GenerateId
+                  prefix="checkbox-id"
+                >
+                  <button
+                    className="pf-c-tree-view__node"
+                    onClick={[Function]}
                   >
-                    Really really really long folder name that overflows the container it is in
-                  </span>
-                </button>
-              </GenerateId>
-            </div>
-          </li>
-        </TreeViewListItem>
-      </ul>
-    </TreeViewList>
-  </div>
+                    <div
+                      className="pf-c-tree-view__node-toggle"
+                      onClick={[Function]}
+                    >
+                      <span
+                        className="pf-c-tree-view__node-toggle-icon"
+                      >
+                        <AngleRightIcon
+                          aria-hidden="true"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </AngleRightIcon>
+                      </span>
+                    </div>
+                    <span
+                      className="pf-c-tree-view__node-text"
+                    >
+                      Really really really long folder name that overflows the container it is in
+                    </span>
+                  </button>
+                </GenerateId>
+              </div>
+            </li>
+          </TreeViewListItem>
+        </ul>
+      </TreeViewList>
+    </div>
+  </TreeViewRoot>
 </TreeView>
 `;
 
@@ -6953,75 +6965,52 @@ exports[`tree view renders search successfully 1`] = `
     }
   }
 >
-  <div
-    className="pf-c-tree-view"
-  >
-    <TreeViewList
-      isNested={false}
-      onSearch={[MockFunction]}
-      searchProps={
-        Object {
-          "aria-label": "Search input example",
-          "id": "input-search",
-          "name": "search-input",
-        }
-      }
+  <TreeViewRoot>
+    <div
+      className="pf-c-tree-view"
     >
-      <TreeViewSearch
-        aria-label="Search input example"
-        id="input-search"
-        name="search-input"
-        onChange={[MockFunction]}
-      >
-        <div
-          className="pf-c-tree-view__search"
-        >
-          <input
-            aria-label="Search input example"
-            className="pf-c-form-control pf-m-search"
-            id="input-search"
-            name="search-input"
-            onChange={[MockFunction]}
-            type="search"
-          />
-        </div>
-      </TreeViewSearch>
-      <Divider>
-        <hr
-          className="pf-c-divider"
-        />
-      </Divider>
-      <ul
-        className="pf-c-tree-view__list"
-        role="tree"
-      >
-        <TreeViewListItem
-          activeItems={
-            Array [
-              Object {
-                "children": Array [
-                  Object {
-                    "id": "App1Settings",
-                    "name": "Settings",
-                  },
-                  Object {
-                    "id": "App1Current",
-                    "name": "Current",
-                  },
-                ],
-                "id": "App1",
-                "name": "Application 1",
-              },
-            ]
+      <TreeViewList
+        isNested={false}
+        onSearch={[MockFunction]}
+        searchProps={
+          Object {
+            "aria-label": "Search input example",
+            "id": "input-search",
+            "name": "search-input",
           }
-          compareItems={[Function]}
-          defaultExpanded={true}
-          hasBadge={false}
-          hasCheck={false}
-          id="AppLaunch"
-          itemData={
-            Object {
-              "children": Array [
+        }
+      >
+        <TreeViewSearch
+          aria-label="Search input example"
+          id="input-search"
+          name="search-input"
+          onChange={[MockFunction]}
+        >
+          <div
+            className="pf-c-tree-view__search"
+          >
+            <input
+              aria-label="Search input example"
+              className="pf-c-form-control pf-m-search"
+              id="input-search"
+              name="search-input"
+              onChange={[MockFunction]}
+              type="search"
+            />
+          </div>
+        </TreeViewSearch>
+        <Divider>
+          <hr
+            className="pf-c-divider"
+          />
+        </Divider>
+        <ul
+          className="pf-c-tree-view__list"
+          role="tree"
+        >
+          <TreeViewListItem
+            activeItems={
+              Array [
                 Object {
                   "children": Array [
                     Object {
@@ -7036,124 +7025,16 @@ exports[`tree view renders search successfully 1`] = `
                   "id": "App1",
                   "name": "Application 1",
                 },
-                Object {
-                  "children": Array [
-                    Object {
-                      "id": "App2Settings",
-                      "name": "Settings",
-                    },
-                    Object {
-                      "children": Array [
-                        Object {
-                          "id": "LoadApp1",
-                          "name": "Loading App 1",
-                        },
-                        Object {
-                          "id": "LoadApp2",
-                          "name": "Loading App 2",
-                        },
-                        Object {
-                          "id": "LoadApp3",
-                          "name": "Loading App 3",
-                        },
-                      ],
-                      "id": "App2Loader",
-                      "name": "Loader",
-                    },
-                  ],
-                  "id": "App2",
-                  "name": "Application 2",
-                },
-              ],
-              "defaultExpanded": true,
-              "id": "AppLaunch",
-              "name": "ApplicationLauncher",
+              ]
             }
-          }
-          key="ApplicationLauncher"
-          name="ApplicationLauncher"
-          onSelect={[MockFunction]}
-        >
-          <li
-            aria-expanded="true"
-            className="pf-c-tree-view__list-item pf-m-expanded"
+            compareItems={[Function]}
+            defaultExpanded={true}
+            hasBadge={false}
+            hasCheck={false}
             id="AppLaunch"
-            role="treeitem"
-            tabIndex={0}
-          >
-            <div
-              className="pf-c-tree-view__content"
-            >
-              <GenerateId
-                prefix="checkbox-id"
-              >
-                <button
-                  className="pf-c-tree-view__node"
-                  onClick={[Function]}
-                >
-                  <div
-                    className="pf-c-tree-view__node-toggle"
-                    onClick={[Function]}
-                  >
-                    <span
-                      className="pf-c-tree-view__node-toggle-icon"
-                    >
-                      <AngleRightIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </AngleRightIcon>
-                    </span>
-                  </div>
-                  <span
-                    className="pf-c-tree-view__node-text"
-                  >
-                    ApplicationLauncher
-                  </span>
-                </button>
-              </GenerateId>
-            </div>
-            <TreeView
-              activeItems={
-                Array [
-                  Object {
-                    "children": Array [
-                      Object {
-                        "id": "App1Settings",
-                        "name": "Settings",
-                      },
-                      Object {
-                        "id": "App1Current",
-                        "name": "Current",
-                      },
-                    ],
-                    "id": "App1",
-                    "name": "Application 1",
-                  },
-                ]
-              }
-              data={
-                Array [
+            itemData={
+              Object {
+                "children": Array [
                   Object {
                     "children": Array [
                       Object {
@@ -7196,16 +7077,96 @@ exports[`tree view renders search successfully 1`] = `
                     "id": "App2",
                     "name": "Application 2",
                   },
-                ]
+                ],
+                "defaultExpanded": true,
+                "id": "AppLaunch",
+                "name": "ApplicationLauncher",
               }
-              defaultAllExpanded={false}
-              hasBadges={false}
-              hasChecks={false}
-              isNested={true}
-              onSelect={[MockFunction]}
-              parentItem={
-                Object {
-                  "children": Array [
+            }
+            key="ApplicationLauncher"
+            name="ApplicationLauncher"
+            onSelect={[MockFunction]}
+          >
+            <li
+              aria-expanded="true"
+              className="pf-c-tree-view__list-item pf-m-expanded"
+              id="AppLaunch"
+              role="treeitem"
+              tabIndex={0}
+            >
+              <div
+                className="pf-c-tree-view__content"
+              >
+                <GenerateId
+                  prefix="checkbox-id"
+                >
+                  <button
+                    className="pf-c-tree-view__node"
+                    onClick={[Function]}
+                  >
+                    <div
+                      className="pf-c-tree-view__node-toggle"
+                      onClick={[Function]}
+                    >
+                      <span
+                        className="pf-c-tree-view__node-toggle-icon"
+                      >
+                        <AngleRightIcon
+                          aria-hidden="true"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </AngleRightIcon>
+                      </span>
+                    </div>
+                    <span
+                      className="pf-c-tree-view__node-text"
+                    >
+                      ApplicationLauncher
+                    </span>
+                  </button>
+                </GenerateId>
+              </div>
+              <TreeView
+                activeItems={
+                  Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "id": "App1Settings",
+                          "name": "Settings",
+                        },
+                        Object {
+                          "id": "App1Current",
+                          "name": "Current",
+                        },
+                      ],
+                      "id": "App1",
+                      "name": "Application 1",
+                    },
+                  ]
+                }
+                data={
+                  Array [
                     Object {
                       "children": Array [
                         Object {
@@ -7248,45 +7209,16 @@ exports[`tree view renders search successfully 1`] = `
                       "id": "App2",
                       "name": "Application 2",
                     },
-                  ],
-                  "defaultExpanded": true,
-                  "id": "AppLaunch",
-                  "name": "ApplicationLauncher",
+                  ]
                 }
-              }
-            >
-              <TreeViewList
+                defaultAllExpanded={false}
+                hasBadges={false}
+                hasChecks={false}
                 isNested={true}
-              >
-                <ul
-                  className="pf-c-tree-view__list"
-                  role="group"
-                >
-                  <TreeViewListItem
-                    activeItems={
-                      Array [
-                        Object {
-                          "children": Array [
-                            Object {
-                              "id": "App1Settings",
-                              "name": "Settings",
-                            },
-                            Object {
-                              "id": "App1Current",
-                              "name": "Current",
-                            },
-                          ],
-                          "id": "App1",
-                          "name": "Application 1",
-                        },
-                      ]
-                    }
-                    compareItems={[Function]}
-                    defaultExpanded={false}
-                    hasBadge={false}
-                    hasCheck={false}
-                    id="App1"
-                    itemData={
+                onSelect={[MockFunction]}
+                parentItem={
+                  Object {
+                    "children": Array [
                       Object {
                         "children": Array [
                           Object {
@@ -7300,148 +7232,7 @@ exports[`tree view renders search successfully 1`] = `
                         ],
                         "id": "App1",
                         "name": "Application 1",
-                      }
-                    }
-                    key="Application 1"
-                    name="Application 1"
-                    onSelect={[MockFunction]}
-                    parentItem={
-                      Object {
-                        "children": Array [
-                          Object {
-                            "children": Array [
-                              Object {
-                                "id": "App1Settings",
-                                "name": "Settings",
-                              },
-                              Object {
-                                "id": "App1Current",
-                                "name": "Current",
-                              },
-                            ],
-                            "id": "App1",
-                            "name": "Application 1",
-                          },
-                          Object {
-                            "children": Array [
-                              Object {
-                                "id": "App2Settings",
-                                "name": "Settings",
-                              },
-                              Object {
-                                "children": Array [
-                                  Object {
-                                    "id": "LoadApp1",
-                                    "name": "Loading App 1",
-                                  },
-                                  Object {
-                                    "id": "LoadApp2",
-                                    "name": "Loading App 2",
-                                  },
-                                  Object {
-                                    "id": "LoadApp3",
-                                    "name": "Loading App 3",
-                                  },
-                                ],
-                                "id": "App2Loader",
-                                "name": "Loader",
-                              },
-                            ],
-                            "id": "App2",
-                            "name": "Application 2",
-                          },
-                        ],
-                        "defaultExpanded": true,
-                        "id": "AppLaunch",
-                        "name": "ApplicationLauncher",
-                      }
-                    }
-                  >
-                    <li
-                      className="pf-c-tree-view__list-item"
-                      id="App1"
-                      role="treeitem"
-                      tabIndex={0}
-                    >
-                      <div
-                        className="pf-c-tree-view__content"
-                      >
-                        <GenerateId
-                          prefix="checkbox-id"
-                        >
-                          <button
-                            className="pf-c-tree-view__node"
-                            onClick={[Function]}
-                          >
-                            <div
-                              className="pf-c-tree-view__node-toggle"
-                              onClick={[Function]}
-                            >
-                              <span
-                                className="pf-c-tree-view__node-toggle-icon"
-                              >
-                                <AngleRightIcon
-                                  aria-hidden="true"
-                                  color="currentColor"
-                                  noVerticalAlign={false}
-                                  size="sm"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    aria-labelledby={null}
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    style={
-                                      Object {
-                                        "verticalAlign": "-0.125em",
-                                      }
-                                    }
-                                    viewBox="0 0 256 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                    />
-                                  </svg>
-                                </AngleRightIcon>
-                              </span>
-                            </div>
-                            <span
-                              className="pf-c-tree-view__node-text"
-                            >
-                              Application 1
-                            </span>
-                          </button>
-                        </GenerateId>
-                      </div>
-                    </li>
-                  </TreeViewListItem>
-                  <TreeViewListItem
-                    activeItems={
-                      Array [
-                        Object {
-                          "children": Array [
-                            Object {
-                              "id": "App1Settings",
-                              "name": "Settings",
-                            },
-                            Object {
-                              "id": "App1Current",
-                              "name": "Current",
-                            },
-                          ],
-                          "id": "App1",
-                          "name": "Application 1",
-                        },
-                      ]
-                    }
-                    compareItems={[Function]}
-                    defaultExpanded={false}
-                    hasBadge={false}
-                    hasCheck={false}
-                    id="App2"
-                    itemData={
+                      },
                       Object {
                         "children": Array [
                           Object {
@@ -7469,14 +7260,24 @@ exports[`tree view renders search successfully 1`] = `
                         ],
                         "id": "App2",
                         "name": "Application 2",
-                      }
-                    }
-                    key="Application 2"
-                    name="Application 2"
-                    onSelect={[MockFunction]}
-                    parentItem={
-                      Object {
-                        "children": Array [
+                      },
+                    ],
+                    "defaultExpanded": true,
+                    "id": "AppLaunch",
+                    "name": "ApplicationLauncher",
+                  }
+                }
+              >
+                <TreeViewList
+                  isNested={true}
+                >
+                  <ul
+                    className="pf-c-tree-view__list"
+                    role="group"
+                  >
+                    <TreeViewListItem
+                      activeItems={
+                        Array [
                           Object {
                             "children": Array [
                               Object {
@@ -7491,424 +7292,637 @@ exports[`tree view renders search successfully 1`] = `
                             "id": "App1",
                             "name": "Application 1",
                           },
+                        ]
+                      }
+                      compareItems={[Function]}
+                      defaultExpanded={false}
+                      hasBadge={false}
+                      hasCheck={false}
+                      id="App1"
+                      itemData={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "id": "App1Settings",
+                              "name": "Settings",
+                            },
+                            Object {
+                              "id": "App1Current",
+                              "name": "Current",
+                            },
+                          ],
+                          "id": "App1",
+                          "name": "Application 1",
+                        }
+                      }
+                      key="Application 1"
+                      name="Application 1"
+                      onSelect={[MockFunction]}
+                      parentItem={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "App1Settings",
+                                  "name": "Settings",
+                                },
+                                Object {
+                                  "id": "App1Current",
+                                  "name": "Current",
+                                },
+                              ],
+                              "id": "App1",
+                              "name": "Application 1",
+                            },
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "App2Settings",
+                                  "name": "Settings",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "id": "LoadApp1",
+                                      "name": "Loading App 1",
+                                    },
+                                    Object {
+                                      "id": "LoadApp2",
+                                      "name": "Loading App 2",
+                                    },
+                                    Object {
+                                      "id": "LoadApp3",
+                                      "name": "Loading App 3",
+                                    },
+                                  ],
+                                  "id": "App2Loader",
+                                  "name": "Loader",
+                                },
+                              ],
+                              "id": "App2",
+                              "name": "Application 2",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "id": "AppLaunch",
+                          "name": "ApplicationLauncher",
+                        }
+                      }
+                    >
+                      <li
+                        className="pf-c-tree-view__list-item"
+                        id="App1"
+                        role="treeitem"
+                        tabIndex={0}
+                      >
+                        <div
+                          className="pf-c-tree-view__content"
+                        >
+                          <GenerateId
+                            prefix="checkbox-id"
+                          >
+                            <button
+                              className="pf-c-tree-view__node"
+                              onClick={[Function]}
+                            >
+                              <div
+                                className="pf-c-tree-view__node-toggle"
+                                onClick={[Function]}
+                              >
+                                <span
+                                  className="pf-c-tree-view__node-toggle-icon"
+                                >
+                                  <AngleRightIcon
+                                    aria-hidden="true"
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                      />
+                                    </svg>
+                                  </AngleRightIcon>
+                                </span>
+                              </div>
+                              <span
+                                className="pf-c-tree-view__node-text"
+                              >
+                                Application 1
+                              </span>
+                            </button>
+                          </GenerateId>
+                        </div>
+                      </li>
+                    </TreeViewListItem>
+                    <TreeViewListItem
+                      activeItems={
+                        Array [
                           Object {
                             "children": Array [
                               Object {
-                                "id": "App2Settings",
+                                "id": "App1Settings",
                                 "name": "Settings",
                               },
                               Object {
-                                "children": Array [
-                                  Object {
-                                    "id": "LoadApp1",
-                                    "name": "Loading App 1",
-                                  },
-                                  Object {
-                                    "id": "LoadApp2",
-                                    "name": "Loading App 2",
-                                  },
-                                  Object {
-                                    "id": "LoadApp3",
-                                    "name": "Loading App 3",
-                                  },
-                                ],
-                                "id": "App2Loader",
-                                "name": "Loader",
+                                "id": "App1Current",
+                                "name": "Current",
                               },
                             ],
-                            "id": "App2",
-                            "name": "Application 2",
+                            "id": "App1",
+                            "name": "Application 1",
                           },
-                        ],
-                        "defaultExpanded": true,
-                        "id": "AppLaunch",
-                        "name": "ApplicationLauncher",
+                        ]
                       }
-                    }
-                  >
-                    <li
-                      className="pf-c-tree-view__list-item"
+                      compareItems={[Function]}
+                      defaultExpanded={false}
+                      hasBadge={false}
+                      hasCheck={false}
                       id="App2"
-                      role="treeitem"
-                      tabIndex={0}
+                      itemData={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "id": "App2Settings",
+                              "name": "Settings",
+                            },
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "LoadApp1",
+                                  "name": "Loading App 1",
+                                },
+                                Object {
+                                  "id": "LoadApp2",
+                                  "name": "Loading App 2",
+                                },
+                                Object {
+                                  "id": "LoadApp3",
+                                  "name": "Loading App 3",
+                                },
+                              ],
+                              "id": "App2Loader",
+                              "name": "Loader",
+                            },
+                          ],
+                          "id": "App2",
+                          "name": "Application 2",
+                        }
+                      }
+                      key="Application 2"
+                      name="Application 2"
+                      onSelect={[MockFunction]}
+                      parentItem={
+                        Object {
+                          "children": Array [
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "App1Settings",
+                                  "name": "Settings",
+                                },
+                                Object {
+                                  "id": "App1Current",
+                                  "name": "Current",
+                                },
+                              ],
+                              "id": "App1",
+                              "name": "Application 1",
+                            },
+                            Object {
+                              "children": Array [
+                                Object {
+                                  "id": "App2Settings",
+                                  "name": "Settings",
+                                },
+                                Object {
+                                  "children": Array [
+                                    Object {
+                                      "id": "LoadApp1",
+                                      "name": "Loading App 1",
+                                    },
+                                    Object {
+                                      "id": "LoadApp2",
+                                      "name": "Loading App 2",
+                                    },
+                                    Object {
+                                      "id": "LoadApp3",
+                                      "name": "Loading App 3",
+                                    },
+                                  ],
+                                  "id": "App2Loader",
+                                  "name": "Loader",
+                                },
+                              ],
+                              "id": "App2",
+                              "name": "Application 2",
+                            },
+                          ],
+                          "defaultExpanded": true,
+                          "id": "AppLaunch",
+                          "name": "ApplicationLauncher",
+                        }
+                      }
                     >
-                      <div
-                        className="pf-c-tree-view__content"
+                      <li
+                        className="pf-c-tree-view__list-item"
+                        id="App2"
+                        role="treeitem"
+                        tabIndex={0}
                       >
-                        <GenerateId
-                          prefix="checkbox-id"
+                        <div
+                          className="pf-c-tree-view__content"
                         >
-                          <button
-                            className="pf-c-tree-view__node"
-                            onClick={[Function]}
+                          <GenerateId
+                            prefix="checkbox-id"
                           >
-                            <div
-                              className="pf-c-tree-view__node-toggle"
+                            <button
+                              className="pf-c-tree-view__node"
                               onClick={[Function]}
                             >
-                              <span
-                                className="pf-c-tree-view__node-toggle-icon"
+                              <div
+                                className="pf-c-tree-view__node-toggle"
+                                onClick={[Function]}
                               >
-                                <AngleRightIcon
-                                  aria-hidden="true"
-                                  color="currentColor"
-                                  noVerticalAlign={false}
-                                  size="sm"
+                                <span
+                                  className="pf-c-tree-view__node-toggle-icon"
                                 >
-                                  <svg
+                                  <AngleRightIcon
                                     aria-hidden="true"
-                                    aria-labelledby={null}
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    style={
-                                      Object {
-                                        "verticalAlign": "-0.125em",
-                                      }
-                                    }
-                                    viewBox="0 0 256 512"
-                                    width="1em"
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
                                   >
-                                    <path
-                                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                    />
-                                  </svg>
-                                </AngleRightIcon>
+                                    <svg
+                                      aria-hidden="true"
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                      />
+                                    </svg>
+                                  </AngleRightIcon>
+                                </span>
+                              </div>
+                              <span
+                                className="pf-c-tree-view__node-text"
+                              >
+                                Application 2
                               </span>
-                            </div>
-                            <span
-                              className="pf-c-tree-view__node-text"
-                            >
-                              Application 2
-                            </span>
-                          </button>
-                        </GenerateId>
-                      </div>
-                    </li>
-                  </TreeViewListItem>
-                </ul>
-              </TreeViewList>
-            </TreeView>
-          </li>
-        </TreeViewListItem>
-        <TreeViewListItem
-          activeItems={
-            Array [
-              Object {
-                "children": Array [
-                  Object {
-                    "id": "App1Settings",
-                    "name": "Settings",
-                  },
-                  Object {
-                    "id": "App1Current",
-                    "name": "Current",
-                  },
-                ],
-                "id": "App1",
-                "name": "Application 1",
-              },
-            ]
-          }
-          compareItems={[Function]}
-          defaultExpanded={false}
-          hasBadge={false}
-          hasCheck={false}
-          id="Cost"
-          itemData={
-            Object {
-              "children": Array [
+                            </button>
+                          </GenerateId>
+                        </div>
+                      </li>
+                    </TreeViewListItem>
+                  </ul>
+                </TreeViewList>
+              </TreeView>
+            </li>
+          </TreeViewListItem>
+          <TreeViewListItem
+            activeItems={
+              Array [
                 Object {
                   "children": Array [
                     Object {
-                      "id": "App3Settings",
+                      "id": "App1Settings",
                       "name": "Settings",
                     },
                     Object {
-                      "id": "App3Current",
+                      "id": "App1Current",
                       "name": "Current",
                     },
                   ],
-                  "id": "App3",
-                  "name": "Application 3",
+                  "id": "App1",
+                  "name": "Application 1",
                 },
-              ],
-              "id": "Cost",
-              "name": "Cost Management",
+              ]
             }
-          }
-          key="Cost Management"
-          name="Cost Management"
-          onSelect={[MockFunction]}
-        >
-          <li
-            className="pf-c-tree-view__list-item"
+            compareItems={[Function]}
+            defaultExpanded={false}
+            hasBadge={false}
+            hasCheck={false}
             id="Cost"
-            role="treeitem"
-            tabIndex={0}
-          >
-            <div
-              className="pf-c-tree-view__content"
-            >
-              <GenerateId
-                prefix="checkbox-id"
-              >
-                <button
-                  className="pf-c-tree-view__node"
-                  onClick={[Function]}
-                >
-                  <div
-                    className="pf-c-tree-view__node-toggle"
-                    onClick={[Function]}
-                  >
-                    <span
-                      className="pf-c-tree-view__node-toggle-icon"
-                    >
-                      <AngleRightIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </AngleRightIcon>
-                    </span>
-                  </div>
-                  <span
-                    className="pf-c-tree-view__node-text"
-                  >
-                    Cost Management
-                  </span>
-                </button>
-              </GenerateId>
-            </div>
-          </li>
-        </TreeViewListItem>
-        <TreeViewListItem
-          activeItems={
-            Array [
+            itemData={
               Object {
                 "children": Array [
                   Object {
-                    "id": "App1Settings",
-                    "name": "Settings",
-                  },
-                  Object {
-                    "id": "App1Current",
-                    "name": "Current",
+                    "children": Array [
+                      Object {
+                        "id": "App3Settings",
+                        "name": "Settings",
+                      },
+                      Object {
+                        "id": "App3Current",
+                        "name": "Current",
+                      },
+                    ],
+                    "id": "App3",
+                    "name": "Application 3",
                   },
                 ],
-                "id": "App1",
-                "name": "Application 1",
-              },
-            ]
-          }
-          compareItems={[Function]}
-          defaultExpanded={false}
-          hasBadge={false}
-          hasCheck={false}
-          id="Sources"
-          itemData={
-            Object {
-              "children": Array [
+                "id": "Cost",
+                "name": "Cost Management",
+              }
+            }
+            key="Cost Management"
+            name="Cost Management"
+            onSelect={[MockFunction]}
+          >
+            <li
+              className="pf-c-tree-view__list-item"
+              id="Cost"
+              role="treeitem"
+              tabIndex={0}
+            >
+              <div
+                className="pf-c-tree-view__content"
+              >
+                <GenerateId
+                  prefix="checkbox-id"
+                >
+                  <button
+                    className="pf-c-tree-view__node"
+                    onClick={[Function]}
+                  >
+                    <div
+                      className="pf-c-tree-view__node-toggle"
+                      onClick={[Function]}
+                    >
+                      <span
+                        className="pf-c-tree-view__node-toggle-icon"
+                      >
+                        <AngleRightIcon
+                          aria-hidden="true"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </AngleRightIcon>
+                      </span>
+                    </div>
+                    <span
+                      className="pf-c-tree-view__node-text"
+                    >
+                      Cost Management
+                    </span>
+                  </button>
+                </GenerateId>
+              </div>
+            </li>
+          </TreeViewListItem>
+          <TreeViewListItem
+            activeItems={
+              Array [
                 Object {
                   "children": Array [
                     Object {
-                      "id": "App4Settings",
+                      "id": "App1Settings",
                       "name": "Settings",
                     },
+                    Object {
+                      "id": "App1Current",
+                      "name": "Current",
+                    },
                   ],
-                  "id": "App4",
-                  "name": "Application 4",
+                  "id": "App1",
+                  "name": "Application 1",
                 },
-              ],
-              "id": "Sources",
-              "name": "Sources",
+              ]
             }
-          }
-          key="Sources"
-          name="Sources"
-          onSelect={[MockFunction]}
-        >
-          <li
-            className="pf-c-tree-view__list-item"
+            compareItems={[Function]}
+            defaultExpanded={false}
+            hasBadge={false}
+            hasCheck={false}
             id="Sources"
-            role="treeitem"
-            tabIndex={0}
-          >
-            <div
-              className="pf-c-tree-view__content"
-            >
-              <GenerateId
-                prefix="checkbox-id"
-              >
-                <button
-                  className="pf-c-tree-view__node"
-                  onClick={[Function]}
-                >
-                  <div
-                    className="pf-c-tree-view__node-toggle"
-                    onClick={[Function]}
-                  >
-                    <span
-                      className="pf-c-tree-view__node-toggle-icon"
-                    >
-                      <AngleRightIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 256 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </AngleRightIcon>
-                    </span>
-                  </div>
-                  <span
-                    className="pf-c-tree-view__node-text"
-                  >
-                    Sources
-                  </span>
-                </button>
-              </GenerateId>
-            </div>
-          </li>
-        </TreeViewListItem>
-        <TreeViewListItem
-          activeItems={
-            Array [
+            itemData={
               Object {
                 "children": Array [
                   Object {
-                    "id": "App1Settings",
-                    "name": "Settings",
-                  },
-                  Object {
-                    "id": "App1Current",
-                    "name": "Current",
+                    "children": Array [
+                      Object {
+                        "id": "App4Settings",
+                        "name": "Settings",
+                      },
+                    ],
+                    "id": "App4",
+                    "name": "Application 4",
                   },
                 ],
-                "id": "App1",
-                "name": "Application 1",
-              },
-            ]
-          }
-          compareItems={[Function]}
-          defaultExpanded={false}
-          hasBadge={false}
-          hasCheck={false}
-          id="Long"
-          itemData={
-            Object {
-              "children": Array [
-                Object {
-                  "id": "App5",
-                  "name": "Application 5",
-                },
-              ],
-              "id": "Long",
-              "name": "Really really really long folder name that overflows the container it is in",
+                "id": "Sources",
+                "name": "Sources",
+              }
             }
-          }
-          key="Really really really long folder name that overflows the container it is in"
-          name="Really really really long folder name that overflows the container it is in"
-          onSelect={[MockFunction]}
-        >
-          <li
-            className="pf-c-tree-view__list-item"
-            id="Long"
-            role="treeitem"
-            tabIndex={0}
+            key="Sources"
+            name="Sources"
+            onSelect={[MockFunction]}
           >
-            <div
-              className="pf-c-tree-view__content"
+            <li
+              className="pf-c-tree-view__list-item"
+              id="Sources"
+              role="treeitem"
+              tabIndex={0}
             >
-              <GenerateId
-                prefix="checkbox-id"
+              <div
+                className="pf-c-tree-view__content"
               >
-                <button
-                  className="pf-c-tree-view__node"
-                  onClick={[Function]}
+                <GenerateId
+                  prefix="checkbox-id"
                 >
-                  <div
-                    className="pf-c-tree-view__node-toggle"
+                  <button
+                    className="pf-c-tree-view__node"
                     onClick={[Function]}
                   >
-                    <span
-                      className="pf-c-tree-view__node-toggle-icon"
+                    <div
+                      className="pf-c-tree-view__node-toggle"
+                      onClick={[Function]}
                     >
-                      <AngleRightIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
+                      <span
+                        className="pf-c-tree-view__node-toggle-icon"
                       >
-                        <svg
+                        <AngleRightIcon
                           aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 256 512"
-                          width="1em"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
                         >
-                          <path
-                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                          />
-                        </svg>
-                      </AngleRightIcon>
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </AngleRightIcon>
+                      </span>
+                    </div>
+                    <span
+                      className="pf-c-tree-view__node-text"
+                    >
+                      Sources
                     </span>
-                  </div>
-                  <span
-                    className="pf-c-tree-view__node-text"
+                  </button>
+                </GenerateId>
+              </div>
+            </li>
+          </TreeViewListItem>
+          <TreeViewListItem
+            activeItems={
+              Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "id": "App1Settings",
+                      "name": "Settings",
+                    },
+                    Object {
+                      "id": "App1Current",
+                      "name": "Current",
+                    },
+                  ],
+                  "id": "App1",
+                  "name": "Application 1",
+                },
+              ]
+            }
+            compareItems={[Function]}
+            defaultExpanded={false}
+            hasBadge={false}
+            hasCheck={false}
+            id="Long"
+            itemData={
+              Object {
+                "children": Array [
+                  Object {
+                    "id": "App5",
+                    "name": "Application 5",
+                  },
+                ],
+                "id": "Long",
+                "name": "Really really really long folder name that overflows the container it is in",
+              }
+            }
+            key="Really really really long folder name that overflows the container it is in"
+            name="Really really really long folder name that overflows the container it is in"
+            onSelect={[MockFunction]}
+          >
+            <li
+              className="pf-c-tree-view__list-item"
+              id="Long"
+              role="treeitem"
+              tabIndex={0}
+            >
+              <div
+                className="pf-c-tree-view__content"
+              >
+                <GenerateId
+                  prefix="checkbox-id"
+                >
+                  <button
+                    className="pf-c-tree-view__node"
+                    onClick={[Function]}
                   >
-                    Really really really long folder name that overflows the container it is in
-                  </span>
-                </button>
-              </GenerateId>
-            </div>
-          </li>
-        </TreeViewListItem>
-      </ul>
-    </TreeViewList>
-  </div>
+                    <div
+                      className="pf-c-tree-view__node-toggle"
+                      onClick={[Function]}
+                    >
+                      <span
+                        className="pf-c-tree-view__node-toggle-icon"
+                      >
+                        <AngleRightIcon
+                          aria-hidden="true"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 256 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            />
+                          </svg>
+                        </AngleRightIcon>
+                      </span>
+                    </div>
+                    <span
+                      className="pf-c-tree-view__node-text"
+                    >
+                      Really really really long folder name that overflows the container it is in
+                    </span>
+                  </button>
+                </GenerateId>
+              </div>
+            </li>
+          </TreeViewListItem>
+        </ul>
+      </TreeViewList>
+    </div>
+  </TreeViewRoot>
 </TreeView>
 `;

--- a/packages/react-core/src/components/TreeView/__tests__/__snapshots__/TreeView.test.tsx.snap
+++ b/packages/react-core/src/components/TreeView/__tests__/__snapshots__/TreeView.test.tsx.snap
@@ -218,7 +218,7 @@ exports[`tree view renders active successfully 1`] = `
               className="pf-c-tree-view__list-item pf-m-expanded"
               id="AppLaunch"
               role="treeitem"
-              tabIndex={0}
+              tabIndex={-1}
             >
               <div
                 className="pf-c-tree-view__content"
@@ -229,10 +229,12 @@ exports[`tree view renders active successfully 1`] = `
                   <button
                     className="pf-c-tree-view__node"
                     onClick={[Function]}
+                    tabIndex={-1}
                   >
                     <div
                       className="pf-c-tree-view__node-toggle"
                       onClick={[Function]}
+                      tabIndex={-1}
                     >
                       <span
                         className="pf-c-tree-view__node-toggle-icon"
@@ -500,7 +502,7 @@ exports[`tree view renders active successfully 1`] = `
                         className="pf-c-tree-view__list-item"
                         id="App1"
                         role="treeitem"
-                        tabIndex={0}
+                        tabIndex={-1}
                       >
                         <div
                           className="pf-c-tree-view__content"
@@ -511,10 +513,12 @@ exports[`tree view renders active successfully 1`] = `
                             <button
                               className="pf-c-tree-view__node"
                               onClick={[Function]}
+                              tabIndex={-1}
                             >
                               <div
                                 className="pf-c-tree-view__node-toggle"
                                 onClick={[Function]}
+                                tabIndex={-1}
                               >
                                 <span
                                   className="pf-c-tree-view__node-toggle-icon"
@@ -669,7 +673,7 @@ exports[`tree view renders active successfully 1`] = `
                         className="pf-c-tree-view__list-item"
                         id="App2"
                         role="treeitem"
-                        tabIndex={0}
+                        tabIndex={-1}
                       >
                         <div
                           className="pf-c-tree-view__content"
@@ -680,10 +684,12 @@ exports[`tree view renders active successfully 1`] = `
                             <button
                               className="pf-c-tree-view__node"
                               onClick={[Function]}
+                              tabIndex={-1}
                             >
                               <div
                                 className="pf-c-tree-view__node-toggle"
                                 onClick={[Function]}
+                                tabIndex={-1}
                               >
                                 <span
                                   className="pf-c-tree-view__node-toggle-icon"
@@ -784,7 +790,7 @@ exports[`tree view renders active successfully 1`] = `
               className="pf-c-tree-view__list-item"
               id="Cost"
               role="treeitem"
-              tabIndex={0}
+              tabIndex={-1}
             >
               <div
                 className="pf-c-tree-view__content"
@@ -795,10 +801,12 @@ exports[`tree view renders active successfully 1`] = `
                   <button
                     className="pf-c-tree-view__node"
                     onClick={[Function]}
+                    tabIndex={-1}
                   >
                     <div
                       className="pf-c-tree-view__node-toggle"
                       onClick={[Function]}
+                      tabIndex={-1}
                     >
                       <span
                         className="pf-c-tree-view__node-toggle-icon"
@@ -890,7 +898,7 @@ exports[`tree view renders active successfully 1`] = `
               className="pf-c-tree-view__list-item"
               id="Sources"
               role="treeitem"
-              tabIndex={0}
+              tabIndex={-1}
             >
               <div
                 className="pf-c-tree-view__content"
@@ -901,10 +909,12 @@ exports[`tree view renders active successfully 1`] = `
                   <button
                     className="pf-c-tree-view__node"
                     onClick={[Function]}
+                    tabIndex={-1}
                   >
                     <div
                       className="pf-c-tree-view__node-toggle"
                       onClick={[Function]}
+                      tabIndex={-1}
                     >
                       <span
                         className="pf-c-tree-view__node-toggle-icon"
@@ -990,7 +1000,7 @@ exports[`tree view renders active successfully 1`] = `
               className="pf-c-tree-view__list-item"
               id="Long"
               role="treeitem"
-              tabIndex={0}
+              tabIndex={-1}
             >
               <div
                 className="pf-c-tree-view__content"
@@ -1001,10 +1011,12 @@ exports[`tree view renders active successfully 1`] = `
                   <button
                     className="pf-c-tree-view__node"
                     onClick={[Function]}
+                    tabIndex={-1}
                   >
                     <div
                       className="pf-c-tree-view__node-toggle"
                       onClick={[Function]}
+                      tabIndex={-1}
                     >
                       <span
                         className="pf-c-tree-view__node-toggle-icon"
@@ -1272,7 +1284,7 @@ exports[`tree view renders badges successfully 1`] = `
               className="pf-c-tree-view__list-item pf-m-expanded"
               id="AppLaunch"
               role="treeitem"
-              tabIndex={0}
+              tabIndex={-1}
             >
               <div
                 className="pf-c-tree-view__content"
@@ -1283,10 +1295,12 @@ exports[`tree view renders badges successfully 1`] = `
                   <button
                     className="pf-c-tree-view__node"
                     onClick={[Function]}
+                    tabIndex={-1}
                   >
                     <div
                       className="pf-c-tree-view__node-toggle"
                       onClick={[Function]}
+                      tabIndex={-1}
                     >
                       <span
                         className="pf-c-tree-view__node-toggle-icon"
@@ -1567,7 +1581,7 @@ exports[`tree view renders badges successfully 1`] = `
                         className="pf-c-tree-view__list-item"
                         id="App1"
                         role="treeitem"
-                        tabIndex={0}
+                        tabIndex={-1}
                       >
                         <div
                           className="pf-c-tree-view__content"
@@ -1578,10 +1592,12 @@ exports[`tree view renders badges successfully 1`] = `
                             <button
                               className="pf-c-tree-view__node"
                               onClick={[Function]}
+                              tabIndex={-1}
                             >
                               <div
                                 className="pf-c-tree-view__node-toggle"
                                 onClick={[Function]}
+                                tabIndex={-1}
                               >
                                 <span
                                   className="pf-c-tree-view__node-toggle-icon"
@@ -1749,7 +1765,7 @@ exports[`tree view renders badges successfully 1`] = `
                         className="pf-c-tree-view__list-item"
                         id="App2"
                         role="treeitem"
-                        tabIndex={0}
+                        tabIndex={-1}
                       >
                         <div
                           className="pf-c-tree-view__content"
@@ -1760,10 +1776,12 @@ exports[`tree view renders badges successfully 1`] = `
                             <button
                               className="pf-c-tree-view__node"
                               onClick={[Function]}
+                              tabIndex={-1}
                             >
                               <div
                                 className="pf-c-tree-view__node-toggle"
                                 onClick={[Function]}
+                                tabIndex={-1}
                               >
                                 <span
                                   className="pf-c-tree-view__node-toggle-icon"
@@ -1877,7 +1895,7 @@ exports[`tree view renders badges successfully 1`] = `
               className="pf-c-tree-view__list-item"
               id="Cost"
               role="treeitem"
-              tabIndex={0}
+              tabIndex={-1}
             >
               <div
                 className="pf-c-tree-view__content"
@@ -1888,10 +1906,12 @@ exports[`tree view renders badges successfully 1`] = `
                   <button
                     className="pf-c-tree-view__node"
                     onClick={[Function]}
+                    tabIndex={-1}
                   >
                     <div
                       className="pf-c-tree-view__node-toggle"
                       onClick={[Function]}
+                      tabIndex={-1}
                     >
                       <span
                         className="pf-c-tree-view__node-toggle-icon"
@@ -1996,7 +2016,7 @@ exports[`tree view renders badges successfully 1`] = `
               className="pf-c-tree-view__list-item"
               id="Sources"
               role="treeitem"
-              tabIndex={0}
+              tabIndex={-1}
             >
               <div
                 className="pf-c-tree-view__content"
@@ -2007,10 +2027,12 @@ exports[`tree view renders badges successfully 1`] = `
                   <button
                     className="pf-c-tree-view__node"
                     onClick={[Function]}
+                    tabIndex={-1}
                   >
                     <div
                       className="pf-c-tree-view__node-toggle"
                       onClick={[Function]}
+                      tabIndex={-1}
                     >
                       <span
                         className="pf-c-tree-view__node-toggle-icon"
@@ -2109,7 +2131,7 @@ exports[`tree view renders badges successfully 1`] = `
               className="pf-c-tree-view__list-item"
               id="Long"
               role="treeitem"
-              tabIndex={0}
+              tabIndex={-1}
             >
               <div
                 className="pf-c-tree-view__content"
@@ -2120,10 +2142,12 @@ exports[`tree view renders badges successfully 1`] = `
                   <button
                     className="pf-c-tree-view__node"
                     onClick={[Function]}
+                    tabIndex={-1}
                   >
                     <div
                       className="pf-c-tree-view__node-toggle"
                       onClick={[Function]}
+                      tabIndex={-1}
                     >
                       <span
                         className="pf-c-tree-view__node-toggle-icon"
@@ -2367,7 +2391,7 @@ exports[`tree view renders basic successfully 1`] = `
               className="pf-c-tree-view__list-item pf-m-expanded"
               id="AppLaunch"
               role="treeitem"
-              tabIndex={0}
+              tabIndex={-1}
             >
               <div
                 className="pf-c-tree-view__content"
@@ -2378,10 +2402,12 @@ exports[`tree view renders basic successfully 1`] = `
                   <button
                     className="pf-c-tree-view__node"
                     onClick={[Function]}
+                    tabIndex={-1}
                   >
                     <div
                       className="pf-c-tree-view__node-toggle"
                       onClick={[Function]}
+                      tabIndex={-1}
                     >
                       <span
                         className="pf-c-tree-view__node-toggle-icon"
@@ -2613,7 +2639,7 @@ exports[`tree view renders basic successfully 1`] = `
                         className="pf-c-tree-view__list-item"
                         id="App1"
                         role="treeitem"
-                        tabIndex={0}
+                        tabIndex={-1}
                       >
                         <div
                           className="pf-c-tree-view__content"
@@ -2624,10 +2650,12 @@ exports[`tree view renders basic successfully 1`] = `
                             <button
                               className="pf-c-tree-view__node"
                               onClick={[Function]}
+                              tabIndex={-1}
                             >
                               <div
                                 className="pf-c-tree-view__node-toggle"
                                 onClick={[Function]}
+                                tabIndex={-1}
                               >
                                 <span
                                   className="pf-c-tree-view__node-toggle-icon"
@@ -2764,7 +2792,7 @@ exports[`tree view renders basic successfully 1`] = `
                         className="pf-c-tree-view__list-item"
                         id="App2"
                         role="treeitem"
-                        tabIndex={0}
+                        tabIndex={-1}
                       >
                         <div
                           className="pf-c-tree-view__content"
@@ -2775,10 +2803,12 @@ exports[`tree view renders basic successfully 1`] = `
                             <button
                               className="pf-c-tree-view__node"
                               onClick={[Function]}
+                              tabIndex={-1}
                             >
                               <div
                                 className="pf-c-tree-view__node-toggle"
                                 onClick={[Function]}
+                                tabIndex={-1}
                               >
                                 <span
                                   className="pf-c-tree-view__node-toggle-icon"
@@ -2861,7 +2891,7 @@ exports[`tree view renders basic successfully 1`] = `
               className="pf-c-tree-view__list-item"
               id="Cost"
               role="treeitem"
-              tabIndex={0}
+              tabIndex={-1}
             >
               <div
                 className="pf-c-tree-view__content"
@@ -2872,10 +2902,12 @@ exports[`tree view renders basic successfully 1`] = `
                   <button
                     className="pf-c-tree-view__node"
                     onClick={[Function]}
+                    tabIndex={-1}
                   >
                     <div
                       className="pf-c-tree-view__node-toggle"
                       onClick={[Function]}
+                      tabIndex={-1}
                     >
                       <span
                         className="pf-c-tree-view__node-toggle-icon"
@@ -2949,7 +2981,7 @@ exports[`tree view renders basic successfully 1`] = `
               className="pf-c-tree-view__list-item"
               id="Sources"
               role="treeitem"
-              tabIndex={0}
+              tabIndex={-1}
             >
               <div
                 className="pf-c-tree-view__content"
@@ -2960,10 +2992,12 @@ exports[`tree view renders basic successfully 1`] = `
                   <button
                     className="pf-c-tree-view__node"
                     onClick={[Function]}
+                    tabIndex={-1}
                   >
                     <div
                       className="pf-c-tree-view__node-toggle"
                       onClick={[Function]}
+                      tabIndex={-1}
                     >
                       <span
                         className="pf-c-tree-view__node-toggle-icon"
@@ -3031,7 +3065,7 @@ exports[`tree view renders basic successfully 1`] = `
               className="pf-c-tree-view__list-item"
               id="Long"
               role="treeitem"
-              tabIndex={0}
+              tabIndex={-1}
             >
               <div
                 className="pf-c-tree-view__content"
@@ -3042,10 +3076,12 @@ exports[`tree view renders basic successfully 1`] = `
                   <button
                     className="pf-c-tree-view__node"
                     onClick={[Function]}
+                    tabIndex={-1}
                   >
                     <div
                       className="pf-c-tree-view__node-toggle"
                       onClick={[Function]}
+                      tabIndex={-1}
                     >
                       <span
                         className="pf-c-tree-view__node-toggle-icon"
@@ -3313,7 +3349,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
               className="pf-c-tree-view__list-item pf-m-expanded"
               id="AppLaunch"
               role="treeitem"
-              tabIndex={0}
+              tabIndex={-1}
             >
               <div
                 className="pf-c-tree-view__content"
@@ -3324,11 +3360,13 @@ exports[`tree view renders checkboxes successfully 1`] = `
                   <div
                     className="pf-c-tree-view__node"
                     onClick={[Function]}
+                    tabIndex={-1}
                   >
                     <button
                       aria-labelledby="label-checkbox-id18"
                       className="pf-c-tree-view__node-toggle"
                       onClick={[Function]}
+                      tabIndex={-1}
                     >
                       <span
                         className="pf-c-tree-view__node-toggle-icon"
@@ -3368,6 +3406,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
                         id="checkbox-id18"
                         onChange={[Function]}
                         onClick={[Function]}
+                        tabIndex={-1}
                         type="checkbox"
                       />
                     </span>
@@ -3609,7 +3648,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
                         className="pf-c-tree-view__list-item"
                         id="App1"
                         role="treeitem"
-                        tabIndex={0}
+                        tabIndex={-1}
                       >
                         <div
                           className="pf-c-tree-view__content"
@@ -3620,11 +3659,13 @@ exports[`tree view renders checkboxes successfully 1`] = `
                             <div
                               className="pf-c-tree-view__node"
                               onClick={[Function]}
+                              tabIndex={-1}
                             >
                               <button
                                 aria-labelledby="label-checkbox-id19"
                                 className="pf-c-tree-view__node-toggle"
                                 onClick={[Function]}
+                                tabIndex={-1}
                               >
                                 <span
                                   className="pf-c-tree-view__node-toggle-icon"
@@ -3664,6 +3705,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
                                   id="checkbox-id19"
                                   onChange={[Function]}
                                   onClick={[Function]}
+                                  tabIndex={-1}
                                   type="checkbox"
                                 />
                               </span>
@@ -3792,7 +3834,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
                         className="pf-c-tree-view__list-item"
                         id="App2"
                         role="treeitem"
-                        tabIndex={0}
+                        tabIndex={-1}
                       >
                         <div
                           className="pf-c-tree-view__content"
@@ -3803,11 +3845,13 @@ exports[`tree view renders checkboxes successfully 1`] = `
                             <div
                               className="pf-c-tree-view__node"
                               onClick={[Function]}
+                              tabIndex={-1}
                             >
                               <button
                                 aria-labelledby="label-checkbox-id20"
                                 className="pf-c-tree-view__node-toggle"
                                 onClick={[Function]}
+                                tabIndex={-1}
                               >
                                 <span
                                   className="pf-c-tree-view__node-toggle-icon"
@@ -3847,6 +3891,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
                                   id="checkbox-id20"
                                   onChange={[Function]}
                                   onClick={[Function]}
+                                  tabIndex={-1}
                                   type="checkbox"
                                 />
                               </span>
@@ -3921,7 +3966,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
               className="pf-c-tree-view__list-item"
               id="Cost"
               role="treeitem"
-              tabIndex={0}
+              tabIndex={-1}
             >
               <div
                 className="pf-c-tree-view__content"
@@ -3932,11 +3977,13 @@ exports[`tree view renders checkboxes successfully 1`] = `
                   <div
                     className="pf-c-tree-view__node"
                     onClick={[Function]}
+                    tabIndex={-1}
                   >
                     <button
                       aria-labelledby="label-checkbox-id21"
                       className="pf-c-tree-view__node-toggle"
                       onClick={[Function]}
+                      tabIndex={-1}
                     >
                       <span
                         className="pf-c-tree-view__node-toggle-icon"
@@ -3976,6 +4023,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
                         id="checkbox-id21"
                         onChange={[Function]}
                         onClick={[Function]}
+                        tabIndex={-1}
                         type="checkbox"
                       />
                     </span>
@@ -4041,7 +4089,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
               className="pf-c-tree-view__list-item"
               id="Sources"
               role="treeitem"
-              tabIndex={0}
+              tabIndex={-1}
             >
               <div
                 className="pf-c-tree-view__content"
@@ -4052,11 +4100,13 @@ exports[`tree view renders checkboxes successfully 1`] = `
                   <div
                     className="pf-c-tree-view__node"
                     onClick={[Function]}
+                    tabIndex={-1}
                   >
                     <button
                       aria-labelledby="label-checkbox-id22"
                       className="pf-c-tree-view__node-toggle"
                       onClick={[Function]}
+                      tabIndex={-1}
                     >
                       <span
                         className="pf-c-tree-view__node-toggle-icon"
@@ -4096,6 +4146,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
                         id="checkbox-id22"
                         onChange={[Function]}
                         onClick={[Function]}
+                        tabIndex={-1}
                         type="checkbox"
                       />
                     </span>
@@ -4155,7 +4206,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
               className="pf-c-tree-view__list-item"
               id="Long"
               role="treeitem"
-              tabIndex={0}
+              tabIndex={-1}
             >
               <div
                 className="pf-c-tree-view__content"
@@ -4166,11 +4217,13 @@ exports[`tree view renders checkboxes successfully 1`] = `
                   <div
                     className="pf-c-tree-view__node"
                     onClick={[Function]}
+                    tabIndex={-1}
                   >
                     <button
                       aria-labelledby="label-checkbox-id23"
                       className="pf-c-tree-view__node-toggle"
                       onClick={[Function]}
+                      tabIndex={-1}
                     >
                       <span
                         className="pf-c-tree-view__node-toggle-icon"
@@ -4210,6 +4263,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
                         id="checkbox-id23"
                         onChange={[Function]}
                         onClick={[Function]}
+                        tabIndex={-1}
                         type="checkbox"
                       />
                     </span>
@@ -4478,7 +4532,7 @@ exports[`tree view renders icons successfully 1`] = `
               className="pf-c-tree-view__list-item pf-m-expanded"
               id="AppLaunch"
               role="treeitem"
-              tabIndex={0}
+              tabIndex={-1}
             >
               <div
                 className="pf-c-tree-view__content"
@@ -4489,10 +4543,12 @@ exports[`tree view renders icons successfully 1`] = `
                   <button
                     className="pf-c-tree-view__node"
                     onClick={[Function]}
+                    tabIndex={-1}
                   >
                     <div
                       className="pf-c-tree-view__node-toggle"
                       onClick={[Function]}
+                      tabIndex={-1}
                     >
                       <span
                         className="pf-c-tree-view__node-toggle-icon"
@@ -4816,7 +4872,7 @@ exports[`tree view renders icons successfully 1`] = `
                         className="pf-c-tree-view__list-item"
                         id="App1"
                         role="treeitem"
-                        tabIndex={0}
+                        tabIndex={-1}
                       >
                         <div
                           className="pf-c-tree-view__content"
@@ -4827,10 +4883,12 @@ exports[`tree view renders icons successfully 1`] = `
                             <button
                               className="pf-c-tree-view__node"
                               onClick={[Function]}
+                              tabIndex={-1}
                             >
                               <div
                                 className="pf-c-tree-view__node-toggle"
                                 onClick={[Function]}
+                                tabIndex={-1}
                               >
                                 <span
                                   className="pf-c-tree-view__node-toggle-icon"
@@ -5027,7 +5085,7 @@ exports[`tree view renders icons successfully 1`] = `
                         className="pf-c-tree-view__list-item"
                         id="App2"
                         role="treeitem"
-                        tabIndex={0}
+                        tabIndex={-1}
                       >
                         <div
                           className="pf-c-tree-view__content"
@@ -5038,10 +5096,12 @@ exports[`tree view renders icons successfully 1`] = `
                             <button
                               className="pf-c-tree-view__node"
                               onClick={[Function]}
+                              tabIndex={-1}
                             >
                               <div
                                 className="pf-c-tree-view__node-toggle"
                                 onClick={[Function]}
+                                tabIndex={-1}
                               >
                                 <span
                                   className="pf-c-tree-view__node-toggle-icon"
@@ -5184,7 +5244,7 @@ exports[`tree view renders icons successfully 1`] = `
               className="pf-c-tree-view__list-item"
               id="Cost"
               role="treeitem"
-              tabIndex={0}
+              tabIndex={-1}
             >
               <div
                 className="pf-c-tree-view__content"
@@ -5195,10 +5255,12 @@ exports[`tree view renders icons successfully 1`] = `
                   <button
                     className="pf-c-tree-view__node"
                     onClick={[Function]}
+                    tabIndex={-1}
                   >
                     <div
                       className="pf-c-tree-view__node-toggle"
                       onClick={[Function]}
+                      tabIndex={-1}
                     >
                       <span
                         className="pf-c-tree-view__node-toggle-icon"
@@ -5332,7 +5394,7 @@ exports[`tree view renders icons successfully 1`] = `
               className="pf-c-tree-view__list-item"
               id="Sources"
               role="treeitem"
-              tabIndex={0}
+              tabIndex={-1}
             >
               <div
                 className="pf-c-tree-view__content"
@@ -5343,10 +5405,12 @@ exports[`tree view renders icons successfully 1`] = `
                   <button
                     className="pf-c-tree-view__node"
                     onClick={[Function]}
+                    tabIndex={-1}
                   >
                     <div
                       className="pf-c-tree-view__node-toggle"
                       onClick={[Function]}
+                      tabIndex={-1}
                     >
                       <span
                         className="pf-c-tree-view__node-toggle-icon"
@@ -5474,7 +5538,7 @@ exports[`tree view renders icons successfully 1`] = `
               className="pf-c-tree-view__list-item"
               id="Long"
               role="treeitem"
-              tabIndex={0}
+              tabIndex={-1}
             >
               <div
                 className="pf-c-tree-view__content"
@@ -5485,10 +5549,12 @@ exports[`tree view renders icons successfully 1`] = `
                   <button
                     className="pf-c-tree-view__node"
                     onClick={[Function]}
+                    tabIndex={-1}
                   >
                     <div
                       className="pf-c-tree-view__node-toggle"
                       onClick={[Function]}
+                      tabIndex={-1}
                     >
                       <span
                         className="pf-c-tree-view__node-toggle-icon"
@@ -5834,7 +5900,7 @@ exports[`tree view renders individual flag options successfully 1`] = `
               className="pf-c-tree-view__list-item pf-m-expanded"
               id="AppLaunch"
               role="treeitem"
-              tabIndex={0}
+              tabIndex={-1}
             >
               <div
                 className="pf-c-tree-view__content"
@@ -5845,11 +5911,13 @@ exports[`tree view renders individual flag options successfully 1`] = `
                   <div
                     className="pf-c-tree-view__node"
                     onClick={[Function]}
+                    tabIndex={-1}
                   >
                     <button
                       aria-labelledby="label-checkbox-id36"
                       className="pf-c-tree-view__node-toggle"
                       onClick={[Function]}
+                      tabIndex={-1}
                     >
                       <span
                         className="pf-c-tree-view__node-toggle-icon"
@@ -5889,6 +5957,7 @@ exports[`tree view renders individual flag options successfully 1`] = `
                         id="checkbox-id36"
                         onChange={[Function]}
                         onClick={[Function]}
+                        tabIndex={-1}
                         type="checkbox"
                       />
                     </span>
@@ -6186,7 +6255,7 @@ exports[`tree view renders individual flag options successfully 1`] = `
                         className="pf-c-tree-view__list-item"
                         id="App1"
                         role="treeitem"
-                        tabIndex={0}
+                        tabIndex={-1}
                       >
                         <div
                           className="pf-c-tree-view__content"
@@ -6197,10 +6266,12 @@ exports[`tree view renders individual flag options successfully 1`] = `
                             <button
                               className="pf-c-tree-view__node"
                               onClick={[Function]}
+                              tabIndex={-1}
                             >
                               <div
                                 className="pf-c-tree-view__node-toggle"
                                 onClick={[Function]}
+                                tabIndex={-1}
                               >
                                 <span
                                   className="pf-c-tree-view__node-toggle-icon"
@@ -6370,7 +6441,7 @@ exports[`tree view renders individual flag options successfully 1`] = `
                         className="pf-c-tree-view__list-item"
                         id="App2"
                         role="treeitem"
-                        tabIndex={0}
+                        tabIndex={-1}
                       >
                         <div
                           className="pf-c-tree-view__content"
@@ -6381,10 +6452,12 @@ exports[`tree view renders individual flag options successfully 1`] = `
                             <button
                               className="pf-c-tree-view__node"
                               onClick={[Function]}
+                              tabIndex={-1}
                             >
                               <div
                                 className="pf-c-tree-view__node-toggle"
                                 onClick={[Function]}
+                                tabIndex={-1}
                               >
                                 <span
                                   className="pf-c-tree-view__node-toggle-icon"
@@ -6521,7 +6594,7 @@ exports[`tree view renders individual flag options successfully 1`] = `
               className="pf-c-tree-view__list-item"
               id="Cost"
               role="treeitem"
-              tabIndex={0}
+              tabIndex={-1}
             >
               <div
                 className="pf-c-tree-view__content"
@@ -6532,10 +6605,12 @@ exports[`tree view renders individual flag options successfully 1`] = `
                   <button
                     className="pf-c-tree-view__node"
                     onClick={[Function]}
+                    tabIndex={-1}
                   >
                     <div
                       className="pf-c-tree-view__node-toggle"
                       onClick={[Function]}
+                      tabIndex={-1}
                     >
                       <span
                         className="pf-c-tree-view__node-toggle-icon"
@@ -6685,7 +6760,7 @@ exports[`tree view renders individual flag options successfully 1`] = `
               className="pf-c-tree-view__list-item"
               id="Sources"
               role="treeitem"
-              tabIndex={0}
+              tabIndex={-1}
             >
               <div
                 className="pf-c-tree-view__content"
@@ -6696,10 +6771,12 @@ exports[`tree view renders individual flag options successfully 1`] = `
                   <button
                     className="pf-c-tree-view__node"
                     onClick={[Function]}
+                    tabIndex={-1}
                   >
                     <div
                       className="pf-c-tree-view__node-toggle"
                       onClick={[Function]}
+                      tabIndex={-1}
                     >
                       <span
                         className="pf-c-tree-view__node-toggle-icon"
@@ -6785,7 +6862,7 @@ exports[`tree view renders individual flag options successfully 1`] = `
               className="pf-c-tree-view__list-item"
               id="Long"
               role="treeitem"
-              tabIndex={0}
+              tabIndex={-1}
             >
               <div
                 className="pf-c-tree-view__content"
@@ -6796,10 +6873,12 @@ exports[`tree view renders individual flag options successfully 1`] = `
                   <button
                     className="pf-c-tree-view__node"
                     onClick={[Function]}
+                    tabIndex={-1}
                   >
                     <div
                       className="pf-c-tree-view__node-toggle"
                       onClick={[Function]}
+                      tabIndex={-1}
                     >
                       <span
                         className="pf-c-tree-view__node-toggle-icon"
@@ -7106,7 +7185,7 @@ exports[`tree view renders search successfully 1`] = `
               className="pf-c-tree-view__list-item pf-m-expanded"
               id="AppLaunch"
               role="treeitem"
-              tabIndex={0}
+              tabIndex={-1}
             >
               <div
                 className="pf-c-tree-view__content"
@@ -7117,10 +7196,12 @@ exports[`tree view renders search successfully 1`] = `
                   <button
                     className="pf-c-tree-view__node"
                     onClick={[Function]}
+                    tabIndex={-1}
                   >
                     <div
                       className="pf-c-tree-view__node-toggle"
                       onClick={[Function]}
+                      tabIndex={-1}
                     >
                       <span
                         className="pf-c-tree-view__node-toggle-icon"
@@ -7388,7 +7469,7 @@ exports[`tree view renders search successfully 1`] = `
                         className="pf-c-tree-view__list-item"
                         id="App1"
                         role="treeitem"
-                        tabIndex={0}
+                        tabIndex={-1}
                       >
                         <div
                           className="pf-c-tree-view__content"
@@ -7399,10 +7480,12 @@ exports[`tree view renders search successfully 1`] = `
                             <button
                               className="pf-c-tree-view__node"
                               onClick={[Function]}
+                              tabIndex={-1}
                             >
                               <div
                                 className="pf-c-tree-view__node-toggle"
                                 onClick={[Function]}
+                                tabIndex={-1}
                               >
                                 <span
                                   className="pf-c-tree-view__node-toggle-icon"
@@ -7557,7 +7640,7 @@ exports[`tree view renders search successfully 1`] = `
                         className="pf-c-tree-view__list-item"
                         id="App2"
                         role="treeitem"
-                        tabIndex={0}
+                        tabIndex={-1}
                       >
                         <div
                           className="pf-c-tree-view__content"
@@ -7568,10 +7651,12 @@ exports[`tree view renders search successfully 1`] = `
                             <button
                               className="pf-c-tree-view__node"
                               onClick={[Function]}
+                              tabIndex={-1}
                             >
                               <div
                                 className="pf-c-tree-view__node-toggle"
                                 onClick={[Function]}
+                                tabIndex={-1}
                               >
                                 <span
                                   className="pf-c-tree-view__node-toggle-icon"
@@ -7672,7 +7757,7 @@ exports[`tree view renders search successfully 1`] = `
               className="pf-c-tree-view__list-item"
               id="Cost"
               role="treeitem"
-              tabIndex={0}
+              tabIndex={-1}
             >
               <div
                 className="pf-c-tree-view__content"
@@ -7683,10 +7768,12 @@ exports[`tree view renders search successfully 1`] = `
                   <button
                     className="pf-c-tree-view__node"
                     onClick={[Function]}
+                    tabIndex={-1}
                   >
                     <div
                       className="pf-c-tree-view__node-toggle"
                       onClick={[Function]}
+                      tabIndex={-1}
                     >
                       <span
                         className="pf-c-tree-view__node-toggle-icon"
@@ -7778,7 +7865,7 @@ exports[`tree view renders search successfully 1`] = `
               className="pf-c-tree-view__list-item"
               id="Sources"
               role="treeitem"
-              tabIndex={0}
+              tabIndex={-1}
             >
               <div
                 className="pf-c-tree-view__content"
@@ -7789,10 +7876,12 @@ exports[`tree view renders search successfully 1`] = `
                   <button
                     className="pf-c-tree-view__node"
                     onClick={[Function]}
+                    tabIndex={-1}
                   >
                     <div
                       className="pf-c-tree-view__node-toggle"
                       onClick={[Function]}
+                      tabIndex={-1}
                     >
                       <span
                         className="pf-c-tree-view__node-toggle-icon"
@@ -7878,7 +7967,7 @@ exports[`tree view renders search successfully 1`] = `
               className="pf-c-tree-view__list-item"
               id="Long"
               role="treeitem"
-              tabIndex={0}
+              tabIndex={-1}
             >
               <div
                 className="pf-c-tree-view__content"
@@ -7889,10 +7978,12 @@ exports[`tree view renders search successfully 1`] = `
                   <button
                     className="pf-c-tree-view__node"
                     onClick={[Function]}
+                    tabIndex={-1}
                   >
                     <div
                       className="pf-c-tree-view__node-toggle"
                       onClick={[Function]}
+                      tabIndex={-1}
                     >
                       <span
                         className="pf-c-tree-view__node-toggle-icon"

--- a/packages/react-core/src/components/TreeView/index.ts
+++ b/packages/react-core/src/components/TreeView/index.ts
@@ -2,3 +2,4 @@ export * from './TreeView';
 export * from './TreeViewList';
 export * from './TreeViewListItem';
 export * from './TreeViewSearch';
+export * from './TreeViewRoot';

--- a/packages/react-integration/cypress/integration/treeview.spec.ts
+++ b/packages/react-integration/cypress/integration/treeview.spec.ts
@@ -25,7 +25,7 @@ describe('TreeView Demo Test', () => {
     cy.get('#App1 > .pf-c-tree-view__content > .pf-c-tree-view__node').type('{rightArrow}');
     cy.get('#App1Settings').should('exist');
     cy.get('#App1Current').should('exist');
-    cy.get('#App1 > .pf-c-tree-view__content > .pf-c-tree-view__node').type('{downArrow}{leftArrow}');
+    cy.get('#App1 > .pf-c-tree-view__content > .pf-c-tree-view__node').type('{downArrow}{leftArrow}{leftArrow}');
     cy.get('#App1Settings').should('not.exist');
     cy.get('#App1Current').should('not.exist');
     cy.get('#App1 > .pf-c-tree-view__content > .pf-c-tree-view__node').type('{upArrow}');

--- a/packages/react-integration/cypress/integration/treeview.spec.ts
+++ b/packages/react-integration/cypress/integration/treeview.spec.ts
@@ -17,4 +17,17 @@ describe('TreeView Demo Test', () => {
     cy.get('#Sources').should('exist');
     cy.get('#mixed').should('exist');
   });
+
+  it('Verify treeview keyboard interactions', () => {
+    cy.get('#input-search').type('{Backspace}{Backspace}{Backspace}{Backspace}{Backspace}{Backspace}{Backspace}');
+    cy.get('#basic').should('exist');
+    cy.get('#App1').should('exist');
+    cy.get('#App1 > .pf-c-tree-view__content > .pf-c-tree-view__node').type('{rightArrow}');
+    cy.get('#App1Settings').should('exist');
+    cy.get('#App1Current').should('exist');
+    cy.get('#App1 > .pf-c-tree-view__content > .pf-c-tree-view__node').type('{downArrow}{leftArrow}');
+    cy.get('#App1Settings').should('not.exist');
+    cy.get('#App1Current').should('not.exist');
+    cy.get('#App1 > .pf-c-tree-view__content > .pf-c-tree-view__node').type('{upArrow}');
+  });
 });


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4726

Keyboard interaction:
- `ArrowUp` and `ArrowDown` move through the list of displayed tree items
- `ArrowRight` and `ArrowLeft` respectively open and close expandable folders. Focus is moved to the first child item when a folder is opened, and focus is moved to the parent folder if the `ArrowLeft` is triggered while within a folder, or remains on the folder if already on the expanded folder.
- `ArrowRight` and `ArrowLeft` iterate through a node for the checkbox variant, and do not expand/collapse a folder (left to `Space`).
- `Space` acts as a click to expand/collapse a folder or select a leaf item (or checkbox for checkbox variants)

@jessiehuff Let me know if there's anything I'm missing or anything I should add for a11y!