### PR TITLE
fix(CalendarMonth): fix selecting month in Popover for React 17

### DIFF
--- a/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
+++ b/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
@@ -217,13 +217,15 @@ export const CalendarMonth = ({
             onSelect={(_ev, monthNum) => {
               // When we put CalendarMonth in a Popover we want the Popover's onDocumentClick
               // to see the SelectOption as a child so it doesn't close the Popover.
-              setIsSelectOpen(false);
-              onSelectToggle(false);
-              const newDate = new Date(focusedDate);
-              newDate.setMonth(Number(monthNum as string));
-              setFocusedDate(newDate);
-              setHoveredDate(newDate);
-              setShouldFocus(false);
+              setTimeout(() => {
+                setIsSelectOpen(false);
+                onSelectToggle(false);
+                const newDate = new Date(focusedDate);
+                newDate.setMonth(Number(monthNum as string));
+                setFocusedDate(newDate);
+                setHoveredDate(newDate);
+                setShouldFocus(false);
+              }, 0);
             }}
             variant="single"
             selections={monthFormatted}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5515

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
