### PR TITLE
fix(NavItem): tabIndex should be passed to cloned children

### DIFF
--- a/packages/react-core/src/components/Nav/NavItem.tsx
+++ b/packages/react-core/src/components/Nav/NavItem.tsx
@@ -67,7 +67,8 @@ export const NavItem: React.FunctionComponent<NavItemProps> = ({
       'aria-current': isActive ? 'page' : null,
       ...(styleChildren && {
         className: css(styles.navLink, isActive && styles.modifiers.current, child.props && child.props.className)
-      })
+      }),
+      tabIndex: child.props.tabIndex || isNavOpen ? null : -1
     });
 
   const ouiaProps = useOUIAProps(NavItem.displayName, ouiaId, ouiaSafe);

--- a/packages/react-core/src/components/Nav/__tests__/__snapshots__/Nav.test.tsx.snap
+++ b/packages/react-core/src/components/Nav/__tests__/__snapshots__/Nav.test.tsx.snap
@@ -1298,6 +1298,7 @@ exports[`Nav List with custom item nodes 1`] = `
               aria-current={null}
               className="pf-c-nav__link my-custom-node"
               onClick={[Function]}
+              tabIndex={null}
             >
               My custom node
             </div>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5561
