### PR TITLE
feat(ClipboardCopy): add inline variant

### DIFF
--- a/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
+++ b/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
@@ -22,7 +22,8 @@ export const clipboardCopyFunc = (event: React.ClipboardEvent<HTMLDivElement>, t
 
 export enum ClipboardCopyVariant {
   inline = 'inline',
-  expansion = 'expansion'
+  expansion = 'expansion',
+  inlineCompact = 'inline-compact'
 }
 
 export interface ClipboardCopyState {
@@ -51,7 +52,7 @@ export interface ClipboardCopyProps extends Omit<React.HTMLProps<HTMLDivElement>
   /** Flag to determine if inline clipboard copy should be block styling */
   isBlock?: boolean;
   /** Adds Clipboard Copy variant styles. */
-  variant?: typeof ClipboardCopyVariant | 'inline' | 'expansion';
+  variant?: typeof ClipboardCopyVariant | 'inline' | 'expansion' | 'inline-compact';
   /** Copy button popover position. */
   position?: PopoverPosition | 'auto' | 'top' | 'bottom' | 'left' | 'right';
   /** Maximum width of the tooltip (default 150px). */
@@ -68,7 +69,7 @@ export interface ClipboardCopyProps extends Omit<React.HTMLProps<HTMLDivElement>
   onChange?: (text?: string | number) => void;
   /** The text which is copied. */
   children: React.ReactNode;
-  /** Additional actions for inline clipboad copy. Should be wrapped with ClipboardCopyAction. */
+  /** Additional actions for inline clipboard copy. Should be wrapped with ClipboardCopyAction. */
   additionalActions?: React.ReactNode;
 }
 
@@ -90,7 +91,7 @@ export class ClipboardCopy extends React.Component<ClipboardCopyProps, Clipboard
     isReadOnly: false,
     isExpanded: false,
     isCode: false,
-    variant: null,
+    variant: 'inline',
     position: TooltipPosition.top,
     maxWidth: '150px',
     exitDelay: 1600,
@@ -153,14 +154,14 @@ export class ClipboardCopy extends React.Component<ClipboardCopyProps, Clipboard
       <div
         className={css(
           styles.clipboardCopy,
-          variant === 'inline' && styles.modifiers.inline,
+          variant === 'inline-compact' && styles.modifiers.inline,
           isBlock && styles.modifiers.block,
           this.state.expanded && styles.modifiers.expanded,
           className
         )}
         {...divProps}
       >
-        {variant === 'inline' && (
+        {variant === 'inline-compact' && (
           <GenerateId prefix="">
             {id => (
               <React.Fragment>
@@ -208,7 +209,7 @@ export class ClipboardCopy extends React.Component<ClipboardCopyProps, Clipboard
             )}
           </GenerateId>
         )}
-        {variant !== 'inline' && (
+        {variant !== 'inline-compact' && (
           <GenerateId prefix="">
             {id => (
               <React.Fragment>

--- a/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
+++ b/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
@@ -166,12 +166,12 @@ export class ClipboardCopy extends React.Component<ClipboardCopyProps, Clipboard
             {id => (
               <React.Fragment>
                 {!isCode && (
-                  <span className={css(styles.clipboardCopyText)} id={`${textIdPrefix}-${id}`}>
+                  <span className={css(styles.clipboardCopyText)} id={`${textIdPrefix}${id}`}>
                     {this.state.text}
                   </span>
                 )}
                 {isCode && (
-                  <code className={css(styles.clipboardCopyText, styles.modifiers.code)} id={`${textIdPrefix}-${id}`}>
+                  <code className={css(styles.clipboardCopyText, styles.modifiers.code)} id={`${textIdPrefix}${id}`}>
                     {this.state.text}
                   </code>
                 )}
@@ -218,9 +218,9 @@ export class ClipboardCopy extends React.Component<ClipboardCopyProps, Clipboard
                     <ClipboardCopyToggle
                       isExpanded={this.state.expanded}
                       onClick={this.expandContent}
-                      id={`${toggleIdPrefix}-${id}`}
-                      textId={`${textIdPrefix}-${id}`}
-                      contentId={`${contentIdPrefix}-${id}`}
+                      id={`${toggleIdPrefix}${id}`}
+                      textId={`${textIdPrefix}${id}`}
+                      contentId={`${contentIdPrefix}${id}`}
                       aria-label={toggleAriaLabel}
                     />
                   )}

--- a/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
+++ b/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
@@ -166,12 +166,12 @@ export class ClipboardCopy extends React.Component<ClipboardCopyProps, Clipboard
             {id => (
               <React.Fragment>
                 {!isCode && (
-                  <span className={css(styles.clipboardCopyText)} id={`text-${id}`}>
+                  <span className={css(styles.clipboardCopyText)} id={`${textIdPrefix}-${id}`}>
                     {this.state.text}
                   </span>
                 )}
                 {isCode && (
-                  <code className={css(styles.clipboardCopyText, styles.modifiers.code)} id={`code-${id}`}>
+                  <code className={css(styles.clipboardCopyText, styles.modifiers.code)} id={`${textIdPrefix}-${id}`}>
                     {this.state.text}
                   </code>
                 )}

--- a/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
+++ b/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
@@ -48,6 +48,8 @@ export interface ClipboardCopyProps extends Omit<React.HTMLProps<HTMLDivElement>
   isExpanded?: boolean;
   /** Flag to determine if clipboard copy content includes code */
   isCode?: boolean;
+  /** Flag to determine if inline clipboard copy should be block styling */
+  isBlock?: boolean;
   /** Adds Clipboard Copy variant styles. */
   variant?: typeof ClipboardCopyVariant | 'inline' | 'expansion';
   /** Copy button popover position. */
@@ -66,6 +68,8 @@ export interface ClipboardCopyProps extends Omit<React.HTMLProps<HTMLDivElement>
   onChange?: (text?: string | number) => void;
   /** The text which is copied. */
   children: React.ReactNode;
+  /** Additional actions for inline clipboad copy. Should be wrapped with ClipboardCopyAction. */
+  additionalActions?: React.ReactNode;
 }
 
 export class ClipboardCopy extends React.Component<ClipboardCopyProps, ClipboardCopyState> {
@@ -86,7 +90,7 @@ export class ClipboardCopy extends React.Component<ClipboardCopyProps, Clipboard
     isReadOnly: false,
     isExpanded: false,
     isCode: false,
-    variant: 'inline',
+    variant: null,
     position: TooltipPosition.top,
     maxWidth: '150px',
     exitDelay: 1600,
@@ -95,7 +99,8 @@ export class ClipboardCopy extends React.Component<ClipboardCopyProps, Clipboard
     onCopy: clipboardCopyFunc,
     onChange: (): any => undefined,
     textAriaLabel: 'Copyable input',
-    toggleAriaLabel: 'Show content'
+    toggleAriaLabel: 'Show content',
+    additionalActions: null
   };
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -125,6 +130,7 @@ export class ClipboardCopy extends React.Component<ClipboardCopyProps, Clipboard
       /* eslint-enable @typescript-eslint/no-unused-vars */
       isReadOnly,
       isCode,
+      isBlock,
       exitDelay,
       maxWidth,
       entryDelay,
@@ -137,6 +143,7 @@ export class ClipboardCopy extends React.Component<ClipboardCopyProps, Clipboard
       variant,
       position,
       className,
+      additionalActions,
       ...divProps
     } = this.props;
     const textIdPrefix = 'text-input-';
@@ -144,68 +151,124 @@ export class ClipboardCopy extends React.Component<ClipboardCopyProps, Clipboard
     const contentIdPrefix = 'content-';
     return (
       <div
-        className={css(styles.clipboardCopy, this.state.expanded && styles.modifiers.expanded, className)}
+        className={css(
+          styles.clipboardCopy,
+          variant === 'inline' && styles.modifiers.inline,
+          isBlock && styles.modifiers.block,
+          this.state.expanded && styles.modifiers.expanded,
+          className
+        )}
         {...divProps}
       >
-        <GenerateId prefix="">
-          {id => (
-            <React.Fragment>
-              <div className={css(styles.clipboardCopyGroup)}>
-                {variant === 'expansion' && (
-                  <ClipboardCopyToggle
-                    isExpanded={this.state.expanded}
-                    onClick={this.expandContent}
-                    id={`${toggleIdPrefix}-${id}`}
-                    textId={`${textIdPrefix}-${id}`}
-                    contentId={`${contentIdPrefix}-${id}`}
-                    aria-label={toggleAriaLabel}
-                  />
+        {variant === 'inline' && (
+          <GenerateId prefix="">
+            {id => (
+              <React.Fragment>
+                {!isCode && (
+                  <span className={css(styles.clipboardCopyText)} id={`text-${id}`}>
+                    {this.state.text}
+                  </span>
                 )}
-                <TextInput
-                  isReadOnly={isReadOnly || this.state.expanded}
-                  onChange={this.updateText}
-                  value={this.state.text as string | number}
-                  id={`text-input-${id}`}
-                  aria-label={textAriaLabel}
-                />
-                <ClipboardCopyButton
-                  exitDelay={exitDelay}
-                  entryDelay={entryDelay}
-                  maxWidth={maxWidth}
-                  position={position}
-                  id={`copy-button-${id}`}
-                  textId={`text-input-${id}`}
-                  aria-label={hoverTip}
-                  onClick={(event: any) => {
-                    if (this.timer) {
-                      window.clearTimeout(this.timer);
-                      this.setState({ copied: false });
-                    }
-                    onCopy(event, this.state.text);
-                    this.setState({ copied: true }, () => {
-                      this.timer = window.setTimeout(() => {
+                {isCode && (
+                  <code className={css(styles.clipboardCopyText, styles.modifiers.code)} id={`code-${id}`}>
+                    {this.state.text}
+                  </code>
+                )}
+                <span className={css(styles.clipboardCopyActions)}>
+                  <span className={css(styles.clipboardCopyActionsItem)}>
+                    <ClipboardCopyButton
+                      variant="plain"
+                      exitDelay={exitDelay}
+                      entryDelay={entryDelay}
+                      maxWidth={maxWidth}
+                      position={position}
+                      id={`copy-button-${id}`}
+                      textId={`text-input-${id}`}
+                      aria-label={hoverTip}
+                      onClick={(event: any) => {
+                        if (this.timer) {
+                          window.clearTimeout(this.timer);
+                          this.setState({ copied: false });
+                        }
+                        onCopy(event, this.state.text);
+                        this.setState({ copied: true }, () => {
+                          this.timer = window.setTimeout(() => {
+                            this.setState({ copied: false });
+                            this.timer = null;
+                          }, switchDelay);
+                        });
+                      }}
+                    >
+                      {this.state.copied ? clickTip : hoverTip}
+                    </ClipboardCopyButton>
+                  </span>
+                  {additionalActions && additionalActions}
+                </span>
+              </React.Fragment>
+            )}
+          </GenerateId>
+        )}
+        {variant !== 'inline' && (
+          <GenerateId prefix="">
+            {id => (
+              <React.Fragment>
+                <div className={css(styles.clipboardCopyGroup)}>
+                  {variant === 'expansion' && (
+                    <ClipboardCopyToggle
+                      isExpanded={this.state.expanded}
+                      onClick={this.expandContent}
+                      id={`${toggleIdPrefix}-${id}`}
+                      textId={`${textIdPrefix}-${id}`}
+                      contentId={`${contentIdPrefix}-${id}`}
+                      aria-label={toggleAriaLabel}
+                    />
+                  )}
+                  <TextInput
+                    isReadOnly={isReadOnly || this.state.expanded}
+                    onChange={this.updateText}
+                    value={this.state.text as string | number}
+                    id={`text-input-${id}`}
+                    aria-label={textAriaLabel}
+                  />
+                  <ClipboardCopyButton
+                    exitDelay={exitDelay}
+                    entryDelay={entryDelay}
+                    maxWidth={maxWidth}
+                    position={position}
+                    id={`copy-button-${id}`}
+                    textId={`text-input-${id}`}
+                    aria-label={hoverTip}
+                    onClick={(event: any) => {
+                      if (this.timer) {
+                        window.clearTimeout(this.timer);
                         this.setState({ copied: false });
-                        this.timer = null;
-                      }, switchDelay);
-                    });
-                  }}
-                >
-                  {this.state.copied ? clickTip : hoverTip}
-                </ClipboardCopyButton>
-              </div>
-              {this.state.expanded && (
-                <ClipboardCopyExpanded
-                  isReadOnly={isReadOnly}
-                  isCode={isCode}
-                  id={`content-${id}`}
-                  onChange={this.updateText}
-                >
-                  {this.state.text}
-                </ClipboardCopyExpanded>
-              )}
-            </React.Fragment>
-          )}
-        </GenerateId>
+                      }
+                      onCopy(event, this.state.text);
+                      this.setState({ copied: true }, () => {
+                        this.timer = window.setTimeout(() => {
+                          this.setState({ copied: false });
+                          this.timer = null;
+                        }, switchDelay);
+                      });
+                    }}
+                  >
+                    {this.state.copied ? clickTip : hoverTip}
+                  </ClipboardCopyButton>
+                </div>
+                {this.state.expanded && (
+                  <ClipboardCopyExpanded
+                    isReadOnly={isReadOnly}
+                    isCode={isCode}
+                    id={`content-${id}`}
+                    onChange={this.updateText}
+                  >
+                    {this.state.text}
+                  </ClipboardCopyExpanded>
+                )}
+              </React.Fragment>
+            )}
+          </GenerateId>
+        )}
       </div>
     );
   };

--- a/packages/react-core/src/components/ClipboardCopy/ClipboardCopyAction.tsx
+++ b/packages/react-core/src/components/ClipboardCopy/ClipboardCopyAction.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import styles from '@patternfly/react-styles/css/components/ClipboardCopy/clipboard-copy';
+import { css } from '@patternfly/react-styles';
+
+export interface ClipboardCopyActionProps extends React.HTMLProps<HTMLLIElement> {
+  /** Content rendered inside the clipboard copy action. */
+  children?: React.ReactNode;
+  /** Additional classes added to the clipboard copy action. */
+  className?: string;
+}
+
+export const ClipboardCopyAction: React.FunctionComponent<ClipboardCopyActionProps> = ({
+  children = null,
+  className = '',
+  ...props
+}: ClipboardCopyActionProps) => (
+  <span className={css(styles.clipboardCopyActionsItem, className)} {...props}>
+    {children}
+  </span>
+);
+ClipboardCopyAction.displayName = 'ClipboardCopyAction';

--- a/packages/react-core/src/components/ClipboardCopy/ClipboardCopyButton.tsx
+++ b/packages/react-core/src/components/ClipboardCopy/ClipboardCopyButton.tsx
@@ -15,6 +15,7 @@ export interface ClipboardCopyButtonProps
   maxWidth?: string;
   position?: 'auto' | 'top' | 'bottom' | 'left' | 'right';
   'aria-label'?: string;
+  variant?: 'control' | 'plain';
 }
 
 export const ClipboardCopyButton: React.FunctionComponent<ClipboardCopyButtonProps> = ({
@@ -27,6 +28,7 @@ export const ClipboardCopyButton: React.FunctionComponent<ClipboardCopyButtonPro
   id,
   textId,
   children,
+  variant = 'control',
   ...props
 }: ClipboardCopyButtonProps) => (
   <Tooltip
@@ -39,7 +41,7 @@ export const ClipboardCopyButton: React.FunctionComponent<ClipboardCopyButtonPro
   >
     <Button
       type="button"
-      variant="control"
+      variant={variant}
       onClick={onClick}
       aria-label={ariaLabel}
       id={id}

--- a/packages/react-core/src/components/ClipboardCopy/__tests__/Generated/__snapshots__/ClipboardCopy.test.tsx.snap
+++ b/packages/react-core/src/components/ClipboardCopy/__tests__/Generated/__snapshots__/ClipboardCopy.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ClipboardCopy should match snapshot (auto-generated) 1`] = `
 <div
-  className="pf-c-clipboard-copy string"
+  className="pf-c-clipboard-copy pf-m-inline string"
 >
   <GenerateId
     prefix=""

--- a/packages/react-core/src/components/ClipboardCopy/__tests__/Generated/__snapshots__/ClipboardCopy.test.tsx.snap
+++ b/packages/react-core/src/components/ClipboardCopy/__tests__/Generated/__snapshots__/ClipboardCopy.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ClipboardCopy should match snapshot (auto-generated) 1`] = `
 <div
-  className="pf-c-clipboard-copy pf-m-inline string"
+  className="pf-c-clipboard-copy string"
 >
   <GenerateId
     prefix=""

--- a/packages/react-core/src/components/ClipboardCopy/examples/ClipboardCopy.md
+++ b/packages/react-core/src/components/ClipboardCopy/examples/ClipboardCopy.md
@@ -100,7 +100,7 @@ import { ClipboardCopy, ClipboardCopyVariant } from '@patternfly/react-core';
 </ClipboardCopy>;
 ```
 
-### Inline
+### Compact inline
 
 ```js
 import React from 'react';
@@ -109,7 +109,7 @@ import { ClipboardCopy } from '@patternfly/react-core';
 <ClipboardCopy variant="inline-compact">2.3.4-2-redhat</ClipboardCopy>;
 ```
 
-### Inline code
+### Compact inline code
 
 ```js
 import React from 'react';
@@ -120,7 +120,7 @@ import { ClipboardCopy } from '@patternfly/react-core';
 </ClipboardCopy>;
 ```
 
-### Inline with additional action
+### Compact inline with additional action
 
 ```js
 import React from 'react';
@@ -141,7 +141,7 @@ import PlayIcon from '@patternfly/react-icons/dist/js/icons/play-icon';
 </ClipboardCopy>;
 ```
 
-### Inline in sentence
+### Compact inline in sentence
 
 ```js
 import React from 'react';

--- a/packages/react-core/src/components/ClipboardCopy/examples/ClipboardCopy.md
+++ b/packages/react-core/src/components/ClipboardCopy/examples/ClipboardCopy.md
@@ -100,7 +100,7 @@ import { ClipboardCopy, ClipboardCopyVariant } from '@patternfly/react-core';
 </ClipboardCopy>;
 ```
 
-### Compact inline
+### Inline compact
 
 ```js
 import React from 'react';
@@ -109,7 +109,7 @@ import { ClipboardCopy } from '@patternfly/react-core';
 <ClipboardCopy variant="inline-compact">2.3.4-2-redhat</ClipboardCopy>;
 ```
 
-### Compact inline code
+### Inline compact code
 
 ```js
 import React from 'react';
@@ -120,7 +120,7 @@ import { ClipboardCopy } from '@patternfly/react-core';
 </ClipboardCopy>;
 ```
 
-### Compact inline with additional action
+### Inline compact with additional action
 
 ```js
 import React from 'react';
@@ -141,7 +141,7 @@ import PlayIcon from '@patternfly/react-icons/dist/js/icons/play-icon';
 </ClipboardCopy>;
 ```
 
-### Compact inline in sentence
+### Inline compact in sentence
 
 ```js
 import React from 'react';

--- a/packages/react-core/src/components/ClipboardCopy/examples/ClipboardCopy.md
+++ b/packages/react-core/src/components/ClipboardCopy/examples/ClipboardCopy.md
@@ -5,8 +5,12 @@ cssPrefix: pf-c-copyclipboard
 propComponents: ['ClipboardCopy']
 ---
 
+import PlayIcon from '@patternfly/react-icons/dist/js/icons/play-icon';
+
 ## Examples
+
 ### Basic
+
 ```js
 import React from 'react';
 import { ClipboardCopy } from '@patternfly/react-core';
@@ -15,6 +19,7 @@ import { ClipboardCopy } from '@patternfly/react-core';
 ```
 
 ### Read Only
+
 ```js
 import React from 'react';
 import { ClipboardCopy } from '@patternfly/react-core';
@@ -23,6 +28,7 @@ import { ClipboardCopy } from '@patternfly/react-core';
 ```
 
 ### Expanded
+
 ```js
 import React from 'react';
 import { ClipboardCopy, ClipboardCopyVariant } from '@patternfly/react-core';
@@ -30,9 +36,11 @@ import { ClipboardCopy, ClipboardCopyVariant } from '@patternfly/react-core';
 <ClipboardCopy variant={ClipboardCopyVariant.expansion}>
   Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting
   expansion.
-</ClipboardCopy>
+</ClipboardCopy>;
 ```
+
 ### Read only expanded
+
 ```js
 import React from 'react';
 import { ClipboardCopy, ClipboardCopyVariant } from '@patternfly/react-core';
@@ -40,10 +48,11 @@ import { ClipboardCopy, ClipboardCopyVariant } from '@patternfly/react-core';
 <ClipboardCopy isReadOnly variant={ClipboardCopyVariant.expansion}>
   Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting
   expansion.
-</ClipboardCopy>
+</ClipboardCopy>;
 ```
 
 ### Read only expanded by default
+
 ```js
 import React from 'react';
 import { ClipboardCopy, ClipboardCopyVariant } from '@patternfly/react-core';
@@ -51,35 +60,33 @@ import { ClipboardCopy, ClipboardCopyVariant } from '@patternfly/react-core';
 <ClipboardCopy isReadOnly isExpanded variant={ClipboardCopyVariant.expansion}>
   Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting
   expansion.
-</ClipboardCopy>
+</ClipboardCopy>;
 ```
 
 ### Expanded with array
+
 ```js
 import React from 'react';
 import { ClipboardCopy, ClipboardCopyVariant } from '@patternfly/react-core';
 
 ClipboardCopyArrayOfElements = () => {
   let text = [
-    "Got a lot of text here," ,
-    "need to see all of it?" ,
-    "Click that arrow on the left side and check out the resulting expansion."
-  ]
-  return <ClipboardCopy variant={ClipboardCopyVariant.expansion}>
-    {text.join(" ")}
-  </ClipboardCopy>
-}
+    'Got a lot of text here,',
+    'need to see all of it?',
+    'Click that arrow on the left side and check out the resulting expansion.'
+  ];
+  return <ClipboardCopy variant={ClipboardCopyVariant.expansion}>{text.join(' ')}</ClipboardCopy>;
+};
 ```
 
 ### JSON object (wrap code with pre)
+
 ```js
 import React from 'react';
 import { ClipboardCopy, ClipboardCopyVariant } from '@patternfly/react-core';
 
 <ClipboardCopy isCode variant={ClipboardCopyVariant.expansion}>
-  
-
-{ `{ "menu": {
+  {`{ "menu": {
   "id": "file",
   "value": "File",
   "popup": {
@@ -90,6 +97,79 @@ import { ClipboardCopy, ClipboardCopyVariant } from '@patternfly/react-core';
     ]
   }
 }} `}
-  
-</ClipboardCopy>
+</ClipboardCopy>;
+```
+
+### Inline
+
+```js
+import React from 'react';
+import { ClipboardCopy } from '@patternfly/react-core';
+
+<ClipboardCopy variant="inline">2.3.4-2-redhat</ClipboardCopy>;
+```
+
+### Inline code
+
+```js
+import React from 'react';
+import { ClipboardCopy } from '@patternfly/react-core';
+
+<ClipboardCopy variant="inline" isCode>
+  2.3.4-2-redhat
+</ClipboardCopy>;
+```
+
+### Inline with additional action
+
+```js
+import React from 'react';
+import { ClipboardCopy, ClipboardCopyAction, Button } from '@patternfly/react-core';
+import PlayIcon from '@patternfly/react-icons/dist/js/icons/play-icon';
+
+<ClipboardCopy
+  variant="inline"
+  additionalActions={
+    <ClipboardCopyAction>
+      <Button variant="plain" aria-label="Run in web terminal">
+        <PlayIcon aria-hidden />
+      </Button>
+    </ClipboardCopyAction>
+  }
+>
+  2.3.4-2-redhat
+</ClipboardCopy>;
+```
+
+### Inline in sentence
+
+```js
+import React from 'react';
+import { ClipboardCopy } from '@patternfly/react-core';
+
+<React.Fragment>
+  <b>Basic</b>
+  <br />
+  Lorem ipsum {<ClipboardCopy variant="inline">2.3.4-2-redhat</ClipboardCopy>} dolor sit amet.
+  <br /> <br />
+  <b>Long copy string</b>
+  <br />
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit.{' '}
+  {
+    <ClipboardCopy variant="inline">
+      https://app.openshift.io/path/sub-path/sub-sub-path/?runtime=quarkus/12345678901234567890/abcdefghijklmnopqrstuvwxyz1234567890
+    </ClipboardCopy>
+  }{' '}
+  Mauris luctus, libero nec dapibus ultricies, urna purus pretium mauris, ullamcorper pharetra lacus nibh vitae enim.
+  <br /> <br />
+  <b>Long copy string in block</b>
+  <br />
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit.{' '}
+  {
+    <ClipboardCopy variant="inline" isBlock>
+      https://app.openshift.io/path/sub-path/sub-sub-path/?runtime=quarkus/12345678901234567890/abcdefghijklmnopqrstuvwxyz1234567890
+    </ClipboardCopy>
+  }{' '}
+  Mauris luctus, libero nec dapibus ultricies, urna purus pretium mauris, ullamcorper pharetra lacus nibh vitae enim.
+</React.Fragment>;
 ```

--- a/packages/react-core/src/components/ClipboardCopy/examples/ClipboardCopy.md
+++ b/packages/react-core/src/components/ClipboardCopy/examples/ClipboardCopy.md
@@ -106,7 +106,7 @@ import { ClipboardCopy, ClipboardCopyVariant } from '@patternfly/react-core';
 import React from 'react';
 import { ClipboardCopy } from '@patternfly/react-core';
 
-<ClipboardCopy variant="inline">2.3.4-2-redhat</ClipboardCopy>;
+<ClipboardCopy variant="inline-compact">2.3.4-2-redhat</ClipboardCopy>;
 ```
 
 ### Inline code
@@ -115,7 +115,7 @@ import { ClipboardCopy } from '@patternfly/react-core';
 import React from 'react';
 import { ClipboardCopy } from '@patternfly/react-core';
 
-<ClipboardCopy variant="inline" isCode>
+<ClipboardCopy variant="inline-compact" isCode>
   2.3.4-2-redhat
 </ClipboardCopy>;
 ```
@@ -128,7 +128,7 @@ import { ClipboardCopy, ClipboardCopyAction, Button } from '@patternfly/react-co
 import PlayIcon from '@patternfly/react-icons/dist/js/icons/play-icon';
 
 <ClipboardCopy
-  variant="inline"
+  variant="inline-compact"
   additionalActions={
     <ClipboardCopyAction>
       <Button variant="plain" aria-label="Run in web terminal">
@@ -150,13 +150,13 @@ import { ClipboardCopy } from '@patternfly/react-core';
 <React.Fragment>
   <b>Basic</b>
   <br />
-  Lorem ipsum {<ClipboardCopy variant="inline">2.3.4-2-redhat</ClipboardCopy>} dolor sit amet.
+  Lorem ipsum {<ClipboardCopy variant="inline-compact">2.3.4-2-redhat</ClipboardCopy>} dolor sit amet.
   <br /> <br />
   <b>Long copy string</b>
   <br />
   Lorem ipsum dolor sit amet, consectetur adipiscing elit.{' '}
   {
-    <ClipboardCopy variant="inline">
+    <ClipboardCopy variant="inline-compact">
       https://app.openshift.io/path/sub-path/sub-sub-path/?runtime=quarkus/12345678901234567890/abcdefghijklmnopqrstuvwxyz1234567890
     </ClipboardCopy>
   }{' '}
@@ -166,7 +166,7 @@ import { ClipboardCopy } from '@patternfly/react-core';
   <br />
   Lorem ipsum dolor sit amet, consectetur adipiscing elit.{' '}
   {
-    <ClipboardCopy variant="inline" isBlock>
+    <ClipboardCopy variant="inline-compact" isBlock>
       https://app.openshift.io/path/sub-path/sub-sub-path/?runtime=quarkus/12345678901234567890/abcdefghijklmnopqrstuvwxyz1234567890
     </ClipboardCopy>
   }{' '}

--- a/packages/react-core/src/components/ClipboardCopy/index.ts
+++ b/packages/react-core/src/components/ClipboardCopy/index.ts
@@ -1,1 +1,2 @@
 export * from './ClipboardCopy';
+export * from './ClipboardCopyAction';

--- a/packages/react-integration/cypress/integration/clipboardcopy.spec.ts
+++ b/packages/react-integration/cypress/integration/clipboardcopy.spec.ts
@@ -13,4 +13,9 @@ describe('Clipboard Copy Demo Test', () => {
     cy.get('.pf-c-clipboard-copy__group [id*="toggle-"]').click();
     cy.get('.pf-c-clipboard-copy__expandable-content').should('exist');
   });
+
+  it('Verify inline clipboard copy', () => {
+    cy.get('#inline-copy').should('have.class', 'pf-m-inline');
+    cy.get('#inline-copy').should('have.class', 'pf-m-block');
+  });
 });

--- a/packages/react-integration/demo-app-ts/src/components/demos/ClipboardCopyDemo/ClipboardCopyDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/ClipboardCopyDemo/ClipboardCopyDemo.tsx
@@ -14,7 +14,7 @@ export class ClipboardCopyDemo extends React.Component {
         <br />
         <div style={{ backgroundColor: 'white', padding: '10px' }}>
           This copy:
-          <ClipboardCopy id="inline-copy" variant={ClipboardCopyVariant.inline} isBlock>
+          <ClipboardCopy id="inline-copy" variant={ClipboardCopyVariant.inlineCompact} isBlock>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris luctus, libero nec dapibus ultricies, urna
             purus pretium mauris, ullamcorper pharetra lacus nibh vitae enim.
           </ClipboardCopy>

--- a/packages/react-integration/demo-app-ts/src/components/demos/ClipboardCopyDemo/ClipboardCopyDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/ClipboardCopyDemo/ClipboardCopyDemo.tsx
@@ -5,10 +5,22 @@ export class ClipboardCopyDemo extends React.Component {
   static displayName = 'ClipboardCopyDemo';
   render() {
     return (
-      <ClipboardCopy variant={ClipboardCopyVariant.expansion}>
-        Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting
-        expansion.
-      </ClipboardCopy>
+      <React.Fragment>
+        <ClipboardCopy variant={ClipboardCopyVariant.expansion}>
+          Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting
+          expansion.
+        </ClipboardCopy>
+        <br />
+        <br />
+        <div style={{ backgroundColor: 'white', padding: '10px' }}>
+          This copy:
+          <ClipboardCopy id="inline-copy" variant={ClipboardCopyVariant.inline} isBlock>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris luctus, libero nec dapibus ultricies, urna
+            purus pretium mauris, ullamcorper pharetra lacus nibh vitae enim.
+          </ClipboardCopy>
+          is inline in a sentence.
+        </div>
+      </React.Fragment>
     );
   }
 }

--- a/packages/react-integration/demo-app-ts/src/components/demos/ClipboardCopyDemo/ClipboardCopyDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/ClipboardCopyDemo/ClipboardCopyDemo.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { ClipboardCopy, ClipboardCopyVariant } from '@patternfly/react-core';
+import { ClipboardCopy, ClipboardCopyVariant, ClipboardCopyAction, Button } from '@patternfly/react-core';
+import PlayIcon from '@patternfly/react-icons/dist/js/icons/play-icon';
 
 export class ClipboardCopyDemo extends React.Component {
   static displayName = 'ClipboardCopyDemo';
@@ -14,7 +15,18 @@ export class ClipboardCopyDemo extends React.Component {
         <br />
         <div style={{ backgroundColor: 'white', padding: '10px' }}>
           This copy:
-          <ClipboardCopy id="inline-copy" variant={ClipboardCopyVariant.inlineCompact} isBlock>
+          <ClipboardCopy
+            id="inline-copy"
+            variant={ClipboardCopyVariant.inlineCompact}
+            isBlock
+            additionalActions={
+              <ClipboardCopyAction>
+                <Button variant="plain" aria-label="Run in web terminal">
+                  <PlayIcon aria-hidden />
+                </Button>
+              </ClipboardCopyAction>
+            }
+          >
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris luctus, libero nec dapibus ultricies, urna
             purus pretium mauris, ullamcorper pharetra lacus nibh vitae enim.
           </ClipboardCopy>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5555

- Utilizes `inline` value of `variant` property to toggle between inline/expand/default types of ClipboardCopy.
- Reuses internal `ClipboardCopyButton` for inline variant, changing the button styling from control to plain. (@mcoker so the html structure for the button differs slightly from core, since the current button has a tooltip. Let me know if I should keep/remove the tooltip).
- Exposes `ClipboardCopyAction` as a wrapper for additional actions added to inline ClipboardCopy via the `additionalActions` property.

 