### PR TITLE
Interactive legend example for pie chart

### DIFF
--- a/packages/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/react-charts/src/components/Chart/Chart.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 
+/* eslint-disable camelcase */
+import chart_legend_Margin from '@patternfly/react-tokens/dist/js/chart_legend_Margin';
+
 import {
   AnimatePropTypeInterface,
   D3Scale,
@@ -17,6 +20,7 @@ import {
   VictoryStyleObject
 } from 'victory-core';
 import { AxesType, VictoryChart, VictoryChartProps } from 'victory-chart';
+import { ChartAxis } from '../ChartAxis';
 import { ChartContainer } from '../ChartContainer';
 import { ChartLegend, ChartLegendOrientation, ChartLegendPosition } from '../ChartLegend';
 import { ChartCommonStyles, ChartThemeDefinition } from '../ChartTheme';
@@ -337,6 +341,11 @@ export interface ChartProps extends VictoryChartProps {
    */
   sharedEvents?: { events: any[]; getEventState: Function };
   /**
+   * Convenience prop to hide both x and y axis, which are shown by default. Alternatively, the axis can be hidden via
+   * chart styles.
+   */
+  showAxis?: boolean;
+  /**
    * By default domainPadding is coerced to existing quadrants. This means that if a given domain only includes positive
    * values, no amount of padding applied by domainPadding will result in a domain with negative values. This is the
    * desired behavior in most cases. For users that need to apply padding without regard to quadrant, the
@@ -420,6 +429,7 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
   legendData,
   legendPosition = ChartCommonStyles.legend.position as ChartLegendPosition,
   padding,
+  showAxis = true,
   themeColor,
   themeVariant,
 
@@ -454,6 +464,34 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
     ...legendComponent.props
   });
 
+  const getAxis = () => {
+    const Noop = (): any => null;
+
+    // Do nothing to show axis by default
+    if (showAxis) {
+      return null;
+    }
+    return (
+      <React.Fragment>
+        <ChartAxis
+          axisComponent={<Noop />}
+          axisLabelComponent={<Noop />}
+          gridComponent={<Noop />}
+          tickComponent={<Noop />}
+          tickLabelComponent={<Noop />}
+        />
+        <ChartAxis
+          axisComponent={<Noop />}
+          axisLabelComponent={<Noop />}
+          gridComponent={<Noop />}
+          tickComponent={<Noop />}
+          tickLabelComponent={<Noop />}
+          dependentAxis
+        />
+      </React.Fragment>
+    );
+  };
+
   // Returns a computed legend
   const getLegend = () => {
     if (!legend.props.data) {
@@ -478,6 +516,12 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
       dy += xAxisLabelHeight + legendTitleHeight;
       dx = -10;
     }
+
+    // Adjust legend position when axis is hidden
+    if (!showAxis) {
+      dy -= chart_legend_Margin.value;
+    }
+
     return getComputedLegend({
       allowWrap: legendAllowWrap,
       chartType: 'chart',
@@ -503,6 +547,7 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
       width={width}
       {...rest}
     >
+      {getAxis()}
       {children}
       {getLegend()}
     </VictoryChartWithContainerComponent>

--- a/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
+++ b/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
@@ -452,6 +452,130 @@ class InteractiveLegendChart extends React.Component {
 }
 ```
 
+### Interactive legend with pie chart
+
+This demonstrates how to add an interactive legend to a pie chart using events such as `onMouseOver`, `onMouseOut`, and `onClick`.
+
+```js
+import React from 'react';
+import { 
+  Chart,
+  ChartLegend,
+  ChartThemeColor,
+  ChartPie,
+  getInteractiveLegendEvents, 
+  getInteractiveLegendItemStyles 
+} from '@patternfly/react-charts';
+
+class InteractivePieLegendChart extends React.Component {
+  constructor(props) {
+    super(props);
+    this.containerRef = React.createRef();
+    this.state = {
+      hiddenSeries: new Set(),
+      width: 0
+    };
+    this.series = [{
+      datapoints: { x: 'Cats', y: 35 },
+      legendItem: { name: 'Cats: 35' }
+    }, {
+      datapoints: { x: 'Dogs', y: 55 },
+      legendItem: { name: 'Dogs: 55' }
+    }, {
+      datapoints: { x: 'Birds', y: 10 },
+      legendItem: { name: 'Birds: 10' }
+    }];
+
+    // Returns groups of chart names associated with each data series
+    this.getChartNames = () => {
+      const result = [];
+      this.series.map((_, index) => {
+        // Provide names for each series hidden / shown -- use the same name for a pie chart
+        result.push(['pie']);
+      });
+      return result;
+    };
+
+    // Returns onMouseOver, onMouseOut, and onClick events for the interactive legend
+    this.getEvents = () => getInteractiveLegendEvents({
+      chartNames: this.getChartNames(),
+      isHidden: this.isHidden,
+      legendName: 'legend',
+      onLegendClick: this.handleLegendClick
+    });
+
+    // Returns legend data styled per hiddenSeries
+    this.getLegendData = () => {
+      const { hiddenSeries } = this.state;
+      return this.series.map((s, index) => {
+        return {
+          childName: 'pie', // Sync tooltip legend with the series associated with given chart name
+          ...s.legendItem, // name property
+          ...getInteractiveLegendItemStyles(hiddenSeries.has(index)) // hidden styles
+        };
+      });
+    };
+
+    // Hide each data series individually
+    this.handleLegendClick = (props) => {
+      if (!this.state.hiddenSeries.delete(props.index)) {
+        this.state.hiddenSeries.add(props.index);
+      }
+      this.setState({ hiddenSeries: new Set(this.state.hiddenSeries) });
+    };
+
+    // Returns true if data series is hidden
+    this.isHidden = (index) => {
+      const { hiddenSeries } = this.state; // Skip if already hidden                
+      return hiddenSeries.has(index);
+    };
+
+    this.isDataAvailable = () => {
+      const { hiddenSeries } = this.state;
+      return hiddenSeries.size !== this.series.length;
+    };
+  };
+
+  render() {
+    const { hiddenSeries, width } = this.state;
+
+    const data = [];
+    this.series.map((s, index) => {
+      data.push(!hiddenSeries.has(index) ? s.datapoints : [{ y: null}]);
+    });
+
+    return (
+      <div style={{ height: '275px', width: '300px' }}>
+        <Chart
+          ariaDesc="Average number of pets"
+          ariaTitle="Pie chart example"
+          events={this.getEvents()}
+          height={275}
+          labels={({ datum }) => `${datum.x}: ${datum.y}`}
+          legendComponent={<ChartLegend name={'legend'} data={this.getLegendData()} />}
+          legendPosition="bottom"
+          padding={{
+            bottom: 65,
+            left: 20,
+            right: 20,
+            top: 20
+          }}
+          showAxis={false}
+          themeColor={ChartThemeColor.multiUnordered}
+          width={300}
+        >
+          <ChartPie
+            constrainToVisibleArea={true}
+            data={data}
+            name="pie"
+          />
+        </Chart>
+      </div>
+    );
+  }
+}
+```
+
 ### Legend tooltips
 
 This demonstrates an approach for applying tooltips to a legend using a custom label component. These tooltips are keyboard navigable.

--- a/packages/react-charts/src/components/ChartUtils/chart-interactive-legend.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-interactive-legend.ts
@@ -116,10 +116,16 @@ const getInteractiveLegendTargetEvents = ({
                       ? null
                       : ({
                           // Skip if hidden
-                          style: {
-                            ...props.style,
-                            opacity: chart_area_Opacity.value
-                          }
+                          style:
+                            props.padAngle !== undefined // Support for pie chart
+                              ? {
+                                  ...props.style,
+                                  ...(index !== props.index && { opacity: chart_area_Opacity.value })
+                                }
+                              : {
+                                  ...props.style,
+                                  opacity: chart_area_Opacity.value
+                                }
                         } as any)
                 },
                 {


### PR DESCRIPTION
This provides an example showing how to use a pie chart with an interactive legend. 

Note that pie charts are not typically wrapped by a `Chart` component, but in this case we need something to attach `onMouseOver` events to.

https://github.com/patternfly/patternfly-react/issues/5586

![chrome-capture](https://user-images.githubusercontent.com/17481322/118683452-68d78480-b7cf-11eb-8398-fb16c03c2a91.gif)
