### PR TITLE
Slider: add showBoundaries property to the min/max slider variant

### DIFF
--- a/packages/react-core/src/components/Slider/Slider.tsx
+++ b/packages/react-core/src/components/Slider/Slider.tsx
@@ -30,6 +30,8 @@ export interface SliderProps extends Omit<React.HTMLProps<HTMLDivElement>, 'onCh
   min?: number;
   /** The maximum permitted value */
   max?: number;
+  /** Flag to indicate if boundaries should be shown for slider that does not have custom steps */
+  showBoundaries?: boolean;
   /** Flag to indicate if ticks should be shown for slider that does not have custom steps  */
   showTicks?: boolean;
   /** Array of custom slider step objects (value and label of each step) for the slider. */
@@ -75,6 +77,7 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
   min = 0,
   max = 100,
   showTicks = false,
+  showBoundaries = true,
   ...props
 }: SliderProps) => {
   const sliderRailRef = React.useRef<HTMLDivElement>();
@@ -308,7 +311,13 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
     for (let i = min; i <= max; i = i + step) {
       const stepValue = ((i - min) * 100) / (max - min);
       builtSteps.push(
-        <SliderStep key={i} value={stepValue} label={i.toString()} isLabelHidden={true} isActive={i <= localValue} />
+        <SliderStep
+          key={i}
+          value={stepValue}
+          label={i.toString()}
+          isLabelHidden={(i === min || i === max) && showBoundaries ? false : true}
+          isActive={i <= localValue}
+        />
       );
     }
     return builtSteps;

--- a/packages/react-core/src/components/Slider/examples/Slider.md
+++ b/packages/react-core/src/components/Slider/examples/Slider.md
@@ -73,7 +73,9 @@ class DiscreteInput extends React.Component {
         <Slider value={this.state.value2} onChange={this.onChange2} max={200} step={50} showTicks/>
         <br />
         <Text component={TextVariants.h3}>Slider value is: {Math.floor(this.state.value3)}</Text>
-        <Text component={TextVariants.small}>(min = -25, max = 75, step = 10) </Text>
+        <Text component={TextVariants.small}>(min = -25, max = 75, step = 10, boundaries not shown) </Text>
+        <Slider value={this.state.value3} onChange={this.onChange3} min={-25} max={75} step={10} showTicks showBoundaries={false}/>
+        <Text component={TextVariants.small}>(min = -25, max = 75, step = 10, boundaries shown) </Text>
         <Slider value={this.state.value3} onChange={this.onChange3} min={-25} max={75} step={10} showTicks />
       </>
     );


### PR DESCRIPTION
Also make the new property default to true, showing boundaries is
probably what most consumers of this components want anyway.

Fixes #5709