### PR TITLE
feat(Table): Add optional icons to tree table rows, add responsive view

### DIFF
--- a/packages/react-catalog-view-extension/package.json
+++ b/packages/react-catalog-view-extension/package.json
@@ -35,7 +35,7 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
-    "@patternfly/patternfly": "4.96.3",
+    "@patternfly/patternfly": "4.102.0",
     "@patternfly/react-core": "^4.111.0",
     "@patternfly/react-styles": "^4.9.5",
     "classnames": "^2.2.5",

--- a/packages/react-console/package.json
+++ b/packages/react-console/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@novnc/novnc": "^1.2.0",
-    "@patternfly/patternfly": "4.96.3",
+    "@patternfly/patternfly": "4.102.0",
     "@patternfly/react-core": "^4.111.0",
     "@spice-project/spice-html5": "^0.2.1",
     "@types/file-saver": "^2.0.1",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -44,7 +44,7 @@
     "tslib": "1.13.0"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "4.101.0",
+    "@patternfly/patternfly": "4.102.0",
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",
     "@rollup/plugin-replace": "^2.3.1",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -44,7 +44,7 @@
     "tslib": "1.13.0"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "4.96.3",
+    "@patternfly/patternfly": "4.97.0",
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",
     "@rollup/plugin-replace": "^2.3.1",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -44,7 +44,7 @@
     "tslib": "1.13.0"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "4.99.0",
+    "@patternfly/patternfly": "4.101.0",
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",
     "@rollup/plugin-replace": "^2.3.1",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -44,7 +44,7 @@
     "tslib": "1.13.0"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "4.97.0",
