### PR TITLE
feat(Card): add isToggleRightAligned prop

### DIFF
--- a/packages/react-core/src/components/Card/CardHeader.tsx
+++ b/packages/react-core/src/components/Card/CardHeader.tsx
@@ -16,6 +16,8 @@ export interface CardHeaderProps extends React.HTMLProps<HTMLDivElement> {
   onExpand?: (event: React.MouseEvent, id: string) => void;
   /** Additional props for expandable toggle button */
   toggleButtonProps?: any;
+  /** Whether to right-align expandable toggle button */
+  isToggleRightAligned?: boolean;
 }
 
 export const CardHeader: React.FunctionComponent<CardHeaderProps> = ({
@@ -24,11 +26,16 @@ export const CardHeader: React.FunctionComponent<CardHeaderProps> = ({
   id,
   onExpand,
   toggleButtonProps,
+  isToggleRightAligned,
   ...props
 }: CardHeaderProps) => (
   <CardContext.Consumer>
     {({ cardId }) => (
-      <div className={css(styles.cardHeader, className)} id={id} {...props}>
+      <div
+        className={css(styles.cardHeader, isToggleRightAligned && styles.modifiers.toggleRight, className)}
+        id={id}
+        {...props}
+      >
         {onExpand && (
           <div className={css(styles.cardHeaderToggle)}>
             <Button

--- a/packages/react-core/src/components/Card/CardHeader.tsx
+++ b/packages/react-core/src/components/Card/CardHeader.tsx
@@ -30,31 +30,36 @@ export const CardHeader: React.FunctionComponent<CardHeaderProps> = ({
   ...props
 }: CardHeaderProps) => (
   <CardContext.Consumer>
-    {({ cardId }) => (
-      <div
-        className={css(styles.cardHeader, isToggleRightAligned && styles.modifiers.toggleRight, className)}
-        id={id}
-        {...props}
-      >
-        {onExpand && (
-          <div className={css(styles.cardHeaderToggle)}>
-            <Button
-              variant="plain"
-              type="button"
-              onClick={evt => {
-                onExpand(evt, cardId);
-              }}
-              {...toggleButtonProps}
-            >
-              <span className={css(styles.cardHeaderToggleIcon)}>
-                <AngleRightIcon aria-hidden="true" />
-              </span>
-            </Button>
-          </div>
-        )}
-        {children}
-      </div>
-    )}
+    {({ cardId }) => {
+      const cardHeaderToggle = (
+        <div className={css(styles.cardHeaderToggle)}>
+          <Button
+            variant="plain"
+            type="button"
+            onClick={evt => {
+              onExpand(evt, cardId);
+            }}
+            {...toggleButtonProps}
+          >
+            <span className={css(styles.cardHeaderToggleIcon)}>
+              <AngleRightIcon aria-hidden="true" />
+            </span>
+          </Button>
+        </div>
+      );
+
+      return (
+        <div
+          className={css(styles.cardHeader, isToggleRightAligned && styles.modifiers.toggleRight, className)}
+          id={id}
+          {...props}
+        >
+          {onExpand && !isToggleRightAligned && cardHeaderToggle}
+          {children}
+          {onExpand && isToggleRightAligned && cardHeaderToggle}
+        </div>
+      );
+    }}
   </CardContext.Consumer>
 );
 CardHeader.displayName = 'CardHeader';

--- a/packages/react-core/src/components/Card/examples/Card.md
+++ b/packages/react-core/src/components/Card/examples/Card.md
@@ -2,7 +2,7 @@
 id: Card
 section: components
 cssPrefix: pf-c-card
-propComponents: ['Card', 'CardHeaderMain', 'CardTitle', 'CardBody', 'CardFooter', 'CardExpandableContent']
+propComponents: ['Card', 'CardHeader', 'CardHeaderMain', 'CardTitle', 'CardBody', 'CardFooter', 'CardExpandableContent']
 ouia: true
 ---
 
@@ -571,7 +571,6 @@ import {
   Brand,
   Card,
   CardHeader,
-  CardHeaderMain,
   CardActions,
   CardTitle,
   CardBody,
@@ -594,7 +593,8 @@ class ExpandableCard extends React.Component {
     this.state = {
       isOpen: false,
       check1: false,
-      isExpanded: false
+      isExpanded: false,
+      isToggleRightAligned: false
     };
     this.onToggle = isOpen => {
       this.setState({
@@ -616,6 +616,11 @@ class ExpandableCard extends React.Component {
       console.log(id);
       this.setState({
         isExpanded: !this.state.isExpanded
+      });
+    };
+    this.onRightAlign = event => {
+      this.setState({
+        isToggleRightAligned: !this.state.isToggleRightAligned
       });
     };
   }
@@ -640,40 +645,52 @@ class ExpandableCard extends React.Component {
       </DropdownItem>
     ];
     return (
-      <Card id="card1" isExpanded={this.state.isExpanded}>
-        <CardHeader
-          onExpand={this.onExpand}
-          toggleButtonProps={{
-            id: 'toggle-button',
-            'aria-label': 'Details',
-            'aria-labelledby': 'titleId toggle-button',
-            'aria-expanded': this.state.isExpanded
-          }}
-        >
-          <CardActions>
-            <Dropdown
-              onSelect={this.onSelect}
-              toggle={<KebabToggle onToggle={this.onToggle} />}
-              isOpen={isOpen}
-              isPlain
-              dropdownItems={dropdownItems}
-              position={'right'}
-            />
-            <Checkbox
-              isChecked={this.state.check1}
-              onChange={this.onClick}
-              aria-label="card checkbox example"
-              id="check-1"
-              name="check1"
-            />
-          </CardActions>
-          <CardTitle id="titleId">Header</CardTitle>
-        </CardHeader>
-        <CardExpandableContent>
-          <CardBody>Body</CardBody>
-          <CardFooter>Footer</CardFooter>
-        </CardExpandableContent>
-      </Card>
+      <React.Fragment>
+        <div style={{ marginBottom: '12px' }}>
+          <Checkbox
+            id={'isToggleRightAligned'}
+            key={'isToggleRightAligned'}
+            label={'isToggleRightAligned'}
+            isChecked={this.state.isToggleRightAligned}
+            onChange={this.onRightAlign}
+          />
+        </div>
+        <Card id="card1" isExpanded={this.state.isExpanded}>
+          <CardHeader
+            onExpand={this.onExpand}
+            isToggleRightAligned={this.state.isToggleRightAligned}
+            toggleButtonProps={{
+              id: 'toggle-button',
+              'aria-label': 'Details',
+              'aria-labelledby': 'titleId toggle-button',
+              'aria-expanded': this.state.isExpanded
+            }}
+          >
+            <CardActions>
+              <Dropdown
+                onSelect={this.onSelect}
+                toggle={<KebabToggle onToggle={this.onToggle} />}
+                isOpen={isOpen}
+                isPlain
+                dropdownItems={dropdownItems}
+                position={'right'}
+              />
+              <Checkbox
+                isChecked={this.state.check1}
+                onChange={this.onClick}
+                aria-label="card checkbox example"
+                id="check-1"
+                name="check1"
+              />
+            </CardActions>
+            <CardTitle id="titleId">Header</CardTitle>
+          </CardHeader>
+          <CardExpandableContent>
+            <CardBody>Body</CardBody>
+            <CardFooter>Footer</CardFooter>
+          </CardExpandableContent>
+        </Card>
+      </React.Fragment>
     );
   }
 }
@@ -687,7 +704,6 @@ import {
   Brand,
   Card,
   CardHeader,
-  CardHeaderMain,
   CardActions,
   CardTitle,
   CardBody,

--- a/packages/react-integration/cypress/integration/card.spec.ts
+++ b/packages/react-integration/cypress/integration/card.spec.ts
@@ -60,6 +60,7 @@ describe('Card Demo Test', () => {
 
   it('Verify card is expandable', () => {
     cy.get('#expand-card').should('not.have.class', 'pf-m-expanded');
+    cy.get('#expand-card .pf-c-card__header').should('have.class', 'pf-m-toggle-right');
     cy.get('.pf-c-card__header-toggle .pf-c-button').click();
     cy.get('#expand-card').should('have.class', 'pf-m-expanded');
   });

--- a/packages/react-integration/demo-app-ts/src/components/demos/CardDemo/CardDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/CardDemo/CardDemo.tsx
@@ -102,7 +102,7 @@ export class CardDemo extends React.Component {
         </Card>
         <br></br>
         <Card id="expand-card" isExpanded={this.state.isExpanded}>
-          <CardHeader onExpand={this.onExpand}>
+          <CardHeader onExpand={this.onExpand} isToggleRightAligned>
             <CardTitle>Header</CardTitle>
           </CardHeader>
           {this.state.isExpanded && (


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5583 

This PR adds the `isToggleRightAligned` prop to the expandable Card to move the carrot icon to the right of the `CardHeader` component. Note that spacing is to be fixed [per this comment](https://github.com/patternfly/patternfly/pull/3848/files#r591988545).

Updated the `Expandable` example allowing to toggle this prop on & off.