### PR TITLE
feat(CodeBlock): add component

### DIFF
--- a/packages/react-core/src/components/ClipboardCopy/ClipboardCopyButton.tsx
+++ b/packages/react-core/src/components/ClipboardCopy/ClipboardCopyButton.tsx
@@ -5,15 +5,25 @@ import { Tooltip } from '../Tooltip';
 
 export interface ClipboardCopyButtonProps
   extends React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> {
+  /** Callback for the copy when the button is clicked */
   onClick: (event: React.MouseEvent) => void;
+  /** Content of the copy button */
   children: React.ReactNode;
+  /** ID of the copy button */
   id: string;
+  /** ID of the content that is being copied */
   textId: string;
+  /** Additional classes added to the copy button */
   className?: string;
+  /** Exit delay on the copy button tooltip */
   exitDelay?: number;
+  /** Entry delay on the copy button tooltip */
   entryDelay?: number;
+  /** Max width of the copy button tooltip */
   maxWidth?: string;
+  /** Position of the copy button tooltip */
   position?: 'auto' | 'top' | 'bottom' | 'left' | 'right';
+  /** Aria-label for the copy button */
   'aria-label'?: string;
   variant?: 'control' | 'plain';
 }

--- a/packages/react-core/src/components/ClipboardCopy/ClipboardCopyButton.tsx
+++ b/packages/react-core/src/components/ClipboardCopy/ClipboardCopyButton.tsx
@@ -25,6 +25,7 @@ export interface ClipboardCopyButtonProps
   position?: 'auto' | 'top' | 'bottom' | 'left' | 'right';
   /** Aria-label for the copy button */
   'aria-label'?: string;
+  /** Variant of the copy button */
   variant?: 'control' | 'plain';
 }
 

--- a/packages/react-core/src/components/ClipboardCopy/examples/ClipboardCopy.md
+++ b/packages/react-core/src/components/ClipboardCopy/examples/ClipboardCopy.md
@@ -2,7 +2,7 @@
 id: Clipboard copy
 section: components
 cssPrefix: pf-c-copyclipboard
-propComponents: ['ClipboardCopy']
+propComponents: ['ClipboardCopy', 'ClipboardCopyButton']
 ---
 
 import PlayIcon from '@patternfly/react-icons/dist/js/icons/play-icon';

--- a/packages/react-core/src/components/ClipboardCopy/index.ts
+++ b/packages/react-core/src/components/ClipboardCopy/index.ts
@@ -1,2 +1,3 @@
 export * from './ClipboardCopy';
 export * from './ClipboardCopyAction';
+export * from './ClipboardCopyButton';

--- a/packages/react-core/src/components/CodeBlock/CodeBlock.tsx
+++ b/packages/react-core/src/components/CodeBlock/CodeBlock.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import styles from '@patternfly/react-styles/css/components/CodeBlock/code-block';
+import { css } from '@patternfly/react-styles';
+
+export interface CodeBlockProps extends React.HTMLProps<HTMLDivElement> {
+  /** Content rendered inside the code block */
+  children?: React.ReactNode;
+  /** Additional classes passed to the code block wrapper */
+  className?: string;
+  /** Actions in the code block header. Should be wrapped with CodeBlockAction. */
+  actions?: React.ReactNode;
+}
+
+export const CodeBlock: React.FunctionComponent<CodeBlockProps> = ({
+  children = null,
+  className,
+  actions = null,
+  ...props
+}: CodeBlockProps) => (
+  <div className={css(styles.codeBlock, className)} {...props}>
+    <div className={css(styles.codeBlockHeader)}>
+      <div className={css(styles.codeBlockActions)}>{actions && actions}</div>
+    </div>
+    <div className={css(styles.codeBlockContent)}>{children}</div>
+  </div>
+);
+
+CodeBlock.displayName = 'CodeBlock';

