### PR TITLE
feat(Menu): add scrollable support

### DIFF
--- a/packages/react-core/src/components/Menu/Menu.tsx
+++ b/packages/react-core/src/components/Menu/Menu.tsx
@@ -53,6 +53,8 @@ export interface MenuProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'r
   innerRef?: React.Ref<any>;
   /** Internal flag indicating if the Menu is the root of a menu tree */
   isRootMenu?: boolean;
+  /** Maximum height of any menu */
+  maxMenuHeight?: string;
 }
 
 export interface MenuState {
@@ -66,7 +68,8 @@ class MenuBase extends React.Component<MenuProps, MenuState> {
   private activeMenu = null as Element;
   static defaultProps: MenuProps = {
     ouiaSafe: true,
-    isRootMenu: true
+    isRootMenu: true,
+    maxMenuHeight: 'auto'
   };
 
   state: MenuState = {
@@ -276,6 +279,7 @@ class MenuBase extends React.Component<MenuProps, MenuState> {
       onDrillIn,
       onDrillOut,
       onGetMenuHeight,
+      maxMenuHeight,
       parentMenu = null,
       activeItemId = null,
       innerRef,
@@ -313,6 +317,7 @@ class MenuBase extends React.Component<MenuProps, MenuState> {
             className
           )}
           aria-label={ariaLabel || containsFlyout ? 'Local' : 'Global'}
+          style={{ '--pf-c-menu--MaxHeight': maxMenuHeight } as React.CSSProperties}
           ref={innerRef || this.menuRef || null}
           {...getOUIAProps(Menu.displayName, ouiaId !== undefined ? ouiaId : this.state.ouiaStateId, ouiaSafe)}
           {...props}

--- a/packages/react-core/src/components/Menu/Menu.tsx
+++ b/packages/react-core/src/components/Menu/Menu.tsx
@@ -53,8 +53,6 @@ export interface MenuProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'r
   innerRef?: React.Ref<any>;
   /** Internal flag indicating if the Menu is the root of a menu tree */
   isRootMenu?: boolean;
-  /** Maximum height of any menu */
-  maxMenuHeight?: string;
 }
 
 export interface MenuState {
@@ -68,8 +66,7 @@ class MenuBase extends React.Component<MenuProps, MenuState> {
   private activeMenu = null as Element;
   static defaultProps: MenuProps = {
     ouiaSafe: true,
-    isRootMenu: true,
-    maxMenuHeight: 'auto'
+    isRootMenu: true
   };
 
   state: MenuState = {
@@ -279,7 +276,6 @@ class MenuBase extends React.Component<MenuProps, MenuState> {
       onDrillIn,
       onDrillOut,
       onGetMenuHeight,
-      maxMenuHeight,
       parentMenu = null,
       activeItemId = null,
       innerRef,
@@ -317,7 +313,6 @@ class MenuBase extends React.Component<MenuProps, MenuState> {
             className
           )}
           aria-label={ariaLabel || containsFlyout ? 'Local' : 'Global'}
-          style={{ '--pf-c-menu--MaxHeight': maxMenuHeight } as React.CSSProperties}
           ref={innerRef || this.menuRef || null}
           {...getOUIAProps(Menu.displayName, ouiaId !== undefined ? ouiaId : this.state.ouiaStateId, ouiaSafe)}
           {...props}

--- a/packages/react-core/src/components/Menu/MenuContent.tsx
+++ b/packages/react-core/src/components/Menu/MenuContent.tsx
@@ -10,12 +10,14 @@ export interface MenuContentProps extends React.HTMLProps<HTMLElement> {
   innerRef?: React.Ref<any>;
   /** Height of the menu content */
   menuHeight?: string;
+  /** Maximum height of menu content */
+  maxMenuHeight?: string;
   /** Callback to return the height of the menu content */
   getHeight?: (height: string) => void;
 }
 
 export const MenuContent = React.forwardRef((props: MenuContentProps, ref: React.Ref<HTMLDivElement>) => {
-  const { getHeight, children, menuHeight, ...rest } = props;
+  const { getHeight, children, menuHeight, maxMenuHeight, ...rest } = props;
   const menuContentRef = React.createRef<HTMLDivElement>();
   const refCallback = (el: any, menuId: string, onGetMenuHeight: (menuId: string, height: number) => void) => {
     if (el) {
@@ -31,7 +33,12 @@ export const MenuContent = React.forwardRef((props: MenuContentProps, ref: React
           {...rest}
           className={css(styles.menuContent, props.className)}
           ref={el => refCallback(el, menuId, onGetMenuHeight)}
-          style={{ '--pf-c-menu__content--Height': menuHeight } as React.CSSProperties}
+          style={
+            {
+              '--pf-c-menu__content--Height': menuHeight || 'auto',
+              '--pf-c-menu__content--MaxHeight': maxMenuHeight || 'auto'
+            } as React.CSSProperties
+          }
         >
           {children}
         </div>

--- a/packages/react-core/src/components/Menu/examples/Menu.md
+++ b/packages/react-core/src/components/Menu/examples/Menu.md
@@ -1308,21 +1308,21 @@ class MenuBasicList extends React.Component {
       <Menu activeItemId={activeItem} onSelect={this.onSelect}>
         <MenuContent menuHeight="300px">
           <MenuList>
-            <MenuItem>Action</MenuItem>
-            <MenuItem>Action</MenuItem>
-            <MenuItem>Action</MenuItem>
-            <MenuItem>Action</MenuItem>
-            <MenuItem>Action</MenuItem>
-            <MenuItem>Action</MenuItem>
-            <MenuItem>Action</MenuItem>
-            <MenuItem>Action</MenuItem>
-            <MenuItem>Action</MenuItem>
-            <MenuItem>Action</MenuItem>
-            <MenuItem>Action</MenuItem>
-            <MenuItem>Action</MenuItem>
-            <MenuItem>Action</MenuItem>
-            <MenuItem>Action</MenuItem>
-            <MenuItem>Action</MenuItem>
+            <MenuItem>Action 1</MenuItem>
+            <MenuItem>Action 2</MenuItem>
+            <MenuItem>Action 3</MenuItem>
+            <MenuItem>Action 4</MenuItem>
+            <MenuItem>Action 5</MenuItem>
+            <MenuItem>Action 6</MenuItem>
+            <MenuItem>Action 7</MenuItem>
+            <MenuItem>Action 8</MenuItem>
+            <MenuItem>Action 9</MenuItem>
+            <MenuItem>Action 10</MenuItem>
+            <MenuItem>Action 11</MenuItem>
+            <MenuItem>Action 12</MenuItem>
+            <MenuItem>Action 13</MenuItem>
+            <MenuItem>Action 14</MenuItem>
+            <MenuItem>Action 15</MenuItem>
             <MenuItem
               itemId={1}
               to="#default-link2"

--- a/packages/react-core/src/components/Menu/examples/Menu.md
+++ b/packages/react-core/src/components/Menu/examples/Menu.md
@@ -23,7 +23,7 @@ import AngleLeftIcon from '@patternfly/react-icons/dist/js/icons/angle-left-icon
 
 ```js
 import React from 'react';
-import { Menu, MenuList, MenuItem } from '@patternfly/react-core';
+import { Menu, MenuContent, MenuList, MenuItem } from '@patternfly/react-core';
 
 class MenuBasicList extends React.Component {
   constructor(props) {
@@ -43,21 +43,23 @@ class MenuBasicList extends React.Component {
     const { activeItem } = this.state;
     return (
       <Menu activeItemId={activeItem} onSelect={this.onSelect}>
-        <MenuList>
-          <MenuItem itemId={0}>Action</MenuItem>
-          <MenuItem
-            itemId={1}
-            to="#default-link2"
-            // just for demo so that navigation is not triggered
-            onClick={event => event.preventDefault()}
-          >
-            Link
-          </MenuItem>
-          <MenuItem isDisabled>Disabled Action</MenuItem>
-          <MenuItem isDisabled to="#default-link4">
-            Disabled Link
-          </MenuItem>
-        </MenuList>
+        <MenuContent>
+          <MenuList>
+            <MenuItem itemId={0}>Action</MenuItem>
+            <MenuItem
+              itemId={1}
+              to="#default-link2"
+              // just for demo so that navigation is not triggered
+              onClick={event => event.preventDefault()}
+            >
+              Link
+            </MenuItem>
+            <MenuItem isDisabled>Disabled Action</MenuItem>
+            <MenuItem isDisabled to="#default-link4">
+              Disabled Link
+            </MenuItem>
+          </MenuList>
+        </MenuContent>
       </Menu>
     );
   }
@@ -68,7 +70,7 @@ class MenuBasicList extends React.Component {
 
 ```js
 import React from 'react';
-import { Menu, MenuList, MenuItem } from '@patternfly/react-core';
+import { Menu, MenuContent, MenuList, MenuItem } from '@patternfly/react-core';
 import CodeBranchIcon from '@patternfly/react-icons/dist/js/icons/code-branch-icon';
 import LayerGroupIcon from '@patternfly/react-icons/dist/js/icons/layer-group-icon';
 import CubeIcon from '@patternfly/react-icons/dist/js/icons/cube-icon';
@@ -90,17 +92,19 @@ class MenuIconsList extends React.Component {
     const { activeItem } = this.state;
     return (
       <Menu onSelect={this.onSelect} activeItemId={activeItem}>
-        <MenuList>
-          <MenuItem icon={<CodeBranchIcon aria-hidden />} itemId={0}>
-            From Git
-          </MenuItem>
-          <MenuItem icon={<LayerGroupIcon aria-hidden />} itemId={1}>
-            Container Image
-          </MenuItem>
-          <MenuItem icon={<CubeIcon aria-hidden />} itemId={2}>
-            Docker File
-          </MenuItem>
-        </MenuList>
+        <MenuContent>
+          <MenuList>
+            <MenuItem icon={<CodeBranchIcon aria-hidden />} itemId={0}>
+              From Git
+            </MenuItem>
+            <MenuItem icon={<LayerGroupIcon aria-hidden />} itemId={1}>
+              Container Image
+            </MenuItem>
+            <MenuItem icon={<CubeIcon aria-hidden />} itemId={2}>
+              Docker File
+            </MenuItem>
+          </MenuList>
+        </MenuContent>
       </Menu>
     );
   }
@@ -111,7 +115,7 @@ class MenuIconsList extends React.Component {
 
 ```js
 import React from 'react';
-import { Menu, MenuList, MenuItem } from '@patternfly/react-core';
+import { Menu, MenuContent, MenuList, MenuItem } from '@patternfly/react-core';
 
 class MenuWithFlyout extends React.Component {
   constructor(props) {
@@ -130,26 +134,30 @@ class MenuWithFlyout extends React.Component {
     const { activeItem } = this.state;
     const flyoutMenu = (
       <Menu onSelect={this.onSelect} activeItemId={activeItem}>
-        <MenuList>
-          <MenuItem itemId={10}>Application Grouping</MenuItem>
-          <MenuItem itemId={11}>Count</MenuItem>
-          <MenuItem itemId={12}>Labels</MenuItem>
-          <MenuItem itemId={13}>Annotations</MenuItem>
-        </MenuList>
+        <MenuContent>
+          <MenuList>
+            <MenuItem itemId={10}>Application Grouping</MenuItem>
+            <MenuItem itemId={11}>Count</MenuItem>
+            <MenuItem itemId={12}>Labels</MenuItem>
+            <MenuItem itemId={13}>Annotations</MenuItem>
+          </MenuList>
+        </MenuContent>
       </Menu>
     );
 
     return (
       <Menu containsFlyout onSelect={this.onSelect} activeItemId={activeItem}>
-        <MenuList>
-          <MenuItem itemId={0}>Start rollout</MenuItem>
-          <MenuItem itemId={1}>Pause rollouts</MenuItem>
-          <MenuItem itemId={2}>Add storage</MenuItem>
-          <MenuItem description="Description" itemId={3} flyoutMenu={flyoutMenu} aria-label="Has flyout menu">
-            Edit
-          </MenuItem>
-          <MenuItem itemId={4}>Delete deployment config</MenuItem>
-        </MenuList>
+        <MenuContent>
+          <MenuList>
+            <MenuItem itemId={0}>Start rollout</MenuItem>
+            <MenuItem itemId={1}>Pause rollouts</MenuItem>
+            <MenuItem itemId={2}>Add storage</MenuItem>
+            <MenuItem description="Description" itemId={3} flyoutMenu={flyoutMenu} aria-label="Has flyout menu">
+              Edit
+            </MenuItem>
+            <MenuItem itemId={4}>Delete deployment config</MenuItem>
+          </MenuList>
+        </MenuContent>
       </Menu>
     );
   }
@@ -225,7 +233,7 @@ class MenuWithFiltering extends React.Component {
 
 ```js
 import React from 'react';
-import { Menu, MenuList, MenuItem } from '@patternfly/react-core';
+import { Menu, MenuContent, MenuList, MenuItem } from '@patternfly/react-core';
 
 class MenuWithLinks extends React.Component {
   constructor(props) {
@@ -244,17 +252,19 @@ class MenuWithLinks extends React.Component {
     const { activeItem } = this.state;
     return (
       <Menu onSelect={this.onSelect} activeItemId={activeItem}>
-        <MenuList>
-          <MenuItem isExternalLink to="#default-link1" itemId={0}>
-            Link 1
-          </MenuItem>
-          <MenuItem isExternalLink to="#default-link2" itemId={1}>
-            Link 2
-          </MenuItem>
-          <MenuItem to="#default-link3" itemId={2}>
-            Link 3
-          </MenuItem>
-        </MenuList>
+        <MenuContent>
+          <MenuList>
+            <MenuItem isExternalLink to="#default-link1" itemId={0}>
+              Link 1
+            </MenuItem>
+            <MenuItem isExternalLink to="#default-link2" itemId={1}>
+              Link 2
+            </MenuItem>
+            <MenuItem to="#default-link3" itemId={2}>
+              Link 3
+            </MenuItem>
+          </MenuList>
+        </MenuContent>
       </Menu>
     );
   }
@@ -265,7 +275,7 @@ class MenuWithLinks extends React.Component {
 
 ```js
 import React from 'react';
-import { Divider, Menu, MenuList, MenuItem } from '@patternfly/react-core';
+import { Divider, Menu, MenuContent, MenuList, MenuItem } from '@patternfly/react-core';
 
 class MenuWithSeparators extends React.Component {
   constructor(props) {
@@ -284,12 +294,14 @@ class MenuWithSeparators extends React.Component {
     const { activeItem } = this.state;
     return (
       <Menu onSelect={this.onSelect} activeItemId={activeItem}>
-        <MenuList>
-          <MenuItem itemId={0}>Action 1</MenuItem>
-          <MenuItem itemId={1}>Action 2</MenuItem>
-          <Divider component="li" />
-          <MenuItem itemId={2}>Action 3</MenuItem>
-        </MenuList>
+        <MenuContent>
+          <MenuList>
+            <MenuItem itemId={0}>Action 1</MenuItem>
+            <MenuItem itemId={1}>Action 2</MenuItem>
+            <Divider component="li" />
+            <MenuItem itemId={2}>Action 3</MenuItem>
+          </MenuList>
+        </MenuContent>
       </Menu>
     );
   }
@@ -300,7 +312,7 @@ class MenuWithSeparators extends React.Component {
 
 ```js
 import React from 'react';
-import { Menu, MenuGroup, MenuList, MenuItem, Divider } from '@patternfly/react-core';
+import { Menu, MenuContent, MenuGroup, MenuList, MenuItem, Divider } from '@patternfly/react-core';
 
 class MenuWithTitledGroups extends React.Component {
   constructor(props) {
@@ -319,33 +331,35 @@ class MenuWithTitledGroups extends React.Component {
     const { activeItem } = this.state;
     return (
       <Menu onSelect={this.onSelect} activeItemId={activeItem}>
-        <MenuGroup>
-          <MenuList>
-            <MenuItem to="#" itemId={0}>
-              Link not in group
-            </MenuItem>
-          </MenuList>
-        </MenuGroup>
-        <Divider />
-        <MenuGroup label="Group 1">
-          <MenuList>
-            <MenuItem to="#" itemId={1}>
-              Link 1
-            </MenuItem>
-            <MenuItem itemId={2}>Link 2</MenuItem>
-          </MenuList>
-        </MenuGroup>
-        <Divider />
-        <MenuGroup label="Group 2">
-          <MenuList>
-            <MenuItem to="#" itemId={3}>
-              Link 1
-            </MenuItem>
-            <MenuItem to="#" itemId={4}>
-              Link 2
-            </MenuItem>
-          </MenuList>
-        </MenuGroup>
+        <MenuContent>
+          <MenuGroup>
+            <MenuList>
+              <MenuItem to="#" itemId={0}>
+                Link not in group
+              </MenuItem>
+            </MenuList>
+          </MenuGroup>
+          <Divider />
+          <MenuGroup label="Group 1">
+            <MenuList>
+              <MenuItem to="#" itemId={1}>
+                Link 1
+              </MenuItem>
+              <MenuItem itemId={2}>Link 2</MenuItem>
+            </MenuList>
+          </MenuGroup>
+          <Divider />
+          <MenuGroup label="Group 2">
+            <MenuList>
+              <MenuItem to="#" itemId={3}>
+                Link 1
+              </MenuItem>
+              <MenuItem to="#" itemId={4}>
+                Link 2
+              </MenuItem>
+            </MenuList>
+          </MenuGroup>
+        </MenuContent>
       </Menu>
     );
   }
@@ -356,7 +370,7 @@ class MenuWithTitledGroups extends React.Component {
 
 ```js
 import React from 'react';
-import { Menu, MenuList, MenuItem } from '@patternfly/react-core';
+import { Menu, MenuContent, MenuList, MenuItem } from '@patternfly/react-core';
 import CodeBranchIcon from '@patternfly/react-icons/dist/js/icons/code-branch-icon';
 import LayerGroupIcon from '@patternfly/react-icons/dist/js/icons/layer-group-icon';
 import CubeIcon from '@patternfly/react-icons/dist/js/icons/cube-icon';
@@ -378,21 +392,23 @@ class MenuWithDescription extends React.Component {
     const { activeItem } = this.state;
     return (
       <Menu onSelect={this.onSelect} activeItemId={activeItem}>
-        <MenuList>
-          <MenuItem icon={<CodeBranchIcon aria-hidden />} description="Description" itemId={0}>
-            Action 1
-          </MenuItem>
-          <MenuItem isDisabled icon={<CodeBranchIcon aria-hidden />} description="Description" itemId={1}>
-            Action 2 disabled
-          </MenuItem>
-          <MenuItem
-            icon={<CodeBranchIcon aria-hidden />}
-            description="Nunc non ornare ex, et pretium dui. Duis nec augue at urna elementum blandit tincidunt eget metus. Aenean sed metus id urna dignissim interdum. Aenean vel nisl vitae arcu vehicula pulvinar eget nec turpis. Cras sit amet est est."
-            itemId={2}
-          >
-            Action 3
-          </MenuItem>
-        </MenuList>
+        <MenuContent>
+          <MenuList>
+            <MenuItem icon={<CodeBranchIcon aria-hidden />} description="Description" itemId={0}>
+              Action 1
+            </MenuItem>
+            <MenuItem isDisabled icon={<CodeBranchIcon aria-hidden />} description="Description" itemId={1}>
+              Action 2 disabled
+            </MenuItem>
+            <MenuItem
+              icon={<CodeBranchIcon aria-hidden />}
+              description="Nunc non ornare ex, et pretium dui. Duis nec augue at urna elementum blandit tincidunt eget metus. Aenean sed metus id urna dignissim interdum. Aenean vel nisl vitae arcu vehicula pulvinar eget nec turpis. Cras sit amet est est."
+              itemId={2}
+            >
+              Action 3
+            </MenuItem>
+          </MenuList>
+        </MenuContent>
       </Menu>
     );
   }
@@ -403,7 +419,7 @@ class MenuWithDescription extends React.Component {
 
 ```js
 import React from 'react';
-import { Menu, MenuGroup, MenuList, MenuItem, MenuItemAction } from '@patternfly/react-core';
+import { Menu, MenuContent, MenuGroup, MenuList, MenuItem, MenuItemAction } from '@patternfly/react-core';
 import BarsIcon from '@patternfly/react-icons/dist/js/icons/bars-icon';
 import ClipboardIcon from '@patternfly/react-icons/dist/js/icons/clipboard-icon';
 import CodeBranchIcon from '@patternfly/react-icons/dist/js/icons/code-branch-icon';
@@ -443,49 +459,51 @@ class MenuWithActions extends React.Component {
         onActionClick={(event, itemId, actionId) => console.log(`clicked on ${itemId} - ${actionId}`)}
         activeItemId={activeItem}
       >
-        <MenuGroup label="Actions">
-          <MenuList>
-            <MenuItem
-              isSelected={selectedItems.indexOf(0) !== -1}
-              actions={
-                <MenuItemAction
-                  icon={<CodeBranchIcon aria-hidden />}
-                  actionId="code"
-                  onClick={() => console.log('clicked on code icon')}
-                  aria-label="Code"
-                />
-              }
-              description="This is a description"
-              itemId={0}
-            >
-              Item 1
-            </MenuItem>
-            <MenuItem
-              isDisabled
-              isSelected={selectedItems.indexOf(1) !== -1}
-              actions={<MenuItemAction icon={<BellIcon aria-hidden />} actionId="alert" aria-label="Alert" />}
-              description="This is a description"
-              itemId={1}
-            >
-              Item 2
-            </MenuItem>
-            <MenuItem
-              isSelected={selectedItems.indexOf(2) !== -1}
-              actions={<MenuItemAction icon={<ClipboardIcon aria-hidden />} actionId="copy" aria-label="Copy" />}
-              itemId={2}
-            >
-              Item 3
-            </MenuItem>
-            <MenuItem
-              isSelected={selectedItems.indexOf(3) !== -1}
-              actions={<MenuItemAction icon={<BarsIcon aria-hidden />} actionId="expand" aria-label="Expand" />}
-              description="This is a description"
-              itemId={3}
-            >
-              Item 4
-            </MenuItem>
-          </MenuList>
-        </MenuGroup>
+        <MenuContent>
+          <MenuGroup label="Actions">
+            <MenuList>
+              <MenuItem
+                isSelected={selectedItems.indexOf(0) !== -1}
+                actions={
+                  <MenuItemAction
+                    icon={<CodeBranchIcon aria-hidden />}
+                    actionId="code"
+                    onClick={() => console.log('clicked on code icon')}
+                    aria-label="Code"
+                  />
+                }
+                description="This is a description"
+                itemId={0}
+              >
+                Item 1
+              </MenuItem>
+              <MenuItem
+                isDisabled
+                isSelected={selectedItems.indexOf(1) !== -1}
+                actions={<MenuItemAction icon={<BellIcon aria-hidden />} actionId="alert" aria-label="Alert" />}
+                description="This is a description"
+                itemId={1}
+              >
+                Item 2
+              </MenuItem>
+              <MenuItem
+                isSelected={selectedItems.indexOf(2) !== -1}
+                actions={<MenuItemAction icon={<ClipboardIcon aria-hidden />} actionId="copy" aria-label="Copy" />}
+                itemId={2}
+              >
+                Item 3
+              </MenuItem>
+              <MenuItem
+                isSelected={selectedItems.indexOf(3) !== -1}
+                actions={<MenuItemAction icon={<BarsIcon aria-hidden />} actionId="expand" aria-label="Expand" />}
+                description="This is a description"
+                itemId={3}
+              >
+                Item 4
+              </MenuItem>
+            </MenuList>
+          </MenuGroup>
+        </MenuContent>
       </Menu>
     );
   }
@@ -496,7 +514,7 @@ class MenuWithActions extends React.Component {
 
 ```js
 import React from 'react';
-import { Menu, MenuItem, MenuItemAction, MenuGroup, MenuList, Divider } from '@patternfly/react-core';
+import { Menu, MenuContent, MenuItem, MenuItemAction, MenuGroup, MenuList, Divider } from '@patternfly/react-core';
 import BarsIcon from '@patternfly/react-icons/dist/js/icons/bars-icon';
 import ClipboardIcon from '@patternfly/react-icons/dist/js/icons/clipboard-icon';
 import BellIcon from '@patternfly/react-icons/dist/js/icons/bell-icon';
@@ -560,51 +578,53 @@ class MenuWithFavorites extends React.Component {
 
     return (
       <Menu onSelect={this.onSelect} onActionClick={this.onFavorite} activeItemId={activeItem}>
-        {favorites.length > 0 && (
-          <React.Fragment>
-            <MenuGroup label="Favorites">
-              <MenuList>
-                {items
-                  // map the items into the favorites group that have been favorited
-                  .filter(item => favorites.includes(item.itemId))
-                  .map(item => {
-                    const { text, description, itemId, action, actionId } = item;
-                    return (
-                      <MenuItem
-                        key={`fav-${itemId}`}
-                        isFavorited
-                        description={description}
-                        itemId={itemId}
-                        actions={<MenuItemAction actionId={actionId} icon={action} aria-label={actionId} />}
-                      >
-                        {text}
-                      </MenuItem>
-                    );
-                  })}
-              </MenuList>
-            </MenuGroup>
-            <Divider />
-          </React.Fragment>
-        )}
-        <MenuGroup label="All actions">
-          <MenuList>
-            {items.map(item => {
-              const { text, description, itemId, action, actionId } = item;
-              const isFavorited = favorites.includes(item.itemId);
-              return (
-                <MenuItem
-                  key={itemId}
-                  isFavorited={isFavorited}
-                  description={description}
-                  itemId={itemId}
-                  actions={<MenuItemAction actionId={actionId} icon={action} aria-label={actionId} />}
-                >
-                  {text}
-                </MenuItem>
-              );
-            })}
-          </MenuList>
-        </MenuGroup>
+        <MenuContent>
+          {favorites.length > 0 && (
+            <React.Fragment>
+              <MenuGroup label="Favorites">
+                <MenuList>
+                  {items
+                    // map the items into the favorites group that have been favorited
+                    .filter(item => favorites.includes(item.itemId))
+                    .map(item => {
+                      const { text, description, itemId, action, actionId } = item;
+                      return (
+                        <MenuItem
+                          key={`fav-${itemId}`}
+                          isFavorited
+                          description={description}
+                          itemId={itemId}
+                          actions={<MenuItemAction actionId={actionId} icon={action} aria-label={actionId} />}
+                        >
+                          {text}
+                        </MenuItem>
+                      );
+                    })}
+                </MenuList>
+              </MenuGroup>
+              <Divider />
+            </React.Fragment>
+          )}
+          <MenuGroup label="All actions">
+            <MenuList>
+              {items.map(item => {
+                const { text, description, itemId, action, actionId } = item;
+                const isFavorited = favorites.includes(item.itemId);
+                return (
+                  <MenuItem
+                    key={itemId}
+                    isFavorited={isFavorited}
+                    description={description}
+                    itemId={itemId}
+                    actions={<MenuItemAction actionId={actionId} icon={action} aria-label={actionId} />}
+                  >
+                    {text}
+                  </MenuItem>
+                );
+              })}
+            </MenuList>
+          </MenuGroup>
+        </MenuContent>
       </Menu>
     );
   }
@@ -615,7 +635,7 @@ class MenuWithFavorites extends React.Component {
 
 ```js
 import React from 'react';
-import { Menu, MenuList, MenuItem } from '@patternfly/react-core';
+import { Menu, MenuContent, MenuList, MenuItem } from '@patternfly/react-core';
 import TableIcon from '@patternfly/react-icons/dist/js/icons/table-icon';
 
 class MenuOptionSingleSelect extends React.Component {
@@ -638,13 +658,15 @@ class MenuOptionSingleSelect extends React.Component {
     const { activeItem, selectedItem } = this.state;
     return (
       <Menu onSelect={this.onSelect} activeItemId={activeItem} selected={selectedItem}>
-        <MenuList>
-          <MenuItem itemId={0}>Option 1</MenuItem>
-          <MenuItem itemId={1}>Option 2</MenuItem>
-          <MenuItem icon={<TableIcon aria-hidden />} itemId={2}>
-            Option 3
-          </MenuItem>
-        </MenuList>
+        <MenuContent>
+          <MenuList>
+            <MenuItem itemId={0}>Option 1</MenuItem>
+            <MenuItem itemId={1}>Option 2</MenuItem>
+            <MenuItem icon={<TableIcon aria-hidden />} itemId={2}>
+              Option 3
+            </MenuItem>
+          </MenuList>    
+        </MenuContent>
       </Menu>
     );
   }
@@ -655,7 +677,7 @@ class MenuOptionSingleSelect extends React.Component {
 
 ```js
 import React from 'react';
-import { Menu, MenuList, MenuItem } from '@patternfly/react-core';
+import { Menu, MenuContent, MenuList, MenuItem } from '@patternfly/react-core';
 import TableIcon from '@patternfly/react-icons/dist/js/icons/table-icon';
 
 class MenuOptionMultiSelect extends React.Component {
@@ -682,13 +704,15 @@ class MenuOptionMultiSelect extends React.Component {
     const { activeItem, selectedItems } = this.state;
     return (
       <Menu onSelect={this.onSelect} activeItemId={activeItem} selected={selectedItems}>
-        <MenuList>
-          <MenuItem itemId={0}>Option 1</MenuItem>
-          <MenuItem itemId={1}>Option 2</MenuItem>
-          <MenuItem icon={<TableIcon aria-hidden />} itemId={2}>
-            Option 3
-          </MenuItem>
-        </MenuList>
+        <MenuContent>
+          <MenuList>
+            <MenuItem itemId={0}>Option 1</MenuItem>
+            <MenuItem itemId={1}>Option 2</MenuItem>
+            <MenuItem icon={<TableIcon aria-hidden />} itemId={2}>
+              Option 3
+            </MenuItem>
+          </MenuList>
+        </MenuContent>
       </Menu>
     );
   }
@@ -911,7 +935,8 @@ import {
   Dropdown,
   DropdownToggle,
   DropdownItem,
-  BadgeToggle
+  BadgeToggle,
+  Checkbox
 } from '@patternfly/react-core';
 import StorageDomainIcon from '@patternfly/react-icons/dist/js/icons/storage-domain-icon';
 import CodeBranchIcon from '@patternfly/react-icons/dist/js/icons/code-branch-icon';
@@ -927,7 +952,8 @@ class MenuWithDrilldownBreadcrumbs extends React.Component {
       drilldownPath: [],
       menuHeights: {},
       activeMenu: 'rootMenu',
-      breadcrumb: undefined
+      breadcrumb: undefined,
+      withMaxMenuHeight: false
     };
 
     this.onToggle = (isOpen, key) => {
@@ -945,6 +971,12 @@ class MenuWithDrilldownBreadcrumbs extends React.Component {
         default:
           break;
       }
+    };
+    
+    this.onToggleMaxMenuHeight = checked => {
+      this.setState({
+        withMaxMenuHeight: checked
+      });
     };
 
     this.drillOut = (toMenuId, fromPathId, breadcrumb) => {
@@ -1098,134 +1130,211 @@ class MenuWithDrilldownBreadcrumbs extends React.Component {
   }
 
   render() {
-    const { menuDrilledIn, drilldownPath, activeMenu, menuHeights, breadcrumb } = this.state;
+    const { menuDrilledIn, drilldownPath, activeMenu, menuHeights, breadcrumb, withMaxMenuHeight } = this.state;
 
     return (
-      <Menu
-        id="rootMenu"
-        containsDrilldown
-        drilldownItemPath={drilldownPath}
-        drilledInMenus={menuDrilledIn}
-        activeMenu={activeMenu}
-        onDrillIn={this.drillIn}
-        onDrillOut={this.drillOut}
-        onGetMenuHeight={this.setHeight}
-      >
-        {breadcrumb && (
-          <>
-            <MenuBreadcrumb>{breadcrumb}</MenuBreadcrumb>
-            <Divider component="li" />
-          </>
-        )}
-        <MenuContent menuHeight={`${menuHeights[activeMenu]}px`}>
+      <>
+        <Checkbox
+          label="Set max menu height"
+          isChecked={withMaxMenuHeight}
+          onChange={this.onToggleMaxMenuHeight}
+          aria-label="Set max menu height checkbox"
+          id="toggle-max-menu-height"
+          name="toggle-max-menu-height"
+        />
+        <br />
+        <Menu
+          id="rootMenu"
+          containsDrilldown
+          drilldownItemPath={drilldownPath}
+          drilledInMenus={menuDrilledIn}
+          activeMenu={activeMenu}
+          onDrillIn={this.drillIn}
+          onDrillOut={this.drillOut}
+          onGetMenuHeight={this.setHeight}
+          maxMenuHeight={withMaxMenuHeight ? '200px' : 'auto'}
+        >
+          {breadcrumb && (
+            <>
+              <MenuBreadcrumb>{breadcrumb}</MenuBreadcrumb>
+              <Divider component="li" />
+            </>
+          )}
+          <MenuContent menuHeight={`${menuHeights[activeMenu]}px`}>
+            <MenuList>
+              <MenuItem
+                itemId="group:start_rollout"
+                direction="down"
+                onClick={() => this.setState({ breadcrumb: this.startRolloutBreadcrumb })}
+                drilldownMenu={
+                  <DrilldownMenu id="drilldownMenuStart">
+                    <MenuItem
+                      itemId="group:app_grouping_start"
+                      description="Groups A-G"
+                      direction="down"
+                      onClick={() => this.setState({ breadcrumb: this.appGroupingBreadcrumb(false) })}
+                      drilldownMenu={
+                        <DrilldownMenu id="drilldownMenuStartGrouping">
+                          <MenuItem itemId="group_a">Group A</MenuItem>
+                          <MenuItem itemId="group_b">Group B</MenuItem>
+                          <MenuItem itemId="group_c">Group C</MenuItem>
+                          <MenuItem itemId="group_d">Group D</MenuItem>
+                          <MenuItem itemId="group_e">Group E</MenuItem>
+                          <MenuItem itemId="group_f">Group F</MenuItem>
+                          <MenuItem itemId="group_g">Group G</MenuItem>
+                        </DrilldownMenu>
+                      }
+                    >
+                      Application Grouping
+                    </MenuItem>
+                    <MenuItem itemId="count">Count</MenuItem>
+                    <MenuItem
+                      itemId="group:labels_start"
+                      direction="down"
+                      onClick={() => this.setState({ breadcrumb: this.labelsBreadcrumb(false) })}
+                      drilldownMenu={
+                        <DrilldownMenu id="drilldownMenuStartLabels">
+                          <MenuItem itemId="label_1">Label 1</MenuItem>
+                          <MenuItem itemId="label_2">Label 2</MenuItem>
+                          <MenuItem itemId="label_3">Label 3</MenuItem>
+                        </DrilldownMenu>
+                      }
+                    >
+                      Labels
+                    </MenuItem>
+                    <MenuItem itemId="annotations">Annotations</MenuItem>
+                  </DrilldownMenu>
+                }
+              >
+                Start rollout
+              </MenuItem>
+              <MenuItem
+                itemId="group:pause_rollout"
+                direction="down"
+                onClick={() => this.setState({ breadcrumb: this.pauseRolloutsBreadcrumb })}
+                drilldownMenu={
+                  <DrilldownMenu id="drilldownMenuPause">
+                    <MenuItem
+                      itemId="group:app_grouping"
+                      description="Groups A-C"
+                      direction="down"
+                      onClick={() => this.setState({ breadcrumb: this.pauseRolloutsAppGrpBreadcrumb })}
+                      drilldownMenu={
+                        <DrilldownMenu id="drilldownMenuGrouping">
+                          <MenuItem itemId="group_a">Group A</MenuItem>
+                          <MenuItem itemId="group_b">Group B</MenuItem>
+                          <MenuItem itemId="group_c">Group C</MenuItem>
+                        </DrilldownMenu>
+                      }
+                    >
+                      Application Grouping
+                    </MenuItem>
+                    <MenuItem itemId="count">Count</MenuItem>
+                    <MenuItem
+                      itemId="group:labels"
+                      direction="down"
+                      onClick={() => this.setState({ breadcrumb: this.pauseRolloutsLabelsBreadcrumb })}
+                      drilldownMenu={
+                        <DrilldownMenu id="drilldownMenuLabels">
+                          <MenuItem itemId="label_1">Label 1</MenuItem>
+                          <MenuItem itemId="label_2">Label 2</MenuItem>
+                          <MenuItem itemId="label_3">Label 3</MenuItem>
+                        </DrilldownMenu>
+                      }
+                    >
+                      Labels
+                    </MenuItem>
+                    <MenuItem itemId="annotations">Annotations</MenuItem>
+                  </DrilldownMenu>
+                }
+              >
+                Pause rollouts
+              </MenuItem>
+              <MenuItem
+                itemId="group:storage"
+                icon={<StorageDomainIcon aria-hidden />}
+                direction="down"
+                onClick={() => this.setState({ breadcrumb: this.addStorageBreadcrumb })}
+                drilldownMenu={
+                  <DrilldownMenu id="drilldownMenuStorage">
+                    <MenuItem icon={<CodeBranchIcon aria-hidden />} itemId="git">
+                      From Git
+                    </MenuItem>
+                    <MenuItem icon={<LayerGroupIcon aria-hidden />} itemId="container">
+                      Container Image
+                    </MenuItem>
+                    <MenuItem icon={<CubeIcon aria-hidden />} itemId="docker">
+                      Docker File
+                    </MenuItem>
+                  </DrilldownMenu>
+                }
+              >
+                Add storage
+              </MenuItem>
+              <MenuItem itemId="edit">Edit</MenuItem>
+              <MenuItem itemId="delete_deployment">Delete deployment config</MenuItem>
+            </MenuList>
+          </MenuContent>
+        </Menu>
+      </>
+    );
+  }
+}
+```
+
+### Scrollable
+
+```js
+import React from 'react';
+import { Menu, MenuContent, MenuList, MenuItem } from '@patternfly/react-core';
+
+class MenuBasicList extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      activeItem: 0
+    };
+    this.onSelect = (event, itemId) => {
+      console.log(`clicked ${itemId}`);
+      this.setState({
+        activeItem: itemId
+      });
+    };
+  }
+
+  render() {
+    const { activeItem } = this.state;
+    return (
+      <Menu activeItemId={activeItem} onSelect={this.onSelect}>
+        <MenuContent menuHeight="300px">
           <MenuList>
+            <MenuItem>Action</MenuItem>
+            <MenuItem>Action</MenuItem>
+            <MenuItem>Action</MenuItem>
+            <MenuItem>Action</MenuItem>
+            <MenuItem>Action</MenuItem>
+            <MenuItem>Action</MenuItem>
+            <MenuItem>Action</MenuItem>
+            <MenuItem>Action</MenuItem>
+            <MenuItem>Action</MenuItem>
+            <MenuItem>Action</MenuItem>
+            <MenuItem>Action</MenuItem>
+            <MenuItem>Action</MenuItem>
+            <MenuItem>Action</MenuItem>
+            <MenuItem>Action</MenuItem>
+            <MenuItem>Action</MenuItem>
             <MenuItem
-              itemId="group:start_rollout"
-              direction="down"
-              onClick={() => this.setState({ breadcrumb: this.startRolloutBreadcrumb })}
-              drilldownMenu={
-                <DrilldownMenu id="drilldownMenuStart">
-                  <MenuItem
-                    itemId="group:app_grouping_start"
-                    description="Groups A-C"
-                    direction="down"
-                    onClick={() => this.setState({ breadcrumb: this.appGroupingBreadcrumb(false) })}
-                    drilldownMenu={
-                      <DrilldownMenu id="drilldownMenuStartGrouping">
-                        <MenuItem itemId="group_a">Group A</MenuItem>
-                        <MenuItem itemId="group_b">Group B</MenuItem>
-                        <MenuItem itemId="group_c">Group C</MenuItem>
-                      </DrilldownMenu>
-                    }
-                  >
-                    Application Grouping
-                  </MenuItem>
-                  <MenuItem itemId="count">Count</MenuItem>
-                  <MenuItem
-                    itemId="group:labels_start"
-                    direction="down"
-                    onClick={() => this.setState({ breadcrumb: this.labelsBreadcrumb(false) })}
-                    drilldownMenu={
-                      <DrilldownMenu id="drilldownMenuStartLabels">
-                        <MenuItem itemId="label_1">Label 1</MenuItem>
-                        <MenuItem itemId="label_2">Label 2</MenuItem>
-                        <MenuItem itemId="label_3">Label 3</MenuItem>
-                      </DrilldownMenu>
-                    }
-                  >
-                    Labels
-                  </MenuItem>
-                  <MenuItem itemId="annotations">Annotations</MenuItem>
-                </DrilldownMenu>
-              }
+              itemId={1}
+              to="#default-link2"
+              // just for demo so that navigation is not triggered
+              onClick={event => event.preventDefault()}
             >
-              Start rollout
+              Link
             </MenuItem>
-            <MenuItem
-              itemId="group:pause_rollout"
-              direction="down"
-              onClick={() => this.setState({ breadcrumb: this.pauseRolloutsBreadcrumb })}
-              drilldownMenu={
-                <DrilldownMenu id="drilldownMenuPause">
-                  <MenuItem
-                    itemId="group:app_grouping"
-                    description="Groups A-C"
-                    direction="down"
-                    onClick={() => this.setState({ breadcrumb: this.pauseRolloutsAppGrpBreadcrumb })}
-                    drilldownMenu={
-                      <DrilldownMenu id="drilldownMenuGrouping">
-                        <MenuItem itemId="group_a">Group A</MenuItem>
-                        <MenuItem itemId="group_b">Group B</MenuItem>
-                        <MenuItem itemId="group_c">Group C</MenuItem>
-                      </DrilldownMenu>
-                    }
-                  >
-                    Application Grouping
-                  </MenuItem>
-                  <MenuItem itemId="count">Count</MenuItem>
-                  <MenuItem
-                    itemId="group:labels"
-                    direction="down"
-                    onClick={() => this.setState({ breadcrumb: this.pauseRolloutsLabelsBreadcrumb })}
-                    drilldownMenu={
-                      <DrilldownMenu id="drilldownMenuLabels">
-                        <MenuItem itemId="label_1">Label 1</MenuItem>
-                        <MenuItem itemId="label_2">Label 2</MenuItem>
-                        <MenuItem itemId="label_3">Label 3</MenuItem>
-                      </DrilldownMenu>
-                    }
-                  >
-                    Labels
-                  </MenuItem>
-                  <MenuItem itemId="annotations">Annotations</MenuItem>
-                </DrilldownMenu>
-              }
-            >
-              Pause rollouts
+            <MenuItem isDisabled>Disabled Action</MenuItem>
+            <MenuItem isDisabled to="#default-link4">
+              Disabled Link
             </MenuItem>
-            <MenuItem
-              itemId="group:storage"
-              icon={<StorageDomainIcon aria-hidden />}
-              direction="down"
-              onClick={() => this.setState({ breadcrumb: this.addStorageBreadcrumb })}
-              drilldownMenu={
-                <DrilldownMenu id="drilldownMenuStorage">
-                  <MenuItem icon={<CodeBranchIcon aria-hidden />} itemId="git">
-                    From Git
-                  </MenuItem>
-                  <MenuItem icon={<LayerGroupIcon aria-hidden />} itemId="container">
-                    Container Image
-                  </MenuItem>
-                  <MenuItem icon={<CubeIcon aria-hidden />} itemId="docker">
-                    Docker File
-                  </MenuItem>
-                </DrilldownMenu>
-              }
-            >
-              Add storage
-            </MenuItem>
-            <MenuItem itemId="edit">Edit</MenuItem>
-            <MenuItem itemId="delete_deployment">Delete deployment config</MenuItem>
           </MenuList>
         </MenuContent>
       </Menu>

--- a/packages/react-core/src/components/Menu/examples/Menu.md
+++ b/packages/react-core/src/components/Menu/examples/Menu.md
@@ -1152,7 +1152,6 @@ class MenuWithDrilldownBreadcrumbs extends React.Component {
           onDrillIn={this.drillIn}
           onDrillOut={this.drillOut}
           onGetMenuHeight={this.setHeight}
-          maxMenuHeight={withMaxMenuHeight ? '200px' : 'auto'}
         >
           {breadcrumb && (
             <>
@@ -1160,7 +1159,10 @@ class MenuWithDrilldownBreadcrumbs extends React.Component {
               <Divider component="li" />
             </>
           )}
-          <MenuContent menuHeight={`${menuHeights[activeMenu]}px`}>
+          <MenuContent 
+            menuHeight={`${menuHeights[activeMenu]}px`} 
+            maxMenuHeight={withMaxMenuHeight ? '100px' : 'auto'}
+          >
             <MenuList>
               <MenuItem
                 itemId="group:start_rollout"


### PR DESCRIPTION
Closes: #5525 and #5610

 - wraps all `MenuList` components in a `MenuContent` in the examples
 - demonstrates how to set the `maxMenuHeight` prop in the `With drilldown breadcrumbs` example
 - demonstrates how to set the `menuHeight` prop in the new `Scrollable` example