+    "@patternfly/patternfly": "4.99.0",
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",
     "@rollup/plugin-replace": "^2.3.1",

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -22,7 +22,7 @@
     "test:a11y": "patternfly-a11y --config patternfly-a11y.config"
   },
   "dependencies": {
-    "@patternfly/patternfly": "4.96.3",
+    "@patternfly/patternfly": "4.102.0",
     "@patternfly/react-catalog-view-extension": "^4.10.43",
     "@patternfly/react-charts": "^6.14.13",
     "@patternfly/react-code-editor": "^4.2.33",

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -32,7 +32,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.14.0",
     "@fortawesome/free-regular-svg-icons": "^5.14.0",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
-    "@patternfly/patternfly": "4.97.0",
+    "@patternfly/patternfly": "4.99.0",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",
     "rimraf": "^2.6.2",

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -32,7 +32,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.14.0",
     "@fortawesome/free-regular-svg-icons": "^5.14.0",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
-    "@patternfly/patternfly": "4.101.0",
+    "@patternfly/patternfly": "4.102.0",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",
     "rimraf": "^2.6.2",

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -32,7 +32,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.14.0",
     "@fortawesome/free-regular-svg-icons": "^5.14.0",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
-    "@patternfly/patternfly": "4.96.3",
+    "@patternfly/patternfly": "4.97.0",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",
     "rimraf": "^2.6.2",

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -32,7 +32,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.14.0",
     "@fortawesome/free-regular-svg-icons": "^5.14.0",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
-    "@patternfly/patternfly": "4.99.0",
+    "@patternfly/patternfly": "4.101.0",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",
     "rimraf": "^2.6.2",

--- a/packages/react-styles/package.json
+++ b/packages/react-styles/package.json
@@ -19,7 +19,7 @@
     "clean": "rimraf dist css"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "4.97.0",
+    "@patternfly/patternfly": "4.99.0",
     "camel-case": "^3.0.0",
     "css": "^2.2.3",
     "fs-extra": "^6.0.1",

--- a/packages/react-styles/package.json
+++ b/packages/react-styles/package.json
@@ -19,7 +19,7 @@
     "clean": "rimraf dist css"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "4.99.0",
+    "@patternfly/patternfly": "4.101.0",
     "camel-case": "^3.0.0",
     "css": "^2.2.3",
     "fs-extra": "^6.0.1",

--- a/packages/react-styles/package.json
+++ b/packages/react-styles/package.json
@@ -19,7 +19,7 @@
     "clean": "rimraf dist css"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "4.101.0",
+    "@patternfly/patternfly": "4.102.0",
     "camel-case": "^3.0.0",
     "css": "^2.2.3",
     "fs-extra": "^6.0.1",

--- a/packages/react-styles/package.json
+++ b/packages/react-styles/package.json
@@ -19,7 +19,7 @@
     "clean": "rimraf dist css"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "4.96.3",
+    "@patternfly/patternfly": "4.97.0",
     "camel-case": "^3.0.0",
     "css": "^2.2.3",
     "fs-extra": "^6.0.1",

--- a/packages/react-table/src/components/Table/TableTypes.ts
+++ b/packages/react-table/src/components/Table/TableTypes.ts
@@ -69,6 +69,7 @@ export type OnFavorite = (
   extraData: IExtraData
 ) => void;
 export type OnTreeRowCollapse = (event: any, rowIndex: number, title: React.ReactNode, rowData: IRowData) => void;
+export type OnToggleRowDetails = (event: any, rowIndex: number, title: React.ReactNode, rowData: IRowData) => void;
 export type OnCheckChange = (
   event: React.FormEvent<HTMLInputElement>,
   isChecked: boolean,

--- a/packages/react-table/src/components/Table/TreeRowWrapper.tsx
+++ b/packages/react-table/src/components/Table/TreeRowWrapper.tsx
@@ -29,7 +29,6 @@ export const TreeRowWrapper: React.FunctionComponent<RowWrapperProps> = ({
       isHidden={isHidden}
       className={css(
         className,
-        isExpanded && 'pf-m-expandable',
         isExpanded && styles.modifiers.expanded,
         isDetailsExpanded && stylesTreeView.modifiers.treeViewDetailsExpanded
       )}

--- a/packages/react-table/src/components/Table/TreeRowWrapper.tsx
+++ b/packages/react-table/src/components/Table/TreeRowWrapper.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
+import stylesTreeView from '@patternfly/react-styles/css/components/Table/table-tree-view';
 import { RowWrapperProps } from './RowWrapper';
 import { Tr } from '../TableComposable';
 
@@ -11,7 +12,14 @@ export const TreeRowWrapper: React.FunctionComponent<RowWrapperProps> = ({
   row,
   ...props
 }: RowWrapperProps) => {
-  const { 'aria-level': level, 'aria-posinset': posinset, 'aria-setsize': setsize, isExpanded, isHidden } = row.props;
+  const {
+    'aria-level': level,
+    'aria-posinset': posinset,
+    'aria-setsize': setsize,
+    isExpanded,
+    isDetailsExpanded,
+    isHidden
+  } = row.props;
   return (
     <Tr
       aria-level={level}
@@ -19,7 +27,12 @@ export const TreeRowWrapper: React.FunctionComponent<RowWrapperProps> = ({
       aria-setsize={setsize}
       aria-expanded={!!isExpanded}
       isHidden={isHidden}
-      className={css(className, isExpanded && 'pf-m-expandable', isExpanded && styles.modifiers.expanded)}
+      className={css(
+        className,
+        isExpanded && 'pf-m-expandable',
+        isExpanded && styles.modifiers.expanded,
+        isDetailsExpanded && stylesTreeView.modifiers.treeViewDetailsExpanded
+      )}
       {...props}
     />
   );

--- a/packages/react-table/src/components/Table/examples/Table.md
+++ b/packages/react-table/src/components/Table/examples/Table.md
@@ -26,6 +26,9 @@ import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon';
 import CodeBranchIcon from '@patternfly/react-icons/dist/js/icons/code-branch-icon';
 import CodeIcon from '@patternfly/react-icons/dist/js/icons/code-icon';
 import CubeIcon from '@patternfly/react-icons/dist/js/icons/cube-icon';
+import LeafIcon from '@patternfly/react-icons/dist/js/icons/leaf-icon';
+import FolderIcon from '@patternfly/react-icons/dist/js/icons/folder-icon';
+import FolderOpenIcon from '@patternfly/react-icons/dist/js/icons/folder-open-icon';
 
 import { ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
 
@@ -2003,7 +2006,8 @@ To enable a tree table:
     - `aria-level` - number representing how many levels deep this node is nested
     - `aria-posinset` - number representing where in the order this node sits amongst its siblings 
     - `aria-setsize` - number representing the number of children this node has
-    - `isChecked` - (optional) if this row uses checkboxes, flag indicating the checkbox checked
+    - `isChecked` - (optional) boolean used if this row uses checkboxes, flag indicating the checkbox checked
+    -  `icon` - (optional) ReactNode icon to display before the row title
 3. Use the `treeRow` cellTransform in the first column of the table. `treeRow` expects one or two callbacks as params.
     - `onCollapse` - Callback when user expands/collapses a row to reveal/hide the row's children.
     - `onCheckChange` - (optional) Callback when user changes the checkbox on a row.
@@ -2017,6 +2021,9 @@ import React from 'react';
 import { Table, TableHeader, TableBody, headerCol, treeRow } from '@patternfly/react-table';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
+import LeafIcon from '@patternfly/react-icons/dist/js/icons/leaf-icon';
+import FolderIcon from '@patternfly/react-icons/dist/js/icons/folder-icon';
+import FolderOpenIcon from '@patternfly/react-icons/dist/js/icons/folder-open-icon';
 
 class TreeTable extends React.Component {
   constructor(props) {
@@ -2095,6 +2102,11 @@ class TreeTable extends React.Component {
       if (x) {
         const isExpanded = this.state.expandedRows.includes(x.repositories);
         const isChecked = this.state.checkedRows.includes(x.repositories);
+        let icon = <LeafIcon />;
+        if (x.children) {
+          icon = isExpanded ? <FolderOpenIcon /> : <FolderIcon/>;
+        }
+        
         return [
           {
             cells: [x.repositories, x.branches, x.pullRequests, x.workspaces],
@@ -2104,7 +2116,8 @@ class TreeTable extends React.Component {
               'aria-level': level,
               'aria-posinset': posinset,
               'aria-setsize': x.children ? x.children.length : 0,
-              isChecked
+              isChecked,
+              icon
             }
           },
           ...(x.children && x.children.length) ? this.buildRows(x.children, level + 1, 1, !isExpanded || isHidden) : [],
@@ -3266,6 +3279,7 @@ To enable a tree table:
     - `aria-posinset` - number representing where in the order this node sits amongst its siblings 
     - `aria-setsize` - number representing the number of children this node has
     - `isChecked` - (optional) if this row uses checkboxes, flag indicating the checkbox checked
+    -  `icon` - (optional) ReactNode icon to display before the row title
 4. The first `Td` in each row will pass the following to the `treeRow` prop:
     - `onCollapse` - Callback when user expands/collapses a row to reveal/hide the row's children.
     - `onCheckChange` - (optional) Callback when user changes the checkbox on a row.
@@ -3280,6 +3294,9 @@ the voice over technologies will recognize the flat table structure as a tree.
 import React from 'react';
 import { TableComposable, Thead, Tbody, Tr, Th, Td, Caption, TreeRowWrapper } from '@patternfly/react-table';
 import { ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
+import LeafIcon from '@patternfly/react-icons/dist/js/icons/leaf-icon';
+import FolderIcon from '@patternfly/react-icons/dist/js/icons/folder-icon';
+import FolderOpenIcon from '@patternfly/react-icons/dist/js/icons/folder-open-icon';
 
 class TreeTable extends React.Component {
   constructor(props) {
@@ -3359,6 +3376,10 @@ class TreeTable extends React.Component {
       if (x) {
         const isExpanded = this.state.expandedRows.includes(x.repositories);
         const isChecked = this.state.checkedRows.includes(x.repositories);
+        let icon = <LeafIcon />;
+        if (x.children) {
+          icon = isExpanded ? <FolderOpenIcon /> : <FolderIcon/>;
+        }
         return [
           {
             cells: [x.repositories, x.branches, x.pullRequests, x.workspaces],
@@ -3368,7 +3389,8 @@ class TreeTable extends React.Component {
               'aria-level': level,
               'aria-posinset': posinset,
               'aria-setsize': x.children ? x.children.length : 0,
-              isChecked
+              isChecked,
+              icon
             }
           },
           ...(x.children && x.children.length) ? this.buildRows(x.children, level + 1, 1, !isExpanded || isHidden) : [],

--- a/packages/react-table/src/components/Table/examples/Table.md
+++ b/packages/react-table/src/components/Table/examples/Table.md
@@ -2109,7 +2109,7 @@ class TreeTable extends React.Component {
         const isChecked = this.state.checkedRows.includes(x.repositories);
         let icon = <LeafIcon />;
         if (x.children) {
-          icon = isExpanded ? <FolderOpenIcon /> : <FolderIcon/>;
+          icon = isExpanded ? <FolderOpenIcon aria-hidden /> : <FolderIcon aria-hidden />;
         }
         
         return [
@@ -3403,7 +3403,7 @@ class TreeTable extends React.Component {
         const isChecked = this.state.checkedRows.includes(x.repositories);
         let icon = <LeafIcon />;
         if (x.children) {
-          icon = isExpanded ? <FolderOpenIcon /> : <FolderIcon/>;
+          icon = isExpanded ? <FolderOpenIcon aria-hidden /> : <FolderIcon aria-hidden />;
         }
         return [
           {

--- a/packages/react-table/src/components/Table/examples/Table.md
+++ b/packages/react-table/src/components/Table/examples/Table.md
@@ -2002,15 +2002,20 @@ To enable a tree table:
 1. Pass the `isTreeTable` prop to the `Table` component
 2. Pass the following props to each row:
     - `isExpanded` - Flag indicating the node is expanded and its children are visible
+    - `isDetailsExpanded` - (optional) Flag indicating the row's details are visible in responsive view
     - `isHidden` - Flag indicating the node's parent is expanded and this node is visible
     - `aria-level` - number representing how many levels deep this node is nested
     - `aria-posinset` - number representing where in the order this node sits amongst its siblings 
     - `aria-setsize` - number representing the number of children this node has
     - `isChecked` - (optional) boolean used if this row uses checkboxes, flag indicating the checkbox checked
-    -  `icon` - (optional) ReactNode icon to display before the row title
+    - `icon` - (optional) ReactNode icon to display before the row title
+    - `toggleAriaLabel` - (optional) accessible label for the expand/collapse children rows toggle arrow
+    - `checkAriaLabel` - (optional) accessible label for the checkbox
+    - `showDetailsAriaLabel` - (optional) accessible label for the show row details button in the responsive view
 3. Use the `treeRow` cellTransform in the first column of the table. `treeRow` expects one or two callbacks as params.
     - `onCollapse` - Callback when user expands/collapses a row to reveal/hide the row's children.
     - `onCheckChange` - (optional) Callback when user changes the checkbox on a row.
+    - `onToggleRowDetails` - (optional) Callback when user shows/hides the row details in responsive view.
 
 Note: If this table is going to be tested using axe-core, the tests will flag the use of aria-level, 
 aria-posinset, and aria-setsize as violations. This is an intentional choice at this time so that
@@ -2019,8 +2024,6 @@ the voice over technologies will recognize the flat table structure as a tree.
 ```js
 import React from 'react';
 import { Table, TableHeader, TableBody, headerCol, treeRow } from '@patternfly/react-table';
-import { css } from '@patternfly/react-styles';
-import styles from '@patternfly/react-styles/css/components/Table/table';
 import LeafIcon from '@patternfly/react-icons/dist/js/icons/leaf-icon';
 import FolderIcon from '@patternfly/react-icons/dist/js/icons/folder-icon';
 import FolderOpenIcon from '@patternfly/react-icons/dist/js/icons/folder-open-icon';
@@ -2086,6 +2089,7 @@ class TreeTable extends React.Component {
         }
       ],
       expandedRows: ['Repositories one', 'Repositories six'],
+      expandedDetailsRows: [],
       checkedRows: []
     };
     
@@ -2101,6 +2105,7 @@ class TreeTable extends React.Component {
     this.buildRows = ([x, ...xs], level, posinset, isHidden = false) => {
       if (x) {
         const isExpanded = this.state.expandedRows.includes(x.repositories);
+        const isDetailsExpanded = this.state.expandedDetailsRows.includes(x.repositories);
         const isChecked = this.state.checkedRows.includes(x.repositories);
         let icon = <LeafIcon />;
         if (x.children) {
@@ -2112,6 +2117,7 @@ class TreeTable extends React.Component {
             cells: [x.repositories, x.branches, x.pullRequests, x.workspaces],
             props: {
               isExpanded,
+              isDetailsExpanded,
               isHidden,
               'aria-level': level,
               'aria-posinset': posinset,
@@ -2127,7 +2133,19 @@ class TreeTable extends React.Component {
       return [];
     };
     
+    this.onToggleRowDetails = (event, rowIndex, title) => {
+      this.setState(prevState => {
+        const { expandedDetailsRows } = prevState;
+        const openedIndex = expandedDetailsRows.indexOf(title);
+        const newExpandedDetailsRows = openedIndex === -1 ? [...expandedDetailsRows, title] : expandedDetailsRows.filter(o => o !== title);
+        return {
+          expandedDetailsRows: newExpandedDetailsRows
+        }
+      });
+    };
+    
     this.onCollapse = (event, rowIndex, title) => {
+      console.log(title);
       this.setState(prevState => {
         const { expandedRows } = prevState;
         const openedIndex = expandedRows.indexOf(title);
@@ -2156,7 +2174,7 @@ class TreeTable extends React.Component {
         isTreeTable
         aria-label="Tree table"
         cells={[
-          { title: 'Repositories', cellTransforms: [treeRow(this.onCollapse, this.onCheckChange)] }, 
+          { title: 'Repositories', cellTransforms: [treeRow(this.onCollapse, this.onCheckChange, this.onToggleRowDetails)] }, 
           'Branches', 
           { title: 'Pull requests' }, 
           'Workspaces']}
@@ -3274,15 +3292,20 @@ To enable a tree table:
 2. Use a `TreeRowWrapper` rather than `Tr`
 3. Pass the following `props` to each row (both the `TreeRowWrapper` and the `treeRow` in the first column):
     - `isExpanded` - Flag indicating the node is expanded and its children are visible
+    - `isDetailsExpanded` - (optional) Flag indicating the row's details are visible in responsive view
     - `isHidden` - Flag indicating the node's parent is expanded and this node is visible
     - `aria-level` - number representing how many levels deep this node is nested
     - `aria-posinset` - number representing where in the order this node sits amongst its siblings 
     - `aria-setsize` - number representing the number of children this node has
     - `isChecked` - (optional) if this row uses checkboxes, flag indicating the checkbox checked
-    -  `icon` - (optional) ReactNode icon to display before the row title
+    - `icon` - (optional) ReactNode icon to display before the row title
+    - `toggleAriaLabel` - (optional) accessible label for the expand/collapse children rows toggle arrow
+    - `checkAriaLabel` - (optional) accessible label for the checkbox
+    - `showDetailsAriaLabel` - (optional) accessible label for the show row details button in the responsive view
 4. The first `Td` in each row will pass the following to the `treeRow` prop:
     - `onCollapse` - Callback when user expands/collapses a row to reveal/hide the row's children.
     - `onCheckChange` - (optional) Callback when user changes the checkbox on a row.
+    - `onToggleRowDetails` - (optional) Callback when user shows/hides the row details in responsive view.
     - `props` - (as defined above)
     - `rowIndex` - number representing the index of the row
     
@@ -3359,6 +3382,7 @@ class TreeTable extends React.Component {
         }
       ],
       expandedRows: ['Repositories one', 'Repositories six'],
+      expandedDetailsRows: [],
       checkedRows: []
     };
     
@@ -3375,6 +3399,7 @@ class TreeTable extends React.Component {
       // take the first datum from the array (if any)
       if (x) {
         const isExpanded = this.state.expandedRows.includes(x.repositories);
+        const isDetailsExpanded = this.state.expandedDetailsRows.includes(x.repositories);
         const isChecked = this.state.checkedRows.includes(x.repositories);
         let icon = <LeafIcon />;
         if (x.children) {
@@ -3385,6 +3410,7 @@ class TreeTable extends React.Component {
             cells: [x.repositories, x.branches, x.pullRequests, x.workspaces],
             props: {
               isExpanded,
+              isDetailsExpanded,
               isHidden,
               'aria-level': level,
               'aria-posinset': posinset,
@@ -3421,6 +3447,17 @@ class TreeTable extends React.Component {
         }
       });
     }
+    
+    this.onToggleRowDetails = (event, rowIndex, title) => {
+      this.setState(prevState => {
+        const { expandedDetailsRows } = prevState;
+        const openedIndex = expandedDetailsRows.indexOf(title);
+        const newExpandedDetailsRows = openedIndex === -1 ? [...expandedDetailsRows, title] : expandedDetailsRows.filter(o => o !== title);
+        return {
+          expandedDetailsRows: newExpandedDetailsRows
+        }
+      });
+    };
   }
 
   render() {
@@ -3442,13 +3479,14 @@ class TreeTable extends React.Component {
                 <Td key={cellIndex} treeRow={{
                   onCollapse: this.onCollapse, 
                   onCheckChange: this.onCheckChange,
+                  onToggleRowDetails: this.onToggleRowDetails,
                   props: row.props,
                   rowIndex: rowIndex
                 }}>
                   {cell}
                 </Td>
               ) : (
-                <Td key={cellIndex}>{cell}</Td>
+                <Td key={cellIndex} data-label={columns[cellIndex]}>{cell}</Td>
               ))}
             </TreeRowWrapper>
           ))}

--- a/packages/react-table/src/components/Table/utils/decorators/treeRow.tsx
+++ b/packages/react-table/src/components/Table/utils/decorators/treeRow.tsx
@@ -71,7 +71,6 @@ export const treeRow = (
               <Button
                 variant="plain"
                 aria-expanded={isDetailsExpanded}
-                className={css(isDetailsExpanded && styles.modifiers.expanded)}
                 aria-label={showDetailsAriaLabel || 'Show row details'}
                 onClick={event => onToggleRowDetails && onToggleRowDetails(event, rowIndex, content, rowData)}
               >

--- a/packages/react-table/src/components/Table/utils/decorators/treeRow.tsx
+++ b/packages/react-table/src/components/Table/utils/decorators/treeRow.tsx
@@ -17,11 +17,13 @@ export const treeRow = (onCollapse: OnTreeRowCollapse, onCheckChange?: OnCheckCh
     toggleAriaLabel,
     checkAriaLabel,
     isChecked,
-    checkboxId
+    checkboxId,
+    icon
   } = rowData.props;
   const content = value.title || value;
   const text = (
     <div className={css(stylesTreeView.tableTreeViewContent)}>
+      {icon && <span className={css(stylesTreeView.tableTreeViewIcon)}>{icon}</span>}
       <span className="pf-c-table__text">{content}</span>
     </div>
   );

--- a/packages/react-table/src/components/Table/utils/decorators/treeRow.tsx
+++ b/packages/react-table/src/components/Table/utils/decorators/treeRow.tsx
@@ -75,7 +75,7 @@ export const treeRow = (
                 onClick={event => onToggleRowDetails && onToggleRowDetails(event, rowIndex, content, rowData)}
               >
                 <span className="pf-c-table__details-toggle-icon">
-                  <EllipsisHIcon />
+                  <EllipsisHIcon aria-hidden />
                 </span>
               </Button>
             </span>

--- a/packages/react-table/src/components/Table/utils/decorators/treeRow.tsx
+++ b/packages/react-table/src/components/Table/utils/decorators/treeRow.tsx
@@ -1,21 +1,25 @@
 import * as React from 'react';
-import { IExtra, IFormatterValueType, OnCheckChange, OnTreeRowCollapse } from '../../TableTypes';
+import { IExtra, IFormatterValueType, OnCheckChange, OnTreeRowCollapse, OnToggleRowDetails } from '../../TableTypes';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 import stylesTreeView from '@patternfly/react-styles/css/components/Table/table-tree-view';
 import { Button, Checkbox } from '@patternfly/react-core';
 import AngleDownIcon from '@patternfly/react-icons/dist/js/icons/angle-down-icon';
+import EllipsisHIcon from '@patternfly/react-icons/dist/js/icons/ellipsis-h-icon';
 
-export const treeRow = (onCollapse: OnTreeRowCollapse, onCheckChange?: OnCheckChange) => (
-  value: IFormatterValueType,
-  { rowIndex, rowData }: IExtra
-) => {
+export const treeRow = (
+  onCollapse: OnTreeRowCollapse,
+  onCheckChange?: OnCheckChange,
+  onToggleRowDetails?: OnToggleRowDetails
+) => (value: IFormatterValueType, { rowIndex, rowData }: IExtra) => {
   const {
     isExpanded,
+    isDetailsExpanded,
     'aria-level': level,
     'aria-setsize': setsize,
     toggleAriaLabel,
     checkAriaLabel,
+    showDetailsAriaLabel,
     isChecked,
     checkboxId,
     icon
@@ -31,7 +35,6 @@ export const treeRow = (onCollapse: OnTreeRowCollapse, onCheckChange?: OnCheckCh
     onCheckChange(event, isChecked, rowIndex, content, rowData);
   };
   return {
-    value,
     component: 'th',
     className: 'pf-c-table__tree-view-title-cell',
     children:
@@ -63,6 +66,21 @@ export const treeRow = (onCollapse: OnTreeRowCollapse, onCheckChange?: OnCheckCh
             </span>
           )}
           {text}
+          {!!onToggleRowDetails && (
+            <span className={css(stylesTreeView.tableTreeViewDetailsToggle)}>
+              <Button
+                variant="plain"
+                aria-expanded={isDetailsExpanded}
+                className={css(isDetailsExpanded && styles.modifiers.expanded)}
+                aria-label={showDetailsAriaLabel || 'Show row details'}
+                onClick={event => onToggleRowDetails && onToggleRowDetails(event, rowIndex, content, rowData)}
+              >
+                <span className="pf-c-table__details-toggle-icon">
+                  <EllipsisHIcon />
+                </span>
+              </Button>
+            </span>
+          )}
         </div>
       ) : (
         text

--- a/packages/react-table/src/components/Table/utils/decorators/treeRow.tsx
+++ b/packages/react-table/src/components/Table/utils/decorators/treeRow.tsx
@@ -22,7 +22,7 @@ export const treeRow = (onCollapse: OnTreeRowCollapse, onCheckChange?: OnCheckCh
   } = rowData.props;
   const content = value.title || value;
   const text = (
-    <div className={css(stylesTreeView.tableTreeViewContent)}>
+    <div className={css(stylesTreeView.tableTreeViewText)}>
       {icon && <span className={css(stylesTreeView.tableTreeViewIcon)}>{icon}</span>}
       <span className="pf-c-table__text">{content}</span>
     </div>

--- a/packages/react-table/src/components/TableComposable/TableComposable.tsx
+++ b/packages/react-table/src/components/TableComposable/TableComposable.tsx
@@ -77,6 +77,16 @@ const TableComposableBase: React.FunctionComponent<TableComposableProps> = ({
     stylesGrid.modifiers?.[
       toCamel(gridBreakPoint || '').replace(/-?2xl/, '_2xl') as 'grid' | 'gridMd' | 'gridLg' | 'gridXl' | 'grid_2xl'
     ];
+  const breakPointPrefix = `treeView${gridBreakPoint.charAt(0).toUpperCase() + gridBreakPoint.slice(1)}`;
+  const treeGrid =
+    stylesTreeView.modifiers?.[
+      toCamel(breakPointPrefix || '').replace(/-?2xl/, '_2xl') as
+        | 'treeViewGrid'
+        | 'treeViewGridMd'
+        | 'treeViewGridLg'
+        | 'treeViewGridXl'
+        | 'treeViewGrid_2xl'
+    ];
   return (
     <table
       aria-label={ariaLabel}
@@ -84,7 +94,7 @@ const TableComposableBase: React.FunctionComponent<TableComposableProps> = ({
       className={css(
         className,
         styles.table,
-        !isTreeTable && grid,
+        isTreeTable ? treeGrid : grid,
         styles.modifiers[variant],
         !borders && styles.modifiers.noBorderRows,
         isStickyHeader && styles.modifiers.stickyHeader,

--- a/packages/react-table/src/components/TableComposable/Td.tsx
+++ b/packages/react-table/src/components/TableComposable/Td.tsx
@@ -230,9 +230,14 @@ const TdBase: React.FunctionComponent<TdProps> = ({
     component: MergedComponent = component,
     ...mergedProps
   } = merged;
+
+  const treeTableTitleCell =
+    (className && className.includes('pf-c-table__tree-view-title-cell')) ||
+    (mergedClassName && mergedClassName.includes('pf-c-table__tree-view-title-cell'));
+
   return (
     <MergedComponent
-      data-label={dataLabel}
+      {...(!treeTableTitleCell && { 'data-label': dataLabel })}
       className={css(
         className,
         textCenter && styles.modifiers.center,

--- a/packages/react-table/src/components/TableComposable/Td.tsx
+++ b/packages/react-table/src/components/TableComposable/Td.tsx
@@ -25,7 +25,8 @@ import {
   OnFavorite,
   OnCheckChange,
   OnTreeRowCollapse,
-  IExtra
+  IExtra,
+  OnToggleRowDetails
 } from '../Table/TableTypes';
 export interface TdProps extends BaseCellProps, Omit<React.HTMLProps<HTMLTableDataCellElement>, 'onSelect' | 'width'> {
   /**
@@ -85,10 +86,12 @@ export interface TdProps extends BaseCellProps, Omit<React.HTMLProps<HTMLTableDa
     props?: any;
   };
   treeRow?: {
-    /** */
+    /** Callback when user expands/collapses a row to reveal/hide the row's children */
     onCollapse: OnTreeRowCollapse;
-    /** */
-    onCheckChange: OnCheckChange;
+    /** (optional) Callback when user changes the checkbox on a row */
+    onCheckChange?: OnCheckChange;
+    /** (optional) Callback when user shows/hides the row details in responsive view. */
+    onToggleRowDetails?: OnToggleRowDetails;
     /** The row index */
     rowIndex?: number;
     /** Additional props forwarded to the title cell of the tree row */
@@ -199,7 +202,11 @@ const TdBase: React.FunctionComponent<TdProps> = ({
     : null;
   const treeRowParams =
     treeRowProp !== null
-      ? treeRow(treeRowProp.onCollapse, treeRowProp.onCheckChange)(
+      ? treeRow(
+          treeRowProp.onCollapse,
+          treeRowProp.onCheckChange,
+          treeRowProp.onToggleRowDetails
+        )(
           {
             title: children
           } as IFormatterValueType,

--- a/packages/react-tokens/package.json
+++ b/packages/react-tokens/package.json
@@ -29,7 +29,7 @@
     "clean": "rimraf dist"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "4.101.0",
+    "@patternfly/patternfly": "4.102.0",
     "css": "^2.2.3",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",

--- a/packages/react-tokens/package.json
+++ b/packages/react-tokens/package.json
@@ -29,7 +29,7 @@
     "clean": "rimraf dist"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "4.97.0",
+    "@patternfly/patternfly": "4.99.0",
     "css": "^2.2.3",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",

--- a/packages/react-tokens/package.json
+++ b/packages/react-tokens/package.json
@@ -29,7 +29,7 @@
     "clean": "rimraf dist"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "4.96.3",
+    "@patternfly/patternfly": "4.97.0",
     "css": "^2.2.3",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",

--- a/packages/react-tokens/package.json
+++ b/packages/react-tokens/package.json
@@ -29,7 +29,7 @@
     "clean": "rimraf dist"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "4.99.0",
+    "@patternfly/patternfly": "4.101.0",
     "css": "^2.2.3",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3236,10 +3236,10 @@
     webpack-dev-server "^3.11.0"
     xmldoc "^1.1.2"
 
-"@patternfly/patternfly@4.101.0":
-  version "4.101.0"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.101.0.tgz#6485d05ac44a0de3ec45f4692a2a21ee8a274853"
-  integrity sha512-BMUGqFPT8PzE1nNYb+Mn1M2NnLtNLP2CkFU2rji5tUm3pugMFh9+49OOGzaNQK0Om9BLOrMF7mIKD4XTm10h2g==
+"@patternfly/patternfly@4.102.0":
+  version "4.102.0"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.102.0.tgz#14aeacba12185d61c6626a5671626e62b5153e30"
+  integrity sha512-Gvn7oVsLL2MqeoeTaw0NKKCDaAnMZnEdd4G2vrbSgoSKqNx4WaqGm5hZ98ZJ0EiPvCqf2i/x0y5sEX/wCNtRbg==
 
 "@reach/router@^1.2.1", "@reach/router@^1.3.4":
   version "1.3.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3236,10 +3236,10 @@
     webpack-dev-server "^3.11.0"
     xmldoc "^1.1.2"
 
-"@patternfly/patternfly@4.96.3":
-  version "4.96.3"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.96.3.tgz#518e958a7ca0b6b8d8ec05741b5224f83d8fea36"
-  integrity sha512-f9blcxesGN/Nh3Xdr7CbaDCwyRVULymFlZkaL/TMxEJWhE4Ly5ZLv85aFmcf9gyQnACTmNH3FZhlA49NBV9gAQ==
+"@patternfly/patternfly@4.97.0":
+  version "4.97.0"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.97.0.tgz#e6d61481b773833a8768f7959ad9b80fdf92df0c"
+  integrity sha512-U78RazE+zI03HMJOT6t0QZlylo0Ior/NT9u3LJMuMMl7OcK4Su/leCTWpVezWXPzUKVo1SMdcqOtkioV3Ey25A==
 
 "@reach/router@^1.2.1", "@reach/router@^1.3.4":
   version "1.3.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3236,6 +3236,11 @@
     webpack-dev-server "^3.11.0"
     xmldoc "^1.1.2"
 
+"@patternfly/patternfly@4.101.0":
+  version "4.101.0"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.101.0.tgz#6485d05ac44a0de3ec45f4692a2a21ee8a274853"
+  integrity sha512-BMUGqFPT8PzE1nNYb+Mn1M2NnLtNLP2CkFU2rji5tUm3pugMFh9+49OOGzaNQK0Om9BLOrMF7mIKD4XTm10h2g==
+
 "@patternfly/patternfly@4.99.0":
   version "4.99.0"
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.99.0.tgz#42f6553be8fe4eb693c14edb95dbf4e15c734169"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3236,10 +3236,10 @@
     webpack-dev-server "^3.11.0"
     xmldoc "^1.1.2"
 
-"@patternfly/patternfly@4.97.0":
-  version "4.97.0"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.97.0.tgz#e6d61481b773833a8768f7959ad9b80fdf92df0c"
-  integrity sha512-U78RazE+zI03HMJOT6t0QZlylo0Ior/NT9u3LJMuMMl7OcK4Su/leCTWpVezWXPzUKVo1SMdcqOtkioV3Ey25A==
+"@patternfly/patternfly@4.99.0":
+  version "4.99.0"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.99.0.tgz#42f6553be8fe4eb693c14edb95dbf4e15c734169"
+  integrity sha512-6jcZ+Y4+BnjW2V/HqZNJhMdOtQ8pYZygMr5KpmjKtwgiYuPkBGgEPNxhS8wWKxKkZLbyZXhK0ZyWXBK+uG2WHg==
 
 "@reach/router@^1.2.1", "@reach/router@^1.3.4":
   version "1.3.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3241,11 +3241,6 @@
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.101.0.tgz#6485d05ac44a0de3ec45f4692a2a21ee8a274853"
   integrity sha512-BMUGqFPT8PzE1nNYb+Mn1M2NnLtNLP2CkFU2rji5tUm3pugMFh9+49OOGzaNQK0Om9BLOrMF7mIKD4XTm10h2g==
 
-"@patternfly/patternfly@4.99.0":
-  version "4.99.0"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.99.0.tgz#42f6553be8fe4eb693c14edb95dbf4e15c734169"
-  integrity sha512-6jcZ+Y4+BnjW2V/HqZNJhMdOtQ8pYZygMr5KpmjKtwgiYuPkBGgEPNxhS8wWKxKkZLbyZXhK0ZyWXBK+uG2WHg==
-
 "@reach/router@^1.2.1", "@reach/router@^1.3.4":
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.3.4.tgz#d2574b19370a70c80480ed91f3da840136d10f8c"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5598 and #5576

 - Adds optional icons to tree table rows - demonstrated in the tree table examples
 - Adds responsive layout to all tree table examples