### PR TITLE
fix(Select): fix typeahead variant crashing when empty string option is passed

### DIFF
--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -306,7 +306,9 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
       } else {
         typeaheadFilteredChildren =
           typeaheadInputValue.toString() !== ''
-            ? childrenArray.filter(child => this.getDisplay(child.props.value.toString(), 'text').search(input) === 0)
+            ? childrenArray.filter(
+                child => child.props.value && this.getDisplay(child.props.value.toString(), 'text').search(input) === 0
+              )
             : childrenArray;
       }
     }


### PR DESCRIPTION
Fixes #4361