### PR TITLE
feat(Gallery): add min/max widths at breakpoints

### DIFF
--- a/packages/react-core/src/layouts/Gallery/Gallery.tsx
+++ b/packages/react-core/src/layouts/Gallery/Gallery.tsx
@@ -9,15 +9,61 @@ export interface GalleryProps extends React.HTMLProps<HTMLDivElement> {
   className?: string;
   /** Adds space between children. */
   hasGutter?: boolean;
+  /** Minimum widths at various breakpoints. */
+  minWidths?: {
+    default?: string;
+    sm?: string;
+    md?: string;
+    lg?: string;
+    xl?: string;
+    '2xl'?: string;
+  };
+  /** Maximum widths at various breakpoints. */
+  maxWidths?: {
+    default?: string;
+    sm?: string;
+    md?: string;
+    lg?: string;
+    xl?: string;
+    '2xl'?: string;
+  };
 }
 export const Gallery: React.FunctionComponent<GalleryProps> = ({
   children = null,
   className = '',
   hasGutter = false,
+  minWidths,
+  maxWidths,
   ...props
-}: GalleryProps) => (
-  <div className={css(styles.gallery, hasGutter && styles.modifiers.gutter, className)} {...props}>
-    {children}
-  </div>
-);
+}: GalleryProps) => {
+  const minWidthStyles: any = {};
+  if (minWidths) {
+    Object.entries(minWidths || {}).map(
+      ([breakpoint, value]) =>
+        (minWidthStyles[
+          `--pf-l-gallery--GridTemplateColumns--min${breakpoint !== 'default' ? `-on-${breakpoint}` : ''}`
+        ] = value)
+    );
+  }
+  const maxWidthStyles: any = {};
+  if (maxWidths) {
+    Object.entries(maxWidths || {}).map(
+      ([breakpoint, value]) =>
+        (maxWidthStyles[
+          `--pf-l-gallery--GridTemplateColumns--max${breakpoint !== 'default' ? `-on-${breakpoint}` : ''}`
+        ] = value)
+    );
+  }
+  const widthStyles = { ...minWidthStyles, ...maxWidthStyles };
+
+  return (
+    <div
+      className={css(styles.gallery, hasGutter && styles.modifiers.gutter, className)}
+      {...props}
+      {...((minWidths || maxWidths) && { style: { ...widthStyles, ...props.style } as React.CSSProperties })}
+    >
+      {children}
+    </div>
+  );
+};
 Gallery.displayName = 'Gallery';

--- a/packages/react-core/src/layouts/Gallery/__tests__/Gallery.test.tsx
+++ b/packages/react-core/src/layouts/Gallery/__tests__/Gallery.test.tsx
@@ -1,9 +1,26 @@
 import * as React from 'react';
 import { Gallery } from '../Gallery';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 test('gutter', () => {
   const view = shallow(<Gallery hasGutter />);
   expect(view).toMatchSnapshot();
 });
 
+test('gutter breakpoints', () => {
+  const view = mount(
+    <Gallery
+      hasGutter
+      minWidths={{
+        default: '100%',
+        md: '100px',
+        xl: '300px'
+      }}
+      maxWidths={{
+        md: '200px',
+        xl: '1fr'
+      }}
+    />
+  );
+  expect(view).toMatchSnapshot();
+});

--- a/packages/react-core/src/layouts/Gallery/__tests__/__snapshots__/Gallery.test.tsx.snap
+++ b/packages/react-core/src/layouts/Gallery/__tests__/__snapshots__/Gallery.test.tsx.snap
@@ -5,3 +5,35 @@ exports[`gutter 1`] = `
   className="pf-l-gallery pf-m-gutter"
 />
 `;
+
+exports[`gutter breakpoints 1`] = `
+<Gallery
+  hasGutter={true}
+  maxWidths={
+    Object {
+      "md": "200px",
+      "xl": "1fr",
+    }
+  }
+  minWidths={
+    Object {
+      "default": "100%",
+      "md": "100px",
+      "xl": "300px",
+    }
+  }
+>
+  <div
+    className="pf-l-gallery pf-m-gutter"
+    style={
+      Object {
+        "--pf-l-gallery--GridTemplateColumns--max-on-md": "200px",
+        "--pf-l-gallery--GridTemplateColumns--max-on-xl": "1fr",
+        "--pf-l-gallery--GridTemplateColumns--min": "100%",
+        "--pf-l-gallery--GridTemplateColumns--min-on-md": "100px",
+        "--pf-l-gallery--GridTemplateColumns--min-on-xl": "300px",
+      }
+    }
+  />
+</Gallery>
+`;

