### PR TITLE
feat(charts): Add left and right triangle legend symbols

### DIFF
--- a/packages/react-charts/src/components/ChartPoint/ChartPoint.tsx
+++ b/packages/react-charts/src/components/ChartPoint/ChartPoint.tsx
@@ -87,6 +87,8 @@ export interface ChartPointProps {
     | 'square'
     | 'star'
     | 'triangleDown'
+    | 'triangleLeft'
+    | 'triangleRight'
     | 'triangleUp'
     | 'dash'
     | 'threshold'
@@ -121,6 +123,8 @@ const getPath = (props: ChartPointProps) => {
     diamond: PathHelpers.diamond,
     eyeSlash: PathHelpers.eyeSlash,
     triangleDown: PathHelpers.triangleDown,
+    triangleLeft: PathHelpers.triangleLeft,
+    triangleRight: PathHelpers.triangleRight,
     triangleUp: PathHelpers.triangleUp,
     plus: PathHelpers.plus,
     minus: PathHelpers.minus,

--- a/packages/react-charts/src/components/ChartPoint/path-helpers.ts
+++ b/packages/react-charts/src/components/ChartPoint/path-helpers.ts
@@ -9,6 +9,8 @@ export interface PathHelpersInterface {
   square: Function;
   threshold: Function;
   triangleDown: Function;
+  triangleLeft: Function;
+  triangleRight: Function;
   triangleUp: Function;
 }
 
@@ -61,7 +63,7 @@ export const PathHelpers: PathHelpersInterface = {
     const y1 = y - size * 1.25;
 
     // For converting to relative paths, see https://aydos.com/svgedit/
-    // Data taken from path of assets/Eyecon.svg
+    // Data taken from path of assets/Eyecon.svg, minus first two x and y values
     const data =
       '.013 .013 0 0 2.179 2.219c.7-.204 1.418-.307 2.152-.307 2.859 0 5.464 1.551 7.814 4.654.243 .321.268 .753.073 1.097l-.073.111-.236.305c-.632.801-1.282 1.491-1.951 2.071l1.773 1.806c.382.389 .382 1.012 0 1.401l-.058.059c-.387.394-1.02.4-1.414.013l-.013-.013-11.732-11.956c-.382-.389-.382-1.012 0-1.401l.058-.059c.387-.394 1.02-.4 1.414-.013zm-.674 3.71 1.407 1.436c-.329.604-.516 1.298-.516 2.038 0 2.323 1.848 4.206 4.127 4.206.726 0 1.408-.191 2-.526l.966.984c-.956.396-1.945.593-2.966.593-2.859 0-5.464-1.551-7.814-4.654-.243-.321-.268-.753-.073-1.097l.073-.111.236-.305c.823-1.042 1.676-1.897 2.56-2.565zm2.177 2.22 4.072 4.149c-.377.167-.793.259-1.23.259-1.71 0-3.096-1.412-3.096-3.155 0-.445.091-.869.254-1.253zm2.842-2.953c-.43 0-.845.067-1.234.191l.865.882c.121-.015.244-.022.369-.022 1.71 0 3.096 1.412 3.096 3.155 0 .127-.007.252-.022.375l.866.882c.122-.397.187-.819.187-1.257 0-2.323-1.848-4.206-4.127-4.206z';
     return `m${x0}, ${y1} ${data}`;
@@ -150,6 +152,30 @@ export const PathHelpers: PathHelpersInterface = {
     return `M ${x0}, ${y0}
       L ${x1}, ${y0}
       L ${x}, ${y1}
+      z`;
+  },
+
+  triangleLeft: (x: number, y: number, size: number) => {
+    const height = (size / 2) * Math.sqrt(3);
+    const x0 = x - height;
+    const x1 = x + size;
+    const y0 = y - size;
+    const y1 = y + size;
+    return `M ${x1}, ${y0}
+      L ${x1}, ${y1}
+      L ${x0}, ${y}
+      z`;
+  },
+
+  triangleRight: (x: number, y: number, size: number) => {
+    const height = (size / 2) * Math.sqrt(3);
+    const x0 = x - size;
+    const x1 = x + height;
+    const y0 = y - size;
+    const y1 = y + size;
+    return `M ${x0}, ${y0}
+      L ${x0}, ${y1}
+      L ${x1}, ${y}
       z`;
   },
 


### PR DESCRIPTION
For Cost Management, we want to use left pointing triangles as legend symbols. Unfortunately, Victory only supports up and down pointing triangles, not left and right. A left pointing triangle would better represent a forecast's "cone of confidence" in our tooltips.

<img width="1063" alt="triangle" src="https://user-images.githubusercontent.com/17481322/120542782-81dc5a00-c3b9-11eb-8b71-f567dde6bbd4.png">

https://github.com/patternfly/patternfly-react/issues/5867