### PR TITLE
feat(Menu): add footer, add view more demo

### DIFF
--- a/packages/react-core/src/components/Menu/MenuFooter.tsx
+++ b/packages/react-core/src/components/Menu/MenuFooter.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import styles from '@patternfly/react-styles/css/components/Menu/menu';
+import { css } from '@patternfly/react-styles';
+
+export interface MenuFooterProps extends React.HTMLProps<HTMLDivElement> {
+  /** Content rendered inside the footer */
+  children?: React.ReactNode;
+  /** Additional classes added to the footer */
+  className?: string;
+}
+
+export const MenuFooter: React.FunctionComponent<MenuFooterProps> = ({
+  children,
+  className = '',
+  ...props
+}: MenuFooterProps) => (
+  <div {...props} className={css(styles.menuFooter, className)}>
+    {children}
+  </div>
+);
+
+MenuFooter.displayName = 'MenuFooter';

--- a/packages/react-core/src/components/Menu/MenuItem.tsx
+++ b/packages/react-core/src/components/Menu/MenuItem.tsx
@@ -21,6 +21,10 @@ export interface MenuItemProps extends Omit<React.HTMLProps<HTMLLIElement>, 'onC
   isActive?: boolean;
   /** Flag indicating if the item is favorited */
   isFavorited?: boolean;
+  /** Flag indicating if the item causes a load */
+  isLoadButton?: boolean;
+  /** Flag indicating a loading state */
+  isLoading?: boolean;
   /** Callback for item click */
   onClick?: (event?: any) => void;
   /** Component used to render the menu item */
@@ -60,6 +64,8 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
   to,
   isActive = null,
   isFavorited = null,
+  isLoadButton = false,
+  isLoading = false,
   flyoutMenu,
   direction,
   description = null as string,
@@ -242,6 +248,8 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
               styles.menuListItem,
               isDisabled && styles.modifiers.disabled,
               _isOnPath && styles.modifiers.currentPath,
+              isLoadButton && styles.modifiers.load,
+              isLoading && styles.modifiers.loading,
               className
             )}
             onMouseOver={flyoutMenu !== undefined ? () => showFlyout(true) : undefined}
@@ -251,7 +259,8 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
             ref={innerRef}
             {...props}
           >
