### PR TITLE
feat(ExpandableSection): add detached variant, update tests

### DIFF
--- a/packages/react-console/src/components/DesktopViewer/__tests__/__snapshots__/DesktopViewer.test.tsx.snap
+++ b/packages/react-console/src/components/DesktopViewer/__tests__/__snapshots__/DesktopViewer.test.tsx.snap
@@ -96,6 +96,7 @@ exports[`DesktopViewer with Spice and VNC 1`] = `
       <div
         class="pf-c-expandable-section__content"
         hidden=""
+        id=""
       >
         <dl
           class="pf-c-description-list pf-m-horizontal"
@@ -395,6 +396,7 @@ exports[`DesktopViewer with Spice, VNC and RDP (different hostname) 1`] = `
       <div
         class="pf-c-expandable-section__content"
         hidden=""
+        id=""
       >
         <dl
           class="pf-c-description-list pf-m-horizontal"
@@ -533,6 +535,7 @@ exports[`DesktopViewer with Spice, VNC and RDP (different hostname) 1`] = `
       <div
         class="pf-c-expandable-section__content"
         hidden=""
+        id=""
       />
     </div>
   </div>
@@ -774,6 +777,7 @@ exports[`DesktopViewer with Spice, VNC and RDP 1`] = `
       <div
         class="pf-c-expandable-section__content"
         hidden=""
+        id=""
       >
         <dl
           class="pf-c-description-list pf-m-horizontal"
@@ -912,6 +916,7 @@ exports[`DesktopViewer with Spice, VNC and RDP 1`] = `
       <div
         class="pf-c-expandable-section__content"
         hidden=""
+        id=""
       />
     </div>
   </div>
@@ -1132,7 +1137,9 @@ exports[`DesktopViewer with custom more-info content 1`] = `
         </div>
         <ExpandableSection
           className=""
+          contentId=""
           isActive={false}
+          isDetached={false}
           isExpanded={false}
           onToggle={[Function]}
           toggleText="Remote Viewer Details"
