### PR TITLE
fix, feat(Slider): Update Slider API to be more like the range input API

### DIFF
--- a/packages/react-core/src/components/Slider/Slider.tsx
+++ b/packages/react-core/src/components/Slider/Slider.tsx
@@ -136,14 +136,6 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
   };
 
   const handleThumbDragEnd = () => {
-    if (snapValue !== undefined && customSteps) {
-      thumbRef.current.style.setProperty('--pf-c-slider--value', `${snapValue}%`);
-      setValue(snapValue);
-      if (onChange) {
-        onChange(snapValue);
-      }
-    }
-
     document.removeEventListener('mousemove', callbackThumbMove);
     document.removeEventListener('mouseup', callbackThumbUp);
     document.removeEventListener('touchmove', callbackThumbMove);
@@ -216,9 +208,6 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
       snapValue = Math.round((newValue - min) / step) * step + min;
       thumbRef.current.style.setProperty('--pf-c-slider--value', `${snapValue}%`);
       setValue(snapValue);
-      if (onChange) {
-        onChange(snapValue);
-      }
     }
 
     /* If custom steps are discrete, snap to closest step value */
@@ -234,13 +223,16 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
           snapValue = customSteps[stepIndex].value;
         }
       }
+      setValue(snapValue);
     }
 
     // Call onchange callback
     if (onChange) {
-      if (areCustomStepsContinuous && customSteps) {
-        onChange(newValue);
-      }
+      if (snapValue !== undefined) {
+        onChange(snapValue);
+      } else {
+        onChange(newValue)
+      } 
     }
   };
 

--- a/packages/react-core/src/components/Slider/Slider.tsx
+++ b/packages/react-core/src/components/Slider/Slider.tsx
@@ -136,7 +136,7 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
   };
 
   const handleThumbDragEnd = () => {
-    if (snapValue !== undefined) {
+    if (snapValue !== undefined && customSteps) {
       thumbRef.current.style.setProperty('--pf-c-slider--value', `${snapValue}%`);
       setValue(snapValue);
       if (onChange) {
@@ -211,6 +211,16 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
     const newValue = (newPercentage * (max - min)) / 100 + min;
     setValue(newValue);
 
+    if (!customSteps) {
+      // snap to new value if not custom steps
+      snapValue = Math.round((newValue - min) / step) * step + min;
+      thumbRef.current.style.setProperty('--pf-c-slider--value', `${snapValue}%`);
+      setValue(snapValue);
+      if (onChange) {
+        onChange(snapValue);
+      }
+    }
+
     /* If custom steps are discrete, snap to closest step value */
     if (!areCustomStepsContinuous && customSteps) {
       const stepIndex = customSteps.findIndex(stepObj => stepObj.value >= newPercentage);
@@ -224,14 +234,11 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
           snapValue = customSteps[stepIndex].value;
         }
       }
-    } else if (!customSteps && step !== 1) {
-      // snap to new value if not custom steps and step is not 1
-      snapValue = Math.round((newValue - min) / step) * step + min;
     }
 
-    // Call value change callback unless custom steps are discrete or no custom steps and step is 1.  The value will snap after the thumb is released.
+    // Call onchange callback
     if (onChange) {
-      if ((areCustomStepsContinuous && customSteps) || (!customSteps && step === 1)) {
+      if (areCustomStepsContinuous && customSteps) {
         onChange(newValue);
       }
     }

--- a/packages/react-core/src/components/Slider/Slider.tsx
+++ b/packages/react-core/src/components/Slider/Slider.tsx
@@ -297,7 +297,7 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
       return (
         <InputGroup>
           {textInput}
-          <InputGroupText className={css('pf-m-plain')}>{inputLabel}</InputGroupText>
+          <InputGroupText variant="plain"> {inputLabel}</InputGroupText>
         </InputGroup>
       );
     } else {

--- a/packages/react-core/src/components/Slider/Slider.tsx
+++ b/packages/react-core/src/components/Slider/Slider.tsx
@@ -161,7 +161,7 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
     document.addEventListener('mouseup', callbackThumbUp);
   };
 
-  const handleToucheStart = (e: React.TouchEvent) => {
+  const handleTouchStart = (e: React.TouchEvent) => {
     e.stopPropagation();
 
     diff = e.touches[0].clientX - thumbRef.current.getBoundingClientRect().left;
@@ -227,12 +227,11 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
     } else if (!customSteps && step !== 1) {
       // snap to new value if not custom steps and step is not 1
       snapValue = Math.round((newValue - min) / step) * step + min;
-      // snapValue = Math.round(newValue / step) * step;
     }
 
-    // Call value change callback unless custom steps are discrete or no custom steps and step is !== 1.  The value will snap after the thumb is released.
+    // Call value change callback unless custom steps are discrete or no custom steps and step is 1.  The value will snap after the thumb is released.
     if (onChange) {
-      if ((areCustomStepsContinuous && customSteps) || (!customSteps && step !== 1)) {
+      if ((areCustomStepsContinuous && customSteps) || (!customSteps && step === 1)) {
         onChange(newValue);
       }
     }
@@ -353,7 +352,7 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
           aria-label={thumbAriaLabel}
           aria-disabled={isDisabled}
           onMouseDown={!isDisabled ? handleMouseDown : null}
-          onTouchStart={!isDisabled ? handleToucheStart : null}
+          onTouchStart={!isDisabled ? handleTouchStart : null}
           onKeyDown={!isDisabled ? handleThumbKeys : null}
           onClick={!isDisabled ? onThumbClick : null}
         />

--- a/packages/react-core/src/components/Slider/Slider.tsx
+++ b/packages/react-core/src/components/Slider/Slider.tsx
@@ -231,7 +231,7 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
       if (snapValue !== undefined) {
         onChange(snapValue);
       } else {
-        onChange(newValue)
+        onChange(newValue);
       } 
     }
   };

--- a/packages/react-core/src/components/Slider/Slider.tsx
+++ b/packages/react-core/src/components/Slider/Slider.tsx
@@ -232,7 +232,7 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
         onChange(snapValue);
       } else {
         onChange(newValue);
-      } 
+      }
     }
   };
 

