### PR TITLE
feat(TreeView): add flag for expand/collapse all

### DIFF
--- a/packages/react-core/src/components/TreeView/TreeView.tsx
+++ b/packages/react-core/src/components/TreeView/TreeView.tsx
@@ -43,6 +43,8 @@ export interface TreeViewProps {
   icon?: React.ReactNode;
   /** Icon for all expanded node items */
   expandedIcon?: React.ReactNode;
+  /** Sets the expanded state on all tree nodes, overriding default behavior and current internal state */
+  allExpanded?: boolean;
   /** Sets the default expanded behavior */
   defaultAllExpanded?: boolean;
   /** Callback for item selection */
@@ -67,6 +69,7 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
   hasChecks = false,
   hasBadges = false,
   defaultAllExpanded = false,
+  allExpanded,
   icon,
   expandedIcon,
   parentItem,
@@ -85,6 +88,7 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
           key={item.name.toString()}
           name={item.name}
           id={item.id}
+          isExpanded={allExpanded}
           defaultExpanded={item.defaultExpanded !== undefined ? item.defaultExpanded : defaultAllExpanded}
           onSelect={onSelect}
           onCheck={onCheck}
@@ -107,6 +111,7 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
                 parentItem={item}
                 hasChecks={hasChecks}
                 hasBadges={hasBadges}
+                allExpanded={allExpanded}
                 defaultAllExpanded={defaultAllExpanded}
                 onSelect={onSelect}
                 onCheck={onCheck}

--- a/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
+++ b/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
@@ -15,6 +15,8 @@ export interface TreeViewListItemProps {
   name: React.ReactNode;
   /** ID of a tree view item */
   id?: string;
+  /** Flag indicating if the node is expanded, overrides internal state */
+  isExpanded?: boolean;
   /** Flag indicating if node is expanded by default */
   defaultExpanded?: boolean;
   /** Child nodes of a tree view item */
@@ -50,6 +52,7 @@ export interface TreeViewListItemProps {
 export const TreeViewListItem: React.FunctionComponent<TreeViewListItemProps> = ({
   name,
   id,
+  isExpanded,
   defaultExpanded = false,
   children = null,
   onSelect,
@@ -68,19 +71,21 @@ export const TreeViewListItem: React.FunctionComponent<TreeViewListItemProps> = 
   action,
   compareItems
 }: TreeViewListItemProps) => {
-  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+  const [internalIsExpanded, setIsExpanded] = useState(defaultExpanded);
 
   useEffect(() => {
-    setIsExpanded(defaultExpanded);
-  }, [defaultExpanded]);
+    if (isExpanded !== undefined && isExpanded !== null) {
+      setIsExpanded(isExpanded);
+    }
+  }, [isExpanded]);
 
   const Component = hasCheck ? 'div' : 'button';
   const ToggleComponent = hasCheck ? 'button' : 'div';
   return (
     <li
       id={id}
-      className={css(styles.treeViewListItem, isExpanded && styles.modifiers.expanded)}
-      {...(isExpanded && { 'aria-expanded': 'true' })}
+      className={css(styles.treeViewListItem, internalIsExpanded && styles.modifiers.expanded)}
+      {...(internalIsExpanded && { 'aria-expanded': 'true' })}
       role={children ? 'treeitem' : 'none'}
       tabIndex={-1}
     >
@@ -100,7 +105,7 @@ export const TreeViewListItem: React.FunctionComponent<TreeViewListItemProps> = 
               onClick={(evt: React.MouseEvent) => {
                 if (!hasCheck) {
                   if (children) {
-                    setIsExpanded(!isExpanded);
+                    setIsExpanded(!internalIsExpanded);
                   }
                   onSelect && onSelect(evt, itemData, parentItem);
                 }
@@ -113,7 +118,7 @@ export const TreeViewListItem: React.FunctionComponent<TreeViewListItemProps> = 
                   className={css(styles.treeViewNodeToggle)}
                   onClick={() => {
                     if (hasCheck) {
-                      setIsExpanded(!isExpanded);
+                      setIsExpanded(!internalIsExpanded);
                     }
                   }}
                   {...(hasCheck && { 'aria-labelledby': `label-${randomId}` })}
@@ -139,8 +144,8 @@ export const TreeViewListItem: React.FunctionComponent<TreeViewListItemProps> = 
               )}
               {icon && (
                 <span className={css(styles.treeViewNodeIcon)}>
-                  {!isExpanded && icon}
-                  {isExpanded && (expandedIcon || icon)}
+                  {!internalIsExpanded && icon}
+                  {internalIsExpanded && (expandedIcon || icon)}
                 </span>
               )}
               {hasCheck ? (
@@ -160,7 +165,7 @@ export const TreeViewListItem: React.FunctionComponent<TreeViewListItemProps> = 
         </GenerateId>
         {action && <div className={css(styles.treeViewAction)}>{action}</div>}
       </div>
-      {isExpanded && children}
+      {internalIsExpanded && children}
     </li>
   );
 };

--- a/packages/react-core/src/components/TreeView/examples/TreeView.md
+++ b/packages/react-core/src/components/TreeView/examples/TreeView.md
@@ -14,23 +14,30 @@ import { FolderIcon, FolderOpenIcon, EllipsisVIcon, ClipboardIcon, HamburgerIcon
 
 ```js
 import React from 'react';
-import { TreeView, TreeViewDataItem } from '@patternfly/react-core';
+import { TreeView, TreeViewDataItem, Button } from '@patternfly/react-core';
 
 class DefaultTreeView extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = { activeItems: {} };
+    this.state = { activeItems: {}, allExpanded: null };
 
     this.onClick = (evt, treeViewItem, parentItem) => {
       this.setState({
         activeItems: [treeViewItem, parentItem]
       });
     };
+
+    this.onToggle = evt => {
+      const { allExpanded } = this.state;
+      this.setState({
+        allExpanded: allExpanded !== undefined ? !allExpanded : true
+      });
+    };
   }
 
   render() {
-    const { activeItems } = this.state;
+    const { activeItems, allExpanded } = this.state;
 
     const options = [
       {
@@ -89,7 +96,16 @@ class DefaultTreeView extends React.Component {
         children: [{ name: 'Application 5', id: 'App5' }]
       }
     ];
-    return <TreeView data={options} activeItems={activeItems} onSelect={this.onClick} />;
+    console.log('All expand?', allExpanded);
+    return (
+      <React.Fragment>
+        <Button variant="link" onClick={this.onToggle}>
+          {allExpanded && 'Collapse all'}
+          {!allExpanded && 'Expand all'}
+        </Button>
+        <TreeView data={options} activeItems={activeItems} onSelect={this.onClick} allExpanded={allExpanded} />
+      </React.Fragment>
+    );
   }
 }
 ```
@@ -162,7 +178,7 @@ class SearchTreeView extends React.Component {
       }
     ];
 
-    this.state = { activeItems: {}, filteredItems: this.options, isFiltered: false };
+    this.state = { activeItems: {}, filteredItems: this.options, isFiltered: null };
 
     this.onClick = (evt, treeViewItem, parentItem) => {
       this.setState({
@@ -205,7 +221,7 @@ class SearchTreeView extends React.Component {
         onSelect={this.onClick}
         onSearch={this.onChange}
         searchProps={{ id: 'input-search', name: 'search-input', 'aria-label': 'Search input example' }}
-        defaultAllExpanded={isFiltered}
+        allExpanded={isFiltered}
       />
     );
   }

--- a/packages/react-integration/cypress/integration/treeview.spec.ts
+++ b/packages/react-integration/cypress/integration/treeview.spec.ts
@@ -5,6 +5,15 @@ describe('TreeView Demo Test', () => {
     cy.url().should('eq', 'http://localhost:3000/treeview-demo-nav-link');
   });
 
+  it('Verify expand/collapse all', () => {
+    cy.get('#App1').should('exist');
+    cy.get('#expand').click();
+    cy.get('#expand').click();
+    cy.get('#App1').should('not.exist');
+    cy.get('#expand').click();
+    cy.get('#App1').should('exist');
+  });
+
   it('Verify treeview', () => {
     cy.get('#basic').should('exist');
     cy.get('#App1').should('exist');

--- a/packages/react-integration/demo-app-ts/src/components/demos/TreeViewDemo/TreeViewDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TreeViewDemo/TreeViewDemo.tsx
@@ -67,6 +67,7 @@ export class TreeViewDemo extends Component {
   ];
 
   state = {
+    allExpanded: null as boolean,
     activeItems: [] as TreeViewDataItem[],
     activeItems2: [] as TreeViewDataItem[],
     filteredItems: this.options
@@ -115,8 +116,15 @@ export class TreeViewDemo extends Component {
     }
   };
 
+  onToggle = () => {
+    const { allExpanded } = this.state;
+    this.setState({
+      allExpanded: allExpanded !== undefined ? !allExpanded : true
+    });
+  };
+
   render() {
-    const { activeItems, activeItems2, filteredItems } = this.state;
+    const { activeItems, activeItems2, filteredItems, allExpanded } = this.state;
     const flagOptions: TreeViewDataItem[] = [
       {
         name: 'ApplicationLauncher',
@@ -186,8 +194,13 @@ export class TreeViewDemo extends Component {
     ];
     return (
       <React.Fragment>
+        <Button id="expand" variant="link" onClick={this.onToggle}>
+          {allExpanded && 'Collapse all'}
+          {!allExpanded && 'Expand all'}
+        </Button>
         <TreeView
           id="basic"
+          allExpanded={allExpanded}
           data={filteredItems}
           activeItems={activeItems}
           onSelect={this.onClick}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4797

- Adds `allExpanded` prop to TreeView, allowing the override of default and internal flags for the expanded state. Set to `null` or do not pass in to allow the `defaultExpanded` prop to set the initial state.
- Adds a button to the default demo to showcase this prop, and updates the search demo to use the new prop (over `defaultExpanded`).