@@ -1186,6 +1193,7 @@ exports[`DesktopViewer with custom more-info content 1`] = `
             <div
               className="pf-c-expandable-section__content"
               hidden={true}
+              id=""
             >
               <MoreInformationDefaultContent
                 textMoreInfoContent=""

--- a/packages/react-core/src/components/ExpandableSection/ExpandableSection.tsx
+++ b/packages/react-core/src/components/ExpandableSection/ExpandableSection.tsx
@@ -4,23 +4,27 @@ import { css } from '@patternfly/react-styles';
 import AngleRightIcon from '@patternfly/react-icons/dist/js/icons/angle-right-icon';
 import { PickOptional } from '../../helpers/typeUtils';
 
-export interface ExpandableSectionProps {
+export interface ExpandableSectionProps extends React.HTMLProps<HTMLDivElement> {
   /** Content rendered inside the Expandable Component */
   children?: React.ReactNode;
   /** Additional classes added to the Expandable Component */
   className?: string;
   /** Flag to indicate if the content is expanded */
   isExpanded?: boolean;
-  /** Text that appears in the toggle */
+  /** Text that appears in the attached toggle */
   toggleText?: string;
-  /** Text that appears in the toggle when expanded (will override toggleText if both are specified; used for uncontrolled expandable with dynamic toggle text) */
+  /** Text that appears in the attached toggle when expanded (will override toggleText if both are specified; used for uncontrolled expandable with dynamic toggle text) */
   toggleTextExpanded?: string;
-  /** Text that appears in the toggle when collapsed (will override toggleText if both are specified; used for uncontrolled expandable with dynamic toggle text) */
+  /** Text that appears in the attached toggle when collapsed (will override toggleText if both are specified; used for uncontrolled expandable with dynamic toggle text) */
   toggleTextCollapsed?: string;
-  /** Callback function to toggle the expandable content */
+  /** Callback function to toggle the expandable content. Detached expandable sections should use the onToggle property of ExpandableSectionToggle. */
   onToggle?: (isExpanded: boolean) => void;
   /** Forces active state */
   isActive?: boolean;
+  /** Indicates the expandable section has a detached toggle */
+  isDetached?: boolean;
+  /** ID of the content of the expandable section */
+  contentId?: string;
 }
 
 interface ExpandableSectionState {
@@ -44,7 +48,9 @@ export class ExpandableSection extends React.Component<ExpandableSectionProps, E
     toggleTextCollapsed: '',
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     onToggle: (isExpanded): void => undefined,
-    isActive: false
+    isActive: false,
+    isDetached: false,
+    contentId: ''
   };
 
   private calculateToggleText(
@@ -73,6 +79,8 @@ export class ExpandableSection extends React.Component<ExpandableSectionProps, E
       toggleTextCollapsed,
       children,
       isExpanded,
+      isDetached,
+      contentId,
       ...props
     } = this.props;
     let onToggle = onToggleProp;
@@ -100,21 +108,24 @@ export class ExpandableSection extends React.Component<ExpandableSectionProps, E
           styles.expandableSection,
           propOrStateIsExpanded && styles.modifiers.expanded,
           isActive && styles.modifiers.active,
+          isDetached && styles.modifiers.detached,
           className
         )}
       >
-        <button
-          className={css(styles.expandableSectionToggle)}
-          type="button"
-          aria-expanded={propOrStateIsExpanded}
-          onClick={() => onToggle(!propOrStateIsExpanded)}
-        >
-          <span className={css(styles.expandableSectionToggleIcon)}>
-            <AngleRightIcon aria-hidden />
-          </span>
-          <span className={css(styles.expandableSectionToggleText)}>{computedToggleText}</span>
-        </button>
-        <div className={css(styles.expandableSectionContent)} hidden={!propOrStateIsExpanded}>
+        {!isDetached && (
+          <button
+            className={css(styles.expandableSectionToggle)}
+            type="button"
+            aria-expanded={propOrStateIsExpanded}
+            onClick={() => onToggle(!propOrStateIsExpanded)}
+          >
+            <span className={css(styles.expandableSectionToggleIcon)}>
+              <AngleRightIcon aria-hidden />
+            </span>
+            <span className={css(styles.expandableSectionToggleText)}>{computedToggleText}</span>
+          </button>
+        )}
+        <div className={css(styles.expandableSectionContent)} hidden={!propOrStateIsExpanded} id={contentId}>
           {children}
         </div>
       </div>

--- a/packages/react-core/src/components/ExpandableSection/ExpandableSectionToggle.tsx
+++ b/packages/react-core/src/components/ExpandableSection/ExpandableSectionToggle.tsx
@@ -14,6 +14,8 @@ export interface ExpandableSectionToggleProps extends React.HTMLProps<HTMLDivEle
   onToggle?: (isExpanded: boolean) => void;
   /** ID of the toggle's respective expandable section content. */
   contentId?: string;
+  /** Direction the toggle arrow should point when the expandable section is expanded. */
+  direction?: 'up' | 'down';
 }
 
 export const ExpandableSectionToggle: React.FunctionComponent<ExpandableSectionToggleProps> = ({
@@ -22,6 +24,7 @@ export const ExpandableSectionToggle: React.FunctionComponent<ExpandableSectionT
   isExpanded = false,
   onToggle,
   contentId,
+  direction = 'down',
   ...props
 }: ExpandableSectionToggleProps) => (
   <div
@@ -40,7 +43,12 @@ export const ExpandableSectionToggle: React.FunctionComponent<ExpandableSectionT
       aria-controls={contentId}
       onClick={() => onToggle(!isExpanded)}
     >
-      <span className={css(styles.expandableSectionToggleIcon, isExpanded && styles.modifiers.expandTop)}>
+      <span
+        className={css(
+          styles.expandableSectionToggleIcon,
+          isExpanded && direction === 'up' && styles.modifiers.expandTop
+        )}
+      >
         <AngleRightIcon aria-hidden />
       </span>
       <span className={css(styles.expandableSectionToggleText)}>{children}</span>

--- a/packages/react-core/src/components/ExpandableSection/ExpandableSectionToggle.tsx
+++ b/packages/react-core/src/components/ExpandableSection/ExpandableSectionToggle.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import styles from '@patternfly/react-styles/css/components/ExpandableSection/expandable-section';
+import { css } from '@patternfly/react-styles';
+import AngleRightIcon from '@patternfly/react-icons/dist/js/icons/angle-right-icon';
+
+export interface ExpandableSectionToggleProps extends React.HTMLProps<HTMLDivElement> {
+  /** Content rendered inside the expandable toggle. */
+  children?: React.ReactNode;
+  /** Additional classes added to the expandable toggle. */
+  className?: string;
+  /** Flag indicating if the expandable section is expanded. */
+  isExpanded?: boolean;
+  /** Callback function to toggle the expandable content. */
+  onToggle?: (isExpanded: boolean) => void;
+  /** ID of the toggle's respective expandable section content. */
+  contentId?: string;
+}
+
+export const ExpandableSectionToggle: React.FunctionComponent<ExpandableSectionToggleProps> = ({
+  children,
+  className = '',
+  isExpanded = false,
+  onToggle,
+  contentId,
+  ...props
+}: ExpandableSectionToggleProps) => (
+  <div
+    {...props}
+    className={css(
+      styles.expandableSection,
+      isExpanded && styles.modifiers.expanded,
+      styles.modifiers.detached,
+      className
+    )}
+  >
+    <button
+      className={css(styles.expandableSectionToggle)}
+      type="button"
+      aria-expanded={isExpanded}
+      aria-controls={contentId}
+      onClick={() => onToggle(!isExpanded)}
+    >
+      <span className={css(styles.expandableSectionToggleIcon, isExpanded && styles.modifiers.expandTop)}>
+        <AngleRightIcon aria-hidden />
+      </span>
+      <span className={css(styles.expandableSectionToggleText)}>{children}</span>
+    </button>
+  </div>
+);
+
+ExpandableSectionToggle.displayName = 'ExpandableSectionToggle';

--- a/packages/react-core/src/components/ExpandableSection/__tests__/ExpandableSection.test.tsx
+++ b/packages/react-core/src/components/ExpandableSection/__tests__/ExpandableSection.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { ExpandableSection } from '../ExpandableSection';
+import { ExpandableSectionToggle } from '../ExpandableSectionToggle';
 
 const props = {};
 
@@ -26,5 +27,19 @@ test('ExpandableSection onToggle called', () => {
 
 test('Renders Uncontrolled ExpandableSection', () => {
   const view = shallow(<ExpandableSection toggleText="Show More"> test </ExpandableSection>);
+  expect(view).toMatchSnapshot();
+});
+
+test('Detached ExpandableSection renders successfully', () => {
+  const view = mount(
+    <React.Fragment>
+      <ExpandableSectionToggle isExpanded contentId="test">
+        Toggle text
+      </ExpandableSectionToggle>
+      <ExpandableSection {...props} isExpanded isDetached contentId="test">
+        test
+      </ExpandableSection>
+    </React.Fragment>
+  );
   expect(view).toMatchSnapshot();
 });

--- a/packages/react-core/src/components/ExpandableSection/__tests__/ExpandableSection.test.tsx
+++ b/packages/react-core/src/components/ExpandableSection/__tests__/ExpandableSection.test.tsx
@@ -33,12 +33,12 @@ test('Renders Uncontrolled ExpandableSection', () => {
 test('Detached ExpandableSection renders successfully', () => {
   const view = mount(
     <React.Fragment>
-      <ExpandableSectionToggle isExpanded contentId="test">
-        Toggle text
-      </ExpandableSectionToggle>
       <ExpandableSection {...props} isExpanded isDetached contentId="test">
         test
       </ExpandableSection>
+      <ExpandableSectionToggle isExpanded contentId="test" direction="up">
+        Toggle text
+      </ExpandableSectionToggle>
     </React.Fragment>
   );
   expect(view).toMatchSnapshot();

--- a/packages/react-core/src/components/ExpandableSection/__tests__/Generated/__snapshots__/ExpandableSection.test.tsx.snap
+++ b/packages/react-core/src/components/ExpandableSection/__tests__/Generated/__snapshots__/ExpandableSection.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`ExpandableSection should match snapshot (auto-generated) 1`] = `
   <div
     className="pf-c-expandable-section__content"
     hidden={false}