--- a/packages/react-core/src/components/CodeBlock/CodeBlockAction.tsx
+++ b/packages/react-core/src/components/CodeBlock/CodeBlockAction.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { css } from '@patternfly/react-styles';
+
+export interface CodeBlockActionProps extends React.HTMLProps<HTMLDivElement> {
+  /** Content rendered inside the code block action */
+  children?: React.ReactNode;
+  /** Additional classes passed to the code block action */
+  className?: string;
+}
+
+export const CodeBlockAction: React.FunctionComponent<CodeBlockActionProps> = ({
+  children = null,
+  className,
+  ...props
+}: CodeBlockActionProps) => (
+  <div className={css('pf-c-code-block__actions-item', className)} {...props}>
+    {children}
+  </div>
+);
+
+CodeBlockAction.displayName = 'CodeBlockAction';

--- a/packages/react-core/src/components/CodeBlock/CodeBlockCode.tsx
+++ b/packages/react-core/src/components/CodeBlock/CodeBlockCode.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import styles from '@patternfly/react-styles/css/components/CodeBlock/code-block';
+import { css } from '@patternfly/react-styles';
+
+export interface CodeBlockCodeProps extends React.HTMLProps<HTMLPreElement> {
+  /** Code rendered inside the code block */
+  children?: React.ReactNode;
+}
+
+export const CodeBlockCode: React.FunctionComponent<CodeBlockCodeProps> = ({
+  children = null,
+  ...props
+}: CodeBlockCodeProps) => (
+  <pre className={css(styles.codeBlockPre)} {...props}>
+    <code className={css(styles.codeBlockCode)}>{children}</code>
+  </pre>
+);
+
+CodeBlockCode.displayName = 'CodeBlockCode';

--- a/packages/react-core/src/components/CodeBlock/__tests__/CodeBlock.test.tsx
+++ b/packages/react-core/src/components/CodeBlock/__tests__/CodeBlock.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import { CodeBlock } from '../CodeBlock';
+import { CodeBlockAction } from '../CodeBlockAction';
+import { CodeBlockCode } from '../CodeBlockCode';
+
+test('CodeBlock renders successfully', () => {
+  const view = shallow(<CodeBlock>test text</CodeBlock>);
+  expect(view).toMatchSnapshot();
+});
+
+test('CodeBlockAction renders successfully', () => {
+  const view = shallow(<CodeBlockAction>action</CodeBlockAction>);
+  expect(view).toMatchSnapshot();
+});
+
+test('CodeBlockCode renders successfully', () => {
+  const view = shallow(<CodeBlockCode>action</CodeBlockCode>);
+  expect(view).toMatchSnapshot();
+});
+
+test('CodeBlock with components renders successfully', () => {
+  const view = mount(
+    <CodeBlock actions={<CodeBlockAction>button</CodeBlockAction>}>
+      <CodeBlockCode>inside pre/code tags</CodeBlockCode>
+      test outer text
+    </CodeBlock>
+  );
+  expect(view).toMatchSnapshot();
+});

--- a/packages/react-core/src/components/CodeBlock/__tests__/__snapshots__/CodeBlock.test.tsx.snap
+++ b/packages/react-core/src/components/CodeBlock/__tests__/__snapshots__/CodeBlock.test.tsx.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CodeBlock renders successfully 1`] = `
+<div
+  className="pf-c-code-block"
+>
+  <div
+    className="pf-c-code-block__header"
+  >
+    <div
+      className="pf-c-code-block__actions"
+    />
+  </div>
+  <div
+    className="pf-c-code-block__content"
+  >
+    test text
+  </div>
+</div>
+`;
+
+exports[`CodeBlock with components renders successfully 1`] = `
+<CodeBlock
+  actions={
+    <CodeBlockAction>
+      button
+    </CodeBlockAction>
+  }
+>
+  <div
+    className="pf-c-code-block"
+  >
+    <div
+      className="pf-c-code-block__header"
+    >
+      <div
+        className="pf-c-code-block__actions"
+      >
+        <CodeBlockAction>
+          <div
+            className="pf-c-code-block__actions-item"
+          >
+            button
+          </div>
+        </CodeBlockAction>
+      </div>
+    </div>
+    <div
+      className="pf-c-code-block__content"
+    >
+      <CodeBlockCode>
+        <pre
+          className="pf-c-code-block__pre"
+        >
+          <code
+            className="pf-c-code-block__code"
+          >
+            inside pre/code tags
+          </code>
+        </pre>
+      </CodeBlockCode>
+      test outer text
+    </div>
+  </div>
+</CodeBlock>
+`;
+
+exports[`CodeBlockAction renders successfully 1`] = `
+<div
+  className="pf-c-code-block__actions-item"
+>
+  action
+</div>
+`;
+
+exports[`CodeBlockCode renders successfully 1`] = `
+<pre
+  className="pf-c-code-block__pre"
+>
+  <code
+    className="pf-c-code-block__code"
+  >
+    action
+  </code>
+</pre>
+`;

--- a/packages/react-core/src/components/CodeBlock/examples/CodeBlock.md
+++ b/packages/react-core/src/components/CodeBlock/examples/CodeBlock.md
@@ -48,7 +48,7 @@ class BasicCodeBlock extends React.Component {
         this.timer = window.setTimeout(() => {
           this.setState({ copied: false });
           this.timer = null;
-        }, 2000);
+        }, 1000);
       });
     };
   }
@@ -94,11 +94,19 @@ url: https://raw.githubusercontent.com/Azure-Samples/helm-charts/master/docs`;
 }
 ```
 
-<!-- ### Expandable
+### Expandable
 
 ```js
 import React from 'react';
