### PR TITLE
feat(ToolbarItem): add widths on breakpoints

### DIFF
--- a/packages/react-core/src/components/Toolbar/ToolbarItem.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarItem.tsx
@@ -62,6 +62,15 @@ export interface ToolbarItemProps extends React.HTMLProps<HTMLDivElement> {
     xl?: 'spacerNone' | 'spacerSm' | 'spacerMd' | 'spacerLg';
     '2xl'?: 'spacerNone' | 'spacerSm' | 'spacerMd' | 'spacerLg';
   };
+  /** Widths at various breakpoints. */
+  widths?: {
+    default?: string;
+    sm?: string;
+    md?: string;
+    lg?: string;
+    xl?: string;
+    '2xl'?: string;
+  };
   /** id for this data toolbar item */
   id?: string;
   /** Flag indicating if the expand-all variant is expanded or not */
@@ -77,6 +86,7 @@ export const ToolbarItem: React.FunctionComponent<ToolbarItemProps> = ({
   visiblity,
   alignment,
   spacer,
+  widths,
   id,
   children,
   isAllExpanded,
@@ -91,6 +101,14 @@ export const ToolbarItem: React.FunctionComponent<ToolbarItemProps> = ({
     console.warn(
       'The ToolbarItem visiblity prop has been deprecated. ' +
         'Please use the correctly spelled visibility prop instead.'
+    );
+  }
+
+  const widthStyles: any = {};
+  if (widths) {
+    Object.entries(widths || {}).map(
+      ([breakpoint, value]) =>
+        (widthStyles[`--pf-c-toolbar__item--Width${breakpoint !== 'default' ? `-on-${breakpoint}` : ''}`] = value)
     );
   }
 
@@ -111,6 +129,7 @@ export const ToolbarItem: React.FunctionComponent<ToolbarItemProps> = ({
       {...(variant === 'label' && { 'aria-hidden': true })}
       id={id}
       {...props}
+      {...(widths && { style: { ...widthStyles, ...props.style } as React.CSSProperties })}
     >
       {children}
     </div>

--- a/packages/react-core/src/components/Toolbar/__tests__/ToolbarToggleGroup.test.tsx
+++ b/packages/react-core/src/components/Toolbar/__tests__/ToolbarToggleGroup.test.tsx
@@ -59,3 +59,19 @@ describe('Toolbar', () => {
     expect(view).toMatchSnapshot();
   });
 });
+
+describe('ToolbarItem', () => {
+  it('should map width breakpoints', () => {
+    const widths = {
+      default: '100px',
+      sm: '80px',
+      md: '150px',
+      lg: '200px',
+      xl: '250px',
+      '2xl': '300px'
+    };
+
+    const view = mount(<ToolbarItem widths={widths}>Test</ToolbarItem>);
+    expect(view).toMatchSnapshot();
+  });
+});

--- a/packages/react-core/src/components/Toolbar/__tests__/__snapshots__/ToolbarToggleGroup.test.tsx.snap
+++ b/packages/react-core/src/components/Toolbar/__tests__/__snapshots__/ToolbarToggleGroup.test.tsx.snap
@@ -272,3 +272,34 @@ exports[`Toolbar should render with page inset flag 1`] = `
   </div>
 </Toolbar>
 `;
+
+exports[`ToolbarItem should map width breakpoints 1`] = `
+<ToolbarItem
+  widths={
+    Object {
+      "2xl": "300px",
+      "default": "100px",
+      "lg": "200px",
+      "md": "150px",
+      "sm": "80px",
+      "xl": "250px",
+    }
+  }
+>
+  <div
+    className="pf-c-toolbar__item"
+    style={
+      Object {
+        "--pf-c-toolbar__item--Width": "100px",
+        "--pf-c-toolbar__item--Width-on-2xl": "300px",
+        "--pf-c-toolbar__item--Width-on-lg": "200px",
+        "--pf-c-toolbar__item--Width-on-md": "150px",
+        "--pf-c-toolbar__item--Width-on-sm": "80px",
+        "--pf-c-toolbar__item--Width-on-xl": "250px",
+      }
+    }
+  >
+    Test
+  </div>
+</ToolbarItem>
+`;

--- a/packages/react-core/src/components/Toolbar/examples/Toolbar.md
+++ b/packages/react-core/src/components/Toolbar/examples/Toolbar.md
@@ -14,6 +14,7 @@ import FilterIcon from '@patternfly/react-icons/dist/js/icons/filter-icon';
 ## Examples
 
 ### Items
+
 Toolbar items are individual components that can be placed inside of a toolbar. Buttons or select lists are examples of items. (Note: This example does not demonstrate the desired responsive behavior of the toolbar. That is handled in later examples.)
 
 ```js
@@ -134,6 +135,47 @@ class ToolbarSpacers extends React.Component {
 }
 ```
 
+### Adjusting item widths
+
+```js
+import React from 'react';
+import { Toolbar, ToolbarItem, ToolbarGroup, ToolbarContent } from '@patternfly/react-core';
+import { Button } from '@patternfly/react-core';
+
+class ToolbarWidths extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    const widths = {
+      default: '100px',
+      sm: '80px',
+      md: '150px',
+      lg: '200px',
+      xl: '250px',
+      '2xl': '300px'
+    };
+
+    const items = (
+      <React.Fragment>
+        <ToolbarItem widths={widths}>
+          <Button variant="secondary" style={{ width: '100%' }}>
+            Action
+          </Button>
+        </ToolbarItem>
+      </React.Fragment>
+    );
+
+    return (
+      <Toolbar id="toolbar-widths">
+        <ToolbarContent>{items}</ToolbarContent>
+      </Toolbar>
+    );
+  }
+}
+```
+
 ### Adjusting toolbar inset
 
 ```js
@@ -198,6 +240,7 @@ class ToolbarSpacers extends React.Component {
 ```
 
 ### Groups
+
 Often, it makes sense to group sets of like items to create desired associations and to enable items to respond together to changes in viewport width. (Note: This example does not demonstrate the desired responsive behavior of the toolbar. That is handled in later examples.)
 
 ```js
@@ -391,8 +434,8 @@ class ToolbarGroupTypes extends React.Component {
 ```
 
 ## Examples with toggle groups and filters
-A toggle group can be used when you want to collapse a set of items into an overlay panel at a certain breakpoint. This allows complex toolbars with multiple items and groups of items to be responsive. A toggle group is useful for containing filter controls, for example. When the toolbar responds to adapt to a mobile viewport, the contents contained in a toggle group will collapse into an overlay panel that can be toggled by clicking the Filter icon.
 
+A toggle group can be used when you want to collapse a set of items into an overlay panel at a certain breakpoint. This allows complex toolbars with multiple items and groups of items to be responsive. A toggle group is useful for containing filter controls, for example. When the toolbar responds to adapt to a mobile viewport, the contents contained in a toggle group will collapse into an overlay panel that can be toggled by clicking the Filter icon.
 
 ### Component managed toggle groups
 
@@ -545,6 +588,7 @@ class ToolbarComponentMangedToggleGroup extends React.Component {
 ```
 
 ### Consumer managed toggle groups
+
 If the consumer would prefer to manage the expanded state of the toggle group for smaller screen widths:
 
 1. Add a toggleIsExpanded callback to Toolbar
@@ -714,6 +758,7 @@ class ToolbarConsumerMangedToggleGroup extends React.Component {
 ```
 
 ### With filters
+
 The ToolbarFilter component expects a consumer managed list of applied filters and a delete chip handler to be passed as props. Pass a deleteChipGroup prop to provide both a handler and visual styling to remove all chips in a group. Then the rendering of chips will be handled responsively by the Toolbar
 When filters are applied, the toolbar will expand in height to make space for a row of filter chips. Upon clearing the applied filters, the toolbar will collapse to its default height.
 
@@ -987,6 +1032,7 @@ class ToolbarWithFilterExample extends React.Component {
 ```
 
 ### Stacked example
+
 There may be situations where all of the required elements simply cannot fit in a single line.
 
 ```js

--- a/packages/react-integration/cypress/integration/toolbar.spec.ts
+++ b/packages/react-integration/cypress/integration/toolbar.spec.ts
@@ -5,6 +5,14 @@ describe('Data Toolbar Demo Test', () => {
     cy.url().should('eq', 'http://localhost:3000/toolbar-demo-nav-link');
   });
 
+  it('Verify widths styling mapped ', () => {
+    cy.get('#width-item').should(
+      'have.attr',
+      'style',
+      '--pf-c-toolbar__item--Width:100px; --pf-c-toolbar__item--Width-on-sm:80px; --pf-c-toolbar__item--Width-on-md:150px; --pf-c-toolbar__item--Width-on-lg:200px; --pf-c-toolbar__item--Width-on-xl:250px; --pf-c-toolbar__item--Width-on-2xl:300px;'
+    );
+  });
+
   it('Verify no inset applied for all viewport sizes ', () => {
     cy.get('#toolbar-no-inset.pf-m-inset-none').should('exist');
     cy.get('#toolbar-no-inset.pf-m-inset-none-on-md').should('exist');

--- a/packages/react-integration/demo-app-ts/src/components/demos/ToolbarDemo/ToolbarDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/ToolbarDemo/ToolbarDemo.tsx
@@ -246,6 +246,21 @@ export class ToolbarDemo extends React.Component<ToolbarProps, ToolbarState> {
       </DropdownItem>
     ];
 
+    const widths = {
+      default: '100px',
+      sm: '80px',
+      md: '150px',
+      lg: '200px',
+      xl: '250px',
+      '2xl': '300px'
+    };
+
+    const widthsToolbarItems = (
+      <ToolbarItem id="width-item" widths={widths}>
+        <Button variant="plain">Test </Button>
+      </ToolbarItem>
+    );
+
     const toolbarItems = (
       <React.Fragment>
         <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl" id="demo-toggle-group">
@@ -289,6 +304,15 @@ export class ToolbarDemo extends React.Component<ToolbarProps, ToolbarState> {
           clearFiltersButtonText="Clear filters"
         >
           <ToolbarContent>{toolbarItems}</ToolbarContent>
+        </Toolbar>
+        <Toolbar
+          id="toolbar-width-demo"
+          clearAllFilters={this.onDelete}
+          className="pf-m-toggle-group-container"
+          collapseListedFiltersBreakpoint="xl"
+          clearFiltersButtonText="Clear filters"
+        >
+          <ToolbarContent>{widthsToolbarItems}</ToolbarContent>
         </Toolbar>
         <Toolbar
           id="toolbar-no-inset"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5674

- Adds `widths` property to `ToolbarItem`. Specify widths for different breakpoints using strings.