+    id=""
   >
     <div>
       ReactNode

--- a/packages/react-core/src/components/ExpandableSection/__tests__/__snapshots__/ExpandableSection.test.tsx.snap
+++ b/packages/react-core/src/components/ExpandableSection/__tests__/__snapshots__/ExpandableSection.test.tsx.snap
@@ -1,5 +1,84 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Detached ExpandableSection renders successfully 1`] = `
+Array [
+  <ExpandableSectionToggle
+    contentId="test"
+    isExpanded={true}
+  >
+    <div
+      className="pf-c-expandable-section pf-m-expanded pf-m-detached"
+    >
+      <button
+        aria-controls="test"
+        aria-expanded={true}
+        className="pf-c-expandable-section__toggle"
+        onClick={[Function]}
+        type="button"
+      >
+        <span
+          className="pf-c-expandable-section__toggle-icon pf-m-expand-top"
+        >
+          <AngleRightIcon
+            aria-hidden={true}
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
+          >
+            <svg
+              aria-hidden={true}
+              aria-labelledby={null}
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
+              viewBox="0 0 256 512"
+              width="1em"
+            >
+              <path
+                d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+              />
+            </svg>
+          </AngleRightIcon>
+        </span>
+        <span
+          className="pf-c-expandable-section__toggle-text"
+        >
+          Toggle text
+        </span>
+      </button>
+    </div>
+  </ExpandableSectionToggle>,
+  <ExpandableSection
+    className=""
+    contentId="test"
+    isActive={false}
+    isDetached={true}
+    isExpanded={true}
+    onToggle={[Function]}
+    toggleText=""
+    toggleTextCollapsed=""
+    toggleTextExpanded=""
+  >
+    <div
+      className="pf-c-expandable-section pf-m-expanded pf-m-detached"
+    >
+      <div
+        className="pf-c-expandable-section__content"
+        hidden={false}
+        id="test"
+      >
+        test
+      </div>
+    </div>
+  </ExpandableSection>,
+]
+`;
+
 exports[`ExpandableSection 1`] = `
 <div
   className="pf-c-expandable-section"