--- a/packages/react-core/src/layouts/Gallery/examples/Gallery.md
+++ b/packages/react-core/src/layouts/Gallery/examples/Gallery.md
@@ -8,7 +8,9 @@ propComponents: ['Gallery', 'GalleryItem']
 import './gallery.css';
 
 ## Examples
+
 ### Basic
+
 ```js
 import React from 'react';
 import { Gallery, GalleryItem } from '@patternfly/react-core';
@@ -22,10 +24,11 @@ import { Gallery, GalleryItem } from '@patternfly/react-core';
   <GalleryItem>Gallery Item</GalleryItem>
   <GalleryItem>Gallery Item</GalleryItem>
   <GalleryItem>Gallery Item</GalleryItem>
-</Gallery>
+</Gallery>;
 ```
 
 ### With gutters
+
 ```js
 import React from 'react';
 import { Gallery, GalleryItem } from '@patternfly/react-core';
@@ -37,5 +40,85 @@ import { Gallery, GalleryItem } from '@patternfly/react-core';
   <GalleryItem>Gallery Item</GalleryItem>
   <GalleryItem>Gallery Item</GalleryItem>
   <GalleryItem>Gallery Item</GalleryItem>
-</Gallery>
+</Gallery>;
+```
+
+### Adjusting min widths
+
+```js
+import React from 'react';
+import { Gallery, GalleryItem } from '@patternfly/react-core';
+
+<Gallery
+  hasGutter
+  minWidths={{
+    md: '100px',
+    lg: '150px',
+    xl: '200px',
+    '2xl': '300px'
+  }}
+>
+  <GalleryItem>Gallery Item</GalleryItem>
+  <GalleryItem>Gallery Item</GalleryItem>
+  <GalleryItem>Gallery Item</GalleryItem>
+  <GalleryItem>Gallery Item</GalleryItem>
+  <GalleryItem>Gallery Item</GalleryItem>
+  <GalleryItem>Gallery Item</GalleryItem>
+  <GalleryItem>Gallery Item</GalleryItem>
+  <GalleryItem>Gallery Item</GalleryItem>
+</Gallery>;
+```
+
+### Adjusting max widths
+
+```js
+import React from 'react';
+import { Gallery, GalleryItem } from '@patternfly/react-core';
+
+<Gallery
+  hasGutter
+  maxWidths={{
+    md: '280px',
+    lg: '320px',
+    '2xl': '400px'
+  }}
+>
+  <GalleryItem>Gallery Item</GalleryItem>
+  <GalleryItem>Gallery Item</GalleryItem>
+  <GalleryItem>Gallery Item</GalleryItem>
+  <GalleryItem>Gallery Item</GalleryItem>
+  <GalleryItem>Gallery Item</GalleryItem>
+  <GalleryItem>Gallery Item</GalleryItem>
+  <GalleryItem>Gallery Item</GalleryItem>
+  <GalleryItem>Gallery Item</GalleryItem>
+</Gallery>;
+```
+
+### Adjusting min and max widths
+
+```js
+import React from 'react';
+import { Gallery, GalleryItem } from '@patternfly/react-core';
+
+<Gallery
+  hasGutter
+  minWidths={{
+    default: '100%',
+    md: '100px',
+    xl: '300px'
+  }}
+  maxWidths={{
+    md: '200px',
+    xl: '1fr'
+  }}
+>
+  <GalleryItem>Gallery Item</GalleryItem>
+  <GalleryItem>Gallery Item</GalleryItem>
+  <GalleryItem>Gallery Item</GalleryItem>
+  <GalleryItem>Gallery Item</GalleryItem>
+  <GalleryItem>Gallery Item</GalleryItem>
+  <GalleryItem>Gallery Item</GalleryItem>
+  <GalleryItem>Gallery Item</GalleryItem>
+  <GalleryItem>Gallery Item</GalleryItem>
+</Gallery>;
 ```

