### PR TITLE
fix(datepicker): only show non-whitespace error text

### DIFF
--- a/packages/react-core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-core/src/components/DatePicker/DatePicker.tsx
@@ -199,7 +199,7 @@ export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
         </div>
       </Popover>
       {helperText && <div className={styles.datePickerHelperText}>{helperText}</div>}
-      {errorText && <div className={css(styles.datePickerHelperText, styles.modifiers.error)}>{errorText}</div>}
+      {errorText.trim() && <div className={css(styles.datePickerHelperText, styles.modifiers.error)}>{errorText}</div>}
     </div>
   );
 };


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5486

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
