### PR TITLE
DualListSelect: add onAvailableOptionsSelectInputChanged and onChosenOptionsSelectInputChanged

### DIFF
--- a/packages/react-core/src/components/DualListSelector/DualListSelector.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelector.tsx
@@ -69,8 +69,12 @@ export interface DualListSelectorProps {
   isSearchable?: boolean;
   /** Accessible label for the search input on the available options pane. */
   availableOptionsSearchAriaLabel?: string;
+  /** A callback for when the search input value for available options changes. */
+  onAvailableOptionsSearchInputChanged?: (value: string, event: React.FormEvent<HTMLInputElement>) => void;
   /** Accessible label for the search input on the chosen options pane. */
   chosenOptionsSearchAriaLabel?: string;
+  /** A callback for when the search input value for chosen options changes. */
+  onChosenOptionsSearchInputChanged?: (value: string, event: React.FormEvent<HTMLInputElement>) => void;
   /** Optional filter function for custom filtering based on search string. */
   filterOption?: (option: React.ReactNode, input: string) => boolean;
   /** Id of the dual list selector. */
@@ -505,6 +509,8 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
       removeAll,
       addSelected,
       onListChange,
+      onAvailableOptionsSearchInputChanged,
+      onChosenOptionsSearchInputChanged,
       onOptionSelect,
       onOptionCheck,
       id,
@@ -548,6 +554,7 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
           isSearchable={isSearchable}
           searchInputAriaLabel={availableOptionsSearchAriaLabel}
           filterOption={filterOption}
+          onSearchInputChanged={onAvailableOptionsSearchInputChanged}
           status={availableOptionsStatusToDisplay}
           title={availableOptionsTitle}
           options={available}
@@ -618,6 +625,7 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
           isSearchable={isSearchable}
           searchInputAriaLabel={chosenOptionsSearchAriaLabel}
           filterOption={filterOption}
+          onSearchInputChanged={onChosenOptionsSearchInputChanged}
           title={chosenOptionsTitle}
           status={chosenOptionsStatusToDisplay}
           options={chosen}

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorPane.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorPane.tsx
@@ -40,6 +40,8 @@ export interface DualListSelectorPaneProps {
   ) => void;
   /** Actions to place above the pane. */
   actions?: React.ReactNode[];
+  /** A callback for when the search input value for changes. */
+  onSearchInputChanged?: (value: string, event: React.FormEvent<HTMLInputElement>) => void;
   /** Filter function for custom filtering based on search string. */
   filterOption?: (option: React.ReactNode, input: string) => boolean;
   /** Flag indicating a search bar should be included above the pane. */
@@ -79,6 +81,9 @@ export class DualListSelectorPane extends React.Component<DualListSelectorPanePr
 
   onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     this.setState({ input: e.target.value });
+    if (this.props.onSearchInputChanged) {
+      this.props.onSearchInputChanged(e.target.value, e);
+    }
     this.optionsRefs = [];
   };
 
@@ -172,6 +177,8 @@ export class DualListSelectorPane extends React.Component<DualListSelectorPanePr
       selectedOptions,
       options,
       id,
+      /* eslint-disable @typescript-eslint/no-unused-vars */
+      onSearchInputChanged,
       /* eslint-disable @typescript-eslint/no-unused-vars */
       filterOption,
       onOptionSelect,


### PR DESCRIPTION
The use case can be as seen in the linked issue, that the cunsumer might
need to use the left search bar to query an API for available options.

This is understandable as the list of available options can get
really long in some use-cases and in that case the API calls should only
fetch the options that are relevant to the user input.

Fixes #5436