### PR TITLE
feat(alert): don't timeout if isMouseOver

### DIFF
--- a/packages/react-core/src/components/Alert/Alert.tsx
+++ b/packages/react-core/src/components/Alert/Alert.tsx
@@ -38,7 +38,7 @@ export interface AlertProps extends Omit<React.HTMLProps<HTMLDivElement>, 'actio
   variantLabel?: string;
   /** Flag to indicate if the Alert is in a live region */
   isLiveRegion?: boolean;
-  /** If set to true, the time out is 8000 milliseconds.  If a number is provided, alert will be dismissed after that amount of time in milliseconds. */
+  /** If set to true, the timeout is 8000 milliseconds. If a number is provided, alert will be dismissed after that amount of time in milliseconds. */
   timeout?: number | boolean;
   /** Function to be executed on alert timeout. Relevant when the timeout prop is set */
   onTimeout?: () => void;
@@ -64,10 +64,12 @@ export const Alert: React.FunctionComponent<AlertProps> = ({
   ouiaId,
   ouiaSafe = true,
   timeout = false,
-  onTimeout,
+  onTimeout = () => {},
   truncateTitle = 0,
   tooltipPosition,
   customIcon,
+  onMouseEnter = () => {},
+  onMouseLeave = () => {},
   ...props
 }: AlertProps) => {
   const ouiaProps = useOUIAProps(Alert.displayName, ouiaId, ouiaSafe, variant);
@@ -78,7 +80,8 @@ export const Alert: React.FunctionComponent<AlertProps> = ({
     </React.Fragment>
   );
 
-  const [disableAlert, setDisableAlert] = useState(false);
+  const [timedOut, setTimedOut] = useState(false);
+  const [isMouseOver, setIsMouseOver] = useState(false);
   const [isTooltipVisible, setIsTooltipVisible] = useState(false);
   const titleRef = React.useRef(null);
   React.useEffect(() => {
@@ -91,12 +94,12 @@ export const Alert: React.FunctionComponent<AlertProps> = ({
       setIsTooltipVisible(showTooltip);
     }
   }, [titleRef, truncateTitle, isTooltipVisible]);
-  const customClassName = css(
-    styles.alert,
-    isInline && styles.modifiers.inline,
-    variant !== AlertVariant.default && styles.modifiers[variant as 'success' | 'danger' | 'warning' | 'info'],
-    className
-  );
+  React.useEffect(() => {
+    timeout = timeout === true ? 8000 : Number(timeout);
+    if (timeout > 0) {
+      setTimeout(() => setTimedOut(true), timeout);
+    }
+  }, []);
   const Title = (
     <h4
       {...(isTooltipVisible && { tabIndex: 0 })}
@@ -107,49 +110,54 @@ export const Alert: React.FunctionComponent<AlertProps> = ({
     </h4>
   );
 
-  if (disableAlert === false && timeout && timeout !== 0) {
-    setTimeout(
-      () => {
-        setDisableAlert(true);
-        if (onTimeout) {
-          onTimeout();
-        }
-      },
-      timeout === true ? 8000 : timeout
-    );
-  }
+  const myOnMouseEnter = (ev: React.MouseEvent<HTMLDivElement>) => {
+    setIsMouseOver(true);
+    onMouseEnter(ev);
+  };
 
-  if (disableAlert === false) {
-    return (
-      <div
-        {...props}
-        className={customClassName}
-        aria-label={ariaLabel}
-        {...ouiaProps}
-        {...(isLiveRegion && {
-          'aria-live': 'polite',
-          'aria-atomic': 'false'
-        })}
-      >
-        <AlertIcon variant={variant} customIcon={customIcon} />
-        {isTooltipVisible ? (
-          <Tooltip content={getHeadingContent} position={tooltipPosition}>
-            {Title}
-          </Tooltip>
-        ) : (
-          Title
-        )}
-        {actionClose && (
-          <AlertContext.Provider value={{ title, variantLabel }}>
-            <div className={css(styles.alertAction)}>{actionClose}</div>
-          </AlertContext.Provider>
-        )}
-        {children && <div className={css(styles.alertDescription)}>{children}</div>}
-        {actionLinks && <div className={css(styles.alertActionGroup)}>{actionLinks}</div>}
-      </div>
-    );
-  } else {
+  const myOnMouseLeave = (ev: React.MouseEvent<HTMLDivElement>) => {
+    setIsMouseOver(false);
+    onMouseLeave(ev);
+  };
+
+  if (timedOut && !isMouseOver) {
+    onTimeout();
     return null;
   }
+  return (
+    <div
+      className={css(
+        styles.alert,
+        isInline && styles.modifiers.inline,
+        styles.modifiers[variant as 'success' | 'danger' | 'warning' | 'info'],
+        className
+      )}
+      aria-label={ariaLabel}
+      {...ouiaProps}
+      {...(isLiveRegion && {
+        'aria-live': 'polite',
+        'aria-atomic': 'false'
+      })}
+      onMouseEnter={myOnMouseEnter}
+      onMouseLeave={myOnMouseLeave}
+      {...props}
+    >
+      <AlertIcon variant={variant} customIcon={customIcon} />
+      {isTooltipVisible ? (
+        <Tooltip content={getHeadingContent} position={tooltipPosition}>
+          {Title}
+        </Tooltip>
+      ) : (
+        Title
+      )}
+      {actionClose && (
+        <AlertContext.Provider value={{ title, variantLabel }}>
+          <div className={css(styles.alertAction)}>{actionClose}</div>
+        </AlertContext.Provider>
+      )}
+      {children && <div className={css(styles.alertDescription)}>{children}</div>}
+      {actionLinks && <div className={css(styles.alertActionGroup)}>{actionLinks}</div>}
+    </div>
+  );
 };
 Alert.displayName = 'Alert';

--- a/packages/react-core/src/components/Alert/__tests__/Generated/__snapshots__/Alert.test.tsx.snap
+++ b/packages/react-core/src/components/Alert/__tests__/Generated/__snapshots__/Alert.test.tsx.snap
@@ -7,6 +7,8 @@ exports[`Alert should match snapshot (auto-generated) 1`] = `
   data-ouia-component-id="OUIA-Generated-Alert-success-1"
   data-ouia-component-type="PF4/Alert"
   data-ouia-safe={true}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
 >
   <AlertIcon
     variant="success"

--- a/packages/react-core/src/components/Alert/__tests__/__snapshots__/Alert.test.tsx.snap
+++ b/packages/react-core/src/components/Alert/__tests__/__snapshots__/Alert.test.tsx.snap
@@ -17,6 +17,8 @@ exports[`Alert - danger Action Close Button 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-danger-4"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="danger"
@@ -139,6 +141,8 @@ exports[`Alert - danger Action Link 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-danger-3"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="danger"
@@ -235,6 +239,8 @@ exports[`Alert - danger Action and Title 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-danger-5"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="danger"
@@ -333,6 +339,8 @@ exports[`Alert - danger Custom aria label 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-danger-6"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="danger"
@@ -431,6 +439,8 @@ exports[`Alert - danger Custom icon 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-danger-12"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       customIcon={
@@ -501,6 +511,8 @@ exports[`Alert - danger Description 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-danger-1"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="danger"
@@ -563,6 +575,8 @@ exports[`Alert - danger Title 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-danger-2"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="danger"
@@ -630,6 +644,8 @@ exports[`Alert - danger Toast alerts match snapsnot 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-danger-8"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="danger"
@@ -694,6 +710,8 @@ exports[`Alert - danger inline variation 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-danger-7"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="danger"
@@ -763,6 +781,8 @@ exports[`Alert - default Action Close Button 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-default-5"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="default"
@@ -885,6 +905,8 @@ exports[`Alert - default Action Link 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-default-4"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="default"
@@ -981,6 +1003,8 @@ exports[`Alert - default Action and Title 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-default-6"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="default"
@@ -1079,6 +1103,8 @@ exports[`Alert - default Custom aria label 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-default-7"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="default"
@@ -1177,6 +1203,8 @@ exports[`Alert - default Custom icon 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-default-13"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       customIcon={
@@ -1247,6 +1275,8 @@ exports[`Alert - default Description 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-default-2"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="default"
@@ -1309,6 +1339,8 @@ exports[`Alert - default Title 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-default-3"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="default"
@@ -1376,6 +1408,8 @@ exports[`Alert - default Toast alerts match snapsnot 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-default-9"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="default"
@@ -1440,6 +1474,8 @@ exports[`Alert - default inline variation 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-default-8"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="default"
@@ -1509,6 +1545,8 @@ exports[`Alert - info Action Close Button 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-info-4"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="info"
@@ -1631,6 +1669,8 @@ exports[`Alert - info Action Link 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-info-3"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="info"
@@ -1727,6 +1767,8 @@ exports[`Alert - info Action and Title 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-info-5"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="info"
@@ -1825,6 +1867,8 @@ exports[`Alert - info Custom aria label 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-info-6"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="info"
@@ -1923,6 +1967,8 @@ exports[`Alert - info Custom icon 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-info-12"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       customIcon={
@@ -1993,6 +2039,8 @@ exports[`Alert - info Description 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-info-1"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="info"
@@ -2055,6 +2103,8 @@ exports[`Alert - info Title 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-info-2"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="info"
@@ -2122,6 +2172,8 @@ exports[`Alert - info Toast alerts match snapsnot 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-info-8"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="info"
@@ -2186,6 +2238,8 @@ exports[`Alert - info inline variation 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-info-7"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="info"
@@ -2255,6 +2309,8 @@ exports[`Alert - success Action Close Button 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-success-4"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="success"
@@ -2377,6 +2433,8 @@ exports[`Alert - success Action Link 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-success-3"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="success"
@@ -2473,6 +2531,8 @@ exports[`Alert - success Action and Title 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-success-5"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="success"
@@ -2571,6 +2631,8 @@ exports[`Alert - success Custom aria label 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-success-6"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="success"
@@ -2669,6 +2731,8 @@ exports[`Alert - success Custom icon 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-success-12"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       customIcon={
@@ -2739,6 +2803,8 @@ exports[`Alert - success Description 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-success-1"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="success"
@@ -2801,6 +2867,8 @@ exports[`Alert - success Title 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-success-2"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="success"
@@ -2868,6 +2936,8 @@ exports[`Alert - success Toast alerts match snapsnot 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-success-8"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="success"
@@ -2932,6 +3002,8 @@ exports[`Alert - success inline variation 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-success-7"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="success"
@@ -3001,6 +3073,8 @@ exports[`Alert - warning Action Close Button 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-warning-4"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="warning"
@@ -3123,6 +3197,8 @@ exports[`Alert - warning Action Link 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-warning-3"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="warning"
@@ -3219,6 +3295,8 @@ exports[`Alert - warning Action and Title 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-warning-5"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="warning"
@@ -3317,6 +3395,8 @@ exports[`Alert - warning Custom aria label 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-warning-6"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="warning"
@@ -3415,6 +3495,8 @@ exports[`Alert - warning Custom icon 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-warning-12"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       customIcon={
@@ -3485,6 +3567,8 @@ exports[`Alert - warning Description 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-warning-1"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="warning"
@@ -3547,6 +3631,8 @@ exports[`Alert - warning Title 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-warning-2"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="warning"
@@ -3614,6 +3700,8 @@ exports[`Alert - warning Toast alerts match snapsnot 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-warning-8"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="warning"
@@ -3678,6 +3766,8 @@ exports[`Alert - warning inline variation 1`] = `
     data-ouia-component-id="OUIA-Generated-Alert-warning-7"
     data-ouia-component-type="PF4/Alert"
     data-ouia-safe={true}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     <AlertIcon
       variant="warning"

--- a/packages/react-core/src/components/Alert/examples/Alert.md
+++ b/packages/react-core/src/components/Alert/examples/Alert.md
@@ -326,7 +326,7 @@ class AsyncLiveRegionAlert extends React.Component {
 ### Alert timeout
 ```js
 import React from 'react';
-import { Alert, Button } from '@patternfly/react-core';
+import { Alert, AlertActionLink, Button } from '@patternfly/react-core';
 
 class AlertTimeout extends React.Component {
   constructor() {
@@ -346,10 +346,17 @@ class AlertTimeout extends React.Component {
       <React.Fragment>
         <Button variant="secondary" onClick={this.onClick} isDisabled={isOpen} >{buttonText} </Button>
         {this.state.isOpen &&
-        <React.Fragment>
-          <Alert title="Default timeout Alert" timeout={true}>This alert will dismiss after 8 seconds </Alert>
-          <Alert title="Custom timeout Alert" timeout={16000}>This alert will dismiss after 16 seconds </Alert>
-        </React.Fragment>
+          <React.Fragment>
+            <Alert title="Default timeout Alert" timeout actionLinks={
+              <React.Fragment>
+                <AlertActionLink>View details</AlertActionLink>
+                <AlertActionLink>Ignore</AlertActionLink>
+              </React.Fragment>
+            }>
+              This alert will dismiss after 8 seconds
+            </Alert>
+            <Alert title="Custom timeout Alert" timeout={16000}>This alert will dismiss after 16 seconds </Alert>
+          </React.Fragment>
         }
       </React.Fragment>
     );

--- a/packages/react-core/src/components/AlertGroup/AlertGroup.tsx
+++ b/packages/react-core/src/components/AlertGroup/AlertGroup.tsx
@@ -47,9 +47,9 @@ export class AlertGroup extends React.Component<AlertGroupProps, AlertGroupState
   }
 
   render() {
-    const { className, children, isToast } = this.props;
+    const { className, children, isToast, ...props } = this.props;
     const alertGroup = (
-      <AlertGroupInline className={className} isToast={isToast}>
+      <AlertGroupInline className={className} isToast={isToast} {...props}>
         {children}
       </AlertGroupInline>
     );

--- a/packages/react-core/src/components/AlertGroup/__tests__/__snapshots__/AlertGroup.test.tsx.snap
+++ b/packages/react-core/src/components/AlertGroup/__tests__/__snapshots__/AlertGroup.test.tsx.snap
@@ -22,6 +22,8 @@ exports[`Standard Alert Group is not a toast alert group 1`] = `
             data-ouia-component-id="OUIA-Generated-Alert-danger-1"
             data-ouia-component-type="PF4/Alert"
             data-ouia-safe={true}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
           >
             <AlertIcon
               variant="danger"
@@ -145,6 +147,8 @@ exports[`Toast Alert Group contains expected modifier class 1`] = `
               data-ouia-component-id="OUIA-Generated-Alert-warning-1"
               data-ouia-component-type="PF4/Alert"
               data-ouia-safe={true}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
             >
               <AlertIcon
                 variant="warning"
@@ -252,6 +256,7 @@ exports[`alertgroup closes when alerts are closed 1`] = `
       <div />
       <div>
         <ul
+          appendto="[object HTMLBodyElement]"
           class="pf-c-alert-group pf-m-toast"
         >
           <li>
@@ -331,6 +336,7 @@ exports[`alertgroup closes when alerts are closed 1`] = `
     containerInfo={
       <div>
         <ul
+          appendto="[object HTMLBodyElement]"
           class="pf-c-alert-group pf-m-toast"
         >
           <li>
@@ -405,9 +411,263 @@ exports[`alertgroup closes when alerts are closed 1`] = `
     }
   >
     <AlertGroupInline
+      appendTo={
+        <body>
+          <div />
+          <div />
+          <div />
+          <div />
+          <div>
+            <ul
+              class="pf-c-alert-group pf-m-toast"
+            >
+              <li>
+                <div
+                  aria-label="Warning Alert"
+                  class="pf-c-alert pf-m-warning"
+                  data-ouia-component-id="OUIA-Generated-Alert-warning-1"
+                  data-ouia-component-type="PF4/Alert"
+                  data-ouia-safe="true"
+                >
+                  <div
+                    class="pf-c-alert__icon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 576 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                      />
+                    </svg>
+                  </div>
+                  <h4
+                    class="pf-c-alert__title"
+                  >
+                    <span
+                      class="pf-u-screen-reader"
+                    >
+                      Warning alert:
+                    </span>
+                    alert title
+                  </h4>
+                  
+                </div>
+              </li>
+            </ul>
+          </div>
+          <div />
+          <div>
+            <ul
+              appendto="[object HTMLBodyElement]"
+              class="pf-c-alert-group pf-m-toast"
+            >
+              <li>
+                <div
+                  aria-atomic="false"
+                  aria-label="Default Alert"
+                  aria-live="polite"
+                  class="pf-c-alert"
+                  data-ouia-component-id="OUIA-Generated-Alert-default-1"
+                  data-ouia-component-type="PF4/Alert"
+                  data-ouia-safe="true"
+                >
+                  <div
+                    class="pf-c-alert__icon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 896 1024"
+                      width="1em"
+                    >
+                      <path
+                        d="M448,0 C465.333333,0 480.333333,6.33333333 493,19 C505.666667,31.6666667 512,46.6666667 512,64 L512,106 L514.23,106.45 C587.89,121.39 648.48,157.24 696,214 C744,271.333333 768,338.666667 768,416 C768,500 780,568.666667 804,622 C818.666667,652.666667 841.333333,684 872,716 C873.773676,718.829136 875.780658,721.505113 878,724 C890,737.333333 896,752.333333 896,769 C896,785.666667 890,800.333333 878,813 C866,825.666667 850.666667,832 832,832 L63.3,832 C44.9533333,831.84 29.8533333,825.506667 18,813 C6,800.333333 0,785.666667 0,769 C0,752.333333 6,737.333333 18,724 L24,716 L25.06,714.9 C55.1933333,683.28 77.5066667,652.313333 92,622 C116,568.666667 128,500 128,416 C128,338.666667 152,271.333333 200,214 C248,156.666667 309.333333,120.666667 384,106 L384,63.31 C384.166667,46.27 390.5,31.5 403,19 C415.666667,6.33333333 430.666667,0 448,0 Z M576,896 L576,897.08 C575.74,932.6 563.073333,962.573333 538,987 C512.666667,1011.66667 482.666667,1024 448,1024 C413.333333,1024 383.333333,1011.66667 358,987 C332.666667,962.333333 320,932 320,896 L576,896 Z"
+                      />
+                    </svg>
+                  </div>
+                  <h4
+                    class="pf-c-alert__title"
+                  >
+                    <span
+                      class="pf-u-screen-reader"
+                    >
+                      Default alert:
+                    </span>
+                    Test Alert
+                  </h4>
+                  <div
+                    class="pf-c-alert__action"
+                  >
+                    <button
+                      aria-disabled="false"
+                      aria-label="Close"
+                      class="pf-c-button pf-m-plain"
+                      data-ouia-component-id="OUIA-Generated-Button-plain-1"
+                      data-ouia-component-type="PF4/Button"
+                      data-ouia-safe="true"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        style="vertical-align: -0.125em;"
+                        viewBox="0 0 352 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                  
+                </div>
+              </li>
+            </ul>
+          </div>
+        </body>
+      }
       isToast={true}
     >
       <ul
+        appendTo={
+          <body>
+            <div />
+            <div />
+            <div />
+            <div />
+            <div>
+              <ul
+                class="pf-c-alert-group pf-m-toast"
+              >
+                <li>
+                  <div
+                    aria-label="Warning Alert"
+                    class="pf-c-alert pf-m-warning"
+                    data-ouia-component-id="OUIA-Generated-Alert-warning-1"
+                    data-ouia-component-type="PF4/Alert"
+                    data-ouia-safe="true"
+                  >
+                    <div
+                      class="pf-c-alert__icon"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        style="vertical-align: -0.125em;"
+                        viewBox="0 0 576 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                        />
+                      </svg>
+                    </div>
+                    <h4
+                      class="pf-c-alert__title"
+                    >
+                      <span
+                        class="pf-u-screen-reader"
+                      >
+                        Warning alert:
+                      </span>
+                      alert title
+                    </h4>
+                    
+                  </div>
+                </li>
+              </ul>
+            </div>
+            <div />
+            <div>
+              <ul
+                appendto="[object HTMLBodyElement]"
+                class="pf-c-alert-group pf-m-toast"
+              >
+                <li>
+                  <div
+                    aria-atomic="false"
+                    aria-label="Default Alert"
+                    aria-live="polite"
+                    class="pf-c-alert"
+                    data-ouia-component-id="OUIA-Generated-Alert-default-1"
+                    data-ouia-component-type="PF4/Alert"
+                    data-ouia-safe="true"
+                  >
+                    <div
+                      class="pf-c-alert__icon"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        style="vertical-align: -0.125em;"
+                        viewBox="0 0 896 1024"
+                        width="1em"
+                      >
+                        <path
+                          d="M448,0 C465.333333,0 480.333333,6.33333333 493,19 C505.666667,31.6666667 512,46.6666667 512,64 L512,106 L514.23,106.45 C587.89,121.39 648.48,157.24 696,214 C744,271.333333 768,338.666667 768,416 C768,500 780,568.666667 804,622 C818.666667,652.666667 841.333333,684 872,716 C873.773676,718.829136 875.780658,721.505113 878,724 C890,737.333333 896,752.333333 896,769 C896,785.666667 890,800.333333 878,813 C866,825.666667 850.666667,832 832,832 L63.3,832 C44.9533333,831.84 29.8533333,825.506667 18,813 C6,800.333333 0,785.666667 0,769 C0,752.333333 6,737.333333 18,724 L24,716 L25.06,714.9 C55.1933333,683.28 77.5066667,652.313333 92,622 C116,568.666667 128,500 128,416 C128,338.666667 152,271.333333 200,214 C248,156.666667 309.333333,120.666667 384,106 L384,63.31 C384.166667,46.27 390.5,31.5 403,19 C415.666667,6.33333333 430.666667,0 448,0 Z M576,896 L576,897.08 C575.74,932.6 563.073333,962.573333 538,987 C512.666667,1011.66667 482.666667,1024 448,1024 C413.333333,1024 383.333333,1011.66667 358,987 C332.666667,962.333333 320,932 320,896 L576,896 Z"
+                        />
+                      </svg>
+                    </div>
+                    <h4
+                      class="pf-c-alert__title"
+                    >
+                      <span
+                        class="pf-u-screen-reader"
+                      >
+                        Default alert:
+                      </span>
+                      Test Alert
+                    </h4>
+                    <div
+                      class="pf-c-alert__action"
+                    >
+                      <button
+                        aria-disabled="false"
+                        aria-label="Close"
+                        class="pf-c-button pf-m-plain"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-1"
+                        data-ouia-component-type="PF4/Button"
+                        data-ouia-safe="true"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style="vertical-align: -0.125em;"
+                          viewBox="0 0 352 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                    
+                  </div>
+                </li>
+              </ul>
+            </div>
+          </body>
+        }
         className="pf-c-alert-group pf-m-toast"
       >
         <li
@@ -432,6 +692,8 @@ exports[`alertgroup closes when alerts are closed 1`] = `
               data-ouia-component-id="OUIA-Generated-Alert-default-1"
               data-ouia-component-type="PF4/Alert"
               data-ouia-safe={true}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
             >
               <AlertIcon
                 variant="default"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Wait until the Alert is timed out AND the mouse is not over it AND the keyboard isn't focusing an element inside of it. After the mouse exits wait at least `timeoutAnimation` seconds. Closes #5489

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
