### PR TITLE
docs(Menu): add drilldown composable menu demo back

### DIFF
--- a/packages/react-core/src/demos/ComposableMenu.md
+++ b/packages/react-core/src/demos/ComposableMenu.md
@@ -396,3 +396,273 @@ class SelectComposableMenu extends React.Component {
   }
 }
 ```
+
+### Drilldown menu with toggle
+
+```js
+import React from 'react';
+import {
+  MenuToggle,
+  Menu,
+  MenuContent,
+  MenuList,
+  MenuItem,
+  DrilldownMenu,
+  Divider,
+  Popper
+} from '@patternfly/react-core';
+import StorageDomainIcon from '@patternfly/react-icons/dist/js/icons/storage-domain-icon';
+import CodeBranchIcon from '@patternfly/react-icons/dist/js/icons/code-branch-icon';
+import LayerGroupIcon from '@patternfly/react-icons/dist/js/icons/layer-group-icon';
+import CubeIcon from '@patternfly/react-icons/dist/js/icons/cube-icon';
+
+class DrilldownComposableMenu extends React.Component {
+  constructor(props) {
+    super(props);
+    this.containerRef = React.createRef();
+    this.toggleRef = React.createRef();
+    this.menuRef = React.createRef();
+    this.state = {
+      menuDrilledIn: [],
+      drilldownPath: [],
+      menuHeights: {},
+      activeMenu: 'rootMenu',
+      isOpen: false
+    };
+    this.onToggle = event => {
+      event && event.stopPropagation();
+      this.setState({
+        isOpen: !this.state.isOpen,
+        menuDrilledIn: [],
+        drilldownPath: [],
+        activeMenu: 'rootMenu'
+      });
+    };
+    this.drillIn = (fromMenuId, toMenuId, pathId) => {
+      this.setState({
+        menuDrilledIn: [...this.state.menuDrilledIn, fromMenuId],
+        drilldownPath: [...this.state.drilldownPath, pathId],
+        activeMenu: toMenuId
+      });
+    };
+    this.drillOut = toMenuId => {
+      const menuDrilledInSansLast = this.state.menuDrilledIn.slice(0, this.state.menuDrilledIn.length - 1);
+      const pathSansLast = this.state.drilldownPath.slice(0, this.state.drilldownPath.length - 1);
+      this.setState({
+        menuDrilledIn: menuDrilledInSansLast,
+        drilldownPath: pathSansLast,
+        activeMenu: toMenuId
+      });
+    };
+    this.setHeight = (menuId, height) => {
+      if (!this.state.menuHeights[menuId]) {
+        this.setState({
+          menuHeights: {
+            ...this.state.menuHeights,
+            [menuId]: height
+          }
+        });
+      }
+    };
+    this.handleMenuKeys = event => {
+      if ([...event.target.classList].some(c => /pf-c-menu.*/.test(c)) && this.state.isOpen) {
+        if (event.key === 'Escape' || event.key === 'Tab') {
+          this.onToggle();
+          this.toggleRef.current.focus();
+        }
+      }
+
+      if (event.target === this.toggleRef.current && this.state.isOpen) {
+        if (event.key === 'ArrowDown') {
+          this.menuRef.current.querySelector('button, a').focus();
+        }
+      }
+    };
+    this.handleMenuClick = event => {
+      if (![...event.target.classList].some(c => /pf-c-menu.*/.test(c)) && this.state.isOpen) {
+        this.onToggle();
+      }
+    };
+  }
+
+  componentDidMount() {
+    window.addEventListener('keydown', this.handleMenuKeys);
+    window.addEventListener('click', this.handleMenuClick);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('keydown', this.handleMenuKeys);
+    window.removeEventListener('click', this.handleMenuClick);
+  }
+
+  render() {
+    const { isOpen, menuDrilledIn, drilldownPath, activeMenu, menuHeights } = this.state;
+
+    const toggle = (
+      <MenuToggle ref={this.toggleRef} onClick={this.onToggle} isExpanded={isOpen} style={{ width: '300px' }}>
+        {isOpen ? 'Expanded' : 'Collapsed'}
+      </MenuToggle>
+    );
+
+    const menu = (
+      <Menu
+        id="rootMenu"
+        containsDrilldown
+        drilldownItemPath={drilldownPath}
+        drilledInMenus={menuDrilledIn}
+        activeMenu={activeMenu}
+        onDrillIn={this.drillIn}
+        onDrillOut={this.drillOut}
+        onGetMenuHeight={this.setHeight}
+        ref={this.menuRef}
+      >
+        <MenuContent menuHeight={`${menuHeights[activeMenu]}px`}>
+          <MenuList>
+            <MenuItem
+              itemId="group:start_rollout"
+              direction="down"
+              drilldownMenu={
+                <DrilldownMenu id="drilldownMenuStart">
+                  <MenuItem itemId="group:start_rollout" direction="up">
+                    Start rollout
+                  </MenuItem>
+                  <Divider component="li" />
+                  <MenuItem
+                    itemId="group:app_grouping"
+                    description="Groups A-C"
+                    direction="down"
+                    drilldownMenu={
+                      <DrilldownMenu id="drilldownMenuStartGrouping">
+                        <MenuItem itemId="group:app_grouping" direction="up">
+                          Application Grouping
+                        </MenuItem>
+                        <Divider component="li" />
+                        <MenuItem itemId="group_a">Group A</MenuItem>
+                        <MenuItem itemId="group_b">Group B</MenuItem>
+                        <MenuItem itemId="group_c">Group C</MenuItem>
+                      </DrilldownMenu>
+                    }
+                  >
+                    Application Grouping
+                  </MenuItem>
+                  <MenuItem itemId="count">Count</MenuItem>
+                  <MenuItem
+                    itemId="group:labels"
+                    direction="down"
+                    drilldownMenu={
+                      <DrilldownMenu id="drilldownMenuStartLabels">
+                        <MenuItem itemId="group:labels" direction="up">
+                          Labels
+                        </MenuItem>
+                        <Divider component="li" />
+                        <MenuItem itemId="label_1">Label 1</MenuItem>
+                        <MenuItem itemId="label_2">Label 2</MenuItem>
+                        <MenuItem itemId="label_3">Label 3</MenuItem>
+                      </DrilldownMenu>
+                    }
+                  >
+                    Labels
+                  </MenuItem>
+                  <MenuItem itemId="annotations">Annotations</MenuItem>
+                </DrilldownMenu>
+              }
+            >
+              Start rollout
+            </MenuItem>
+            <MenuItem
+              itemId="group:pause_rollout"
+              direction="down"
+              drilldownMenu={
+                <DrilldownMenu id="drilldownMenuPause">
+                  <MenuItem itemId="group:pause_rollout" direction="up">
+                    Pause rollouts
+                  </MenuItem>
+                  <Divider component="li" />
+                  <MenuItem
+                    itemId="group:app_grouping"
+                    description="Groups A-C"
+                    direction="down"
+                    drilldownMenu={
+                      <DrilldownMenu id="drilldownMenuGrouping">
+                        <MenuItem itemId="group:app_grouping" direction="up">
+                          Application Grouping
+                        </MenuItem>
+                        <Divider component="li" />
+                        <MenuItem itemId="group_a">Group A</MenuItem>
+                        <MenuItem itemId="group_b">Group B</MenuItem>
+                        <MenuItem itemId="group_c">Group C</MenuItem>
+                      </DrilldownMenu>
+                    }
+                  >
+                    Application Grouping
+                  </MenuItem>
+                  <MenuItem itemId="count">Count</MenuItem>
+                  <MenuItem
+                    itemId="group:labels"
+                    direction="down"
+                    drilldownMenu={
+                      <DrilldownMenu id="drilldownMenuLabels">
+                        <MenuItem itemId="group:labels" direction="up">
+                          Labels
+                        </MenuItem>
+                        <Divider component="li" />
+                        <MenuItem itemId="label_1">Label 1</MenuItem>
+                        <MenuItem itemId="label_2">Label 2</MenuItem>
+                        <MenuItem itemId="label_3">Label 3</MenuItem>
+                      </DrilldownMenu>
+                    }
+                  >
+                    Labels
+                  </MenuItem>
+                  <MenuItem itemId="annotations">Annotations</MenuItem>
+                </DrilldownMenu>
+              }
+            >
+              Pause rollouts
+            </MenuItem>
+            <MenuItem
+              itemId="group:storage"
+              icon={<StorageDomainIcon aria-hidden />}
+              direction="down"
+              drilldownMenu={
+                <DrilldownMenu id="drilldownMenuStorage">
+                  <MenuItem itemId="group:storage" icon={<StorageDomainIcon aria-hidden />} direction="up">
+                    Add storage
+                  </MenuItem>
+                  <Divider component="li" />
+                  <MenuItem icon={<CodeBranchIcon aria-hidden />} itemId="git">
+                    From Git
+                  </MenuItem>
+                  <MenuItem icon={<LayerGroupIcon aria-hidden />} itemId="container">
+                    Container Image
+                  </MenuItem>
+                  <MenuItem icon={<CubeIcon aria-hidden />} itemId="docker">
+                    Docker File
+                  </MenuItem>
+                </DrilldownMenu>
+              }
+            >
+              Add storage
+            </MenuItem>
+            <MenuItem itemId="edit">Edit</MenuItem>
+            <MenuItem itemId="delete_deployment">Delete deployment config</MenuItem>
+          </MenuList>
+        </MenuContent>
+      </Menu>
+    );
+
+    return (
+      <div ref={this.containerRef}>
+        <Popper
+          trigger={toggle}
+          popper={menu}
+          direction="down"
+          position="left"
+          appendTo={this.containerRef.current}
+          isVisible={isOpen}
+        />
+      </div>
+    );
+  }
+}
+```


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5771

Adds back in the drilldown demo for composable menus.
Needs https://github.com/patternfly/patternfly/issues/4062 for a transition fix.
