### PR TITLE
fix(nav): don't call onExpand twice

### DIFF
--- a/packages/react-core/src/components/Nav/Nav.tsx
+++ b/packages/react-core/src/components/Nav/Nav.tsx
@@ -28,7 +28,7 @@ export interface NavProps
   onToggle?: (toggledItem: {
     groupId: number | string;
     isExpanded: boolean;
-    event: React.FormEvent<HTMLInputElement>;
+    event: React.MouseEvent<HTMLButtonElement>;
   }) => void;
   /** Accessibility label */
   'aria-label'?: string;
@@ -52,7 +52,7 @@ export const NavContext = React.createContext<{
       to: string
     ) => void
   ) => void;
-  onToggle?: (event: React.MouseEvent<HTMLInputElement>, groupId: number | string, expanded: boolean) => void;
+  onToggle?: (event: React.MouseEvent<HTMLButtonElement>, groupId: number | string, expanded: boolean) => void;
   updateIsScrollable?: (isScrollable: boolean) => void;
   isHorizontal?: boolean;
 }>({});
@@ -92,7 +92,7 @@ export class Nav extends React.Component<NavProps, { isScrollable: boolean; ouia
   }
 
   // Callback from NavExpandable
-  onToggle(event: React.MouseEvent<HTMLInputElement>, groupId: number | string, toggleValue: boolean) {
+  onToggle(event: React.MouseEvent<HTMLButtonElement>, groupId: number | string, toggleValue: boolean) {
     this.props.onToggle({
       event,
       groupId,
@@ -133,7 +133,7 @@ export class Nav extends React.Component<NavProps, { isScrollable: boolean; ouia
               to: string
             ) => void
           ) => this.onSelect(event, groupId, itemId, to, preventDefault, onClick),
-          onToggle: (event: React.MouseEvent<HTMLInputElement>, groupId: number | string, expanded: boolean) =>
+          onToggle: (event: React.MouseEvent<HTMLButtonElement>, groupId: number | string, expanded: boolean) =>
             this.onToggle(event, groupId, expanded),
           updateIsScrollable: (isScrollable: boolean) => this.setState({ isScrollable }),
           isHorizontal

--- a/packages/react-core/src/components/Nav/__tests__/__snapshots__/Nav.test.tsx.snap
+++ b/packages/react-core/src/components/Nav/__tests__/__snapshots__/Nav.test.tsx.snap
@@ -380,18 +380,16 @@ exports[`Expandable Nav List - Trigger toggle 1`] = `
           title="Section 1"
         >
           <li
-            className="pf-c-nav__item pf-m-expandable expandable-group"
+            className="pf-c-nav__item pf-m-expandable pf-m-expanded expandable-group"
             data-ouia-component-id="OUIA-Generated-NavExpandable-1"
             data-ouia-component-type="PF4/NavExpandable"
             data-ouia-safe={true}
-            onClick={[Function]}
           >
             <button
-              aria-expanded={false}
+              aria-expanded={true}
               className="pf-c-nav__link"
               id="grp-1"
               onClick={[Function]}
-              onMouseDown={[Function]}
               tabIndex={null}
             >
               Section 1
@@ -432,7 +430,7 @@ exports[`Expandable Nav List - Trigger toggle 1`] = `
             <section
               aria-labelledby="grp-1"
               className="pf-c-nav__subnav"
-              hidden={true}
+              hidden={null}
             >
               <ul
                 className="pf-c-nav__list"
@@ -567,14 +565,12 @@ exports[`Expandable Nav List 1`] = `
             data-ouia-component-id="OUIA-Generated-NavExpandable-1"
             data-ouia-component-type="PF4/NavExpandable"
             data-ouia-safe={true}
-            onClick={[Function]}
           >
             <button
               aria-expanded={false}
               className="pf-c-nav__link"
               id="grp-1"
               onClick={[Function]}
-              onMouseDown={[Function]}
               tabIndex={null}
             >
               Section 1
@@ -751,14 +747,12 @@ exports[`Expandable Nav List with aria label 1`] = `
             data-ouia-component-id="OUIA-Generated-NavExpandable-3"
             data-ouia-component-type="PF4/NavExpandable"
             data-ouia-safe={true}
-            onClick={[Function]}
           >
             <button
               aria-expanded={false}
               className="pf-c-nav__link"
               id={null}
               onClick={[Function]}
-              onMouseDown={[Function]}
               tabIndex={null}
             >
               Section 1


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Towards https://github.com/openshift/console/pull/8534 and releasing.

I think having both `<NavExpandable onExpand` and `<Nav onToggle` callbacks was a poor idea (and I'm in favor of removing `onExpand` for a boolean `managedExpand` in the future).

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
