### PR TITLE
fix(tokens): fix duplicate entries

### DIFF
--- a/packages/react-tokens/scripts/writeTokens.js
+++ b/packages/react-tokens/scripts/writeTokens.js
@@ -33,7 +33,7 @@ export default ${tokenName};
 `.trim()
   );
 
-const allIndex = [];
+const allIndex = {};
 const componentIndex = [];
 
 const outputIndex = (index, indexFile) => {
@@ -65,7 +65,7 @@ function writeTokens(tokens) {
     writeESMExport(tokenName, tokenString);
     writeCJSExport(tokenName, tokenString);
     writeDTSExport(tokenName, tokenString);
-    allIndex.push(tokenName);
+    allIndex[tokenName] = true;
     componentIndex.push(tokenName);
 
     // Legacy token support -- values may be incorrect.
@@ -82,16 +82,16 @@ function writeTokens(tokens) {
         writeESMExport(oldTokenName, oldTokenString);
         writeCJSExport(oldTokenName, oldTokenString);
         writeDTSExport(oldTokenName, oldTokenString);
-        allIndex.push(oldTokenName);
+        allIndex[oldTokenName] = true;
       });
   });
 
   // Index files including legacy tokens
-  outputIndex(allIndex, 'index.js');
+  outputIndex(Object.keys(allIndex), 'index.js');
   outputIndex(componentIndex, 'componentIndex.js');
 
   // eslint-disable-next-line no-console
-  console.log('Wrote', allIndex.length * 3 + 3, 'token files');
+  console.log('Wrote', Object.keys(allIndex).length * 3 + 3, 'token files');
 }
 
 writeTokens(generateTokens());


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Should fix this error from @dtaylor113 :
```js
ERROR in ./node_modules/@patternfly/react-tokens/dist/esm/index.js 226:9
Module parse failed: Duplicate export 'global_FontFamily_sans_serif' (226:9)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
| export { global_target_size_MinWidth } from './global_target_size_MinWidth';
| export { global_target_size_MinHeight } from './global_target_size_MinHeight';
> export { global_FontFamily_sans_serif } from './global_FontFamily_sans_serif';
| export { global_FontFamily_heading_sans_serif } from './global_FontFamily_heading_sans_serif';
| export { global_FontFamily_monospace } from './global_FontFamily_monospace';
```

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
