### PR TITLE
fixed incorrect/missing import statements

### DIFF
--- a/packages/react-core/src/components/Card/examples/Card.md
+++ b/packages/react-core/src/components/Card/examples/Card.md
@@ -718,7 +718,7 @@ import {
   DropdownDirection,
   KebabToggle
 } from '@patternfly/react-core';
-import pfLogoSmall from './pf-logo-small';
+import pfLogoSmall from './pf-logo-small.svg';
 import pfLogo from './pfLogo.svg';
 
 class ExpandableIconCard extends React.Component {

--- a/packages/react-core/src/components/Select/examples/Select.md
+++ b/packages/react-core/src/components/Select/examples/Select.md
@@ -394,7 +394,7 @@ class ValidatedSelect extends React.Component {
 
 ```js
 import React from 'react';
-import { Select, SelectOption, SelectVarian, Divider } from '@patternfly/react-core';
+import { Select, SelectOption, SelectVariant, Divider } from '@patternfly/react-core';
 
 class CheckboxSelectInput extends React.Component {
   constructor(props) {
@@ -471,7 +471,7 @@ class CheckboxSelectInput extends React.Component {
 
 ```js
 import React from 'react';
-import { Select, SelectOption, SelectVarian, Divider } from '@patternfly/react-core';
+import { Select, SelectOption, SelectVariant, Divider } from '@patternfly/react-core';
 
 class CheckboxSelectWithCounts extends React.Component {
   constructor(props) {
@@ -1906,7 +1906,7 @@ class PlainSelectInput extends React.Component {
 ```js
 import React from 'react';
 import CubeIcon from '@patternfly/react-icons/dist/js/icons/cube-icon';
-import { Select, SelectOption, SelectVariant, SelectDirection, Checkbox } from '@patternfly/react-core';
+import { Select, SelectOption, SelectDirection, Checkbox } from '@patternfly/react-core';
 
 class SingleSelectInput extends React.Component {
   constructor(props) {

--- a/packages/react-core/src/components/Toolbar/examples/Toolbar.md
+++ b/packages/react-core/src/components/Toolbar/examples/Toolbar.md
@@ -246,7 +246,7 @@ Often, it makes sense to group sets of like items to create desired associations
 ```js
 import React from 'react';
 import { Toolbar, ToolbarContent, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
-import { Button, Select, SelectOption } from '@patternfly/react-core';
+import { Button, Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 import EditIcon from '@patternfly/react-icons/dist/js/icons/edit-icon';
 import CloneIcon from '@patternfly/react-icons/dist/js/icons/clone-icon';
 import SyncIcon from '@patternfly/react-icons/dist/js/icons/sync-icon';
@@ -442,7 +442,7 @@ A toggle group can be used when you want to collapse a set of items into an over
 ```js
 import React from 'react';
 import { Toolbar, ToolbarItem, ToolbarContent, ToolbarToggleGroup, ToolbarGroup } from '@patternfly/react-core';
-import { Button, ButtonVariant, InputGroup, Select, SelectOption, TextInput } from '@patternfly/react-core';
+import { Button, ButtonVariant, InputGroup, Select, SelectOption, SelectVariant, TextInput } from '@patternfly/react-core';
 import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon';
 import FilterIcon from '@patternfly/react-icons/dist/js/icons/filter-icon';
 
@@ -599,7 +599,7 @@ If the consumer would prefer to manage the expanded state of the toggle group fo
 ```js
 import React from 'react';
 import { Toolbar, ToolbarItem, ToolbarContent, ToolbarToggleGroup, ToolbarGroup } from '@patternfly/react-core';
-import { Button, ButtonVariant, InputGroup, Select, SelectOption } from '@patternfly/react-core';
+import { Button, ButtonVariant, InputGroup, Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 import TextInput from '@patternfly/react-icons/dist/js/icons/text-input';
 import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon';
 import FilterIcon from '@patternfly/react-icons/dist/js/icons/filter-icon';
@@ -778,6 +778,7 @@ import {
   InputGroup,
   Select,
   SelectOption,
+  SelectVariant,
   Dropdown,
   DropdownItem,
   DropdownSeparator,
@@ -1042,6 +1043,7 @@ import {
   KebabToggle,
   Select,
   SelectOption,
+  SelectVariant,
   Pagination,
   Dropdown,
   DropdownSeparator,

--- a/packages/react-core/src/demos/Card/Card.md
+++ b/packages/react-core/src/demos/Card/Card.md
@@ -75,6 +75,7 @@ import {
   Pagination,
   Select,
   SelectOption,
+  SelectVariant,
   SkipToContent,
   TextContent,
   Text,

--- a/packages/react-core/src/demos/PrimaryDetail.md
+++ b/packages/react-core/src/demos/PrimaryDetail.md
@@ -82,6 +82,7 @@ import {
   Progress,
   Select,
   SelectOption,
+  SelectVariant,
   SkipToContent,
   Stack,
   StackItem,
@@ -101,6 +102,8 @@ import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/excla
 import FilterIcon from '@patternfly/react-icons/dist/js/icons/filter-icon';
 import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon';
 import TimesCircleIcon from '@patternfly/react-icons/dist/js/icons/times-circle-icon';
+import imgBrand from '@patternfly/react-core/src/components/Brand/examples/pfLogo.svg';
+import imgAvatar from '@patternfly/react-core/src/components/Avatar/examples/avatarImg.svg';
 
 class PrimaryDetailFullPage extends React.Component {
   constructor(props) {
@@ -666,6 +669,7 @@ import {
   Progress,
   Select,
   SelectOption,
+  SelectVariant,
   SkipToContent,
   Stack,
   StackItem,
@@ -685,6 +689,8 @@ import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/excla
 import FilterIcon from '@patternfly/react-icons/dist/js/icons/filter-icon';
 import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon';
 import TimesCircleIcon from '@patternfly/react-icons/dist/js/icons/times-circle-icon';
+import imgBrand from '@patternfly/react-core/src/components/Brand/examples/pfLogo.svg';
+import imgAvatar from '@patternfly/react-core/src/components/Avatar/examples/avatarImg.svg';
 
 class PrimaryDetailContentPadding extends React.Component {
   constructor(props) {
@@ -1251,6 +1257,7 @@ import {
   Progress,
   Select,
   SelectOption,
+  SelectVariant,
   SkipToContent,
   TextContent,
   Text,
@@ -1769,6 +1776,8 @@ import BellIcon from '@patternfly/react-icons/dist/js/icons/bell-icon';
 import CogIcon from '@patternfly/react-icons/dist/js/icons/cog-icon';
 import FilterIcon from '@patternfly/react-icons/dist/js/icons/filter-icon';
 import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon';
+import imgBrand from '@patternfly/react-core/src/components/Brand/examples/pfLogo.svg';
+import imgAvatar from '@patternfly/react-core/src/components/Avatar/examples/avatarImg.svg';
 
 class PrimaryDetailSimpleListInCard extends React.Component {
   constructor(props) {
@@ -2012,6 +2021,8 @@ import CogIcon from '@patternfly/react-icons/dist/js/icons/cog-icon';
 import FilterIcon from '@patternfly/react-icons/dist/js/icons/filter-icon';
 import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon';
 import CaretDownIcon from '@patternfly/react-icons/dist/js/icons/caret-down-icon';
+import imgBrand from '@patternfly/react-core/src/components/Brand/examples/pfLogo.svg';
+import imgAvatar from '@patternfly/react-core/src/components/Avatar/examples/avatarImg.svg';
 
 class PrimaryDetailDataListInCard extends React.Component {
   constructor(props) {
@@ -2326,6 +2337,7 @@ import {
   Progress,
   Select,
   SelectOption,
+  SelectVariant,
   SkipToContent,
   Stack,
   StackItem,
@@ -2345,6 +2357,8 @@ import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/excla
 import FilterIcon from '@patternfly/react-icons/dist/js/icons/filter-icon';
 import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon';
 import TimesCircleIcon from '@patternfly/react-icons/dist/js/icons/times-circle-icon';
+import imgBrand from '@patternfly/react-core/src/components/Brand/examples/pfLogo.svg';
+import imgAvatar from '@patternfly/react-core/src/components/Avatar/examples/avatarImg.svg';
 
 class PrimaryDetailInlineModifier extends React.Component {
   constructor(props) {


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5759 

This PR fixes broken Codesandbox pages due to incorrect & missing import paths:
- Adds file extension to `./pf-logo-small.svg` in `Card` example
- Adds `SelectVariant` import statements in both the `Card view` and `Primary-detail inline modifier` demos and `Toolbar` examples
-Fixes `SelectVariant` typo in some `Select` demos where it was misspelled `SelectVarian`
- Adds `imgBrand` and `imgAvatar` imports that were missing in several `Primary-detail` demos