-import { CodeBlock, CodeBlockAction, CodeBlockCode, Button } from '@patternfly/react-core';
+import {
+  CodeBlock,
+  CodeBlockAction,
+  CodeBlockCode,
+  ClipboardCopyButton,
+  ExpandableSection,
+  ExpandableSectionToggle,
+  Button
+} from '@patternfly/react-core';
 import CopyIcon from '@patternfly/react-icons/dist/js/icons/copy-icon';
 import PlayIcon from '@patternfly/react-icons/dist/js/icons/play-icon';
 
@@ -138,7 +146,7 @@ class BasicCodeBlock extends React.Component {
         this.timer = window.setTimeout(() => {
           this.setState({ copied: false });
           this.timer = null;
-        }, 2000);
+        }, 1000);
       });
     };
   }
@@ -151,6 +159,14 @@ kind: HelmChartRepository
 metadata:
 name: azure-sample-repo
 spec:
+connectionConfig:
+url: https://raw.githubusercontent.com/Azure-Samples/helm-charts/master/docs`;
+
+    const code = `apiVersion: helm.openshift.io/v1beta1/
+kind: HelmChartRepository
+metadata:
+name: azure-sample-repo`;
+    const expandedCode = `spec:
 connectionConfig:
 url: https://raw.githubusercontent.com/Azure-Samples/helm-charts/master/docs`;
 
@@ -179,27 +195,21 @@ url: https://raw.githubusercontent.com/Azure-Samples/helm-charts/master/docs`;
     return (
       <CodeBlock actions={actions}>
         <CodeBlockCode>
-          apiVersion: helm.openshift.io/v1beta1/
-          <br />
-          kind: HelmChartRepository
-          <br />
-          metadata:
-          <br />
-          name: azure-sample-repo
-          <br />
+          {code}
           <ExpandableSection isExpanded={isExpanded} isDetached contentId="code-block-expand">
-            spec:
-            <br />
-            connectionConfig:
-            <br />
-            url: https://raw.githubusercontent.com/Azure-Samples/helm-charts/master/docs{' '}
+            {expandedCode}
           </ExpandableSection>
         </CodeBlockCode>
-        <ExpandableSectionToggle isExpanded={isExpanded} onToggle={this.onToggle} contentId="code-block-expand">
+        <ExpandableSectionToggle
+          isExpanded={isExpanded}
+          onToggle={this.onToggle}
+          contentId="code-block-expand"
+          direction="up"
+        >
           {isExpanded ? 'Show Less' : 'Show More'}
         </ExpandableSectionToggle>
       </CodeBlock>
     );
   }
 }
-``` -->
+```

