### PR TITLE
fix(icons,tokens): no star reexport

### DIFF
--- a/packages/react-icons/scripts/writeIcons.js
+++ b/packages/react-icons/scripts/writeIcons.js
@@ -84,12 +84,12 @@ function writeIcons(icons) {
     writeCJSExport(fname, jsName, icon);
     writeDTSExport(fname, jsName, icon);
 
-    index.push(fname);
+    index.push({ fname, jsName });
   });
 
   const esmIndexString = index
+    .map(({ fname, jsName }) => `export { ${jsName}, ${jsName}Config } from './${fname}';`)
     .sort()
-    .map(file => `export * from './${file}';`)
     .join('\n');
   outputFileSync(join(outDir, 'esm', 'icons/index.js'), esmIndexString);
   outputFileSync(join(outDir, 'js', 'icons/index.d.ts'), esmIndexString);
@@ -101,8 +101,8 @@ function __export(m) {
 }
 exports.__esModule = true;
 ${index
+  .map(({ fname }) => `__export(require('./${fname}'));`)
   .sort()
-  .map(file => `__export(require('./${file}'));`)
   .join('\n')}
 `.trim()
   );

--- a/packages/react-tokens/scripts/writeTokens.js
+++ b/packages/react-tokens/scripts/writeTokens.js
@@ -37,7 +37,7 @@ const allIndex = [];
 const componentIndex = [];
 
 const outputIndex = (index, indexFile) => {
-  const esmIndexString = index.map(file => `export * from './${file}';`).join('\n');
+  const esmIndexString = index.map(file => `export { ${file} } from './${file}';`).join('\n');
   outputFileSync(join(outDir, 'esm', indexFile), esmIndexString);
   outputFileSync(join(outDir, 'js', indexFile.replace('.js', '.d.ts')), esmIndexString);
   outputFileSync(


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Speed up time from making a change to seeing it by up to 3x. Towards #https://github.com/webpack/webpack/issues/13107

Before:
```js
export * from './accessible-icon-icon';
...
```
After:
```js
export { AccessibleIconIcon } from './accessible-icon-icon';
...
```

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
