### PR TITLE
Select(typeahead): remove onFilter function from example with custom objects

### DIFF
--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -306,7 +306,24 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
       } else {
         typeaheadFilteredChildren =
           typeaheadInputValue.toString() !== ''
-            ? childrenArray.filter(child => this.getDisplay(child.props.value.toString(), 'text').search(input) === 0)
+            ? childrenArray.filter(child => {
+                const valueToCheck = child.props.value;
+                // Dividers don't have value and should not be filtered
+                if (!valueToCheck) {
+                  return true;
+                }
+
+                const isSelectOptionObject =
+                  typeof valueToCheck !== 'string' &&
+                  (valueToCheck as SelectOptionObject).toString &&
+                  (valueToCheck as SelectOptionObject).compareTo;
+
+                if (isSelectOptionObject) {
+                  return (valueToCheck as SelectOptionObject).compareTo(typeaheadInputValue);
+                } else {
+                  return this.getDisplay(child.props.value.toString(), 'text').search(input) === 0;
+                }
+              })
             : childrenArray;
       }
     }

--- a/packages/react-core/src/components/Select/examples/Select.md
+++ b/packages/react-core/src/components/Select/examples/Select.md
@@ -1610,14 +1610,6 @@ class MultiTypeaheadSelectInputCustomObjects extends React.Component {
         isOpen: false
       });
     };
-
-    this.customFilter = e => {
-      console.log(e);
-      const input = e.target.value.toString();
-      let typeaheadFilteredChildren =
-        input !== '' ? this.options.filter(option => option.props.value.compareTo(input)) : this.options;
-      return typeaheadFilteredChildren;
-    };
   }
 
   render() {


### PR DESCRIPTION
    
* fixes the crash on typeahead select component when an empty string option was
    passed (issue#4361)
* fixes the crash on typeahead select with custom objects example
    (issue#5449)
    
Fixes #5449
Fixes #4361

