### PR TITLE
AccessConsoles: clear selection when the selected option is a placeholder

### DIFF
--- a/packages/react-console/src/components/AccessConsoles/AccessConsoles.tsx
+++ b/packages/react-console/src/components/AccessConsoles/AccessConsoles.tsx
@@ -108,10 +108,15 @@ export const AccessConsoles: React.FunctionComponent<AccessConsolesProps> = ({
             toggleId="pf-c-console__type-selector"
             variant={SelectVariant.single}
             onSelect={(_, selection, isPlaceholder) => {
-              setType(Object.keys(items).find(key => items[key] === selection));
-              setIsOpen(isPlaceholder ? false : !isOpen);
+              if (isPlaceholder) {
+                setType(null);
+              } else {
+                setType(Object.keys(items).find(key => items[key] === selection));
+              }
+
+              setIsOpen(false);
             }}
-            selections={items[type]}
+            selections={type ? items[type] : null}
             isOpen={isOpen}
             onToggle={onToggle}
           >


### PR DESCRIPTION
Without this fix one could actually select the placeholder which creates the following unexpected UI:

![Screen Shot 2021-04-16 at 10 44 18](https://user-images.githubusercontent.com/14921356/114840886-8c29a100-9dd7-11eb-975a-7b43b4c777c7.png)
