### PR TITLE
feat(DescriptionList): add responsive layout breakpoint property

### DIFF
--- a/packages/react-core/src/components/DescriptionList/DescriptionList.tsx
+++ b/packages/react-core/src/components/DescriptionList/DescriptionList.tsx
@@ -27,13 +27,23 @@ export interface DescriptionListProps extends Omit<React.HTMLProps<HTMLDListElem
   /** Sets the number of columns on the description list */
   columnModifier?: {
     default?: '1Col' | '2Col' | '3Col';
+    sm?: '1Col' | '2Col' | '3Col';
     md?: '1Col' | '2Col' | '3Col';
     lg?: '1Col' | '2Col' | '3Col';
     xl?: '1Col' | '2Col' | '3Col';
     '2xl'?: '1Col' | '2Col' | '3Col';
   };
+  /** Indicates how the menu will align at screen size breakpoints. Default alignment is set via the position property. */
+  layouts?: {
+    sm?: 'horizontal' | 'vertical';
+    md?: 'horizontal' | 'vertical';
+    lg?: 'horizontal' | 'vertical';
+    xl?: 'horizontal' | 'vertical';
+    '2xl'?: 'horizontal' | 'vertical';
+  };
   autoFitMinModifier?: {
     default?: string;
+    sm?: string;
     md?: string;
     lg?: string;
     xl?: string;
@@ -60,6 +70,7 @@ export const DescriptionList: React.FunctionComponent<DescriptionListProps> = ({
   isInlineGrid,
   columnModifier,
   autoFitMinModifier,
+  layouts,
   style,
   ...props
 }: DescriptionListProps) => (
@@ -70,6 +81,7 @@ export const DescriptionList: React.FunctionComponent<DescriptionListProps> = ({
       isAutoColumnWidths && styles.modifiers.autoColumnWidths,
       isAutoFit && styles.modifiers.autoFit,
       formatBreakpointMods(columnModifier, styles),
+      formatBreakpointMods(layouts, styles),
       isInlineGrid && styles.modifiers.inlineGrid,
       className
     )}

--- a/packages/react-core/src/components/DescriptionList/DescriptionList.tsx
+++ b/packages/react-core/src/components/DescriptionList/DescriptionList.tsx
@@ -34,12 +34,12 @@ export interface DescriptionListProps extends Omit<React.HTMLProps<HTMLDListElem
     '2xl'?: '1Col' | '2Col' | '3Col';
   };
   /** Indicates how the menu will align at screen size breakpoints. Default alignment is set via the position property. */
-  layouts?: {
-    sm?: 'horizontal' | 'vertical';
-    md?: 'horizontal' | 'vertical';
-    lg?: 'horizontal' | 'vertical';
-    xl?: 'horizontal' | 'vertical';
-    '2xl'?: 'horizontal' | 'vertical';
+  orientation?: {
+    sm?: 'vertical' | 'horizontal';
+    md?: 'vertical' | 'horizontal';
+    lg?: 'vertical' | 'horizontal';
+    xl?: 'vertical' | 'horizontal';
+    '2xl'?: 'vertical' | 'horizontal';
   };
   autoFitMinModifier?: {
     default?: string;
@@ -70,7 +70,7 @@ export const DescriptionList: React.FunctionComponent<DescriptionListProps> = ({
   isInlineGrid,
   columnModifier,
   autoFitMinModifier,
-  layouts,
+  orientation,
   style,
   ...props
 }: DescriptionListProps) => (
@@ -81,7 +81,7 @@ export const DescriptionList: React.FunctionComponent<DescriptionListProps> = ({
       isAutoColumnWidths && styles.modifiers.autoColumnWidths,
       isAutoFit && styles.modifiers.autoFit,
       formatBreakpointMods(columnModifier, styles),
-      formatBreakpointMods(layouts, styles),
+      formatBreakpointMods(orientation, styles),
       isInlineGrid && styles.modifiers.inlineGrid,
       className
     )}

--- a/packages/react-core/src/components/DescriptionList/__tests__/DescriptionList.test.tsx
+++ b/packages/react-core/src/components/DescriptionList/__tests__/DescriptionList.test.tsx
@@ -14,22 +14,44 @@ describe('Description List', () => {
   });
 
   test('1 col on all breakpoints', () => {
-    const view = shallow(<DescriptionList columnModifier={{ default: '1Col', md: '1Col', lg: '1Col', xl: '1Col', '2xl': '1Col' }}/>);
+    const view = shallow(
+      <DescriptionList columnModifier={{ default: '1Col', md: '1Col', lg: '1Col', xl: '1Col', '2xl': '1Col' }} />
+    );
     expect(view).toMatchSnapshot();
   });
 
   test('2 col on all breakpoints', () => {
-    const view = shallow(<DescriptionList columnModifier={{ default: '2Col', md: '2Col', lg: '2Col', xl: '2Col', '2xl': '2Col' }}/>);
+    const view = shallow(
+      <DescriptionList columnModifier={{ default: '2Col', md: '2Col', lg: '2Col', xl: '2Col', '2xl': '2Col' }} />
+    );
     expect(view).toMatchSnapshot();
   });
 
   test('3 col on all breakpoints', () => {
-    const view = shallow(<DescriptionList columnModifier={{  default: '3Col', md: '3Col', lg: '3Col', xl: '3Col', '2xl': '3Col'  }}/>);
+    const view = shallow(
+      <DescriptionList columnModifier={{ default: '3Col', md: '3Col', lg: '3Col', xl: '3Col', '2xl': '3Col' }} />
+    );
     expect(view).toMatchSnapshot();
   });
 
   test('Horizontal Description List', () => {
     const view = shallow(<DescriptionList isHorizontal />);
+    expect(view).toMatchSnapshot();
+  });
+
+  test('alignment breakpoints', () => {
+    const view = mount(
+      <DescriptionList
+        isHorizontal
+        layouts={{
+          sm: 'horizontal',
+          md: 'vertical',
+          lg: 'horizontal',
+          xl: 'vertical',
+          '2xl': 'horizontal'
+        }}
+      />
+    );
     expect(view).toMatchSnapshot();
   });
 
@@ -49,14 +71,16 @@ describe('Description List', () => {
   });
 
   test('Auto fit with responsive grid Description List', () => {
-    const view = shallow(<DescriptionList isAutoFit autoFitMinModifier={{ md: '100px', lg: '150px', xl: '200px', '2xl': '300px' }} />);
+    const view = shallow(
+      <DescriptionList isAutoFit autoFitMinModifier={{ md: '100px', lg: '150px', xl: '200px', '2xl': '300px' }} />
+    );
     expect(view).toMatchSnapshot();
   });
 
   test('Term default', () => {
     const view = shallow(
       <DescriptionListTerm key="term-id-1" aria-labelledby="term-1">
-          test
+        test
       </DescriptionListTerm>
     );
     expect(view).toMatchSnapshot();
@@ -65,7 +89,7 @@ describe('Description List', () => {
   test('Term helper text', () => {
     const view = shallow(
       <DescriptionListTermHelpText key="term-id-1" aria-labelledby="term-1">
-          <DescriptionListTermHelpTextButton>test</DescriptionListTermHelpTextButton>
+        <DescriptionListTermHelpTextButton>test</DescriptionListTermHelpTextButton>
       </DescriptionListTermHelpText>
     );
     expect(view).toMatchSnapshot();
@@ -82,11 +106,10 @@ describe('Description List', () => {
 
   test('Description', () => {
     const view = shallow(
-        <DescriptionListDescription className="custom-description-list-description" aria-labelledby="description-1">
-          test
-        </DescriptionListDescription>
-      );
-      expect(view).toMatchSnapshot();
-  })
-  
+      <DescriptionListDescription className="custom-description-list-description" aria-labelledby="description-1">
+        test
+      </DescriptionListDescription>
+    );
+    expect(view).toMatchSnapshot();
+  });
 });

--- a/packages/react-core/src/components/DescriptionList/__tests__/DescriptionList.test.tsx
+++ b/packages/react-core/src/components/DescriptionList/__tests__/DescriptionList.test.tsx
@@ -43,7 +43,7 @@ describe('Description List', () => {
     const view = mount(
       <DescriptionList
         isHorizontal
-        layouts={{
+        orientation={{
           sm: 'horizontal',
           md: 'vertical',
           lg: 'horizontal',

--- a/packages/react-core/src/components/DescriptionList/__tests__/__snapshots__/DescriptionList.test.tsx.snap
+++ b/packages/react-core/src/components/DescriptionList/__tests__/__snapshots__/DescriptionList.test.tsx.snap
@@ -104,7 +104,7 @@ exports[`Description List Term helper text 1`] = `
 exports[`Description List alignment breakpoints 1`] = `
 <DescriptionList
   isHorizontal={true}
-  layouts={
+  orientation={
     Object {
       "2xl": "horizontal",
       "lg": "horizontal",

--- a/packages/react-core/src/components/DescriptionList/__tests__/__snapshots__/DescriptionList.test.tsx.snap
+++ b/packages/react-core/src/components/DescriptionList/__tests__/__snapshots__/DescriptionList.test.tsx.snap
@@ -101,6 +101,25 @@ exports[`Description List Term helper text 1`] = `
 </dt>
 `;
 
+exports[`Description List alignment breakpoints 1`] = `
+<DescriptionList
+  isHorizontal={true}
+  layouts={
+    Object {
+      "2xl": "horizontal",
+      "lg": "horizontal",
+      "md": "vertical",
+      "sm": "horizontal",
+      "xl": "vertical",
+    }
+  }
+>
+  <dl
+    className="pf-c-description-list pf-m-horizontal pf-m-horizontal-on-sm pf-m-vertical-on-md pf-m-horizontal-on-lg pf-m-vertical-on-xl pf-m-horizontal-on-2xl"
+  />
+</DescriptionList>
+`;
+
 exports[`Description List default 1`] = `
 <dl
   className="pf-c-description-list"

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionList.md
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionList.md
@@ -458,7 +458,7 @@ import PlusCircleIcon from '@patternfly/react-icons/dist/js/icons/plus-circle-ic
 
 <DescriptionList
   isHorizontal
-  layouts={{
+  orientation={{
     md: 'vertical',
     lg: 'horizontal',
     xl: 'vertical',

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionList.md
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionList.md
@@ -443,6 +443,57 @@ import PlusCircleIcon from '@patternfly/react-icons/dist/js/icons/plus-circle-ic
 </DescriptionList>;
 ```
 
+### Responsive horizontal, vertical group layout
+
+```js
+import React from 'react';
+import {
+  Button,
+  DescriptionList,
+  DescriptionListTerm,
+  DescriptionListGroup,
+  DescriptionListDescription
+} from '@patternfly/react-core';
+import PlusCircleIcon from '@patternfly/react-icons/dist/js/icons/plus-circle-icon';
+
+<DescriptionList
+  isHorizontal
+  layouts={{
+    md: 'vertical',
+    lg: 'horizontal',
+    xl: 'vertical',
+    '2xl': 'horizontal'
+  }}
+>
+  <DescriptionListGroup>
+    <DescriptionListTerm>Name</DescriptionListTerm>
+    <DescriptionListDescription>Example</DescriptionListDescription>
+  </DescriptionListGroup>
+  <DescriptionListGroup>
+    <DescriptionListTerm>Namespace</DescriptionListTerm>
+    <DescriptionListDescription>
+      <a href="#">mary-test</a>
+    </DescriptionListDescription>
+  </DescriptionListGroup>
+  <DescriptionListGroup>
+    <DescriptionListTerm>Labels</DescriptionListTerm>
+    <DescriptionListDescription>example</DescriptionListDescription>
+  </DescriptionListGroup>
+  <DescriptionListGroup>
+    <DescriptionListTerm>Pod selector</DescriptionListTerm>
+    <DescriptionListDescription>
+      <Button variant="link" isInline icon={<PlusCircleIcon />}>
+        app=MyApp
+      </Button>
+    </DescriptionListDescription>
+  </DescriptionListGroup>
+  <DescriptionListGroup>
+    <DescriptionListTerm>Annotation</DescriptionListTerm>
+    <DescriptionListDescription>2 Annotations</DescriptionListDescription>
+  </DescriptionListGroup>
+</DescriptionList>;
+```
+
 ## Auto-column-width
 
 ### Default auto column width
@@ -639,7 +690,7 @@ import {
 } from '@patternfly/react-core';
 import PlusCircleIcon from '@patternfly/react-icons/dist/js/icons/plus-circle-icon';
 
-<DescriptionList isAutoFit autoFitModifier={{ default: '200px' }}>
+<DescriptionList isAutoFit autoFitMinModifier={{ default: '200px' }}>
   <DescriptionListGroup>
     <DescriptionListTerm>Name</DescriptionListTerm>
     <DescriptionListDescription>example</DescriptionListDescription>
@@ -683,7 +734,7 @@ import {
 } from '@patternfly/react-core';
 import PlusCircleIcon from '@patternfly/react-icons/dist/js/icons/plus-circle-icon';
 
-<DescriptionList isAutoFit autoFitModifier={{ md: '100px', lg: '150px', xl: '200px', '2xl': '300px' }}>
+<DescriptionList isAutoFit autoFitMinModifier={{ md: '100px', lg: '150px', xl: '200px', '2xl': '300px' }}>
   <DescriptionListGroup>
     <DescriptionListTerm>Name</DescriptionListTerm>
     <DescriptionListDescription>example</DescriptionListDescription>

--- a/packages/react-integration/cypress/integration/descriptionlistbreakpoints.spec.ts
+++ b/packages/react-integration/cypress/integration/descriptionlistbreakpoints.spec.ts
@@ -30,7 +30,7 @@ describe('Description List Breakpoints Demo Test', () => {
   });
 
   it('Verify description list has layout breakpoints', () => {
-    const list = cy.get('#layouts-description-list');
+    const list = cy.get('#orientation-description-list');
     list.should('have.class', 'pf-m-horizontal-on-sm');
     list.should('have.class', 'pf-m-vertical-on-md');
     list.should('have.class', 'pf-m-horizontal-on-lg');

--- a/packages/react-integration/cypress/integration/descriptionlistbreakpoints.spec.ts
+++ b/packages/react-integration/cypress/integration/descriptionlistbreakpoints.spec.ts
@@ -28,4 +28,13 @@ describe('Description List Breakpoints Demo Test', () => {
     cy.get('#3-col-description-list.pf-m-3-col-on-xl').should('exist');
     cy.get('#3-col-description-list.pf-m-3-col-on-2xl').should('exist');
   });
+
+  it('Verify description list has layout breakpoints', () => {
+    const list = cy.get('#layouts-description-list');
+    list.should('have.class', 'pf-m-horizontal-on-sm');
+    list.should('have.class', 'pf-m-vertical-on-md');
+    list.should('have.class', 'pf-m-horizontal-on-lg');
+    list.should('have.class', 'pf-m-vertical-on-xl');
+    list.should('have.class', 'pf-m-horizontal-on-2xl');
+  });
 });

--- a/packages/react-integration/demo-app-ts/src/components/demos/DescriptionListDemo/DescriptionListBreakpointsDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DescriptionListDemo/DescriptionListBreakpointsDemo.tsx
@@ -155,12 +155,65 @@ export class DescriptionListBreakpointsDemo extends Component {
     );
   }
 
+  renderResponsiveLayoutDescriptionList() {
+    return (
+      <StackItem isFilled>
+        <Title headingLevel="h2" size="2xl">
+          Responsive Layout Description List
+        </Title>
+        <Divider component="div" />
+        <br />
+        <div className="example">
+          <DescriptionList
+            id="layouts-description-list"
+            isHorizontal
+            layouts={{
+              sm: 'horizontal',
+              md: 'vertical',
+              lg: 'horizontal',
+              xl: 'vertical',
+              '2xl': 'horizontal'
+            }}
+          >
+            <DescriptionListGroup>
+              <DescriptionListTerm>Name</DescriptionListTerm>
+              <DescriptionListDescription>Example</DescriptionListDescription>
+            </DescriptionListGroup>
+            <DescriptionListGroup>
+              <DescriptionListTerm>Namespace</DescriptionListTerm>
+              <DescriptionListDescription>
+                <a href="#">mary-test</a>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+            <DescriptionListGroup>
+              <DescriptionListTerm>Labels</DescriptionListTerm>
+              <DescriptionListDescription>example</DescriptionListDescription>
+            </DescriptionListGroup>
+            <DescriptionListGroup>
+              <DescriptionListTerm>Pod selector</DescriptionListTerm>
+              <DescriptionListDescription>
+                <Button variant="link" isInline icon={<PlusCircleIcon />}>
+                  app=MyApp
+                </Button>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+            <DescriptionListGroup>
+              <DescriptionListTerm>Annotation</DescriptionListTerm>
+              <DescriptionListDescription>2 Annotations</DescriptionListDescription>
+            </DescriptionListGroup>
+          </DescriptionList>
+        </div>
+      </StackItem>
+    );
+  }
+
   render() {
     return (
       <Stack hasGutter>
         {this.render1ColDescriptionList()}
         {this.render2ColDescriptionList()}
         {this.render3ColDescriptionList()}
+        {this.renderResponsiveLayoutDescriptionList()}
       </Stack>
     );
   }

--- a/packages/react-integration/demo-app-ts/src/components/demos/DescriptionListDemo/DescriptionListBreakpointsDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DescriptionListDemo/DescriptionListBreakpointsDemo.tsx
@@ -165,9 +165,9 @@ export class DescriptionListBreakpointsDemo extends Component {
         <br />
         <div className="example">
           <DescriptionList
-            id="layouts-description-list"
+            id="orientation-description-list"
             isHorizontal
-            layouts={{
+            orientation={{
               sm: 'horizontal',
               md: 'vertical',
               lg: 'horizontal',


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5445

- Adds `layouts` property to specify layout orientation per breakpoint
- Adds `sm` breakpoint to `columnModifier` and `autoFitMinModifier`
- Fixes example code using `autoFitModifier` (instead of `autoFitMinModifier`)
