### PR TITLE
feat(Dropdown): add alignment breakpoints, fix ref console warning

### DIFF
--- a/packages/react-core/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-core/src/components/Dropdown/Dropdown.tsx
@@ -18,6 +18,14 @@ export interface DropdownProps extends ToggleMenuBaseProps, React.HTMLProps<HTML
   isPlain?: boolean;
   /** Indicates where menu will be aligned horizontally */
   position?: DropdownPosition | 'right' | 'left';
+  /** Indicates how the menu will align at screen size breakpoints */
+  alignments?: {
+    sm?: 'right' | 'left';
+    md?: 'right' | 'left';
+    lg?: 'right' | 'left';
+    xl?: 'right' | 'left';
+    '2xl'?: 'right' | 'left';
+  };
   /** Display menu above or below dropdown toggle */
   direction?: DropdownDirection | 'up' | 'down';
   /** Flag to indicate if dropdown has groups */
@@ -38,6 +46,7 @@ export const Dropdown: React.FunctionComponent<DropdownProps> = ({
   ref, // Types of Ref are different for React.FC vs React.Component
   ouiaId,
   ouiaSafe,
+  alignments,
   ...props
 }: DropdownProps) => (
   <DropdownContext.Provider
@@ -58,7 +67,8 @@ export const Dropdown: React.FunctionComponent<DropdownProps> = ({
       plainTextClass: styles.modifiers.text,
       ouiaId: useOUIAId(Dropdown.displayName, ouiaId),
       ouiaSafe,
-      ouiaComponentType: Dropdown.displayName
+      ouiaComponentType: Dropdown.displayName,
+      alignments
     }}
   >
     <DropdownWithContext {...props} />

--- a/packages/react-core/src/components/Dropdown/DropdownMenu.tsx
+++ b/packages/react-core/src/components/Dropdown/DropdownMenu.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import styles from '@patternfly/react-styles/css/components/Dropdown/dropdown';
 import { css } from '@patternfly/react-styles';
-import { keyHandler } from '../../helpers/util';
+import { keyHandler, formatBreakpointMods } from '../../helpers/util';
 import { DropdownPosition, DropdownArrowContext, DropdownContext } from './dropdownConstants';
 
 export interface DropdownMenuProps {
@@ -22,6 +22,14 @@ export interface DropdownMenuProps {
   component?: React.ReactNode;
   /** Indicates where menu will be alligned horizontally */
   position?: DropdownPosition | 'right' | 'left';
+  /** Indicates how the menu will align at screen size breakpoints */
+  alignments?: {
+    sm?: 'right' | 'left';
+    md?: 'right' | 'left';
+    lg?: 'right' | 'left';
+    xl?: 'right' | 'left';
+    '2xl'?: 'right' | 'left';
+  };
   /** Flag to indicate if menu is grouped */
   isGrouped?: boolean;
   // Function to call on component mount
@@ -170,6 +178,7 @@ export class DropdownMenu extends React.Component<DropdownMenuProps> {
       setMenuComponentRef,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       openedOnEnter,
+      alignments,
       ...props
     } = this.props;
     return (
@@ -186,6 +195,7 @@ export class DropdownMenu extends React.Component<DropdownMenuProps> {
                 className={css(
                   menuClass,
                   position === DropdownPosition.right && styles.modifiers.alignRight,
+                  formatBreakpointMods(alignments, styles, 'align-'),
                   className
                 )}
                 hidden={!isOpen}
@@ -207,6 +217,7 @@ export class DropdownMenu extends React.Component<DropdownMenuProps> {
                     className={css(
                       menuClass,
                       position === DropdownPosition.right && styles.modifiers.alignRight,
+                      formatBreakpointMods(alignments, styles, 'align-'),
                       className
                     )}
                     hidden={!isOpen}
@@ -228,6 +239,7 @@ export class DropdownMenu extends React.Component<DropdownMenuProps> {
                     className={css(
                       menuClass,
                       position === DropdownPosition.right && styles.modifiers.alignRight,
+                      formatBreakpointMods(alignments, styles, 'align-'),
                       className
                     )}
                     hidden={!isOpen}

--- a/packages/react-core/src/components/Dropdown/DropdownWithContext.tsx
+++ b/packages/react-core/src/components/Dropdown/DropdownWithContext.tsx
@@ -89,7 +89,7 @@ export class DropdownWithContext extends React.Component<DropdownProps & OUIAPro
     const openedOnEnter = this.openedOnEnter;
     return (
       <DropdownContext.Consumer>
-        {({ baseClass, baseComponent, id: contextId, ouiaId, ouiaComponentType, ouiaSafe }) => {
+        {({ baseClass, baseComponent, id: contextId, ouiaId, ouiaComponentType, ouiaSafe, alignments }) => {
           const BaseComponent = baseComponent as any;
           const menuContainer = (
             <DropdownMenu
@@ -100,6 +100,7 @@ export class DropdownWithContext extends React.Component<DropdownProps & OUIAPro
               aria-labelledby={contextId ? `${contextId}-toggle` : id}
               isGrouped={isGrouped}
               autoFocus={openedOnEnter && autoFocus}
+              alignments={alignments}
             >
               {renderedContent}
             </DropdownMenu>

--- a/packages/react-core/src/components/Dropdown/InternalDropdownItem.tsx
+++ b/packages/react-core/src/components/Dropdown/InternalDropdownItem.tsx
@@ -204,7 +204,7 @@ export class InternalDropdownItem extends React.Component<InternalDropdownItemPr
         ...(styleChildren && {
           className: css(element.props.className, classes)
         }),
-        ref: this.componentRef
+        ...(this.props.role !== 'separator' && { ref: this.componentRef })
       });
 
     const renderDefaultComponent = (tag: string) => {

--- a/packages/react-core/src/components/Dropdown/__tests__/Dropdown.test.tsx
+++ b/packages/react-core/src/components/Dropdown/__tests__/Dropdown.test.tsx
@@ -44,6 +44,24 @@ describe('dropdown', () => {
     expect(view).toMatchSnapshot();
   });
 
+  test('alignment breakpoints', () => {
+    const view = mount(
+      <Dropdown
+        dropdownItems={dropdownItems}
+        alignments={{
+          sm: 'left',
+          md: 'right',
+          lg: 'left',
+          xl: 'right',
+          '2xl': 'left'
+        }}
+        toggle={<DropdownToggle id="Dropdown Toggle">Dropdown</DropdownToggle>}
+        isOpen
+      />
+    );
+    expect(view).toMatchSnapshot();
+  });
+
   test('dropup', () => {
     const view = mount(
       <Dropdown

--- a/packages/react-core/src/components/Dropdown/__tests__/Generated/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/react-core/src/components/Dropdown/__tests__/Generated/__snapshots__/Dropdown.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`Dropdown should match snapshot (auto-generated) 1`] = `
 <ContextProvider
   value={
     Object {
+      "alignments": undefined,
       "baseClass": "pf-c-dropdown",
       "baseComponent": "div",
       "disabledClass": "pf-m-disabled",

--- a/packages/react-core/src/components/Dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/react-core/src/components/Dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`KebabToggle basic 1`] = `
   >
     <div
       className="pf-c-dropdown pf-m-expanded"
-      data-ouia-component-id="OUIA-Generated-Dropdown-14"
+      data-ouia-component-id="OUIA-Generated-Dropdown-15"
       data-ouia-component-type="PF4/Dropdown"
       data-ouia-safe={true}
     >
@@ -44,7 +44,7 @@ exports[`KebabToggle basic 1`] = `
           Object {
             "current": <div
               class="pf-c-dropdown pf-m-expanded"
-              data-ouia-component-id="OUIA-Generated-Dropdown-14"
+              data-ouia-component-id="OUIA-Generated-Dropdown-15"
               data-ouia-component-type="PF4/Dropdown"
               data-ouia-safe="true"
             >
@@ -100,7 +100,7 @@ exports[`KebabToggle basic 1`] = `
             Object {
               "current": <div
                 class="pf-c-dropdown pf-m-expanded"
-                data-ouia-component-id="OUIA-Generated-Dropdown-14"
+                data-ouia-component-id="OUIA-Generated-Dropdown-15"
                 data-ouia-component-type="PF4/Dropdown"
                 data-ouia-safe="true"
               >
@@ -589,7 +589,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
   >
     <div
       className="pf-c-dropdown pf-m-top pf-m-align-right"
-      data-ouia-component-id="OUIA-Generated-Dropdown-11"
+      data-ouia-component-id="OUIA-Generated-Dropdown-12"
       data-ouia-component-type="PF4/Dropdown"
       data-ouia-safe={true}
     >
@@ -605,7 +605,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
           Object {
             "current": <div
               class="pf-c-dropdown pf-m-top pf-m-align-right"
-              data-ouia-component-id="OUIA-Generated-Dropdown-11"
+              data-ouia-component-id="OUIA-Generated-Dropdown-12"
               data-ouia-component-type="PF4/Dropdown"
               data-ouia-safe="true"
             >
@@ -654,7 +654,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
             Object {
               "current": <div
                 class="pf-c-dropdown pf-m-top pf-m-align-right"
-                data-ouia-component-id="OUIA-Generated-Dropdown-11"
+                data-ouia-component-id="OUIA-Generated-Dropdown-12"
                 data-ouia-component-type="PF4/Dropdown"
                 data-ouia-safe="true"
               >
@@ -1112,7 +1112,7 @@ exports[`KebabToggle dropup 1`] = `
   >
     <div
       className="pf-c-dropdown pf-m-top"
-      data-ouia-component-id="OUIA-Generated-Dropdown-10"
+      data-ouia-component-id="OUIA-Generated-Dropdown-11"
       data-ouia-component-type="PF4/Dropdown"
       data-ouia-safe={true}
     >
@@ -1128,7 +1128,7 @@ exports[`KebabToggle dropup 1`] = `
           Object {
             "current": <div
               class="pf-c-dropdown pf-m-top"
-              data-ouia-component-id="OUIA-Generated-Dropdown-10"
+              data-ouia-component-id="OUIA-Generated-Dropdown-11"
               data-ouia-component-type="PF4/Dropdown"
               data-ouia-safe="true"
             >
@@ -1177,7 +1177,7 @@ exports[`KebabToggle dropup 1`] = `
             Object {
               "current": <div
                 class="pf-c-dropdown pf-m-top"
-                data-ouia-component-id="OUIA-Generated-Dropdown-10"
+                data-ouia-component-id="OUIA-Generated-Dropdown-11"
                 data-ouia-component-type="PF4/Dropdown"
                 data-ouia-safe="true"
               >
@@ -1635,7 +1635,7 @@ exports[`KebabToggle expanded 1`] = `
   >
     <div
       className="pf-c-dropdown pf-m-expanded"
-      data-ouia-component-id="OUIA-Generated-Dropdown-12"
+      data-ouia-component-id="OUIA-Generated-Dropdown-13"
       data-ouia-component-type="PF4/Dropdown"
       data-ouia-safe={true}
     >
@@ -1651,7 +1651,7 @@ exports[`KebabToggle expanded 1`] = `
           Object {
             "current": <div
               class="pf-c-dropdown pf-m-expanded"
-              data-ouia-component-id="OUIA-Generated-Dropdown-12"
+              data-ouia-component-id="OUIA-Generated-Dropdown-13"
               data-ouia-component-type="PF4/Dropdown"
               data-ouia-safe="true"
             >
@@ -1777,7 +1777,7 @@ exports[`KebabToggle expanded 1`] = `
             Object {
               "current": <div
                 class="pf-c-dropdown pf-m-expanded"
-                data-ouia-component-id="OUIA-Generated-Dropdown-12"
+                data-ouia-component-id="OUIA-Generated-Dropdown-13"
                 data-ouia-component-type="PF4/Dropdown"
                 data-ouia-safe="true"
               >
@@ -2131,7 +2131,7 @@ exports[`KebabToggle expanded 1`] = `
                   "sendRef": [Function],
                 }
               }
-              data-ouia-component-id="OUIA-Generated-DropdownSeparator-2"
+              data-ouia-component-id="OUIA-Generated-DropdownSeparator-3"
               data-ouia-component-type="PF4/DropdownSeparator"
               data-ouia-safe={true}
               description={null}
@@ -2647,7 +2647,7 @@ exports[`KebabToggle plain 1`] = `
   >
     <div
       className="pf-c-dropdown"
-      data-ouia-component-id="OUIA-Generated-Dropdown-13"
+      data-ouia-component-id="OUIA-Generated-Dropdown-14"
       data-ouia-component-type="PF4/Dropdown"
       data-ouia-safe={true}
     >
@@ -2663,7 +2663,7 @@ exports[`KebabToggle plain 1`] = `
           Object {
             "current": <div
               class="pf-c-dropdown"
-              data-ouia-component-id="OUIA-Generated-Dropdown-13"
+              data-ouia-component-id="OUIA-Generated-Dropdown-14"
               data-ouia-component-type="PF4/Dropdown"
               data-ouia-safe="true"
             >
@@ -2712,7 +2712,7 @@ exports[`KebabToggle plain 1`] = `
             Object {
               "current": <div
                 class="pf-c-dropdown"
-                data-ouia-component-id="OUIA-Generated-Dropdown-13"
+                data-ouia-component-id="OUIA-Generated-Dropdown-14"
                 data-ouia-component-type="PF4/Dropdown"
                 data-ouia-safe="true"
               >
@@ -3169,7 +3169,7 @@ exports[`KebabToggle regular 1`] = `
   >
     <div
       className="pf-c-dropdown"
-      data-ouia-component-id="OUIA-Generated-Dropdown-8"
+      data-ouia-component-id="OUIA-Generated-Dropdown-9"
       data-ouia-component-type="PF4/Dropdown"
       data-ouia-safe={true}
     >
@@ -3185,7 +3185,7 @@ exports[`KebabToggle regular 1`] = `
           Object {
             "current": <div
               class="pf-c-dropdown"
-              data-ouia-component-id="OUIA-Generated-Dropdown-8"
+              data-ouia-component-id="OUIA-Generated-Dropdown-9"
               data-ouia-component-type="PF4/Dropdown"
               data-ouia-safe="true"
             >
@@ -3234,7 +3234,7 @@ exports[`KebabToggle regular 1`] = `
             Object {
               "current": <div
                 class="pf-c-dropdown"
-                data-ouia-component-id="OUIA-Generated-Dropdown-8"
+                data-ouia-component-id="OUIA-Generated-Dropdown-9"
                 data-ouia-component-type="PF4/Dropdown"
                 data-ouia-safe="true"
               >
@@ -3692,7 +3692,7 @@ exports[`KebabToggle right aligned 1`] = `
   >
     <div
       className="pf-c-dropdown pf-m-align-right"
-      data-ouia-component-id="OUIA-Generated-Dropdown-9"
+      data-ouia-component-id="OUIA-Generated-Dropdown-10"
       data-ouia-component-type="PF4/Dropdown"
       data-ouia-safe={true}
     >
@@ -3708,7 +3708,7 @@ exports[`KebabToggle right aligned 1`] = `
           Object {
             "current": <div
               class="pf-c-dropdown pf-m-align-right"
-              data-ouia-component-id="OUIA-Generated-Dropdown-9"
+              data-ouia-component-id="OUIA-Generated-Dropdown-10"
               data-ouia-component-type="PF4/Dropdown"
               data-ouia-safe="true"
             >
@@ -3757,7 +3757,7 @@ exports[`KebabToggle right aligned 1`] = `
             Object {
               "current": <div
                 class="pf-c-dropdown pf-m-align-right"
-                data-ouia-component-id="OUIA-Generated-Dropdown-9"
+                data-ouia-component-id="OUIA-Generated-Dropdown-10"
                 data-ouia-component-type="PF4/Dropdown"
                 data-ouia-safe="true"
               >
@@ -3830,6 +3830,1075 @@ exports[`KebabToggle right aligned 1`] = `
 </Dropdown>
 `;
 
+exports[`dropdown alignment breakpoints 1`] = `
+<Dropdown
+  alignments={
+    Object {
+      "2xl": "left",
+      "lg": "left",
+      "md": "right",
+      "sm": "left",
+      "xl": "right",
+    }
+  }
+  dropdownItems={
+    Array [
+      <InternalDropdownItem
+        className=""
+        component="a"
+        context={
+          Object {
+            "keyHandler": [Function],
+            "sendRef": [Function],
+          }
+        }
+        description={null}
+        enterTriggersArrowDown={false}
+        icon={null}
+        index={-1}
+        inoperableEvents={
+          Array [
+            "onClick",
+            "onKeyPress",
+          ]
+        }
+        isDisabled={false}
+        isHovered={false}
+        isPlainText={false}
+        onClick={[Function]}
+        role="none"
+        styleChildren={true}
+        tooltipProps={Object {}}
+      >
+        Link
+      </InternalDropdownItem>,
+      <InternalDropdownItem
+        className=""
+        component="button"
+        context={
+          Object {
+            "keyHandler": [Function],
+            "sendRef": [Function],
+          }
+        }
+        description={null}
+        enterTriggersArrowDown={false}
+        icon={null}
+        index={-1}
+        inoperableEvents={
+          Array [
+            "onClick",
+            "onKeyPress",
+          ]
+        }
+        isDisabled={false}
+        isHovered={false}
+        isPlainText={false}
+        onClick={[Function]}
+        role="none"
+        styleChildren={true}
+        tooltipProps={Object {}}
+      >
+        Action
+      </InternalDropdownItem>,
+      <InternalDropdownItem
+        className=""
+        component="a"
+        context={
+          Object {
+            "keyHandler": [Function],
+            "sendRef": [Function],
+          }
+        }
+        description={null}
+        enterTriggersArrowDown={false}
+        icon={null}
+        index={-1}
+        inoperableEvents={
+          Array [
+            "onClick",
+            "onKeyPress",
+          ]
+        }
+        isDisabled={true}
+        isHovered={false}
+        isPlainText={false}
+        onClick={[Function]}
+        role="none"
+        styleChildren={true}
+        tooltipProps={Object {}}
+      >
+        Disabled Link
+      </InternalDropdownItem>,
+      <InternalDropdownItem
+        className=""
+        component="button"
+        context={
+          Object {
+            "keyHandler": [Function],
+            "sendRef": [Function],
+          }
+        }
+        description={null}
+        enterTriggersArrowDown={false}
+        icon={null}
+        index={-1}
+        inoperableEvents={
+          Array [
+            "onClick",
+            "onKeyPress",
+          ]
+        }
+        isDisabled={true}
+        isHovered={false}
+        isPlainText={false}
+        onClick={[Function]}
+        role="none"
+        styleChildren={true}
+        tooltipProps={Object {}}
+      >
+        Disabled Action
+      </InternalDropdownItem>,
+      <DropdownSeparator />,
+      <InternalDropdownItem
+        className=""
+        component="a"
+        context={
+          Object {
+            "keyHandler": [Function],
+            "sendRef": [Function],
+          }
+        }
+        description={null}
+        enterTriggersArrowDown={false}
+        icon={null}
+        index={-1}
+        inoperableEvents={
+          Array [
+            "onClick",
+            "onKeyPress",
+          ]
+        }
+        isDisabled={false}
+        isHovered={false}
+        isPlainText={false}
+        onClick={[Function]}
+        role="none"
+        styleChildren={true}
+        tooltipProps={Object {}}
+      >
+        Separated Link
+      </InternalDropdownItem>,
+      <InternalDropdownItem
+        className=""
+        component="button"
+        context={
+          Object {
+            "keyHandler": [Function],
+            "sendRef": [Function],
+          }
+        }
+        description={null}
+        enterTriggersArrowDown={false}
+        icon={null}
+        index={-1}
+        inoperableEvents={
+          Array [
+            "onClick",
+            "onKeyPress",
+          ]
+        }
+        isDisabled={false}
+        isHovered={false}
+        isPlainText={false}
+        onClick={[Function]}
+        role="none"
+        styleChildren={true}
+        tooltipProps={Object {}}
+      >
+        Separated Action
+      </InternalDropdownItem>,
+    ]
+  }
+  isOpen={true}
+  toggle={
+    <DropdownToggle
+      id="Dropdown Toggle"
+    >
+      Dropdown
+    </DropdownToggle>
+  }
+>
+  <DropdownWithContext
+    autoFocus={true}
+    className=""
+    direction="down"
+    dropdownItems={
+      Array [
+        <InternalDropdownItem
+          className=""
+          component="a"
+          context={
+            Object {
+              "keyHandler": [Function],
+              "sendRef": [Function],
+            }
+          }
+          description={null}
+          enterTriggersArrowDown={false}
+          icon={null}
+          index={-1}
+          inoperableEvents={
+            Array [
+              "onClick",
+              "onKeyPress",
+            ]
+          }
+          isDisabled={false}
+          isHovered={false}
+          isPlainText={false}
+          onClick={[Function]}
+          role="none"
+          styleChildren={true}
+          tooltipProps={Object {}}
+        >
+          Link
+        </InternalDropdownItem>,
+        <InternalDropdownItem
+          className=""
+          component="button"
+          context={
+            Object {
+              "keyHandler": [Function],
+              "sendRef": [Function],
+            }
+          }
+          description={null}
+          enterTriggersArrowDown={false}
+          icon={null}
+          index={-1}
+          inoperableEvents={
+            Array [
+              "onClick",
+              "onKeyPress",
+            ]
+          }
+          isDisabled={false}
+          isHovered={false}
+          isPlainText={false}
+          onClick={[Function]}
+          role="none"
+          styleChildren={true}
+          tooltipProps={Object {}}
+        >
+          Action
+        </InternalDropdownItem>,
+        <InternalDropdownItem
+          className=""
+          component="a"
+          context={
+            Object {
+              "keyHandler": [Function],
+              "sendRef": [Function],
+            }
+          }
+          description={null}
+          enterTriggersArrowDown={false}
+          icon={null}
+          index={-1}
+          inoperableEvents={
+            Array [
+              "onClick",
+              "onKeyPress",
+            ]
+          }
+          isDisabled={true}
+          isHovered={false}
+          isPlainText={false}
+          onClick={[Function]}
+          role="none"
+          styleChildren={true}
+          tooltipProps={Object {}}
+        >
+          Disabled Link
+        </InternalDropdownItem>,
+        <InternalDropdownItem
+          className=""
+          component="button"
+          context={
+            Object {
+              "keyHandler": [Function],
+              "sendRef": [Function],
+            }
+          }
+          description={null}
+          enterTriggersArrowDown={false}
+          icon={null}
+          index={-1}
+          inoperableEvents={
+            Array [
+              "onClick",
+              "onKeyPress",
+            ]
+          }
+          isDisabled={true}
+          isHovered={false}
+          isPlainText={false}
+          onClick={[Function]}
+          role="none"
+          styleChildren={true}
+          tooltipProps={Object {}}
+        >
+          Disabled Action
+        </InternalDropdownItem>,
+        <DropdownSeparator />,
+        <InternalDropdownItem
+          className=""
+          component="a"
+          context={
+            Object {
+              "keyHandler": [Function],
+              "sendRef": [Function],
+            }
+          }
+          description={null}
+          enterTriggersArrowDown={false}
+          icon={null}
+          index={-1}
+          inoperableEvents={
+            Array [
+              "onClick",
+              "onKeyPress",
+            ]
+          }
+          isDisabled={false}
+          isHovered={false}
+          isPlainText={false}
+          onClick={[Function]}
+          role="none"
+          styleChildren={true}
+          tooltipProps={Object {}}
+        >
+          Separated Link
+        </InternalDropdownItem>,
+        <InternalDropdownItem
+          className=""
+          component="button"
+          context={
+            Object {
+              "keyHandler": [Function],
+              "sendRef": [Function],
+            }
+          }
+          description={null}
+          enterTriggersArrowDown={false}
+          icon={null}
+          index={-1}
+          inoperableEvents={
+            Array [
+              "onClick",
+              "onKeyPress",
+            ]
+          }
+          isDisabled={false}
+          isHovered={false}
+          isPlainText={false}
+          onClick={[Function]}
+          role="none"
+          styleChildren={true}
+          tooltipProps={Object {}}
+        >
+          Separated Action
+        </InternalDropdownItem>,
+      ]
+    }
+    isGrouped={false}
+    isOpen={true}
+    isPlain={false}
+    menuAppendTo="inline"
+    onSelect={[Function]}
+    position="left"
+    toggle={
+      <DropdownToggle
+        id="Dropdown Toggle"
+      >
+        Dropdown
+      </DropdownToggle>
+    }
+  >
+    <div
+      className="pf-c-dropdown pf-m-expanded"
+      data-ouia-component-id="OUIA-Generated-Dropdown-3"
+      data-ouia-component-type="PF4/Dropdown"
+      data-ouia-safe={true}
+    >
+      <DropdownToggle
+        aria-haspopup={true}
+        getMenuRef={[Function]}
+        id="Dropdown Toggle"
+        isOpen={true}
+        isPlain={false}
+        key=".0"
+        onEnter={[Function]}
+        parentRef={
+          Object {
+            "current": <div
+              class="pf-c-dropdown pf-m-expanded"
+              data-ouia-component-id="OUIA-Generated-Dropdown-3"
+              data-ouia-component-type="PF4/Dropdown"
+              data-ouia-safe="true"
+            >
+              <button
+                aria-expanded="true"
+                aria-haspopup="true"
+                class="pf-c-dropdown__toggle"
+                data-ouia-component-id="OUIA-Generated-DropdownToggle-3"
+                data-ouia-component-type="PF4/DropdownToggle"
+                data-ouia-safe="true"
+                id="Dropdown Toggle"
+                type="button"
+              >
+                <span
+                  class="pf-c-dropdown__toggle-text"
+                >
+                  Dropdown
+                </span>
+                <span
+                  class="pf-c-dropdown__toggle-icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <ul
+                aria-labelledby="Dropdown Toggle"
+                class="pf-c-dropdown__menu pf-m-align-left-on-sm pf-m-align-right-on-md pf-m-align-left-on-lg pf-m-align-right-on-xl pf-m-align-left-on-2xl"
+                role="menu"
+              >
+                <li
+                  role="none"
+                >
+                  <a
+                    aria-disabled="false"
+                    class="pf-c-dropdown__menu-item"
+                  >
+                    Link
+                  </a>
+                </li>
+                <li
+                  role="none"
+                >
+                  <button
+                    aria-disabled="false"
+                    class="pf-c-dropdown__menu-item"
+                    type="button"
+                  >
+                    Action
+                  </button>
+                </li>
+                <li
+                  role="none"
+                >
+                  <a
+                    aria-disabled="true"
+                    class="pf-m-disabled pf-c-dropdown__menu-item"
+                  >
+                    Disabled Link
+                  </a>
+                </li>
+                <li
+                  role="none"
+                >
+                  <button
+                    aria-disabled="true"
+                    class="pf-m-disabled pf-c-dropdown__menu-item"
+                    type="button"
+                  >
+                    Disabled Action
+                  </button>
+                </li>
+                <li
+                  role="separator"
+                >
+                  <div
+                    class="pf-c-divider"
+                    role="separator"
+                  />
+                </li>
+                <li
+                  role="none"
+                >
+                  <a
+                    aria-disabled="false"
+                    class="pf-c-dropdown__menu-item"
+                  >
+                    Separated Link
+                  </a>
+                </li>
+                <li
+                  role="none"
+                >
+                  <button
+                    aria-disabled="false"
+                    class="pf-c-dropdown__menu-item"
+                    type="button"
+                  >
+                    Separated Action
+                  </button>
+                </li>
+              </ul>
+            </div>,
+          }
+        }
+      >
+        <Toggle
+          aria-haspopup={true}
+          bubbleEvent={false}
+          className=""
+          data-ouia-component-id="OUIA-Generated-DropdownToggle-3"
+          data-ouia-component-type="PF4/DropdownToggle"
+          data-ouia-safe={true}
+          getMenuRef={[Function]}
+          id="Dropdown Toggle"
+          isActive={false}
+          isDisabled={false}
+          isOpen={true}
+          isPlain={false}
+          isPrimary={false}
+          isSplitButton={false}
+          onEnter={[Function]}
+          onToggle={[Function]}
+          parentRef={
+            Object {
+              "current": <div
+                class="pf-c-dropdown pf-m-expanded"
+                data-ouia-component-id="OUIA-Generated-Dropdown-3"
+                data-ouia-component-type="PF4/Dropdown"
+                data-ouia-safe="true"
+              >
+                <button
+                  aria-expanded="true"
+                  aria-haspopup="true"
+                  class="pf-c-dropdown__toggle"
+                  data-ouia-component-id="OUIA-Generated-DropdownToggle-3"
+                  data-ouia-component-type="PF4/DropdownToggle"
+                  data-ouia-safe="true"
+                  id="Dropdown Toggle"
+                  type="button"
+                >
+                  <span
+                    class="pf-c-dropdown__toggle-text"
+                  >
+                    Dropdown
+                  </span>
+                  <span
+                    class="pf-c-dropdown__toggle-icon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style="vertical-align: -0.125em;"
+                      viewBox="0 0 320 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+                <ul
+                  aria-labelledby="Dropdown Toggle"
+                  class="pf-c-dropdown__menu pf-m-align-left-on-sm pf-m-align-right-on-md pf-m-align-left-on-lg pf-m-align-right-on-xl pf-m-align-left-on-2xl"
+                  role="menu"
+                >
+                  <li
+                    role="none"
+                  >
+                    <a
+                      aria-disabled="false"
+                      class="pf-c-dropdown__menu-item"
+                    >
+                      Link
+                    </a>
+                  </li>
+                  <li
+                    role="none"
+                  >
+                    <button
+                      aria-disabled="false"
+                      class="pf-c-dropdown__menu-item"
+                      type="button"
+                    >
+                      Action
+                    </button>
+                  </li>
+                  <li
+                    role="none"
+                  >
+                    <a
+                      aria-disabled="true"
+                      class="pf-m-disabled pf-c-dropdown__menu-item"
+                    >
+                      Disabled Link
+                    </a>
+                  </li>
+                  <li
+                    role="none"
+                  >
+                    <button
+                      aria-disabled="true"
+                      class="pf-m-disabled pf-c-dropdown__menu-item"
+                      type="button"
+                    >
+                      Disabled Action
+                    </button>
+                  </li>
+                  <li
+                    role="separator"
+                  >
+                    <div
+                      class="pf-c-divider"
+                      role="separator"
+                    />
+                  </li>
+                  <li
+                    role="none"
+                  >
+                    <a
+                      aria-disabled="false"
+                      class="pf-c-dropdown__menu-item"
+                    >
+                      Separated Link
+                    </a>
+                  </li>
+                  <li
+                    role="none"
+                  >
+                    <button
+                      aria-disabled="false"
+                      class="pf-c-dropdown__menu-item"
+                      type="button"
+                    >
+                      Separated Action
+                    </button>
+                  </li>
+                </ul>
+              </div>,
+            }
+          }
+        >
+          <button
+            aria-expanded={true}
+            aria-haspopup={true}
+            className="pf-c-dropdown__toggle"
+            data-ouia-component-id="OUIA-Generated-DropdownToggle-3"
+            data-ouia-component-type="PF4/DropdownToggle"
+            data-ouia-safe={true}
+            disabled={false}
+            id="Dropdown Toggle"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            type="button"
+          >
+            <span
+              className="pf-c-dropdown__toggle-text"
+            >
+              Dropdown
+            </span>
+            <span
+              className="pf-c-dropdown__toggle-icon"
+            >
+              <CaretDownIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
+              >
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                  />
+                </svg>
+              </CaretDownIcon>
+            </span>
+          </button>
+        </Toggle>
+      </DropdownToggle>
+      <DropdownMenu
+        alignments={
+          Object {
+            "2xl": "left",
+            "lg": "left",
+            "md": "right",
+            "sm": "left",
+            "xl": "right",
+          }
+        }
+        aria-labelledby="Dropdown Toggle"
+        autoFocus={false}
+        className=""
+        component="ul"
+        isGrouped={false}
+        isOpen={true}
+        openedOnEnter={false}
+        position="left"
+        setMenuComponentRef={[Function]}
+      >
+        <ul
+          aria-labelledby="Dropdown Toggle"
+          autoFocus={false}
+          className="pf-c-dropdown__menu pf-m-align-left-on-sm pf-m-align-right-on-md pf-m-align-left-on-lg pf-m-align-right-on-xl pf-m-align-left-on-2xl"
+          hidden={false}
+          role="menu"
+        >
+          <InternalDropdownItem
+            className=""
+            component="a"
+            context={
+              Object {
+                "keyHandler": [Function],
+                "sendRef": [Function],
+              }
+            }
+            description={null}
+            enterTriggersArrowDown={false}
+            icon={null}
+            index={0}
+            inoperableEvents={
+              Array [
+                "onClick",
+                "onKeyPress",
+              ]
+            }
+            isDisabled={false}
+            isHovered={false}
+            isPlainText={false}
+            key=".$link"
+            onClick={[Function]}
+            role="none"
+            styleChildren={true}
+            tooltipProps={Object {}}
+          >
+            <li
+              className={null}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="none"
+            >
+              <a
+                aria-disabled={false}
+                className="pf-c-dropdown__menu-item"
+              >
+                Link
+              </a>
+            </li>
+          </InternalDropdownItem>
+          <InternalDropdownItem
+            className=""
+            component="button"
+            context={
+              Object {
+                "keyHandler": [Function],
+                "sendRef": [Function],
+              }
+            }
+            description={null}
+            enterTriggersArrowDown={false}
+            icon={null}
+            index={1}
+            inoperableEvents={
+              Array [
+                "onClick",
+                "onKeyPress",
+              ]
+            }
+            isDisabled={false}
+            isHovered={false}
+            isPlainText={false}
+            key=".$action"
+            onClick={[Function]}
+            role="none"
+            styleChildren={true}
+            tooltipProps={Object {}}
+          >
+            <li
+              className={null}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="none"
+            >
+              <button
+                aria-disabled={false}
+                className="pf-c-dropdown__menu-item"
+                type="button"
+              >
+                Action
+              </button>
+            </li>
+          </InternalDropdownItem>
+          <InternalDropdownItem
+            className=""
+            component="a"
+            context={
+              Object {
+                "keyHandler": [Function],
+                "sendRef": [Function],
+              }
+            }
+            description={null}
+            enterTriggersArrowDown={false}
+            icon={null}
+            index={2}
+            inoperableEvents={
+              Array [
+                "onClick",
+                "onKeyPress",
+              ]
+            }
+            isDisabled={true}
+            isHovered={false}
+            isPlainText={false}
+            key=".$disabled link"
+            onClick={[Function]}
+            role="none"
+            styleChildren={true}
+            tooltipProps={Object {}}
+          >
+            <li
+              className={null}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="none"
+            >
+              <a
+                aria-disabled={true}
+                className="pf-m-disabled pf-c-dropdown__menu-item"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+              >
+                Disabled Link
+              </a>
+            </li>
+          </InternalDropdownItem>
+          <InternalDropdownItem
+            className=""
+            component="button"
+            context={
+              Object {
+                "keyHandler": [Function],
+                "sendRef": [Function],
+              }
+            }
+            description={null}
+            enterTriggersArrowDown={false}
+            icon={null}
+            index={3}
+            inoperableEvents={
+              Array [
+                "onClick",
+                "onKeyPress",
+              ]
+            }
+            isDisabled={true}
+            isHovered={false}
+            isPlainText={false}
+            key=".$disabled action"
+            onClick={[Function]}
+            role="none"
+            styleChildren={true}
+            tooltipProps={Object {}}
+          >
+            <li
+              className={null}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="none"
+            >
+              <button
+                aria-disabled={true}
+                className="pf-m-disabled pf-c-dropdown__menu-item"
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                type="button"
+              >
+                Disabled Action
+              </button>
+            </li>
+          </InternalDropdownItem>
+          <DropdownSeparator
+            index={4}
+            key=".$separator"
+          >
+            <InternalDropdownItem
+              className=""
+              component={
+                <Divider
+                  component="div"
+                />
+              }
+              context={
+                Object {
+                  "keyHandler": [Function],
+                  "sendRef": [Function],
+                }
+              }
+              data-ouia-component-id="OUIA-Generated-DropdownSeparator-1"
+              data-ouia-component-type="PF4/DropdownSeparator"
+              data-ouia-safe={true}
+              description={null}
+              enterTriggersArrowDown={false}
+              icon={null}
+              index={4}
+              inoperableEvents={
+                Array [
+                  "onClick",
+                  "onKeyPress",
+                ]
+              }
+              isDisabled={false}
+              isHovered={false}
+              isPlainText={false}
+              onClick={[Function]}
+              role="separator"
+              styleChildren={true}
+              tooltipProps={Object {}}
+            >
+              <li
+                className={null}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                role="separator"
+              >
+                <Divider
+                  className=""
+                  component="div"
+                >
+                  <div
+                    className="pf-c-divider"
+                    role="separator"
+                  />
+                </Divider>
+              </li>
+            </InternalDropdownItem>
+          </DropdownSeparator>
+          <InternalDropdownItem
+            className=""
+            component="a"
+            context={
+              Object {
+                "keyHandler": [Function],
+                "sendRef": [Function],
+              }
+            }
+            description={null}
+            enterTriggersArrowDown={false}
+            icon={null}
+            index={5}
+            inoperableEvents={
+              Array [
+                "onClick",
+                "onKeyPress",
+              ]
+            }
+            isDisabled={false}
+            isHovered={false}
+            isPlainText={false}
+            key=".$separated link"
+            onClick={[Function]}
+            role="none"
+            styleChildren={true}
+            tooltipProps={Object {}}
+          >
+            <li
+              className={null}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="none"
+            >
+              <a
+                aria-disabled={false}
+                className="pf-c-dropdown__menu-item"
+              >
+                Separated Link
+              </a>
+            </li>
+          </InternalDropdownItem>
+          <InternalDropdownItem
+            className=""
+            component="button"
+            context={
+              Object {
+                "keyHandler": [Function],
+                "sendRef": [Function],
+              }
+            }
+            description={null}
+            enterTriggersArrowDown={false}
+            icon={null}
+            index={6}
+            inoperableEvents={
+              Array [
+                "onClick",
+                "onKeyPress",
+              ]
+            }
+            isDisabled={false}
+            isHovered={false}
+            isPlainText={false}
+            key=".$separated action"
+            onClick={[Function]}
+            role="none"
+            styleChildren={true}
+            tooltipProps={Object {}}
+          >
+            <li
+              className={null}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="none"
+            >
+              <button
+                aria-disabled={false}
+                className="pf-c-dropdown__menu-item"
+                type="button"
+              >
+                Separated Action
+              </button>
+            </li>
+          </InternalDropdownItem>
+        </ul>
+      </DropdownMenu>
+    </div>
+  </DropdownWithContext>
+</Dropdown>
+`;
+
 exports[`dropdown basic 1`] = `
 <Dropdown
   isOpen={true}
@@ -3862,7 +4931,7 @@ exports[`dropdown basic 1`] = `
   >
     <div
       className="pf-c-dropdown pf-m-expanded"
-      data-ouia-component-id="OUIA-Generated-Dropdown-7"
+      data-ouia-component-id="OUIA-Generated-Dropdown-8"
       data-ouia-component-type="PF4/Dropdown"
       data-ouia-safe={true}
     >
@@ -3878,7 +4947,7 @@ exports[`dropdown basic 1`] = `
           Object {
             "current": <div
               class="pf-c-dropdown pf-m-expanded"
-              data-ouia-component-id="OUIA-Generated-Dropdown-7"
+              data-ouia-component-id="OUIA-Generated-Dropdown-8"
               data-ouia-component-type="PF4/Dropdown"
               data-ouia-safe="true"
             >
@@ -3886,7 +4955,7 @@ exports[`dropdown basic 1`] = `
                 aria-expanded="true"
                 aria-haspopup="false"
                 class="pf-c-dropdown__toggle"
-                data-ouia-component-id="OUIA-Generated-DropdownToggle-7"
+                data-ouia-component-id="OUIA-Generated-DropdownToggle-8"
                 data-ouia-component-type="PF4/DropdownToggle"
                 data-ouia-safe="true"
                 id="Dropdown Toggle"
@@ -3930,7 +4999,7 @@ exports[`dropdown basic 1`] = `
           aria-haspopup={false}
           bubbleEvent={false}
           className=""
-          data-ouia-component-id="OUIA-Generated-DropdownToggle-7"
+          data-ouia-component-id="OUIA-Generated-DropdownToggle-8"
           data-ouia-component-type="PF4/DropdownToggle"
           data-ouia-safe={true}
           getMenuRef={[Function]}
@@ -3947,7 +5016,7 @@ exports[`dropdown basic 1`] = `
             Object {
               "current": <div
                 class="pf-c-dropdown pf-m-expanded"
-                data-ouia-component-id="OUIA-Generated-Dropdown-7"
+                data-ouia-component-id="OUIA-Generated-Dropdown-8"
                 data-ouia-component-type="PF4/Dropdown"
                 data-ouia-safe="true"
               >
@@ -3955,7 +5024,7 @@ exports[`dropdown basic 1`] = `
                   aria-expanded="true"
                   aria-haspopup="false"
                   class="pf-c-dropdown__toggle"
-                  data-ouia-component-id="OUIA-Generated-DropdownToggle-7"
+                  data-ouia-component-id="OUIA-Generated-DropdownToggle-8"
                   data-ouia-component-type="PF4/DropdownToggle"
                   data-ouia-safe="true"
                   id="Dropdown Toggle"
@@ -3999,7 +5068,7 @@ exports[`dropdown basic 1`] = `
             aria-expanded={true}
             aria-haspopup={false}
             className="pf-c-dropdown__toggle"
-            data-ouia-component-id="OUIA-Generated-DropdownToggle-7"
+            data-ouia-component-id="OUIA-Generated-DropdownToggle-8"
             data-ouia-component-type="PF4/DropdownToggle"
             data-ouia-safe={true}
             disabled={false}
@@ -4462,7 +5531,7 @@ exports[`dropdown dropup + right aligned 1`] = `
   >
     <div
       className="pf-c-dropdown pf-m-top pf-m-align-right"
-      data-ouia-component-id="OUIA-Generated-Dropdown-4"
+      data-ouia-component-id="OUIA-Generated-Dropdown-5"
       data-ouia-component-type="PF4/Dropdown"
       data-ouia-safe={true}
     >
@@ -4478,7 +5547,7 @@ exports[`dropdown dropup + right aligned 1`] = `
           Object {
             "current": <div
               class="pf-c-dropdown pf-m-top pf-m-align-right"
-              data-ouia-component-id="OUIA-Generated-Dropdown-4"
+              data-ouia-component-id="OUIA-Generated-Dropdown-5"
               data-ouia-component-type="PF4/Dropdown"
               data-ouia-safe="true"
             >
@@ -4486,7 +5555,7 @@ exports[`dropdown dropup + right aligned 1`] = `
                 aria-expanded="false"
                 aria-haspopup="true"
                 class="pf-c-dropdown__toggle"
-                data-ouia-component-id="OUIA-Generated-DropdownToggle-4"
+                data-ouia-component-id="OUIA-Generated-DropdownToggle-5"
                 data-ouia-component-type="PF4/DropdownToggle"
                 data-ouia-safe="true"
                 id="Dropdown Toggle"
@@ -4523,7 +5592,7 @@ exports[`dropdown dropup + right aligned 1`] = `
           aria-haspopup={true}
           bubbleEvent={false}
           className=""
-          data-ouia-component-id="OUIA-Generated-DropdownToggle-4"
+          data-ouia-component-id="OUIA-Generated-DropdownToggle-5"
           data-ouia-component-type="PF4/DropdownToggle"
           data-ouia-safe={true}
           getMenuRef={[Function]}
@@ -4540,7 +5609,7 @@ exports[`dropdown dropup + right aligned 1`] = `
             Object {
               "current": <div
                 class="pf-c-dropdown pf-m-top pf-m-align-right"
-                data-ouia-component-id="OUIA-Generated-Dropdown-4"
+                data-ouia-component-id="OUIA-Generated-Dropdown-5"
                 data-ouia-component-type="PF4/Dropdown"
                 data-ouia-safe="true"
               >
@@ -4548,7 +5617,7 @@ exports[`dropdown dropup + right aligned 1`] = `
                   aria-expanded="false"
                   aria-haspopup="true"
                   class="pf-c-dropdown__toggle"
-                  data-ouia-component-id="OUIA-Generated-DropdownToggle-4"
+                  data-ouia-component-id="OUIA-Generated-DropdownToggle-5"
                   data-ouia-component-type="PF4/DropdownToggle"
                   data-ouia-safe="true"
                   id="Dropdown Toggle"
@@ -4585,7 +5654,7 @@ exports[`dropdown dropup + right aligned 1`] = `
             aria-expanded={false}
             aria-haspopup={true}
             className="pf-c-dropdown__toggle"
-            data-ouia-component-id="OUIA-Generated-DropdownToggle-4"
+            data-ouia-component-id="OUIA-Generated-DropdownToggle-5"
             data-ouia-component-type="PF4/DropdownToggle"
             data-ouia-safe={true}
             disabled={false}
@@ -5024,7 +6093,7 @@ exports[`dropdown dropup 1`] = `
   >
     <div
       className="pf-c-dropdown pf-m-top"
-      data-ouia-component-id="OUIA-Generated-Dropdown-3"
+      data-ouia-component-id="OUIA-Generated-Dropdown-4"
       data-ouia-component-type="PF4/Dropdown"
       data-ouia-safe={true}
     >
@@ -5040,7 +6109,7 @@ exports[`dropdown dropup 1`] = `
           Object {
             "current": <div
               class="pf-c-dropdown pf-m-top"
-              data-ouia-component-id="OUIA-Generated-Dropdown-3"
+              data-ouia-component-id="OUIA-Generated-Dropdown-4"
               data-ouia-component-type="PF4/Dropdown"
               data-ouia-safe="true"
             >
@@ -5048,7 +6117,7 @@ exports[`dropdown dropup 1`] = `
                 aria-expanded="false"
                 aria-haspopup="true"
                 class="pf-c-dropdown__toggle"
-                data-ouia-component-id="OUIA-Generated-DropdownToggle-3"
+                data-ouia-component-id="OUIA-Generated-DropdownToggle-4"
                 data-ouia-component-type="PF4/DropdownToggle"
                 data-ouia-safe="true"
                 id="Dropdown Toggle"
@@ -5085,7 +6154,7 @@ exports[`dropdown dropup 1`] = `
           aria-haspopup={true}
           bubbleEvent={false}
           className=""
-          data-ouia-component-id="OUIA-Generated-DropdownToggle-3"
+          data-ouia-component-id="OUIA-Generated-DropdownToggle-4"
           data-ouia-component-type="PF4/DropdownToggle"
           data-ouia-safe={true}
           getMenuRef={[Function]}
@@ -5102,7 +6171,7 @@ exports[`dropdown dropup 1`] = `
             Object {
               "current": <div
                 class="pf-c-dropdown pf-m-top"
-                data-ouia-component-id="OUIA-Generated-Dropdown-3"
+                data-ouia-component-id="OUIA-Generated-Dropdown-4"
                 data-ouia-component-type="PF4/Dropdown"
                 data-ouia-safe="true"
               >
@@ -5110,7 +6179,7 @@ exports[`dropdown dropup 1`] = `
                   aria-expanded="false"
                   aria-haspopup="true"
                   class="pf-c-dropdown__toggle"
-                  data-ouia-component-id="OUIA-Generated-DropdownToggle-3"
+                  data-ouia-component-id="OUIA-Generated-DropdownToggle-4"
                   data-ouia-component-type="PF4/DropdownToggle"
                   data-ouia-safe="true"
                   id="Dropdown Toggle"
@@ -5147,7 +6216,7 @@ exports[`dropdown dropup 1`] = `
             aria-expanded={false}
             aria-haspopup={true}
             className="pf-c-dropdown__toggle"
-            data-ouia-component-id="OUIA-Generated-DropdownToggle-3"
+            data-ouia-component-id="OUIA-Generated-DropdownToggle-4"
             data-ouia-component-type="PF4/DropdownToggle"
             data-ouia-safe={true}
             disabled={false}
@@ -5586,7 +6655,7 @@ exports[`dropdown expanded 1`] = `
   >
     <div
       className="pf-c-dropdown pf-m-expanded"
-      data-ouia-component-id="OUIA-Generated-Dropdown-5"
+      data-ouia-component-id="OUIA-Generated-Dropdown-6"
       data-ouia-component-type="PF4/Dropdown"
       data-ouia-safe={true}
     >
@@ -5602,7 +6671,7 @@ exports[`dropdown expanded 1`] = `
           Object {
             "current": <div
               class="pf-c-dropdown pf-m-expanded"
-              data-ouia-component-id="OUIA-Generated-Dropdown-5"
+              data-ouia-component-id="OUIA-Generated-Dropdown-6"
               data-ouia-component-type="PF4/Dropdown"
               data-ouia-safe="true"
             >
@@ -5610,7 +6679,7 @@ exports[`dropdown expanded 1`] = `
                 aria-expanded="true"
                 aria-haspopup="true"
                 class="pf-c-dropdown__toggle"
-                data-ouia-component-id="OUIA-Generated-DropdownToggle-5"
+                data-ouia-component-id="OUIA-Generated-DropdownToggle-6"
                 data-ouia-component-type="PF4/DropdownToggle"
                 data-ouia-safe="true"
                 id="Dropdown Toggle"
@@ -5724,7 +6793,7 @@ exports[`dropdown expanded 1`] = `
           aria-haspopup={true}
           bubbleEvent={false}
           className=""
-          data-ouia-component-id="OUIA-Generated-DropdownToggle-5"
+          data-ouia-component-id="OUIA-Generated-DropdownToggle-6"
           data-ouia-component-type="PF4/DropdownToggle"
           data-ouia-safe={true}
           getMenuRef={[Function]}
@@ -5741,7 +6810,7 @@ exports[`dropdown expanded 1`] = `
             Object {
               "current": <div
                 class="pf-c-dropdown pf-m-expanded"
-                data-ouia-component-id="OUIA-Generated-Dropdown-5"
+                data-ouia-component-id="OUIA-Generated-Dropdown-6"
                 data-ouia-component-type="PF4/Dropdown"
                 data-ouia-safe="true"
               >
@@ -5749,7 +6818,7 @@ exports[`dropdown expanded 1`] = `
                   aria-expanded="true"
                   aria-haspopup="true"
                   class="pf-c-dropdown__toggle"
-                  data-ouia-component-id="OUIA-Generated-DropdownToggle-5"
+                  data-ouia-component-id="OUIA-Generated-DropdownToggle-6"
                   data-ouia-component-type="PF4/DropdownToggle"
                   data-ouia-safe="true"
                   id="Dropdown Toggle"
@@ -5863,7 +6932,7 @@ exports[`dropdown expanded 1`] = `
             aria-expanded={true}
             aria-haspopup={true}
             className="pf-c-dropdown__toggle"
-            data-ouia-component-id="OUIA-Generated-DropdownToggle-5"
+            data-ouia-component-id="OUIA-Generated-DropdownToggle-6"
             data-ouia-component-type="PF4/DropdownToggle"
             data-ouia-safe={true}
             disabled={false}
@@ -6117,7 +7186,7 @@ exports[`dropdown expanded 1`] = `
                   "sendRef": [Function],
                 }
               }
-              data-ouia-component-id="OUIA-Generated-DropdownSeparator-1"
+              data-ouia-component-id="OUIA-Generated-DropdownSeparator-2"
               data-ouia-component-type="PF4/DropdownSeparator"
               data-ouia-safe={true}
               description={null}
@@ -6638,7 +7707,7 @@ exports[`dropdown primary 1`] = `
   >
     <div
       className="pf-c-dropdown"
-      data-ouia-component-id="OUIA-Generated-Dropdown-6"
+      data-ouia-component-id="OUIA-Generated-Dropdown-7"
       data-ouia-component-type="PF4/Dropdown"
       data-ouia-safe={true}
     >
@@ -6655,7 +7724,7 @@ exports[`dropdown primary 1`] = `
           Object {
             "current": <div
               class="pf-c-dropdown"
-              data-ouia-component-id="OUIA-Generated-Dropdown-6"
+              data-ouia-component-id="OUIA-Generated-Dropdown-7"
               data-ouia-component-type="PF4/Dropdown"
               data-ouia-safe="true"
             >
@@ -6663,7 +7732,7 @@ exports[`dropdown primary 1`] = `
                 aria-expanded="false"
                 aria-haspopup="true"
                 class="pf-c-dropdown__toggle pf-m-primary"
-                data-ouia-component-id="OUIA-Generated-DropdownToggle-6"
+                data-ouia-component-id="OUIA-Generated-DropdownToggle-7"
                 data-ouia-component-type="PF4/DropdownToggle"
                 data-ouia-safe="true"
                 id="Dropdown Toggle"
@@ -6700,7 +7769,7 @@ exports[`dropdown primary 1`] = `
           aria-haspopup={true}
           bubbleEvent={false}
           className=""
-          data-ouia-component-id="OUIA-Generated-DropdownToggle-6"
+          data-ouia-component-id="OUIA-Generated-DropdownToggle-7"
           data-ouia-component-type="PF4/DropdownToggle"
           data-ouia-safe={true}
           getMenuRef={[Function]}
@@ -6717,7 +7786,7 @@ exports[`dropdown primary 1`] = `
             Object {
               "current": <div
                 class="pf-c-dropdown"
-                data-ouia-component-id="OUIA-Generated-Dropdown-6"
+                data-ouia-component-id="OUIA-Generated-Dropdown-7"
                 data-ouia-component-type="PF4/Dropdown"
                 data-ouia-safe="true"
               >
@@ -6725,7 +7794,7 @@ exports[`dropdown primary 1`] = `
                   aria-expanded="false"
                   aria-haspopup="true"
                   class="pf-c-dropdown__toggle pf-m-primary"
-                  data-ouia-component-id="OUIA-Generated-DropdownToggle-6"
+                  data-ouia-component-id="OUIA-Generated-DropdownToggle-7"
                   data-ouia-component-type="PF4/DropdownToggle"
                   data-ouia-safe="true"
                   id="Dropdown Toggle"
@@ -6762,7 +7831,7 @@ exports[`dropdown primary 1`] = `
             aria-expanded={false}
             aria-haspopup={true}
             className="pf-c-dropdown__toggle pf-m-primary"
-            data-ouia-component-id="OUIA-Generated-DropdownToggle-6"
+            data-ouia-component-id="OUIA-Generated-DropdownToggle-7"
             data-ouia-component-type="PF4/DropdownToggle"
             data-ouia-safe={true}
             disabled={false}

--- a/packages/react-core/src/components/Dropdown/dropdownConstants.tsx
+++ b/packages/react-core/src/components/Dropdown/dropdownConstants.tsx
@@ -30,6 +30,13 @@ export const DropdownContext = React.createContext<
     plainTextClass?: string;
     menuComponent?: string;
     ouiaComponentType?: string;
+    alignments?: {
+      sm?: 'right' | 'left';
+      md?: 'right' | 'left';
+      lg?: 'right' | 'left';
+      xl?: 'right' | 'left';
+      '2xl'?: 'right' | 'left';
+    };
   } & OUIAProps
 >({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/react-core/src/components/Dropdown/examples/Dropdown.md
+++ b/packages/react-core/src/components/Dropdown/examples/Dropdown.md
@@ -445,6 +445,82 @@ class PositionRightDropdown extends React.Component {
 }
 ```
 
+### Alignments on different breakpoints
+
+```js
+import React from 'react';
+import {
+  Dropdown,
+  DropdownToggle,
+  DropdownItem,
+  DropdownSeparator,
+  DropdownPosition,
+  DropdownDirection,
+  KebabToggle
+} from '@patternfly/react-core';
+import ThIcon from '@patternfly/react-icons/dist/js/icons/th-icon';
+
+class AlignmentsDropdown extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isOpen: false
+    };
+    this.onToggle = isOpen => {
+      this.setState({
+        isOpen
+      });
+    };
+    this.onSelect = event => {
+      this.setState({
+        isOpen: !this.state.isOpen
+      });
+      this.onFocus();
+    };
+    this.onFocus = () => {
+      const element = document.getElementById('toggle-id-5');
+      element.focus();
+    };
+  }
+
+  render() {
+    const { isOpen } = this.state;
+    const dropdownItems = [
+      <DropdownItem key="link">Link</DropdownItem>,
+      <DropdownItem key="action" component="button">
+        Action
+      </DropdownItem>,
+      <DropdownItem key="disabled link" isDisabled>
+        Disabled Link
+      </DropdownItem>,
+      <DropdownItem key="disabled action" isDisabled component="button">
+        Disabled Action
+      </DropdownItem>,
+      <DropdownSeparator key="separator" />,
+      <DropdownItem key="separated link">Separated Link</DropdownItem>,
+      <DropdownItem key="separated action" component="button">
+        Separated Action
+      </DropdownItem>
+    ];
+    return (
+      <Dropdown
+        onSelect={this.onSelect}
+        alignments={{
+          sm: 'left',
+          md: 'right',
+          lg: 'left',
+          xl: 'right',
+          '2xl': 'left'
+        }}
+        toggle={<DropdownToggle onToggle={this.onToggle}>Dropdown</DropdownToggle>}
+        isOpen={isOpen}
+        dropdownItems={dropdownItems}
+      />
+    );
+  }
+}
+```
+
 ### Direction up
 
 ```js

--- a/packages/react-core/src/helpers/util.ts
+++ b/packages/react-core/src/helpers/util.ts
@@ -248,10 +248,11 @@ export const formatBreakpointMods = (
     '2xl'?: string;
     '3xl'?: string;
   },
-  styles: any
+  styles: any,
+  stylePrefix: string = ''
 ) =>
   Object.entries(mods || {})
-    .map(([breakpoint, mod]) => `${mod}${breakpoint !== 'default' ? `-on-${breakpoint}` : ''}`)
+    .map(([breakpoint, mod]) => `${stylePrefix}${mod}${breakpoint !== 'default' ? `-on-${breakpoint}` : ''}`)
     .map(toCamel)
     .map(mod => mod.replace(/-?(\dxl)/gi, (_res, group) => `_${group}`))
     .map(modifierKey => styles.modifiers[modifierKey])

--- a/packages/react-integration/cypress/integration/dropdown.spec.ts
+++ b/packages/react-integration/cypress/integration/dropdown.spec.ts
@@ -22,6 +22,19 @@ describe('Dropdown Demo Test', () => {
     cy.get('#dropdown').should('not.have.class', 'pf-m-expanded');
   });
 
+  it('Verify dropdown menu has alignment breakpoints', () => {
+    cy.get('#dropdown > button').click();
+    cy.get('#dropdown').should('have.class', 'pf-m-expanded');
+    const menu = cy.get('#dropdown .pf-c-dropdown__menu');
+    menu.should('have.class', 'pf-m-align-left-on-sm');
+    menu.should('have.class', 'pf-m-align-right-on-md');
+    menu.should('have.class', 'pf-m-align-left-on-lg');
+    menu.should('have.class', 'pf-m-align-right-on-xl');
+    menu.should('have.class', 'pf-m-align-left-on-2xl');
+    cy.get('#toggle-id').click();
+    cy.get('#dropdown').should('not.have.class', 'pf-m-expanded');
+  });
+
   it('Verify dropdown menu items disabled', () => {
     // Links are disabled
     cy.get('#dropdown > button').click();

--- a/packages/react-integration/demo-app-ts/src/components/demos/DropdownDemo/DropdownDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DropdownDemo/DropdownDemo.tsx
@@ -199,6 +199,13 @@ export class DropdownDemo extends React.Component<{}, DropdownState> {
               Dropdown
             </DropdownToggle>
           }
+          alignments={{
+            sm: 'left',
+            md: 'right',
+            lg: 'left',
+            xl: 'right',
+            '2xl': 'left'
+          }}
           isOpen={isOpen}
           dropdownItems={dropdownItems}
         />


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5347

- Adds `alignments` property that dictates left/right alignment on specific breakpoints
- Fixed console warning where `ref` was getting improperly assigned to DropdownSeparator function component (ref isn't used for these).