### PR TITLE
fix(select): remove panel from select variants

### DIFF
--- a/packages/react-core/src/components/Select/examples/Select.md
+++ b/packages/react-core/src/components/Select/examples/Select.md
@@ -1775,7 +1775,6 @@ class SingleSelectInput extends React.Component {
           Title
         </span>
         <Select
-          variant={SelectVariant.panel}
           aria-label="Select Input"
           onToggle={this.onToggle}
           isOpen={isOpen}

--- a/packages/react-core/src/components/Select/selectConstants.tsx
+++ b/packages/react-core/src/components/Select/selectConstants.tsx
@@ -22,8 +22,7 @@ export enum SelectVariant {
   single = 'single',
   checkbox = 'checkbox',
   typeahead = 'typeahead',
-  typeaheadMulti = 'typeaheadmulti',
-  panel = 'panel'
+  typeaheadMulti = 'typeaheadmulti'
 }
 
 export enum SelectDirection {


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5340 .

There should not be a variant named `panel`. When user want to use the customized Select panel, they only need to pass the `customContent` into Select component.

Update the doc as well. users don't need to pass `variant` when they want to use Select Panel.