--- a/packages/react-core/src/components/Slider/_tests_/Slider.test.tsx
+++ b/packages/react-core/src/components/Slider/_tests_/Slider.test.tsx
@@ -10,11 +10,15 @@ describe('slider', () => {
   });
 
   test('renders discrete slider', () => {
+    const view = mount(<Slider value={50} min={10} max={110} step={2} isInputVisible inputValue={50} />);
+    expect(view).toMatchSnapshot();
+  });
+
+  test('renders discrete slider with custom steps', () => {
     const view = mount(
       <Slider
-        isDiscrete
         value={50}
-        steps={[
+        customSteps={[
           { value: 0, label: '0%' },
           { value: 25, label: '25%', isLabelHidden: true },
           { value: 50, label: '50%' },
@@ -26,15 +30,27 @@ describe('slider', () => {
     expect(view).toMatchSnapshot();
   });
 
+  test('renders continuous slider with custom steps', () => {
+    const view = mount(
+      <Slider
+        value={50}
+        areCustomStepsContinuous
+        customSteps={[
+          { value: 0, label: '0%' },
+          { value: 100, label: '100%' }
+        ]}
+      />
+    );
+    expect(view).toMatchSnapshot();
+  });
+
   test('renders slider with input', () => {
-    const view = mount(<Slider value={50} isInputVisible inputValue={50} inputLabel="%" inputPosition="left" />);
+    const view = mount(<Slider value={50} isInputVisible inputValue={50} inputLabel="%" inputPosition="right" />);
     expect(view).toMatchSnapshot();
   });
 
   test('renders slider with input above thumb', () => {
-    const view = mount(
-      <Slider value={50} isInputVisible inputValue={50} inputLabel="%" inputPosition="aboveThumb" />
-    );
+    const view = mount(<Slider value={50} isInputVisible inputValue={50} inputLabel="%" inputPosition="aboveThumb" />);
     expect(view).toMatchSnapshot();
   });
 
@@ -50,7 +66,7 @@ describe('slider', () => {
   });
 
   test('renders disabled slider', () => {
-    const view = mount(<Slider currentValue={50} isDisabled />);
+    const view = mount(<Slider value={50} isDisabled />);
     expect(view).toMatchSnapshot();
   });
 });

--- a/packages/react-core/src/components/Slider/_tests_/Slider.test.tsx
+++ b/packages/react-core/src/components/Slider/_tests_/Slider.test.tsx
@@ -5,7 +5,7 @@ import { Button } from '../../Button';
 
 describe('slider', () => {
   test('renders continuous slider', () => {
-    const view = mount(<Slider currentValue={50} isInputVisible inputValue={50} />);
+    const view = mount(<Slider value={50} isInputVisible inputValue={50} />);
     expect(view).toMatchSnapshot();
   });
 
@@ -13,7 +13,7 @@ describe('slider', () => {
     const view = mount(
       <Slider
         isDiscrete
-        currentValue={50}
+        value={50}
         steps={[
           { value: 0, label: '0%' },
           { value: 25, label: '25%', isLabelHidden: true },
@@ -27,13 +27,13 @@ describe('slider', () => {
   });
 
   test('renders slider with input', () => {
-    const view = mount(<Slider currentValue={50} isInputVisible inputValue={50} inputLabel="%" inputPosition="left" />);
+    const view = mount(<Slider value={50} isInputVisible inputValue={50} inputLabel="%" inputPosition="left" />);
     expect(view).toMatchSnapshot();
   });
 
   test('renders slider with input above thumb', () => {
     const view = mount(
-      <Slider currentValue={50} isInputVisible inputValue={50} inputLabel="%" inputPosition="aboveThumb" />
+      <Slider value={50} isInputVisible inputValue={50} inputLabel="%" inputPosition="aboveThumb" />
     );
     expect(view).toMatchSnapshot();
   });
@@ -41,7 +41,7 @@ describe('slider', () => {
   test('renders slider with input actions', () => {
     const view = mount(
       <Slider
-        currentValue={50}
+        value={50}
         leftActions={<Button variant="plain" aria-label="Minus" />}
         rightActions={<Button variant="plain" aria-label="Plus" />}
       />

--- a/packages/react-core/src/components/Slider/_tests_/__snapshots__/Slider.test.tsx.snap
+++ b/packages/react-core/src/components/Slider/_tests_/__snapshots__/Slider.test.tsx.snap
@@ -2,9 +2,9 @@
 
 exports[`slider renders continuous slider 1`] = `
 <Slider
-  currentValue={50}
   inputValue={50}
   isInputVisible={true}
+  value={50}
 >
   <div
     className="pf-c-slider"
@@ -31,6 +31,7 @@ exports[`slider renders continuous slider 1`] = `
         aria-valuemax={100}
         aria-valuemin={0}
         aria-valuenow={50}
+        aria-valuetext="50"
         className="pf-c-slider__thumb"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -94,10 +95,119 @@ exports[`slider renders continuous slider 1`] = `
 </Slider>
 `;
 
+exports[`slider renders continuous slider with custom steps 1`] = `
+<Slider
+  areCustomStepsContinuous={true}
+  customSteps={
+    Array [
+      Object {
+        "label": "0%",
+        "value": 0,
+      },
+      Object {
+        "label": "100%",
+        "value": 100,
+      },
+    ]
+  }
+  value={50}
+>
+  <div
+    className="pf-c-slider"
+    style={
+      Object {
+        "--pf-c-slider--value": "50%",
+      }
+    }
+  >
+    <div
+      className="pf-c-slider__main"
+    >
+      <div
+        className="pf-c-slider__rail"
+        onClick={[Function]}
+      >
+        <div
+          className="pf-c-slider__rail-track"
+        />
+      </div>
+      <div
+        aria-hidden="true"
+        className="pf-c-slider__steps"
+      >
+        <SliderStep
+          isActive={true}
+          key="0"
+          label="0%"
+          value={0}
+        >
+          <div
+            className="pf-c-slider__step pf-m-active"
+            style={
+              Object {
+                "--pf-c-slider__step--Left": "0%",
+              }
+            }
+          >
+            <div
+              className="pf-c-slider__step-tick"
+            />
+            <div
+              className="pf-c-slider__step-label"
+            >
+              0%
+            </div>
+          </div>
+        </SliderStep>
+        <SliderStep
+          isActive={false}
+          key="100"
+          label="100%"
+          value={100}
+        >
+          <div
+            className="pf-c-slider__step"
+            style={
+              Object {
+                "--pf-c-slider__step--Left": "100%",
+              }
+            }
+          >
+            <div
+              className="pf-c-slider__step-tick"
+            />
+            <div
+              className="pf-c-slider__step-label"
+            >
+              100%
+            </div>
+          </div>
+        </SliderStep>
+      </div>
+      <div
+        aria-disabled={false}
+        aria-label="Value"
+        aria-valuemax={100}
+        aria-valuemin={0}
+        aria-valuenow={50}
+        aria-valuetext="50"
+        className="pf-c-slider__thumb"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
+        role="slider"
+        tabIndex={0}
+      />
+    </div>
+  </div>
+</Slider>
+`;
+
 exports[`slider renders disabled slider 1`] = `
 <Slider
-  currentValue={50}
   isDisabled={true}
+  value={50}
 >
   <div
     className="pf-c-slider pf-m-disabled"
@@ -124,6 +234,7 @@ exports[`slider renders disabled slider 1`] = `
         aria-valuemax={100}
         aria-valuemin={0}
         aria-valuenow={50}
+        aria-valuetext="50"
         className="pf-c-slider__thumb"
         onClick={null}
         onKeyDown={null}
@@ -139,9 +250,105 @@ exports[`slider renders disabled slider 1`] = `
 
 exports[`slider renders discrete slider 1`] = `
 <Slider
-  currentValue={50}
-  isDiscrete={true}
-  steps={
+  inputValue={50}
+  isInputVisible={true}
+  max={110}
+  min={10}
+  step={2}
+  value={50}
+>
+  <div
+    className="pf-c-slider"
+    style={
+      Object {
+        "--pf-c-slider--value": "40%",
+      }
+    }
+  >
+    <div
+      className="pf-c-slider__main"
+    >
+      <div
+        className="pf-c-slider__rail"
+        onClick={[Function]}
+      >
+        <div
+          className="pf-c-slider__rail-track"
+        />
+      </div>
+      <div
+        aria-disabled={false}
+        aria-label="Value"
+        aria-valuemax={110}
+        aria-valuemin={10}
+        aria-valuenow={50}
+        aria-valuetext="50"
+        className="pf-c-slider__thumb"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
+        role="slider"
+        tabIndex={0}
+      />
+    </div>
+    <div
+      className="pf-c-slider__value"
+    >
+      <TextInput
+        aria-label="Slider value input"
+        className="pf-c-form-control"
+        isDisabled={false}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        type="number"
+        value={50}
+      >
+        <TextInputBase
+          aria-label="Slider value input"
+          className="pf-c-form-control"
+          innerRef={null}
+          isDisabled={false}
+          isLeftTruncated={false}
+          isReadOnly={false}
+          isRequired={false}
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          type="number"
+          validated="default"
+          value={50}
+        >
+          <input
+            aria-invalid={false}
+            aria-label="Slider value input"
+            className="pf-c-form-control pf-c-form-control"
+            disabled={false}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            readOnly={false}
+            required={false}
+            type="number"
+            value={50}
+          />
+        </TextInputBase>
+      </TextInput>
+    </div>
+  </div>
+</Slider>
+`;
+
+exports[`slider renders discrete slider with custom steps 1`] = `
+<Slider
+  customSteps={
     Array [
       Object {
         "label": "0%",
@@ -167,6 +374,7 @@ exports[`slider renders discrete slider 1`] = `
       },
     ]
   }
+  value={50}
 >
   <div
     className="pf-c-slider"
@@ -326,11 +534,11 @@ exports[`slider renders discrete slider 1`] = `
 
 exports[`slider renders slider with input 1`] = `
 <Slider
-  currentValue={50}
   inputLabel="%"
-  inputPosition="left"
+  inputPosition="right"
   inputValue={50}
   isInputVisible={true}
+  value={50}
 >
   <div
     className="pf-c-slider"
@@ -357,6 +565,7 @@ exports[`slider renders slider with input 1`] = `
         aria-valuemax={100}
         aria-valuemin={0}
         aria-valuenow={50}
+        aria-valuetext="50"
         className="pf-c-slider__thumb"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -366,17 +575,82 @@ exports[`slider renders slider with input 1`] = `
         tabIndex={0}
       />
     </div>
+    <div
+      className="pf-c-slider__value"
+    >
+      <InputGroup>
+        <div
+          className="pf-c-input-group"
+        >
+          <TextInput
+            aria-label="Slider value input"
+            className="pf-c-form-control"
+            isDisabled={false}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            type="number"
+            value={50}
+          >
+            <TextInputBase
+              aria-label="Slider value input"
+              className="pf-c-form-control"
+              innerRef={null}
+              isDisabled={false}
+              isLeftTruncated={false}
+              isReadOnly={false}
+              isRequired={false}
+              onBlur={[Function]}
+              onChange={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              type="number"
+              validated="default"
+              value={50}
+            >
+              <input
+                aria-invalid={false}
+                aria-label="Slider value input"
+                className="pf-c-form-control pf-c-form-control"
+                disabled={false}
+                onBlur={[Function]}
+                onChange={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                readOnly={false}
+                required={false}
+                type="number"
+                value={50}
+              />
+            </TextInputBase>
+          </TextInput>
+          <InputGroupText
+            className="pf-m-plain"
+          >
+            <span
+              className="pf-c-input-group__text pf-m-plain"
+            >
+              %
+            </span>
+          </InputGroupText>
+        </div>
+      </InputGroup>
+    </div>
   </div>
 </Slider>
 `;
 
 exports[`slider renders slider with input above thumb 1`] = `
 <Slider
-  currentValue={50}
   inputLabel="%"
   inputPosition="aboveThumb"
   inputValue={50}
   isInputVisible={true}
+  value={50}
 >
   <div
     className="pf-c-slider"
@@ -403,6 +677,7 @@ exports[`slider renders slider with input above thumb 1`] = `
         aria-valuemax={100}
         aria-valuemin={0}
         aria-valuenow={50}
+        aria-valuetext="50"
         className="pf-c-slider__thumb"
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -483,7 +758,6 @@ exports[`slider renders slider with input above thumb 1`] = `
 
 exports[`slider renders slider with input actions 1`] = `
 <Slider
-  currentValue={50}
   leftActions={
     <Button
       aria-label="Minus"
@@ -496,6 +770,7 @@ exports[`slider renders slider with input actions 1`] = `
       variant="plain"
     />
   }
+  value={50}
 >
   <div
     className="pf-c-slider"
@@ -542,6 +817,7 @@ exports[`slider renders slider with input actions 1`] = `
         aria-valuemax={100}
         aria-valuemin={0}
         aria-valuenow={50}
+        aria-valuetext="50"
         className="pf-c-slider__thumb"
         onClick={[Function]}
         onKeyDown={[Function]}

--- a/packages/react-core/src/components/Slider/_tests_/__snapshots__/Slider.test.tsx.snap
+++ b/packages/react-core/src/components/Slider/_tests_/__snapshots__/Slider.test.tsx.snap
@@ -629,11 +629,12 @@ exports[`slider renders slider with input 1`] = `
             </TextInputBase>
           </TextInput>
           <InputGroupText
-            className="pf-m-plain"
+            variant="plain"
           >
             <span
               className="pf-c-input-group__text pf-m-plain"
             >
+               
               %
             </span>
           </InputGroupText>
@@ -740,11 +741,12 @@ exports[`slider renders slider with input above thumb 1`] = `
               </TextInputBase>
             </TextInput>
             <InputGroupText
-              className="pf-m-plain"
+              variant="plain"
             >
               <span
                 className="pf-c-input-group__text pf-m-plain"
               >
+                 
                 %
               </span>
             </InputGroupText>

--- a/packages/react-core/src/components/Slider/examples/Slider.md
+++ b/packages/react-core/src/components/Slider/examples/Slider.md
@@ -70,7 +70,7 @@ class DiscreteInput extends React.Component {
         <br />
         <Text component={TextVariants.h3}>Slider value is: {Math.floor(this.state.value2)}</Text>
         <Text component={TextVariants.small}>(min = 0, max = 200, step = 50) </Text>
-        <Slider value={this.state.value2} onChange={this.onChange2} max={200} step={50} />
+        <Slider value={this.state.value2} onChange={this.onChange2} max={200} step={50} showTicks/>
         <br />
         <Text component={TextVariants.h3}>Slider value is: {Math.floor(this.state.value3)}</Text>
         <Text component={TextVariants.small}>(min = -25, max = 75, step = 10) </Text>
@@ -114,6 +114,7 @@ class ContinuousInput extends React.Component {
         <Text component={TextVariants.h3}>Slider Value is: {this.state.value.toFixed(2)}</Text>
         <Slider value={this.state.value} onChange={this.onChange} />
         <br />
+        <Text component={TextVariants.h3}>Slider Value is: {this.state.valueCustom.toFixed(2)}</Text>
         <Slider
           onChange={this.onChangeCustom}
           value={this.state.valueCustom}

--- a/packages/react-core/src/components/Slider/examples/Slider.md
+++ b/packages/react-core/src/components/Slider/examples/Slider.md
@@ -61,7 +61,7 @@ class DiscreteInput extends React.Component {
   }
 
   render() {
-    const step = this.steps.find(step => step.value === this.state.value);
+    const step = this.steps.find(step => step.value === this.state.value1);
     const displayValue = step ? step.label : 0;
     return (
       <>

--- a/packages/react-core/src/components/Slider/examples/Slider.md
+++ b/packages/react-core/src/components/Slider/examples/Slider.md
@@ -172,7 +172,7 @@ class ValueInput extends React.Component {
       let newValue;
       let newInputValue;
 
-      if (!inputValue) { 
+      if (inputValue === undefined) { 
         const step = this.stepsDiscrete.find(step => step.value === value);
         newInputValue = step ? step.label : 0;
         newInputValue = Number(newInputValue);
@@ -209,7 +209,7 @@ class ValueInput extends React.Component {
       let newValue;
       let newInputValue;
 
-      if (!inputValue) { 
+      if (inputValue === undefined) { 
         const step = this.stepsPercent.find(step => step.value === value);
         newInputValue = step ? step.label.slice(0, -1) : 0;
         newInputValue = Number(newInputValue);
@@ -242,8 +242,13 @@ class ValueInput extends React.Component {
       });
     };
 
-    this.onChangeContinuous = (value) => { 
-      const newValue = value > 100 ? 100 : Math.floor(value);
+    this.onChangeContinuous = (value, inputValue) => { 
+      let newValue;
+      if (inputValue === undefined) { 
+        newValue = Math.floor(value);
+      } else {
+        newValue = inputValue > 100 ? 100 : Math.floor(inputValue);
+      }
       this.setState({
         inputValueContinuous: newValue,
         valueContinuous: newValue
@@ -298,16 +303,13 @@ class ThumbValueInput extends React.Component {
       inputValue: 50
     };
 
-    this.onChange = value => {
-      const newValue = Number(value).toFixed(2);
-      this.setState({
-        value: newValue,
-        inputValue: newValue
-      });
-    };
-
-    this.onChange = value => {
-      const newValue = value > 100 ? 100 : Math.floor(value);
+    this.onChange = (value, inputValue) => { 
+      let newValue;
+      if (inputValue === undefined) { 
+        newValue = Number(value).toFixed(2);
+      } else {
+        newValue = inputValue > 100 ? 100 : Math.floor(inputValue);
+      }
       this.setState({
         value: newValue,
         inputValue: newValue
@@ -323,7 +325,6 @@ class ThumbValueInput extends React.Component {
         inputValue={this.state.inputValue}
         inputLabel="%"
         inputPosition="aboveThumb"
-        onChange={this.onChange}
         onChange={this.onChange}
       />
     );
@@ -358,16 +359,13 @@ class SliderActions extends React.Component {
       });
     };
 
-    this.onChange2 = value => {
-      const newValue = Math.floor(Number(value));
-      this.setState({
-        value2: newValue,
-        inputValue: newValue
-      });
-    };
-
-    this.onChange = value => {
-      const newValue = value > 100 ? 100 : Math.floor(Number(value));
+    this.onChange2 =(value, inputValue) => { 
+      let newValue;
+      if (inputValue === undefined) { 
+        newValue = Math.floor(Number(value));
+      } else {
+        newValue = inputValue > 100 ? 100 : Math.floor(inputValue);
+      }
       this.setState({
         value2: newValue,
         inputValue: newValue

--- a/packages/react-core/src/components/Slider/examples/Slider.md
+++ b/packages/react-core/src/components/Slider/examples/Slider.md
@@ -39,7 +39,7 @@ class DiscreteInput extends React.Component {
       { value: 100, label: '8' }
     ];
 
-    this.onValueChange = value => {
+    this.onChange = value => {
         this.setState({
           value
         });
@@ -51,8 +51,8 @@ class DiscreteInput extends React.Component {
     const displayValue = step ? step.label : 0;
     return (
       <>
-        <Text component={TextVariants.h3}>Slider Value is: {displayValue}</Text>
-        <Slider isDiscrete currentValue={this.state.value} onValueChange={this.onValueChange} steps={this.steps} />
+        <Text component={TextVariants.h3}>Slider value is: {displayValue}</Text>
+        <Slider isDiscrete value={this.state.value} onChange={this.onChange} customSteps={this.steps} />
       </>
     );
   }
@@ -72,7 +72,7 @@ class ContinuousInput extends React.Component {
       value: 50
     };
 
-    this.onValueChange = value => {
+    this.onChange = value => {
         this.setState({
           value: value
         });
@@ -83,11 +83,11 @@ class ContinuousInput extends React.Component {
     return (
       <>
         <Text component={TextVariants.h3}>Slider Value is: {this.state.value.toFixed(2)}</Text>
-        <Slider currentValue={this.state.value} onValueChange={this.onValueChange} />
+        <Slider value={this.state.value} onChange={this.onChange} />
         <br />
         <Slider
-          currentValue={50}
-          steps={[
+          value={50}
+          customSteps={[
             { value: 0, label: '0%' },
             { value: 100, label: '100%' }
           ]}
@@ -136,54 +136,34 @@ class ValueInput extends React.Component {
       { value: 100, label: '100%' }
     ];
 
-    this.onValueChangeDiscrete = value => {
-        const step = this.stepsDiscrete.find(step => step.value === value);
-        let inputValue = step ? step.label : 0;
-        inputValue = Number(inputValue);
-        this.setState({
-          valueDiscrete: value,
-          inputValueDiscrete: inputValue
-        });
-    };
+    this.onChangeDiscrete = (value, inputValue) => {
 
-    this.onValueChangePercent = value => {
-        const step = this.stepsPercent.find(step => step.value === value);
-        let inputValue = step ? step.label.slice(0, -1) : 0;
-        inputValue = Number(inputValue);
-        this.setState({
-          valuePercent: value,
-          inputValuePercent: inputValue
-        });
-    };
-
-    this.onValueChangeContinuous = value => {
-      const newValue = Math.floor(value);
-      this.setState({
-        inputValueContinuous: newValue,
-        valueContinuous: newValue
-      });
-    };
-
-    this.onChangeDiscrete = value => {
       let newValue;
       let newInputValue;
 
-      const maxValue =  Number(this.stepsDiscrete[this.stepsDiscrete.length -1].label);
-      if (value > maxValue) {
-         newValue = Number(this.stepsDiscrete[this.stepsDiscrete.length -1].value);
-         newInputValue =  maxValue
+      if (!inputValue) { 
+        const step = this.stepsDiscrete.find(step => step.value === value);
+        newInputValue = step ? step.label : 0;
+        newInputValue = Number(newInputValue);
+        newValue = value;
       } else {
-        const stepIndex = this.stepsDiscrete.findIndex(step => Number(step.label) >= value);
-        if (Number(this.stepsDiscrete[stepIndex].label) === value) {
-          newValue = this.stepsDiscrete[stepIndex].value;
+        const maxValue =  Number(this.stepsDiscrete[this.stepsDiscrete.length -1].label);
+        if (inputValue > maxValue) {
+          newValue = Number(this.stepsDiscrete[this.stepsDiscrete.length -1].value);
+          newInputValue =  maxValue
         } else {
-          const midpoint = (Number(this.stepsDiscrete[stepIndex].label) + Number(this.stepsDiscrete[stepIndex - 1].label)) / 2;
-          if (midpoint > value) {
-            newValue = this.stepsDiscrete[stepIndex - 1].value;
-            newInputValue = Number(this.stepsDiscrete[stepIndex - 1].label);
-          } else {
+          const stepIndex = this.stepsDiscrete.findIndex(step => Number(step.label) >= inputValue);
+          if (Number(this.stepsDiscrete[stepIndex].label) === inputValue) {
             newValue = this.stepsDiscrete[stepIndex].value;
-            newInputValue = Number(this.stepsDiscrete[stepIndex].label);
+          } else {
+            const midpoint = (Number(this.stepsDiscrete[stepIndex].label) + Number(this.stepsDiscrete[stepIndex - 1].label)) / 2;
+            if (midpoint > inputValue) {
+              newValue = this.stepsDiscrete[stepIndex - 1].value;
+              newInputValue = Number(this.stepsDiscrete[stepIndex - 1].label);
+            } else {
+              newValue = this.stepsDiscrete[stepIndex].value;
+              newInputValue = Number(this.stepsDiscrete[stepIndex].label);
+            }
           }
         }
       }
@@ -194,26 +174,33 @@ class ValueInput extends React.Component {
       });
     };
 
-    this.onChangePercent = value => {
+    this.onChangePercent = (value, inputValue) => {
       let newValue;
       let newInputValue;
 
-      const maxValue =  Number(this.stepsPercent[this.stepsPercent.length -1].label.slice(0, -1));
-      if (value > maxValue) {
-         newValue = Number(this.stepsPercent[this.stepsPercent.length -1].value);
-         newInputValue =  maxValue
-      } else {
-        const stepIndex = this.stepsPercent.findIndex(step => Number(step.label.slice(0, -1)) >= value);
-        if (Number(this.stepsPercent[stepIndex].label.slice(0, -1)) === value) {
-          newValue = this.stepsPercent[stepIndex].value;
+      if (!inputValue) { 
+        const step = this.stepsPercent.find(step => step.value === value);
+        newInputValue = step ? step.label.slice(0, -1) : 0;
+        newInputValue = Number(newInputValue);
+        newValue = value;
+      }  else {
+        const maxValue =  Number(this.stepsPercent[this.stepsPercent.length -1].label.slice(0, -1));
+        if (inputValue > maxValue) {
+          newValue = Number(this.stepsPercent[this.stepsPercent.length -1].value);
+          newInputValue =  maxValue
         } else {
-          const midpoint = (Number(this.stepsPercent[stepIndex].label.slice(0, -1)) + Number(this.stepsPercent[stepIndex - 1].label.slice(0, -1))) / 2;
-          if (midpoint > value) {
-            newValue = this.stepsPercent[stepIndex - 1].value;
-            newInputValue = Number(this.stepsPercent[stepIndex - 1].label.slice(0, -1));
-          } else {
+          const stepIndex = this.stepsPercent.findIndex(step => Number(step.label.slice(0, -1)) >= inputValue);
+          if (Number(this.stepsPercent[stepIndex].label.slice(0, -1)) === inputValue) {
             newValue = this.stepsPercent[stepIndex].value;
-            newInputValue = Number(this.stepsPercent[stepIndex].label.slice(0, -1));
+          } else {
+            const midpoint = (Number(this.stepsPercent[stepIndex].label.slice(0, -1)) + Number(this.stepsPercent[stepIndex - 1].label.slice(0, -1))) / 2;
+            if (midpoint > inputValue) {
+              newValue = this.stepsPercent[stepIndex - 1].value;
+              newInputValue = Number(this.stepsPercent[stepIndex - 1].label.slice(0, -1));
+            } else {
+              newValue = this.stepsPercent[stepIndex].value;
+              newInputValue = Number(this.stepsPercent[stepIndex].label.slice(0, -1));
+            }
           }
         }
       }
@@ -238,31 +225,28 @@ class ValueInput extends React.Component {
       <>
         <Slider
           isDiscrete
-          currentValue={this.state.valueDiscrete}
+          value={this.state.valueDiscrete}
           isInputVisible
           inputValue={this.state.inputValueDiscrete}
-          steps={this.stepsDiscrete}
+          customSteps={this.stepsDiscrete}
           onChange={this.onChangeDiscrete}
-          onValueChange={this.onValueChangeDiscrete}
         />
         <br />
         <Slider
-          currentValue={this.state.valuePercent}
+          value={this.state.valuePercent}
           isInputVisible
           inputValue={this.state.inputValuePercent}
           inputLabel="%"
           isDiscrete
-          onValueChange={this.onValueChangePercent}
           onChange={this.onChangePercent}
-          steps={this.stepsPercent}
+          customSteps={this.stepsPercent}
         />
         <br />
         <Slider
-          currentValue={this.state.valueContinuous}
+          value={this.state.valueContinuous}
           isInputVisible
           inputValue={this.state.inputValueContinuous}
           inputLabel="%"
-          onValueChange={this.onValueChangeContinuous}
           onChange={this.onChangeContinuous}
         />
       </>
@@ -285,7 +269,7 @@ class ThumbValueInput extends React.Component {
       inputValue: 50
     };
 
-    this.onValueChange = value => {
+    this.onChange = value => {
       const newValue = Number(value).toFixed(2);
       this.setState({
         value: newValue,
@@ -305,13 +289,13 @@ class ThumbValueInput extends React.Component {
   render() {
     return (
       <Slider
-        currentValue={this.state.value}
+        value={this.state.value}
         isInputVisible
         inputValue={this.state.inputValue}
         inputLabel="%"
         inputPosition="aboveThumb"
         onChange={this.onChange}
-        onValueChange={this.onValueChange}
+        onChange={this.onChange}
       />
     );
   }
@@ -338,14 +322,14 @@ class SliderActions extends React.Component {
       isDisabled: false
     };
 
-    this.onValueChange1 = value => {
+    this.onChange1 = value => {
       const newValue = Math.floor(Number(value));
       this.setState({
         value1: newValue
       });
     };
 
-    this.onValueChange2 = value => {
+    this.onChange2 = value => {
       const newValue = Math.floor(Number(value));
       this.setState({
         value2: newValue,
@@ -403,8 +387,8 @@ class SliderActions extends React.Component {
       <>
         <Text component={TextVariants.h3}>Slider Value is: {this.state.value1}</Text>
         <Slider
-          currentValue={this.state.value1}
-          onValueChange={this.onValueChange1}
+          value={this.state.value1}
+          onChange={this.onChange1}
           leftActions={
             <Button variant="plain" aria-label="Minus" onClick={this.onMinusClick}>
               <MinusIcon />
@@ -419,9 +403,9 @@ class SliderActions extends React.Component {
         <br />
         <br />
         <Slider
-          currentValue={this.state.value2}
+          value={this.state.value2}
           inputValue={this.state.inputValue}
-          onValueChange={this.onValueChange2}
+          onChange={this.onChange2}
           onChange={this.onChange}
           inputLabel="%"
           isInputVisible

--- a/packages/react-core/src/components/Slider/examples/Slider.md
+++ b/packages/react-core/src/components/Slider/examples/Slider.md
@@ -24,7 +24,9 @@ class DiscreteInput extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      value: 50
+      value1: 50,
+      value2: 50,
+      value3: 25
     };
 
     this.steps = [
@@ -41,7 +43,19 @@ class DiscreteInput extends React.Component {
 
     this.onChange = value => {
         this.setState({
-          value
+          value1: value
+        });
+    };
+
+    this.onChange2 = value => {
+        this.setState({
+          value2: value
+        });
+    };
+
+    this.onChange3 = value => {
+        this.setState({
+          value3: value
         });
     };
   }
@@ -52,7 +66,15 @@ class DiscreteInput extends React.Component {
     return (
       <>
         <Text component={TextVariants.h3}>Slider value is: {displayValue}</Text>
-        <Slider isDiscrete value={this.state.value} onChange={this.onChange} customSteps={this.steps} />
+        <Slider value={this.state.value1} onChange={this.onChange} customSteps={this.steps} />
+        <br />
+        <Text component={TextVariants.h3}>Slider value is: {Math.floor(this.state.value2)}</Text>
+        <Text component={TextVariants.small}>(min = 0, max = 200, step = 50) </Text>
+        <Slider value={this.state.value2} onChange={this.onChange2} max={200} step={50} />
+        <br />
+        <Text component={TextVariants.h3}>Slider value is: {Math.floor(this.state.value3)}</Text>
+        <Text component={TextVariants.small}>(min = -25, max = 75, step = 10) </Text>
+        <Slider value={this.state.value3} onChange={this.onChange3} min={-25} max={75} step={10} showTicks />
       </>
     );
   }
@@ -69,12 +91,19 @@ class ContinuousInput extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      value: 50
+      value: 50,
+      valueCustom: 50
     };
 
     this.onChange = value => {
         this.setState({
           value: value
+        });
+    };
+
+    this.onChangeCustom = value => {
+        this.setState({
+          valueCustom: value
         });
     };
   }
@@ -86,7 +115,9 @@ class ContinuousInput extends React.Component {
         <Slider value={this.state.value} onChange={this.onChange} />
         <br />
         <Slider
-          value={50}
+          onChange={this.onChangeCustom}
+          value={this.state.valueCustom}
+          areCustomStepsContinuous
           customSteps={[
             { value: 0, label: '0%' },
             { value: 100, label: '100%' }
@@ -187,7 +218,7 @@ class ValueInput extends React.Component {
         const maxValue =  Number(this.stepsPercent[this.stepsPercent.length -1].label.slice(0, -1));
         if (inputValue > maxValue) {
           newValue = Number(this.stepsPercent[this.stepsPercent.length -1].value);
-          newInputValue =  maxValue
+          newInputValue =  maxValue;
         } else {
           const stepIndex = this.stepsPercent.findIndex(step => Number(step.label.slice(0, -1)) >= inputValue);
           if (Number(this.stepsPercent[stepIndex].label.slice(0, -1)) === inputValue) {
@@ -211,7 +242,7 @@ class ValueInput extends React.Component {
       });
     };
 
-    this.onChangeContinuous = value => { 
+    this.onChangeContinuous = (value) => { 
       const newValue = value > 100 ? 100 : Math.floor(value);
       this.setState({
         inputValueContinuous: newValue,
@@ -224,7 +255,6 @@ class ValueInput extends React.Component {
     return (
       <>
         <Slider
-          isDiscrete
           value={this.state.valueDiscrete}
           isInputVisible
           inputValue={this.state.inputValueDiscrete}
@@ -237,7 +267,6 @@ class ValueInput extends React.Component {
           isInputVisible
           inputValue={this.state.inputValuePercent}
           inputLabel="%"
-          isDiscrete
           onChange={this.onChangePercent}
           customSteps={this.stepsPercent}
         />
@@ -406,7 +435,6 @@ class SliderActions extends React.Component {
           value={this.state.value2}
           inputValue={this.state.inputValue}
           onChange={this.onChange2}
-          onChange={this.onChange}
           inputLabel="%"
           isInputVisible
           isDisabled={this.state.isDisabled}
@@ -456,7 +484,7 @@ class DiscreteInput extends React.Component {
     return (
       <>
         <Text component={TextVariants.h3}>Slider Value is: {displayValue}</Text>
-        <Slider isDisabled currentValue={this.state.value} onValueChange={this.onValueChange} steps={this.steps} />
+        <Slider isDisabled value={this.state.value} onChange={this.onValueChange} customSteps={this.steps} />
       </>
     );
   }

--- a/packages/react-integration/cypress/integration/slider.spec.ts
+++ b/packages/react-integration/cypress/integration/slider.spec.ts
@@ -5,8 +5,31 @@ describe('Slider Demo Test', () => {
     cy.url().should('eq', 'http://localhost:3000/slider-demo-nav-link');
   });
 
-  it('renders the discrete sliders', () => {
+  it('renders the discrete slider', () => {
     cy.get('#discrete-slider').should('exist');
     cy.get('#discrete-slider').should('have.attr', 'style', '--pf-c-slider--value:62.5%;');
+  });
+
+  it('changes discrete slider value when clicked on', () => {
+    cy.get('#discrete-slider > .pf-c-slider__main > .pf-c-slider__thumb')
+      .trigger('mousedown', { which: 1 })
+      .trigger('mousemove', { clientX: 300, clientY: 300 })
+      .trigger('mouseup', { force: true });
+  });
+
+  it('renders the slider with input', () => {
+    cy.get('#discrete-slider-input-label').should('exist');
+    cy.get('#discrete-slider-input-label > .pf-c-slider__value > .pf-c-input-group > .pf-c-form-control').should(
+      'exist'
+    );
+    cy.get('#discrete-slider-input-label > .pf-c-slider__value > .pf-c-input-group > .pf-c-input-group__text').should(
+      'exist'
+    );
+    cy.get('#discrete-slider-input-label').should('have.attr', 'style', '--pf-c-slider--value:50%;');
+  });
+
+  it('renders the continuous slider', () => {
+    cy.get('#continuous-slider').should('exist');
+    cy.get('#continuous-slider').should('have.attr', 'style', '--pf-c-slider--value:50%;');
   });
 });

--- a/packages/react-integration/demo-app-ts/src/components/demos/SliderDemo/SliderDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/SliderDemo/SliderDemo.tsx
@@ -44,44 +44,77 @@ export class SliderDemo extends Component<SliderDemoState> {
     { value: 100, label: '100%' }
   ];
 
-  onValueChangeDiscrete = (value: number) => {
-    if (value) {
+  onChangeDiscrete = (value: number, inputValue: number) => {
+    let newValue;
+    let newInputValue;
+
+    if (!inputValue) {
       const step = this.stepsDiscrete.find(step => step.value === value);
-      const inputValue = step ? step.label : undefined;
-      const inputValueNumber: number = Number(inputValue);
-      this.setState({
-        valueDiscrete: value,
-        inputValueDiscrete: inputValueNumber
-      });
+      newInputValue = step ? step.label : 0;
+      newInputValue = Number(newInputValue);
+      newValue = value;
+    } else {
+      const maxValue = Number(this.stepsDiscrete[this.stepsDiscrete.length - 1].label);
+      if (inputValue > maxValue) {
+        newValue = Number(this.stepsDiscrete[this.stepsDiscrete.length - 1].value);
+        newInputValue = maxValue;
+      } else {
+        const stepIndex = this.stepsDiscrete.findIndex(step => Number(step.label) >= inputValue);
+        if (Number(this.stepsDiscrete[stepIndex].label) === inputValue) {
+          newValue = this.stepsDiscrete[stepIndex].value;
+        } else {
+          const midpoint =
+            (Number(this.stepsDiscrete[stepIndex].label) + Number(this.stepsDiscrete[stepIndex - 1].label)) / 2;
+          if (midpoint > inputValue) {
+            newValue = this.stepsDiscrete[stepIndex - 1].value;
+            newInputValue = Number(this.stepsDiscrete[stepIndex - 1].label);
+          } else {
+            newValue = this.stepsDiscrete[stepIndex].value;
+            newInputValue = Number(this.stepsDiscrete[stepIndex].label);
+          }
+        }
+      }
     }
-  };
 
-  onValueChangePercent = (value: number) => {
-    if (value) {
-      const step = this.stepsPercent.find((step: any) => step.value === value);
-      const inputValue = step ? step.label.slice(0, -1) : undefined;
-      const inputValueNumber: number = Number(inputValue);
-      this.setState({
-        valuePercent: value,
-        inputValuePercent: inputValueNumber
-      });
-    }
-  };
-
-  onChangeValueContinuous = (value: number) => {
-    const newValue = Math.floor(value);
     this.setState({
-      inputValueContinuous: newValue,
-      valueContinuous: newValue
+      inputValueDiscrete: newInputValue,
+      valueDiscrete: newValue
     });
   };
 
-  onChangePercent = (value: number) => {
-    let newValue = this.state.valuePercent;
-    let newInputValue = this.state.inputValuePercent;
-    const step = this.stepsPercent.find(step => step.label === value.toString() + '%');
-    newValue = step ? step.value : this.state.valuePercent;
-    newInputValue = step ? Number(step.label.slice(0, -1)) : this.state.inputValuePercent;
+  onChangePercent = (value: number, inputValue: number) => {
+    let newValue;
+    let newInputValue;
+
+    if (!inputValue) {
+      const step = this.stepsPercent.find(step => step.value === value);
+      newInputValue = step ? step.label.slice(0, -1) : 0;
+      newInputValue = Number(newInputValue);
+      newValue = value;
+    } else {
+      const maxValue = Number(this.stepsPercent[this.stepsPercent.length - 1].label.slice(0, -1));
+      if (inputValue > maxValue) {
+        newValue = Number(this.stepsPercent[this.stepsPercent.length - 1].value);
+        newInputValue = maxValue;
+      } else {
+        const stepIndex = this.stepsPercent.findIndex(step => Number(step.label.slice(0, -1)) >= inputValue);
+        if (Number(this.stepsPercent[stepIndex].label.slice(0, -1)) === inputValue) {
+          newValue = this.stepsPercent[stepIndex].value;
+        } else {
+          const midpoint =
+            (Number(this.stepsPercent[stepIndex].label.slice(0, -1)) +
+              Number(this.stepsPercent[stepIndex - 1].label.slice(0, -1))) /
+            2;
+          if (midpoint > inputValue) {
+            newValue = this.stepsPercent[stepIndex - 1].value;
+            newInputValue = Number(this.stepsPercent[stepIndex - 1].label.slice(0, -1));
+          } else {
+            newValue = this.stepsPercent[stepIndex].value;
+            newInputValue = Number(this.stepsPercent[stepIndex].label.slice(0, -1));
+          }
+        }
+      }
+    }
     this.setState({
       inputValuePercent: newInputValue,
       valuePercent: newValue
@@ -89,9 +122,10 @@ export class SliderDemo extends Component<SliderDemoState> {
   };
 
   onChangeContinuous = (value: number) => {
+    const newValue = Math.floor(value);
     this.setState({
-      inputValueContinuous: value,
-      valueContinuous: value
+      inputValueContinuous: newValue,
+      valueContinuous: newValue
     });
   };
 
@@ -100,32 +134,28 @@ export class SliderDemo extends Component<SliderDemoState> {
       <>
         <Slider
           id="discrete-slider"
-          isDiscrete
-          currentValue={this.state.valueDiscrete}
-          steps={this.stepsDiscrete}
-          onValueChange={this.onValueChangeDiscrete}
+          value={this.state.valueDiscrete}
+          customSteps={this.stepsDiscrete}
+          onChange={this.onChangeDiscrete}
         />
         <br />
         <Slider
           id="discrete-slider-input-label"
-          currentValue={this.state.valuePercent}
+          value={this.state.valuePercent}
           isInputVisible
           inputValue={this.state.inputValuePercent}
           inputLabel="%"
-          isDiscrete
-          onValueChange={this.onValueChangePercent}
           onChange={this.onChangePercent}
-          steps={this.stepsPercent}
+          customSteps={this.stepsPercent}
         />
         <br />
         <Slider
           id="continuous-slider"
-          currentValue={this.state.valueContinuous}
+          value={this.state.valueContinuous}
           isInputVisible
           inputPosition="aboveThumb"
           inputValue={this.state.inputValueContinuous}
           inputLabel="%"
-          onValueChange={this.onChangeValueContinuous}
           onChange={this.onChangeContinuous}
         />
       </>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5464, #5529 

- Added `min`, `max` and `step` props to match the HTML range input API 
- changed prop name `steps` to `customSteps` to be less confusing.
- renamed `currentValue` prop to `value` to match  HTML rang input
- Added `showTicks` prop so the consumer can choose to show ticks when they use the `min`, `max` and `step` props
- Removed the `isDiscrete ` prop and added `areCustomStepsContinuous` prop.  A slider with out custom steps is continuous by default.    A slider with custom steps is discrete unless the `areCustomStepsContinuous` is set to true. This allows the consumer to add labels to a continuous slider.
- Updated Slider to have only one `onChange` callback
- Fixed onChange not getting called for continuous sliders.