### PR TITLE
feat(select): allow filtering in single variant

### DIFF
--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -145,7 +145,7 @@ export interface SelectProps
 }
 
 export interface SelectState {
-  openedOnEnter: boolean;
+  focusFirstOption: boolean;
   typeaheadInputValue: string | null;
   typeaheadFilteredChildren: React.ReactNode[];
   favoritesGroup: React.ReactNode[];
@@ -211,7 +211,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
   };
 
   state: SelectState = {
-    openedOnEnter: false,
+    focusFirstOption: false,
     typeaheadInputValue: null,
     typeaheadFilteredChildren: React.Children.toArray(this.props.children),
     favoritesGroup: [] as React.ReactNode[],
@@ -230,7 +230,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
       this.refCollection[0][0] = this.filterRef.current;
     }
 
-    if (!prevState.openedOnEnter && this.state.openedOnEnter && !this.props.customContent) {
+    if (!prevState.focusFirstOption && this.state.focusFirstOption && !this.props.customContent) {
       const firstRef = this.refCollection.find(ref => ref !== null);
       if (firstRef && firstRef[0]) {
         firstRef[0].focus();
@@ -268,20 +268,25 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
   };
 
   onEnter = () => {
-    this.setState({ openedOnEnter: true });
+    this.setState({ focusFirstOption: true });
   };
 
   onToggle = (isExpanded: boolean) => {
-    const { isInputValuePersisted, onSelect, onToggle } = this.props;
+    const { isInputValuePersisted, onSelect, onToggle, hasInlineFilter } = this.props;
     if (!isExpanded && isInputValuePersisted && onSelect) {
-      onSelect(undefined, this.inputRef && this.inputRef.current ? this.inputRef.current.value : '');
+      onSelect(undefined, this.inputRef.current ? this.inputRef.current.value : '');
+    }
+    if (isExpanded && hasInlineFilter) {
+      this.setState({
+        focusFirstOption: true
+      });
     }
     onToggle(isExpanded);
   };
 
   onClose = () => {
     this.setState({
-      openedOnEnter: false,
+      focusFirstOption: false,
       typeaheadInputValue: null,
       typeaheadFilteredChildren: React.Children.toArray(this.props.children),
       typeaheadCurrIndex: -1,
@@ -393,15 +398,13 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
     });
   };
 
-  onClick = (e: React.MouseEvent) => {
+  onClick = (_e: React.MouseEvent) => {
     if (!this.props.isOpen) {
       this.onToggle(true);
     }
-    e.stopPropagation();
   };
 
-  clearSelection = (e: React.MouseEvent) => {
-    e.stopPropagation();
+  clearSelection = (_e: React.MouseEvent) => {
     this.setState({
       typeaheadInputValue: null,
       typeaheadFilteredChildren: React.Children.toArray(this.props.children),
@@ -709,7 +712,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
       ...props
     } = this.props;
     const {
-      openedOnEnter,
+      focusFirstOption: openedOnEnter,
       typeaheadCurrIndex,
       typeaheadInputValue,
       typeaheadFilteredChildren,
@@ -819,12 +822,16 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
               onKeyDown={event => {
                 if (event.key === KeyTypes.ArrowUp) {
                   this.handleMenuKeys(0, 0, 'up');
+                  event.preventDefault();
                 } else if (event.key === KeyTypes.ArrowDown) {
                   this.handleMenuKeys(0, 0, 'down');
+                  event.preventDefault();
                 } else if (event.key === KeyTypes.ArrowLeft) {
                   this.handleMenuKeys(0, 0, 'left');
+                  event.preventDefault();
                 } else if (event.key === KeyTypes.ArrowRight) {
                   this.handleMenuKeys(0, 0, 'right');
+                  event.preventDefault();
                 } else if (event.key === KeyTypes.Tab && variant === SelectVariant.checkbox) {
                   // More modal-like experience for checkboxes
                   // Let SelectOption handle this
@@ -844,7 +851,6 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
           <Divider key="inline-filter-divider" />
         </React.Fragment>
       );
-      this.refCollection[0][0] = this.filterRef.current;
       renderableItems = [filterBox, ...(typeaheadFilteredChildren as React.ReactElement[])].map((option, index) =>
         React.cloneElement(option, { key: index })
       );

--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -806,7 +806,6 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
       );
     }
 
-    let filterWithChildren = children;
     if (hasInlineFilter) {
       const filterBox = (
         <React.Fragment>
@@ -846,7 +845,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
         </React.Fragment>
       );
       this.refCollection[0][0] = this.filterRef.current;
-      filterWithChildren = [filterBox, ...(typeaheadFilteredChildren as React.ReactElement[])].map((option, index) =>
+      renderableItems = [filterBox, ...(typeaheadFilteredChildren as React.ReactElement[])].map((option, index) =>
         React.cloneElement(option, { key: index })
       );
     }
@@ -865,6 +864,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
         case 'single':
           variantProps = {
             selected: selections[0],
+            hasInlineFilter,
             openedOnEnter
           };
           variantChildren = renderableItems;
@@ -876,7 +876,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
             hasInlineFilter,
             openedOnEnter
           };
-          variantChildren = filterWithChildren;
+          variantChildren = renderableItems;
           break;
         case 'typeahead':
           variantProps = {

--- a/packages/react-core/src/components/Select/SelectMenu.tsx
+++ b/packages/react-core/src/components/Select/SelectMenu.tsx
@@ -61,10 +61,10 @@ class SelectMenuWithRef extends React.Component<SelectMenuProps> {
   };
 
   extendChildren(randomId: string) {
-    const { children, isGrouped } = this.props;
+    const { children, hasInlineFilter, isGrouped } = this.props;
     const childrenArray: React.ReactElement[] = children as React.ReactElement[];
+    let index = hasInlineFilter ? 1 : 0;
     if (isGrouped) {
-      let index = 0;
       return React.Children.map(childrenArray, (group: React.ReactElement) => {
         if (group.type === SelectGroup) {
           return React.cloneElement(group, {
@@ -78,9 +78,7 @@ class SelectMenuWithRef extends React.Component<SelectMenuProps> {
         }
       });
     }
-    return React.Children.map(childrenArray, (child: React.ReactElement, index: number) =>
-      this.cloneOption(child, index, randomId)
-    );
+    return React.Children.map(childrenArray, (child: React.ReactElement) => this.cloneOption(child, index++, randomId));
   }
 
   cloneOption(child: React.ReactElement, index: number, randomId: string) {

--- a/packages/react-core/src/components/Select/SelectMenu.tsx
+++ b/packages/react-core/src/components/Select/SelectMenu.tsx
@@ -223,7 +223,7 @@ class SelectMenuWithRef extends React.Component<SelectMenuProps> {
       }
     } else {
       variantProps.children = extendedChildren();
-      if (isGrouped) {
+      if (!isGrouped) {
         Component = 'ul';
         variantProps.role = 'listbox';
         variantProps['aria-label'] = ariaLabel;
@@ -244,7 +244,7 @@ class SelectMenuWithRef extends React.Component<SelectMenuProps> {
   }
 
   render() {
-    return <SelectConsumer>{context => this.renderSelectMenu(context)}</SelectConsumer>;
+    return <SelectConsumer>{this.renderSelectMenu}</SelectConsumer>;
   }
 }
 

--- a/packages/react-core/src/components/Select/SelectMenu.tsx
+++ b/packages/react-core/src/components/Select/SelectMenu.tsx
@@ -244,7 +244,7 @@ class SelectMenuWithRef extends React.Component<SelectMenuProps> {
   }
 
   render() {
-    return <SelectConsumer>{this.renderSelectMenu}</SelectConsumer>;
+    return <SelectConsumer>{context => this.renderSelectMenu(context)}</SelectConsumer>;
   }
 }
 

--- a/packages/react-core/src/components/Select/SelectToggle.tsx
+++ b/packages/react-core/src/components/Select/SelectToggle.tsx
@@ -291,7 +291,7 @@ export class SelectToggle extends React.Component<SelectToggleProps> {
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             onClick={_event => {
               if (!isDisabled) {
-                onToggle(true);
+                onToggle(!isOpen);
               }
             }}
             onKeyDown={this.onKeyDown}
@@ -303,7 +303,6 @@ export class SelectToggle extends React.Component<SelectToggleProps> {
               className={css(buttonStyles.button, styles.selectToggleButton, styles.modifiers.plain)}
               aria-label={ariaLabel}
               onClick={_event => {
-                _event.stopPropagation();
                 onToggle(!isOpen);
                 if (isOpen) {
                   onClose();

--- a/packages/react-core/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/packages/react-core/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
@@ -70,9 +70,199 @@ exports[`checkbox select renders checkbox select groups successfully 1`] = `
             "current": <div
               class="pf-c-select__menu"
             >
-              <fieldset
-                aria-label=""
-                class="pf-c-form__fieldset"
+              <div
+                class="pf-c-select__menu-group"
+              >
+                <div
+                  aria-hidden="true"
+                  class="pf-c-select__menu-group-title"
+                  id="group-1"
+                >
+                  group 1
+                </div>
+                <fieldset
+                  aria-labelledby="group-1"
+                  class="pf-c-select__menu-fieldset"
+                >
+                  <label
+                    class="pf-c-check pf-c-select__menu-item"
+                  >
+                    <input
+                      class="pf-c-check__input"
+                      id="pf-random-id-15-Mr"
+                      type="checkbox"
+                    />
+                    <span
+                      class="pf-c-check__label"
+                    >
+                      Mr
+                    </span>
+                  </label>
+                  <label
+                    class="pf-c-check pf-c-select__menu-item"
+                  >
+                    <input
+                      class="pf-c-check__input"
+                      id="pf-random-id-15-Mrs"
+                      type="checkbox"
+                    />
+                    <span
+                      class="pf-c-check__label"
+                    >
+                      Mrs
+                    </span>
+                  </label>
+                  <label
+                    class="pf-c-check pf-c-select__menu-item"
+                  >
+                    <input
+                      class="pf-c-check__input"
+                      id="pf-random-id-15-Ms"
+                      type="checkbox"
+                    />
+                    <span
+                      class="pf-c-check__label"
+                    >
+                      Ms
+                    </span>
+                  </label>
+                  <label
+                    class="pf-c-check pf-c-select__menu-item"
+                  >
+                    <input
+                      class="pf-c-check__input"
+                      id="pf-random-id-15-Other"
+                      type="checkbox"
+                    />
+                    <span
+                      class="pf-c-check__label"
+                    >
+                      Other
+                    </span>
+                  </label>
+                </fieldset>
+              </div>
+              <div
+                class="pf-c-select__menu-group"
+              >
+                <div
+                  aria-hidden="true"
+                  class="pf-c-select__menu-group-title"
+                  id="group-2"
+                >
+                  group 2
+                </div>
+                <fieldset
+                  aria-labelledby="group-2"
+                  class="pf-c-select__menu-fieldset"
+                >
+                  <label
+                    class="pf-c-check pf-c-select__menu-item"
+                  >
+                    <input
+                      class="pf-c-check__input"
+                      id="pf-random-id-15-Mr"
+                      type="checkbox"
+                    />
+                    <span
+                      class="pf-c-check__label"
+                    >
+                      Mr
+                    </span>
+                  </label>
+                  <label
+                    class="pf-c-check pf-c-select__menu-item"
+                  >
+                    <input
+                      class="pf-c-check__input"
+                      id="pf-random-id-15-Mrs"
+                      type="checkbox"
+                    />
+                    <span
+                      class="pf-c-check__label"
+                    >
+                      Mrs
+                    </span>
+                  </label>
+                  <label
+                    class="pf-c-check pf-c-select__menu-item"
+                  >
+                    <input
+                      class="pf-c-check__input"
+                      id="pf-random-id-15-Ms"
+                      type="checkbox"
+                    />
+                    <span
+                      class="pf-c-check__label"
+                    >
+                      Ms
+                    </span>
+                  </label>
+                  <label
+                    class="pf-c-check pf-c-select__menu-item"
+                  >
+                    <input
+                      class="pf-c-check__input"
+                      id="pf-random-id-15-Other"
+                      type="checkbox"
+                    />
+                    <span
+                      class="pf-c-check__label"
+                    >
+                      Other
+                    </span>
+                  </label>
+                </fieldset>
+              </div>
+            </div>,
+          }
+        }
+        onClickTypeaheadToggleButton={[Function]}
+        onClose={[Function]}
+        onEnter={[Function]}
+        onToggle={[Function]}
+        parentRef={
+          Object {
+            "current": <div
+              class="pf-c-select pf-m-expanded"
+              data-ouia-component-id="OUIA-Generated-Select-checkbox-8"
+              data-ouia-component-type="PF4/Select"
+              data-ouia-safe="true"
+            >
+              <button
+                aria-expanded="true"
+                aria-labelledby=" pf-select-toggle-id-7"
+                class="pf-c-select__toggle"
+                id="pf-select-toggle-id-7"
+                type="button"
+              >
+                <div
+                  class="pf-c-select__toggle-wrapper"
+                >
+                  <span
+                    class="pf-c-select__toggle-text"
+                  />
+                </div>
+                <span
+                  class="pf-c-select__toggle-arrow"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <div
+                class="pf-c-select__menu"
               >
                 <div
                   class="pf-c-select__menu-group"
@@ -218,206 +408,6 @@ exports[`checkbox select renders checkbox select groups successfully 1`] = `
                     </label>
                   </fieldset>
                 </div>
-              </fieldset>
-            </div>,
-          }
-        }
-        onClickTypeaheadToggleButton={[Function]}
-        onClose={[Function]}
-        onEnter={[Function]}
-        onToggle={[Function]}
-        parentRef={
-          Object {
-            "current": <div
-              class="pf-c-select pf-m-expanded"
-              data-ouia-component-id="OUIA-Generated-Select-checkbox-8"
-              data-ouia-component-type="PF4/Select"
-              data-ouia-safe="true"
-            >
-              <button
-                aria-expanded="true"
-                aria-labelledby=" pf-select-toggle-id-7"
-                class="pf-c-select__toggle"
-                id="pf-select-toggle-id-7"
-                type="button"
-              >
-                <div
-                  class="pf-c-select__toggle-wrapper"
-                >
-                  <span
-                    class="pf-c-select__toggle-text"
-                  />
-                </div>
-                <span
-                  class="pf-c-select__toggle-arrow"
-                >
-                  <svg
-                    aria-hidden="true"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style="vertical-align: -0.125em;"
-                    viewBox="0 0 320 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                    />
-                  </svg>
-                </span>
-              </button>
-              <div
-                class="pf-c-select__menu"
-              >
-                <fieldset
-                  aria-label=""
-                  class="pf-c-form__fieldset"
-                >
-                  <div
-                    class="pf-c-select__menu-group"
-                  >
-                    <div
-                      aria-hidden="true"
-                      class="pf-c-select__menu-group-title"
-                      id="group-1"
-                    >
-                      group 1
-                    </div>
-                    <fieldset
-                      aria-labelledby="group-1"
-                      class="pf-c-select__menu-fieldset"
-                    >
-                      <label
-                        class="pf-c-check pf-c-select__menu-item"
-                      >
-                        <input
-                          class="pf-c-check__input"
-                          id="pf-random-id-15-Mr"
-                          type="checkbox"
-                        />
-                        <span
-                          class="pf-c-check__label"
-                        >
-                          Mr
-                        </span>
-                      </label>
-                      <label
-                        class="pf-c-check pf-c-select__menu-item"
-                      >
-                        <input
-                          class="pf-c-check__input"
-                          id="pf-random-id-15-Mrs"
-                          type="checkbox"
-                        />
-                        <span
-                          class="pf-c-check__label"
-                        >
-                          Mrs
-                        </span>
-                      </label>
-                      <label
-                        class="pf-c-check pf-c-select__menu-item"
-                      >
-                        <input
-                          class="pf-c-check__input"
-                          id="pf-random-id-15-Ms"
-                          type="checkbox"
-                        />
-                        <span
-                          class="pf-c-check__label"
-                        >
-                          Ms
-                        </span>
-                      </label>
-                      <label
-                        class="pf-c-check pf-c-select__menu-item"
-                      >
-                        <input
-                          class="pf-c-check__input"
-                          id="pf-random-id-15-Other"
-                          type="checkbox"
-                        />
-                        <span
-                          class="pf-c-check__label"
-                        >
-                          Other
-                        </span>
-                      </label>
-                    </fieldset>
-                  </div>
-                  <div
-                    class="pf-c-select__menu-group"
-                  >
-                    <div
-                      aria-hidden="true"
-                      class="pf-c-select__menu-group-title"
-                      id="group-2"
-                    >
-                      group 2
-                    </div>
-                    <fieldset
-                      aria-labelledby="group-2"
-                      class="pf-c-select__menu-fieldset"
-                    >
-                      <label
-                        class="pf-c-check pf-c-select__menu-item"
-                      >
-                        <input
-                          class="pf-c-check__input"
-                          id="pf-random-id-15-Mr"
-                          type="checkbox"
-                        />
-                        <span
-                          class="pf-c-check__label"
-                        >
-                          Mr
-                        </span>
-                      </label>
-                      <label
-                        class="pf-c-check pf-c-select__menu-item"
-                      >
-                        <input
-                          class="pf-c-check__input"
-                          id="pf-random-id-15-Mrs"
-                          type="checkbox"
-                        />
-                        <span
-                          class="pf-c-check__label"
-                        >
-                          Mrs
-                        </span>
-                      </label>
-                      <label
-                        class="pf-c-check pf-c-select__menu-item"
-                      >
-                        <input
-                          class="pf-c-check__input"
-                          id="pf-random-id-15-Ms"
-                          type="checkbox"
-                        />
-                        <span
-                          class="pf-c-check__label"
-                        >
-                          Ms
-                        </span>
-                      </label>
-                      <label
-                        class="pf-c-check pf-c-select__menu-item"
-                      >
-                        <input
-                          class="pf-c-check__input"
-                          id="pf-random-id-15-Other"
-                          type="checkbox"
-                        />
-                        <span
-                          class="pf-c-check__label"
-                        >
-                          Other
-                        </span>
-                      </label>
-                    </fieldset>
-                  </div>
-                </fieldset>
               </div>
             </div>,
           }
@@ -505,155 +495,150 @@ exports[`checkbox select renders checkbox select groups successfully 1`] = `
               "current": <div
                 class="pf-c-select__menu"
               >
-                <fieldset
-                  aria-label=""
-                  class="pf-c-form__fieldset"
+                <div
+                  class="pf-c-select__menu-group"
                 >
                   <div
-                    class="pf-c-select__menu-group"
+                    aria-hidden="true"
+                    class="pf-c-select__menu-group-title"
+                    id="group-1"
                   >
-                    <div
-                      aria-hidden="true"
-                      class="pf-c-select__menu-group-title"
-                      id="group-1"
-                    >
-                      group 1
-                    </div>
-                    <fieldset
-                      aria-labelledby="group-1"
-                      class="pf-c-select__menu-fieldset"
-                    >
-                      <label
-                        class="pf-c-check pf-c-select__menu-item"
-                      >
-                        <input
-                          class="pf-c-check__input"
-                          id="pf-random-id-15-Mr"
-                          type="checkbox"
-                        />
-                        <span
-                          class="pf-c-check__label"
-                        >
-                          Mr
-                        </span>
-                      </label>
-                      <label
-                        class="pf-c-check pf-c-select__menu-item"
-                      >
-                        <input
-                          class="pf-c-check__input"
-                          id="pf-random-id-15-Mrs"
-                          type="checkbox"
-                        />
-                        <span
-                          class="pf-c-check__label"
-                        >
-                          Mrs
-                        </span>
-                      </label>
-                      <label
-                        class="pf-c-check pf-c-select__menu-item"
-                      >
-                        <input
-                          class="pf-c-check__input"
-                          id="pf-random-id-15-Ms"
-                          type="checkbox"
-                        />
-                        <span
-                          class="pf-c-check__label"
-                        >
-                          Ms
-                        </span>
-                      </label>
-                      <label
-                        class="pf-c-check pf-c-select__menu-item"
-                      >
-                        <input
-                          class="pf-c-check__input"
-                          id="pf-random-id-15-Other"
-                          type="checkbox"
-                        />
-                        <span
-                          class="pf-c-check__label"
-                        >
-                          Other
-                        </span>
-                      </label>
-                    </fieldset>
+                    group 1
                   </div>
+                  <fieldset
+                    aria-labelledby="group-1"
+                    class="pf-c-select__menu-fieldset"
+                  >
+                    <label
+                      class="pf-c-check pf-c-select__menu-item"
+                    >
+                      <input
+                        class="pf-c-check__input"
+                        id="pf-random-id-15-Mr"
+                        type="checkbox"
+                      />
+                      <span
+                        class="pf-c-check__label"
+                      >
+                        Mr
+                      </span>
+                    </label>
+                    <label
+                      class="pf-c-check pf-c-select__menu-item"
+                    >
+                      <input
+                        class="pf-c-check__input"
+                        id="pf-random-id-15-Mrs"
+                        type="checkbox"
+                      />
+                      <span
+                        class="pf-c-check__label"
+                      >
+                        Mrs
+                      </span>
+                    </label>
+                    <label
+                      class="pf-c-check pf-c-select__menu-item"
+                    >
+                      <input
+                        class="pf-c-check__input"
+                        id="pf-random-id-15-Ms"
+                        type="checkbox"
+                      />
+                      <span
+                        class="pf-c-check__label"
+                      >
+                        Ms
+                      </span>
+                    </label>
+                    <label
+                      class="pf-c-check pf-c-select__menu-item"
+                    >
+                      <input
+                        class="pf-c-check__input"
+                        id="pf-random-id-15-Other"
+                        type="checkbox"
+                      />
+                      <span
+                        class="pf-c-check__label"
+                      >
+                        Other
+                      </span>
+                    </label>
+                  </fieldset>
+                </div>
+                <div
+                  class="pf-c-select__menu-group"
+                >
                   <div
-                    class="pf-c-select__menu-group"
+                    aria-hidden="true"
+                    class="pf-c-select__menu-group-title"
+                    id="group-2"
                   >
-                    <div
-                      aria-hidden="true"
-                      class="pf-c-select__menu-group-title"
-                      id="group-2"
-                    >
-                      group 2
-                    </div>
-                    <fieldset
-                      aria-labelledby="group-2"
-                      class="pf-c-select__menu-fieldset"
-                    >
-                      <label
-                        class="pf-c-check pf-c-select__menu-item"
-                      >
-                        <input
-                          class="pf-c-check__input"
-                          id="pf-random-id-15-Mr"
-                          type="checkbox"
-                        />
-                        <span
-                          class="pf-c-check__label"
-                        >
-                          Mr
-                        </span>
-                      </label>
-                      <label
-                        class="pf-c-check pf-c-select__menu-item"
-                      >
-                        <input
-                          class="pf-c-check__input"
-                          id="pf-random-id-15-Mrs"
-                          type="checkbox"
-                        />
-                        <span
-                          class="pf-c-check__label"
-                        >
-                          Mrs
-                        </span>
-                      </label>
-                      <label
-                        class="pf-c-check pf-c-select__menu-item"
-                      >
-                        <input
-                          class="pf-c-check__input"
-                          id="pf-random-id-15-Ms"
-                          type="checkbox"
-                        />
-                        <span
-                          class="pf-c-check__label"
-                        >
-                          Ms
-                        </span>
-                      </label>
-                      <label
-                        class="pf-c-check pf-c-select__menu-item"
-                      >
-                        <input
-                          class="pf-c-check__input"
-                          id="pf-random-id-15-Other"
-                          type="checkbox"
-                        />
-                        <span
-                          class="pf-c-check__label"
-                        >
-                          Other
-                        </span>
-                      </label>
-                    </fieldset>
+                    group 2
                   </div>
-                </fieldset>
+                  <fieldset
+                    aria-labelledby="group-2"
+                    class="pf-c-select__menu-fieldset"
+                  >
+                    <label
+                      class="pf-c-check pf-c-select__menu-item"
+                    >
+                      <input
+                        class="pf-c-check__input"
+                        id="pf-random-id-15-Mr"
+                        type="checkbox"
+                      />
+                      <span
+                        class="pf-c-check__label"
+                      >
+                        Mr
+                      </span>
+                    </label>
+                    <label
+                      class="pf-c-check pf-c-select__menu-item"
+                    >
+                      <input
+                        class="pf-c-check__input"
+                        id="pf-random-id-15-Mrs"
+                        type="checkbox"
+                      />
+                      <span
+                        class="pf-c-check__label"
+                      >
+                        Mrs
+                      </span>
+                    </label>
+                    <label
+                      class="pf-c-check pf-c-select__menu-item"
+                    >
+                      <input
+                        class="pf-c-check__input"
+                        id="pf-random-id-15-Ms"
+                        type="checkbox"
+                      />
+                      <span
+                        class="pf-c-check__label"
+                      >
+                        Ms
+                      </span>
+                    </label>
+                    <label
+                      class="pf-c-check pf-c-select__menu-item"
+                    >
+                      <input
+                        class="pf-c-check__input"
+                        id="pf-random-id-15-Other"
+                        type="checkbox"
+                      />
+                      <span
+                        class="pf-c-check__label"
+                      >
+                        Other
+                      </span>
+                    </label>
+                  </fieldset>
+                </div>
               </div>,
             }
           }
@@ -669,368 +654,362 @@ exports[`checkbox select renders checkbox select groups successfully 1`] = `
           <div
             className="pf-c-select__menu"
           >
-            <fieldset
-              aria-label=""
-              aria-labelledby={null}
-              className="pf-c-form__fieldset"
+            <SelectGroup
+              key=".0"
+              label="group 1"
+              titleId="group-1"
             >
-              <SelectGroup
-                key=".0"
-                label="group 1"
-                titleId="group-1"
+              <div
+                className="pf-c-select__menu-group"
               >
                 <div
-                  className="pf-c-select__menu-group"
+                  aria-hidden={true}
+                  className="pf-c-select__menu-group-title"
+                  id="group-1"
                 >
-                  <div
-                    aria-hidden={true}
-                    className="pf-c-select__menu-group-title"
-                    id="group-1"
-                  >
-                    group 1
-                  </div>
-                  <fieldset
-                    aria-labelledby="group-1"
-                    className="pf-c-select__menu-fieldset"
-                  >
-                    <SelectOption
-                      className=""
-                      component="button"
-                      id="option-1"
-                      index={0}
-                      inputId=""
-                      isChecked={false}
-                      isDisabled={false}
-                      isFavorite={null}
-                      isLoad={false}
-                      isLoading={false}
-                      isNoResultsOption={false}
-                      isPlaceholder={false}
-                      isSelected={false}
-                      key=".$00"
-                      keyHandler={[Function]}
-                      onClick={[Function]}
-                      sendRef={[Function]}
-                      value="Mr"
-                    >
-                      <label
-                        className="pf-c-check pf-c-select__menu-item"
-                        onKeyDown={[Function]}
-                      >
-                        <input
-                          checked={false}
-                          className="pf-c-check__input"
-                          disabled={false}
-                          id="pf-random-id-15-Mr"
-                          onChange={[Function]}
-                          type="checkbox"
-                        />
-                        <span
-                          className="pf-c-check__label"
-                        >
-                          Mr
-                        </span>
-                      </label>
-                    </SelectOption>
-                    <SelectOption
-                      className=""
-                      component="button"
-                      id="option-2"
-                      index={1}
-                      inputId=""
-                      isChecked={false}
-                      isDisabled={false}
-                      isFavorite={null}
-                      isLoad={false}
-                      isLoading={false}
-                      isNoResultsOption={false}
-                      isPlaceholder={false}
-                      isSelected={false}
-                      key=".$01"
-                      keyHandler={[Function]}
-                      onClick={[Function]}
-                      sendRef={[Function]}
-                      value="Mrs"
-                    >
-                      <label
-                        className="pf-c-check pf-c-select__menu-item"
-                        onKeyDown={[Function]}
-                      >
-                        <input
-                          checked={false}
-                          className="pf-c-check__input"
-                          disabled={false}
-                          id="pf-random-id-15-Mrs"
-                          onChange={[Function]}
-                          type="checkbox"
-                        />
-                        <span
-                          className="pf-c-check__label"
-                        >
-                          Mrs
-                        </span>
-                      </label>
-                    </SelectOption>
-                    <SelectOption
-                      className=""
-                      component="button"
-                      id="option-3"
-                      index={2}
-                      inputId=""
-                      isChecked={false}
-                      isDisabled={false}
-                      isFavorite={null}
-                      isLoad={false}
-                      isLoading={false}
-                      isNoResultsOption={false}
-                      isPlaceholder={false}
-                      isSelected={false}
-                      key=".$02"
-                      keyHandler={[Function]}
-                      onClick={[Function]}
-                      sendRef={[Function]}
-                      value="Ms"
-                    >
-                      <label
-                        className="pf-c-check pf-c-select__menu-item"
-                        onKeyDown={[Function]}
-                      >
-                        <input
-                          checked={false}
-                          className="pf-c-check__input"
-                          disabled={false}
-                          id="pf-random-id-15-Ms"
-                          onChange={[Function]}
-                          type="checkbox"
-                        />
-                        <span
-                          className="pf-c-check__label"
-                        >
-                          Ms
-                        </span>
-                      </label>
-                    </SelectOption>
-                    <SelectOption
-                      className=""
-                      component="button"
-                      id="option-4"
-                      index={3}
-                      inputId=""
-                      isChecked={false}
-                      isDisabled={false}
-                      isFavorite={null}
-                      isLoad={false}
-                      isLoading={false}
-                      isNoResultsOption={false}
-                      isPlaceholder={false}
-                      isSelected={false}
-                      key=".$03"
-                      keyHandler={[Function]}
-                      onClick={[Function]}
-                      sendRef={[Function]}
-                      value="Other"
-                    >
-                      <label
-                        className="pf-c-check pf-c-select__menu-item"
-                        onKeyDown={[Function]}
-                      >
-                        <input
-                          checked={false}
-                          className="pf-c-check__input"
-                          disabled={false}
-                          id="pf-random-id-15-Other"
-                          onChange={[Function]}
-                          type="checkbox"
-                        />
-                        <span
-                          className="pf-c-check__label"
-                        >
-                          Other
-                        </span>
-                      </label>
-                    </SelectOption>
-                  </fieldset>
+                  group 1
                 </div>
-              </SelectGroup>
-              <SelectGroup
-                key=".1"
-                label="group 2"
-                titleId="group-2"
+                <fieldset
+                  aria-labelledby="group-1"
+                  className="pf-c-select__menu-fieldset"
+                >
+                  <SelectOption
+                    className=""
+                    component="button"
+                    id="option-1"
+                    index={0}
+                    inputId=""
+                    isChecked={false}
+                    isDisabled={false}
+                    isFavorite={null}
+                    isLoad={false}
+                    isLoading={false}
+                    isNoResultsOption={false}
+                    isPlaceholder={false}
+                    isSelected={false}
+                    key=".$00"
+                    keyHandler={[Function]}
+                    onClick={[Function]}
+                    sendRef={[Function]}
+                    value="Mr"
+                  >
+                    <label
+                      className="pf-c-check pf-c-select__menu-item"
+                      onKeyDown={[Function]}
+                    >
+                      <input
+                        checked={false}
+                        className="pf-c-check__input"
+                        disabled={false}
+                        id="pf-random-id-15-Mr"
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <span
+                        className="pf-c-check__label"
+                      >
+                        Mr
+                      </span>
+                    </label>
+                  </SelectOption>
+                  <SelectOption
+                    className=""
+                    component="button"
+                    id="option-2"
+                    index={1}
+                    inputId=""
+                    isChecked={false}
+                    isDisabled={false}
+                    isFavorite={null}
+                    isLoad={false}
+                    isLoading={false}
+                    isNoResultsOption={false}
+                    isPlaceholder={false}
+                    isSelected={false}
+                    key=".$01"
+                    keyHandler={[Function]}
+                    onClick={[Function]}
+                    sendRef={[Function]}
+                    value="Mrs"
+                  >
+                    <label
+                      className="pf-c-check pf-c-select__menu-item"
+                      onKeyDown={[Function]}
+                    >
+                      <input
+                        checked={false}
+                        className="pf-c-check__input"
+                        disabled={false}
+                        id="pf-random-id-15-Mrs"
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <span
+                        className="pf-c-check__label"
+                      >
+                        Mrs
+                      </span>
+                    </label>
+                  </SelectOption>
+                  <SelectOption
+                    className=""
+                    component="button"
+                    id="option-3"
+                    index={2}
+                    inputId=""
+                    isChecked={false}
+                    isDisabled={false}
+                    isFavorite={null}
+                    isLoad={false}
+                    isLoading={false}
+                    isNoResultsOption={false}
+                    isPlaceholder={false}
+                    isSelected={false}
+                    key=".$02"
+                    keyHandler={[Function]}
+                    onClick={[Function]}
+                    sendRef={[Function]}
+                    value="Ms"
+                  >
+                    <label
+                      className="pf-c-check pf-c-select__menu-item"
+                      onKeyDown={[Function]}
+                    >
+                      <input
+                        checked={false}
+                        className="pf-c-check__input"
+                        disabled={false}
+                        id="pf-random-id-15-Ms"
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <span
+                        className="pf-c-check__label"
+                      >
+                        Ms
+                      </span>
+                    </label>
+                  </SelectOption>
+                  <SelectOption
+                    className=""
+                    component="button"
+                    id="option-4"
+                    index={3}
+                    inputId=""
+                    isChecked={false}
+                    isDisabled={false}
+                    isFavorite={null}
+                    isLoad={false}
+                    isLoading={false}
+                    isNoResultsOption={false}
+                    isPlaceholder={false}
+                    isSelected={false}
+                    key=".$03"
+                    keyHandler={[Function]}
+                    onClick={[Function]}
+                    sendRef={[Function]}
+                    value="Other"
+                  >
+                    <label
+                      className="pf-c-check pf-c-select__menu-item"
+                      onKeyDown={[Function]}
+                    >
+                      <input
+                        checked={false}
+                        className="pf-c-check__input"
+                        disabled={false}
+                        id="pf-random-id-15-Other"
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <span
+                        className="pf-c-check__label"
+                      >
+                        Other
+                      </span>
+                    </label>
+                  </SelectOption>
+                </fieldset>
+              </div>
+            </SelectGroup>
+            <SelectGroup
+              key=".1"
+              label="group 2"
+              titleId="group-2"
+            >
+              <div
+                className="pf-c-select__menu-group"
               >
                 <div
-                  className="pf-c-select__menu-group"
+                  aria-hidden={true}
+                  className="pf-c-select__menu-group-title"
+                  id="group-2"
                 >
-                  <div
-                    aria-hidden={true}
-                    className="pf-c-select__menu-group-title"
-                    id="group-2"
-                  >
-                    group 2
-                  </div>
-                  <fieldset
-                    aria-labelledby="group-2"
-                    className="pf-c-select__menu-fieldset"
-                  >
-                    <SelectOption
-                      className=""
-                      component="button"
-                      id="option-1"
-                      index={4}
-                      inputId=""
-                      isChecked={false}
-                      isDisabled={false}
-                      isFavorite={null}
-                      isLoad={false}
-                      isLoading={false}
-                      isNoResultsOption={false}
-                      isPlaceholder={false}
-                      isSelected={false}
-                      key=".$00"
-                      keyHandler={[Function]}
-                      onClick={[Function]}
-                      sendRef={[Function]}
-                      value="Mr"
-                    >
-                      <label
-                        className="pf-c-check pf-c-select__menu-item"
-                        onKeyDown={[Function]}
-                      >
-                        <input
-                          checked={false}
-                          className="pf-c-check__input"
-                          disabled={false}
-                          id="pf-random-id-15-Mr"
-                          onChange={[Function]}
-                          type="checkbox"
-                        />
-                        <span
-                          className="pf-c-check__label"
-                        >
-                          Mr
-                        </span>
-                      </label>
-                    </SelectOption>
-                    <SelectOption
-                      className=""
-                      component="button"
-                      id="option-2"
-                      index={5}
-                      inputId=""
-                      isChecked={false}
-                      isDisabled={false}
-                      isFavorite={null}
-                      isLoad={false}
-                      isLoading={false}
-                      isNoResultsOption={false}
-                      isPlaceholder={false}
-                      isSelected={false}
-                      key=".$01"
-                      keyHandler={[Function]}
-                      onClick={[Function]}
-                      sendRef={[Function]}
-                      value="Mrs"
-                    >
-                      <label
-                        className="pf-c-check pf-c-select__menu-item"
-                        onKeyDown={[Function]}
-                      >
-                        <input
-                          checked={false}
-                          className="pf-c-check__input"
-                          disabled={false}
-                          id="pf-random-id-15-Mrs"
-                          onChange={[Function]}
-                          type="checkbox"
-                        />
-                        <span
-                          className="pf-c-check__label"
-                        >
-                          Mrs
-                        </span>
-                      </label>
-                    </SelectOption>
-                    <SelectOption
-                      className=""
-                      component="button"
-                      id="option-3"
-                      index={6}
-                      inputId=""
-                      isChecked={false}
-                      isDisabled={false}
-                      isFavorite={null}
-                      isLoad={false}
-                      isLoading={false}
-                      isNoResultsOption={false}
-                      isPlaceholder={false}
-                      isSelected={false}
-                      key=".$02"
-                      keyHandler={[Function]}
-                      onClick={[Function]}
-                      sendRef={[Function]}
-                      value="Ms"
-                    >
-                      <label
-                        className="pf-c-check pf-c-select__menu-item"
-                        onKeyDown={[Function]}
-                      >
-                        <input
-                          checked={false}
-                          className="pf-c-check__input"
-                          disabled={false}
-                          id="pf-random-id-15-Ms"
-                          onChange={[Function]}
-                          type="checkbox"
-                        />
-                        <span
-                          className="pf-c-check__label"
-                        >
-                          Ms
-                        </span>
-                      </label>
-                    </SelectOption>
-                    <SelectOption
-                      className=""
-                      component="button"
-                      id="option-4"
-                      index={7}
-                      inputId=""
-                      isChecked={false}
-                      isDisabled={false}
-                      isFavorite={null}
-                      isLoad={false}
-                      isLoading={false}
-                      isNoResultsOption={false}
-                      isPlaceholder={false}
-                      isSelected={false}
-                      key=".$03"
-                      keyHandler={[Function]}
-                      onClick={[Function]}
-                      sendRef={[Function]}
-                      value="Other"
-                    >
-                      <label
-                        className="pf-c-check pf-c-select__menu-item"
-                        onKeyDown={[Function]}
-                      >
-                        <input
-                          checked={false}
-                          className="pf-c-check__input"
-                          disabled={false}
-                          id="pf-random-id-15-Other"
-                          onChange={[Function]}
-                          type="checkbox"
-                        />
-                        <span
-                          className="pf-c-check__label"
-                        >
-                          Other
-                        </span>
-                      </label>
-                    </SelectOption>
-                  </fieldset>
+                  group 2
                 </div>
-              </SelectGroup>
-            </fieldset>
+                <fieldset
+                  aria-labelledby="group-2"
+                  className="pf-c-select__menu-fieldset"
+                >
+                  <SelectOption
+                    className=""
+                    component="button"
+                    id="option-1"
+                    index={4}
+                    inputId=""
+                    isChecked={false}
+                    isDisabled={false}
+                    isFavorite={null}
+                    isLoad={false}
+                    isLoading={false}
+                    isNoResultsOption={false}
+                    isPlaceholder={false}
+                    isSelected={false}
+                    key=".$00"
+                    keyHandler={[Function]}
+                    onClick={[Function]}
+                    sendRef={[Function]}
+                    value="Mr"
+                  >
+                    <label
+                      className="pf-c-check pf-c-select__menu-item"
+                      onKeyDown={[Function]}
+                    >
+                      <input
+                        checked={false}
+                        className="pf-c-check__input"
+                        disabled={false}
+                        id="pf-random-id-15-Mr"
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <span
+                        className="pf-c-check__label"
+                      >
+                        Mr
+                      </span>
+                    </label>
+                  </SelectOption>
+                  <SelectOption
+                    className=""
+                    component="button"
+                    id="option-2"
+                    index={5}
+                    inputId=""
+                    isChecked={false}
+                    isDisabled={false}
+                    isFavorite={null}
+                    isLoad={false}
+                    isLoading={false}
+                    isNoResultsOption={false}
+                    isPlaceholder={false}
+                    isSelected={false}
+                    key=".$01"
+                    keyHandler={[Function]}
+                    onClick={[Function]}
+                    sendRef={[Function]}
+                    value="Mrs"
+                  >
+                    <label
+                      className="pf-c-check pf-c-select__menu-item"
+                      onKeyDown={[Function]}
+                    >
+                      <input
+                        checked={false}
+                        className="pf-c-check__input"
+                        disabled={false}
+                        id="pf-random-id-15-Mrs"
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <span
+                        className="pf-c-check__label"
+                      >
+                        Mrs
+                      </span>
+                    </label>
+                  </SelectOption>
+                  <SelectOption
+                    className=""
+                    component="button"
+                    id="option-3"
+                    index={6}
+                    inputId=""
+                    isChecked={false}
+                    isDisabled={false}
+                    isFavorite={null}
+                    isLoad={false}
+                    isLoading={false}
+                    isNoResultsOption={false}
+                    isPlaceholder={false}
+                    isSelected={false}
+                    key=".$02"
+                    keyHandler={[Function]}
+                    onClick={[Function]}
+                    sendRef={[Function]}
+                    value="Ms"
+                  >
+                    <label
+                      className="pf-c-check pf-c-select__menu-item"
+                      onKeyDown={[Function]}
+                    >
+                      <input
+                        checked={false}
+                        className="pf-c-check__input"
+                        disabled={false}
+                        id="pf-random-id-15-Ms"
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <span
+                        className="pf-c-check__label"
+                      >
+                        Ms
+                      </span>
+                    </label>
+                  </SelectOption>
+                  <SelectOption
+                    className=""
+                    component="button"
+                    id="option-4"
+                    index={7}
+                    inputId=""
+                    isChecked={false}
+                    isDisabled={false}
+                    isFavorite={null}
+                    isLoad={false}
+                    isLoading={false}
+                    isNoResultsOption={false}
+                    isPlaceholder={false}
+                    isSelected={false}
+                    key=".$03"
+                    keyHandler={[Function]}
+                    onClick={[Function]}
+                    sendRef={[Function]}
+                    value="Other"
+                  >
+                    <label
+                      className="pf-c-check pf-c-select__menu-item"
+                      onKeyDown={[Function]}
+                    >
+                      <input
+                        checked={false}
+                        className="pf-c-check__input"
+                        disabled={false}
+                        id="pf-random-id-15-Other"
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <span
+                        className="pf-c-check__label"
+                      >
+                        Other
+                      </span>
+                    </label>
+                  </SelectOption>
+                </fieldset>
+              </div>
+            </SelectGroup>
           </div>
         </SelectMenu>
       </ForwardRef>
@@ -1686,12 +1665,118 @@ exports[`checkbox select renders expanded successfully 1`] = `
         isPlain={false}
         menuRef={
           Object {
-            "current": <div
+            "current": <ul
+              aria-label=""
               class="pf-c-select__menu"
+              role="listbox"
             >
-              <fieldset
+              <label
+                class="pf-c-check pf-c-select__menu-item"
+              >
+                <input
+                  class="pf-c-check__input"
+                  id="pf-random-id-11-Mr"
+                  type="checkbox"
+                />
+                <span
+                  class="pf-c-check__label"
+                >
+                  Mr
+                </span>
+              </label>
+              <label
+                class="pf-c-check pf-c-select__menu-item"
+              >
+                <input
+                  class="pf-c-check__input"
+                  id="pf-random-id-11-Mrs"
+                  type="checkbox"
+                />
+                <span
+                  class="pf-c-check__label"
+                >
+                  Mrs
+                </span>
+              </label>
+              <label
+                class="pf-c-check pf-c-select__menu-item"
+              >
+                <input
+                  class="pf-c-check__input"
+                  id="pf-random-id-11-Ms"
+                  type="checkbox"
+                />
+                <span
+                  class="pf-c-check__label"
+                >
+                  Ms
+                </span>
+              </label>
+              <label
+                class="pf-c-check pf-c-select__menu-item"
+              >
+                <input
+                  class="pf-c-check__input"
+                  id="pf-random-id-11-Other"
+                  type="checkbox"
+                />
+                <span
+                  class="pf-c-check__label"
+                >
+                  Other
+                </span>
+              </label>
+            </ul>,
+          }
+        }
+        onClickTypeaheadToggleButton={[Function]}
+        onClose={[Function]}
+        onEnter={[Function]}
+        onToggle={[Function]}
+        parentRef={
+          Object {
+            "current": <div
+              class="pf-c-select pf-m-expanded"
+              data-ouia-component-id="OUIA-Generated-Select-checkbox-4"
+              data-ouia-component-type="PF4/Select"
+              data-ouia-safe="true"
+            >
+              <button
+                aria-expanded="true"
+                aria-labelledby=" pf-select-toggle-id-4"
+                class="pf-c-select__toggle"
+                id="pf-select-toggle-id-4"
+                type="button"
+              >
+                <div
+                  class="pf-c-select__toggle-wrapper"
+                >
+                  <span
+                    class="pf-c-select__toggle-text"
+                  />
+                </div>
+                <span
+                  class="pf-c-select__toggle-arrow"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <ul
                 aria-label=""
-                class="pf-c-form__fieldset"
+                class="pf-c-select__menu"
+                role="listbox"
               >
                 <label
                   class="pf-c-check pf-c-select__menu-item"
@@ -1749,119 +1834,7 @@ exports[`checkbox select renders expanded successfully 1`] = `
                     Other
                   </span>
                 </label>
-              </fieldset>
-            </div>,
-          }
-        }
-        onClickTypeaheadToggleButton={[Function]}
-        onClose={[Function]}
-        onEnter={[Function]}
-        onToggle={[Function]}
-        parentRef={
-          Object {
-            "current": <div
-              class="pf-c-select pf-m-expanded"
-              data-ouia-component-id="OUIA-Generated-Select-checkbox-4"
-              data-ouia-component-type="PF4/Select"
-              data-ouia-safe="true"
-            >
-              <button
-                aria-expanded="true"
-                aria-labelledby=" pf-select-toggle-id-4"
-                class="pf-c-select__toggle"
-                id="pf-select-toggle-id-4"
-                type="button"
-              >
-                <div
-                  class="pf-c-select__toggle-wrapper"
-                >
-                  <span
-                    class="pf-c-select__toggle-text"
-                  />
-                </div>
-                <span
-                  class="pf-c-select__toggle-arrow"
-                >
-                  <svg
-                    aria-hidden="true"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style="vertical-align: -0.125em;"
-                    viewBox="0 0 320 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                    />
-                  </svg>
-                </span>
-              </button>
-              <div
-                class="pf-c-select__menu"
-              >
-                <fieldset
-                  aria-label=""
-                  class="pf-c-form__fieldset"
-                >
-                  <label
-                    class="pf-c-check pf-c-select__menu-item"
-                  >
-                    <input
-                      class="pf-c-check__input"
-                      id="pf-random-id-11-Mr"
-                      type="checkbox"
-                    />
-                    <span
-                      class="pf-c-check__label"
-                    >
-                      Mr
-                    </span>
-                  </label>
-                  <label
-                    class="pf-c-check pf-c-select__menu-item"
-                  >
-                    <input
-                      class="pf-c-check__input"
-                      id="pf-random-id-11-Mrs"
-                      type="checkbox"
-                    />
-                    <span
-                      class="pf-c-check__label"
-                    >
-                      Mrs
-                    </span>
-                  </label>
-                  <label
-                    class="pf-c-check pf-c-select__menu-item"
-                  >
-                    <input
-                      class="pf-c-check__input"
-                      id="pf-random-id-11-Ms"
-                      type="checkbox"
-                    />
-                    <span
-                      class="pf-c-check__label"
-                    >
-                      Ms
-                    </span>
-                  </label>
-                  <label
-                    class="pf-c-check pf-c-select__menu-item"
-                  >
-                    <input
-                      class="pf-c-check__input"
-                      id="pf-random-id-11-Other"
-                      type="checkbox"
-                    />
-                    <span
-                      class="pf-c-check__label"
-                    >
-                      Other
-                    </span>
-                  </label>
-                </fieldset>
-              </div>
+              </ul>
             </div>,
           }
         }
@@ -1945,71 +1918,68 @@ exports[`checkbox select renders expanded successfully 1`] = `
           hasInlineFilter={false}
           innerRef={
             Object {
-              "current": <div
+              "current": <ul
+                aria-label=""
                 class="pf-c-select__menu"
+                role="listbox"
               >
-                <fieldset
-                  aria-label=""
-                  class="pf-c-form__fieldset"
+                <label
+                  class="pf-c-check pf-c-select__menu-item"
                 >
-                  <label
-                    class="pf-c-check pf-c-select__menu-item"
+                  <input
+                    class="pf-c-check__input"
+                    id="pf-random-id-11-Mr"
+                    type="checkbox"
+                  />
+                  <span
+                    class="pf-c-check__label"
                   >
-                    <input
-                      class="pf-c-check__input"
-                      id="pf-random-id-11-Mr"
-                      type="checkbox"
-                    />
-                    <span
-                      class="pf-c-check__label"
-                    >
-                      Mr
-                    </span>
-                  </label>
-                  <label
-                    class="pf-c-check pf-c-select__menu-item"
+                    Mr
+                  </span>
+                </label>
+                <label
+                  class="pf-c-check pf-c-select__menu-item"
+                >
+                  <input
+                    class="pf-c-check__input"
+                    id="pf-random-id-11-Mrs"
+                    type="checkbox"
+                  />
+                  <span
+                    class="pf-c-check__label"
                   >
-                    <input
-                      class="pf-c-check__input"
-                      id="pf-random-id-11-Mrs"
-                      type="checkbox"
-                    />
-                    <span
-                      class="pf-c-check__label"
-                    >
-                      Mrs
-                    </span>
-                  </label>
-                  <label
-                    class="pf-c-check pf-c-select__menu-item"
+                    Mrs
+                  </span>
+                </label>
+                <label
+                  class="pf-c-check pf-c-select__menu-item"
+                >
+                  <input
+                    class="pf-c-check__input"
+                    id="pf-random-id-11-Ms"
+                    type="checkbox"
+                  />
+                  <span
+                    class="pf-c-check__label"
                   >
-                    <input
-                      class="pf-c-check__input"
-                      id="pf-random-id-11-Ms"
-                      type="checkbox"
-                    />
-                    <span
-                      class="pf-c-check__label"
-                    >
-                      Ms
-                    </span>
-                  </label>
-                  <label
-                    class="pf-c-check pf-c-select__menu-item"
+                    Ms
+                  </span>
+                </label>
+                <label
+                  class="pf-c-check pf-c-select__menu-item"
+                >
+                  <input
+                    class="pf-c-check__input"
+                    id="pf-random-id-11-Other"
+                    type="checkbox"
+                  />
+                  <span
+                    class="pf-c-check__label"
                   >
-                    <input
-                      class="pf-c-check__input"
-                      id="pf-random-id-11-Other"
-                      type="checkbox"
-                    />
-                    <span
-                      class="pf-c-check__label"
-                    >
-                      Other
-                    </span>
-                  </label>
-                </fieldset>
-              </div>,
+                    Other
+                  </span>
+                </label>
+              </ul>,
             }
           }
           isCustomContent={false}
@@ -2021,172 +1991,169 @@ exports[`checkbox select renders expanded successfully 1`] = `
           selected={Array []}
           sendRef={[Function]}
         >
-          <div
+          <ul
+            aria-label=""
+            aria-labelledby={null}
             className="pf-c-select__menu"
+            role="listbox"
           >
-            <fieldset
-              aria-label=""
-              aria-labelledby={null}
-              className="pf-c-form__fieldset"
+            <SelectOption
+              className=""
+              component="button"
+              id="option-1"
+              index={0}
+              inputId=""
+              isChecked={false}
+              isDisabled={false}
+              isFavorite={null}
+              isLoad={false}
+              isLoading={false}
+              isNoResultsOption={false}
+              isPlaceholder={false}
+              isSelected={false}
+              key=".$00"
+              keyHandler={[Function]}
+              onClick={[Function]}
+              sendRef={[Function]}
+              value="Mr"
             >
-              <SelectOption
-                className=""
-                component="button"
-                id="option-1"
-                index={0}
-                inputId=""
-                isChecked={false}
-                isDisabled={false}
-                isFavorite={null}
-                isLoad={false}
-                isLoading={false}
-                isNoResultsOption={false}
-                isPlaceholder={false}
-                isSelected={false}
-                key=".$00"
-                keyHandler={[Function]}
-                onClick={[Function]}
-                sendRef={[Function]}
-                value="Mr"
+              <label
+                className="pf-c-check pf-c-select__menu-item"
+                onKeyDown={[Function]}
               >
-                <label
-                  className="pf-c-check pf-c-select__menu-item"
-                  onKeyDown={[Function]}
+                <input
+                  checked={false}
+                  className="pf-c-check__input"
+                  disabled={false}
+                  id="pf-random-id-11-Mr"
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                <span
+                  className="pf-c-check__label"
                 >
-                  <input
-                    checked={false}
-                    className="pf-c-check__input"
-                    disabled={false}
-                    id="pf-random-id-11-Mr"
-                    onChange={[Function]}
-                    type="checkbox"
-                  />
-                  <span
-                    className="pf-c-check__label"
-                  >
-                    Mr
-                  </span>
-                </label>
-              </SelectOption>
-              <SelectOption
-                className=""
-                component="button"
-                id="option-2"
-                index={1}
-                inputId=""
-                isChecked={false}
-                isDisabled={false}
-                isFavorite={null}
-                isLoad={false}
-                isLoading={false}
-                isNoResultsOption={false}
-                isPlaceholder={false}
-                isSelected={false}
-                key=".$01"
-                keyHandler={[Function]}
-                onClick={[Function]}
-                sendRef={[Function]}
-                value="Mrs"
+                  Mr
+                </span>
+              </label>
+            </SelectOption>
+            <SelectOption
+              className=""
+              component="button"
+              id="option-2"
+              index={1}
+              inputId=""
+              isChecked={false}
+              isDisabled={false}
+              isFavorite={null}
+              isLoad={false}
+              isLoading={false}
+              isNoResultsOption={false}
+              isPlaceholder={false}
+              isSelected={false}
+              key=".$01"
+              keyHandler={[Function]}
+              onClick={[Function]}
+              sendRef={[Function]}
+              value="Mrs"
+            >
+              <label
+                className="pf-c-check pf-c-select__menu-item"
+                onKeyDown={[Function]}
               >
-                <label
-                  className="pf-c-check pf-c-select__menu-item"
-                  onKeyDown={[Function]}
+                <input
+                  checked={false}
+                  className="pf-c-check__input"
+                  disabled={false}
+                  id="pf-random-id-11-Mrs"
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                <span
+                  className="pf-c-check__label"
                 >
-                  <input
-                    checked={false}
-                    className="pf-c-check__input"
-                    disabled={false}
-                    id="pf-random-id-11-Mrs"
-                    onChange={[Function]}
-                    type="checkbox"
-                  />
-                  <span
-                    className="pf-c-check__label"
-                  >
-                    Mrs
-                  </span>
-                </label>
-              </SelectOption>
-              <SelectOption
-                className=""
-                component="button"
-                id="option-3"
-                index={2}
-                inputId=""
-                isChecked={false}
-                isDisabled={false}
-                isFavorite={null}
-                isLoad={false}
-                isLoading={false}
-                isNoResultsOption={false}
-                isPlaceholder={false}
-                isSelected={false}
-                key=".$02"
-                keyHandler={[Function]}
-                onClick={[Function]}
-                sendRef={[Function]}
-                value="Ms"
+                  Mrs
+                </span>
+              </label>
+            </SelectOption>
+            <SelectOption
+              className=""
+              component="button"
+              id="option-3"
+              index={2}
+              inputId=""
+              isChecked={false}
+              isDisabled={false}
+              isFavorite={null}
+              isLoad={false}
+              isLoading={false}
+              isNoResultsOption={false}
+              isPlaceholder={false}
+              isSelected={false}
+              key=".$02"
+              keyHandler={[Function]}
+              onClick={[Function]}
+              sendRef={[Function]}
+              value="Ms"
+            >
+              <label
+                className="pf-c-check pf-c-select__menu-item"
+                onKeyDown={[Function]}
               >
-                <label
-                  className="pf-c-check pf-c-select__menu-item"
-                  onKeyDown={[Function]}
+                <input
+                  checked={false}
+                  className="pf-c-check__input"
+                  disabled={false}
+                  id="pf-random-id-11-Ms"
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                <span
+                  className="pf-c-check__label"
                 >
-                  <input
-                    checked={false}
-                    className="pf-c-check__input"
-                    disabled={false}
-                    id="pf-random-id-11-Ms"
-                    onChange={[Function]}
-                    type="checkbox"
-                  />
-                  <span
-                    className="pf-c-check__label"
-                  >
-                    Ms
-                  </span>
-                </label>
-              </SelectOption>
-              <SelectOption
-                className=""
-                component="button"
-                id="option-4"
-                index={3}
-                inputId=""
-                isChecked={false}
-                isDisabled={false}
-                isFavorite={null}
-                isLoad={false}
-                isLoading={false}
-                isNoResultsOption={false}
-                isPlaceholder={false}
-                isSelected={false}
-                key=".$03"
-                keyHandler={[Function]}
-                onClick={[Function]}
-                sendRef={[Function]}
-                value="Other"
+                  Ms
+                </span>
+              </label>
+            </SelectOption>
+            <SelectOption
+              className=""
+              component="button"
+              id="option-4"
+              index={3}
+              inputId=""
+              isChecked={false}
+              isDisabled={false}
+              isFavorite={null}
+              isLoad={false}
+              isLoading={false}
+              isNoResultsOption={false}
+              isPlaceholder={false}
+              isSelected={false}
+              key=".$03"
+              keyHandler={[Function]}
+              onClick={[Function]}
+              sendRef={[Function]}
+              value="Other"
+            >
+              <label
+                className="pf-c-check pf-c-select__menu-item"
+                onKeyDown={[Function]}
               >
-                <label
-                  className="pf-c-check pf-c-select__menu-item"
-                  onKeyDown={[Function]}
+                <input
+                  checked={false}
+                  className="pf-c-check__input"
+                  disabled={false}
+                  id="pf-random-id-11-Other"
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                <span
+                  className="pf-c-check__label"
                 >
-                  <input
-                    checked={false}
-                    className="pf-c-check__input"
-                    disabled={false}
-                    id="pf-random-id-11-Other"
-                    onChange={[Function]}
-                    type="checkbox"
-                  />
-                  <span
-                    className="pf-c-check__label"
-                  >
-                    Other
-                  </span>
-                </label>
-              </SelectOption>
-            </fieldset>
-          </div>
+                  Other
+                </span>
+              </label>
+            </SelectOption>
+          </ul>
         </SelectMenu>
       </ForwardRef>
     </div>
@@ -2261,57 +2228,54 @@ exports[`checkbox select renders expanded successfully with custom objects 1`] =
         isPlain={false}
         menuRef={
           Object {
-            "current": <div
+            "current": <ul
+              aria-label=""
               class="pf-c-select__menu"
+              role="listbox"
             >
-              <fieldset
-                aria-label=""
-                class="pf-c-form__fieldset"
+              <label
+                class="pf-c-check pf-c-select__menu-item"
               >
-                <label
-                  class="pf-c-check pf-c-select__menu-item"
+                <input
+                  class="pf-c-check__input"
+                  id="pf-random-id-14-Mr: User One"
+                  type="checkbox"
+                />
+                <span
+                  class="pf-c-check__label"
                 >
-                  <input
-                    class="pf-c-check__input"
-                    id="pf-random-id-14-Mr: User One"
-                    type="checkbox"
-                  />
-                  <span
-                    class="pf-c-check__label"
-                  >
-                    Mr: User One
-                  </span>
-                </label>
-                <label
-                  class="pf-c-check pf-c-select__menu-item"
+                  Mr: User One
+                </span>
+              </label>
+              <label
+                class="pf-c-check pf-c-select__menu-item"
+              >
+                <input
+                  class="pf-c-check__input"
+                  id="pf-random-id-14-Mrs: New User"
+                  type="checkbox"
+                />
+                <span
+                  class="pf-c-check__label"
                 >
-                  <input
-                    class="pf-c-check__input"
-                    id="pf-random-id-14-Mrs: New User"
-                    type="checkbox"
-                  />
-                  <span
-                    class="pf-c-check__label"
-                  >
-                    Mrs: New User
-                  </span>
-                </label>
-                <label
-                  class="pf-c-check pf-c-select__menu-item"
+                  Mrs: New User
+                </span>
+              </label>
+              <label
+                class="pf-c-check pf-c-select__menu-item"
+              >
+                <input
+                  class="pf-c-check__input"
+                  id="pf-random-id-14-Ms: Test Three"
+                  type="checkbox"
+                />
+                <span
+                  class="pf-c-check__label"
                 >
-                  <input
-                    class="pf-c-check__input"
-                    id="pf-random-id-14-Ms: Test Three"
-                    type="checkbox"
-                  />
-                  <span
-                    class="pf-c-check__label"
-                  >
-                    Ms: Test Three
-                  </span>
-                </label>
-              </fieldset>
-            </div>,
+                  Ms: Test Three
+                </span>
+              </label>
+            </ul>,
           }
         }
         onClickTypeaheadToggleButton={[Function]}
@@ -2358,57 +2322,54 @@ exports[`checkbox select renders expanded successfully with custom objects 1`] =
                   </svg>
                 </span>
               </button>
-              <div
+              <ul
+                aria-label=""
                 class="pf-c-select__menu"
+                role="listbox"
               >
-                <fieldset
-                  aria-label=""
-                  class="pf-c-form__fieldset"
+                <label
+                  class="pf-c-check pf-c-select__menu-item"
                 >
-                  <label
-                    class="pf-c-check pf-c-select__menu-item"
+                  <input
+                    class="pf-c-check__input"
+                    id="pf-random-id-14-Mr: User One"
+                    type="checkbox"
+                  />
+                  <span
+                    class="pf-c-check__label"
                   >
-                    <input
-                      class="pf-c-check__input"
-                      id="pf-random-id-14-Mr: User One"
-                      type="checkbox"
-                    />
-                    <span
-                      class="pf-c-check__label"
-                    >
-                      Mr: User One
-                    </span>
-                  </label>
-                  <label
-                    class="pf-c-check pf-c-select__menu-item"
+                    Mr: User One
+                  </span>
+                </label>
+                <label
+                  class="pf-c-check pf-c-select__menu-item"
+                >
+                  <input
+                    class="pf-c-check__input"
+                    id="pf-random-id-14-Mrs: New User"
+                    type="checkbox"
+                  />
+                  <span
+                    class="pf-c-check__label"
                   >
-                    <input
-                      class="pf-c-check__input"
-                      id="pf-random-id-14-Mrs: New User"
-                      type="checkbox"
-                    />
-                    <span
-                      class="pf-c-check__label"
-                    >
-                      Mrs: New User
-                    </span>
-                  </label>
-                  <label
-                    class="pf-c-check pf-c-select__menu-item"
+                    Mrs: New User
+                  </span>
+                </label>
+                <label
+                  class="pf-c-check pf-c-select__menu-item"
+                >
+                  <input
+                    class="pf-c-check__input"
+                    id="pf-random-id-14-Ms: Test Three"
+                    type="checkbox"
+                  />
+                  <span
+                    class="pf-c-check__label"
                   >
-                    <input
-                      class="pf-c-check__input"
-                      id="pf-random-id-14-Ms: Test Three"
-                      type="checkbox"
-                    />
-                    <span
-                      class="pf-c-check__label"
-                    >
-                      Ms: Test Three
-                    </span>
-                  </label>
-                </fieldset>
-              </div>
+                    Ms: Test Three
+                  </span>
+                </label>
+              </ul>
             </div>,
           }
         }
@@ -2492,57 +2453,54 @@ exports[`checkbox select renders expanded successfully with custom objects 1`] =
           hasInlineFilter={false}
           innerRef={
             Object {
-              "current": <div
+              "current": <ul
+                aria-label=""
                 class="pf-c-select__menu"
+                role="listbox"
               >
-                <fieldset
-                  aria-label=""
-                  class="pf-c-form__fieldset"
+                <label
+                  class="pf-c-check pf-c-select__menu-item"
                 >
-                  <label
-                    class="pf-c-check pf-c-select__menu-item"
+                  <input
+                    class="pf-c-check__input"
+                    id="pf-random-id-14-Mr: User One"
+                    type="checkbox"
+                  />
+                  <span
+                    class="pf-c-check__label"
                   >
-                    <input
-                      class="pf-c-check__input"
-                      id="pf-random-id-14-Mr: User One"
-                      type="checkbox"
-                    />
-                    <span
-                      class="pf-c-check__label"
-                    >
-                      Mr: User One
-                    </span>
-                  </label>
-                  <label
-                    class="pf-c-check pf-c-select__menu-item"
+                    Mr: User One
+                  </span>
+                </label>
+                <label
+                  class="pf-c-check pf-c-select__menu-item"
+                >
+                  <input
+                    class="pf-c-check__input"
+                    id="pf-random-id-14-Mrs: New User"
+                    type="checkbox"
+                  />
+                  <span
+                    class="pf-c-check__label"
                   >
-                    <input
-                      class="pf-c-check__input"
-                      id="pf-random-id-14-Mrs: New User"
-                      type="checkbox"
-                    />
-                    <span
-                      class="pf-c-check__label"
-                    >
-                      Mrs: New User
-                    </span>
-                  </label>
-                  <label
-                    class="pf-c-check pf-c-select__menu-item"
+                    Mrs: New User
+                  </span>
+                </label>
+                <label
+                  class="pf-c-check pf-c-select__menu-item"
+                >
+                  <input
+                    class="pf-c-check__input"
+                    id="pf-random-id-14-Ms: Test Three"
+                    type="checkbox"
+                  />
+                  <span
+                    class="pf-c-check__label"
                   >
-                    <input
-                      class="pf-c-check__input"
-                      id="pf-random-id-14-Ms: Test Three"
-                      type="checkbox"
-                    />
-                    <span
-                      class="pf-c-check__label"
-                    >
-                      Ms: Test Three
-                    </span>
-                  </label>
-                </fieldset>
-              </div>,
+                    Ms: Test Three
+                  </span>
+                </label>
+              </ul>,
             }
           }
           isCustomContent={false}
@@ -2554,157 +2512,154 @@ exports[`checkbox select renders expanded successfully with custom objects 1`] =
           selected={Array []}
           sendRef={[Function]}
         >
-          <div
+          <ul
+            aria-label=""
+            aria-labelledby={null}
             className="pf-c-select__menu"
+            role="listbox"
           >
-            <fieldset
-              aria-label=""
-              aria-labelledby={null}
-              className="pf-c-form__fieldset"
+            <SelectOption
+              className=""
+              component="button"
+              id="option-1"
+              index={0}
+              inputId=""
+              isChecked={false}
+              isDisabled={false}
+              isFavorite={null}
+              isLoad={false}
+              isLoading={false}
+              isNoResultsOption={false}
+              isPlaceholder={false}
+              isSelected={false}
+              key=".$0"
+              keyHandler={[Function]}
+              onClick={[Function]}
+              sendRef={[Function]}
+              value={
+                User {
+                  "compareTo": [Function],
+                  "firstName": "User",
+                  "lastName": "One",
+                  "title": "Mr",
+                  "toString": [Function],
+                }
+              }
             >
-              <SelectOption
-                className=""
-                component="button"
-                id="option-1"
-                index={0}
-                inputId=""
-                isChecked={false}
-                isDisabled={false}
-                isFavorite={null}
-                isLoad={false}
-                isLoading={false}
-                isNoResultsOption={false}
-                isPlaceholder={false}
-                isSelected={false}
-                key=".$0"
-                keyHandler={[Function]}
-                onClick={[Function]}
-                sendRef={[Function]}
-                value={
-                  User {
-                    "compareTo": [Function],
-                    "firstName": "User",
-                    "lastName": "One",
-                    "title": "Mr",
-                    "toString": [Function],
-                  }
-                }
+              <label
+                className="pf-c-check pf-c-select__menu-item"
+                onKeyDown={[Function]}
               >
-                <label
-                  className="pf-c-check pf-c-select__menu-item"
-                  onKeyDown={[Function]}
+                <input
+                  checked={false}
+                  className="pf-c-check__input"
+                  disabled={false}
+                  id="pf-random-id-14-Mr: User One"
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                <span
+                  className="pf-c-check__label"
                 >
-                  <input
-                    checked={false}
-                    className="pf-c-check__input"
-                    disabled={false}
-                    id="pf-random-id-14-Mr: User One"
-                    onChange={[Function]}
-                    type="checkbox"
-                  />
-                  <span
-                    className="pf-c-check__label"
-                  >
-                    Mr: User One
-                  </span>
-                </label>
-              </SelectOption>
-              <SelectOption
-                className=""
-                component="button"
-                id="option-2"
-                index={1}
-                inputId=""
-                isChecked={false}
-                isDisabled={false}
-                isFavorite={null}
-                isLoad={false}
-                isLoading={false}
-                isNoResultsOption={false}
-                isPlaceholder={false}
-                isSelected={false}
-                key=".$1"
-                keyHandler={[Function]}
-                onClick={[Function]}
-                sendRef={[Function]}
-                value={
-                  User {
-                    "compareTo": [Function],
-                    "firstName": "New",
-                    "lastName": "User",
-                    "title": "Mrs",
-                    "toString": [Function],
-                  }
+                  Mr: User One
+                </span>
+              </label>
+            </SelectOption>
+            <SelectOption
+              className=""
+              component="button"
+              id="option-2"
+              index={1}
+              inputId=""
+              isChecked={false}
+              isDisabled={false}
+              isFavorite={null}
+              isLoad={false}
+              isLoading={false}
+              isNoResultsOption={false}
+              isPlaceholder={false}
+              isSelected={false}
+              key=".$1"
+              keyHandler={[Function]}
+              onClick={[Function]}
+              sendRef={[Function]}
+              value={
+                User {
+                  "compareTo": [Function],
+                  "firstName": "New",
+                  "lastName": "User",
+                  "title": "Mrs",
+                  "toString": [Function],
                 }
+              }
+            >
+              <label
+                className="pf-c-check pf-c-select__menu-item"
+                onKeyDown={[Function]}
               >
-                <label
-                  className="pf-c-check pf-c-select__menu-item"
-                  onKeyDown={[Function]}
+                <input
+                  checked={false}
+                  className="pf-c-check__input"
+                  disabled={false}
+                  id="pf-random-id-14-Mrs: New User"
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                <span
+                  className="pf-c-check__label"
                 >
-                  <input
-                    checked={false}
-                    className="pf-c-check__input"
-                    disabled={false}
-                    id="pf-random-id-14-Mrs: New User"
-                    onChange={[Function]}
-                    type="checkbox"
-                  />
-                  <span
-                    className="pf-c-check__label"
-                  >
-                    Mrs: New User
-                  </span>
-                </label>
-              </SelectOption>
-              <SelectOption
-                className=""
-                component="button"
-                id="option-3"
-                index={2}
-                inputId=""
-                isChecked={false}
-                isDisabled={false}
-                isFavorite={null}
-                isLoad={false}
-                isLoading={false}
-                isNoResultsOption={false}
-                isPlaceholder={false}
-                isSelected={false}
-                key=".$2"
-                keyHandler={[Function]}
-                onClick={[Function]}
-                sendRef={[Function]}
-                value={
-                  User {
-                    "compareTo": [Function],
-                    "firstName": "Test",
-                    "lastName": "Three",
-                    "title": "Ms",
-                    "toString": [Function],
-                  }
+                  Mrs: New User
+                </span>
+              </label>
+            </SelectOption>
+            <SelectOption
+              className=""
+              component="button"
+              id="option-3"
+              index={2}
+              inputId=""
+              isChecked={false}
+              isDisabled={false}
+              isFavorite={null}
+              isLoad={false}
+              isLoading={false}
+              isNoResultsOption={false}
+              isPlaceholder={false}
+              isSelected={false}
+              key=".$2"
+              keyHandler={[Function]}
+              onClick={[Function]}
+              sendRef={[Function]}
+              value={
+                User {
+                  "compareTo": [Function],
+                  "firstName": "Test",
+                  "lastName": "Three",
+                  "title": "Ms",
+                  "toString": [Function],
                 }
+              }
+            >
+              <label
+                className="pf-c-check pf-c-select__menu-item"
+                onKeyDown={[Function]}
               >
-                <label
-                  className="pf-c-check pf-c-select__menu-item"
-                  onKeyDown={[Function]}
+                <input
+                  checked={false}
+                  className="pf-c-check__input"
+                  disabled={false}
+                  id="pf-random-id-14-Ms: Test Three"
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                <span
+                  className="pf-c-check__label"
                 >
-                  <input
-                    checked={false}
-                    className="pf-c-check__input"
-                    disabled={false}
-                    id="pf-random-id-14-Ms: Test Three"
-                    onChange={[Function]}
-                    type="checkbox"
-                  />
-                  <span
-                    className="pf-c-check__label"
-                  >
-                    Ms: Test Three
-                  </span>
-                </label>
-              </SelectOption>
-            </fieldset>
-          </div>
+                  Ms: Test Three
+                </span>
+              </label>
+            </SelectOption>
+          </ul>
         </SelectMenu>
       </ForwardRef>
     </div>
@@ -4797,6 +4752,7 @@ exports[`renders select with favorites successfully 1`] = `
             "current": null,
           }
         }
+        hasInlineFilter={false}
         isGrouped={true}
         keyHandler={[Function]}
         openedOnEnter={false}
@@ -6711,6 +6667,7 @@ exports[`select renders select groups successfully 1`] = `
             "current": null,
           }
         }
+        hasInlineFilter={false}
         isGrouped={true}
         keyHandler={[Function]}
         openedOnEnter={false}
@@ -8057,6 +8014,7 @@ exports[`select single select renders expanded successfully 1`] = `
             "current": null,
           }
         }
+        hasInlineFilter={false}
         isGrouped={false}
         keyHandler={[Function]}
         openedOnEnter={false}
@@ -8575,6 +8533,7 @@ exports[`select single select renders expanded successfully with custom objects 
             "current": null,
           }
         }
+        hasInlineFilter={false}
         isGrouped={false}
         keyHandler={[Function]}
         openedOnEnter={false}

--- a/packages/react-core/src/components/Select/examples/Select.md
+++ b/packages/react-core/src/components/Select/examples/Select.md
@@ -735,9 +735,7 @@ class FilteringSingleSelectInput extends React.Component {
     ];
 
     this.onToggle = isOpen => {
-      this.setState({
-        isOpen
-      });
+      this.setState({ isOpen });
     };
 
     this.onSelect = (event, selection) => {

--- a/packages/react-core/src/components/Select/examples/Select.md
+++ b/packages/react-core/src/components/Select/examples/Select.md
@@ -704,7 +704,7 @@ class GroupedCheckboxSelectInput extends React.Component {
 }
 ```
 
-### Single checkbox input with filtering
+### Grouped single with filtering
 
 ```js
 import React from 'react';

--- a/packages/react-core/src/components/Select/examples/Select.md
+++ b/packages/react-core/src/components/Select/examples/Select.md
@@ -704,6 +704,94 @@ class GroupedCheckboxSelectInput extends React.Component {
 }
 ```
 
+### Single checkbox input with filtering
+
+```js
+import React from 'react';
+import { Select, SelectOption, SelectGroup, SelectVariant } from '@patternfly/react-core';
+
+class FilteringSingleSelectInput extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isOpen: false,
+      selected: ''
+    };
+
+    this.options = [
+      <SelectGroup label="Status" key="group1">
+        <SelectOption key={0} value="Running" />
+        <SelectOption key={1} value="Stopped" />
+        <SelectOption key={2} value="Down" />
+        <SelectOption key={3} value="Degraded" />
+        <SelectOption key={4} value="Needs Maintenence" />
+      </SelectGroup>,
+      <SelectGroup label="Vendor Names" key="group2">
+        <SelectOption key={5} value="Dell" />
+        <SelectOption key={6} value="Samsung" isDisabled />
+        <SelectOption key={7} value="Hewlett-Packard" />
+      </SelectGroup>
+    ];
+
+    this.onToggle = isOpen => {
+      this.setState({
+        isOpen
+      });
+    };
+
+    this.onSelect = (event, selection) => {
+      this.setState({ selected: selection, isOpen: false }),
+      console.log('selected: ', selection);
+    };
+
+    this.onFilter = (_, textInput) => {
+      if (textInput === '') {
+        return this.options;
+      } else {
+        let filteredGroups = this.options
+          .map(group => {
+            let filteredGroup = React.cloneElement(group, {
+              children: group.props.children.filter(item => {
+                return item.props.value.toLowerCase().includes(textInput.toLowerCase());
+              })
+            });
+            if (filteredGroup.props.children.length > 0) return filteredGroup;
+          })
+          .filter(Boolean);
+        return filteredGroups;
+      }
+    };
+  }
+
+  render() {
+    const { isOpen, selected, filteredOptions } = this.state;
+    const titleId = 'single-filtering-select-id';
+    return (
+      <div>
+        <span id={titleId} hidden>
+          Single select with filter
+        </span>
+        <Select
+          variant={SelectVariant.single}
+          onToggle={this.onToggle}
+          onSelect={this.onSelect}
+          selections={selected}
+          isOpen={isOpen}
+          placeholderText="Filter by status"
+          aria-labelledby={titleId}
+          onFilter={this.onFilter}
+          isGrouped
+          hasInlineFilter
+        >
+          {this.options}
+        </Select>
+      </div>
+    );
+  }
+}
+```
+
 ### Grouped checkbox input with filtering
 
 ```js

--- a/packages/react-integration/cypress/integration/selectfiltering.spec.ts
+++ b/packages/react-integration/cypress/integration/selectfiltering.spec.ts
@@ -1,3 +1,14 @@
+function checkFiltering() {
+  cy.get('.pf-c-form-control').type('run');
+  cy.get('#Running').should('exist');
+  cy.get('#Hewlett-Packard').should('not.exist');
+  cy.get('.pf-c-form-control').type('{backspace}{backspace}{backspace}degr');
+  cy.get('#Running').should('not.exist');
+  cy.get('#Degraded').should('exist');
+  cy.get('#Degraded').click();
+  cy.get('#filter-select').click();
+}
+
 describe('Select with Filtering Test', () => {
   it('Navigate to demo section', () => {
     cy.visit('http://localhost:3000/');
@@ -5,24 +16,23 @@ describe('Select with Filtering Test', () => {
     cy.url().should('eq', 'http://localhost:3000/select-demo-filtering-nav-link');
   });
 
-  it('Verify Checkbox Select with filtering', () => {
+  it('Verify Checkbox Select with filtering chips', () => {
     cy.get('#filter-select').click();
     cy.get('#Running').click();
     cy.get('.pf-c-select__toggle')
       .contains('1')
       .should('exist');
   });
-
-  it('Verify filtering works', () => {
-    cy.get('.pf-c-form-control').type('run');
-    cy.get('#Running').should('exist');
-    cy.get('#Hewlett-Packard').should('not.exist');
-    cy.get('.pf-c-form-control').type('{backspace}{backspace}{backspace}degr');
-    cy.get('#Running').should('not.exist');
-    cy.get('#Degraded').should('exist');
-    cy.get('#Degraded').click();
+  it('Verify Checkbox Select with filtering works', () => {
+    checkFiltering();
     cy.get('.pf-c-select__toggle')
       .contains('2')
       .should('exist');
+  });
+
+  it('Verify Single Select with filtering works', () => {
+    cy.get('#single-toggle').click();
+    cy.get('#filter-select').click();
+    checkFiltering();
   });
 });

--- a/packages/react-integration/demo-app-ts/src/components/demos/SelectDemo/FilteringSelectDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/SelectDemo/FilteringSelectDemo.tsx
@@ -1,4 +1,4 @@
-import { Select, SelectOption, SelectOptionObject, SelectGroup, SelectVariant } from '@patternfly/react-core';
+import { Select, SelectOption, SelectOptionObject, SelectGroup, SelectVariant, Checkbox } from '@patternfly/react-core';
 import React, { Component } from 'react';
 
 /* eslint-disable no-console */
@@ -10,21 +10,20 @@ export interface FilteringSelectDemoState {
 export class FilteringSelectDemo extends Component<FilteringSelectDemoState> {
   state = {
     isOpen: false,
-    selections: ['']
+    selections: [''],
+    isSingle: false
   };
 
   options = [
     <SelectGroup label="Status" key="group1">
-      <SelectOption key={0} value="Running" inputId="Running" />
-      <SelectOption key={1} value="Stopped" inputId="Stopped" />
-      <SelectOption key={2} value="Down" inputId="Down" />
-      <SelectOption key={3} value="Degraded" inputId="Degraded" />
-      <SelectOption key={4} value="Needs Maintenence" inputId="Needs-Maintenence" />
+      {['Running', 'Stopped', 'Down', 'Degraded', 'Needs-Maintenence'].map((option, index) => (
+        <SelectOption key={index} value={option} id={option} inputId={option} />
+      ))}
     </SelectGroup>,
     <SelectGroup label="Vendor Names" key="group2">
-      <SelectOption key={5} value="Dell" inputId="Dell" />
-      <SelectOption key={6} value="Samsung" isDisabled inputId="Samsung" />
-      <SelectOption key={7} value="Hewlett-Packard" inputId="Hewlett-Packard" />
+      <SelectOption key={5} value="Dell" />
+      <SelectOption key={6} value="Samsung" isDisabled />
+      <SelectOption key={7} value="Hewlett-Packard" />
     </SelectGroup>
   ];
 
@@ -34,7 +33,7 @@ export class FilteringSelectDemo extends Component<FilteringSelectDemoState> {
     });
   };
 
-  onSelect = (event: React.MouseEvent | React.ChangeEvent, selection: string | SelectOptionObject) => {
+  onSelect = (_event: React.MouseEvent | React.ChangeEvent, selection: string | SelectOptionObject) => {
     const { selections } = this.state;
     if (selections.includes(selection.toString())) {
       this.setState(
@@ -79,16 +78,16 @@ export class FilteringSelectDemo extends Component<FilteringSelectDemoState> {
   };
 
   render() {
-    const { isOpen, selections } = this.state;
+    const { isOpen, selections, isSingle } = this.state;
     const titleId = 'checkbox-select-id';
     return (
       <div>
         <span id={titleId} hidden>
-          Filtering Checkbox Title
+          Filtering Select Title
         </span>
         <Select
           toggleId="filter-select"
-          variant={SelectVariant.checkbox}
+          variant={isSingle ? SelectVariant.single : SelectVariant.checkbox}
           aria-label="Select Input"
           onToggle={this.onToggle}
           onSelect={this.onSelect}
@@ -102,6 +101,12 @@ export class FilteringSelectDemo extends Component<FilteringSelectDemoState> {
         >
           {this.options}
         </Select>
+        <Checkbox
+          id="single-toggle"
+          label="Is single select"
+          isChecked={isSingle}
+          onChange={() => this.setState({ isSingle: !isSingle, selections: [] })}
+        />
       </div>
     );
   }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Refactor `SelectMenu.tsx` to allow `hasInlineFilter` to work for non-checkbox variants.
Closes https://github.com/patternfly/patternfly/issues/4047
Closes #5764
Closes #5847

https://patternfly-react-pr-5793.surge.sh/components/select#grouped-single-with-filtering

Bug fixes:
- Stop entire page scrolling when pressing down arrow when focused on filter
- Clicking on typeahead variant's input while open now closes them
- Focus inline filter input when opening with mouse

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