--- a/packages/react-integration/cypress/integration/gallery.spec.ts
+++ b/packages/react-integration/cypress/integration/gallery.spec.ts
@@ -19,7 +19,7 @@ describe('Gallery Demo Test', () => {
     cy.get('.pf-l-gallery').should(
       'have.attr',
       'style',
-      '--pf-l-gallery--GridTemplateColumns--min:100%; --pf-l-gallery--GridTemplateColumns--min-on-md:100px; --pf-l-gallery--GridTemplateColumns--min-on-xl:300px; --pf-l-gallery--GridTemplateColumns--max-on-md:200px; --pf-l-gallery--GridTemplateColumns--max-on-xl:1fr;'
+      '--pf-l-gallery--GridTemplateColumns--min:100%; --pf-l-gallery--GridTemplateColumns--min-on-sm:80px; --pf-l-gallery--GridTemplateColumns--min-on-md:100px; --pf-l-gallery--GridTemplateColumns--min-on-lg:150px; --pf-l-gallery--GridTemplateColumns--min-on-xl:300px; --pf-l-gallery--GridTemplateColumns--min-on-2xl:500px; --pf-l-gallery--GridTemplateColumns--max:100%; --pf-l-gallery--GridTemplateColumns--max-on-sm:80px; --pf-l-gallery--GridTemplateColumns--max-on-md:120px; --pf-l-gallery--GridTemplateColumns--max-on-lg:150px; --pf-l-gallery--GridTemplateColumns--max-on-xl:1fr; --pf-l-gallery--GridTemplateColumns--max-on-2xl:500px;'
     );
   });
 });

--- a/packages/react-integration/cypress/integration/gallery.spec.ts
+++ b/packages/react-integration/cypress/integration/gallery.spec.ts
@@ -14,4 +14,12 @@ describe('Gallery Demo Test', () => {
   it('Verify gutters', () => {
     cy.get('.pf-l-gallery').should('have.class', 'pf-m-gutter');
   });
+
+  it('Verify gallery min/max breakpoints ', () => {
+    cy.get('.pf-l-gallery').should(
+      'have.attr',
+      'style',
+      '--pf-l-gallery--GridTemplateColumns--min:100%; --pf-l-gallery--GridTemplateColumns--min-on-md:100px; --pf-l-gallery--GridTemplateColumns--min-on-xl:300px; --pf-l-gallery--GridTemplateColumns--max-on-md:200px; --pf-l-gallery--GridTemplateColumns--max-on-xl:1fr;'
+    );
+  });
 });

--- a/packages/react-integration/demo-app-ts/src/components/demos/GalleryDemo/GalleryDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/GalleryDemo/GalleryDemo.tsx
@@ -9,12 +9,19 @@ export class GalleryDemo extends React.Component {
         hasGutter
         minWidths={{
           default: '100%',
+          sm: '80px',
           md: '100px',
-          xl: '300px'
+          lg: '150px',
+          xl: '300px',
+          '2xl': '500px'
         }}
         maxWidths={{
-          md: '200px',
-          xl: '1fr'
+          default: '100%',
+          sm: '80px',
+          md: '120px',
+          lg: '150px',
+          xl: '1fr',
+          '2xl': '500px'
         }}
       >
         <GalleryItem>Gallery Item</GalleryItem>

--- a/packages/react-integration/demo-app-ts/src/components/demos/GalleryDemo/GalleryDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/GalleryDemo/GalleryDemo.tsx
@@ -5,7 +5,18 @@ export class GalleryDemo extends React.Component {
   static displayName = 'GalleryDemo';
   render() {
     return (
-      <Gallery hasGutter>
+      <Gallery
+        hasGutter
+        minWidths={{
+          default: '100%',
+          md: '100px',
+          xl: '300px'
+        }}
+        maxWidths={{
+          md: '200px',
+          xl: '1fr'
+        }}
+      >
         <GalleryItem>Gallery Item</GalleryItem>
         <GalleryItem>Gallery Item</GalleryItem>
         <GalleryItem>Gallery Item</GalleryItem>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5055

- Adds `minWidths` and `maxWidths` properties that specify their respective width modifier at different breakpoints. The `default` will set a min or max width in general (not at any breakpoint).
