### PR TITLE
fix(Table): empty state cell should not have data-label

### DIFF
--- a/packages/react-table/src/components/Table/BodyCell.tsx
+++ b/packages/react-table/src/components/Table/BodyCell.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Tooltip } from '@patternfly/react-core/dist/js/components/Tooltip/Tooltip';
-import { SelectProps } from '@patternfly/react-core';
+import { Bullseye, EmptyState, SelectProps } from '@patternfly/react-core';
 import { Td } from '../TableComposable/Td';
 
 export interface BodyCellProps {
@@ -64,11 +64,20 @@ export const BodyCell: React.FunctionComponent<BodyCellProps> = ({
     onMouseEnterProp(event);
   };
 
+  let isEmptyStateCell = false;
+  if (children) {
+    isEmptyStateCell =
+      ((children as React.ReactElement).type === Bullseye &&
+        (children as React.ReactElement).props.children &&
+        (children as React.ReactElement).props.children.type === EmptyState) ||
+      (children as React.ReactElement).type === EmptyState;
+  }
+
   const cell = (
     <Td
       className={className}
       component={component}
-      dataLabel={dataLabel && parentId == null ? dataLabel : null}
+      dataLabel={dataLabel && parentId == null && !isEmptyStateCell ? dataLabel : null}
       onMouseEnter={onMouseEnter}
       textCenter={textCenter}
       colSpan={colSpan}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5379

Removes the header cell data label if a BodyCell child is either an `EmptyState` component or a `Bullseye` component with an `EmptyState` direct child. Visually only changes the mobile view (where column headers are now unseen).