--- a/packages/react-core/src/components/CodeBlock/examples/CodeBlock.md
+++ b/packages/react-core/src/components/CodeBlock/examples/CodeBlock.md
@@ -39,23 +39,18 @@ class BasicCodeBlock extends React.Component {
         </CodeBlockAction>
       </React.Fragment>
     );
+
+    const code = `apiVersion: helm.openshift.io/v1beta1/
+kind: HelmChartRepository
+metadata:
+name: azure-sample-repo
+spec:
+connectionConfig:
+url: https://raw.githubusercontent.com/Azure-Samples/helm-charts/master/docs`;
+
     return (
       <CodeBlock actions={actions}>
-        <CodeBlockCode>
-          apiVersion: helm.openshift.io/v1beta1/
-          <br />
-          kind: HelmChartRepository
-          <br />
-          metadata:
-          <br />
-          name: azure-sample-repo
-          <br />
-          spec:
-          <br />
-          connectionConfig:
-          <br />
-          url: https://raw.githubusercontent.com/Azure-Samples/helm-charts/master/docs
-        </CodeBlockCode>
+        <CodeBlockCode>{code}</CodeBlockCode>
       </CodeBlock>
     );
   }

--- a/packages/react-core/src/components/CodeBlock/examples/CodeBlock.md
+++ b/packages/react-core/src/components/CodeBlock/examples/CodeBlock.md
@@ -15,22 +15,66 @@ import PlayIcon from '@patternfly/react-icons/dist/js/icons/play-icon';
 
 ```js
 import React from 'react';
-import { CodeBlock, CodeBlockAction, CodeBlockCode, Button } from '@patternfly/react-core';
+import { CodeBlock, CodeBlockAction, CodeBlockCode, ClipboardCopyButton, Button } from '@patternfly/react-core';
 import CopyIcon from '@patternfly/react-icons/dist/js/icons/copy-icon';
 import PlayIcon from '@patternfly/react-icons/dist/js/icons/play-icon';
 
 class BasicCodeBlock extends React.Component {
   constructor(props) {
     super(props);
+    this.timer = null;
+
+    this.state = {
+      copied: false
+    };
+
+    this.clipboardCopyFunc = (event, text) => {
+      const clipboard = event.currentTarget.parentElement;
+      const el = document.createElement('textarea');
+      el.value = text.toString();
+      clipboard.appendChild(el);
+      el.select();
+      document.execCommand('copy');
+      clipboard.removeChild(el);
+    };
+
+    this.onClick = (event, text) => {
+      if (this.timer) {
+        window.clearTimeout(this.timer);
+        this.setState({ copied: false });
+      }
+      this.clipboardCopyFunc(event, text);
+      this.setState({ copied: true }, () => {
+        this.timer = window.setTimeout(() => {
+          this.setState({ copied: false });
+          this.timer = null;
+        }, 2000);
+      });
+    };
   }
 
   render() {
+    const code = `apiVersion: helm.openshift.io/v1beta1/
+kind: HelmChartRepository
+metadata:
+name: azure-sample-repo
+spec:
+connectionConfig:
+url: https://raw.githubusercontent.com/Azure-Samples/helm-charts/master/docs`;
+
     const actions = (
       <React.Fragment>
         <CodeBlockAction>
-          <Button variant="plain" aria-label="Copy icon">
-            <CopyIcon />
-          </Button>
+          <ClipboardCopyButton
+            id="copy-button"
+            textId="code-content"
+            aria-label="Copy to clipboard"
+            onClick={e => this.onClick(e, code)}
+            exitDelay={600}
+            variant="plain"
+          >
+            {this.state.copied ? 'Successfully copied to clipboard!' : 'Copy to clipboard'}
+          </ClipboardCopyButton>
         </CodeBlockAction>
         <CodeBlockAction>
           <Button variant="plain" aria-label="Play icon">
@@ -40,17 +84,9 @@ class BasicCodeBlock extends React.Component {
       </React.Fragment>
     );
 
-    const code = `apiVersion: helm.openshift.io/v1beta1/
-kind: HelmChartRepository
-metadata:
-name: azure-sample-repo
-spec:
-connectionConfig:
-url: https://raw.githubusercontent.com/Azure-Samples/helm-charts/master/docs`;
-
     return (
       <CodeBlock actions={actions}>
-        <CodeBlockCode>{code}</CodeBlockCode>
+        <CodeBlockCode id="code-content">{code}</CodeBlockCode>
       </CodeBlock>
     );
   }
