### PR TITLE
react-charts(fix): Ensure ChartPie uses non-negative default radius

### DIFF
--- a/packages/react-charts/src/components/ChartPie/ChartPie.tsx
+++ b/packages/react-charts/src/components/ChartPie/ChartPie.tsx
@@ -496,13 +496,16 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
     right: getPaddingForSide('right', padding, theme.pie.padding),
     top: getPaddingForSide('top', padding, theme.pie.padding)
   };
-  const chartRadius = radius
-    ? radius
-    : Helpers.getRadius({
-        height,
-        width,
-        padding: defaultPadding
-      });
+  // Ensure non-negative value is returned
+  const getDefaultRadius = () => {
+    const result = Helpers.getRadius({
+      height,
+      width,
+      padding: defaultPadding
+    });
+    return result > -1 ? result : undefined;
+  };
+  const chartRadius = radius ? radius : getDefaultRadius();
 
   const chart = (
     <VictoryPie


### PR DESCRIPTION
This ensures the pie chart uses a non-negative default radius.

https://github.com/patternfly/patternfly-react/issues/5821