-            {renderItem(onSelect, activeItemId, selected, _isOnPath, _drill)}
+            {isLoading && children}
+            {!isLoading && renderItem(onSelect, activeItemId, selected, _isOnPath, _drill)}
             <MenuItemContext.Provider value={{ itemId, isDisabled }}>
               {actions}
               {isFavorited !== null && (

--- a/packages/react-core/src/components/Menu/examples/Menu.md
+++ b/packages/react-core/src/components/Menu/examples/Menu.md
@@ -1233,3 +1233,185 @@ class MenuWithDrilldownBreadcrumbs extends React.Component {
   }
 }
 ```
+
+### With footer
+
+```js
+import React from 'react';
+import { Menu, MenuList, MenuItem, MenuContent, MenuFooter, Button } from '@patternfly/react-core';
+
+class FooterMenu extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      activeItem: 0
+    };
+    this.onSelect = (event, itemId) => {
+      console.log(`clicked ${itemId}`);
+      this.setState({
+        activeItem: itemId
+      });
+    };
+  }
+
+  render() {
+    const { activeItem } = this.state;
+    return (
+      <Menu activeItemId={activeItem} onSelect={this.onSelect}>
+        <MenuContent>
+          <MenuList>
+            <MenuItem itemId={0}>Action</MenuItem>
+            <MenuItem
+              itemId={1}
+              to="#default-link2"
+              // just for demo so that navigation is not triggered
+              onClick={event => event.preventDefault()}
+            >
+              Link
+            </MenuItem>
+            <MenuItem isDisabled>Disabled Action</MenuItem>
+            <MenuItem isDisabled to="#default-link4">
+              Disabled Link
+            </MenuItem>
+          </MenuList>
+        </MenuContent>
+        <MenuFooter>
+          <Button variant="link" isInline>
+            Action
+          </Button>
+        </MenuFooter>
+      </Menu>
+    );
+  }
+}
+```
+
+### With view more
+
+```js
+import React from 'react';
+import { Menu, MenuList, MenuItem, MenuContent, MenuFooter, Spinner } from '@patternfly/react-core';
+
+class ViewMoreMenu extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      activeItem: 0,
+      isLoading: false,
+      numOptions: 3
+    };
+
+    this.menuOptions = [
+      <MenuItem key={0} itemId={0} ref={React.createRef()}>
+        Action
+      </MenuItem>,
+      <MenuItem
+        key={2}
+        itemId={1}
+        to="#default-link2"
+        // just for demo so that navigation is not triggered
+        onClick={event => event.preventDefault()}
+        ref={React.createRef()}
+      >
+        Link
+      </MenuItem>,
+      <MenuItem key={3} isDisabled>
+        Disabled Action
+      </MenuItem>,
+      <MenuItem key={4} isDisabled to="#default-link4">
+        Disabled Link
+      </MenuItem>,
+      <MenuItem key={5} itemId={2} ref={React.createRef()}>
+        Action 2
+      </MenuItem>,
+      <MenuItem key={6} itemId={3} ref={React.createRef()}>
+        Action 3
+      </MenuItem>,
+      <MenuItem key={7} itemId={4} ref={React.createRef()}>
+        Action 4
+      </MenuItem>,
+      <MenuItem key={8} itemId={5} ref={React.createRef()}>
+        Action 5
+      </MenuItem>,
+      <MenuItem key={9} itemId={6} ref={React.createRef()}>
+        Final option
+      </MenuItem>
+    ];
+
+    this.onSelect = (event, itemId) => {
+      console.log(`clicked ${itemId}`);
+      this.setState({
+        activeItem: itemId
+      });
+    };
+
+    this.simulateNetworkCall = callback => {
+      setTimeout(callback, 2000);
+    };
+
+    this.getNextValidRef = startingIndex => {
+      let index = startingIndex;
+      while (index < this.menuOptions.length && this.menuOptions[index].ref === null) {
+        index++;
+      }
+      return this.menuOptions[index].ref.current;
+    };
+
+    this.onViewMoreClick = () => {
+      this.setState({ isLoading: true });
+      this.simulateNetworkCall(() => {
+        const newLength =
+          this.state.numOptions + 3 <= this.menuOptions.length ? this.state.numOptions + 3 : this.menuOptions.length;
+        const prevPosition = this.state.numOptions;
+        this.setState({ numOptions: newLength, isLoading: false });
+      });
+    };
+
+    this.onViewMoreKeyDown = event => {
+      if (!(event.key === ' ' || event.key === 'Enter')) {
+        return;
+      }
+      event.stopPropagation();
+      event.preventDefault();
+
+      this.setState({ isLoading: true });
+      this.simulateNetworkCall(() => {
+        const newLength =
+          this.state.numOptions + 3 <= this.menuOptions.length ? this.state.numOptions + 3 : this.menuOptions.length;
+        const prevPosition = this.state.numOptions;
+
+        this.setState({ numOptions: newLength, isLoading: false }, () => {
+          const nextFocus = this.getNextValidRef(prevPosition).querySelector('button, a');
+          this.getNextValidRef(0).querySelector('button, a').tabIndex = -1;
+          nextFocus.tabIndex = 0;
+          nextFocus.focus();
+        });
+      });
+    };
+  }
+
+  render() {
+    const { activeItem, isLoading, numOptions } = this.state;
+    return (
+      <Menu activeItemId={activeItem} onSelect={this.onSelect}>
+        <MenuContent>
+          <MenuList>
+            {this.menuOptions.slice(0, numOptions)}
+            {numOptions !== this.menuOptions.length && (
+              <MenuItem
+                {...(!isLoading && { isLoadButton: true })}
+                {...(isLoading && { isLoading: true })}
+                onKeyDown={this.onViewMoreKeyDown}
+                onClick={this.onViewMoreClick}
+                itemId="loader"
+              >
+                {isLoading ? <Spinner size="lg" /> : 'View more'}
+              </MenuItem>
+            )}
+          </MenuList>
+        </MenuContent>
+      </Menu>
+    );
+  }
+}
+```

--- a/packages/react-core/src/components/Menu/index.ts
+++ b/packages/react-core/src/components/Menu/index.ts
@@ -1,5 +1,6 @@
 export * from './Menu';
 export * from './MenuContent';
+export * from './MenuFooter';
 export * from './MenuInput';
 export * from './MenuGroup';
 export * from './MenuItem';

--- a/packages/react-integration/cypress/integration/menu.spec.ts
+++ b/packages/react-integration/cypress/integration/menu.spec.ts
@@ -112,6 +112,29 @@ describe('Menu Test', () => {
     cy.get('#multi-select-item-3.pf-c-menu__list-item > button').should('have.class', 'pf-m-selected');
   });
 
+  it('Verify Footer Menu', () => {
+    cy.get('#menu-footer.pf-c-menu').should('exist');
+
+    cy.get('#menu-footer .pf-c-menu__footer').should('exist');
+  });
+
+  it('Verify View More Menu', () => {
+    cy.get('#menu-view-more.pf-c-menu').should('exist');
+
+    cy.get('#menu-view-more .pf-c-menu__list')
+      .find('.pf-c-menu__list-item')
+      .should('have.length', 4);
+
+    cy.get('#menu-view-more .pf-c-menu__list-item')
+      .last()
+      .should('have.text', 'View more')
+      .click();
+
+    cy.get('#menu-view-more .pf-c-menu__list')
+      .find('.pf-c-menu__list-item')
+      .should('have.length', 7);
+  });
+
   it('Navigate to drilldown demo section', () => {
     cy.visit('http://localhost:3000/');
     cy.get('#menu-drilldown-demo-nav-item-link').click();

--- a/packages/react-integration/demo-app-ts/src/components/demos/MenuDemo/MenuDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/MenuDemo/MenuDemo.tsx
@@ -12,7 +12,10 @@ import {
   MenuItemAction,
   MenuContent,
   MenuInput,
-  TextInput
+  TextInput,
+  MenuFooter,
+  Button,
+  Spinner
 } from '@patternfly/react-core';
 import CodeBranchIcon from '@patternfly/react-icons/dist/js/icons/code-branch-icon';
 import CubeIcon from '@patternfly/react-icons/dist/js/icons/cube-icon';
@@ -29,7 +32,59 @@ export class MenuDemo extends Component {
     defaultActiveItem: 0,
     input: '',
     selectedItems: [0, 2, 3],
-    favorites: [] as string[]
+    favorites: [] as string[],
+    numOptions: 3,
+    isLoading: false
+  };
+
+  menuOptions = [
+    <MenuItem key={0} itemId={0}>
+      Action
+    </MenuItem>,
+    <MenuItem
+      key={2}
+      itemId={1}
+      to="#default-link2"
+      // just for demo so that navigation is not triggered
+      onClick={event => event.preventDefault()}
+    >
+      Link
+    </MenuItem>,
+    <MenuItem key={3} isDisabled>
+      Disabled Action
+    </MenuItem>,
+    <MenuItem key={4} isDisabled to="#default-link4">
+      Disabled Link
+    </MenuItem>,
+    <MenuItem key={5} itemId={2}>
+      Action 2
+    </MenuItem>,
+    <MenuItem key={6} itemId={3}>
+      Action 3
+    </MenuItem>,
+    <MenuItem key={7} itemId={4}>
+      Action 4
+    </MenuItem>,
+    <MenuItem key={8} itemId={5}>
+      Action 5
+    </MenuItem>,
+    <MenuItem key={9} itemId={6}>
+      Final option
+    </MenuItem>
+  ];
+
+  simulateNetworkCall = (callback: any) => {
+    setTimeout(callback, 2);
+  };
+
+  onViewMoreClick = () => {
+    // Set select loadingVariant to spinner then simulate network call before loading more options
+    this.setState({ isLoading: true });
+    this.simulateNetworkCall(() => {
+      const newLength =
+        this.state.numOptions + 3 <= this.menuOptions.length ? this.state.numOptions + 3 : this.menuOptions.length;
+      this.setState({ numOptions: newLength, isLoading: false });
+    });
   };
 
   onSimpleSelect = (event: React.MouseEvent, itemId: string) => {
@@ -560,6 +615,60 @@ export class MenuDemo extends Component {
     );
   }
 
+  renderFooterMenu() {
+    const { activeItem } = this.state;
+    return (
+      <StackItem isFilled>
+        <Title headingLevel="h2" size="2xl">
+          Footer Menu
+        </Title>
+        <Menu activeItemId={activeItem} onSelect={this.onSimpleSelect} id="menu-footer">
+          <MenuList>
+            <MenuItem itemId={0}>Action</MenuItem>
+            <MenuItem itemId={1} to="#default-link2" id="default-link2">
+              Link
+            </MenuItem>
+            <MenuItem isDisabled>Disabled Action</MenuItem>
+            <MenuItem isDisabled to="#default-link4">
+              Disabled Link
+            </MenuItem>
+          </MenuList>
+          <MenuFooter>
+            <Button variant="link" isInline>
+              Action
+            </Button>
+          </MenuFooter>
+        </Menu>
+      </StackItem>
+    );
+  }
+
+  renderViewMoreMenu() {
+    const { activeItem, numOptions, isLoading } = this.state;
+    return (
+      <StackItem isFilled>
+        <Title headingLevel="h2" size="2xl">
+          View More Menu
+        </Title>
+        <Menu activeItemId={activeItem} onSelect={this.onSimpleSelect} id="menu-view-more">
+          <MenuList>
+            {this.menuOptions.slice(0, numOptions)}
+            {numOptions !== this.menuOptions.length && (
+              <MenuItem
+                {...(!isLoading && { isLoadButton: true })}
+                {...(isLoading && { isLoading: true })}
+                onClick={this.onViewMoreClick}
+                itemId="loader"
+              >
+                {isLoading ? <Spinner size="lg" /> : 'View more'}
+              </MenuItem>
+            )}
+          </MenuList>
+        </Menu>
+      </StackItem>
+    );
+  }
+
   render() {
     return (
       <Stack hasGutter>
@@ -575,6 +684,8 @@ export class MenuDemo extends Component {
         {this.renderMenuWithFavorites()}
         {this.renderMenuWithSingleSelect()}
         {this.renderMenuWithMultiSelect()}
+        {this.renderFooterMenu()}
+        {this.renderViewMoreMenu()}
       </Stack>
     );
   }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5699 

**In this PR**:
- Adds `MenuFooter`
- Adds "view more" menu demo

**Notes**:
- In the "view more" demo, when the complete options list is displayed, the "view more" button will disappear.
- For the menu footer keyboard interaction, I followed a previous menu pattern. `Tab` shifts focus between the active menu item and footer (as in the breadcrumb drilldown interaction). The content of the footer has no pre-built keyboard handling. 
- For the "view more" menu demo keyboard interaction, `ArrowUp`/`ArrowDown` navigates through the options list and the "view more" button as usual. The demo hooks in and manages the `Space`/`Enter` keydown for the "view more" button, focusing the next valid option from where the "view more" button used to be.