### PR TITLE
fix(Switch): fix error message regarding accessibility usage

### DIFF
--- a/packages/react-core/src/components/Switch/Switch.tsx
+++ b/packages/react-core/src/components/Switch/Switch.tsx
@@ -39,10 +39,11 @@ export class Switch extends React.Component<SwitchProps & OUIAProps, { ouiaState
 
   constructor(props: SwitchProps & OUIAProps) {
     super(props);
-    if (!props.id && !props['aria-label']) {
+    if (!props.label && !props['aria-label']) {
       // eslint-disable-next-line no-console
-      console.error('Switch: Switch requires either an id or aria-label to be specified');
+      console.error('Switch: Switch requires either a label or an aria-label to be specified');
     }
+
     this.id = props.id || getUniqueId();
     this.state = {
       ouiaStateId: getDefaultOUIAId(Switch.displayName)

--- a/packages/react-core/src/components/Switch/__tests__/Switch.test.tsx
+++ b/packages/react-core/src/components/Switch/__tests__/Switch.test.tsx
@@ -67,3 +67,24 @@ test('switch passes value and event to onChange handler', () => {
   input.simulate('change', { target: { checked: true } });
   expect(props.onChange.mock.calls[0][0]).toBe(true);
 });
+
+test('should throw console error when no aria-label or label is given', () => {
+  const myMock = jest.fn();
+  global.console = { ...global.console, error: myMock };
+  mount(<Switch {...props} />);
+  expect(myMock).toBeCalled();
+});
+
+test('should not throw console error when label is given but no aria-label', () => {
+  const myMock = jest.fn();
+  global.console = { ...global.console, error: myMock };
+  mount(<Switch {...props} label="test switch" />);
+  expect(myMock).not.toBeCalled();
+});
+
+test('should not throw console error when aria-label is given but no label', () => {
+  const myMock = jest.fn();
+  global.console = { ...global.console, error: myMock };
+  mount(<Switch {...props} aria-label="test switch" />);
+  expect(myMock).not.toBeCalled();
+});


### PR DESCRIPTION
When the user has not provided an 'id', `getUniqueId` is used to
generate a random one. That id is used after for the aria-labelled-by
property. Therefore when ensuring correct usage of accessibility
properties we need to check that a label is provided, not an id.

Closes #5521