@@ -26,6 +105,7 @@ exports[`ExpandableSection 1`] = `
   <div
     className="pf-c-expandable-section__content"
     hidden={true}
+    id=""
   >
     test 
   </div>
@@ -59,6 +139,7 @@ exports[`Renders ExpandableSection expanded 1`] = `
   <div
     className="pf-c-expandable-section__content"
     hidden={false}
+    id=""
   >
      test 
   </div>
@@ -93,6 +174,7 @@ exports[`Renders Uncontrolled ExpandableSection 1`] = `
   <div
     className="pf-c-expandable-section__content"
     hidden={true}
+    id=""
   >
      test 
   </div>

--- a/packages/react-core/src/components/ExpandableSection/__tests__/__snapshots__/ExpandableSection.test.tsx.snap
+++ b/packages/react-core/src/components/ExpandableSection/__tests__/__snapshots__/ExpandableSection.test.tsx.snap
@@ -2,8 +2,32 @@
 
 exports[`Detached ExpandableSection renders successfully 1`] = `
 Array [
+  <ExpandableSection
+    className=""
+    contentId="test"
+    isActive={false}
+    isDetached={true}
+    isExpanded={true}
+    onToggle={[Function]}
+    toggleText=""
+    toggleTextCollapsed=""
+    toggleTextExpanded=""
+  >
+    <div
+      className="pf-c-expandable-section pf-m-expanded pf-m-detached"
+    >
+      <div
+        className="pf-c-expandable-section__content"
+        hidden={false}
+        id="test"
+      >
+        test
+      </div>
+    </div>
+  </ExpandableSection>,
   <ExpandableSectionToggle
     contentId="test"
+    direction="up"
     isExpanded={true}
   >
     <div
@@ -53,29 +77,6 @@ Array [
       </button>
     </div>
   </ExpandableSectionToggle>,
-  <ExpandableSection
-    className=""
-    contentId="test"
-    isActive={false}
-    isDetached={true}
-    isExpanded={true}
-    onToggle={[Function]}
-    toggleText=""
-    toggleTextCollapsed=""
-    toggleTextExpanded=""
-  >
-    <div
-      className="pf-c-expandable-section pf-m-expanded pf-m-detached"
-    >
-      <div
-        className="pf-c-expandable-section__content"
-        hidden={false}
-        id="test"
-      >
-        test
-      </div>
-    </div>
-  </ExpandableSection>,
 ]
 `;
 

--- a/packages/react-core/src/components/ExpandableSection/examples/ExpandableSection.md
+++ b/packages/react-core/src/components/ExpandableSection/examples/ExpandableSection.md
@@ -93,7 +93,12 @@ class DetachedExpandableSection extends React.Component {
           </ExpandableSection>
         </StackItem>
         <StackItem>
-          <ExpandableSectionToggle isExpanded={isExpanded} onToggle={this.onToggle} contentId={contentId}>
+          <ExpandableSectionToggle
+            isExpanded={isExpanded}
+            onToggle={this.onToggle}
+            contentId={contentId}
+            direction="up"
+          >
             {isExpanded ? 'Show Less' : 'Show More'}
           </ExpandableSectionToggle>
         </StackItem>

--- a/packages/react-core/src/components/ExpandableSection/examples/ExpandableSection.md
+++ b/packages/react-core/src/components/ExpandableSection/examples/ExpandableSection.md
@@ -2,11 +2,13 @@
 id: Expandable section
 section: components
 cssPrefix: pf-c-expandable-section
-propComponents: ['ExpandableSection']
+propComponents: ['ExpandableSection', 'ExpandableSectionToggle']
 ---
 
 ## Examples
+
 ### Basic
+
 ```js
 import React from 'react';
 import { ExpandableSection } from '@patternfly/react-core';
@@ -17,7 +19,7 @@ class SimpleExpandableSection extends React.Component {
     this.state = {
       isExpanded: false
     };
-    this.onToggle = (isExpanded) => {
+    this.onToggle = isExpanded => {
       this.setState({
         isExpanded
       });
@@ -27,7 +29,11 @@ class SimpleExpandableSection extends React.Component {
   render() {
     const { isExpanded } = this.state;
     return (
-      <ExpandableSection toggleText={isExpanded ? 'Show Less' : 'Show More'} onToggle={this.onToggle} isExpanded={isExpanded}>
+      <ExpandableSection
+        toggleText={isExpanded ? 'Show Less' : 'Show More'}
+        onToggle={this.onToggle}
+        isExpanded={isExpanded}
+      >
         This content is visible only when the component is expanded.
       </ExpandableSection>
     );
@@ -36,23 +42,63 @@ class SimpleExpandableSection extends React.Component {
 ```
 
 ### Uncontrolled
+
 ```js
 import React from 'react';
 import { ExpandableSection } from '@patternfly/react-core';
-
 
 <ExpandableSection toggleText="Show More">
   This content is visible only when the component is expanded.
-</ExpandableSection>
+</ExpandableSection>;
 ```
 
 ### Uncontrolled with dynamic toggle text
+
 ```js
 import React from 'react';
 import { ExpandableSection } from '@patternfly/react-core';
 
-
 <ExpandableSection toggleTextExpanded="Show Less" toggleTextCollapsed="Show More">
   This content is visible only when the component is expanded.
-</ExpandableSection>
+</ExpandableSection>;
+```
+
+### Detached
+
+```js
+import React from 'react';
+import { ExpandableSection, ExpandableSectionToggle, Stack, StackItem } from '@patternfly/react-core';
+
+class DetachedExpandableSection extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isExpanded: false
+    };
+    this.onToggle = isExpanded => {
+      this.setState({
+        isExpanded
+      });
+    };
+  }
+
+  render() {
+    const { isExpanded } = this.state;
+    const contentId = 'detached-toggle-content';
+    return (
+      <Stack hasGutter>
+        <StackItem>
+          <ExpandableSection isExpanded={isExpanded} isDetached contentId={contentId}>
+            This content is visible only when the component is expanded.
+          </ExpandableSection>
+        </StackItem>
+        <StackItem>
+          <ExpandableSectionToggle isExpanded={isExpanded} onToggle={this.onToggle} contentId={contentId}>
+            {isExpanded ? 'Show Less' : 'Show More'}
+          </ExpandableSectionToggle>
+        </StackItem>
+      </Stack>
+    );
+  }
+}
 ```

--- a/packages/react-core/src/components/ExpandableSection/index.ts
+++ b/packages/react-core/src/components/ExpandableSection/index.ts
@@ -1,1 +1,2 @@
 export * from './ExpandableSection';
+export * from './ExpandableSectionToggle';

--- a/packages/react-integration/cypress/integration/expandablesection.spec.ts
+++ b/packages/react-integration/cypress/integration/expandablesection.spec.ts
@@ -34,4 +34,11 @@ describe('Expandable Demo Test', () => {
       .find('span')
       .should('contain', 'Show Less');
   });
+
+  it('Verify detached expandable', () => {
+    cy.get('#detached').should('have.class', 'pf-m-detached');
+    cy.get('#detached-section').should('have.class', 'pf-m-detached');
+    cy.get('#detached button').click();
+    cy.get('#detached-section').should('have.class', 'pf-m-expanded');
+  });
 });

--- a/packages/react-integration/demo-app-ts/src/components/demos/ExpandableSectionDemo/ExpandableSectionDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/ExpandableSectionDemo/ExpandableSectionDemo.tsx
@@ -60,6 +60,7 @@ export class ExpandableSectionDemo extends React.Component<null, ExpandableSecti
               isExpanded={isDetachedExpanded}
               onToggle={this.onToggleDetached}
               contentId="detached-section"
+              direction="up"
             >
               {isExpanded ? 'Show Less' : 'Show More'}
             </ExpandableSectionToggle>

--- a/packages/react-integration/demo-app-ts/src/components/demos/ExpandableSectionDemo/ExpandableSectionDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/ExpandableSectionDemo/ExpandableSectionDemo.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
-import { ExpandableSection } from '@patternfly/react-core';
+import { ExpandableSection, ExpandableSectionToggle, Stack, StackItem } from '@patternfly/react-core';
 
 interface ExpandableSectionState {
   isExpanded: boolean;
+  isDetachedExpanded: boolean;
 }
 
 export class ExpandableSectionDemo extends React.Component<null, ExpandableSectionState> {
   static displayName = 'ExpandableSectionDemo';
   state = {
-    isExpanded: false
+    isExpanded: false,
+    isDetachedExpanded: false
   };
 
   componentDidMount() {
@@ -16,9 +18,10 @@ export class ExpandableSectionDemo extends React.Component<null, ExpandableSecti
   }
 
   onToggle = (isOpen: boolean) => this.setState({ isExpanded: isOpen });
+  onToggleDetached = (isOpen: boolean) => this.setState({ isDetachedExpanded: isOpen });
 
   render() {
-    const { isExpanded } = this.state;
+    const { isExpanded, isDetachedExpanded } = this.state;
     return (
       <React.Fragment>
         <h1> Simple Expandable Example: </h1>
@@ -38,6 +41,30 @@ export class ExpandableSectionDemo extends React.Component<null, ExpandableSecti
         <ExpandableSection toggleTextExpanded="Show Less" toggleTextCollapsed="Show More">
           This content is visible only when the component is expanded.
         </ExpandableSection>
+        <br />
+        <h1>Detached expandable section</h1>
+        <Stack hasGutter>
+          <StackItem>
+            <ExpandableSection
+              id="detached-section"
+              isExpanded={isDetachedExpanded}
+              isDetached
+              contentId="detached-section"
+            >
+              This content is visible only when the component is expanded.
+            </ExpandableSection>
+          </StackItem>
+          <StackItem>
+            <ExpandableSectionToggle
+              id="detached"
+              isExpanded={isDetachedExpanded}
+              onToggle={this.onToggleDetached}
+              contentId="detached-section"
+            >
+              {isExpanded ? 'Show Less' : 'Show More'}
+            </ExpandableSectionToggle>
+          </StackItem>
+        </Stack>
       </React.Fragment>
     );
   }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5581

- Adds `ExpandableSectionToggle` component for detached expandable sections.
- Adds `isDetached` flag to `ExpandableSection`. This removes the built in toggle and adds the appropriate styling.
- Adds `contentId` property to both components to populate `aria-controls` label. There might be a better name for this property?
- `isExpanded` must be passed in to both components (there is no uncontrolled variation for detached section).

Also updated tests + added to integration/cypress.
