### PR TITLE
[wip] recursive index for DropdownItem

### DIFF
--- a/packages/react-core/src/components/Dropdown/DropdownMenu.tsx
+++ b/packages/react-core/src/components/Dropdown/DropdownMenu.tsx
@@ -152,11 +152,25 @@ export class DropdownMenu extends React.Component<DropdownMenuProps> {
         return React.cloneElement(group, props);
       });
     }
-    return React.Children.map(children, (child, index) =>
-      React.cloneElement(child as React.ReactElement, {
-        index
-      })
-    );
+    return this.recursiveMap(children);
+  }
+
+  recursiveMap(children: any) {
+    return React.Children.map(children, (child, index) => {
+      if (!React.isValidElement(child)) {
+        return child;
+      }
+
+      if ((child.props as any).children) {
+        const obj = {
+          children: this.recursiveMap((child.props as any).children),
+          index
+        };
+        child = React.cloneElement(child, obj);
+      }
+
+      return child;
+    });
   }
 
   render() {

--- a/packages/react-core/src/components/Dropdown/DropdownMenu.tsx
+++ b/packages/react-core/src/components/Dropdown/DropdownMenu.tsx
@@ -152,18 +152,18 @@ export class DropdownMenu extends React.Component<DropdownMenuProps> {
         return React.cloneElement(group, props);
       });
     }
-    return this.recursiveMap(children);
+    return React.Children.map(children, (child, index) => this.recursiveMap(child, index));
   }
 
-  recursiveMap(children: any) {
-    return React.Children.map(children, (child, index) => {
+  recursiveMap(children: any, index: number) {
+    return React.Children.map(children, child => {
       if (!React.isValidElement(child)) {
         return child;
       }
 
       if ((child.props as any).children) {
         const obj = {
-          children: this.recursiveMap((child.props as any).children),
+          children: this.recursiveMap((child.props as any).children, index),
           index
         };
         child = React.cloneElement(child, obj);

--- a/packages/react-core/src/components/Dropdown/examples/Dropdown.md
+++ b/packages/react-core/src/components/Dropdown/examples/Dropdown.md
@@ -59,9 +59,11 @@ class SimpleDropdown extends React.Component {
     const { isOpen } = this.state;
     const dropdownItems = [
       <DropdownItem key="link">Link</DropdownItem>,
-      <DropdownItem key="action" component="button">
-        Action
-      </DropdownItem>,
+      <React.Fragment>
+        <DropdownItem key="action" component="button">
+          Action
+        </DropdownItem>
+      </React.Fragment>,
       <DropdownItem key="disabled link" isDisabled href="www.google.com">
         Disabled Link
       </DropdownItem>,

--- a/packages/react-core/src/components/Dropdown/examples/Dropdown.md
+++ b/packages/react-core/src/components/Dropdown/examples/Dropdown.md
@@ -64,10 +64,10 @@ class SimpleDropdown extends React.Component {
           Action
         </DropdownItem>
       </React.Fragment>,
-      <DropdownItem key="disabled link" isDisabled href="www.google.com">
+      <DropdownItem key="disabled link" href="www.google.com">
         Disabled Link
       </DropdownItem>,
-      <DropdownItem key="disabled action" isDisabled component="button">
+      <DropdownItem key="disabled action" component="button">
         Disabled Action
       </DropdownItem>,
       <DropdownSeparator key="separator" />,


### PR DESCRIPTION
Problem:

If DropdownItem / ApplicationLauncherItem (and other items that extend out from DropdownItem) are wrapped, then keyboard interaction doesn't find them.

Example with no problem:
```
const dropdownItems = [
      <DropdownItem key="link">Link</DropdownItem>,
        <DropdownItem key="action" component="button">
          Action
        </DropdownItem>,
      <DropdownItem key="another_item">
        Another Item
      </DropdownItem>
    ];
    return (
      <Dropdown
        onSelect={this.onSelect}
        toggle={
          <DropdownToggle id="toggle-id" onToggle={this.onToggle} toggleIndicator={CaretDownIcon}>
            Dropdown
          </DropdownToggle>
        }
        isOpen={isOpen}
        dropdownItems={dropdownItems}
      />
    );
```

Example with problem:
**Note how one of the items is wrapped in a fragment**
```
const dropdownItems = [
      <DropdownItem key="link">Link</DropdownItem>,
      <React.Fragment>
        <DropdownItem key="action" component="button">
          In a fragment
        </DropdownItem>
      </React.Fragment>,
      <DropdownItem key="another_item">
        Another Item
      </DropdownItem>
    ];
    return (
      <Dropdown
        onSelect={this.onSelect}
        toggle={
          <DropdownToggle id="toggle-id" onToggle={this.onToggle} toggleIndicator={CaretDownIcon}>
            Dropdown
          </DropdownToggle>
        }
        isOpen={isOpen}
        dropdownItems={dropdownItems}
      />
    );
```

Solution currently would be to either assign `index` manually to the nested DropdownItem (in this case `index={1}`) or do something like in this PR where you recursively assign index to all the children...