### PR TITLE
fix(breadcrumb): moved divider outside of header element

### DIFF
--- a/packages/react-core/src/components/Breadcrumb/BreadcrumbHeading.tsx
+++ b/packages/react-core/src/components/Breadcrumb/BreadcrumbHeading.tsx
@@ -30,12 +30,12 @@ export const BreadcrumbHeading: React.FunctionComponent<BreadcrumbHeadingProps> 
   const Component = component as any;
   return (
     <li {...props} className={css(styles.breadcrumbItem, className)}>
+      {showDivider && (
+        <span className={styles.breadcrumbItemDivider}>
+          <AngleRightIcon />
+        </span>
+      )}
       <h1 className={styles.breadcrumbHeading}>
-        {showDivider && (
-          <span className={styles.breadcrumbItemDivider}>
-            <AngleRightIcon />
-          </span>
-        )}
         {!to && component === 'button' && (
           <button className={css(styles.breadcrumbLink, styles.modifiers.current)} aria-current type="button">
             {children}


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-react/issues/5508

updates the markup to match the core example at https://www.patternfly.org/v4/components/breadcrumb/html#with-heading