### PR TITLE
fix(Dropdown, Select): fix scrollbar click closing menu

### DIFF
--- a/packages/react-core/src/components/Dropdown/Toggle.tsx
+++ b/packages/react-core/src/components/Dropdown/Toggle.tsx
@@ -61,13 +61,13 @@ export class Toggle extends React.Component<ToggleProps> {
   };
 
   componentDidMount = () => {
-    document.addEventListener('mousedown', this.onDocClick);
+    document.addEventListener('click', this.onDocClick);
     document.addEventListener('touchstart', this.onDocClick);
     document.addEventListener('keydown', this.onEscPress, { capture: true });
   };
 
   componentWillUnmount = () => {
-    document.removeEventListener('mousedown', this.onDocClick);
+    document.removeEventListener('click', this.onDocClick);
     document.removeEventListener('touchstart', this.onDocClick);
     document.removeEventListener('keydown', this.onEscPress, { capture: true });
   };

--- a/packages/react-core/src/components/Dropdown/__tests__/DropdownToggle.test.tsx
+++ b/packages/react-core/src/components/Dropdown/__tests__/DropdownToggle.test.tsx
@@ -53,7 +53,7 @@ describe('API', () => {
     view.unmount();
     mousedown({ target: document } as any);
     expect(mockToggle.mock.calls).toHaveLength(0);
-    expect(document.removeEventListener).toHaveBeenCalledWith('mousedown', expect.any(Function));
+    expect(document.removeEventListener).toHaveBeenCalledWith('click', expect.any(Function));
   });
 
   test('on touch outside has been removed', () => {

--- a/packages/react-core/src/components/Select/SelectToggle.tsx
+++ b/packages/react-core/src/components/Select/SelectToggle.tsx
@@ -76,13 +76,13 @@ export class SelectToggle extends React.Component<SelectToggleProps> {
   }
 
   componentDidMount() {
-    document.addEventListener('mousedown', this.onDocClick);
+    document.addEventListener('click', this.onDocClick);
     document.addEventListener('touchstart', this.onDocClick);
     document.addEventListener('keydown', this.handleGlobalKeys);
   }
 
   componentWillUnmount() {
-    document.removeEventListener('mousedown', this.onDocClick);
+    document.removeEventListener('click', this.onDocClick);
     document.removeEventListener('touchstart', this.onDocClick);
     document.removeEventListener('keydown', this.handleGlobalKeys);
   }

--- a/packages/react-core/src/components/Select/__tests__/SelectToggle.test.tsx
+++ b/packages/react-core/src/components/Select/__tests__/SelectToggle.test.tsx
@@ -55,7 +55,7 @@ describe('API', () => {
       </SelectToggle>
     );
 
-    map.mousedown({ target: document });
+    map.click({ target: document });
     expect(mockToggle.mock.calls[0][0]).toBe(false);
   });
 
@@ -102,9 +102,9 @@ describe('API', () => {
       </SelectToggle>
     );
     view.unmount();
-    map.mousedown({ target: document });
+    map.click({ target: document });
     expect(mockToggle.mock.calls).toHaveLength(0);
-    expect(document.removeEventListener).toHaveBeenCalledWith('mousedown', expect.any(Function));
+    expect(document.removeEventListener).toHaveBeenCalledWith('click', expect.any(Function));
   });
 
   test('on touch outside has been removed', () => {

--- a/packages/react-integration/cypress/integration/selectfavorites.spec.ts
+++ b/packages/react-integration/cypress/integration/selectfavorites.spec.ts
@@ -16,8 +16,6 @@ describe('Select Test', () => {
       .first()
       .click();
     cy.get('#Favorites').should('not.exist');
-    // toggle closed
-    cy.get('#favorites-select').click();
   });
 
   it('Verify Single Grouped Select with Favorites', () => {
@@ -56,8 +54,6 @@ describe('Select Test', () => {
       .first()
       .click();
     cy.get('#Favorites').should('not.exist');
-    // toggle closed
-    cy.get('#typeahead-select').click();
   });
 
   it('Verify Multi Typeahead  Select with Favorites', () => {
@@ -86,7 +82,5 @@ describe('Select Test', () => {
       .first()
       .click();
     cy.get('.pf-c-select__menu-group-title').should('not.exist');
-    // toggle closed
-    cy.get('#typeahead-multi-select').click();
   });
 });


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5703

Replaces `mousedown` event handler trigger with `click` in Dropdown and Select toggles, to prevent clicking on the scrollbar from closing the menu. 

@tlabaj The behavior otherwise should remain the same. Was there a particular reason we went with `mousedown` at the time? I can't recall.
