### PR TITLE
feat(Button): add danger modifier to link/secondary buttons

### DIFF
--- a/packages/react-core/src/components/Button/Button.tsx
+++ b/packages/react-core/src/components/Button/Button.tsx
@@ -60,6 +60,8 @@ export interface ButtonProps extends React.HTMLProps<HTMLButtonElement>, OUIAPro
   isSmall?: boolean;
   /** Adds large styling to the button */
   isLarge?: boolean;
+  /** Adds danger styling to secondary or link button variants */
+  isDanger?: boolean;
 }
 
 export const Button: React.FunctionComponent<ButtonProps> = ({
@@ -71,6 +73,7 @@ export const Button: React.FunctionComponent<ButtonProps> = ({
   isDisabled = false,
   isAriaDisabled = false,
   isLoading = null,
+  isDanger = false,
   spinnerAriaValueText,
   isSmall = false,
   isLarge = false,
@@ -132,6 +135,7 @@ export const Button: React.FunctionComponent<ButtonProps> = ({
         isAriaDisabled && styles.modifiers.ariaDisabled,
         isActive && styles.modifiers.active,
         isInline && variant === ButtonVariant.link && styles.modifiers.inline,
+        isDanger && (variant === ButtonVariant.secondary || variant === ButtonVariant.link) && styles.modifiers.danger,
         isLoading !== null && styles.modifiers.progress,
         isLoading && styles.modifiers.inProgress,
         isSmall && styles.modifiers.small,

--- a/packages/react-core/src/components/Button/__tests__/Button.test.tsx
+++ b/packages/react-core/src/components/Button/__tests__/Button.test.tsx
@@ -39,6 +39,24 @@ test('isDisabled', () => {
   expect(view).toMatchSnapshot();
 });
 
+test('isDanger secondary', () => {
+  const view = mount(
+    <Button variant="secondary" isDanger>
+      Disabled Button
+    </Button>
+  );
+  expect(view).toMatchSnapshot();
+});
+
+test('isDanger link', () => {
+  const view = mount(
+    <Button variant="link" isDanger>
+      Disabled Button
+    </Button>
+  );
+  expect(view).toMatchSnapshot();
+});
+
 test('isAriaDisabled button', () => {
   const view = mount(<Button isAriaDisabled>Disabled yet focusable button</Button>);
   expect(view).toMatchSnapshot();
@@ -73,7 +91,11 @@ test('isLarge', () => {
 });
 
 test('isLoading', () => {
-  const view = mount(<Button isLoading spinnerAriaValueText="Loading">Loading Button</Button>);
+  const view = mount(
+    <Button isLoading spinnerAriaValueText="Loading">
+      Loading Button
+    </Button>
+  );
   expect(view).toMatchSnapshot();
 });
 

--- a/packages/react-core/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/react-core/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -133,6 +133,48 @@ exports[`isBlock 1`] = `
 </Button>
 `;
 
+exports[`isDanger link 1`] = `
+<Button
+  isDanger={true}
+  variant="link"
+>
+  <button
+    aria-disabled={false}
+    aria-label={null}
+    className="pf-c-button pf-m-link pf-m-danger"
+    data-ouia-component-id="OUIA-Generated-Button-link-3"
+    data-ouia-component-type="PF4/Button"
+    data-ouia-safe={true}
+    disabled={false}
+    role={null}
+    type="button"
+  >
+    Disabled Button
+  </button>
+</Button>
+`;
+
+exports[`isDanger secondary 1`] = `
+<Button
+  isDanger={true}
+  variant="secondary"
+>
+  <button
+    aria-disabled={false}
+    aria-label={null}
+    className="pf-c-button pf-m-secondary pf-m-danger"
+    data-ouia-component-id="OUIA-Generated-Button-secondary-2"
+    data-ouia-component-type="PF4/Button"
+    data-ouia-safe={true}
+    disabled={false}
+    role={null}
+    type="button"
+  >
+    Disabled Button
+  </button>
+</Button>
+`;
+
 exports[`isDisabled 1`] = `
 <Button
   isDisabled={true}
@@ -163,7 +205,7 @@ exports[`isInline 1`] = `
     aria-disabled={false}
     aria-label={null}
     className="pf-c-button pf-m-link pf-m-inline"
-    data-ouia-component-id="OUIA-Generated-Button-link-3"
+    data-ouia-component-id="OUIA-Generated-Button-link-4"
     data-ouia-component-type="PF4/Button"
     data-ouia-safe={true}
     disabled={false}

--- a/packages/react-core/src/components/Button/examples/Button.md
+++ b/packages/react-core/src/components/Button/examples/Button.md
@@ -15,6 +15,7 @@ import ArrowRightIcon from '@patternfly/react-icons/dist/js/icons/arrow-right-ic
 ## Examples
 
 ### Variations
+
 ```js
 import React from 'react';
 import { Button } from '@patternfly/react-core';
@@ -24,29 +25,44 @@ import ExternalLinkSquareAltIcon from '@patternfly/react-icons/dist/js/icons/ext
 import CopyIcon from '@patternfly/react-icons/dist/js/icons/copy-icon';
 
 <React.Fragment>
-  <Button variant="primary">Primary</Button> <Button variant="secondary">Secondary</Button>{' '}
-  <Button variant="tertiary">Tertiary</Button> <Button variant="danger">Danger</Button>{' '}
-  <Button variant="warning">Warning</Button><br /><br />
+  <Button variant="primary">Primary</Button>{' '}
+  <Button variant="secondary">Secondary</Button>{' '}
+  <Button variant="secondary" isDanger>
+    Danger Secondary
+  </Button>{' '}
+  <Button variant="tertiary">Tertiary</Button>{' '}
+  <Button variant="danger">Danger</Button>{' '}
+  <Button variant="warning">Warning</Button>
+  <br />
+  <br />
   <Button variant="link" icon={<PlusCircleIcon />}>
     Link
   </Button>{' '}
   <Button variant="link" icon={<ExternalLinkSquareAltIcon />} iconPosition="right">
     Link
-  </Button>
+  </Button>{' '}
   <Button variant="link" isInline>
     Inline link
-  </Button><br /><br />
+  </Button>{' '}
+  <Button variant="link" isDanger>
+    Danger link
+  </Button>
+  <br />
+  <br />
   <Button variant="plain" aria-label="Action">
     <TimesIcon />
-  </Button><br /><br />
+  </Button>
+  <br />
+  <br />
   <Button variant="control">Control</Button>{' '}
   <Button variant="control" aria-label="Copy">
     <CopyIcon />
   </Button>
-</React.Fragment>
+</React.Fragment>;
 ```
 
 ### Disabled
+
 ```js
 import React from 'react';
 import { Button } from '@patternfly/react-core';
@@ -54,29 +70,42 @@ import TimesIcon from '@patternfly/react-icons/dist/js/icons/times-icon';
 import PlusCircleIcon from '@patternfly/react-icons/dist/js/icons/plus-circle-icon';
 
 <React.Fragment>
-  <Button isDisabled>
-    Primary disabled
+  <Button isDisabled>Primary disabled</Button>{' '}
+  <Button isDisabled>Secondary disabled</Button>{' '}
+  <Button variant="secondary" isDanger isDisabled>
+    Danger secondary disabled
   </Button>{' '}
-  <Button isDisabled>
-    Secondary disabled
+  <Button isDisabled variant="tertiary">
+    Tertiary disabled
   </Button>{' '}
-  <Button isDisabled variant="tertiary">Tertiary disabled</Button>{' '}
-  <Button isDisabled variant="danger">Danger disabled</Button>{' '}
-  <Button isDisabled variant="warning">Warning disabled</Button><br /><br />
+  <Button isDisabled variant="danger">
+    Danger disabled
+  </Button>{' '}
+  <Button isDisabled variant="warning">
+    Warning disabled
+  </Button>
+  <br />
+  <br />
   <Button isDisabled variant="link" icon={<PlusCircleIcon />}>
     Link disabled
   </Button>{' '}
   <Button isDisabled variant="link" isInline>
     Inline link disabled
   </Button>{' '}
+  <Button variant="link" isDanger isDisabled>
+    Danger link disabled
+  </Button>{' '}
   <Button isDisabled variant="plain" aria-label="Action">
     <TimesIcon />
   </Button>{' '}
-  <Button isDisabled variant="control">Control disabled</Button>
-</React.Fragment>
+  <Button isDisabled variant="control">
+    Control disabled
+  </Button>
+</React.Fragment>;
 ```
 
 ### Aria disabled
+
 ```js
 import React from 'react';
 import { Button } from '@patternfly/react-core';
@@ -84,29 +113,42 @@ import TimesIcon from '@patternfly/react-icons/dist/js/icons/times-icon';
 import PlusCircleIcon from '@patternfly/react-icons/dist/js/icons/plus-circle-icon';
 
 <React.Fragment>
-  <Button isAriaDisabled>
-    Primary aria disabled
+  <Button isAriaDisabled>Primary aria disabled</Button>{' '}
+  <Button isAriaDisabled>Secondary aria disabled</Button>{' '}
+  <Button variant="secondary" isDanger isAriaDisabled>
+    Danger secondary aria disabled
   </Button>{' '}
-  <Button isAriaDisabled>
-    Secondary aria disabled
+  <Button isAriaDisabled variant="tertiary">
+    Tertiary aria disabled
   </Button>{' '}
-  <Button isAriaDisabled variant="tertiary">Tertiary aria disabled</Button>{' '}
-  <Button isAriaDisabled variant="danger">Danger disabled</Button>{' '}
-  <Button isAriaDisabled variant="warning">Warning disabled</Button><br /><br />
+  <Button isAriaDisabled variant="danger">
+    Danger disabled
+  </Button>{' '}
+  <Button isAriaDisabled variant="warning">
+    Warning disabled
+  </Button>
+  <br />
+  <br />
   <Button isAriaDisabled variant="link" icon={<PlusCircleIcon />}>
     Link aria disabled
   </Button>{' '}
   <Button isAriaDisabled variant="link" isInline>
     Inline link aria disabled
   </Button>{' '}
+  <Button variant="link" isDanger isAriaDisabled>
+    Danger link disabled
+  </Button>{' '}
   <Button isAriaDisabled variant="plain" aria-label="Action">
     <TimesIcon />
   </Button>{' '}
-  <Button isAriaDisabled variant="control">Control aria disabled</Button>
-</React.Fragment>
+  <Button isAriaDisabled variant="control">
+    Control aria disabled
+  </Button>
+</React.Fragment>;
 ```
 
 ### Aria disabled button with tooltip
+
 ```js
 import React from 'react';
 import { Button, Tooltip } from '@patternfly/react-core';
@@ -115,10 +157,11 @@ import { Button, Tooltip } from '@patternfly/react-core';
   <Button isAriaDisabled variant="secondary">
     Secondary button to core docs
   </Button>
-</Tooltip>
+</Tooltip>;
 ```
 
 ### Aria disabled link as button with tooltip
+
 ```js
 import React from 'react';
 import { Button, Tooltip } from '@patternfly/react-core';
@@ -127,10 +170,11 @@ import { Button, Tooltip } from '@patternfly/react-core';
   <Button component="a" isAriaDisabled href="https://pf4.patternfly.org/" target="_blank" variant="tertiary">
     Tertiary link as button to core docs
   </Button>
-</Tooltip>
+</Tooltip>;
 ```
 
 ### Links as buttons
+
 ```js
 import React from 'react';
 import { Button } from '@patternfly/react-core';
@@ -148,10 +192,11 @@ import { Button } from '@patternfly/react-core';
   <Button component="a" href="https://pf4.patternfly.org/contribution/#modifiers" variant="link">
     Jump to modifiers in contribution guidelines
   </Button>
-</React.Fragment>
+</React.Fragment>;
 ```
 
 ### Inline link as span
+
 ```js
 import React from 'react';
 import { Button } from '@patternfly/react-core';
@@ -165,7 +210,7 @@ InlineLinkAsSpan = () => {
       evt.preventDefault();
       alert(`${keyCode === 13 ? 'Enter' : 'Space'} key default behavior stopped by onKeyDown`);
     }
-  }
+  };
 
   return (
     <>
@@ -173,8 +218,7 @@ InlineLinkAsSpan = () => {
         Lorem ipsum dolor sit amet, consectetur adipiscing elit.
         <Button variant="link" isInline component="span">
           This is long button text that needs to be a span so that it will wrap inline with the text around it.
-        </Button>
-        {' '}Sed hendrerit nisi in cursus maximus. Ut malesuada nisi turpis, in condimentum velit elementum non.
+        </Button> Sed hendrerit nisi in cursus maximus. Ut malesuada nisi turpis, in condimentum velit elementum non.
       </p>
 
       <br />
@@ -182,9 +226,9 @@ InlineLinkAsSpan = () => {
       <p>
         Note that using a <b>span</b> as a button does not fire the <b>onclick</b> event for Enter or Space keys.
         <Button variant="link" isInline component="span" onKeyDown={handleKeydown}>
-          An <b>onKeyDown</b> event listener is needed for Enter and Space key presses to prevent their default behavior and trigger your code.
-        </Button>
-        {' '}Pressing the Enter or Space keys on the inline link as span above demonstrates this by triggering an alert.
+          An <b>onKeyDown</b> event listener is needed for Enter and Space key presses to prevent their default behavior
+          and trigger your code.
+        </Button> Pressing the Enter or Space keys on the inline link as span above demonstrates this by triggering an alert.
       </p>
     </>
   );
@@ -192,56 +236,79 @@ InlineLinkAsSpan = () => {
 ```
 
 ### Block level
+
 ```js
 import React from 'react';
 import { Button } from '@patternfly/react-core';
 
-<Button isBlock>Block level button</Button>
+<Button isBlock>Block level button</Button>;
 ```
 
 ### Types
+
 ```js
 import React from 'react';
 import { Button } from '@patternfly/react-core';
 
 <React.Fragment>
-  <Button type="submit">Submit</Button>{' '}
-  <Button type="reset">Reset</Button>{' '}
-  <Button>Default</Button>
-</React.Fragment>
+  <Button type="submit">Submit</Button> <Button type="reset">Reset</Button> <Button>Default</Button>
+</React.Fragment>;
 ```
 
 ### Small
+
 ```js
 import React from 'react';
 import { Button } from '@patternfly/react-core';
 
 <React.Fragment>
-  <Button variant="primary" isSmall>Primary</Button>{' '}
-  <Button variant="secondary" isSmall>Secondary</Button>{' '}
-  <Button variant="tertiary" isSmall>Tertiary</Button>{' '}
-  <Button variant="danger" isSmall>Danger</Button>{' '}
-  <Button variant="warning" isSmall>Warning</Button>
-  <br /><br />
-</React.Fragment>
+  <Button variant="primary" isSmall>
+    Primary
+  </Button>{' '}
+  <Button variant="secondary" isSmall>
+    Secondary
+  </Button>{' '}
+  <Button variant="tertiary" isSmall>
+    Tertiary
+  </Button>{' '}
+  <Button variant="danger" isSmall>
+    Danger
+  </Button>{' '}
+  <Button variant="warning" isSmall>
+    Warning
+  </Button>
+  <br />
+  <br />
+</React.Fragment>;
 ```
 
 ### Call to action
+
 ```js
 import React from 'react';
 import { Button } from '@patternfly/react-core';
 import ArrowRightIcon from '@patternfly/react-icons/dist/js/icons/arrow-right-icon';
 
 <React.Fragment>
-  <Button variant="primary" isLarge>Call to action</Button>{' '}
-  <Button variant="secondary" isLarge>Call to action</Button>{' '}
-  <Button variant="tertiary" isLarge>Call to action</Button>{' '}
-  <Button variant="link" isLarge>Call to action <ArrowRightIcon/></Button>
-  <br /><br />
-</React.Fragment>
+  <Button variant="primary" isLarge>
+    Call to action
+  </Button>{' '}
+  <Button variant="secondary" isLarge>
+    Call to action
+  </Button>{' '}
+  <Button variant="tertiary" isLarge>
+    Call to action
+  </Button>{' '}
+  <Button variant="link" isLarge>
+    Call to action <ArrowRightIcon />
+  </Button>
+  <br />
+  <br />
+</React.Fragment>;
 ```
 
 ### Progress
+
 ```js
 import React from 'react';
 import { Button } from '@patternfly/react-core';
@@ -251,30 +318,35 @@ ButtonProgressVariants = () => {
   const [isSecondaryLoading, setIsSecondaryLoading] = React.useState(true);
   const extraPrimaryProps = {};
   if (isPrimaryLoading) {
-    extraPrimaryProps.spinnerAriaValueText = "Loading";
+    extraPrimaryProps.spinnerAriaValueText = 'Loading';
   }
   const extraSecondaryProps = {};
   if (isSecondaryLoading) {
-    extraSecondaryProps.spinnerAriaValueText = "Loading";
+    extraSecondaryProps.spinnerAriaValueText = 'Loading';
   }
 
   return (
     <React.Fragment>
-      <Button spinnerAriaValueText={isPrimaryLoading ? "Loading" : undefined}
-              isLoading={isPrimaryLoading}
-              variant="primary"
-              onClick={() => setIsPrimaryLoading(!isPrimaryLoading)}
-              {...extraPrimaryProps}>
+      <Button
+        spinnerAriaValueText={isPrimaryLoading ? 'Loading' : undefined}
+        isLoading={isPrimaryLoading}
+        variant="primary"
+        onClick={() => setIsPrimaryLoading(!isPrimaryLoading)}
+        {...extraPrimaryProps}
+      >
         {isPrimaryLoading ? 'Click to stop loading' : 'Click to start loading'}
       </Button>{' '}
-      <Button spinnerAriaValueText={isSecondaryLoading ? "Loading" : undefined}
-              isLoading={isSecondaryLoading}
-              variant="secondary"
-              onClick={() => setIsSecondaryLoading(!isSecondaryLoading)}
-              {...extraSecondaryProps}>
+      <Button
+        spinnerAriaValueText={isSecondaryLoading ? 'Loading' : undefined}
+        isLoading={isSecondaryLoading}
+        variant="secondary"
+        onClick={() => setIsSecondaryLoading(!isSecondaryLoading)}
+        {...extraSecondaryProps}
+      >
         {isSecondaryLoading ? 'Click to stop loading' : 'Click to start loading'}
       </Button>
-      <br /><br />
+      <br />
+      <br />
     </React.Fragment>
   );
 };

--- a/packages/react-integration/cypress/integration/button.spec.ts
+++ b/packages/react-integration/cypress/integration/button.spec.ts
@@ -9,6 +9,9 @@ describe('Button Demo Test', () => {
     cy.get('.btn-demo-area').within(() => {
       cy.get('.pf-c-button[id="normal-btn-1"]').should('have.class', 'pf-m-primary');
       cy.get('.pf-c-button[id="normal-btn-2"]').should('have.class', 'pf-m-secondary');
+      cy.get('.pf-c-button[id="normal-btn-2-danger"]')
+        .should('have.class', 'pf-m-secondary')
+        .should('have.class', 'pf-m-danger');
       cy.get('.pf-c-button[id="normal-btn-3"]').should('have.class', 'pf-m-tertiary');
       cy.get('.pf-c-button[id="normal-btn-4"]').should('have.class', 'pf-m-danger');
       cy.get('.pf-c-button[id="normal-btn-5"]').should('have.class', 'pf-m-link');
@@ -109,6 +112,9 @@ describe('Button Demo Test', () => {
   it('Verify link button classes and attributes', () => {
     cy.get('.btn-demo-area').within(() => {
       cy.get('.pf-c-button[id="link-btn-1"]').should('have.class', 'pf-m-link');
+      cy.get('.pf-c-button[id="link-btn-1-danger"]')
+        .should('have.class', 'pf-m-link')
+        .should('have.class', 'pf-m-danger');
       cy.get('.pf-c-button[id="link-btn-2"]').should('have.class', 'pf-m-inline');
 
       cy.get('.pf-c-button[id="link-btn-3"]').should('have.class', 'pf-m-disabled');

--- a/packages/react-integration/demo-app-ts/src/components/demos/ButtonDemo/ButtonDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/ButtonDemo/ButtonDemo.tsx
@@ -81,6 +81,9 @@ export class ButtonDemo extends React.Component<ButtonProps, ButtonDemoState> {
         <Button {...this.normalButton} id="normal-btn-2" variant="secondary">
           Secondary
         </Button>
+        <Button {...this.normalButton} id="normal-btn-2-danger" variant="secondary" isDanger>
+          Danger secondary
+        </Button>
         <Button {...this.normalButton} id="normal-btn-3" variant="tertiary">
           Tertiary
         </Button>
@@ -151,6 +154,9 @@ export class ButtonDemo extends React.Component<ButtonProps, ButtonDemoState> {
         </Button>
         <Button {...this.linkButton} id="link-btn-2" isInline>
           Inline Link Button
+        </Button>
+        <Button {...this.linkButton} id="link-btn-1-danger" isDanger>
+          Danger link button
         </Button>
         <Button {...this.linkButton} id="link-btn-3" isDisabled>
           Disabled link button


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5578

Adds `isDanger` flag. When the button variant is `link` or `secondary`, danger styling will be added to the button with the new flag.

Should the `danger` variant be removed in the next breaking change release? 
And should the `isDanger` flag be made to add danger styling to any variant or is there a reason to limit the flag to just link/secondary?
