### PR TITLE
fix(Dropdown, Select): fix focus on toggle after click off menu

### DIFF
--- a/packages/react-core/src/components/Dropdown/Toggle.tsx
+++ b/packages/react-core/src/components/Dropdown/Toggle.tsx
@@ -79,7 +79,6 @@ export class Toggle extends React.Component<ToggleProps> {
     const clickedWithinMenu = menuRef && menuRef.contains && menuRef.contains(event.target as Node);
     if (isOpen && !(clickedOnToggle || clickedWithinMenu)) {
       onToggle(false, event);
-      this.buttonRef.current.focus();
     }
   };
 

--- a/packages/react-core/src/components/Select/SelectToggle.tsx
+++ b/packages/react-core/src/components/Select/SelectToggle.tsx
@@ -95,7 +95,6 @@ export class SelectToggle extends React.Component<SelectToggleProps> {
     if (isOpen && !(clickedOnToggle || clickedWithinMenu)) {
       onToggle(false);
       onClose();
-      this.toggle.current.focus();
     }
   };
 


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5788 

Focus shouldn't need to be manually set after a `click` event fires outside of an open menu, the clicked element should receive focus rather than the toggle. The menu should still close when a user clicks outside of the menu.

@jessiehuff Removing this shouldn't cause any accessibility issues right? This should be pure mouse behavior, where `click` already focuses the event target.
