### PR TITLE
fix(Accordion): set button type, update prop extension

### DIFF
--- a/packages/react-core/src/components/Accordion/AccordionToggle.tsx
+++ b/packages/react-core/src/components/Accordion/AccordionToggle.tsx
@@ -4,7 +4,8 @@ import styles from '@patternfly/react-styles/css/components/Accordion/accordion'
 import AngleRightIcon from '@patternfly/react-icons/dist/js/icons/angle-right-icon';
 import { AccordionContext } from './AccordionContext';
 
-export interface AccordionToggleProps extends Omit<React.HTMLProps<HTMLButtonElement>, 'type'> {
+export interface AccordionToggleProps
+  extends React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> {
   /** Content rendered inside the Accordion toggle  */
   children?: React.ReactNode;
   /** Additional classes added to the Accordion Toggle  */
@@ -33,8 +34,9 @@ export const AccordionToggle: React.FunctionComponent<AccordionToggleProps> = ({
           <button
             id={id}
             className={css(styles.accordionToggle, isExpanded && styles.modifiers.expanded, className)}
-            {...props}
             aria-expanded={isExpanded}
+            type="button"
+            {...props}
           >
             <span className={css(styles.accordionToggleText)}>{children}</span>
             <span className={css(styles.accordionToggleIcon)}>

--- a/packages/react-core/src/components/Accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/react-core/src/components/Accordion/__tests__/__snapshots__/Accordion.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`Accordion Accordion with non-default headingLevel 1`] = `
       aria-expanded="false"
       class="pf-c-accordion__toggle"
       id="item-1"
+      type="button"
     >
       <span
         class="pf-c-accordion__toggle-text"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5661

@tlabaj I'm not sure, but would this be considered a breaking change? It sets a default, but the default probably shouldn't be `submit` for this component.