@@ -68,24 +104,68 @@ import PlayIcon from '@patternfly/react-icons/dist/js/icons/play-icon';
 class BasicCodeBlock extends React.Component {
   constructor(props) {
     super(props);
+    this.timer = null;
+
     this.state = {
-      isExpanded: false
+      isExpanded: false,
+      copied: false
     };
+
     this.onToggle = isExpanded => {
       this.setState({
         isExpanded
+      });
+    };
+
+    this.clipboardCopyFunc = (event, text) => {
+      const clipboard = event.currentTarget.parentElement;
+      const el = document.createElement('textarea');
+      el.value = text.toString();
+      clipboard.appendChild(el);
+      el.select();
+      document.execCommand('copy');
+      clipboard.removeChild(el);
+    };
+
+    this.onClick = (event, text) => {
+      if (this.timer) {
+        window.clearTimeout(this.timer);
+        this.setState({ copied: false });
+      }
+      this.clipboardCopyFunc(event, text);
+      this.setState({ copied: true }, () => {
+        this.timer = window.setTimeout(() => {
+          this.setState({ copied: false });
+          this.timer = null;
+        }, 2000);
       });
     };
   }
 
   render() {
     const { isExpanded } = this.state;
+
+    const copyBlock = `apiVersion: helm.openshift.io/v1beta1/
+kind: HelmChartRepository
+metadata:
+name: azure-sample-repo
+spec:
+connectionConfig:
+url: https://raw.githubusercontent.com/Azure-Samples/helm-charts/master/docs`;
+
     const actions = (
       <React.Fragment>
         <CodeBlockAction>
-          <Button variant="plain" aria-label="Copy icon">
-            <CopyIcon />
-          </Button>
+          <ClipboardCopyButton
+            id="copy-button"
+            textId="code-content"
+            aria-label="Copy to clipboard"
+            onClick={e => this.onClick(e, copyBlock)}
+            exitDelay={600}
+            variant="plain"
+          >
+            {this.state.copied ? 'Successfully copied to clipboard!' : 'Copy to clipboard'}
+          </ClipboardCopyButton>
         </CodeBlockAction>
         <CodeBlockAction>
           <Button variant="plain" aria-label="Play icon">

--- a/packages/react-core/src/components/CodeBlock/examples/CodeBlock.md
+++ b/packages/react-core/src/components/CodeBlock/examples/CodeBlock.md
@@ -71,6 +71,7 @@ url: https://raw.githubusercontent.com/Azure-Samples/helm-charts/master/docs`;
             aria-label="Copy to clipboard"
             onClick={e => this.onClick(e, code)}
             exitDelay={600}
+            maxWidth="110px"
             variant="plain"
           >
             {this.state.copied ? 'Successfully copied to clipboard!' : 'Copy to clipboard'}
@@ -162,6 +163,7 @@ url: https://raw.githubusercontent.com/Azure-Samples/helm-charts/master/docs`;
             aria-label="Copy to clipboard"
             onClick={e => this.onClick(e, copyBlock)}
             exitDelay={600}
+            maxWidth="110px"
             variant="plain"
           >
             {this.state.copied ? 'Successfully copied to clipboard!' : 'Copy to clipboard'}

--- a/packages/react-core/src/components/CodeBlock/examples/CodeBlock.md
+++ b/packages/react-core/src/components/CodeBlock/examples/CodeBlock.md
@@ -1,0 +1,128 @@
+---
+id: Code block
+section: components
+cssPrefix: pf-c-code-block
+propComponents: ['CodeBlock', 'CodeBlockAction', 'CodeBlockCode']
+beta: true
+---
+
+import CopyIcon from '@patternfly/react-icons/dist/js/icons/copy-icon';
+import PlayIcon from '@patternfly/react-icons/dist/js/icons/play-icon';
+
+## Examples
+
+### Basic
+
+```js
+import React from 'react';
+import { CodeBlock, CodeBlockAction, CodeBlockCode, Button } from '@patternfly/react-core';
+import CopyIcon from '@patternfly/react-icons/dist/js/icons/copy-icon';
+import PlayIcon from '@patternfly/react-icons/dist/js/icons/play-icon';
+
+class BasicCodeBlock extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    const actions = (
+      <React.Fragment>
+        <CodeBlockAction>
+          <Button variant="plain" aria-label="Copy icon">
+            <CopyIcon />
+          </Button>
+        </CodeBlockAction>
+        <CodeBlockAction>
+          <Button variant="plain" aria-label="Play icon">
+            <PlayIcon />
+          </Button>
+        </CodeBlockAction>
+      </React.Fragment>
+    );
+    return (
+      <CodeBlock actions={actions}>
+        <CodeBlockCode>
+          apiVersion: helm.openshift.io/v1beta1/
+          <br />
+          kind: HelmChartRepository
+          <br />
+          metadata:
+          <br />
+          name: azure-sample-repo
+          <br />
+          spec:
+          <br />
+          connectionConfig:
+          <br />
+          url: https://raw.githubusercontent.com/Azure-Samples/helm-charts/master/docs
+        </CodeBlockCode>
+      </CodeBlock>
+    );
+  }
+}
+```
+
+<!-- ### Expandable
+
+```js
+import React from 'react';
+import { CodeBlock, CodeBlockAction, CodeBlockCode, Button } from '@patternfly/react-core';
+import CopyIcon from '@patternfly/react-icons/dist/js/icons/copy-icon';
+import PlayIcon from '@patternfly/react-icons/dist/js/icons/play-icon';
+
+class BasicCodeBlock extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isExpanded: false
+    };
+    this.onToggle = isExpanded => {
+      this.setState({
+        isExpanded
+      });
+    };
+  }
+
+  render() {
+    const { isExpanded } = this.state;
+    const actions = (
+      <React.Fragment>
+        <CodeBlockAction>
+          <Button variant="plain" aria-label="Copy icon">
+            <CopyIcon />
+          </Button>
+        </CodeBlockAction>
+        <CodeBlockAction>
+          <Button variant="plain" aria-label="Play icon">
+            <PlayIcon />
+          </Button>
+        </CodeBlockAction>
+      </React.Fragment>
+    );
+    return (
+      <CodeBlock actions={actions}>
+        <CodeBlockCode>
+          apiVersion: helm.openshift.io/v1beta1/
+          <br />
+          kind: HelmChartRepository
+          <br />
+          metadata:
+          <br />
+          name: azure-sample-repo
+          <br />
+          <ExpandableSection isExpanded={isExpanded} isDetached contentId="code-block-expand">
+            spec:
+            <br />
+            connectionConfig:
+            <br />
+            url: https://raw.githubusercontent.com/Azure-Samples/helm-charts/master/docs{' '}
+          </ExpandableSection>
+        </CodeBlockCode>
+        <ExpandableSectionToggle isExpanded={isExpanded} onToggle={this.onToggle} contentId="code-block-expand">
+          {isExpanded ? 'Show Less' : 'Show More'}
+        </ExpandableSectionToggle>
+      </CodeBlock>
+    );
+  }
+}
+``` -->

--- a/packages/react-core/src/components/CodeBlock/index.ts
+++ b/packages/react-core/src/components/CodeBlock/index.ts
@@ -1,0 +1,3 @@
+export * from './CodeBlock';
+export * from './CodeBlockCode';
+export * from './CodeBlockAction';

--- a/packages/react-core/src/components/index.ts
+++ b/packages/react-core/src/components/index.ts
@@ -18,6 +18,7 @@ export * from './Card';
 export * from './Checkbox';
 export * from './ChipGroup';
 export * from './ClipboardCopy';
+export * from './CodeBlock';
 export * from './ContextSelector';
 export * from './DataList';
 export * from './DatePicker';

--- a/packages/react-integration/cypress/integration/codeblock.spec.ts
+++ b/packages/react-integration/cypress/integration/codeblock.spec.ts
@@ -1,0 +1,13 @@
+describe('Brand Demo Test', () => {
+  it('Navigate to demo section', () => {
+    cy.visit('http://localhost:3000/');
+    cy.get('#code-block-demo-nav-item-link').click();
+    cy.url().should('eq', 'http://localhost:3000/code-block-demo-nav-link');
+  });
+
+  it('Verify code block', () => {
+    cy.get('.pf-c-code-block').should('exist');
+    cy.get('.pf-c-code-block__actions-item').should('exist');
+    cy.get('.pf-c-code-block__code').should('exist');
+  });
+});

--- a/packages/react-integration/demo-app-ts/src/Demos.ts
+++ b/packages/react-integration/demo-app-ts/src/Demos.ts
@@ -181,6 +181,11 @@ export const Demos: DemoInterface[] = [
     componentType: Examples.ClipboardCopyExpandedDemo
   },
   {
+    id: 'code-block-demo',
+    name: 'CodeBlock Demo',
+    componentType: Examples.CodeBlockDemo
+  },
+  {
     id: 'code-editor-demo',
     name: 'CodeEditor Demo',
     componentType: Examples.CodeEditorDemo

--- a/packages/react-integration/demo-app-ts/src/components/demos/CodeBlockDemo/CodeBlockDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/CodeBlockDemo/CodeBlockDemo.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { CodeBlock, CodeBlockAction, CodeBlockCode, Button } from '@patternfly/react-core';
+import CopyIcon from '@patternfly/react-icons/dist/js/icons/copy-icon';
+import PlayIcon from '@patternfly/react-icons/dist/js/icons/play-icon';
+
+export class CodeBlockDemo extends React.Component {
+  static displayName = 'CodeBlockDemo';
+  render() {
+    const actions = (
+      <React.Fragment>
+        <CodeBlockAction>
+          <Button variant="plain" aria-label="Copy icon">
+            <CopyIcon />
+          </Button>
+        </CodeBlockAction>
+        <CodeBlockAction>
+          <Button variant="plain" aria-label="Play icon">
+            <PlayIcon />
+          </Button>
+        </CodeBlockAction>
+      </React.Fragment>
+    );
+    return (
+      <CodeBlock actions={actions}>
+        <CodeBlockCode>
+          apiVersion: helm.openshift.io/v1beta1/
+          <br />
+          kind: HelmChartRepository
+          <br />
+          metadata:
+          <br />
+          name: azure-sample-repo
+          <br />
+          spec:
+          <br />
+          connectionConfig:
+          <br />
+          url: https://raw.githubusercontent.com/Azure-Samples/helm-charts/master/docs
+        </CodeBlockCode>
+      </CodeBlock>
+    );
+  }
+}

--- a/packages/react-integration/demo-app-ts/src/components/demos/index.ts
+++ b/packages/react-integration/demo-app-ts/src/components/demos/index.ts
@@ -34,6 +34,7 @@ export * from './ContextSelectorDemo/ContextSelectorDemo';
 export * from './ConsolesDemo/ConsolesDemo';
 export * from './ClipboardCopyDemo/ClipboardCopyDemo';
 export * from './ClipboardCopyDemo/ClipboardCopyExpandedDemo';
+export * from './CodeBlockDemo/CodeBlockDemo';
 export * from './DataListDemo/DataListDemo';
 export * from './DataListDemo/DataListDraggableDemo';
 export * from './DataListDemo/DataListCompactDemo';


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5556

- Adds `CodeBlock`, `CodeBlockAction`, `CodeBlockCode` components
- `CodeBlockAction` styles buttons for the header and multiple actions may be passed to `CodeBlock` via the `actions` property.
- `CodeBlockCode` styles code content for the `CodeBlock`. Detached expandable sections can be combined with `CodeBlockCode` to create expandable code sections (example is in, but commented out until #5643 merges).

Docs: https://patternfly-react-pr-5656.surge.sh/components/code-block

@mcoker Is `.pf-c-code-block__actions-item` a placeholder class? I couldn't find it in the styles object so I have it hardcoded atm.