### PR TITLE
feat(HelperText): add helper text component

### DIFF
--- a/packages/react-core/src/components/HelperText/HelperText.tsx
+++ b/packages/react-core/src/components/HelperText/HelperText.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import styles from '@patternfly/react-styles/css/components/HelperText/helper-text';
+import { css } from '@patternfly/react-styles';
+
+export interface HelperTextProps extends React.HTMLProps<HTMLDivElement | HTMLUListElement> {
+  /** Content rendered inside the helper text container. */
+  children?: React.ReactNode;
+  /** Additional classes applied to the helper text container. */
+  className?: string;
+  /** Component type of the helper text container */
+  component?: 'div' | 'ul';
+}
+
+export const HelperText: React.FunctionComponent<HelperTextProps> = ({
+  children,
+  className,
+  component = 'div',
+  ...props
+}: HelperTextProps) => {
+  const Component = component as any;
+  return (
+    <Component className={css(styles.helperText, className)} {...props}>
+      {children}
+    </Component>
+  );
+};
+HelperText.displayName = 'HelperText';

--- a/packages/react-core/src/components/HelperText/HelperTextItem.tsx
+++ b/packages/react-core/src/components/HelperText/HelperTextItem.tsx
@@ -28,7 +28,7 @@ const variantStyle = {
   indeterminate: styles.modifiers.indeterminate,
   warning: styles.modifiers.warning,
   success: styles.modifiers.success,
-  error: styles.modifiers.invalid
+  error: styles.modifiers.error
 };
 
 export const HelperTextItem: React.FunctionComponent<HelperTextItemProps> = ({

--- a/packages/react-core/src/components/HelperText/HelperTextItem.tsx
+++ b/packages/react-core/src/components/HelperText/HelperTextItem.tsx
@@ -15,7 +15,7 @@ export interface HelperTextItemProps extends React.HTMLProps<HTMLDivElement | HT
   component?: 'div' | 'li';
   /** Variant styling of the helper text item. */
   variant?: 'default' | 'indeterminate' | 'warning' | 'success' | 'invalid';
-  /** Icon prefixing the helper text. */
+  /** Icon prefixing the helper text. This property will override the default icon paired with a dynamic helper text. */
   icon?: React.ReactNode;
   /** Flag indicating the helper text item is dynamic. */
   isDynamic?: boolean;

--- a/packages/react-core/src/components/HelperText/HelperTextItem.tsx
+++ b/packages/react-core/src/components/HelperText/HelperTextItem.tsx
@@ -14,7 +14,7 @@ export interface HelperTextItemProps extends React.HTMLProps<HTMLDivElement | HT
   /** Sets the component type of the helper text item. */
   component?: 'div' | 'li';
   /** Variant styling of the helper text item. */
-  variant?: 'default' | 'indeterminate' | 'warning' | 'success' | 'invalid';
+  variant?: 'default' | 'indeterminate' | 'warning' | 'success' | 'error';
   /** Icon prefixing the helper text. This property will override the default icon paired with a dynamic helper text. */
   icon?: React.ReactNode;
   /** Flag indicating the helper text item is dynamic. */
@@ -28,7 +28,7 @@ const variantStyle = {
   indeterminate: styles.modifiers.indeterminate,
   warning: styles.modifiers.warning,
   success: styles.modifiers.success,
-  invalid: styles.modifiers.invalid
+  error: styles.modifiers.invalid
 };
 
 export const HelperTextItem: React.FunctionComponent<HelperTextItemProps> = ({
@@ -57,7 +57,7 @@ export const HelperTextItem: React.FunctionComponent<HelperTextItemProps> = ({
           {(variant === 'default' || variant === 'indeterminate') && <MinusIcon />}
           {variant === 'warning' && <ExclamationTriangleIcon />}
           {variant === 'success' && <CheckIcon />}
-          {variant === 'invalid' && <TimesIcon />}
+          {variant === 'error' && <TimesIcon />}
         </span>
       )}
       <span className={css(styles.helperTextItemText)}>{children}</span>

--- a/packages/react-core/src/components/HelperText/HelperTextItem.tsx
+++ b/packages/react-core/src/components/HelperText/HelperTextItem.tsx
@@ -15,7 +15,7 @@ export interface HelperTextItemProps extends React.HTMLProps<HTMLDivElement | HT
   component?: 'div' | 'li';
   /** Variant styling of the helper text item. */
   variant?: 'default' | 'indeterminate' | 'warning' | 'success' | 'error';
-  /** Icon prefixing the helper text. This property will override the default icon paired with a helper text. */
+  /** Custom icon prefixing the helper text. This property will override the default icon paired with each helper text variant. */
   icon?: React.ReactNode;
   /** Flag indicating the helper text item is dynamic. */
   isDynamic?: boolean;

--- a/packages/react-core/src/components/HelperText/HelperTextItem.tsx
+++ b/packages/react-core/src/components/HelperText/HelperTextItem.tsx
@@ -15,11 +15,11 @@ export interface HelperTextItemProps extends React.HTMLProps<HTMLDivElement | HT
   component?: 'div' | 'li';
   /** Variant styling of the helper text item. */
   variant?: 'default' | 'indeterminate' | 'warning' | 'success' | 'error';
-  /** Icon prefixing the helper text. This property will override the default icon paired with a dynamic helper text. */
+  /** Icon prefixing the helper text. This property will override the default icon paired with a helper text. */
   icon?: React.ReactNode;
   /** Flag indicating the helper text item is dynamic. */
   isDynamic?: boolean;
-  /** Flag indicating the dynamic helper text should have an icon */
+  /** Flag indicating the helper text should have an icon. Dynamic helper texts include icons by default while static helper texts do not. */
   hasIcon?: boolean;
 }
 
@@ -37,8 +37,8 @@ export const HelperTextItem: React.FunctionComponent<HelperTextItemProps> = ({
   component = 'div',
   variant = 'default',
   icon,
-  isDynamic,
-  hasIcon = true,
+  isDynamic = false,
+  hasIcon = isDynamic,
   ...props
 }: HelperTextItemProps) => {
   const Component = component as any;
@@ -52,7 +52,7 @@ export const HelperTextItem: React.FunctionComponent<HelperTextItemProps> = ({
           {icon}
         </span>
       )}
-      {isDynamic && hasIcon && !icon && (
+      {hasIcon && !icon && (
         <span className={css(styles.helperTextItemIcon)} aria-hidden>
           {(variant === 'default' || variant === 'indeterminate') && <MinusIcon />}
           {variant === 'warning' && <ExclamationTriangleIcon />}

--- a/packages/react-core/src/components/HelperText/HelperTextItem.tsx
+++ b/packages/react-core/src/components/HelperText/HelperTextItem.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import styles from '@patternfly/react-styles/css/components/HelperText/helper-text';
+import { css } from '@patternfly/react-styles';
+
+export interface HelperTextItemProps extends React.HTMLProps<HTMLDivElement | HTMLLIElement> {
+  /** Content rendered inside the helper text item. */
+  children?: React.ReactNode;
+  /** Additional classes applied to the helper text item. */
+  className?: string;
+  /** Sets the component type of the helper text item. */
+  component?: 'div' | 'li';
+  /** Variant styling of the helper text item. */
+  variant?: 'default' | 'indeterminate' | 'warning' | 'success' | 'invalid';
+  /** Icon prefixing the helper text. */
+  icon?: React.ReactNode;
+  /** Flag indicating the helper text item is dynamic. */
+  isDynamic?: boolean;
+}
+
+const variantStyle = {
+  default: '',
+  indeterminate: styles.modifiers.indeterminate,
+  warning: styles.modifiers.warning,
+  success: styles.modifiers.success,
+  invalid: styles.modifiers.invalid
+};
+
+export const HelperTextItem: React.FunctionComponent<HelperTextItemProps> = ({
+  children,
+  className,
+  component = 'div',
+  variant = 'default',
+  icon,
+  isDynamic,
+  ...props
+}: HelperTextItemProps) => {
+  const Component = component as any;
+  return (
+    <Component
+      className={css(styles.helperTextItem, variantStyle[variant], isDynamic && styles.modifiers.dynamic, className)}
+      {...props}
+    >
+      {icon && (
+        <span className={css(styles.helperTextItemIcon)} aria-hidden>
+          {icon}
+        </span>
+      )}
+      <span className={css(styles.helperTextItemText)}>{children}</span>
+    </Component>
+  );
+};
+HelperTextItem.displayName = 'HelperTextItem';

--- a/packages/react-core/src/components/HelperText/HelperTextItem.tsx
+++ b/packages/react-core/src/components/HelperText/HelperTextItem.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/HelperText/helper-text';
 import { css } from '@patternfly/react-styles';
+import MinusIcon from '@patternfly/react-icons/dist/js/icons/minus-icon';
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
+import CheckIcon from '@patternfly/react-icons/dist/js/icons/check-icon';
+import TimesIcon from '@patternfly/react-icons/dist/js/icons/times-icon';
 
 export interface HelperTextItemProps extends React.HTMLProps<HTMLDivElement | HTMLLIElement> {
   /** Content rendered inside the helper text item. */
@@ -15,6 +19,8 @@ export interface HelperTextItemProps extends React.HTMLProps<HTMLDivElement | HT
   icon?: React.ReactNode;
   /** Flag indicating the helper text item is dynamic. */
   isDynamic?: boolean;
+  /** Flag indicating the dynamic helper text should have an icon */
+  hasIcon?: boolean;
 }
 
 const variantStyle = {
@@ -32,6 +38,7 @@ export const HelperTextItem: React.FunctionComponent<HelperTextItemProps> = ({
   variant = 'default',
   icon,
   isDynamic,
+  hasIcon = true,
   ...props
 }: HelperTextItemProps) => {
   const Component = component as any;
@@ -43,6 +50,14 @@ export const HelperTextItem: React.FunctionComponent<HelperTextItemProps> = ({
       {icon && (
         <span className={css(styles.helperTextItemIcon)} aria-hidden>
           {icon}
+        </span>
+      )}
+      {isDynamic && hasIcon && !icon && (
+        <span className={css(styles.helperTextItemIcon)} aria-hidden>
+          {(variant === 'default' || variant === 'indeterminate') && <MinusIcon />}
+          {variant === 'warning' && <ExclamationTriangleIcon />}
+          {variant === 'success' && <CheckIcon />}
+          {variant === 'invalid' && <TimesIcon />}
         </span>
       )}
       <span className={css(styles.helperTextItemText)}>{children}</span>

--- a/packages/react-core/src/components/HelperText/__tests__/HelperText.test.tsx
+++ b/packages/react-core/src/components/HelperText/__tests__/HelperText.test.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+import { HelperText } from '../HelperText';
+import { HelperTextItem } from '../HelperTextItem';
+import { CheckIcon } from '@patternfly/react-icons';
+
+describe('HelperText', () => {
+  test('simple helper text renders successfully', () => {
+    const view = mount(
+      <HelperText>
+        <HelperTextItem>help test text</HelperTextItem>
+      </HelperText>
+    );
+    expect(view).toMatchSnapshot();
+  });
+
+  Object.values(['default', 'indeterminate', 'warning', 'success', 'invalid']).forEach(variant => {
+    test(`${variant} helper text variant applies successfully`, () => {
+      const view = mount(
+        <HelperTextItem variant={variant as 'default' | 'indeterminate' | 'warning' | 'success' | 'invalid'}>
+          {variant} help test text
+        </HelperTextItem>
+      );
+      expect(view).toMatchSnapshot();
+    });
+  });
+
+  test('variant comonent helper text renders properly', () => {
+    const view = mount(
+      <HelperText component="ul">
+        <HelperTextItem component="li">help test text 1</HelperTextItem>
+        <HelperTextItem component="li">help test text 2</HelperTextItem>
+      </HelperText>
+    );
+    expect(view).toMatchSnapshot();
+  });
+
+  test('icon helper text renders properly', () => {
+    const view = mount(
+      <HelperText>
+        <HelperTextItem icon={<CheckIcon />}>help test text</HelperTextItem>
+      </HelperText>
+    );
+    expect(view).toMatchSnapshot();
+  });
+
+  test('dynamic helper text renders successfully', () => {
+    const view = mount(
+      <HelperText>
+        <HelperTextItem isDynamic>help test text</HelperTextItem>
+      </HelperText>
+    );
+    expect(view).toMatchSnapshot();
+  });
+
+  test('helper text block renders successfully', () => {
+    const view = mount(
+      <HelperText>
+        <HelperTextItem>help test text 1</HelperTextItem>
+        <HelperTextItem>help test text 2</HelperTextItem>
+        <HelperTextItem>help test text 3</HelperTextItem>
+      </HelperText>
+    );
+    expect(view).toMatchSnapshot();
+  });
+});

--- a/packages/react-core/src/components/HelperText/__tests__/__snapshots__/HelperText.test.tsx.snap
+++ b/packages/react-core/src/components/HelperText/__tests__/__snapshots__/HelperText.test.tsx.snap
@@ -29,6 +29,35 @@ exports[`HelperText dynamic helper text renders successfully 1`] = `
         className="pf-c-helper-text__item pf-m-dynamic"
       >
         <span
+          aria-hidden={true}
+          className="pf-c-helper-text__item-icon"
+        >
+          <MinusIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
+          >
+            <svg
+              aria-hidden={true}
+              aria-labelledby={null}
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
+              viewBox="0 0 448 512"
+              width="1em"
+            >
+              <path
+                d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+              />
+            </svg>
+          </MinusIcon>
+        </span>
+        <span
           className="pf-c-helper-text__item-text"
         >
           help test text

--- a/packages/react-core/src/components/HelperText/__tests__/__snapshots__/HelperText.test.tsx.snap
+++ b/packages/react-core/src/components/HelperText/__tests__/__snapshots__/HelperText.test.tsx.snap
@@ -189,7 +189,7 @@ exports[`HelperText invalid helper text variant applies successfully 1`] = `
   variant="invalid"
 >
   <div
-    className="pf-c-helper-text__item pf-m-invalid"
+    className="pf-c-helper-text__item"
   >
     <span
       className="pf-c-helper-text__item-text"

--- a/packages/react-core/src/components/HelperText/__tests__/__snapshots__/HelperText.test.tsx.snap
+++ b/packages/react-core/src/components/HelperText/__tests__/__snapshots__/HelperText.test.tsx.snap
@@ -1,0 +1,264 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HelperText default helper text variant applies successfully 1`] = `
+<HelperTextItem
+  variant="default"
+>
+  <div
+    className="pf-c-helper-text__item"
+  >
+    <span
+      className="pf-c-helper-text__item-text"
+    >
+      default
+       help test text
+    </span>
+  </div>
+</HelperTextItem>
+`;
+
+exports[`HelperText dynamic helper text renders successfully 1`] = `
+<HelperText>
+  <div
+    className="pf-c-helper-text"
+  >
+    <HelperTextItem
+      isDynamic={true}
+    >
+      <div
+        className="pf-c-helper-text__item pf-m-dynamic"
+      >
+        <span
+          className="pf-c-helper-text__item-text"
+        >
+          help test text
+        </span>
+      </div>
+    </HelperTextItem>
+  </div>
+</HelperText>
+`;
+
+exports[`HelperText helper text block renders successfully 1`] = `
+<HelperText>
+  <div
+    className="pf-c-helper-text"
+  >
+    <HelperTextItem>
+      <div
+        className="pf-c-helper-text__item"
+      >
+        <span
+          className="pf-c-helper-text__item-text"
+        >
+          help test text 1
+        </span>
+      </div>
+    </HelperTextItem>
+    <HelperTextItem>
+      <div
+        className="pf-c-helper-text__item"
+      >
+        <span
+          className="pf-c-helper-text__item-text"
+        >
+          help test text 2
+        </span>
+      </div>
+    </HelperTextItem>
+    <HelperTextItem>
+      <div
+        className="pf-c-helper-text__item"
+      >
+        <span
+          className="pf-c-helper-text__item-text"
+        >
+          help test text 3
+        </span>
+      </div>
+    </HelperTextItem>
+  </div>
+</HelperText>
+`;
+
+exports[`HelperText icon helper text renders properly 1`] = `
+<HelperText>
+  <div
+    className="pf-c-helper-text"
+  >
+    <HelperTextItem
+      icon={
+        <CheckIcon
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
+        />
+      }
+    >
+      <div
+        className="pf-c-helper-text__item"
+      >
+        <span
+          aria-hidden={true}
+          className="pf-c-helper-text__item-icon"
+        >
+          <CheckIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
+          >
+            <svg
+              aria-hidden={true}
+              aria-labelledby={null}
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
+              />
+            </svg>
+          </CheckIcon>
+        </span>
+        <span
+          className="pf-c-helper-text__item-text"
+        >
+          help test text
+        </span>
+      </div>
+    </HelperTextItem>
+  </div>
+</HelperText>
+`;
+
+exports[`HelperText indeterminate helper text variant applies successfully 1`] = `
+<HelperTextItem
+  variant="indeterminate"
+>
+  <div
+    className="pf-c-helper-text__item pf-m-indeterminate"
+  >
+    <span
+      className="pf-c-helper-text__item-text"
+    >
+      indeterminate
+       help test text
+    </span>
+  </div>
+</HelperTextItem>
+`;
+
+exports[`HelperText invalid helper text variant applies successfully 1`] = `
+<HelperTextItem
+  variant="invalid"
+>
+  <div
+    className="pf-c-helper-text__item pf-m-invalid"
+  >
+    <span
+      className="pf-c-helper-text__item-text"
+    >
+      invalid
+       help test text
+    </span>
+  </div>
+</HelperTextItem>
+`;
+
+exports[`HelperText simple helper text renders successfully 1`] = `
+<HelperText>
+  <div
+    className="pf-c-helper-text"
+  >
+    <HelperTextItem>
+      <div
+        className="pf-c-helper-text__item"
+      >
+        <span
+          className="pf-c-helper-text__item-text"
+        >
+          help test text
+        </span>
+      </div>
+    </HelperTextItem>
+  </div>
+</HelperText>
+`;
+
+exports[`HelperText success helper text variant applies successfully 1`] = `
+<HelperTextItem
+  variant="success"
+>
+  <div
+    className="pf-c-helper-text__item pf-m-success"
+  >
+    <span
+      className="pf-c-helper-text__item-text"
+    >
+      success
+       help test text
+    </span>
+  </div>
+</HelperTextItem>
+`;
+
+exports[`HelperText variant comonent helper text renders properly 1`] = `
+<HelperText
+  component="ul"
+>
+  <ul
+    className="pf-c-helper-text"
+  >
+    <HelperTextItem
+      component="li"
+    >
+      <li
+        className="pf-c-helper-text__item"
+      >
+        <span
+          className="pf-c-helper-text__item-text"
+        >
+          help test text 1
+        </span>
+      </li>
+    </HelperTextItem>
+    <HelperTextItem
+      component="li"
+    >
+      <li
+        className="pf-c-helper-text__item"
+      >
+        <span
+          className="pf-c-helper-text__item-text"
+        >
+          help test text 2
+        </span>
+      </li>
+    </HelperTextItem>
+  </ul>
+</HelperText>
+`;
+
+exports[`HelperText warning helper text variant applies successfully 1`] = `
+<HelperTextItem
+  variant="warning"
+>
+  <div
+    className="pf-c-helper-text__item pf-m-warning"
+  >
+    <span
+      className="pf-c-helper-text__item-text"
+    >
+      warning
+       help test text
+    </span>
+  </div>
+</HelperTextItem>
+`;

--- a/packages/react-core/src/components/HelperText/examples/HelperText.md
+++ b/packages/react-core/src/components/HelperText/examples/HelperText.md
@@ -34,7 +34,7 @@ import { HelperText, HelperTextItem } from '@patternfly/react-core';
     <HelperTextItem variant="success">This is success helper text</HelperTextItem>
   </HelperText>
   <HelperText>
-    <HelperTextItem variant="invalid">This is invalid helper text</HelperTextItem>
+    <HelperTextItem variant="error">This is error helper text</HelperTextItem>
   </HelperText>
 </React.Fragment>;
 ```
@@ -70,8 +70,8 @@ import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclama
     </HelperTextItem>
   </HelperText>
   <HelperText>
-    <HelperTextItem variant="invalid" icon={<ExclamationCircleIcon />}>
-      This is invalid helper text
+    <HelperTextItem variant="error" icon={<ExclamationCircleIcon />}>
+      This is error helper text
     </HelperTextItem>
   </HelperText>
 </React.Fragment>;
@@ -117,18 +117,18 @@ import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclama
     </HelperTextItem>
   </HelperText>
   <HelperText>
-    <HelperTextItem isDynamic variant="invalid">
-      This is invalid helper text
+    <HelperTextItem isDynamic variant="error">
+      This is error helper text
     </HelperTextItem>
   </HelperText>
   <HelperText>
-    <HelperTextItem isDynamic variant="invalid" icon={<ExclamationCircleIcon />}>
-      This is invalid helper text with a custom icon
+    <HelperTextItem isDynamic variant="error" icon={<ExclamationCircleIcon />}>
+      This is error helper text with a custom icon
     </HelperTextItem>
   </HelperText>
   <HelperText>
-    <HelperTextItem isDynamic variant="invalid" hasIcon={false}>
-      This is invalid helper text with no icon
+    <HelperTextItem isDynamic variant="error" hasIcon={false}>
+      This is error helper text with no icon
     </HelperTextItem>
   </HelperText>
 </React.Fragment>;
@@ -144,7 +144,7 @@ import { HelperText, HelperTextItem } from '@patternfly/react-core';
   <HelperTextItem isDynamic variant="success" component="li">
     Must be at least 14 characters
   </HelperTextItem>
-  <HelperTextItem isDynamic variant="invalid" component="li">
+  <HelperTextItem isDynamic variant="error" component="li">
     Cannot contain any variation of the word "redhat"
   </HelperTextItem>
   <HelperTextItem isDynamic variant="success" component="li">

--- a/packages/react-core/src/components/HelperText/examples/HelperText.md
+++ b/packages/react-core/src/components/HelperText/examples/HelperText.md
@@ -11,9 +11,6 @@ import QuestionIcon from '@patternfly/react-icons/dist/js/icons/question-icon';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
-import MinusIcon from '@patternfly/react-icons/dist/js/icons/minus-icon';
-import CheckIcon from '@patternfly/react-icons/dist/js/icons/check-icon';
-import TimesIcon from '@patternfly/react-icons/dist/js/icons/times-icon';
 
 ## Examples
 
@@ -98,35 +95,40 @@ import { HelperText, HelperTextItem } from '@patternfly/react-core';
 ```js
 import React from 'react';
 import { HelperText, HelperTextItem } from '@patternfly/react-core';
-import MinusIcon from '@patternfly/react-icons/dist/js/icons/minus-icon';
-import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
-import CheckIcon from '@patternfly/react-icons/dist/js/icons/check-icon';
-import TimesIcon from '@patternfly/react-icons/dist/js/icons/times-icon';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
 
 <React.Fragment>
   <HelperText>
-    <HelperTextItem isDynamic icon={<MinusIcon />}>
-      This is default helper text
-    </HelperTextItem>
+    <HelperTextItem isDynamic>This is default helper text</HelperTextItem>
   </HelperText>
   <HelperText>
-    <HelperTextItem isDynamic variant="indeterminate" icon={<MinusIcon />}>
+    <HelperTextItem isDynamic variant="indeterminate">
       This is indeterminate helper text
     </HelperTextItem>
   </HelperText>
   <HelperText>
-    <HelperTextItem isDynamic variant="warning" icon={<ExclamationTriangleIcon />}>
+    <HelperTextItem isDynamic variant="warning">
       This is warning helper text
     </HelperTextItem>
   </HelperText>
   <HelperText>
-    <HelperTextItem isDynamic variant="success" icon={<CheckIcon />}>
+    <HelperTextItem isDynamic variant="success">
       This is success helper text
     </HelperTextItem>
   </HelperText>
   <HelperText>
-    <HelperTextItem isDynamic variant="invalid" icon={<TimesIcon />}>
+    <HelperTextItem isDynamic variant="invalid">
       This is invalid helper text
+    </HelperTextItem>
+  </HelperText>
+  <HelperText>
+    <HelperTextItem isDynamic variant="invalid" icon={<ExclamationCircleIcon />}>
+      This is invalid helper text with a custom icon
+    </HelperTextItem>
+  </HelperText>
+  <HelperText>
+    <HelperTextItem isDynamic variant="invalid" hasIcon={false}>
+      This is invalid helper text with no icon
     </HelperTextItem>
   </HelperText>
 </React.Fragment>;
@@ -137,17 +139,15 @@ import TimesIcon from '@patternfly/react-icons/dist/js/icons/times-icon';
 ```js
 import React from 'react';
 import { HelperText, HelperTextItem } from '@patternfly/react-core';
-import CheckIcon from '@patternfly/react-icons/dist/js/icons/check-icon';
-import TimesIcon from '@patternfly/react-icons/dist/js/icons/times-icon';
 
 <HelperText component="ul">
-  <HelperTextItem isDynamic variant="success" component="li" icon={<CheckIcon />}>
+  <HelperTextItem isDynamic variant="success" component="li">
     Must be at least 14 characters
   </HelperTextItem>
-  <HelperTextItem isDynamic variant="invalid" component="li" icon={<TimesIcon />}>
+  <HelperTextItem isDynamic variant="invalid" component="li">
     Cannot contain any variation of the word "redhat"
   </HelperTextItem>
-  <HelperTextItem isDynamic variant="success" component="li" icon={<CheckIcon />}>
+  <HelperTextItem isDynamic variant="success" component="li">
     Must include at least 3 of the following: lowercase letter, uppercase letters, numbers, symbols
   </HelperTextItem>
 </HelperText>;

--- a/packages/react-core/src/components/HelperText/examples/HelperText.md
+++ b/packages/react-core/src/components/HelperText/examples/HelperText.md
@@ -39,7 +39,45 @@ import { HelperText, HelperTextItem } from '@patternfly/react-core';
 </React.Fragment>;
 ```
 
-### Icon
+### Static with default icons
+
+```js
+import React from 'react';
+import { HelperText, HelperTextItem } from '@patternfly/react-core';
+import InfoIcon from '@patternfly/react-icons/dist/js/icons/info-icon';
+import QuestionIcon from '@patternfly/react-icons/dist/js/icons/question-icon';
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
+import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
+
+<React.Fragment>
+  <HelperText>
+    <HelperTextItem hasIcon>This is default helper text</HelperTextItem>
+  </HelperText>
+  <HelperText>
+    <HelperTextItem variant="indeterminate" hasIcon>
+      This is indeterminate helper text
+    </HelperTextItem>
+  </HelperText>
+  <HelperText>
+    <HelperTextItem variant="warning" hasIcon>
+      This is warning helper text
+    </HelperTextItem>
+  </HelperText>
+  <HelperText>
+    <HelperTextItem variant="success" hasIcon>
+      This is success helper text
+    </HelperTextItem>
+  </HelperText>
+  <HelperText>
+    <HelperTextItem variant="error" hasIcon>
+      This is error helper text
+    </HelperTextItem>
+  </HelperText>
+</React.Fragment>;
+```
+
+### Static with custom icons
 
 ```js
 import React from 'react';

--- a/packages/react-core/src/components/HelperText/examples/HelperText.md
+++ b/packages/react-core/src/components/HelperText/examples/HelperText.md
@@ -1,0 +1,154 @@
+---
+id: Helper text
+section: components
+cssPrefix: pf-c-helper-text
+propComponents: ['HelperText', 'HelperTextItem']
+beta: true
+---
+
+import InfoIcon from '@patternfly/react-icons/dist/js/icons/info-icon';
+import QuestionIcon from '@patternfly/react-icons/dist/js/icons/question-icon';
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
+import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
+import MinusIcon from '@patternfly/react-icons/dist/js/icons/minus-icon';
+import CheckIcon from '@patternfly/react-icons/dist/js/icons/check-icon';
+import TimesIcon from '@patternfly/react-icons/dist/js/icons/times-icon';
+
+## Examples
+
+### Static
+
+```js
+import React from 'react';
+import { HelperText, HelperTextItem } from '@patternfly/react-core';
+
+<React.Fragment>
+  <HelperText>
+    <HelperTextItem>This is default helper text</HelperTextItem>
+  </HelperText>
+  <HelperText>
+    <HelperTextItem variant="indeterminate">This is indeterminate helper text</HelperTextItem>
+  </HelperText>
+  <HelperText>
+    <HelperTextItem variant="warning">This is warning helper text</HelperTextItem>
+  </HelperText>
+  <HelperText>
+    <HelperTextItem variant="success">This is success helper text</HelperTextItem>
+  </HelperText>
+  <HelperText>
+    <HelperTextItem variant="invalid">This is invalid helper text</HelperTextItem>
+  </HelperText>
+</React.Fragment>;
+```
+
+### Icon
+
+```js
+import React from 'react';
+import { HelperText, HelperTextItem } from '@patternfly/react-core';
+import InfoIcon from '@patternfly/react-icons/dist/js/icons/info-icon';
+import QuestionIcon from '@patternfly/react-icons/dist/js/icons/question-icon';
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
+import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
+
+<React.Fragment>
+  <HelperText>
+    <HelperTextItem icon={<InfoIcon />}>This is default helper text</HelperTextItem>
+  </HelperText>
+  <HelperText>
+    <HelperTextItem variant="indeterminate" icon={<QuestionIcon />}>
+      This is indeterminate helper text
+    </HelperTextItem>
+  </HelperText>
+  <HelperText>
+    <HelperTextItem variant="warning" icon={<ExclamationTriangleIcon />}>
+      This is warning helper text
+    </HelperTextItem>
+  </HelperText>
+  <HelperText>
+    <HelperTextItem variant="success" icon={<CheckCircleIcon />}>
+      This is success helper text
+    </HelperTextItem>
+  </HelperText>
+  <HelperText>
+    <HelperTextItem variant="invalid" icon={<ExclamationCircleIcon />}>
+      This is invalid helper text
+    </HelperTextItem>
+  </HelperText>
+</React.Fragment>;
+```
+
+### Multiple static
+
+```js
+import React from 'react';
+import { HelperText, HelperTextItem } from '@patternfly/react-core';
+
+<HelperText>
+  <HelperTextItem>This is default helper text</HelperTextItem>
+  <HelperTextItem>This is another default helper text in the same block</HelperTextItem>
+  <HelperTextItem>And this is more default text in the same block</HelperTextItem>
+</HelperText>;
+```
+
+### Dynamic
+
+```js
+import React from 'react';
+import { HelperText, HelperTextItem } from '@patternfly/react-core';
+import MinusIcon from '@patternfly/react-icons/dist/js/icons/minus-icon';
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
+import CheckIcon from '@patternfly/react-icons/dist/js/icons/check-icon';
+import TimesIcon from '@patternfly/react-icons/dist/js/icons/times-icon';
+
+<React.Fragment>
+  <HelperText>
+    <HelperTextItem isDynamic icon={<MinusIcon />}>
+      This is default helper text
+    </HelperTextItem>
+  </HelperText>
+  <HelperText>
+    <HelperTextItem isDynamic variant="indeterminate" icon={<MinusIcon />}>
+      This is indeterminate helper text
+    </HelperTextItem>
+  </HelperText>
+  <HelperText>
+    <HelperTextItem isDynamic variant="warning" icon={<ExclamationTriangleIcon />}>
+      This is warning helper text
+    </HelperTextItem>
+  </HelperText>
+  <HelperText>
+    <HelperTextItem isDynamic variant="success" icon={<CheckIcon />}>
+      This is success helper text
+    </HelperTextItem>
+  </HelperText>
+  <HelperText>
+    <HelperTextItem isDynamic variant="invalid" icon={<TimesIcon />}>
+      This is invalid helper text
+    </HelperTextItem>
+  </HelperText>
+</React.Fragment>;
+```
+
+### Dynamic list
+
+```js
+import React from 'react';
+import { HelperText, HelperTextItem } from '@patternfly/react-core';
+import CheckIcon from '@patternfly/react-icons/dist/js/icons/check-icon';
+import TimesIcon from '@patternfly/react-icons/dist/js/icons/times-icon';
+
+<HelperText component="ul">
+  <HelperTextItem isDynamic variant="success" component="li" icon={<CheckIcon />}>
+    Must be at least 14 characters
+  </HelperTextItem>
+  <HelperTextItem isDynamic variant="invalid" component="li" icon={<TimesIcon />}>
+    Cannot contain any variation of the word "redhat"
+  </HelperTextItem>
+  <HelperTextItem isDynamic variant="success" component="li" icon={<CheckIcon />}>
+    Must include at least 3 of the following: lowercase letter, uppercase letters, numbers, symbols
+  </HelperTextItem>
+</HelperText>;
+```

--- a/packages/react-core/src/components/HelperText/index.ts
+++ b/packages/react-core/src/components/HelperText/index.ts
@@ -1,0 +1,2 @@
+export * from './HelperText';
+export * from './HelperTextItem';

--- a/packages/react-core/src/components/index.ts
+++ b/packages/react-core/src/components/index.ts
@@ -32,6 +32,7 @@ export * from './ExpandableSection';
 export * from './FileUpload';
 export * from './Form';
 export * from './FormSelect';
+export * from './HelperText';
 export * from './Hint';
 export * from './InputGroup';
 export * from './JumpLinks';

--- a/packages/react-integration/cypress/integration/helpertext.spec.ts
+++ b/packages/react-integration/cypress/integration/helpertext.spec.ts
@@ -11,7 +11,7 @@ describe('Hint Demo Test', () => {
     cy.get(`#default .pf-c-helper-text__item-icon`).should('exist');
   });
 
-  ['indeterminate', 'warning', 'success', 'invalid'].forEach(variant => {
+  ['indeterminate', 'warning', 'success', 'error'].forEach(variant => {
     it(`Verify ${variant} helper text`, () => {
       cy.get(`#${variant}.pf-m-${variant}`).should('exist');
       cy.get(`#${variant} .pf-c-helper-text__item-text`).should('exist');
@@ -28,5 +28,6 @@ describe('Hint Demo Test', () => {
     cy.get('li.pf-c-helper-text__item')
       .first()
       .should('have.id', 'list1');
+    cy.get('#list1 .pf-c-helper-text__item-icon').should('not.exist');
   });
 });

--- a/packages/react-integration/cypress/integration/helpertext.spec.ts
+++ b/packages/react-integration/cypress/integration/helpertext.spec.ts
@@ -18,4 +18,15 @@ describe('Hint Demo Test', () => {
       cy.get(`#${variant} .pf-c-helper-text__item-icon`).should('exist');
     });
   });
+
+  it('Verify dynamic helper text', () => {
+    cy.get('#success.pf-m-dynamic').should('exist');
+  });
+
+  it('Verify alternate component helper text', () => {
+    cy.get('ul.pf-c-helper-text').should('have.id', 'list-container');
+    cy.get('li.pf-c-helper-text__item')
+      .first()
+      .should('have.id', 'list1');
+  });
 });

--- a/packages/react-integration/cypress/integration/helpertext.spec.ts
+++ b/packages/react-integration/cypress/integration/helpertext.spec.ts
@@ -1,0 +1,21 @@
+describe('Hint Demo Test', () => {
+  it('Navigate to demo section', () => {
+    cy.visit('http://localhost:3000/');
+    cy.get('#helper-text-demo-nav-item-link').click();
+    cy.url().should('eq', 'http://localhost:3000/helper-text-demo-nav-link');
+  });
+
+  it('Verify default helper text', () => {
+    cy.get('#default-container.pf-c-helper-text').should('exist');
+    cy.get('#default .pf-c-helper-text__item-text').should('exist');
+    cy.get(`#default .pf-c-helper-text__item-icon`).should('exist');
+  });
+
+  ['indeterminate', 'warning', 'success', 'invalid'].forEach(variant => {
+    it(`Verify ${variant} helper text`, () => {
+      cy.get(`#${variant}.pf-m-${variant}`).should('exist');
+      cy.get(`#${variant} .pf-c-helper-text__item-text`).should('exist');
+      cy.get(`#${variant} .pf-c-helper-text__item-icon`).should('exist');
+    });
+  });
+});

--- a/packages/react-integration/demo-app-ts/src/Demos.ts
+++ b/packages/react-integration/demo-app-ts/src/Demos.ts
@@ -422,6 +422,11 @@ export const Demos: DemoInterface[] = [
     componentType: Examples.GridDemo
   },
   {
+    id: 'helper-text-demo',
+    name: 'Helper Text Demo',
+    componentType: Examples.HelperTextDemo
+  },
+  {
     id: 'hint-demo',
     name: 'Hint Demo',
     componentType: Examples.HintDemo

--- a/packages/react-integration/demo-app-ts/src/components/demos/HelperText/HelperTextDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/HelperText/HelperTextDemo.tsx
@@ -1,0 +1,43 @@
+import { HelperText, HelperTextItem } from '@patternfly/react-core';
+import React from 'react';
+import InfoIcon from '@patternfly/react-icons/dist/js/icons/info-icon';
+import QuestionIcon from '@patternfly/react-icons/dist/js/icons/question-icon';
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
+import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
+
+export class HelperTextDemo extends React.Component {
+  static displayName = 'HelperTextDemo';
+
+  componentDidMount() {
+    window.scrollTo(0, 0);
+  }
+
+  render() {
+    return (
+      <React.Fragment>
+        <HelperText id="default-container">
+          <HelperTextItem id="default" icon={<InfoIcon />}>
+            This is default helper text
+          </HelperTextItem>
+        </HelperText>
+        <HelperText>
+          <HelperTextItem id="warning" variant="warning" icon={<ExclamationTriangleIcon />}>
+            This is warning helper text
+          </HelperTextItem>
+        </HelperText>
+        <HelperText>
+          <HelperTextItem id="success" isDynamic variant="success" icon={<CheckCircleIcon />}>
+            This is success helper text
+          </HelperTextItem>
+          <HelperTextItem id="invalid" isDynamic variant="invalid" icon={<ExclamationCircleIcon />}>
+            This is invalid helper text
+          </HelperTextItem>
+          <HelperTextItem id="indeterminate" isDynamic variant="indeterminate" icon={<QuestionIcon />}>
+            This is indeterminate helper text
+          </HelperTextItem>
+        </HelperText>
+      </React.Fragment>
+    );
+  }
+}

--- a/packages/react-integration/demo-app-ts/src/components/demos/HelperText/HelperTextDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/HelperText/HelperTextDemo.tsx
@@ -30,8 +30,8 @@ export class HelperTextDemo extends React.Component {
           <HelperTextItem id="success" isDynamic variant="success" icon={<CheckCircleIcon />}>
             This is success helper text
           </HelperTextItem>
-          <HelperTextItem id="invalid" isDynamic variant="invalid" icon={<ExclamationCircleIcon />}>
-            This is invalid helper text
+          <HelperTextItem id="invalid" isDynamic variant="error" icon={<ExclamationCircleIcon />}>
+            This is error helper text
           </HelperTextItem>
           <HelperTextItem id="indeterminate" isDynamic variant="indeterminate" icon={<QuestionIcon />}>
             This is indeterminate helper text
@@ -41,7 +41,7 @@ export class HelperTextDemo extends React.Component {
           <HelperTextItem id="list1" isDynamic variant="success" component="li" icon={<CheckCircleIcon />}>
             This is a list item
           </HelperTextItem>
-          <HelperTextItem id="list2" isDynamic variant="invalid" component="li" icon={<ExclamationCircleIcon />}>
+          <HelperTextItem id="list2" isDynamic variant="error" component="li" icon={<ExclamationCircleIcon />}>
             This is a list item
           </HelperTextItem>
           <HelperTextItem id="list3" isDynamic variant="indeterminate" component="li" icon={<QuestionIcon />}>

--- a/packages/react-integration/demo-app-ts/src/components/demos/HelperText/HelperTextDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/HelperText/HelperTextDemo.tsx
@@ -37,6 +37,17 @@ export class HelperTextDemo extends React.Component {
             This is indeterminate helper text
           </HelperTextItem>
         </HelperText>
+        <HelperText id="list-container" component="ul">
+          <HelperTextItem id="list1" isDynamic variant="success" component="li" icon={<CheckCircleIcon />}>
+            This is a list item
+          </HelperTextItem>
+          <HelperTextItem id="list2" isDynamic variant="invalid" component="li" icon={<ExclamationCircleIcon />}>
+            This is a list item
+          </HelperTextItem>
+          <HelperTextItem id="list3" isDynamic variant="indeterminate" component="li" icon={<QuestionIcon />}>
+            This is a list item
+          </HelperTextItem>
+        </HelperText>
       </React.Fragment>
     );
   }

--- a/packages/react-integration/demo-app-ts/src/components/demos/HelperText/HelperTextDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/HelperText/HelperTextDemo.tsx
@@ -1,10 +1,8 @@
 import { HelperText, HelperTextItem } from '@patternfly/react-core';
 import React from 'react';
 import InfoIcon from '@patternfly/react-icons/dist/js/icons/info-icon';
-import QuestionIcon from '@patternfly/react-icons/dist/js/icons/question-icon';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
-import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
 
 export class HelperTextDemo extends React.Component {
   static displayName = 'HelperTextDemo';
@@ -30,21 +28,21 @@ export class HelperTextDemo extends React.Component {
           <HelperTextItem id="success" isDynamic variant="success" icon={<CheckCircleIcon />}>
             This is success helper text
           </HelperTextItem>
-          <HelperTextItem id="invalid" isDynamic variant="error" icon={<ExclamationCircleIcon />}>
+          <HelperTextItem id="error" isDynamic variant="error">
             This is error helper text
           </HelperTextItem>
-          <HelperTextItem id="indeterminate" isDynamic variant="indeterminate" icon={<QuestionIcon />}>
+          <HelperTextItem id="indeterminate" isDynamic variant="indeterminate">
             This is indeterminate helper text
           </HelperTextItem>
         </HelperText>
         <HelperText id="list-container" component="ul">
-          <HelperTextItem id="list1" isDynamic variant="success" component="li" icon={<CheckCircleIcon />}>
+          <HelperTextItem id="list1" isDynamic variant="success" component="li" hasIcon={false}>
             This is a list item
           </HelperTextItem>
-          <HelperTextItem id="list2" isDynamic variant="error" component="li" icon={<ExclamationCircleIcon />}>
+          <HelperTextItem id="list2" isDynamic variant="error" component="li">
             This is a list item
           </HelperTextItem>
-          <HelperTextItem id="list3" isDynamic variant="indeterminate" component="li" icon={<QuestionIcon />}>
+          <HelperTextItem id="list3" isDynamic variant="indeterminate" component="li">
             This is a list item
           </HelperTextItem>
         </HelperText>

--- a/packages/react-integration/demo-app-ts/src/components/demos/index.ts
+++ b/packages/react-integration/demo-app-ts/src/components/demos/index.ts
@@ -83,6 +83,7 @@ export * from './FormDemo/FormFieldGroupDemo';
 export * from './FormSelectDemo/FormSelectDemo';
 export * from './GalleryDemo/GalleryDemo';
 export * from './GridDemo/GridDemo';
+export * from './HelperText/HelperTextDemo';
 export * from './HintDemo/HintDemo';
 export * from './InputGroupDemo/InputGroupDemo';
 export * from './LabelDemo/LabelDemo';


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5818

Users should be able to update individual HelperTextItem properties (like `variant`) to reflect a validation update. Perhaps a more detailed demo showcasing a validated input field with a HelperText list would be a good follow up?
