### PR TITLE
add ApplicationLauncherContent to docs

### DIFF
--- a/packages/react-core/src/components/ApplicationLauncher/examples/ApplicationLauncher.md
+++ b/packages/react-core/src/components/ApplicationLauncher/examples/ApplicationLauncher.md
@@ -2,7 +2,7 @@
 id: Application launcher
 section: components
 cssPrefix: pf-c-app-launcher
-propComponents: ['ApplicationLauncher', 'ApplicationLauncherItem']
+propComponents: ['ApplicationLauncher', 'ApplicationLauncherItem', 'ApplicationLauncherContent']
 ouia: true
 ---
 


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5718 

This PR adds the `ApplicationLauncherContent` component to the docs.
