### PR TITLE
feat(Table): allow for more customizable Table actions

### DIFF
--- a/packages/react-table/src/components/Table/Table.tsx
+++ b/packages/react-table/src/components/Table/Table.tsx
@@ -86,6 +86,8 @@ export interface TableProps extends OUIAProps {
   dropdownPosition?: 'right' | 'left';
   /** The desired direction to show the dropdown when clicking on the actions Kebab. Can only be used together with `actions` property */
   dropdownDirection?: 'up' | 'down';
+  /** The toggle of the actions menu dropdown. A KebabToggle or DropdownToggle component */
+  actionsToggle?: React.ReactElement;
   /** Row data */
   rows: (IRow | string[])[];
   /** Cell/column data */
@@ -177,6 +179,7 @@ export class Table extends React.Component<TableProps, {}> {
       rowLabeledBy,
       dropdownPosition,
       dropdownDirection,
+      actionsToggle,
       contentId,
       expandId,
       variant,
@@ -214,6 +217,7 @@ export class Table extends React.Component<TableProps, {}> {
       contentId,
       dropdownPosition,
       dropdownDirection,
+      actionsToggle,
       onFavorite,
       canSortFavorites,
       // order of columns: Collapsible | Selectable | Favoritable

--- a/packages/react-table/src/components/Table/TableTypes.ts
+++ b/packages/react-table/src/components/Table/TableTypes.ts
@@ -6,6 +6,7 @@ import {
   DropdownPosition
 } from '@patternfly/react-core/dist/js/components/Dropdown/dropdownConstants';
 import * as React from 'react';
+import { CustomActionsToggleProps } from './ActionsColumn';
 
 export enum TableGridBreakpoint {
   none = '',
@@ -102,6 +103,7 @@ export interface IColumn {
     contentId?: string;
     dropdownPosition?: DropdownPosition;
     dropdownDirection?: DropdownDirection;
+    actionsToggle?: (props: CustomActionsToggleProps) => React.ReactNode;
     allRowsSelected?: boolean;
     onFavorite?: OnFavorite;
   };
@@ -141,6 +143,7 @@ export interface IAction extends Omit<DropdownItemProps, 'title' | 'onClick'> {
   itemKey?: string;
   title?: string | React.ReactNode;
   onClick?: (event: React.MouseEvent, rowIndex: number, rowData: IRowData, extraData: IExtraData) => void;
+  isOutsideDropdown?: boolean;
 }
 
 export interface ISeparator extends IAction {

--- a/packages/react-table/src/components/Table/examples/Table.md
+++ b/packages/react-table/src/components/Table/examples/Table.md
@@ -608,13 +608,15 @@ To use actions you can either specify an array of actions and pass that into the
 ```js
 import React from 'react';
 import { Table, TableHeader, TableBody, headerCol } from '@patternfly/react-table';
-import { ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
+import { ButtonVariant, Checkbox, DropdownToggle, ToggleGroup, ToggleGroupItem, Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
 
 class ActionsTable extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       propToUse: 'actions',
+      useCustomToggle: false,
+      useExtraAction: false,
       columns: [
         { title: 'Repositories', cellTransforms: [headerCol()] },
         'Branches',
@@ -628,7 +630,7 @@ class ActionsTable extends React.Component {
         },
         {
           cells: ['disable actions', 'two', 3, 'four', 'five'],
-          disableActions: true
+          disableActions: true,
         },
         {
           cells: ['green actions', 'two', 4, 'four', 'five'],
@@ -638,7 +640,7 @@ class ActionsTable extends React.Component {
           cells: ['extra action props', 'two', 5, 'four', 'five'],
           actionProps: {
             'data-specific-attr': 'some-value'
-          }
+          },
         },
         {
           cells: ['blue actions', 'two', 6, 'four', 'five'],
@@ -647,6 +649,8 @@ class ActionsTable extends React.Component {
       ]
     };
     this.handleItemClick = this.handleItemClick.bind(this);
+    this.toggleCustomToggle = this.toggleCustomToggle.bind(this);
+    this.toggleExtraAction = this.toggleExtraAction.bind(this);
   }
 
   /**
@@ -656,7 +660,7 @@ class ActionsTable extends React.Component {
     return [
       {
         title: 'Some action',
-        onClick: (event, rowId, rowData, extra) => console.log('clicked on Some action, on row: ', rowId)
+        onClick: (event, rowId, rowData, extra) => console.log('clicked on Some action, on row: ', rowId),
       },
       {
         title: <a href="https://www.patternfly.org">Link action</a>
@@ -667,7 +671,16 @@ class ActionsTable extends React.Component {
       {
         title: 'Third action',
         onClick: (event, rowId, rowData, extra) => console.log('clicked on Third action, on row: ', rowId)
-      }
+      },
+      ...(this.state.useExtraAction ? 
+      [
+        {
+          title: 'Start',
+          variant: ButtonVariant.secondary,
+          onClick: (event, rowId, rowData, extra) => console.log('clicked on extra action on row: ', rowId),
+          isOutsideDropdown: true
+        },
+      ] : [])
     ];
   }
 
@@ -701,7 +714,49 @@ class ActionsTable extends React.Component {
       {
         title: <div>Another action</div>,
         onClick: (event, rowId, rowData, extra) =>
-          console.log(`clicked on Another action, on row ${rowId} of type ${rowData.type}`)
+          console.log(`clicked on Another action, on row ${rowId} of type ${rowData.type}`),
+      },
+      ...thirdAction
+    ];
+  }
+
+  /**
+   * Use actions or actionResolver, not both
+   */
+  actionResolverWithActions(rowData, { rowIndex }) {
+    if (rowIndex === 1) {
+      return null;
+    }
+
+    const thirdAction = rowData.type
+      ? [
+          {
+            isSeparator: true
+          },
+          {
+            title: `${rowData.type} action`,
+            onClick: (event, rowId, rowData, extra) =>
+              console.log(`clicked on ${rowData.type} action, on row ${rowId} of type ${rowData.type}`)
+          }
+        ]
+      : [];
+
+    return [
+      {
+        title: 'Start',
+        variant: ButtonVariant.secondary,
+        onClick: (event, rowId, rowData, extra) => console.log('clicked on extra action on row: ', rowId),
+        isOutsideDropdown: true
+      },
+      {
+        title: 'actionResolver action',
+        onClick: (event, rowId, rowData, extra) =>
+          console.log(`clicked on Some action, on row ${rowId} of type ${rowData.type}`)
+      },
+      {
+        title: <div>Another action</div>,
+        onClick: (event, rowId, rowData, extra) =>
+          console.log(`clicked on Another action, on row ${rowId} of type ${rowData.type}`),
       },
       ...thirdAction
     ];
@@ -717,34 +772,80 @@ class ActionsTable extends React.Component {
       propToUse: action
     });
   }
+  
+  toggleCustomToggle(checked) {
+    this.setState({
+      useCustomToggle: checked
+    });
+  };
+  
+  toggleExtraAction(checked) {
+    this.setState({
+      useExtraAction: checked
+    });
+  };
 
   render() {
-    const { columns, rows, propToUse } = this.state;
+    const { columns, rows, propToUse, useCustomToggle, useExtraAction } = this.state;
+    
+    const customActionsToggle = (props) => (
+      <DropdownToggle onToggle={props.onToggle} isDisabled={props.isDisabled}>
+        Actions
+      </DropdownToggle>
+    );
+    
     return (
       <React.Fragment>
-        <ToggleGroup aria-label="actions or actionResolver">
-          <ToggleGroupItem
-            text="Use actions prop"
-            buttonId="actions"
-            isSelected={propToUse === 'actions'}
-            onChange={this.handleItemClick}
-          />
-          <ToggleGroupItem
-            text="Use actionResolver prop"
-            buttonId="actionResolver"
-            isSelected={propToUse === 'actionResolver'}
-            onChange={this.handleItemClick}
-          />
-        </ToggleGroup>
+        <Toolbar>
+          <ToolbarContent>
+            <ToolbarItem>
+              <ToggleGroup aria-label="actions or actionResolver">
+                <ToggleGroupItem
+                  text="Use actions prop"
+                  buttonId="actions"
+                  isSelected={propToUse === 'actions'}
+                  onChange={this.handleItemClick}
+                />
+                <ToggleGroupItem
+                  text="Use actionResolver prop"
+                  buttonId="actionResolver"
+                  isSelected={propToUse === 'actionResolver'}
+                  onChange={this.handleItemClick}
+                />
+              </ToggleGroup>
+            </ToolbarItem>
+            <ToolbarItem>
+              <Checkbox 
+                label="Use custom actions toggle"
+                isChecked={useCustomToggle}
+                onChange={this.toggleCustomToggle}
+                aria-label="toggle use of custom actions toggle"
+                id="toggle-custom-actions-toggle"
+                name="toggle-custom-actions-toggle"
+              />
+            </ToolbarItem>
+            <ToolbarItem>
+              <Checkbox 
+                label="Add extra actions"
+                isChecked={useExtraAction}
+                onChange={this.toggleExtraAction}
+                aria-label="toggle extra actions"
+                id="toggle-extra-action"
+                name="toggle-extra-action"
+              />
+            </ToolbarItem>
+          </ToolbarContent>
+        </Toolbar>
         <Table
           aria-label="Actions table"
           cells={columns}
           rows={rows}
           actions={propToUse === 'actions' ? this.actions() : null}
-          actionResolver={propToUse === 'actionResolver' ? this.actionResolver : null}
+          {...(propToUse === 'actionResolver' && {actionResolver: useExtraAction ? this.actionResolverWithActions : this.actionResolver })}
           areActionsDisabled={this.areActionsDisabled}
           dropdownPosition="left"
           dropdownDirection="bottom"
+          actionsToggle={useCustomToggle ? customActionsToggle : undefined}
         >
           <TableHeader />
           <TableBody />
@@ -2624,6 +2725,7 @@ This example demonstrates adding actions as the last column. The header's last c
 ```js isBeta
 import React from 'react';
 import { TableComposable, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import { ButtonVariant, DropdownToggle } from '@patternfly/react-core';
 
 ComposableTableActions = () => {
   const defaultActions = [
@@ -2640,6 +2742,12 @@ ComposableTableActions = () => {
     {
       title: 'Third action',
       onClick: (event, rowId, rowData, extra) => console.log('clicked on Third action, on row: ', rowId)
+    },
+    {
+      title: 'Start',
+      variant: ButtonVariant.secondary,
+      onClick: (event, rowId, rowData, extra) => console.log('clicked on extra action, on row: ', rowId),
+      isOutsideDropdown: true
     }
   ];
   const lastRowActions = [
@@ -2667,6 +2775,13 @@ ComposableTableActions = () => {
     ['4', '2', 'b', 'four', 'five'],
     ['5', '2', 'b', 'four', 'five']
   ];
+  
+  const customActionsToggle = (props) => (
+    <DropdownToggle onToggle={props.onToggle} isDisabled={props.isDisabled}>
+      Actions
+    </DropdownToggle>
+  );
+  
   return (
     <TableComposable aria-label="Actions table">
       <Thead>
@@ -2693,6 +2808,7 @@ ComposableTableActions = () => {
                 items: rowIndex === 1 ? null : rowIndex === 4 ? lastRowActions : defaultActions,
                 disable: rowIndex === 3
               }}
+              actionsToggle={customActionsToggle}
             />
           </Tr>
         ))}

--- a/packages/react-table/src/components/Table/utils/decorators/cellActions.tsx
+++ b/packages/react-table/src/components/Table/utils/decorators/cellActions.tsx
@@ -33,7 +33,7 @@ export const cellActions = (
     rowIndex,
     columnIndex,
     column: {
-      extraParams: { dropdownPosition, dropdownDirection }
+      extraParams: { dropdownPosition, dropdownDirection, actionsToggle }
     },
     property
   }: IExtra
@@ -63,6 +63,7 @@ export const cellActions = (
               isDisabled={resolvedIsDisabled}
               rowData={rowData}
               extraData={extraData}
+              actionsToggle={actionsToggle}
             >
               {label}
             </ActionsColumn>
@@ -72,6 +73,7 @@ export const cellActions = (
 
   return {
     className: css(styles.tableAction),
+    style: { width: 'auto', paddingRight: 0 },
     isVisible: true,
     ...renderProps
   };

--- a/packages/react-table/src/components/TableComposable/Td.tsx
+++ b/packages/react-table/src/components/TableComposable/Td.tsx
@@ -28,6 +28,7 @@ import {
   IExtra,
   OnToggleRowDetails
 } from '../Table/TableTypes';
+import { CustomActionsToggleProps } from '../Table';
 export interface TdProps extends BaseCellProps, Omit<React.HTMLProps<HTMLTableDataCellElement>, 'onSelect' | 'width'> {
   /**
    * The column header the cell corresponds to.
@@ -57,6 +58,8 @@ export interface TdProps extends BaseCellProps, Omit<React.HTMLProps<HTMLTableDa
     dropdownPosition?: DropdownPosition;
     /** Actions dropdown direction */
     dropdownDirection?: DropdownDirection;
+    /** */
+    actionsToggle?: (props: CustomActionsToggleProps) => React.ReactNode;
   };
   /** Turns the cell into an expansion toggle and determines if the corresponding expansion row is open */
   expand?: {
@@ -158,7 +161,8 @@ const TdBase: React.FunctionComponent<TdProps> = ({
         column: {
           extraParams: {
             dropdownPosition: actions?.dropdownPosition,
-            dropdownDirection: actions?.dropdownDirection
+            dropdownDirection: actions?.dropdownDirection,
+            actionsToggle: actions?.actionsToggle
           }
         }
       })

--- a/packages/react-virtualized-extension/src/components/Virtualized/__snapshots__/VirtualizedTable.test.tsx.snap
+++ b/packages/react-virtualized-extension/src/components/Virtualized/__snapshots__/VirtualizedTable.test.tsx.snap
@@ -144,6 +144,7 @@ exports[`Actions virtualized table 1`] = `
           "extraParams": Object {
             "actionResolver": [Function],
             "actions": undefined,
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": [Function],
             "canSelectAll": true,
@@ -191,6 +192,7 @@ exports[`Actions virtualized table 1`] = `
           "extraParams": Object {
             "actionResolver": [Function],
             "actions": undefined,
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": [Function],
             "canSelectAll": true,
@@ -237,6 +239,7 @@ exports[`Actions virtualized table 1`] = `
           "extraParams": Object {
             "actionResolver": [Function],
             "actions": undefined,
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": [Function],
             "canSelectAll": true,
@@ -283,6 +286,7 @@ exports[`Actions virtualized table 1`] = `
           "extraParams": Object {
             "actionResolver": [Function],
             "actions": undefined,
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": [Function],
             "canSelectAll": true,
@@ -329,6 +333,7 @@ exports[`Actions virtualized table 1`] = `
           "extraParams": Object {
             "actionResolver": [Function],
             "actions": undefined,
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": [Function],
             "canSelectAll": true,
@@ -376,6 +381,7 @@ exports[`Actions virtualized table 1`] = `
           "extraParams": Object {
             "actionResolver": [Function],
             "actions": undefined,
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": [Function],
             "canSelectAll": true,
@@ -487,6 +493,7 @@ exports[`Actions virtualized table 1`] = `
                         "extraParams": Object {
                           "actionResolver": [Function],
                           "actions": undefined,
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": [Function],
                           "canSelectAll": true,
@@ -534,6 +541,7 @@ exports[`Actions virtualized table 1`] = `
                         "extraParams": Object {
                           "actionResolver": [Function],
                           "actions": undefined,
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": [Function],
                           "canSelectAll": true,
@@ -580,6 +588,7 @@ exports[`Actions virtualized table 1`] = `
                         "extraParams": Object {
                           "actionResolver": [Function],
                           "actions": undefined,
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": [Function],
                           "canSelectAll": true,
@@ -626,6 +635,7 @@ exports[`Actions virtualized table 1`] = `
                         "extraParams": Object {
                           "actionResolver": [Function],
                           "actions": undefined,
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": [Function],
                           "canSelectAll": true,
@@ -672,6 +682,7 @@ exports[`Actions virtualized table 1`] = `
                         "extraParams": Object {
                           "actionResolver": [Function],
                           "actions": undefined,
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": [Function],
                           "canSelectAll": true,
@@ -719,6 +730,7 @@ exports[`Actions virtualized table 1`] = `
                         "extraParams": Object {
                           "actionResolver": [Function],
                           "actions": undefined,
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": [Function],
                           "canSelectAll": true,
@@ -821,6 +833,7 @@ exports[`Actions virtualized table 1`] = `
                                 "extraParams": Object {
                                   "actionResolver": [Function],
                                   "actions": undefined,
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": [Function],
                                   "canSelectAll": true,
@@ -868,6 +881,7 @@ exports[`Actions virtualized table 1`] = `
                                 "extraParams": Object {
                                   "actionResolver": [Function],
                                   "actions": undefined,
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": [Function],
                                   "canSelectAll": true,
@@ -914,6 +928,7 @@ exports[`Actions virtualized table 1`] = `
                                 "extraParams": Object {
                                   "actionResolver": [Function],
                                   "actions": undefined,
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": [Function],
                                   "canSelectAll": true,
@@ -960,6 +975,7 @@ exports[`Actions virtualized table 1`] = `
                                 "extraParams": Object {
                                   "actionResolver": [Function],
                                   "actions": undefined,
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": [Function],
                                   "canSelectAll": true,
@@ -1006,6 +1022,7 @@ exports[`Actions virtualized table 1`] = `
                                 "extraParams": Object {
                                   "actionResolver": [Function],
                                   "actions": undefined,
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": [Function],
                                   "canSelectAll": true,
@@ -1053,6 +1070,7 @@ exports[`Actions virtualized table 1`] = `
                                 "extraParams": Object {
                                   "actionResolver": [Function],
                                   "actions": undefined,
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": [Function],
                                   "canSelectAll": true,
@@ -1552,6 +1570,7 @@ exports[`Selectable virtualized table 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
@@ -1599,6 +1618,7 @@ exports[`Selectable virtualized table 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
@@ -1646,6 +1666,7 @@ exports[`Selectable virtualized table 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
@@ -1692,6 +1713,7 @@ exports[`Selectable virtualized table 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
@@ -1738,6 +1760,7 @@ exports[`Selectable virtualized table 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
@@ -1784,6 +1807,7 @@ exports[`Selectable virtualized table 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
@@ -1895,6 +1919,7 @@ exports[`Selectable virtualized table 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
@@ -1942,6 +1967,7 @@ exports[`Selectable virtualized table 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
@@ -1989,6 +2015,7 @@ exports[`Selectable virtualized table 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
@@ -2035,6 +2062,7 @@ exports[`Selectable virtualized table 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
@@ -2081,6 +2109,7 @@ exports[`Selectable virtualized table 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
@@ -2127,6 +2156,7 @@ exports[`Selectable virtualized table 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
@@ -2229,6 +2259,7 @@ exports[`Selectable virtualized table 1`] = `
                                 "extraParams": Object {
                                   "actionResolver": undefined,
                                   "actions": undefined,
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": undefined,
                                   "canSelectAll": true,
@@ -2276,6 +2307,7 @@ exports[`Selectable virtualized table 1`] = `
                                 "extraParams": Object {
                                   "actionResolver": undefined,
                                   "actions": undefined,
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": undefined,
                                   "canSelectAll": true,
@@ -2323,6 +2355,7 @@ exports[`Selectable virtualized table 1`] = `
                                 "extraParams": Object {
                                   "actionResolver": undefined,
                                   "actions": undefined,
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": undefined,
                                   "canSelectAll": true,
@@ -2369,6 +2402,7 @@ exports[`Selectable virtualized table 1`] = `
                                 "extraParams": Object {
                                   "actionResolver": undefined,
                                   "actions": undefined,
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": undefined,
                                   "canSelectAll": true,
@@ -2415,6 +2449,7 @@ exports[`Selectable virtualized table 1`] = `
                                 "extraParams": Object {
                                   "actionResolver": undefined,
                                   "actions": undefined,
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": undefined,
                                   "canSelectAll": true,
@@ -2461,6 +2496,7 @@ exports[`Selectable virtualized table 1`] = `
                                 "extraParams": Object {
                                   "actionResolver": undefined,
                                   "actions": undefined,
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": undefined,
                                   "canSelectAll": true,
@@ -3026,6 +3062,7 @@ exports[`Simple Actions table 1`] = `
                 "title": "Third action",
               },
             ],
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
@@ -3092,6 +3129,7 @@ exports[`Simple Actions table 1`] = `
                 "title": "Third action",
               },
             ],
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
@@ -3157,6 +3195,7 @@ exports[`Simple Actions table 1`] = `
                 "title": "Third action",
               },
             ],
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
@@ -3222,6 +3261,7 @@ exports[`Simple Actions table 1`] = `
                 "title": "Third action",
               },
             ],
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
@@ -3287,6 +3327,7 @@ exports[`Simple Actions table 1`] = `
                 "title": "Third action",
               },
             ],
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
@@ -3353,6 +3394,7 @@ exports[`Simple Actions table 1`] = `
                 "title": "Third action",
               },
             ],
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
@@ -3483,6 +3525,7 @@ exports[`Simple Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
@@ -3549,6 +3592,7 @@ exports[`Simple Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
@@ -3614,6 +3658,7 @@ exports[`Simple Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
@@ -3679,6 +3724,7 @@ exports[`Simple Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
@@ -3744,6 +3790,7 @@ exports[`Simple Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
@@ -3810,6 +3857,7 @@ exports[`Simple Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
@@ -3931,6 +3979,7 @@ exports[`Simple Actions table 1`] = `
                                       "title": "Third action",
                                     },
                                   ],
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": undefined,
                                   "canSelectAll": true,
@@ -3997,6 +4046,7 @@ exports[`Simple Actions table 1`] = `
                                       "title": "Third action",
                                     },
                                   ],
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": undefined,
                                   "canSelectAll": true,
@@ -4062,6 +4112,7 @@ exports[`Simple Actions table 1`] = `
                                       "title": "Third action",
                                     },
                                   ],
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": undefined,
                                   "canSelectAll": true,
@@ -4127,6 +4178,7 @@ exports[`Simple Actions table 1`] = `
                                       "title": "Third action",
                                     },
                                   ],
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": undefined,
                                   "canSelectAll": true,
@@ -4192,6 +4244,7 @@ exports[`Simple Actions table 1`] = `
                                       "title": "Third action",
                                     },
                                   ],
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": undefined,
                                   "canSelectAll": true,
@@ -4258,6 +4311,7 @@ exports[`Simple Actions table 1`] = `
                                       "title": "Third action",
                                     },
                                   ],
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": undefined,
                                   "canSelectAll": true,
@@ -4752,6 +4806,7 @@ exports[`Simple virtualized table aria-label 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
@@ -4798,6 +4853,7 @@ exports[`Simple virtualized table aria-label 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
@@ -4844,6 +4900,7 @@ exports[`Simple virtualized table aria-label 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
@@ -4890,6 +4947,7 @@ exports[`Simple virtualized table aria-label 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
@@ -4936,6 +4994,7 @@ exports[`Simple virtualized table aria-label 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
@@ -5046,6 +5105,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
@@ -5092,6 +5152,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
@@ -5138,6 +5199,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
@@ -5184,6 +5246,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
@@ -5230,6 +5293,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
@@ -5331,6 +5395,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                                 "extraParams": Object {
                                   "actionResolver": undefined,
                                   "actions": undefined,
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": undefined,
                                   "canSelectAll": true,
@@ -5377,6 +5442,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                                 "extraParams": Object {
                                   "actionResolver": undefined,
                                   "actions": undefined,
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": undefined,
                                   "canSelectAll": true,
@@ -5423,6 +5489,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                                 "extraParams": Object {
                                   "actionResolver": undefined,
                                   "actions": undefined,
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": undefined,
                                   "canSelectAll": true,
@@ -5469,6 +5536,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                                 "extraParams": Object {
                                   "actionResolver": undefined,
                                   "actions": undefined,
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": undefined,
                                   "canSelectAll": true,
@@ -5515,6 +5583,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                                 "extraParams": Object {
                                   "actionResolver": undefined,
                                   "actions": undefined,
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": undefined,
                                   "canSelectAll": true,
@@ -5915,6 +5984,7 @@ exports[`Simple virtualized table className 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
@@ -5961,6 +6031,7 @@ exports[`Simple virtualized table className 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
@@ -6007,6 +6078,7 @@ exports[`Simple virtualized table className 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
@@ -6053,6 +6125,7 @@ exports[`Simple virtualized table className 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
@@ -6099,6 +6172,7 @@ exports[`Simple virtualized table className 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
@@ -6209,6 +6283,7 @@ exports[`Simple virtualized table className 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
@@ -6255,6 +6330,7 @@ exports[`Simple virtualized table className 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
@@ -6301,6 +6377,7 @@ exports[`Simple virtualized table className 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
@@ -6347,6 +6424,7 @@ exports[`Simple virtualized table className 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
@@ -6393,6 +6471,7 @@ exports[`Simple virtualized table className 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
@@ -6494,6 +6573,7 @@ exports[`Simple virtualized table className 1`] = `
                                 "extraParams": Object {
                                   "actionResolver": undefined,
                                   "actions": undefined,
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": undefined,
                                   "canSelectAll": true,
@@ -6540,6 +6620,7 @@ exports[`Simple virtualized table className 1`] = `
                                 "extraParams": Object {
                                   "actionResolver": undefined,
                                   "actions": undefined,
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": undefined,
                                   "canSelectAll": true,
@@ -6586,6 +6667,7 @@ exports[`Simple virtualized table className 1`] = `
                                 "extraParams": Object {
                                   "actionResolver": undefined,
                                   "actions": undefined,
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": undefined,
                                   "canSelectAll": true,
@@ -6632,6 +6714,7 @@ exports[`Simple virtualized table className 1`] = `
                                 "extraParams": Object {
                                   "actionResolver": undefined,
                                   "actions": undefined,
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": undefined,
                                   "canSelectAll": true,
@@ -6678,6 +6761,7 @@ exports[`Simple virtualized table className 1`] = `
                                 "extraParams": Object {
                                   "actionResolver": undefined,
                                   "actions": undefined,
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": undefined,
                                   "canSelectAll": true,
@@ -7083,6 +7167,7 @@ exports[`Sortable Virtualized Table 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
@@ -7130,6 +7215,7 @@ exports[`Sortable Virtualized Table 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
@@ -7176,6 +7262,7 @@ exports[`Sortable Virtualized Table 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
@@ -7222,6 +7309,7 @@ exports[`Sortable Virtualized Table 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
@@ -7268,6 +7356,7 @@ exports[`Sortable Virtualized Table 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
+            "actionsToggle": undefined,
             "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
@@ -7378,6 +7467,7 @@ exports[`Sortable Virtualized Table 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
@@ -7425,6 +7515,7 @@ exports[`Sortable Virtualized Table 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
@@ -7471,6 +7562,7 @@ exports[`Sortable Virtualized Table 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
@@ -7517,6 +7609,7 @@ exports[`Sortable Virtualized Table 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
@@ -7563,6 +7656,7 @@ exports[`Sortable Virtualized Table 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
+                          "actionsToggle": undefined,
                           "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
@@ -7664,6 +7758,7 @@ exports[`Sortable Virtualized Table 1`] = `
                                 "extraParams": Object {
                                   "actionResolver": undefined,
                                   "actions": undefined,
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": undefined,
                                   "canSelectAll": true,
@@ -7711,6 +7806,7 @@ exports[`Sortable Virtualized Table 1`] = `
                                 "extraParams": Object {
                                   "actionResolver": undefined,
                                   "actions": undefined,
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": undefined,
                                   "canSelectAll": true,
@@ -7757,6 +7853,7 @@ exports[`Sortable Virtualized Table 1`] = `
                                 "extraParams": Object {
                                   "actionResolver": undefined,
                                   "actions": undefined,
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": undefined,
                                   "canSelectAll": true,
@@ -7803,6 +7900,7 @@ exports[`Sortable Virtualized Table 1`] = `
                                 "extraParams": Object {
                                   "actionResolver": undefined,
                                   "actions": undefined,
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": undefined,
                                   "canSelectAll": true,
@@ -7849,6 +7947,7 @@ exports[`Sortable Virtualized Table 1`] = `
                                 "extraParams": Object {
                                   "actionResolver": undefined,
                                   "actions": undefined,
+                                  "actionsToggle": undefined,
                                   "allRowsSelected": false,
                                   "areActionsDisabled": undefined,
                                   "canSelectAll": true,


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4612

https://patternfly-react-pr-5744.surge.sh/components/table#actions-and-first-cell-in-body-rows-as-th

I added two checkboxes to demonstrate the feature:
- Use custom actions toggle
- Add extra actions

They demonstrate how to change the dropdown toggle to make it something other than a kebab toggle, and how to move some actions out of the dropdown.
