### PR TITLE
Adds a props key:value pair to the rowData for end user customization

### DIFF
--- a/packages/react-table/src/components/TableComposable/Td.tsx
+++ b/packages/react-table/src/components/TableComposable/Td.tsx
@@ -35,6 +35,8 @@ export interface TdProps extends BaseCellProps, Omit<React.HTMLProps<HTMLTableDa
     disable?: boolean;
     /** The row index */
     rowIndex: number;
+    /** Additional props forwarded to select rowData */
+    props?: any;
   };
   /** Turns the cell into an actions cell */
   actions?: {
@@ -101,7 +103,8 @@ const TdBase: React.FunctionComponent<TdProps> = ({
         rowIndex: select.rowIndex,
         rowData: {
           selected: select.isSelected,
-          disableSelection: select?.disable
+          disableSelection: select?.disable,
+          props: select?.props
         },
         column: {
           extraParams: {


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5776
Allow additional props to be passed into rowData for user customization. 

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
