### PR TITLE
fix(JumpLinks): added check for null scrollItems

### DIFF
--- a/packages/react-core/src/components/JumpLinks/JumpLinks.tsx
+++ b/packages/react-core/src/components/JumpLinks/JumpLinks.tsx
@@ -119,7 +119,7 @@ export const JumpLinks: React.FunctionComponent<JumpLinksProps> = ({
         window.requestAnimationFrame(() => {
           let newScrollItems = scrollItems;
           // Items might have rendered after this component. Do a quick refresh.
-          if (!newScrollItems[0]) {
+          if (!newScrollItems[0] || newScrollItems.includes(null)) {
             newScrollItems = getScrollItems(children, []);
             setScrollItems(newScrollItems);
           }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5753 

This PR fixes the JumpLinks component from breaking after navigating between pages. Existing code already checks that `newScrollItems` array is not empty, this PR adds a check that is does not contain `null` values.