### PR TITLE
feat(DualListSelector): add tooltips to control buttons

### DIFF
--- a/packages/react-console/src/components/DesktopViewer/__tests__/__snapshots__/DesktopViewer.test.tsx.snap
+++ b/packages/react-console/src/components/DesktopViewer/__tests__/__snapshots__/DesktopViewer.test.tsx.snap
@@ -1119,20 +1119,27 @@ exports[`DesktopViewer with custom more-info content 1`] = `
             isDisabled={false}
             onClick={[Function]}
           >
-            <button
-              aria-disabled={false}
-              aria-label={null}
-              className="pf-c-button pf-m-primary pf-c-console__remote-viewer-launch-vv"
-              data-ouia-component-id="OUIA-Generated-Button-primary-10"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={false}
+            <ButtonBase
+              className="pf-c-console__remote-viewer-launch-vv"
+              innerRef={null}
+              isDisabled={false}
               onClick={[Function]}
-              role={null}
-              type="button"
             >
-              Launch Remote Viewer
-            </button>
+              <button
+                aria-disabled={false}
+                aria-label={null}
+                className="pf-c-button pf-m-primary pf-c-console__remote-viewer-launch-vv"
+                data-ouia-component-id="OUIA-Generated-Button-primary-10"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={false}
+                onClick={[Function]}
+                role={null}
+                type="button"
+              >
+                Launch Remote Viewer
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <ExpandableSection

--- a/packages/react-core/src/components/Alert/__tests__/__snapshots__/Alert.test.tsx.snap
+++ b/packages/react-core/src/components/Alert/__tests__/__snapshots__/Alert.test.tsx.snap
@@ -74,43 +74,50 @@ exports[`Alert - danger Action Close Button 1`] = `
           onClick={[MockFunction]}
           variant="plain"
         >
-          <button
-            aria-disabled={false}
+          <ButtonBase
             aria-label="Close"
-            className="pf-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Button-plain-2"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={false}
+            innerRef={null}
             onClick={[MockFunction]}
-            role={null}
-            type="button"
+            variant="plain"
           >
-            <TimesIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <button
+              aria-disabled={false}
+              aria-label="Close"
+              className="pf-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-2"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              onClick={[MockFunction]}
+              role={null}
+              type="button"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 352 512"
-                width="1em"
+              <TimesIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                />
-              </svg>
-            </TimesIcon>
-          </button>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  />
+                </svg>
+              </TimesIcon>
+            </button>
+          </ButtonBase>
         </Button>
       </AlertActionCloseButton>
     </div>
@@ -201,19 +208,26 @@ exports[`Alert - danger Action Link 1`] = `
           isInline={true}
           variant="link"
         >
-          <button
-            aria-disabled={false}
-            aria-label={null}
-            className="pf-c-button pf-m-link pf-m-inline"
-            data-ouia-component-id="OUIA-Generated-Button-link-4"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={false}
-            role={null}
-            type="button"
+          <ButtonBase
+            className=""
+            innerRef={null}
+            isInline={true}
+            variant="link"
           >
-            test
-          </button>
+            <button
+              aria-disabled={false}
+              aria-label={null}
+              className="pf-c-button pf-m-link pf-m-inline"
+              data-ouia-component-id="OUIA-Generated-Button-link-4"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              role={null}
+              type="button"
+            >
+              test
+            </button>
+          </ButtonBase>
         </Button>
       </AlertActionLink>
     </div>
@@ -300,19 +314,26 @@ exports[`Alert - danger Action and Title 1`] = `
           isInline={true}
           variant="link"
         >
-          <button
-            aria-disabled={false}
-            aria-label={null}
-            className="pf-c-button pf-m-link pf-m-inline"
-            data-ouia-component-id="OUIA-Generated-Button-link-5"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={false}
-            role={null}
-            type="button"
+          <ButtonBase
+            className=""
+            innerRef={null}
+            isInline={true}
+            variant="link"
           >
-            test
-          </button>
+            <button
+              aria-disabled={false}
+              aria-label={null}
+              className="pf-c-button pf-m-link pf-m-inline"
+              data-ouia-component-id="OUIA-Generated-Button-link-5"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              role={null}
+              type="button"
+            >
+              test
+            </button>
+          </ButtonBase>
         </Button>
       </AlertActionLink>
     </div>
@@ -400,19 +421,26 @@ exports[`Alert - danger Custom aria label 1`] = `
           isInline={true}
           variant="link"
         >
-          <button
-            aria-disabled={false}
-            aria-label={null}
-            className="pf-c-button pf-m-link pf-m-inline"
-            data-ouia-component-id="OUIA-Generated-Button-link-6"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={false}
-            role={null}
-            type="button"
+          <ButtonBase
+            className=""
+            innerRef={null}
+            isInline={true}
+            variant="link"
           >
-            test
-          </button>
+            <button
+              aria-disabled={false}
+              aria-label={null}
+              className="pf-c-button pf-m-link pf-m-inline"
+              data-ouia-component-id="OUIA-Generated-Button-link-6"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              role={null}
+              type="button"
+            >
+              test
+            </button>
+          </ButtonBase>
         </Button>
       </AlertActionLink>
     </div>
@@ -838,43 +866,50 @@ exports[`Alert - default Action Close Button 1`] = `
           onClick={[MockFunction]}
           variant="plain"
         >
-          <button
-            aria-disabled={false}
+          <ButtonBase
             aria-label="Close"
-            className="pf-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Button-plain-5"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={false}
+            innerRef={null}
             onClick={[MockFunction]}
-            role={null}
-            type="button"
+            variant="plain"
           >
-            <TimesIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <button
+              aria-disabled={false}
+              aria-label="Close"
+              className="pf-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-5"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              onClick={[MockFunction]}
+              role={null}
+              type="button"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 352 512"
-                width="1em"
+              <TimesIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                />
-              </svg>
-            </TimesIcon>
-          </button>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  />
+                </svg>
+              </TimesIcon>
+            </button>
+          </ButtonBase>
         </Button>
       </AlertActionCloseButton>
     </div>
@@ -965,19 +1000,26 @@ exports[`Alert - default Action Link 1`] = `
           isInline={true}
           variant="link"
         >
-          <button
-            aria-disabled={false}
-            aria-label={null}
-            className="pf-c-button pf-m-link pf-m-inline"
-            data-ouia-component-id="OUIA-Generated-Button-link-13"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={false}
-            role={null}
-            type="button"
+          <ButtonBase
+            className=""
+            innerRef={null}
+            isInline={true}
+            variant="link"
           >
-            test
-          </button>
+            <button
+              aria-disabled={false}
+              aria-label={null}
+              className="pf-c-button pf-m-link pf-m-inline"
+              data-ouia-component-id="OUIA-Generated-Button-link-13"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              role={null}
+              type="button"
+            >
+              test
+            </button>
+          </ButtonBase>
         </Button>
       </AlertActionLink>
     </div>
@@ -1064,19 +1106,26 @@ exports[`Alert - default Action and Title 1`] = `
           isInline={true}
           variant="link"
         >
-          <button
-            aria-disabled={false}
-            aria-label={null}
-            className="pf-c-button pf-m-link pf-m-inline"
-            data-ouia-component-id="OUIA-Generated-Button-link-14"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={false}
-            role={null}
-            type="button"
+          <ButtonBase
+            className=""
+            innerRef={null}
+            isInline={true}
+            variant="link"
           >
-            test
-          </button>
+            <button
+              aria-disabled={false}
+              aria-label={null}
+              className="pf-c-button pf-m-link pf-m-inline"
+              data-ouia-component-id="OUIA-Generated-Button-link-14"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              role={null}
+              type="button"
+            >
+              test
+            </button>
+          </ButtonBase>
         </Button>
       </AlertActionLink>
     </div>
@@ -1164,19 +1213,26 @@ exports[`Alert - default Custom aria label 1`] = `
           isInline={true}
           variant="link"
         >
-          <button
-            aria-disabled={false}
-            aria-label={null}
-            className="pf-c-button pf-m-link pf-m-inline"
-            data-ouia-component-id="OUIA-Generated-Button-link-15"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={false}
-            role={null}
-            type="button"
+          <ButtonBase
+            className=""
+            innerRef={null}
+            isInline={true}
+            variant="link"
           >
-            test
-          </button>
+            <button
+              aria-disabled={false}
+              aria-label={null}
+              className="pf-c-button pf-m-link pf-m-inline"
+              data-ouia-component-id="OUIA-Generated-Button-link-15"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              role={null}
+              type="button"
+            >
+              test
+            </button>
+          </ButtonBase>
         </Button>
       </AlertActionLink>
     </div>
@@ -1602,43 +1658,50 @@ exports[`Alert - info Action Close Button 1`] = `
           onClick={[MockFunction]}
           variant="plain"
         >
-          <button
-            aria-disabled={false}
+          <ButtonBase
             aria-label="Close"
-            className="pf-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Button-plain-4"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={false}
+            innerRef={null}
             onClick={[MockFunction]}
-            role={null}
-            type="button"
+            variant="plain"
           >
-            <TimesIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <button
+              aria-disabled={false}
+              aria-label="Close"
+              className="pf-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-4"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              onClick={[MockFunction]}
+              role={null}
+              type="button"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 352 512"
-                width="1em"
+              <TimesIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                />
-              </svg>
-            </TimesIcon>
-          </button>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  />
+                </svg>
+              </TimesIcon>
+            </button>
+          </ButtonBase>
         </Button>
       </AlertActionCloseButton>
     </div>
@@ -1729,19 +1792,26 @@ exports[`Alert - info Action Link 1`] = `
           isInline={true}
           variant="link"
         >
-          <button
-            aria-disabled={false}
-            aria-label={null}
-            className="pf-c-button pf-m-link pf-m-inline"
-            data-ouia-component-id="OUIA-Generated-Button-link-10"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={false}
-            role={null}
-            type="button"
+          <ButtonBase
+            className=""
+            innerRef={null}
+            isInline={true}
+            variant="link"
           >
-            test
-          </button>
+            <button
+              aria-disabled={false}
+              aria-label={null}
+              className="pf-c-button pf-m-link pf-m-inline"
+              data-ouia-component-id="OUIA-Generated-Button-link-10"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              role={null}
+              type="button"
+            >
+              test
+            </button>
+          </ButtonBase>
         </Button>
       </AlertActionLink>
     </div>
@@ -1828,19 +1898,26 @@ exports[`Alert - info Action and Title 1`] = `
           isInline={true}
           variant="link"
         >
-          <button
-            aria-disabled={false}
-            aria-label={null}
-            className="pf-c-button pf-m-link pf-m-inline"
-            data-ouia-component-id="OUIA-Generated-Button-link-11"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={false}
-            role={null}
-            type="button"
+          <ButtonBase
+            className=""
+            innerRef={null}
+            isInline={true}
+            variant="link"
           >
-            test
-          </button>
+            <button
+              aria-disabled={false}
+              aria-label={null}
+              className="pf-c-button pf-m-link pf-m-inline"
+              data-ouia-component-id="OUIA-Generated-Button-link-11"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              role={null}
+              type="button"
+            >
+              test
+            </button>
+          </ButtonBase>
         </Button>
       </AlertActionLink>
     </div>
@@ -1928,19 +2005,26 @@ exports[`Alert - info Custom aria label 1`] = `
           isInline={true}
           variant="link"
         >
-          <button
-            aria-disabled={false}
-            aria-label={null}
-            className="pf-c-button pf-m-link pf-m-inline"
-            data-ouia-component-id="OUIA-Generated-Button-link-12"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={false}
-            role={null}
-            type="button"
+          <ButtonBase
+            className=""
+            innerRef={null}
+            isInline={true}
+            variant="link"
           >
-            test
-          </button>
+            <button
+              aria-disabled={false}
+              aria-label={null}
+              className="pf-c-button pf-m-link pf-m-inline"
+              data-ouia-component-id="OUIA-Generated-Button-link-12"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              role={null}
+              type="button"
+            >
+              test
+            </button>
+          </ButtonBase>
         </Button>
       </AlertActionLink>
     </div>
@@ -2366,43 +2450,50 @@ exports[`Alert - success Action Close Button 1`] = `
           onClick={[MockFunction]}
           variant="plain"
         >
-          <button
-            aria-disabled={false}
+          <ButtonBase
             aria-label="Close"
-            className="pf-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Button-plain-1"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={false}
+            innerRef={null}
             onClick={[MockFunction]}
-            role={null}
-            type="button"
+            variant="plain"
           >
-            <TimesIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <button
+              aria-disabled={false}
+              aria-label="Close"
+              className="pf-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-1"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              onClick={[MockFunction]}
+              role={null}
+              type="button"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 352 512"
-                width="1em"
+              <TimesIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                />
-              </svg>
-            </TimesIcon>
-          </button>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  />
+                </svg>
+              </TimesIcon>
+            </button>
+          </ButtonBase>
         </Button>
       </AlertActionCloseButton>
     </div>
@@ -2493,19 +2584,26 @@ exports[`Alert - success Action Link 1`] = `
           isInline={true}
           variant="link"
         >
-          <button
-            aria-disabled={false}
-            aria-label={null}
-            className="pf-c-button pf-m-link pf-m-inline"
-            data-ouia-component-id="OUIA-Generated-Button-link-1"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={false}
-            role={null}
-            type="button"
+          <ButtonBase
+            className=""
+            innerRef={null}
+            isInline={true}
+            variant="link"
           >
-            test
-          </button>
+            <button
+              aria-disabled={false}
+              aria-label={null}
+              className="pf-c-button pf-m-link pf-m-inline"
+              data-ouia-component-id="OUIA-Generated-Button-link-1"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              role={null}
+              type="button"
+            >
+              test
+            </button>
+          </ButtonBase>
         </Button>
       </AlertActionLink>
     </div>
@@ -2592,19 +2690,26 @@ exports[`Alert - success Action and Title 1`] = `
           isInline={true}
           variant="link"
         >
-          <button
-            aria-disabled={false}
-            aria-label={null}
-            className="pf-c-button pf-m-link pf-m-inline"
-            data-ouia-component-id="OUIA-Generated-Button-link-2"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={false}
-            role={null}
-            type="button"
+          <ButtonBase
+            className=""
+            innerRef={null}
+            isInline={true}
+            variant="link"
           >
-            test
-          </button>
+            <button
+              aria-disabled={false}
+              aria-label={null}
+              className="pf-c-button pf-m-link pf-m-inline"
+              data-ouia-component-id="OUIA-Generated-Button-link-2"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              role={null}
+              type="button"
+            >
+              test
+            </button>
+          </ButtonBase>
         </Button>
       </AlertActionLink>
     </div>
@@ -2692,19 +2797,26 @@ exports[`Alert - success Custom aria label 1`] = `
           isInline={true}
           variant="link"
         >
-          <button
-            aria-disabled={false}
-            aria-label={null}
-            className="pf-c-button pf-m-link pf-m-inline"
-            data-ouia-component-id="OUIA-Generated-Button-link-3"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={false}
-            role={null}
-            type="button"
+          <ButtonBase
+            className=""
+            innerRef={null}
+            isInline={true}
+            variant="link"
           >
-            test
-          </button>
+            <button
+              aria-disabled={false}
+              aria-label={null}
+              className="pf-c-button pf-m-link pf-m-inline"
+              data-ouia-component-id="OUIA-Generated-Button-link-3"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              role={null}
+              type="button"
+            >
+              test
+            </button>
+          </ButtonBase>
         </Button>
       </AlertActionLink>
     </div>
@@ -3130,43 +3242,50 @@ exports[`Alert - warning Action Close Button 1`] = `
           onClick={[MockFunction]}
           variant="plain"
         >
-          <button
-            aria-disabled={false}
+          <ButtonBase
             aria-label="Close"
-            className="pf-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Button-plain-3"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={false}
+            innerRef={null}
             onClick={[MockFunction]}
-            role={null}
-            type="button"
+            variant="plain"
           >
-            <TimesIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <button
+              aria-disabled={false}
+              aria-label="Close"
+              className="pf-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-3"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              onClick={[MockFunction]}
+              role={null}
+              type="button"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 352 512"
-                width="1em"
+              <TimesIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                />
-              </svg>
-            </TimesIcon>
-          </button>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 352 512"
+                  width="1em"
+                >
+                  <path
+                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  />
+                </svg>
+              </TimesIcon>
+            </button>
+          </ButtonBase>
         </Button>
       </AlertActionCloseButton>
     </div>
@@ -3257,19 +3376,26 @@ exports[`Alert - warning Action Link 1`] = `
           isInline={true}
           variant="link"
         >
-          <button
-            aria-disabled={false}
-            aria-label={null}
-            className="pf-c-button pf-m-link pf-m-inline"
-            data-ouia-component-id="OUIA-Generated-Button-link-7"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={false}
-            role={null}
-            type="button"
+          <ButtonBase
+            className=""
+            innerRef={null}
+            isInline={true}
+            variant="link"
           >
-            test
-          </button>
+            <button
+              aria-disabled={false}
+              aria-label={null}
+              className="pf-c-button pf-m-link pf-m-inline"
+              data-ouia-component-id="OUIA-Generated-Button-link-7"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              role={null}
+              type="button"
+            >
+              test
+            </button>
+          </ButtonBase>
         </Button>
       </AlertActionLink>
     </div>
@@ -3356,19 +3482,26 @@ exports[`Alert - warning Action and Title 1`] = `
           isInline={true}
           variant="link"
         >
-          <button
-            aria-disabled={false}
-            aria-label={null}
-            className="pf-c-button pf-m-link pf-m-inline"
-            data-ouia-component-id="OUIA-Generated-Button-link-8"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={false}
-            role={null}
-            type="button"
+          <ButtonBase
+            className=""
+            innerRef={null}
+            isInline={true}
+            variant="link"
           >
-            test
-          </button>
+            <button
+              aria-disabled={false}
+              aria-label={null}
+              className="pf-c-button pf-m-link pf-m-inline"
+              data-ouia-component-id="OUIA-Generated-Button-link-8"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              role={null}
+              type="button"
+            >
+              test
+            </button>
+          </ButtonBase>
         </Button>
       </AlertActionLink>
     </div>
@@ -3456,19 +3589,26 @@ exports[`Alert - warning Custom aria label 1`] = `
           isInline={true}
           variant="link"
         >
-          <button
-            aria-disabled={false}
-            aria-label={null}
-            className="pf-c-button pf-m-link pf-m-inline"
-            data-ouia-component-id="OUIA-Generated-Button-link-9"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={false}
-            role={null}
-            type="button"
+          <ButtonBase
+            className=""
+            innerRef={null}
+            isInline={true}
+            variant="link"
           >
-            test
-          </button>
+            <button
+              aria-disabled={false}
+              aria-label={null}
+              className="pf-c-button pf-m-link pf-m-inline"
+              data-ouia-component-id="OUIA-Generated-Button-link-9"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              role={null}
+              type="button"
+            >
+              test
+            </button>
+          </ButtonBase>
         </Button>
       </AlertActionLink>
     </div>

--- a/packages/react-core/src/components/AlertGroup/__tests__/__snapshots__/AlertGroup.test.tsx.snap
+++ b/packages/react-core/src/components/AlertGroup/__tests__/__snapshots__/AlertGroup.test.tsx.snap
@@ -749,43 +749,50 @@ exports[`alertgroup closes when alerts are closed 1`] = `
                     onClick={[MockFunction]}
                     variant="plain"
                   >
-                    <button
-                      aria-disabled={false}
+                    <ButtonBase
                       aria-label="Close"
-                      className="pf-c-button pf-m-plain"
-                      data-ouia-component-id="OUIA-Generated-Button-plain-1"
-                      data-ouia-component-type="PF4/Button"
-                      data-ouia-safe={true}
-                      disabled={false}
+                      innerRef={null}
                       onClick={[MockFunction]}
-                      role={null}
-                      type="button"
+                      variant="plain"
                     >
-                      <TimesIcon
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
+                      <button
+                        aria-disabled={false}
+                        aria-label="Close"
+                        className="pf-c-button pf-m-plain"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-1"
+                        data-ouia-component-type="PF4/Button"
+                        data-ouia-safe={true}
+                        disabled={false}
+                        onClick={[MockFunction]}
+                        role={null}
+                        type="button"
                       >
-                        <svg
-                          aria-hidden={true}
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 352 512"
-                          width="1em"
+                        <TimesIcon
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
                         >
-                          <path
-                            d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                          />
-                        </svg>
-                      </TimesIcon>
-                    </button>
+                          <svg
+                            aria-hidden={true}
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 352 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                            />
+                          </svg>
+                        </TimesIcon>
+                      </button>
+                    </ButtonBase>
                   </Button>
                 </AlertActionCloseButton>
               </div>

--- a/packages/react-core/src/components/Button/Button.tsx
+++ b/packages/react-core/src/components/Button/Button.tsx
@@ -20,8 +20,7 @@ export enum ButtonType {
   submit = 'submit',
   reset = 'reset'
 }
-
-export interface ButtonProps extends React.HTMLProps<HTMLButtonElement>, OUIAProps {
+export interface ButtonProps extends Omit<React.HTMLProps<HTMLButtonElement>, 'ref'>, OUIAProps {
   /** Content rendered inside the button */
   children?: React.ReactNode;
   /** Additional classes added to the button */
@@ -62,9 +61,11 @@ export interface ButtonProps extends React.HTMLProps<HTMLButtonElement>, OUIAPro
   isLarge?: boolean;
   /** Adds danger styling to secondary or link button variants */
   isDanger?: boolean;
+  /** Forwarded ref */
+  innerRef?: React.Ref<any>;
 }
 
-export const Button: React.FunctionComponent<ButtonProps> = ({
+const ButtonBase: React.FunctionComponent<ButtonProps> = ({
   children = null,
   className = '',
   component = 'button',
@@ -87,6 +88,7 @@ export const Button: React.FunctionComponent<ButtonProps> = ({
   ouiaId,
   ouiaSafe = true,
   tabIndex = null,
+  innerRef,
   ...props
 }: ButtonProps) => {
   const ouiaProps = useOUIAProps(Button.displayName, ouiaId, ouiaSafe, variant);
@@ -146,6 +148,7 @@ export const Button: React.FunctionComponent<ButtonProps> = ({
       tabIndex={tabIndex !== null ? tabIndex : getDefaultTabIdx()}
       type={isButtonElement || isInlineSpan ? type : null}
       role={isInlineSpan ? 'button' : null}
+      ref={innerRef}
       {...ouiaProps}
     >
       {isLoading && (
@@ -163,4 +166,9 @@ export const Button: React.FunctionComponent<ButtonProps> = ({
     </Component>
   );
 };
+
+export const Button = React.forwardRef((props: ButtonProps, ref: React.Ref<any>) => (
+  <ButtonBase innerRef={ref} {...props} />
+));
+
 Button.displayName = 'Button';

--- a/packages/react-core/src/components/Button/__tests__/Generated/__snapshots__/Button.test.tsx.snap
+++ b/packages/react-core/src/components/Button/__tests__/Generated/__snapshots__/Button.test.tsx.snap
@@ -1,17 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Button should match snapshot (auto-generated) 1`] = `
-<button
-  aria-disabled={false}
+<ButtonBase
   aria-label="null"
-  className="pf-c-button pf-m-primary ''"
-  data-ouia-component-id="OUIA-Generated-Button-primary-1"
-  data-ouia-component-type="PF4/Button"
-  data-ouia-safe={true}
-  disabled={false}
-  role={null}
+  className="''"
+  component="button"
+  icon={null}
+  iconPosition="left"
+  innerRef={null}
+  inoperableEvents={
+    Array [
+      "onClick",
+      "onKeyPress",
+    ]
+  }
+  isActive={false}
+  isAriaDisabled={false}
+  isBlock={false}
+  isDisabled={false}
+  isInline={false}
+  tabIndex={null}
   type="button"
+  variant="primary"
 >
   ReactNode
-</button>
+</ButtonBase>
 `;

--- a/packages/react-core/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/react-core/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -5,20 +5,26 @@ exports[`aria-disabled is set to true and tabIndex to -1 if component is not a b
   component="a"
   isDisabled={true}
 >
-  <a
-    aria-disabled={true}
-    aria-label={null}
-    className="pf-c-button pf-m-primary pf-m-disabled"
-    data-ouia-component-id="OUIA-Generated-Button-primary-12"
-    data-ouia-component-type="PF4/Button"
-    data-ouia-safe={true}
-    disabled={null}
-    role={null}
-    tabIndex={-1}
-    type={null}
+  <ButtonBase
+    component="a"
+    innerRef={null}
+    isDisabled={true}
   >
-    Disabled Anchor Button
-  </a>
+    <a
+      aria-disabled={true}
+      aria-label={null}
+      className="pf-c-button pf-m-primary pf-m-disabled"
+      data-ouia-component-id="OUIA-Generated-Button-primary-12"
+      data-ouia-component-type="PF4/Button"
+      data-ouia-safe={true}
+      disabled={null}
+      role={null}
+      tabIndex={-1}
+      type={null}
+    >
+      Disabled Anchor Button
+    </a>
+  </ButtonBase>
 </Button>
 `;
 
@@ -27,20 +33,26 @@ exports[`control button 1`] = `
   aria-label="control"
   variant="control"
 >
-  <button
-    aria-disabled={false}
+  <ButtonBase
     aria-label="control"
-    className="pf-c-button pf-m-control"
-    data-ouia-component-id="OUIA-Generated-Button-control-1"
-    data-ouia-component-type="PF4/Button"
-    data-ouia-safe={true}
-    disabled={false}
-    role={null}
-    type="button"
+    innerRef={null}
+    variant="control"
   >
-    control
-     Button
-  </button>
+    <button
+      aria-disabled={false}
+      aria-label="control"
+      className="pf-c-button pf-m-control"
+      data-ouia-component-id="OUIA-Generated-Button-control-1"
+      data-ouia-component-type="PF4/Button"
+      data-ouia-safe={true}
+      disabled={false}
+      role={null}
+      type="button"
+    >
+      control
+       Button
+    </button>
+  </ButtonBase>
 </Button>
 `;
 
@@ -49,20 +61,26 @@ exports[`danger button 1`] = `
   aria-label="danger"
   variant="danger"
 >
-  <button
-    aria-disabled={false}
+  <ButtonBase
     aria-label="danger"
-    className="pf-c-button pf-m-danger"
-    data-ouia-component-id="OUIA-Generated-Button-danger-1"
-    data-ouia-component-type="PF4/Button"
-    data-ouia-safe={true}
-    disabled={false}
-    role={null}
-    type="button"
+    innerRef={null}
+    variant="danger"
   >
-    danger
-     Button
-  </button>
+    <button
+      aria-disabled={false}
+      aria-label="danger"
+      className="pf-c-button pf-m-danger"
+      data-ouia-component-id="OUIA-Generated-Button-danger-1"
+      data-ouia-component-type="PF4/Button"
+      data-ouia-safe={true}
+      disabled={false}
+      role={null}
+      type="button"
+    >
+      danger
+       Button
+    </button>
+  </ButtonBase>
 </Button>
 `;
 
@@ -70,22 +88,27 @@ exports[`isAriaDisabled button 1`] = `
 <Button
   isAriaDisabled={true}
 >
-  <button
-    aria-disabled={true}
-    aria-label={null}
-    className="pf-c-button pf-m-primary pf-m-aria-disabled"
-    data-ouia-component-id="OUIA-Generated-Button-primary-5"
-    data-ouia-component-type="PF4/Button"
-    data-ouia-safe={true}
-    disabled={false}
-    onClick={[Function]}
-    onKeyPress={[Function]}
-    role={null}
-    tabIndex={null}
-    type="button"
+  <ButtonBase
+    innerRef={null}
+    isAriaDisabled={true}
   >
-    Disabled yet focusable button
-  </button>
+    <button
+      aria-disabled={true}
+      aria-label={null}
+      className="pf-c-button pf-m-primary pf-m-aria-disabled"
+      data-ouia-component-id="OUIA-Generated-Button-primary-5"
+      data-ouia-component-type="PF4/Button"
+      data-ouia-safe={true}
+      disabled={false}
+      onClick={[Function]}
+      onKeyPress={[Function]}
+      role={null}
+      tabIndex={null}
+      type="button"
+    >
+      Disabled yet focusable button
+    </button>
+  </ButtonBase>
 </Button>
 `;
 
@@ -94,22 +117,28 @@ exports[`isAriaDisabled link button 1`] = `
   component="a"
   isAriaDisabled={true}
 >
-  <a
-    aria-disabled={true}
-    aria-label={null}
-    className="pf-c-button pf-m-primary pf-m-aria-disabled"
-    data-ouia-component-id="OUIA-Generated-Button-primary-6"
-    data-ouia-component-type="PF4/Button"
-    data-ouia-safe={true}
-    disabled={null}
-    onClick={[Function]}
-    onKeyPress={[Function]}
-    role={null}
-    tabIndex={null}
-    type={null}
+  <ButtonBase
+    component="a"
+    innerRef={null}
+    isAriaDisabled={true}
   >
-    Disabled yet focusable button
-  </a>
+    <a
+      aria-disabled={true}
+      aria-label={null}
+      className="pf-c-button pf-m-primary pf-m-aria-disabled"
+      data-ouia-component-id="OUIA-Generated-Button-primary-6"
+      data-ouia-component-type="PF4/Button"
+      data-ouia-safe={true}
+      disabled={null}
+      onClick={[Function]}
+      onKeyPress={[Function]}
+      role={null}
+      tabIndex={null}
+      type={null}
+    >
+      Disabled yet focusable button
+    </a>
+  </ButtonBase>
 </Button>
 `;
 
@@ -117,19 +146,24 @@ exports[`isBlock 1`] = `
 <Button
   isBlock={true}
 >
-  <button
-    aria-disabled={false}
-    aria-label={null}
-    className="pf-c-button pf-m-primary pf-m-block"
-    data-ouia-component-id="OUIA-Generated-Button-primary-3"
-    data-ouia-component-type="PF4/Button"
-    data-ouia-safe={true}
-    disabled={false}
-    role={null}
-    type="button"
+  <ButtonBase
+    innerRef={null}
+    isBlock={true}
   >
-    Block Button
-  </button>
+    <button
+      aria-disabled={false}
+      aria-label={null}
+      className="pf-c-button pf-m-primary pf-m-block"
+      data-ouia-component-id="OUIA-Generated-Button-primary-3"
+      data-ouia-component-type="PF4/Button"
+      data-ouia-safe={true}
+      disabled={false}
+      role={null}
+      type="button"
+    >
+      Block Button
+    </button>
+  </ButtonBase>
 </Button>
 `;
 
@@ -138,19 +172,25 @@ exports[`isDanger link 1`] = `
   isDanger={true}
   variant="link"
 >
-  <button
-    aria-disabled={false}
-    aria-label={null}
-    className="pf-c-button pf-m-link pf-m-danger"
-    data-ouia-component-id="OUIA-Generated-Button-link-3"
-    data-ouia-component-type="PF4/Button"
-    data-ouia-safe={true}
-    disabled={false}
-    role={null}
-    type="button"
+  <ButtonBase
+    innerRef={null}
+    isDanger={true}
+    variant="link"
   >
-    Disabled Button
-  </button>
+    <button
+      aria-disabled={false}
+      aria-label={null}
+      className="pf-c-button pf-m-link pf-m-danger"
+      data-ouia-component-id="OUIA-Generated-Button-link-3"
+      data-ouia-component-type="PF4/Button"
+      data-ouia-safe={true}
+      disabled={false}
+      role={null}
+      type="button"
+    >
+      Disabled Button
+    </button>
+  </ButtonBase>
 </Button>
 `;
 
@@ -159,19 +199,25 @@ exports[`isDanger secondary 1`] = `
   isDanger={true}
   variant="secondary"
 >
-  <button
-    aria-disabled={false}
-    aria-label={null}
-    className="pf-c-button pf-m-secondary pf-m-danger"
-    data-ouia-component-id="OUIA-Generated-Button-secondary-2"
-    data-ouia-component-type="PF4/Button"
-    data-ouia-safe={true}
-    disabled={false}
-    role={null}
-    type="button"
+  <ButtonBase
+    innerRef={null}
+    isDanger={true}
+    variant="secondary"
   >
-    Disabled Button
-  </button>
+    <button
+      aria-disabled={false}
+      aria-label={null}
+      className="pf-c-button pf-m-secondary pf-m-danger"
+      data-ouia-component-id="OUIA-Generated-Button-secondary-2"
+      data-ouia-component-type="PF4/Button"
+      data-ouia-safe={true}
+      disabled={false}
+      role={null}
+      type="button"
+    >
+      Disabled Button
+    </button>
+  </ButtonBase>
 </Button>
 `;
 
@@ -179,20 +225,25 @@ exports[`isDisabled 1`] = `
 <Button
   isDisabled={true}
 >
-  <button
-    aria-disabled={true}
-    aria-label={null}
-    className="pf-c-button pf-m-primary pf-m-disabled"
-    data-ouia-component-id="OUIA-Generated-Button-primary-4"
-    data-ouia-component-type="PF4/Button"
-    data-ouia-safe={true}
-    disabled={true}
-    role={null}
-    tabIndex={null}
-    type="button"
+  <ButtonBase
+    innerRef={null}
+    isDisabled={true}
   >
-    Disabled Button
-  </button>
+    <button
+      aria-disabled={true}
+      aria-label={null}
+      className="pf-c-button pf-m-primary pf-m-disabled"
+      data-ouia-component-id="OUIA-Generated-Button-primary-4"
+      data-ouia-component-type="PF4/Button"
+      data-ouia-safe={true}
+      disabled={true}
+      role={null}
+      tabIndex={null}
+      type="button"
+    >
+      Disabled Button
+    </button>
+  </ButtonBase>
 </Button>
 `;
 
@@ -201,19 +252,25 @@ exports[`isInline 1`] = `
   isInline={true}
   variant="link"
 >
-  <button
-    aria-disabled={false}
-    aria-label={null}
-    className="pf-c-button pf-m-link pf-m-inline"
-    data-ouia-component-id="OUIA-Generated-Button-link-4"
-    data-ouia-component-type="PF4/Button"
-    data-ouia-safe={true}
-    disabled={false}
-    role={null}
-    type="button"
+  <ButtonBase
+    innerRef={null}
+    isInline={true}
+    variant="link"
   >
-    Hovered Button
-  </button>
+    <button
+      aria-disabled={false}
+      aria-label={null}
+      className="pf-c-button pf-m-link pf-m-inline"
+      data-ouia-component-id="OUIA-Generated-Button-link-4"
+      data-ouia-component-type="PF4/Button"
+      data-ouia-safe={true}
+      disabled={false}
+      role={null}
+      type="button"
+    >
+      Hovered Button
+    </button>
+  </ButtonBase>
 </Button>
 `;
 
@@ -221,19 +278,24 @@ exports[`isLarge 1`] = `
 <Button
   isLarge={true}
 >
-  <button
-    aria-disabled={false}
-    aria-label={null}
-    className="pf-c-button pf-m-primary pf-m-display-lg"
-    data-ouia-component-id="OUIA-Generated-Button-primary-8"
-    data-ouia-component-type="PF4/Button"
-    data-ouia-safe={true}
-    disabled={false}
-    role={null}
-    type="button"
+  <ButtonBase
+    innerRef={null}
+    isLarge={true}
   >
-    Large Button
-  </button>
+    <button
+      aria-disabled={false}
+      aria-label={null}
+      className="pf-c-button pf-m-primary pf-m-display-lg"
+      data-ouia-component-id="OUIA-Generated-Button-primary-8"
+      data-ouia-component-type="PF4/Button"
+      data-ouia-safe={true}
+      disabled={false}
+      role={null}
+      type="button"
+    >
+      Large Button
+    </button>
+  </ButtonBase>
 </Button>
 `;
 
@@ -242,43 +304,49 @@ exports[`isLoading 1`] = `
   isLoading={true}
   spinnerAriaValueText="Loading"
 >
-  <button
-    aria-disabled={false}
-    aria-label={null}
-    className="pf-c-button pf-m-primary pf-m-progress pf-m-in-progress"
-    data-ouia-component-id="OUIA-Generated-Button-primary-9"
-    data-ouia-component-type="PF4/Button"
-    data-ouia-safe={true}
-    disabled={false}
-    role={null}
-    type="button"
+  <ButtonBase
+    innerRef={null}
+    isLoading={true}
+    spinnerAriaValueText="Loading"
   >
-    <span
-      className="pf-c-button__progress"
+    <button
+      aria-disabled={false}
+      aria-label={null}
+      className="pf-c-button pf-m-primary pf-m-progress pf-m-in-progress"
+      data-ouia-component-id="OUIA-Generated-Button-primary-9"
+      data-ouia-component-type="PF4/Button"
+      data-ouia-safe={true}
+      disabled={false}
+      role={null}
+      type="button"
     >
-      <Spinner
-        aria-valuetext="Loading"
-        size="md"
+      <span
+        className="pf-c-button__progress"
       >
-        <span
+        <Spinner
           aria-valuetext="Loading"
-          className="pf-c-spinner pf-m-md"
-          role="progressbar"
+          size="md"
         >
           <span
-            className="pf-c-spinner__clipper"
-          />
-          <span
-            className="pf-c-spinner__lead-ball"
-          />
-          <span
-            className="pf-c-spinner__tail-ball"
-          />
-        </span>
-      </Spinner>
-    </span>
-    Loading Button
-  </button>
+            aria-valuetext="Loading"
+            className="pf-c-spinner pf-m-md"
+            role="progressbar"
+          >
+            <span
+              className="pf-c-spinner__clipper"
+            />
+            <span
+              className="pf-c-spinner__lead-ball"
+            />
+            <span
+              className="pf-c-spinner__tail-ball"
+            />
+          </span>
+        </Spinner>
+      </span>
+      Loading Button
+    </button>
+  </ButtonBase>
 </Button>
 `;
 
@@ -286,19 +354,24 @@ exports[`isSmall 1`] = `
 <Button
   isSmall={true}
 >
-  <button
-    aria-disabled={false}
-    aria-label={null}
-    className="pf-c-button pf-m-primary pf-m-small"
-    data-ouia-component-id="OUIA-Generated-Button-primary-7"
-    data-ouia-component-type="PF4/Button"
-    data-ouia-safe={true}
-    disabled={false}
-    role={null}
-    type="button"
+  <ButtonBase
+    innerRef={null}
+    isSmall={true}
   >
-    Small Button
-  </button>
+    <button
+      aria-disabled={false}
+      aria-label={null}
+      className="pf-c-button pf-m-primary pf-m-small"
+      data-ouia-component-id="OUIA-Generated-Button-primary-7"
+      data-ouia-component-type="PF4/Button"
+      data-ouia-safe={true}
+      disabled={false}
+      role={null}
+      type="button"
+    >
+      Small Button
+    </button>
+  </ButtonBase>
 </Button>
 `;
 
@@ -307,20 +380,26 @@ exports[`link button 1`] = `
   aria-label="link"
   variant="link"
 >
-  <button
-    aria-disabled={false}
+  <ButtonBase
     aria-label="link"
-    className="pf-c-button pf-m-link"
-    data-ouia-component-id="OUIA-Generated-Button-link-1"
-    data-ouia-component-type="PF4/Button"
-    data-ouia-safe={true}
-    disabled={false}
-    role={null}
-    type="button"
+    innerRef={null}
+    variant="link"
   >
-    link
-     Button
-  </button>
+    <button
+      aria-disabled={false}
+      aria-label="link"
+      className="pf-c-button pf-m-link"
+      data-ouia-component-id="OUIA-Generated-Button-link-1"
+      data-ouia-component-type="PF4/Button"
+      data-ouia-safe={true}
+      disabled={false}
+      role={null}
+      type="button"
+    >
+      link
+       Button
+    </button>
+  </ButtonBase>
 </Button>
 `;
 
@@ -335,47 +414,59 @@ exports[`link with icon 1`] = `
   }
   variant="link"
 >
-  <button
-    aria-disabled={false}
-    aria-label={null}
-    className="pf-c-button pf-m-link"
-    data-ouia-component-id="OUIA-Generated-Button-link-2"
-    data-ouia-component-type="PF4/Button"
-    data-ouia-safe={true}
-    disabled={false}
-    role={null}
-    type="button"
-  >
-    <span
-      className="pf-c-button__icon pf-m-start"
-    >
+  <ButtonBase
+    icon={
       <CartArrowDownIcon
         color="currentColor"
         noVerticalAlign={false}
         size="sm"
+      />
+    }
+    innerRef={null}
+    variant="link"
+  >
+    <button
+      aria-disabled={false}
+      aria-label={null}
+      className="pf-c-button pf-m-link"
+      data-ouia-component-id="OUIA-Generated-Button-link-2"
+      data-ouia-component-type="PF4/Button"
+      data-ouia-safe={true}
+      disabled={false}
+      role={null}
+      type="button"
+    >
+      <span
+        className="pf-c-button__icon pf-m-start"
       >
-        <svg
-          aria-hidden={true}
-          aria-labelledby={null}
-          fill="currentColor"
-          height="1em"
-          role="img"
-          style={
-            Object {
-              "verticalAlign": "-0.125em",
-            }
-          }
-          viewBox="0 0 576 512"
-          width="1em"
+        <CartArrowDownIcon
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
         >
-          <path
-            d="M504.717 320H211.572l6.545 32h268.418c15.401 0 26.816 14.301 23.403 29.319l-5.517 24.276C523.112 414.668 536 433.828 536 456c0 31.202-25.519 56.444-56.824 55.994-29.823-.429-54.35-24.631-55.155-54.447-.44-16.287 6.085-31.049 16.803-41.548H231.176C241.553 426.165 248 440.326 248 456c0 31.813-26.528 57.431-58.67 55.938-28.54-1.325-51.751-24.385-53.251-52.917-1.158-22.034 10.436-41.455 28.051-51.586L93.883 64H24C10.745 64 0 53.255 0 40V24C0 10.745 10.745 0 24 0h102.529c11.401 0 21.228 8.021 23.513 19.19L159.208 64H551.99c15.401 0 26.816 14.301 23.403 29.319l-47.273 208C525.637 312.246 515.923 320 504.717 320zM403.029 192H360v-60c0-6.627-5.373-12-12-12h-24c-6.627 0-12 5.373-12 12v60h-43.029c-10.691 0-16.045 12.926-8.485 20.485l67.029 67.029c4.686 4.686 12.284 4.686 16.971 0l67.029-67.029c7.559-7.559 2.205-20.485-8.486-20.485z"
-          />
-        </svg>
-      </CartArrowDownIcon>
-    </span>
-    Block Button
-  </button>
+          <svg
+            aria-hidden={true}
+            aria-labelledby={null}
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
+            viewBox="0 0 576 512"
+            width="1em"
+          >
+            <path
+              d="M504.717 320H211.572l6.545 32h268.418c15.401 0 26.816 14.301 23.403 29.319l-5.517 24.276C523.112 414.668 536 433.828 536 456c0 31.202-25.519 56.444-56.824 55.994-29.823-.429-54.35-24.631-55.155-54.447-.44-16.287 6.085-31.049 16.803-41.548H231.176C241.553 426.165 248 440.326 248 456c0 31.813-26.528 57.431-58.67 55.938-28.54-1.325-51.751-24.385-53.251-52.917-1.158-22.034 10.436-41.455 28.051-51.586L93.883 64H24C10.745 64 0 53.255 0 40V24C0 10.745 10.745 0 24 0h102.529c11.401 0 21.228 8.021 23.513 19.19L159.208 64H551.99c15.401 0 26.816 14.301 23.403 29.319l-47.273 208C525.637 312.246 515.923 320 504.717 320zM403.029 192H360v-60c0-6.627-5.373-12-12-12h-24c-6.627 0-12 5.373-12 12v60h-43.029c-10.691 0-16.045 12.926-8.485 20.485l67.029 67.029c4.686 4.686 12.284 4.686 16.971 0l67.029-67.029c7.559-7.559 2.205-20.485-8.486-20.485z"
+            />
+          </svg>
+        </CartArrowDownIcon>
+      </span>
+      Block Button
+    </button>
+  </ButtonBase>
 </Button>
 `;
 
@@ -384,20 +475,26 @@ exports[`plain button 1`] = `
   aria-label="plain"
   variant="plain"
 >
-  <button
-    aria-disabled={false}
+  <ButtonBase
     aria-label="plain"
-    className="pf-c-button pf-m-plain"
-    data-ouia-component-id="OUIA-Generated-Button-plain-1"
-    data-ouia-component-type="PF4/Button"
-    data-ouia-safe={true}
-    disabled={false}
-    role={null}
-    type="button"
+    innerRef={null}
+    variant="plain"
   >
-    plain
-     Button
-  </button>
+    <button
+      aria-disabled={false}
+      aria-label="plain"
+      className="pf-c-button pf-m-plain"
+      data-ouia-component-id="OUIA-Generated-Button-plain-1"
+      data-ouia-component-type="PF4/Button"
+      data-ouia-safe={true}
+      disabled={false}
+      role={null}
+      type="button"
+    >
+      plain
+       Button
+    </button>
+  </ButtonBase>
 </Button>
 `;
 
@@ -406,20 +503,26 @@ exports[`primary button 1`] = `
   aria-label="primary"
   variant="primary"
 >
-  <button
-    aria-disabled={false}
+  <ButtonBase
     aria-label="primary"
-    className="pf-c-button pf-m-primary"
-    data-ouia-component-id="OUIA-Generated-Button-primary-1"
-    data-ouia-component-type="PF4/Button"
-    data-ouia-safe={true}
-    disabled={false}
-    role={null}
-    type="button"
+    innerRef={null}
+    variant="primary"
   >
-    primary
-     Button
-  </button>
+    <button
+      aria-disabled={false}
+      aria-label="primary"
+      className="pf-c-button pf-m-primary"
+      data-ouia-component-id="OUIA-Generated-Button-primary-1"
+      data-ouia-component-type="PF4/Button"
+      data-ouia-safe={true}
+      disabled={false}
+      role={null}
+      type="button"
+    >
+      primary
+       Button
+    </button>
+  </ButtonBase>
 </Button>
 `;
 
@@ -428,20 +531,26 @@ exports[`secondary button 1`] = `
   aria-label="secondary"
   variant="secondary"
 >
-  <button
-    aria-disabled={false}
+  <ButtonBase
     aria-label="secondary"
-    className="pf-c-button pf-m-secondary"
-    data-ouia-component-id="OUIA-Generated-Button-secondary-1"
-    data-ouia-component-type="PF4/Button"
-    data-ouia-safe={true}
-    disabled={false}
-    role={null}
-    type="button"
+    innerRef={null}
+    variant="secondary"
   >
-    secondary
-     Button
-  </button>
+    <button
+      aria-disabled={false}
+      aria-label="secondary"
+      className="pf-c-button pf-m-secondary"
+      data-ouia-component-id="OUIA-Generated-Button-secondary-1"
+      data-ouia-component-type="PF4/Button"
+      data-ouia-safe={true}
+      disabled={false}
+      role={null}
+      type="button"
+    >
+      secondary
+       Button
+    </button>
+  </ButtonBase>
 </Button>
 `;
 
@@ -450,20 +559,26 @@ exports[`tertiary button 1`] = `
   aria-label="tertiary"
   variant="tertiary"
 >
-  <button
-    aria-disabled={false}
+  <ButtonBase
     aria-label="tertiary"
-    className="pf-c-button pf-m-tertiary"
-    data-ouia-component-id="OUIA-Generated-Button-tertiary-1"
-    data-ouia-component-type="PF4/Button"
-    data-ouia-safe={true}
-    disabled={false}
-    role={null}
-    type="button"
+    innerRef={null}
+    variant="tertiary"
   >
-    tertiary
-     Button
-  </button>
+    <button
+      aria-disabled={false}
+      aria-label="tertiary"
+      className="pf-c-button pf-m-tertiary"
+      data-ouia-component-id="OUIA-Generated-Button-tertiary-1"
+      data-ouia-component-type="PF4/Button"
+      data-ouia-safe={true}
+      disabled={false}
+      role={null}
+      type="button"
+    >
+      tertiary
+       Button
+    </button>
+  </ButtonBase>
 </Button>
 `;
 
@@ -472,19 +587,25 @@ exports[`warning button 1`] = `
   aria-label="warning"
   variant="warning"
 >
-  <button
-    aria-disabled={false}
+  <ButtonBase
     aria-label="warning"
-    className="pf-c-button pf-m-warning"
-    data-ouia-component-id="OUIA-Generated-Button-warning-1"
-    data-ouia-component-type="PF4/Button"
-    data-ouia-safe={true}
-    disabled={false}
-    role={null}
-    type="button"
+    innerRef={null}
+    variant="warning"
   >
-    warning
-     Button
-  </button>
+    <button
+      aria-disabled={false}
+      aria-label="warning"
+      className="pf-c-button pf-m-warning"
+      data-ouia-component-id="OUIA-Generated-Button-warning-1"
+      data-ouia-component-type="PF4/Button"
+      data-ouia-safe={true}
+      disabled={false}
+      role={null}
+      type="button"
+    >
+      warning
+       Button
+    </button>
+  </ButtonBase>
 </Button>
 `;

--- a/packages/react-core/src/components/Card/__tests__/__snapshots__/CardHeader.test.tsx.snap
+++ b/packages/react-core/src/components/Card/__tests__/__snapshots__/CardHeader.test.tsx.snap
@@ -17,48 +17,55 @@ exports[`onExpand adds the toggle button 1`] = `
         type="button"
         variant="plain"
       >
-        <button
-          aria-disabled={false}
-          aria-label={null}
-          className="pf-c-button pf-m-plain"
-          data-ouia-component-id="OUIA-Generated-Button-plain-1"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe={true}
-          disabled={false}
+        <ButtonBase
+          innerRef={null}
           onClick={[Function]}
-          role={null}
           type="button"
+          variant="plain"
         >
-          <span
-            className="pf-c-card__header-toggle-icon"
+          <button
+            aria-disabled={false}
+            aria-label={null}
+            className="pf-c-button pf-m-plain"
+            data-ouia-component-id="OUIA-Generated-Button-plain-1"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={false}
+            onClick={[Function]}
+            role={null}
+            type="button"
           >
-            <AngleRightIcon
-              aria-hidden="true"
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <span
+              className="pf-c-card__header-toggle-icon"
             >
-              <svg
+              <AngleRightIcon
                 aria-hidden="true"
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 256 512"
-                width="1em"
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                />
-              </svg>
-            </AngleRightIcon>
-          </span>
-        </button>
+                <svg
+                  aria-hidden="true"
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                  />
+                </svg>
+              </AngleRightIcon>
+            </span>
+          </button>
+        </ButtonBase>
       </Button>
     </div>
   </div>

--- a/packages/react-core/src/components/ChipGroup/__tests__/__snapshots__/Chip.test.tsx.snap
+++ b/packages/react-core/src/components/ChipGroup/__tests__/__snapshots__/Chip.test.tsx.snap
@@ -34,46 +34,56 @@ exports[`Chip closable 1`] = `
         ouiaId="close"
         variant="plain"
       >
-        <button
-          aria-disabled={false}
+        <ButtonBase
           aria-label="close"
           aria-labelledby="remove_chip_one chip_one"
-          className="pf-c-button pf-m-plain"
-          data-ouia-component-id="close"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe={true}
-          disabled={false}
           id="remove_chip_one"
+          innerRef={null}
           onClick={[Function]}
-          role={null}
-          type="button"
+          ouiaId="close"
+          variant="plain"
         >
-          <TimesIcon
-            aria-hidden="true"
-            color="currentColor"
-            noVerticalAlign={false}
-            size="sm"
+          <button
+            aria-disabled={false}
+            aria-label="close"
+            aria-labelledby="remove_chip_one chip_one"
+            className="pf-c-button pf-m-plain"
+            data-ouia-component-id="close"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={false}
+            id="remove_chip_one"
+            onClick={[Function]}
+            role={null}
+            type="button"
           >
-            <svg
+            <TimesIcon
               aria-hidden="true"
-              aria-labelledby={null}
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style={
-                Object {
-                  "verticalAlign": "-0.125em",
-                }
-              }
-              viewBox="0 0 352 512"
-              width="1em"
+              color="currentColor"
+              noVerticalAlign={false}
+              size="sm"
             >
-              <path
-                d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-              />
-            </svg>
-          </TimesIcon>
-        </button>
+              <svg
+                aria-hidden="true"
+                aria-labelledby={null}
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style={
+                  Object {
+                    "verticalAlign": "-0.125em",
+                  }
+                }
+                viewBox="0 0 352 512"
+                width="1em"
+              >
+                <path
+                  d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                />
+              </svg>
+            </TimesIcon>
+          </button>
+        </ButtonBase>
       </Button>
     </div>
   </GenerateId>
@@ -114,46 +124,56 @@ exports[`Chip closable with tooltip 1`] = `
         ouiaId="close"
         variant="plain"
       >
-        <button
-          aria-disabled={false}
+        <ButtonBase
           aria-label="close"
           aria-labelledby="remove_chip_one chip_one"
-          className="pf-c-button pf-m-plain"
-          data-ouia-component-id="close"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe={true}
-          disabled={false}
           id="remove_chip_one"
+          innerRef={null}
           onClick={[Function]}
-          role={null}
-          type="button"
+          ouiaId="close"
+          variant="plain"
         >
-          <TimesIcon
-            aria-hidden="true"
-            color="currentColor"
-            noVerticalAlign={false}
-            size="sm"
+          <button
+            aria-disabled={false}
+            aria-label="close"
+            aria-labelledby="remove_chip_one chip_one"
+            className="pf-c-button pf-m-plain"
+            data-ouia-component-id="close"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={false}
+            id="remove_chip_one"
+            onClick={[Function]}
+            role={null}
+            type="button"
           >
-            <svg
+            <TimesIcon
               aria-hidden="true"
-              aria-labelledby={null}
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style={
-                Object {
-                  "verticalAlign": "-0.125em",
-                }
-              }
-              viewBox="0 0 352 512"
-              width="1em"
+              color="currentColor"
+              noVerticalAlign={false}
+              size="sm"
             >
-              <path
-                d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-              />
-            </svg>
-          </TimesIcon>
-        </button>
+              <svg
+                aria-hidden="true"
+                aria-labelledby={null}
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style={
+                  Object {
+                    "verticalAlign": "-0.125em",
+                  }
+                }
+                viewBox="0 0 352 512"
+                width="1em"
+              >
+                <path
+                  d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                />
+              </svg>
+            </TimesIcon>
+          </button>
+        </ButtonBase>
       </Button>
     </div>
   </GenerateId>

--- a/packages/react-core/src/components/ChipGroup/__tests__/__snapshots__/ChipGroup.test.tsx.snap
+++ b/packages/react-core/src/components/ChipGroup/__tests__/__snapshots__/ChipGroup.test.tsx.snap
@@ -67,46 +67,56 @@ exports[`ChipGroup chip group default 1`] = `
                     ouiaId="close"
                     variant="plain"
                   >
-                    <button
-                      aria-disabled={false}
+                    <ButtonBase
                       aria-label="close"
                       aria-labelledby="remove_pf-random-id-1 pf-random-id-1"
-                      className="pf-c-button pf-m-plain"
-                      data-ouia-component-id="close"
-                      data-ouia-component-type="PF4/Button"
-                      data-ouia-safe={true}
-                      disabled={false}
                       id="remove_pf-random-id-1"
+                      innerRef={null}
                       onClick={[Function]}
-                      role={null}
-                      type="button"
+                      ouiaId="close"
+                      variant="plain"
                     >
-                      <TimesIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
+                      <button
+                        aria-disabled={false}
+                        aria-label="close"
+                        aria-labelledby="remove_pf-random-id-1 pf-random-id-1"
+                        className="pf-c-button pf-m-plain"
+                        data-ouia-component-id="close"
+                        data-ouia-component-type="PF4/Button"
+                        data-ouia-safe={true}
+                        disabled={false}
+                        id="remove_pf-random-id-1"
+                        onClick={[Function]}
+                        role={null}
+                        type="button"
                       >
-                        <svg
+                        <TimesIcon
                           aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 352 512"
-                          width="1em"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
                         >
-                          <path
-                            d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                          />
-                        </svg>
-                      </TimesIcon>
-                    </button>
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 352 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                            />
+                          </svg>
+                        </TimesIcon>
+                      </button>
+                    </ButtonBase>
                   </Button>
                 </div>
               </GenerateId>
@@ -193,46 +203,56 @@ exports[`ChipGroup chip group with category 1`] = `
                     ouiaId="close"
                     variant="plain"
                   >
-                    <button
-                      aria-disabled={false}
+                    <ButtonBase
                       aria-label="close"
                       aria-labelledby="remove_pf-random-id-3 pf-random-id-3"
-                      className="pf-c-button pf-m-plain"
-                      data-ouia-component-id="close"
-                      data-ouia-component-type="PF4/Button"
-                      data-ouia-safe={true}
-                      disabled={false}
                       id="remove_pf-random-id-3"
+                      innerRef={null}
                       onClick={[Function]}
-                      role={null}
-                      type="button"
+                      ouiaId="close"
+                      variant="plain"
                     >
-                      <TimesIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
+                      <button
+                        aria-disabled={false}
+                        aria-label="close"
+                        aria-labelledby="remove_pf-random-id-3 pf-random-id-3"
+                        className="pf-c-button pf-m-plain"
+                        data-ouia-component-id="close"
+                        data-ouia-component-type="PF4/Button"
+                        data-ouia-safe={true}
+                        disabled={false}
+                        id="remove_pf-random-id-3"
+                        onClick={[Function]}
+                        role={null}
+                        type="button"
                       >
-                        <svg
+                        <TimesIcon
                           aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 352 512"
-                          width="1em"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
                         >
-                          <path
-                            d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                          />
-                        </svg>
-                      </TimesIcon>
-                    </button>
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 352 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                            />
+                          </svg>
+                        </TimesIcon>
+                      </button>
+                    </ButtonBase>
                   </Button>
                 </div>
               </GenerateId>
@@ -319,46 +339,56 @@ exports[`ChipGroup chip group with category and tooltip 1`] = `
                     ouiaId="close"
                     variant="plain"
                   >
-                    <button
-                      aria-disabled={false}
+                    <ButtonBase
                       aria-label="close"
                       aria-labelledby="remove_pf-random-id-13 pf-random-id-13"
-                      className="pf-c-button pf-m-plain"
-                      data-ouia-component-id="close"
-                      data-ouia-component-type="PF4/Button"
-                      data-ouia-safe={true}
-                      disabled={false}
                       id="remove_pf-random-id-13"
+                      innerRef={null}
                       onClick={[Function]}
-                      role={null}
-                      type="button"
+                      ouiaId="close"
+                      variant="plain"
                     >
-                      <TimesIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
+                      <button
+                        aria-disabled={false}
+                        aria-label="close"
+                        aria-labelledby="remove_pf-random-id-13 pf-random-id-13"
+                        className="pf-c-button pf-m-plain"
+                        data-ouia-component-id="close"
+                        data-ouia-component-type="PF4/Button"
+                        data-ouia-safe={true}
+                        disabled={false}
+                        id="remove_pf-random-id-13"
+                        onClick={[Function]}
+                        role={null}
+                        type="button"
                       >
-                        <svg
+                        <TimesIcon
                           aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 352 512"
-                          width="1em"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
                         >
-                          <path
-                            d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                          />
-                        </svg>
-                      </TimesIcon>
-                    </button>
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 352 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                            />
+                          </svg>
+                        </TimesIcon>
+                      </button>
+                    </ButtonBase>
                   </Button>
                 </div>
               </GenerateId>
@@ -445,46 +475,56 @@ exports[`ChipGroup chip group with closable category 1`] = `
                     ouiaId="close"
                     variant="plain"
                   >
-                    <button
-                      aria-disabled={false}
+                    <ButtonBase
                       aria-label="close"
                       aria-labelledby="remove_pf-random-id-5 pf-random-id-5"
-                      className="pf-c-button pf-m-plain"
-                      data-ouia-component-id="close"
-                      data-ouia-component-type="PF4/Button"
-                      data-ouia-safe={true}
-                      disabled={false}
                       id="remove_pf-random-id-5"
+                      innerRef={null}
                       onClick={[Function]}
-                      role={null}
-                      type="button"
+                      ouiaId="close"
+                      variant="plain"
                     >
-                      <TimesIcon
-                        aria-hidden="true"
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
+                      <button
+                        aria-disabled={false}
+                        aria-label="close"
+                        aria-labelledby="remove_pf-random-id-5 pf-random-id-5"
+                        className="pf-c-button pf-m-plain"
+                        data-ouia-component-id="close"
+                        data-ouia-component-type="PF4/Button"
+                        data-ouia-safe={true}
+                        disabled={false}
+                        id="remove_pf-random-id-5"
+                        onClick={[Function]}
+                        role={null}
+                        type="button"
                       >
-                        <svg
+                        <TimesIcon
                           aria-hidden="true"
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 352 512"
-                          width="1em"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
                         >
-                          <path
-                            d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                          />
-                        </svg>
-                      </TimesIcon>
-                    </button>
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 352 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                            />
+                          </svg>
+                        </TimesIcon>
+                      </button>
+                    </ButtonBase>
                   </Button>
                 </div>
               </GenerateId>
@@ -503,46 +543,56 @@ exports[`ChipGroup chip group with closable category 1`] = `
           ouiaId="Close chip group"
           variant="plain"
         >
-          <button
-            aria-disabled={false}
+          <ButtonBase
             aria-label="Close chip group"
             aria-labelledby="remove_group_pf-random-id-4 pf-random-id-4"
-            className="pf-c-button pf-m-plain"
-            data-ouia-component-id="Close chip group"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={false}
             id="remove_group_pf-random-id-4"
+            innerRef={null}
             onClick={[Function]}
-            role={null}
-            type="button"
+            ouiaId="Close chip group"
+            variant="plain"
           >
-            <TimesCircleIcon
-              aria-hidden="true"
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <button
+              aria-disabled={false}
+              aria-label="Close chip group"
+              aria-labelledby="remove_group_pf-random-id-4 pf-random-id-4"
+              className="pf-c-button pf-m-plain"
+              data-ouia-component-id="Close chip group"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              id="remove_group_pf-random-id-4"
+              onClick={[Function]}
+              role={null}
+              type="button"
             >
-              <svg
+              <TimesCircleIcon
                 aria-hidden="true"
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 512 512"
-                width="1em"
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
-                />
-              </svg>
-            </TimesCircleIcon>
-          </button>
+                <svg
+                  aria-hidden="true"
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z"
+                  />
+                </svg>
+              </TimesCircleIcon>
+            </button>
+          </ButtonBase>
         </Button>
       </div>
     </div>

--- a/packages/react-core/src/components/Drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/react-core/src/components/Drawer/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -72,43 +72,50 @@ exports[`Drawer expands from bottom 1`] = `
                                 onClick={[Function]}
                                 variant="plain"
                               >
-                                <button
-                                  aria-disabled={false}
+                                <ButtonBase
                                   aria-label="Close drawer panel"
-                                  className="pf-c-button pf-m-plain"
-                                  data-ouia-component-id="OUIA-Generated-Button-plain-4"
-                                  data-ouia-component-type="PF4/Button"
-                                  data-ouia-safe={true}
-                                  disabled={false}
+                                  innerRef={null}
                                   onClick={[Function]}
-                                  role={null}
-                                  type="button"
+                                  variant="plain"
                                 >
-                                  <TimesIcon
-                                    color="currentColor"
-                                    noVerticalAlign={false}
-                                    size="sm"
+                                  <button
+                                    aria-disabled={false}
+                                    aria-label="Close drawer panel"
+                                    className="pf-c-button pf-m-plain"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-4"
+                                    data-ouia-component-type="PF4/Button"
+                                    data-ouia-safe={true}
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    role={null}
+                                    type="button"
                                   >
-                                    <svg
-                                      aria-hidden={true}
-                                      aria-labelledby={null}
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      style={
-                                        Object {
-                                          "verticalAlign": "-0.125em",
-                                        }
-                                      }
-                                      viewBox="0 0 352 512"
-                                      width="1em"
+                                    <TimesIcon
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      size="sm"
                                     >
-                                      <path
-                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                      />
-                                    </svg>
-                                  </TimesIcon>
-                                </button>
+                                      <svg
+                                        aria-hidden={true}
+                                        aria-labelledby={null}
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        style={
+                                          Object {
+                                            "verticalAlign": "-0.125em",
+                                          }
+                                        }
+                                        viewBox="0 0 352 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                        />
+                                      </svg>
+                                    </TimesIcon>
+                                  </button>
+                                </ButtonBase>
                               </Button>
                             </div>
                           </DrawerCloseButton>
@@ -234,43 +241,50 @@ exports[`Drawer has resizable callback and id 1`] = `
                                   onClick={[Function]}
                                   variant="plain"
                                 >
-                                  <button
-                                    aria-disabled={false}
+                                  <ButtonBase
                                     aria-label="Close drawer panel"
-                                    className="pf-c-button pf-m-plain"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-6"
-                                    data-ouia-component-type="PF4/Button"
-                                    data-ouia-safe={true}
-                                    disabled={false}
+                                    innerRef={null}
                                     onClick={[Function]}
-                                    role={null}
-                                    type="button"
+                                    variant="plain"
                                   >
-                                    <TimesIcon
-                                      color="currentColor"
-                                      noVerticalAlign={false}
-                                      size="sm"
+                                    <button
+                                      aria-disabled={false}
+                                      aria-label="Close drawer panel"
+                                      className="pf-c-button pf-m-plain"
+                                      data-ouia-component-id="OUIA-Generated-Button-plain-6"
+                                      data-ouia-component-type="PF4/Button"
+                                      data-ouia-safe={true}
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      role={null}
+                                      type="button"
                                     >
-                                      <svg
-                                        aria-hidden={true}
-                                        aria-labelledby={null}
-                                        fill="currentColor"
-                                        height="1em"
-                                        role="img"
-                                        style={
-                                          Object {
-                                            "verticalAlign": "-0.125em",
-                                          }
-                                        }
-                                        viewBox="0 0 352 512"
-                                        width="1em"
+                                      <TimesIcon
+                                        color="currentColor"
+                                        noVerticalAlign={false}
+                                        size="sm"
                                       >
-                                        <path
-                                          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                        />
-                                      </svg>
-                                    </TimesIcon>
-                                  </button>
+                                        <svg
+                                          aria-hidden={true}
+                                          aria-labelledby={null}
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          style={
+                                            Object {
+                                              "verticalAlign": "-0.125em",
+                                            }
+                                          }
+                                          viewBox="0 0 352 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                          />
+                                        </svg>
+                                      </TimesIcon>
+                                    </button>
+                                  </ButtonBase>
                                 </Button>
                               </div>
                             </DrawerCloseButton>
@@ -407,43 +421,50 @@ exports[`Drawer has resizable css and color variants 1`] = `
                                   onClick={[Function]}
                                   variant="plain"
                                 >
-                                  <button
-                                    aria-disabled={false}
+                                  <ButtonBase
                                     aria-label="Close drawer panel"
-                                    className="pf-c-button pf-m-plain"
-                                    data-ouia-component-id="OUIA-Generated-Button-plain-5"
-                                    data-ouia-component-type="PF4/Button"
-                                    data-ouia-safe={true}
-                                    disabled={false}
+                                    innerRef={null}
                                     onClick={[Function]}
-                                    role={null}
-                                    type="button"
+                                    variant="plain"
                                   >
-                                    <TimesIcon
-                                      color="currentColor"
-                                      noVerticalAlign={false}
-                                      size="sm"
+                                    <button
+                                      aria-disabled={false}
+                                      aria-label="Close drawer panel"
+                                      className="pf-c-button pf-m-plain"
+                                      data-ouia-component-id="OUIA-Generated-Button-plain-5"
+                                      data-ouia-component-type="PF4/Button"
+                                      data-ouia-safe={true}
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      role={null}
+                                      type="button"
                                     >
-                                      <svg
-                                        aria-hidden={true}
-                                        aria-labelledby={null}
-                                        fill="currentColor"
-                                        height="1em"
-                                        role="img"
-                                        style={
-                                          Object {
-                                            "verticalAlign": "-0.125em",
-                                          }
-                                        }
-                                        viewBox="0 0 352 512"
-                                        width="1em"
+                                      <TimesIcon
+                                        color="currentColor"
+                                        noVerticalAlign={false}
+                                        size="sm"
                                       >
-                                        <path
-                                          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                        />
-                                      </svg>
-                                    </TimesIcon>
-                                  </button>
+                                        <svg
+                                          aria-hidden={true}
+                                          aria-labelledby={null}
+                                          fill="currentColor"
+                                          height="1em"
+                                          role="img"
+                                          style={
+                                            Object {
+                                              "verticalAlign": "-0.125em",
+                                            }
+                                          }
+                                          viewBox="0 0 352 512"
+                                          width="1em"
+                                        >
+                                          <path
+                                            d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                          />
+                                        </svg>
+                                      </TimesIcon>
+                                    </button>
+                                  </ButtonBase>
                                 </Button>
                               </div>
                             </DrawerCloseButton>
@@ -647,43 +668,50 @@ exports[`Drawer isExpanded = true and isInline = false and isStatic = false 1`] 
                                 onClick={[Function]}
                                 variant="plain"
                               >
-                                <button
-                                  aria-disabled={false}
+                                <ButtonBase
                                   aria-label="Close drawer panel"
-                                  className="pf-c-button pf-m-plain"
-                                  data-ouia-component-id="OUIA-Generated-Button-plain-1"
-                                  data-ouia-component-type="PF4/Button"
-                                  data-ouia-safe={true}
-                                  disabled={false}
+                                  innerRef={null}
                                   onClick={[Function]}
-                                  role={null}
-                                  type="button"
+                                  variant="plain"
                                 >
-                                  <TimesIcon
-                                    color="currentColor"
-                                    noVerticalAlign={false}
-                                    size="sm"
+                                  <button
+                                    aria-disabled={false}
+                                    aria-label="Close drawer panel"
+                                    className="pf-c-button pf-m-plain"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-1"
+                                    data-ouia-component-type="PF4/Button"
+                                    data-ouia-safe={true}
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    role={null}
+                                    type="button"
                                   >
-                                    <svg
-                                      aria-hidden={true}
-                                      aria-labelledby={null}
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      style={
-                                        Object {
-                                          "verticalAlign": "-0.125em",
-                                        }
-                                      }
-                                      viewBox="0 0 352 512"
-                                      width="1em"
+                                    <TimesIcon
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      size="sm"
                                     >
-                                      <path
-                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                      />
-                                    </svg>
-                                  </TimesIcon>
-                                </button>
+                                      <svg
+                                        aria-hidden={true}
+                                        aria-labelledby={null}
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        style={
+                                          Object {
+                                            "verticalAlign": "-0.125em",
+                                          }
+                                        }
+                                        viewBox="0 0 352 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                        />
+                                      </svg>
+                                    </TimesIcon>
+                                  </button>
+                                </ButtonBase>
                               </Button>
                             </div>
                           </DrawerCloseButton>
@@ -780,43 +808,50 @@ exports[`Drawer isExpanded = true and isInline = false and isStatic = true 1`] =
                                 onClick={[Function]}
                                 variant="plain"
                               >
-                                <button
-                                  aria-disabled={false}
+                                <ButtonBase
                                   aria-label="Close drawer panel"
-                                  className="pf-c-button pf-m-plain"
-                                  data-ouia-component-id="OUIA-Generated-Button-plain-3"
-                                  data-ouia-component-type="PF4/Button"
-                                  data-ouia-safe={true}
-                                  disabled={false}
+                                  innerRef={null}
                                   onClick={[Function]}
-                                  role={null}
-                                  type="button"
+                                  variant="plain"
                                 >
-                                  <TimesIcon
-                                    color="currentColor"
-                                    noVerticalAlign={false}
-                                    size="sm"
+                                  <button
+                                    aria-disabled={false}
+                                    aria-label="Close drawer panel"
+                                    className="pf-c-button pf-m-plain"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-3"
+                                    data-ouia-component-type="PF4/Button"
+                                    data-ouia-safe={true}
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    role={null}
+                                    type="button"
                                   >
-                                    <svg
-                                      aria-hidden={true}
-                                      aria-labelledby={null}
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      style={
-                                        Object {
-                                          "verticalAlign": "-0.125em",
-                                        }
-                                      }
-                                      viewBox="0 0 352 512"
-                                      width="1em"
+                                    <TimesIcon
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      size="sm"
                                     >
-                                      <path
-                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                      />
-                                    </svg>
-                                  </TimesIcon>
-                                </button>
+                                      <svg
+                                        aria-hidden={true}
+                                        aria-labelledby={null}
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        style={
+                                          Object {
+                                            "verticalAlign": "-0.125em",
+                                          }
+                                        }
+                                        viewBox="0 0 352 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                        />
+                                      </svg>
+                                    </TimesIcon>
+                                  </button>
+                                </ButtonBase>
                               </Button>
                             </div>
                           </DrawerCloseButton>
@@ -913,43 +948,50 @@ exports[`Drawer isExpanded = true and isInline = true and isStatic = false 1`] =
                                 onClick={[Function]}
                                 variant="plain"
                               >
-                                <button
-                                  aria-disabled={false}
+                                <ButtonBase
                                   aria-label="Close drawer panel"
-                                  className="pf-c-button pf-m-plain"
-                                  data-ouia-component-id="OUIA-Generated-Button-plain-2"
-                                  data-ouia-component-type="PF4/Button"
-                                  data-ouia-safe={true}
-                                  disabled={false}
+                                  innerRef={null}
                                   onClick={[Function]}
-                                  role={null}
-                                  type="button"
+                                  variant="plain"
                                 >
-                                  <TimesIcon
-                                    color="currentColor"
-                                    noVerticalAlign={false}
-                                    size="sm"
+                                  <button
+                                    aria-disabled={false}
+                                    aria-label="Close drawer panel"
+                                    className="pf-c-button pf-m-plain"
+                                    data-ouia-component-id="OUIA-Generated-Button-plain-2"
+                                    data-ouia-component-type="PF4/Button"
+                                    data-ouia-safe={true}
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    role={null}
+                                    type="button"
                                   >
-                                    <svg
-                                      aria-hidden={true}
-                                      aria-labelledby={null}
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      style={
-                                        Object {
-                                          "verticalAlign": "-0.125em",
-                                        }
-                                      }
-                                      viewBox="0 0 352 512"
-                                      width="1em"
+                                    <TimesIcon
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      size="sm"
                                     >
-                                      <path
-                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                      />
-                                    </svg>
-                                  </TimesIcon>
-                                </button>
+                                      <svg
+                                        aria-hidden={true}
+                                        aria-labelledby={null}
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        style={
+                                          Object {
+                                            "verticalAlign": "-0.125em",
+                                          }
+                                        }
+                                        viewBox="0 0 352 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                        />
+                                      </svg>
+                                    </TimesIcon>
+                                  </button>
+                                </ButtonBase>
                               </Button>
                             </div>
                           </DrawerCloseButton>

--- a/packages/react-core/src/components/DualListSelector/DualListSelector.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelector.tsx
@@ -9,6 +9,7 @@ import AngleRightIcon from '@patternfly/react-icons/dist/js/icons/angle-right-ic
 import { DualListSelectorPane } from './DualListSelectorPane';
 import { getUniqueId, PickOptional } from '../../helpers';
 import { DualListSelectorTreeItemData } from './DualListSelectorTree';
+import { Tooltip } from '../Tooltip';
 import {
   flattenTree,
   flattenTreeWithFolders,
@@ -43,20 +44,36 @@ export interface DualListSelectorProps {
   addSelected?: (newAvailableOptions: React.ReactNode[], newChosenOptions: React.ReactNode[]) => void;
   /** Accessible label for the add selected button */
   addSelectedAriaLabel?: string;
+  /** Tooltip content for the add selected button */
+  addSelectedTooltip?: React.ReactNode;
+  /** Additonal tooltip properties for the add selected tooltip */
+  addSelectedTooltipProps?: any;
   /** Callback fired every time options are chosen or removed */
   onListChange?: (newAvailableOptions: React.ReactNode[], newChosenOptions: React.ReactNode[]) => void;
   /** Optional callback for the add all button */
   addAll?: (newAvailableOptions: React.ReactNode[], newChosenOptions: React.ReactNode[]) => void;
   /** Accessible label for the add all button */
   addAllAriaLabel?: string;
+  /** Tooltip content for the add all button */
+  addAllTooltip?: React.ReactNode;
+  /** Additonal tooltip properties for the add all tooltip */
+  addAllTooltipProps?: any;
   /** Optional callback for the remove selected button */
   removeSelected?: (newAvailableOptions: React.ReactNode[], newChosenOptions: React.ReactNode[]) => void;
   /** Accessible label for the remove selected button */
   removeSelectedAriaLabel?: string;
+  /** Tooltip content for the remove selected button */
+  removeSelectedTooltip?: React.ReactNode;
+  /** Additonal tooltip properties for the remove selected tooltip  */
+  removeSelectedTooltipProps?: any;
   /** Optional callback for the remove all button */
   removeAll?: (newAvailableOptions: React.ReactNode[], newChosenOptions: React.ReactNode[]) => void;
   /** Accessible label for the remove all button */
   removeAllAriaLabel?: string;
+  /** Tooltip content for the remove all button */
+  removeAllTooltip?: React.ReactNode;
+  /** Additonal tooltip properties for the remove all tooltip */
+  removeAllTooltipProps?: any;
   /** Optional callback fired when an option is selected */
   onOptionSelect?: (e: React.MouseEvent | React.ChangeEvent) => void;
   /** Optional callback fired when an option is checked */
@@ -98,6 +115,10 @@ interface DualListSelectorState {
 export class DualListSelector extends React.Component<DualListSelectorProps, DualListSelectorState> {
   static displayName = 'DualListSelector';
   private controlsEl = React.createRef<HTMLDivElement>();
+  private addAllButtonRef = React.createRef<HTMLButtonElement>();
+  private addSelectedButtonRef = React.createRef<HTMLButtonElement>();
+  private removeSelectedButtonRef = React.createRef<HTMLButtonElement>();
+  private removeAllButtonRef = React.createRef<HTMLButtonElement>();
   static defaultProps: PickOptional<DualListSelectorProps> = {
     availableOptions: [] as React.ReactNode[],
     availableOptionsTitle: 'Available options',
@@ -520,6 +541,14 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
       onOptionCheck,
       id,
       isTree,
+      addAllTooltip,
+      addAllTooltipProps,
+      addSelectedTooltip,
+      addSelectedTooltipProps,
+      removeAllTooltip,
+      removeAllTooltipProps,
+      removeSelectedTooltip,
+      removeSelectedTooltipProps,
       ...props
     } = this.props;
     const {
@@ -584,9 +613,18 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
               onClick={this.addAll}
               aria-label={addAllAriaLabel}
               tabIndex={-1}
+              ref={this.addAllButtonRef}
             >
               <AngleDoubleRightIcon />
             </Button>
+            {addAllTooltip && (
+              <Tooltip
+                content={addAllTooltip}
+                position="left"
+                reference={this.addAllButtonRef}
+                {...addAllTooltipProps}
+              />
+            )}
           </div>
           <div className={css('pf-c-dual-list-selector__controls-item')}>
             <Button
@@ -596,9 +634,18 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
               onClick={isTree ? this.addTreeSelected : this.addSelected}
               aria-label={addSelectedAriaLabel}
               tabIndex={-1}
+              ref={this.addSelectedButtonRef}
             >
               <AngleRightIcon />
             </Button>
+            {addSelectedTooltip && (
+              <Tooltip
+                content={addSelectedTooltip}
+                position="right"
+                reference={this.addSelectedButtonRef}
+                {...addSelectedTooltipProps}
+              />
+            )}
           </div>
           <div className={css('pf-c-dual-list-selector__controls-item')}>
             <Button
@@ -608,9 +655,18 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
               tabIndex={-1}
               isDisabled={isTree ? chosenTreeOptionsSelected.length === 0 : chosenOptionsSelected.length === 0}
               aria-disabled={isTree ? chosenTreeOptionsSelected.length === 0 : chosenOptionsSelected.length === 0}
+              ref={this.removeSelectedButtonRef}
             >
               <AngleLeftIcon />
             </Button>
+            {removeSelectedTooltip && (
+              <Tooltip
+                content={removeSelectedTooltip}
+                position="left"
+                reference={this.removeSelectedButtonRef}
+                {...removeSelectedTooltipProps}
+              />
+            )}
           </div>
           <div className={css('pf-c-dual-list-selector__controls-item')}>
             <Button
@@ -620,9 +676,18 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
               onClick={this.removeAll}
               aria-label={removeAllAriaLabel}
               tabIndex={-1}
+              ref={this.removeAllButtonRef}
             >
               <AngleDoubleLeftIcon />
             </Button>
+            {removeAllTooltip && (
+              <Tooltip
+                content={removeAllTooltip}
+                position="right"
+                reference={this.removeAllButtonRef}
+                {...removeAllTooltipProps}
+              />
+            )}
           </div>
         </div>
         <DualListSelectorPane

--- a/packages/react-core/src/components/DualListSelector/__tests__/__snapshots__/DualListSelector.test.tsx.snap
+++ b/packages/react-core/src/components/DualListSelector/__tests__/__snapshots__/DualListSelector.test.tsx.snap
@@ -168,44 +168,81 @@ exports[`DualListSelector basic 1`] = `
           tabIndex={-1}
           variant="plain"
         >
-          <button
+          <ButtonBase
             aria-disabled={false}
             aria-label="Add all"
-            className="pf-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Button-plain-1"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={false}
+            innerRef={
+              Object {
+                "current": <button
+                  aria-disabled="false"
+                  aria-label="Add all"
+                  class="pf-c-button pf-m-plain"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-1"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                    />
+                  </svg>
+                </button>,
+              }
+            }
+            isDisabled={false}
             onClick={[Function]}
-            role={null}
             tabIndex={-1}
-            type="button"
+            variant="plain"
           >
-            <AngleDoubleRightIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <button
+              aria-disabled={false}
+              aria-label="Add all"
+              className="pf-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-1"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              onClick={[Function]}
+              role={null}
+              tabIndex={-1}
+              type="button"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+              <AngleDoubleRightIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                />
-              </svg>
-            </AngleDoubleRightIcon>
-          </button>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                  />
+                </svg>
+              </AngleDoubleRightIcon>
+            </button>
+          </ButtonBase>
         </Button>
       </div>
       <div
@@ -219,44 +256,82 @@ exports[`DualListSelector basic 1`] = `
           tabIndex={-1}
           variant="plain"
         >
-          <button
+          <ButtonBase
             aria-disabled={true}
             aria-label="Add selected"
-            className="pf-c-button pf-m-plain pf-m-disabled"
-            data-ouia-component-id="OUIA-Generated-Button-plain-2"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={true}
+            innerRef={
+              Object {
+                "current": <button
+                  aria-disabled="true"
+                  aria-label="Add selected"
+                  class="pf-c-button pf-m-plain pf-m-disabled"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-2"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </button>,
+              }
+            }
+            isDisabled={true}
             onClick={[Function]}
-            role={null}
             tabIndex={-1}
-            type="button"
+            variant="plain"
           >
-            <AngleRightIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <button
+              aria-disabled={true}
+              aria-label="Add selected"
+              className="pf-c-button pf-m-plain pf-m-disabled"
+              data-ouia-component-id="OUIA-Generated-Button-plain-2"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={true}
+              onClick={[Function]}
+              role={null}
+              tabIndex={-1}
+              type="button"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 256 512"
-                width="1em"
+              <AngleRightIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                />
-              </svg>
-            </AngleRightIcon>
-          </button>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                  />
+                </svg>
+              </AngleRightIcon>
+            </button>
+          </ButtonBase>
         </Button>
       </div>
       <div
@@ -270,44 +345,82 @@ exports[`DualListSelector basic 1`] = `
           tabIndex={-1}
           variant="plain"
         >
-          <button
+          <ButtonBase
             aria-disabled={true}
             aria-label="Remove selected"
-            className="pf-c-button pf-m-plain pf-m-disabled"
-            data-ouia-component-id="OUIA-Generated-Button-plain-3"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={true}
+            innerRef={
+              Object {
+                "current": <button
+                  aria-disabled="true"
+                  aria-label="Remove selected"
+                  class="pf-c-button pf-m-plain pf-m-disabled"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-3"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                    />
+                  </svg>
+                </button>,
+              }
+            }
+            isDisabled={true}
             onClick={[Function]}
-            role={null}
             tabIndex={-1}
-            type="button"
+            variant="plain"
           >
-            <AngleLeftIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <button
+              aria-disabled={true}
+              aria-label="Remove selected"
+              className="pf-c-button pf-m-plain pf-m-disabled"
+              data-ouia-component-id="OUIA-Generated-Button-plain-3"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={true}
+              onClick={[Function]}
+              role={null}
+              tabIndex={-1}
+              type="button"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 256 512"
-                width="1em"
+              <AngleLeftIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                />
-              </svg>
-            </AngleLeftIcon>
-          </button>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                  />
+                </svg>
+              </AngleLeftIcon>
+            </button>
+          </ButtonBase>
         </Button>
       </div>
       <div
@@ -321,44 +434,82 @@ exports[`DualListSelector basic 1`] = `
           tabIndex={-1}
           variant="plain"
         >
-          <button
+          <ButtonBase
             aria-disabled={true}
             aria-label="Remove all"
-            className="pf-c-button pf-m-plain pf-m-disabled"
-            data-ouia-component-id="OUIA-Generated-Button-plain-4"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={true}
+            innerRef={
+              Object {
+                "current": <button
+                  aria-disabled="true"
+                  aria-label="Remove all"
+                  class="pf-c-button pf-m-plain pf-m-disabled"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-4"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                    />
+                  </svg>
+                </button>,
+              }
+            }
+            isDisabled={true}
             onClick={[Function]}
-            role={null}
             tabIndex={-1}
-            type="button"
+            variant="plain"
           >
-            <AngleDoubleLeftIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <button
+              aria-disabled={true}
+              aria-label="Remove all"
+              className="pf-c-button pf-m-plain pf-m-disabled"
+              data-ouia-component-id="OUIA-Generated-Button-plain-4"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={true}
+              onClick={[Function]}
+              role={null}
+              tabIndex={-1}
+              type="button"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+              <AngleDoubleLeftIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                />
-              </svg>
-            </AngleDoubleLeftIcon>
-          </button>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                  />
+                </svg>
+              </AngleDoubleLeftIcon>
+            </button>
+          </ButtonBase>
         </Button>
       </div>
     </div>
@@ -625,44 +776,81 @@ exports[`DualListSelector with actions 1`] = `
           tabIndex={-1}
           variant="plain"
         >
-          <button
+          <ButtonBase
             aria-disabled={false}
             aria-label="Add all"
-            className="pf-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Button-plain-17"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={false}
+            innerRef={
+              Object {
+                "current": <button
+                  aria-disabled="false"
+                  aria-label="Add all"
+                  class="pf-c-button pf-m-plain"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-17"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                    />
+                  </svg>
+                </button>,
+              }
+            }
+            isDisabled={false}
             onClick={[Function]}
-            role={null}
             tabIndex={-1}
-            type="button"
+            variant="plain"
           >
-            <AngleDoubleRightIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <button
+              aria-disabled={false}
+              aria-label="Add all"
+              className="pf-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-17"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              onClick={[Function]}
+              role={null}
+              tabIndex={-1}
+              type="button"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+              <AngleDoubleRightIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                />
-              </svg>
-            </AngleDoubleRightIcon>
-          </button>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                  />
+                </svg>
+              </AngleDoubleRightIcon>
+            </button>
+          </ButtonBase>
         </Button>
       </div>
       <div
@@ -676,44 +864,82 @@ exports[`DualListSelector with actions 1`] = `
           tabIndex={-1}
           variant="plain"
         >
-          <button
+          <ButtonBase
             aria-disabled={true}
             aria-label="Add selected"
-            className="pf-c-button pf-m-plain pf-m-disabled"
-            data-ouia-component-id="OUIA-Generated-Button-plain-18"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={true}
+            innerRef={
+              Object {
+                "current": <button
+                  aria-disabled="true"
+                  aria-label="Add selected"
+                  class="pf-c-button pf-m-plain pf-m-disabled"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-18"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </button>,
+              }
+            }
+            isDisabled={true}
             onClick={[Function]}
-            role={null}
             tabIndex={-1}
-            type="button"
+            variant="plain"
           >
-            <AngleRightIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <button
+              aria-disabled={true}
+              aria-label="Add selected"
+              className="pf-c-button pf-m-plain pf-m-disabled"
+              data-ouia-component-id="OUIA-Generated-Button-plain-18"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={true}
+              onClick={[Function]}
+              role={null}
+              tabIndex={-1}
+              type="button"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 256 512"
-                width="1em"
+              <AngleRightIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                />
-              </svg>
-            </AngleRightIcon>
-          </button>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                  />
+                </svg>
+              </AngleRightIcon>
+            </button>
+          </ButtonBase>
         </Button>
       </div>
       <div
@@ -727,44 +953,82 @@ exports[`DualListSelector with actions 1`] = `
           tabIndex={-1}
           variant="plain"
         >
-          <button
+          <ButtonBase
             aria-disabled={true}
             aria-label="Remove selected"
-            className="pf-c-button pf-m-plain pf-m-disabled"
-            data-ouia-component-id="OUIA-Generated-Button-plain-19"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={true}
+            innerRef={
+              Object {
+                "current": <button
+                  aria-disabled="true"
+                  aria-label="Remove selected"
+                  class="pf-c-button pf-m-plain pf-m-disabled"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-19"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                    />
+                  </svg>
+                </button>,
+              }
+            }
+            isDisabled={true}
             onClick={[Function]}
-            role={null}
             tabIndex={-1}
-            type="button"
+            variant="plain"
           >
-            <AngleLeftIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <button
+              aria-disabled={true}
+              aria-label="Remove selected"
+              className="pf-c-button pf-m-plain pf-m-disabled"
+              data-ouia-component-id="OUIA-Generated-Button-plain-19"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={true}
+              onClick={[Function]}
+              role={null}
+              tabIndex={-1}
+              type="button"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 256 512"
-                width="1em"
+              <AngleLeftIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                />
-              </svg>
-            </AngleLeftIcon>
-          </button>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                  />
+                </svg>
+              </AngleLeftIcon>
+            </button>
+          </ButtonBase>
         </Button>
       </div>
       <div
@@ -778,44 +1042,81 @@ exports[`DualListSelector with actions 1`] = `
           tabIndex={-1}
           variant="plain"
         >
-          <button
+          <ButtonBase
             aria-disabled={false}
             aria-label="Remove all"
-            className="pf-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Button-plain-20"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={false}
+            innerRef={
+              Object {
+                "current": <button
+                  aria-disabled="false"
+                  aria-label="Remove all"
+                  class="pf-c-button pf-m-plain"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-20"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                    />
+                  </svg>
+                </button>,
+              }
+            }
+            isDisabled={false}
             onClick={[Function]}
-            role={null}
             tabIndex={-1}
-            type="button"
+            variant="plain"
           >
-            <AngleDoubleLeftIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <button
+              aria-disabled={false}
+              aria-label="Remove all"
+              className="pf-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-20"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              onClick={[Function]}
+              role={null}
+              tabIndex={-1}
+              type="button"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+              <AngleDoubleLeftIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                />
-              </svg>
-            </AngleDoubleLeftIcon>
-          </button>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                  />
+                </svg>
+              </AngleDoubleLeftIcon>
+            </button>
+          </ButtonBase>
         </Button>
       </div>
     </div>
@@ -1141,44 +1442,81 @@ exports[`DualListSelector with custom status 1`] = `
           tabIndex={-1}
           variant="plain"
         >
-          <button
+          <ButtonBase
             aria-disabled={false}
             aria-label="Add all"
-            className="pf-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Button-plain-9"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={false}
+            innerRef={
+              Object {
+                "current": <button
+                  aria-disabled="false"
+                  aria-label="Add all"
+                  class="pf-c-button pf-m-plain"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-9"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                    />
+                  </svg>
+                </button>,
+              }
+            }
+            isDisabled={false}
             onClick={[Function]}
-            role={null}
             tabIndex={-1}
-            type="button"
+            variant="plain"
           >
-            <AngleDoubleRightIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <button
+              aria-disabled={false}
+              aria-label="Add all"
+              className="pf-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-9"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              onClick={[Function]}
+              role={null}
+              tabIndex={-1}
+              type="button"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+              <AngleDoubleRightIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                />
-              </svg>
-            </AngleDoubleRightIcon>
-          </button>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                  />
+                </svg>
+              </AngleDoubleRightIcon>
+            </button>
+          </ButtonBase>
         </Button>
       </div>
       <div
@@ -1192,44 +1530,82 @@ exports[`DualListSelector with custom status 1`] = `
           tabIndex={-1}
           variant="plain"
         >
-          <button
+          <ButtonBase
             aria-disabled={true}
             aria-label="Add selected"
-            className="pf-c-button pf-m-plain pf-m-disabled"
-            data-ouia-component-id="OUIA-Generated-Button-plain-10"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={true}
+            innerRef={
+              Object {
+                "current": <button
+                  aria-disabled="true"
+                  aria-label="Add selected"
+                  class="pf-c-button pf-m-plain pf-m-disabled"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-10"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </button>,
+              }
+            }
+            isDisabled={true}
             onClick={[Function]}
-            role={null}
             tabIndex={-1}
-            type="button"
+            variant="plain"
           >
-            <AngleRightIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <button
+              aria-disabled={true}
+              aria-label="Add selected"
+              className="pf-c-button pf-m-plain pf-m-disabled"
+              data-ouia-component-id="OUIA-Generated-Button-plain-10"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={true}
+              onClick={[Function]}
+              role={null}
+              tabIndex={-1}
+              type="button"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 256 512"
-                width="1em"
+              <AngleRightIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                />
-              </svg>
-            </AngleRightIcon>
-          </button>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                  />
+                </svg>
+              </AngleRightIcon>
+            </button>
+          </ButtonBase>
         </Button>
       </div>
       <div
@@ -1243,44 +1619,82 @@ exports[`DualListSelector with custom status 1`] = `
           tabIndex={-1}
           variant="plain"
         >
-          <button
+          <ButtonBase
             aria-disabled={true}
             aria-label="Remove selected"
-            className="pf-c-button pf-m-plain pf-m-disabled"
-            data-ouia-component-id="OUIA-Generated-Button-plain-11"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={true}
+            innerRef={
+              Object {
+                "current": <button
+                  aria-disabled="true"
+                  aria-label="Remove selected"
+                  class="pf-c-button pf-m-plain pf-m-disabled"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-11"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                    />
+                  </svg>
+                </button>,
+              }
+            }
+            isDisabled={true}
             onClick={[Function]}
-            role={null}
             tabIndex={-1}
-            type="button"
+            variant="plain"
           >
-            <AngleLeftIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <button
+              aria-disabled={true}
+              aria-label="Remove selected"
+              className="pf-c-button pf-m-plain pf-m-disabled"
+              data-ouia-component-id="OUIA-Generated-Button-plain-11"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={true}
+              onClick={[Function]}
+              role={null}
+              tabIndex={-1}
+              type="button"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 256 512"
-                width="1em"
+              <AngleLeftIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                />
-              </svg>
-            </AngleLeftIcon>
-          </button>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                  />
+                </svg>
+              </AngleLeftIcon>
+            </button>
+          </ButtonBase>
         </Button>
       </div>
       <div
@@ -1294,44 +1708,82 @@ exports[`DualListSelector with custom status 1`] = `
           tabIndex={-1}
           variant="plain"
         >
-          <button
+          <ButtonBase
             aria-disabled={true}
             aria-label="Remove all"
-            className="pf-c-button pf-m-plain pf-m-disabled"
-            data-ouia-component-id="OUIA-Generated-Button-plain-12"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={true}
+            innerRef={
+              Object {
+                "current": <button
+                  aria-disabled="true"
+                  aria-label="Remove all"
+                  class="pf-c-button pf-m-plain pf-m-disabled"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-12"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                    />
+                  </svg>
+                </button>,
+              }
+            }
+            isDisabled={true}
             onClick={[Function]}
-            role={null}
             tabIndex={-1}
-            type="button"
+            variant="plain"
           >
-            <AngleDoubleLeftIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <button
+              aria-disabled={true}
+              aria-label="Remove all"
+              className="pf-c-button pf-m-plain pf-m-disabled"
+              data-ouia-component-id="OUIA-Generated-Button-plain-12"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={true}
+              onClick={[Function]}
+              role={null}
+              tabIndex={-1}
+              type="button"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+              <AngleDoubleLeftIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                />
-              </svg>
-            </AngleDoubleLeftIcon>
-          </button>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                  />
+                </svg>
+              </AngleDoubleLeftIcon>
+            </button>
+          </ButtonBase>
         </Button>
       </div>
     </div>
@@ -1574,44 +2026,81 @@ exports[`DualListSelector with search inputs 1`] = `
           tabIndex={-1}
           variant="plain"
         >
-          <button
+          <ButtonBase
             aria-disabled={false}
             aria-label="Add all"
-            className="pf-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Button-plain-5"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={false}
+            innerRef={
+              Object {
+                "current": <button
+                  aria-disabled="false"
+                  aria-label="Add all"
+                  class="pf-c-button pf-m-plain"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-5"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                    />
+                  </svg>
+                </button>,
+              }
+            }
+            isDisabled={false}
             onClick={[Function]}
-            role={null}
             tabIndex={-1}
-            type="button"
+            variant="plain"
           >
-            <AngleDoubleRightIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <button
+              aria-disabled={false}
+              aria-label="Add all"
+              className="pf-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-5"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              onClick={[Function]}
+              role={null}
+              tabIndex={-1}
+              type="button"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+              <AngleDoubleRightIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                />
-              </svg>
-            </AngleDoubleRightIcon>
-          </button>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                  />
+                </svg>
+              </AngleDoubleRightIcon>
+            </button>
+          </ButtonBase>
         </Button>
       </div>
       <div
@@ -1625,44 +2114,82 @@ exports[`DualListSelector with search inputs 1`] = `
           tabIndex={-1}
           variant="plain"
         >
-          <button
+          <ButtonBase
             aria-disabled={true}
             aria-label="Add selected"
-            className="pf-c-button pf-m-plain pf-m-disabled"
-            data-ouia-component-id="OUIA-Generated-Button-plain-6"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={true}
+            innerRef={
+              Object {
+                "current": <button
+                  aria-disabled="true"
+                  aria-label="Add selected"
+                  class="pf-c-button pf-m-plain pf-m-disabled"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-6"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </button>,
+              }
+            }
+            isDisabled={true}
             onClick={[Function]}
-            role={null}
             tabIndex={-1}
-            type="button"
+            variant="plain"
           >
-            <AngleRightIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <button
+              aria-disabled={true}
+              aria-label="Add selected"
+              className="pf-c-button pf-m-plain pf-m-disabled"
+              data-ouia-component-id="OUIA-Generated-Button-plain-6"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={true}
+              onClick={[Function]}
+              role={null}
+              tabIndex={-1}
+              type="button"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 256 512"
-                width="1em"
+              <AngleRightIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                />
-              </svg>
-            </AngleRightIcon>
-          </button>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                  />
+                </svg>
+              </AngleRightIcon>
+            </button>
+          </ButtonBase>
         </Button>
       </div>
       <div
@@ -1676,44 +2203,82 @@ exports[`DualListSelector with search inputs 1`] = `
           tabIndex={-1}
           variant="plain"
         >
-          <button
+          <ButtonBase
             aria-disabled={true}
             aria-label="Remove selected"
-            className="pf-c-button pf-m-plain pf-m-disabled"
-            data-ouia-component-id="OUIA-Generated-Button-plain-7"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={true}
+            innerRef={
+              Object {
+                "current": <button
+                  aria-disabled="true"
+                  aria-label="Remove selected"
+                  class="pf-c-button pf-m-plain pf-m-disabled"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-7"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                    />
+                  </svg>
+                </button>,
+              }
+            }
+            isDisabled={true}
             onClick={[Function]}
-            role={null}
             tabIndex={-1}
-            type="button"
+            variant="plain"
           >
-            <AngleLeftIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <button
+              aria-disabled={true}
+              aria-label="Remove selected"
+              className="pf-c-button pf-m-plain pf-m-disabled"
+              data-ouia-component-id="OUIA-Generated-Button-plain-7"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={true}
+              onClick={[Function]}
+              role={null}
+              tabIndex={-1}
+              type="button"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 256 512"
-                width="1em"
+              <AngleLeftIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                />
-              </svg>
-            </AngleLeftIcon>
-          </button>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                  />
+                </svg>
+              </AngleLeftIcon>
+            </button>
+          </ButtonBase>
         </Button>
       </div>
       <div
@@ -1727,44 +2292,82 @@ exports[`DualListSelector with search inputs 1`] = `
           tabIndex={-1}
           variant="plain"
         >
-          <button
+          <ButtonBase
             aria-disabled={true}
             aria-label="Remove all"
-            className="pf-c-button pf-m-plain pf-m-disabled"
-            data-ouia-component-id="OUIA-Generated-Button-plain-8"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={true}
+            innerRef={
+              Object {
+                "current": <button
+                  aria-disabled="true"
+                  aria-label="Remove all"
+                  class="pf-c-button pf-m-plain pf-m-disabled"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-8"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                    />
+                  </svg>
+                </button>,
+              }
+            }
+            isDisabled={true}
             onClick={[Function]}
-            role={null}
             tabIndex={-1}
-            type="button"
+            variant="plain"
           >
-            <AngleDoubleLeftIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <button
+              aria-disabled={true}
+              aria-label="Remove all"
+              className="pf-c-button pf-m-plain pf-m-disabled"
+              data-ouia-component-id="OUIA-Generated-Button-plain-8"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={true}
+              onClick={[Function]}
+              role={null}
+              tabIndex={-1}
+              type="button"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+              <AngleDoubleLeftIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                />
-              </svg>
-            </AngleDoubleLeftIcon>
-          </button>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                  />
+                </svg>
+              </AngleDoubleLeftIcon>
+            </button>
+          </ButtonBase>
         </Button>
       </div>
     </div>
@@ -2251,44 +2854,81 @@ exports[`DualListSelector with tree 1`] = `
           tabIndex={-1}
           variant="plain"
         >
-          <button
+          <ButtonBase
             aria-disabled={false}
             aria-label="Add all"
-            className="pf-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Button-plain-13"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={false}
+            innerRef={
+              Object {
+                "current": <button
+                  aria-disabled="false"
+                  aria-label="Add all"
+                  class="pf-c-button pf-m-plain"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-13"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                    />
+                  </svg>
+                </button>,
+              }
+            }
+            isDisabled={false}
             onClick={[Function]}
-            role={null}
             tabIndex={-1}
-            type="button"
+            variant="plain"
           >
-            <AngleDoubleRightIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <button
+              aria-disabled={false}
+              aria-label="Add all"
+              className="pf-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-13"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              onClick={[Function]}
+              role={null}
+              tabIndex={-1}
+              type="button"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+              <AngleDoubleRightIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                />
-              </svg>
-            </AngleDoubleRightIcon>
-          </button>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                  />
+                </svg>
+              </AngleDoubleRightIcon>
+            </button>
+          </ButtonBase>
         </Button>
       </div>
       <div
@@ -2302,44 +2942,82 @@ exports[`DualListSelector with tree 1`] = `
           tabIndex={-1}
           variant="plain"
         >
-          <button
+          <ButtonBase
             aria-disabled={true}
             aria-label="Add selected"
-            className="pf-c-button pf-m-plain pf-m-disabled"
-            data-ouia-component-id="OUIA-Generated-Button-plain-14"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={true}
+            innerRef={
+              Object {
+                "current": <button
+                  aria-disabled="true"
+                  aria-label="Add selected"
+                  class="pf-c-button pf-m-plain pf-m-disabled"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-14"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </button>,
+              }
+            }
+            isDisabled={true}
             onClick={[Function]}
-            role={null}
             tabIndex={-1}
-            type="button"
+            variant="plain"
           >
-            <AngleRightIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <button
+              aria-disabled={true}
+              aria-label="Add selected"
+              className="pf-c-button pf-m-plain pf-m-disabled"
+              data-ouia-component-id="OUIA-Generated-Button-plain-14"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={true}
+              onClick={[Function]}
+              role={null}
+              tabIndex={-1}
+              type="button"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 256 512"
-                width="1em"
+              <AngleRightIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                />
-              </svg>
-            </AngleRightIcon>
-          </button>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                  />
+                </svg>
+              </AngleRightIcon>
+            </button>
+          </ButtonBase>
         </Button>
       </div>
       <div
@@ -2353,44 +3031,82 @@ exports[`DualListSelector with tree 1`] = `
           tabIndex={-1}
           variant="plain"
         >
-          <button
+          <ButtonBase
             aria-disabled={true}
             aria-label="Remove selected"
-            className="pf-c-button pf-m-plain pf-m-disabled"
-            data-ouia-component-id="OUIA-Generated-Button-plain-15"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={true}
+            innerRef={
+              Object {
+                "current": <button
+                  aria-disabled="true"
+                  aria-label="Remove selected"
+                  class="pf-c-button pf-m-plain pf-m-disabled"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-15"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                    />
+                  </svg>
+                </button>,
+              }
+            }
+            isDisabled={true}
             onClick={[Function]}
-            role={null}
             tabIndex={-1}
-            type="button"
+            variant="plain"
           >
-            <AngleLeftIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <button
+              aria-disabled={true}
+              aria-label="Remove selected"
+              className="pf-c-button pf-m-plain pf-m-disabled"
+              data-ouia-component-id="OUIA-Generated-Button-plain-15"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={true}
+              onClick={[Function]}
+              role={null}
+              tabIndex={-1}
+              type="button"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 256 512"
-                width="1em"
+              <AngleLeftIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                />
-              </svg>
-            </AngleLeftIcon>
-          </button>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                  />
+                </svg>
+              </AngleLeftIcon>
+            </button>
+          </ButtonBase>
         </Button>
       </div>
       <div
@@ -2404,44 +3120,82 @@ exports[`DualListSelector with tree 1`] = `
           tabIndex={-1}
           variant="plain"
         >
-          <button
+          <ButtonBase
             aria-disabled={true}
             aria-label="Remove all"
-            className="pf-c-button pf-m-plain pf-m-disabled"
-            data-ouia-component-id="OUIA-Generated-Button-plain-16"
-            data-ouia-component-type="PF4/Button"
-            data-ouia-safe={true}
-            disabled={true}
+            innerRef={
+              Object {
+                "current": <button
+                  aria-disabled="true"
+                  aria-label="Remove all"
+                  class="pf-c-button pf-m-plain pf-m-disabled"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-16"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                    />
+                  </svg>
+                </button>,
+              }
+            }
+            isDisabled={true}
             onClick={[Function]}
-            role={null}
             tabIndex={-1}
-            type="button"
+            variant="plain"
           >
-            <AngleDoubleLeftIcon
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <button
+              aria-disabled={true}
+              aria-label="Remove all"
+              className="pf-c-button pf-m-plain pf-m-disabled"
+              data-ouia-component-id="OUIA-Generated-Button-plain-16"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={true}
+              onClick={[Function]}
+              role={null}
+              tabIndex={-1}
+              type="button"
             >
-              <svg
-                aria-hidden={true}
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+              <AngleDoubleLeftIcon
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                />
-              </svg>
-            </AngleDoubleLeftIcon>
-          </button>
+                <svg
+                  aria-hidden={true}
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                  />
+                </svg>
+              </AngleDoubleLeftIcon>
+            </button>
+          </ButtonBase>
         </Button>
       </div>
     </div>

--- a/packages/react-core/src/components/DualListSelector/examples/DualListSelector.md
+++ b/packages/react-core/src/components/DualListSelector/examples/DualListSelector.md
@@ -45,6 +45,49 @@ class BasicDualListSelector extends React.Component {
 }
 ```
 
+### Basic with tooltips
+
+```js
+import React from 'react';
+import { DualListSelector } from '@patternfly/react-core';
+
+class BasicDualListSelector extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      availableOptions: ['Option 1', 'Option 2', 'Option 3', 'Option 4'],
+      chosenOptions: []
+    };
+
+    this.onListChange = (newAvailableOptions, newChosenOptions) => {
+      this.setState({
+        availableOptions: newAvailableOptions.sort(),
+        chosenOptions: newChosenOptions.sort()
+      });
+    };
+  }
+
+  render() {
+    return (
+      <DualListSelector
+        availableOptions={this.state.availableOptions}
+        chosenOptions={this.state.chosenOptions}
+        onListChange={this.onListChange}
+        addAllTooltip="Add all options"
+        addAllTooltipProps={{ position: 'top' }}
+        addSelectedTooltip="Add selected options"
+        addSelectedTooltipProps={{ position: 'right' }}
+        removeSelectedTooltip="Remove selected options"
+        removeSelectedTooltipProps={{ position: 'left' }}
+        removeAllTooltip="Remove all options"
+        removeAllTooltipProps={{ position: 'bottom' }}
+        id="basicSelector"
+      />
+    );
+  }
+}
+```
+
 ### Basic with search
 
 ```js

--- a/packages/react-core/src/components/Form/__tests__/__snapshots__/FormFieldGroup.test.tsx.snap
+++ b/packages/react-core/src/components/Form/__tests__/__snapshots__/FormFieldGroup.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Check expandable form field group example against snapshot 1`] = `
 <FormFieldGroupExpandable
   header={
     <FormFieldGroupHeader
-      actions={<Button />}
+      actions={<ForwardRef(Button) />}
       titleDescription="Field group 4 description text."
       titleText={
         Object {
@@ -20,7 +20,7 @@ exports[`Check expandable form field group example against snapshot 1`] = `
   <InternalFormFieldGroup
     header={
       <FormFieldGroupHeader
-        actions={<Button />}
+        actions={<ForwardRef(Button) />}
         titleDescription="Field group 4 description text."
         titleText={
           Object {
@@ -62,58 +62,68 @@ exports[`Check expandable form field group example against snapshot 1`] = `
                 onClick={[Function]}
                 variant="plain"
               >
-                <button
-                  aria-disabled={false}
+                <ButtonBase
                   aria-expanded={true}
                   aria-label="toggle"
                   aria-labelledby="title-text-id2 form-field-group-toggle0"
-                  className="pf-c-button pf-m-plain"
-                  data-ouia-component-id="OUIA-Generated-Button-plain-1"
-                  data-ouia-component-type="PF4/Button"
-                  data-ouia-safe={true}
-                  disabled={false}
                   id="form-field-group-toggle0"
+                  innerRef={null}
                   onClick={[Function]}
-                  role={null}
-                  type="button"
+                  variant="plain"
                 >
-                  <span
-                    className="pf-c-form__field-group-toggle-icon"
+                  <button
+                    aria-disabled={false}
+                    aria-expanded={true}
+                    aria-label="toggle"
+                    aria-labelledby="title-text-id2 form-field-group-toggle0"
+                    className="pf-c-button pf-m-plain"
+                    data-ouia-component-id="OUIA-Generated-Button-plain-1"
+                    data-ouia-component-type="PF4/Button"
+                    data-ouia-safe={true}
+                    disabled={false}
+                    id="form-field-group-toggle0"
+                    onClick={[Function]}
+                    role={null}
+                    type="button"
                   >
-                    <AngleRightIcon
-                      aria-hidden="true"
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="sm"
+                    <span
+                      className="pf-c-form__field-group-toggle-icon"
                     >
-                      <svg
+                      <AngleRightIcon
                         aria-hidden="true"
-                        aria-labelledby={null}
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style={
-                          Object {
-                            "verticalAlign": "-0.125em",
-                          }
-                        }
-                        viewBox="0 0 256 512"
-                        width="1em"
+                        color="currentColor"
+                        noVerticalAlign={false}
+                        size="sm"
                       >
-                        <path
-                          d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                        />
-                      </svg>
-                    </AngleRightIcon>
-                  </span>
-                </button>
+                        <svg
+                          aria-hidden="true"
+                          aria-labelledby={null}
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style={
+                            Object {
+                              "verticalAlign": "-0.125em",
+                            }
+                          }
+                          viewBox="0 0 256 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                          />
+                        </svg>
+                      </AngleRightIcon>
+                    </span>
+                  </button>
+                </ButtonBase>
               </Button>
             </div>
           </div>
         </FormFieldGroupToggle>
       </GenerateId>
       <FormFieldGroupHeader
-        actions={<Button />}
+        actions={<ForwardRef(Button) />}
         titleDescription="Field group 4 description text."
         titleText={
           Object {
@@ -148,17 +158,21 @@ exports[`Check expandable form field group example against snapshot 1`] = `
             className="pf-c-form__field-group-header-actions"
           >
             <Button>
-              <button
-                aria-disabled={false}
-                aria-label={null}
-                className="pf-c-button pf-m-primary"
-                data-ouia-component-id="OUIA-Generated-Button-primary-2"
-                data-ouia-component-type="PF4/Button"
-                data-ouia-safe={true}
-                disabled={false}
-                role={null}
-                type="button"
-              />
+              <ButtonBase
+                innerRef={null}
+              >
+                <button
+                  aria-disabled={false}
+                  aria-label={null}
+                  className="pf-c-button pf-m-primary"
+                  data-ouia-component-id="OUIA-Generated-Button-primary-2"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe={true}
+                  disabled={false}
+                  role={null}
+                  type="button"
+                />
+              </ButtonBase>
             </Button>
           </div>
         </div>
@@ -175,7 +189,7 @@ exports[`Check form filed group example against snapshot 1`] = `
 <FormFieldGroup
   header={
     <FormFieldGroupHeader
-      actions={<Button />}
+      actions={<ForwardRef(Button) />}
       titleDescription="Field group 4 description text."
       titleText={
         Object {
@@ -189,7 +203,7 @@ exports[`Check form filed group example against snapshot 1`] = `
   <InternalFormFieldGroup
     header={
       <FormFieldGroupHeader
-        actions={<Button />}
+        actions={<ForwardRef(Button) />}
         titleDescription="Field group 4 description text."
         titleText={
           Object {
@@ -204,7 +218,7 @@ exports[`Check form filed group example against snapshot 1`] = `
       className="pf-c-form__field-group"
     >
       <FormFieldGroupHeader
-        actions={<Button />}
+        actions={<ForwardRef(Button) />}
         titleDescription="Field group 4 description text."
         titleText={
           Object {
@@ -239,17 +253,21 @@ exports[`Check form filed group example against snapshot 1`] = `
             className="pf-c-form__field-group-header-actions"
           >
             <Button>
-              <button
-                aria-disabled={false}
-                aria-label={null}
-                className="pf-c-button pf-m-primary"
-                data-ouia-component-id="OUIA-Generated-Button-primary-1"
-                data-ouia-component-type="PF4/Button"
-                data-ouia-safe={true}
-                disabled={false}
-                role={null}
-                type="button"
-              />
+              <ButtonBase
+                innerRef={null}
+              >
+                <button
+                  aria-disabled={false}
+                  aria-label={null}
+                  className="pf-c-button pf-m-primary"
+                  data-ouia-component-id="OUIA-Generated-Button-primary-1"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe={true}
+                  disabled={false}
+                  role={null}
+                  type="button"
+                />
+              </ButtonBase>
             </Button>
           </div>
         </div>

--- a/packages/react-core/src/components/NumberInput/__tests__/__snapshots__/NumberInput.test.tsx.snap
+++ b/packages/react-core/src/components/NumberInput/__tests__/__snapshots__/NumberInput.test.tsx.snap
@@ -17,49 +17,57 @@ exports[`numberInput disables lower threshold 1`] = `
         onClick={[Function]}
         variant="control"
       >
-        <button
-          aria-disabled={true}
+        <ButtonBase
           aria-label="Minus"
-          className="pf-c-button pf-m-control pf-m-disabled"
-          data-ouia-component-id="OUIA-Generated-Button-control-7"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe={true}
-          disabled={true}
+          innerRef={null}
+          isDisabled={true}
           onClick={[Function]}
-          role={null}
-          tabIndex={null}
-          type="button"
+          variant="control"
         >
-          <span
-            className="pf-c-number-input__icon"
+          <button
+            aria-disabled={true}
+            aria-label="Minus"
+            className="pf-c-button pf-m-control pf-m-disabled"
+            data-ouia-component-id="OUIA-Generated-Button-control-7"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={true}
+            onClick={[Function]}
+            role={null}
+            tabIndex={null}
+            type="button"
           >
-            <MinusIcon
-              aria-hidden="true"
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <span
+              className="pf-c-number-input__icon"
             >
-              <svg
+              <MinusIcon
                 aria-hidden="true"
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                />
-              </svg>
-            </MinusIcon>
-          </span>
-        </button>
+                <svg
+                  aria-hidden="true"
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                  />
+                </svg>
+              </MinusIcon>
+            </span>
+          </button>
+        </ButtonBase>
       </Button>
       <input
         aria-label="Input"
@@ -74,48 +82,56 @@ exports[`numberInput disables lower threshold 1`] = `
         onClick={[Function]}
         variant="control"
       >
-        <button
-          aria-disabled={false}
+        <ButtonBase
           aria-label="Plus"
-          className="pf-c-button pf-m-control"
-          data-ouia-component-id="OUIA-Generated-Button-control-8"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe={true}
-          disabled={false}
+          innerRef={null}
+          isDisabled={false}
           onClick={[Function]}
-          role={null}
-          type="button"
+          variant="control"
         >
-          <span
-            className="pf-c-number-input__icon"
+          <button
+            aria-disabled={false}
+            aria-label="Plus"
+            className="pf-c-button pf-m-control"
+            data-ouia-component-id="OUIA-Generated-Button-control-8"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={false}
+            onClick={[Function]}
+            role={null}
+            type="button"
           >
-            <PlusIcon
-              aria-hidden="true"
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <span
+              className="pf-c-number-input__icon"
             >
-              <svg
+              <PlusIcon
                 aria-hidden="true"
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                />
-              </svg>
-            </PlusIcon>
-          </span>
-        </button>
+                <svg
+                  aria-hidden="true"
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                  />
+                </svg>
+              </PlusIcon>
+            </span>
+          </button>
+        </ButtonBase>
       </Button>
     </div>
   </div>
@@ -139,48 +155,56 @@ exports[`numberInput disables upper threshold 1`] = `
         onClick={[Function]}
         variant="control"
       >
-        <button
-          aria-disabled={false}
+        <ButtonBase
           aria-label="Minus"
-          className="pf-c-button pf-m-control"
-          data-ouia-component-id="OUIA-Generated-Button-control-9"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe={true}
-          disabled={false}
+          innerRef={null}
+          isDisabled={false}
           onClick={[Function]}
-          role={null}
-          type="button"
+          variant="control"
         >
-          <span
-            className="pf-c-number-input__icon"
+          <button
+            aria-disabled={false}
+            aria-label="Minus"
+            className="pf-c-button pf-m-control"
+            data-ouia-component-id="OUIA-Generated-Button-control-9"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={false}
+            onClick={[Function]}
+            role={null}
+            type="button"
           >
-            <MinusIcon
-              aria-hidden="true"
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <span
+              className="pf-c-number-input__icon"
             >
-              <svg
+              <MinusIcon
                 aria-hidden="true"
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                />
-              </svg>
-            </MinusIcon>
-          </span>
-        </button>
+                <svg
+                  aria-hidden="true"
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                  />
+                </svg>
+              </MinusIcon>
+            </span>
+          </button>
+        </ButtonBase>
       </Button>
       <input
         aria-label="Input"
@@ -195,49 +219,57 @@ exports[`numberInput disables upper threshold 1`] = `
         onClick={[Function]}
         variant="control"
       >
-        <button
-          aria-disabled={true}
+        <ButtonBase
           aria-label="Plus"
-          className="pf-c-button pf-m-control pf-m-disabled"
-          data-ouia-component-id="OUIA-Generated-Button-control-10"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe={true}
-          disabled={true}
+          innerRef={null}
+          isDisabled={true}
           onClick={[Function]}
-          role={null}
-          tabIndex={null}
-          type="button"
+          variant="control"
         >
-          <span
-            className="pf-c-number-input__icon"
+          <button
+            aria-disabled={true}
+            aria-label="Plus"
+            className="pf-c-button pf-m-control pf-m-disabled"
+            data-ouia-component-id="OUIA-Generated-Button-control-10"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={true}
+            onClick={[Function]}
+            role={null}
+            tabIndex={null}
+            type="button"
           >
-            <PlusIcon
-              aria-hidden="true"
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <span
+              className="pf-c-number-input__icon"
             >
-              <svg
+              <PlusIcon
                 aria-hidden="true"
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                />
-              </svg>
-            </PlusIcon>
-          </span>
-        </button>
+                <svg
+                  aria-hidden="true"
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                  />
+                </svg>
+              </PlusIcon>
+            </span>
+          </button>
+        </ButtonBase>
       </Button>
     </div>
   </div>
@@ -273,49 +305,58 @@ exports[`numberInput passes button props successfully 1`] = `
         onClick={[Function]}
         variant="control"
       >
-        <button
-          aria-disabled={false}
+        <ButtonBase
           aria-label="Minus"
-          className="pf-c-button pf-m-control"
-          data-ouia-component-id="OUIA-Generated-Button-control-19"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe={true}
-          disabled={false}
           id="minus-id"
+          innerRef={null}
+          isDisabled={false}
           onClick={[Function]}
-          role={null}
-          type="button"
+          variant="control"
         >
-          <span
-            className="pf-c-number-input__icon"
+          <button
+            aria-disabled={false}
+            aria-label="Minus"
+            className="pf-c-button pf-m-control"
+            data-ouia-component-id="OUIA-Generated-Button-control-19"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={false}
+            id="minus-id"
+            onClick={[Function]}
+            role={null}
+            type="button"
           >
-            <MinusIcon
-              aria-hidden="true"
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <span
+              className="pf-c-number-input__icon"
             >
-              <svg
+              <MinusIcon
                 aria-hidden="true"
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                />
-              </svg>
-            </MinusIcon>
-          </span>
-        </button>
+                <svg
+                  aria-hidden="true"
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                  />
+                </svg>
+              </MinusIcon>
+            </span>
+          </button>
+        </ButtonBase>
       </Button>
       <input
         aria-label="Input"
@@ -331,49 +372,58 @@ exports[`numberInput passes button props successfully 1`] = `
         onClick={[Function]}
         variant="control"
       >
-        <button
-          aria-disabled={false}
+        <ButtonBase
           aria-label="Plus"
-          className="pf-c-button pf-m-control"
-          data-ouia-component-id="OUIA-Generated-Button-control-20"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe={true}
-          disabled={false}
           id="plus-id"
+          innerRef={null}
+          isDisabled={false}
           onClick={[Function]}
-          role={null}
-          type="button"
+          variant="control"
         >
-          <span
-            className="pf-c-number-input__icon"
+          <button
+            aria-disabled={false}
+            aria-label="Plus"
+            className="pf-c-button pf-m-control"
+            data-ouia-component-id="OUIA-Generated-Button-control-20"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={false}
+            id="plus-id"
+            onClick={[Function]}
+            role={null}
+            type="button"
           >
-            <PlusIcon
-              aria-hidden="true"
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <span
+              className="pf-c-number-input__icon"
             >
-              <svg
+              <PlusIcon
                 aria-hidden="true"
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                />
-              </svg>
-            </PlusIcon>
-          </span>
-        </button>
+                <svg
+                  aria-hidden="true"
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                  />
+                </svg>
+              </PlusIcon>
+            </span>
+          </button>
+        </ButtonBase>
       </Button>
     </div>
   </div>
@@ -398,48 +448,56 @@ exports[`numberInput passes input props successfully 1`] = `
         onClick={[Function]}
         variant="control"
       >
-        <button
-          aria-disabled={false}
+        <ButtonBase
           aria-label="Minus"
-          className="pf-c-button pf-m-control"
-          data-ouia-component-id="OUIA-Generated-Button-control-17"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe={true}
-          disabled={false}
+          innerRef={null}
+          isDisabled={false}
           onClick={[Function]}
-          role={null}
-          type="button"
+          variant="control"
         >
-          <span
-            className="pf-c-number-input__icon"
+          <button
+            aria-disabled={false}
+            aria-label="Minus"
+            className="pf-c-button pf-m-control"
+            data-ouia-component-id="OUIA-Generated-Button-control-17"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={false}
+            onClick={[Function]}
+            role={null}
+            type="button"
           >
-            <MinusIcon
-              aria-hidden="true"
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <span
+              className="pf-c-number-input__icon"
             >
-              <svg
+              <MinusIcon
                 aria-hidden="true"
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                />
-              </svg>
-            </MinusIcon>
-          </span>
-        </button>
+                <svg
+                  aria-hidden="true"
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                  />
+                </svg>
+              </MinusIcon>
+            </span>
+          </button>
+        </ButtonBase>
       </Button>
       <input
         aria-label="Input"
@@ -455,48 +513,56 @@ exports[`numberInput passes input props successfully 1`] = `
         onClick={[Function]}
         variant="control"
       >
-        <button
-          aria-disabled={false}
+        <ButtonBase
           aria-label="Plus"
-          className="pf-c-button pf-m-control"
-          data-ouia-component-id="OUIA-Generated-Button-control-18"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe={true}
-          disabled={false}
+          innerRef={null}
+          isDisabled={false}
           onClick={[Function]}
-          role={null}
-          type="button"
+          variant="control"
         >
-          <span
-            className="pf-c-number-input__icon"
+          <button
+            aria-disabled={false}
+            aria-label="Plus"
+            className="pf-c-button pf-m-control"
+            data-ouia-component-id="OUIA-Generated-Button-control-18"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={false}
+            onClick={[Function]}
+            role={null}
+            type="button"
           >
-            <PlusIcon
-              aria-hidden="true"
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <span
+              className="pf-c-number-input__icon"
             >
-              <svg
+              <PlusIcon
                 aria-hidden="true"
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                />
-              </svg>
-            </PlusIcon>
-          </span>
-        </button>
+                <svg
+                  aria-hidden="true"
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                  />
+                </svg>
+              </PlusIcon>
+            </span>
+          </button>
+        </ButtonBase>
       </Button>
     </div>
   </div>
@@ -525,48 +591,56 @@ exports[`numberInput renders custom width 1`] = `
         onClick={[Function]}
         variant="control"
       >
-        <button
-          aria-disabled={false}
+        <ButtonBase
           aria-label="Minus"
-          className="pf-c-button pf-m-control"
-          data-ouia-component-id="OUIA-Generated-Button-control-15"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe={true}
-          disabled={false}
+          innerRef={null}
+          isDisabled={false}
           onClick={[Function]}
-          role={null}
-          type="button"
+          variant="control"
         >
-          <span
-            className="pf-c-number-input__icon"
+          <button
+            aria-disabled={false}
+            aria-label="Minus"
+            className="pf-c-button pf-m-control"
+            data-ouia-component-id="OUIA-Generated-Button-control-15"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={false}
+            onClick={[Function]}
+            role={null}
+            type="button"
           >
-            <MinusIcon
-              aria-hidden="true"
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <span
+              className="pf-c-number-input__icon"
             >
-              <svg
+              <MinusIcon
                 aria-hidden="true"
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                />
-              </svg>
-            </MinusIcon>
-          </span>
-        </button>
+                <svg
+                  aria-hidden="true"
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                  />
+                </svg>
+              </MinusIcon>
+            </span>
+          </button>
+        </ButtonBase>
       </Button>
       <input
         aria-label="Input"
@@ -581,48 +655,56 @@ exports[`numberInput renders custom width 1`] = `
         onClick={[Function]}
         variant="control"
       >
-        <button
-          aria-disabled={false}
+        <ButtonBase
           aria-label="Plus"
-          className="pf-c-button pf-m-control"
-          data-ouia-component-id="OUIA-Generated-Button-control-16"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe={true}
-          disabled={false}
+          innerRef={null}
+          isDisabled={false}
           onClick={[Function]}
-          role={null}
-          type="button"
+          variant="control"
         >
-          <span
-            className="pf-c-number-input__icon"
+          <button
+            aria-disabled={false}
+            aria-label="Plus"
+            className="pf-c-button pf-m-control"
+            data-ouia-component-id="OUIA-Generated-Button-control-16"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={false}
+            onClick={[Function]}
+            role={null}
+            type="button"
           >
-            <PlusIcon
-              aria-hidden="true"
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <span
+              className="pf-c-number-input__icon"
             >
-              <svg
+              <PlusIcon
                 aria-hidden="true"
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                />
-              </svg>
-            </PlusIcon>
-          </span>
-        </button>
+                <svg
+                  aria-hidden="true"
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                  />
+                </svg>
+              </PlusIcon>
+            </span>
+          </button>
+        </ButtonBase>
       </Button>
     </div>
   </div>
@@ -647,48 +729,56 @@ exports[`numberInput renders defaults & extra props 1`] = `
         onClick={[Function]}
         variant="control"
       >
-        <button
-          aria-disabled={false}
+        <ButtonBase
           aria-label="Minus"
-          className="pf-c-button pf-m-control"
-          data-ouia-component-id="OUIA-Generated-Button-control-1"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe={true}
-          disabled={false}
+          innerRef={null}
+          isDisabled={false}
           onClick={[Function]}
-          role={null}
-          type="button"
+          variant="control"
         >
-          <span
-            className="pf-c-number-input__icon"
+          <button
+            aria-disabled={false}
+            aria-label="Minus"
+            className="pf-c-button pf-m-control"
+            data-ouia-component-id="OUIA-Generated-Button-control-1"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={false}
+            onClick={[Function]}
+            role={null}
+            type="button"
           >
-            <MinusIcon
-              aria-hidden="true"
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <span
+              className="pf-c-number-input__icon"
             >
-              <svg
+              <MinusIcon
                 aria-hidden="true"
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                />
-              </svg>
-            </MinusIcon>
-          </span>
-        </button>
+                <svg
+                  aria-hidden="true"
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                  />
+                </svg>
+              </MinusIcon>
+            </span>
+          </button>
+        </ButtonBase>
       </Button>
       <input
         aria-label="Input"
@@ -703,48 +793,56 @@ exports[`numberInput renders defaults & extra props 1`] = `
         onClick={[Function]}
         variant="control"
       >
-        <button
-          aria-disabled={false}
+        <ButtonBase
           aria-label="Plus"
-          className="pf-c-button pf-m-control"
-          data-ouia-component-id="OUIA-Generated-Button-control-2"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe={true}
-          disabled={false}
+          innerRef={null}
+          isDisabled={false}
           onClick={[Function]}
-          role={null}
-          type="button"
+          variant="control"
         >
-          <span
-            className="pf-c-number-input__icon"
+          <button
+            aria-disabled={false}
+            aria-label="Plus"
+            className="pf-c-button pf-m-control"
+            data-ouia-component-id="OUIA-Generated-Button-control-2"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={false}
+            onClick={[Function]}
+            role={null}
+            type="button"
           >
-            <PlusIcon
-              aria-hidden="true"
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <span
+              className="pf-c-number-input__icon"
             >
-              <svg
+              <PlusIcon
                 aria-hidden="true"
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                />
-              </svg>
-            </PlusIcon>
-          </span>
-        </button>
+                <svg
+                  aria-hidden="true"
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                  />
+                </svg>
+              </PlusIcon>
+            </span>
+          </button>
+        </ButtonBase>
       </Button>
     </div>
   </div>
@@ -768,49 +866,57 @@ exports[`numberInput renders disabled 1`] = `
         onClick={[Function]}
         variant="control"
       >
-        <button
-          aria-disabled={true}
+        <ButtonBase
           aria-label="Minus"
-          className="pf-c-button pf-m-control pf-m-disabled"
-          data-ouia-component-id="OUIA-Generated-Button-control-5"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe={true}
-          disabled={true}
+          innerRef={null}
+          isDisabled={true}
           onClick={[Function]}
-          role={null}
-          tabIndex={null}
-          type="button"
+          variant="control"
         >
-          <span
-            className="pf-c-number-input__icon"
+          <button
+            aria-disabled={true}
+            aria-label="Minus"
+            className="pf-c-button pf-m-control pf-m-disabled"
+            data-ouia-component-id="OUIA-Generated-Button-control-5"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={true}
+            onClick={[Function]}
+            role={null}
+            tabIndex={null}
+            type="button"
           >
-            <MinusIcon
-              aria-hidden="true"
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <span
+              className="pf-c-number-input__icon"
             >
-              <svg
+              <MinusIcon
                 aria-hidden="true"
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                />
-              </svg>
-            </MinusIcon>
-          </span>
-        </button>
+                <svg
+                  aria-hidden="true"
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                  />
+                </svg>
+              </MinusIcon>
+            </span>
+          </button>
+        </ButtonBase>
       </Button>
       <input
         aria-label="Input"
@@ -826,49 +932,57 @@ exports[`numberInput renders disabled 1`] = `
         onClick={[Function]}
         variant="control"
       >
-        <button
-          aria-disabled={true}
+        <ButtonBase
           aria-label="Plus"
-          className="pf-c-button pf-m-control pf-m-disabled"
-          data-ouia-component-id="OUIA-Generated-Button-control-6"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe={true}
-          disabled={true}
+          innerRef={null}
+          isDisabled={true}
           onClick={[Function]}
-          role={null}
-          tabIndex={null}
-          type="button"
+          variant="control"
         >
-          <span
-            className="pf-c-number-input__icon"
+          <button
+            aria-disabled={true}
+            aria-label="Plus"
+            className="pf-c-button pf-m-control pf-m-disabled"
+            data-ouia-component-id="OUIA-Generated-Button-control-6"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={true}
+            onClick={[Function]}
+            role={null}
+            tabIndex={null}
+            type="button"
           >
-            <PlusIcon
-              aria-hidden="true"
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <span
+              className="pf-c-number-input__icon"
             >
-              <svg
+              <PlusIcon
                 aria-hidden="true"
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                />
-              </svg>
-            </PlusIcon>
-          </span>
-        </button>
+                <svg
+                  aria-hidden="true"
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                  />
+                </svg>
+              </PlusIcon>
+            </span>
+          </button>
+        </ButtonBase>
       </Button>
     </div>
   </div>
@@ -898,48 +1012,56 @@ exports[`numberInput renders unit & position 1`] = `
         onClick={[Function]}
         variant="control"
       >
-        <button
-          aria-disabled={false}
+        <ButtonBase
           aria-label="Minus"
-          className="pf-c-button pf-m-control"
-          data-ouia-component-id="OUIA-Generated-Button-control-13"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe={true}
-          disabled={false}
+          innerRef={null}
+          isDisabled={false}
           onClick={[Function]}
-          role={null}
-          type="button"
+          variant="control"
         >
-          <span
-            className="pf-c-number-input__icon"
+          <button
+            aria-disabled={false}
+            aria-label="Minus"
+            className="pf-c-button pf-m-control"
+            data-ouia-component-id="OUIA-Generated-Button-control-13"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={false}
+            onClick={[Function]}
+            role={null}
+            type="button"
           >
-            <MinusIcon
-              aria-hidden="true"
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <span
+              className="pf-c-number-input__icon"
             >
-              <svg
+              <MinusIcon
                 aria-hidden="true"
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                />
-              </svg>
-            </MinusIcon>
-          </span>
-        </button>
+                <svg
+                  aria-hidden="true"
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                  />
+                </svg>
+              </MinusIcon>
+            </span>
+          </button>
+        </ButtonBase>
       </Button>
       <input
         aria-label="Input"
@@ -954,48 +1076,56 @@ exports[`numberInput renders unit & position 1`] = `
         onClick={[Function]}
         variant="control"
       >
-        <button
-          aria-disabled={false}
+        <ButtonBase
           aria-label="Plus"
-          className="pf-c-button pf-m-control"
-          data-ouia-component-id="OUIA-Generated-Button-control-14"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe={true}
-          disabled={false}
+          innerRef={null}
+          isDisabled={false}
           onClick={[Function]}
-          role={null}
-          type="button"
+          variant="control"
         >
-          <span
-            className="pf-c-number-input__icon"
+          <button
+            aria-disabled={false}
+            aria-label="Plus"
+            className="pf-c-button pf-m-control"
+            data-ouia-component-id="OUIA-Generated-Button-control-14"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={false}
+            onClick={[Function]}
+            role={null}
+            type="button"
           >
-            <PlusIcon
-              aria-hidden="true"
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <span
+              className="pf-c-number-input__icon"
             >
-              <svg
+              <PlusIcon
                 aria-hidden="true"
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                />
-              </svg>
-            </PlusIcon>
-          </span>
-        </button>
+                <svg
+                  aria-hidden="true"
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                  />
+                </svg>
+              </PlusIcon>
+            </span>
+          </button>
+        </ButtonBase>
       </Button>
     </div>
   </div>
@@ -1020,48 +1150,56 @@ exports[`numberInput renders unit 1`] = `
         onClick={[Function]}
         variant="control"
       >
-        <button
-          aria-disabled={false}
+        <ButtonBase
           aria-label="Minus"
-          className="pf-c-button pf-m-control"
-          data-ouia-component-id="OUIA-Generated-Button-control-11"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe={true}
-          disabled={false}
+          innerRef={null}
+          isDisabled={false}
           onClick={[Function]}
-          role={null}
-          type="button"
+          variant="control"
         >
-          <span
-            className="pf-c-number-input__icon"
+          <button
+            aria-disabled={false}
+            aria-label="Minus"
+            className="pf-c-button pf-m-control"
+            data-ouia-component-id="OUIA-Generated-Button-control-11"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={false}
+            onClick={[Function]}
+            role={null}
+            type="button"
           >
-            <MinusIcon
-              aria-hidden="true"
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <span
+              className="pf-c-number-input__icon"
             >
-              <svg
+              <MinusIcon
                 aria-hidden="true"
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                />
-              </svg>
-            </MinusIcon>
-          </span>
-        </button>
+                <svg
+                  aria-hidden="true"
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                  />
+                </svg>
+              </MinusIcon>
+            </span>
+          </button>
+        </ButtonBase>
       </Button>
       <input
         aria-label="Input"
@@ -1076,48 +1214,56 @@ exports[`numberInput renders unit 1`] = `
         onClick={[Function]}
         variant="control"
       >
-        <button
-          aria-disabled={false}
+        <ButtonBase
           aria-label="Plus"
-          className="pf-c-button pf-m-control"
-          data-ouia-component-id="OUIA-Generated-Button-control-12"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe={true}
-          disabled={false}
+          innerRef={null}
+          isDisabled={false}
           onClick={[Function]}
-          role={null}
-          type="button"
+          variant="control"
         >
-          <span
-            className="pf-c-number-input__icon"
+          <button
+            aria-disabled={false}
+            aria-label="Plus"
+            className="pf-c-button pf-m-control"
+            data-ouia-component-id="OUIA-Generated-Button-control-12"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={false}
+            onClick={[Function]}
+            role={null}
+            type="button"
           >
-            <PlusIcon
-              aria-hidden="true"
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <span
+              className="pf-c-number-input__icon"
             >
-              <svg
+              <PlusIcon
                 aria-hidden="true"
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                />
-              </svg>
-            </PlusIcon>
-          </span>
-        </button>
+                <svg
+                  aria-hidden="true"
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                  />
+                </svg>
+              </PlusIcon>
+            </span>
+          </button>
+        </ButtonBase>
       </Button>
     </div>
     <div
@@ -1145,48 +1291,56 @@ exports[`numberInput renders value 1`] = `
         onClick={[Function]}
         variant="control"
       >
-        <button
-          aria-disabled={false}
+        <ButtonBase
           aria-label="Minus"
-          className="pf-c-button pf-m-control"
-          data-ouia-component-id="OUIA-Generated-Button-control-3"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe={true}
-          disabled={false}
+          innerRef={null}
+          isDisabled={false}
           onClick={[Function]}
-          role={null}
-          type="button"
+          variant="control"
         >
-          <span
-            className="pf-c-number-input__icon"
+          <button
+            aria-disabled={false}
+            aria-label="Minus"
+            className="pf-c-button pf-m-control"
+            data-ouia-component-id="OUIA-Generated-Button-control-3"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={false}
+            onClick={[Function]}
+            role={null}
+            type="button"
           >
-            <MinusIcon
-              aria-hidden="true"
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <span
+              className="pf-c-number-input__icon"
             >
-              <svg
+              <MinusIcon
                 aria-hidden="true"
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                />
-              </svg>
-            </MinusIcon>
-          </span>
-        </button>
+                <svg
+                  aria-hidden="true"
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                  />
+                </svg>
+              </MinusIcon>
+            </span>
+          </button>
+        </ButtonBase>
       </Button>
       <input
         aria-label="Input"
@@ -1201,48 +1355,56 @@ exports[`numberInput renders value 1`] = `
         onClick={[Function]}
         variant="control"
       >
-        <button
-          aria-disabled={false}
+        <ButtonBase
           aria-label="Plus"
-          className="pf-c-button pf-m-control"
-          data-ouia-component-id="OUIA-Generated-Button-control-4"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe={true}
-          disabled={false}
+          innerRef={null}
+          isDisabled={false}
           onClick={[Function]}
-          role={null}
-          type="button"
+          variant="control"
         >
-          <span
-            className="pf-c-number-input__icon"
+          <button
+            aria-disabled={false}
+            aria-label="Plus"
+            className="pf-c-button pf-m-control"
+            data-ouia-component-id="OUIA-Generated-Button-control-4"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={false}
+            onClick={[Function]}
+            role={null}
+            type="button"
           >
-            <PlusIcon
-              aria-hidden="true"
-              color="currentColor"
-              noVerticalAlign={false}
-              size="sm"
+            <span
+              className="pf-c-number-input__icon"
             >
-              <svg
+              <PlusIcon
                 aria-hidden="true"
-                aria-labelledby={null}
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
-                  }
-                }
-                viewBox="0 0 448 512"
-                width="1em"
+                color="currentColor"
+                noVerticalAlign={false}
+                size="sm"
               >
-                <path
-                  d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
-                />
-              </svg>
-            </PlusIcon>
-          </span>
-        </button>
+                <svg
+                  aria-hidden="true"
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 448 512"
+                  width="1em"
+                >
+                  <path
+                    d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                  />
+                </svg>
+              </PlusIcon>
+            </span>
+          </button>
+        </ButtonBase>
       </Button>
     </div>
   </div>

--- a/packages/react-core/src/components/Pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/react-core/src/components/Pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -496,45 +496,54 @@ exports[`component render custom pagination toggle 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to first page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="first"
-              data-ouia-component-id="OUIA-Generated-Button-plain-55"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to first page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="first"
+                data-ouia-component-id="OUIA-Generated-Button-plain-55"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                  />
-                </svg>
-              </AngleDoubleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                    />
+                  </svg>
+                </AngleDoubleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -547,45 +556,54 @@ exports[`component render custom pagination toggle 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to previous page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="previous"
-              data-ouia-component-id="OUIA-Generated-Button-plain-56"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to previous page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="previous"
+                data-ouia-component-id="OUIA-Generated-Button-plain-56"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                  />
-                </svg>
-              </AngleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                    />
+                  </svg>
+                </AngleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -620,44 +638,53 @@ exports[`component render custom pagination toggle 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={false}
+            <ButtonBase
               aria-label="Go to next page"
-              className="pf-c-button pf-m-plain"
               data-action="next"
-              data-ouia-component-id="OUIA-Generated-Button-plain-57"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={false}
+              innerRef={null}
+              isDisabled={false}
               onClick={[Function]}
-              role={null}
-              type="button"
+              variant="plain"
             >
-              <AngleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={false}
+                aria-label="Go to next page"
+                className="pf-c-button pf-m-plain"
+                data-action="next"
+                data-ouia-component-id="OUIA-Generated-Button-plain-57"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={false}
+                onClick={[Function]}
+                role={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                  />
-                </svg>
-              </AngleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </AngleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -670,44 +697,53 @@ exports[`component render custom pagination toggle 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={false}
+            <ButtonBase
               aria-label="Go to last page"
-              className="pf-c-button pf-m-plain"
               data-action="last"
-              data-ouia-component-id="OUIA-Generated-Button-plain-58"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={false}
+              innerRef={null}
+              isDisabled={false}
               onClick={[Function]}
-              role={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={false}
+                aria-label="Go to last page"
+                className="pf-c-button pf-m-plain"
+                data-action="last"
+                data-ouia-component-id="OUIA-Generated-Button-plain-58"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={false}
+                onClick={[Function]}
+                role={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                  />
-                </svg>
-              </AngleDoubleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                    />
+                  </svg>
+                </AngleDoubleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
       </nav>
@@ -1206,45 +1242,54 @@ exports[`component render custom perPageOptions 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to first page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="first"
-              data-ouia-component-id="OUIA-Generated-Button-plain-35"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to first page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="first"
+                data-ouia-component-id="OUIA-Generated-Button-plain-35"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                  />
-                </svg>
-              </AngleDoubleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                    />
+                  </svg>
+                </AngleDoubleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -1257,45 +1302,54 @@ exports[`component render custom perPageOptions 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to previous page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="previous"
-              data-ouia-component-id="OUIA-Generated-Button-plain-36"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to previous page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="previous"
+                data-ouia-component-id="OUIA-Generated-Button-plain-36"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                  />
-                </svg>
-              </AngleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                    />
+                  </svg>
+                </AngleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -1330,44 +1384,53 @@ exports[`component render custom perPageOptions 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={false}
+            <ButtonBase
               aria-label="Go to next page"
-              className="pf-c-button pf-m-plain"
               data-action="next"
-              data-ouia-component-id="OUIA-Generated-Button-plain-37"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={false}
+              innerRef={null}
+              isDisabled={false}
               onClick={[Function]}
-              role={null}
-              type="button"
+              variant="plain"
             >
-              <AngleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={false}
+                aria-label="Go to next page"
+                className="pf-c-button pf-m-plain"
+                data-action="next"
+                data-ouia-component-id="OUIA-Generated-Button-plain-37"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={false}
+                onClick={[Function]}
+                role={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                  />
-                </svg>
-              </AngleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </AngleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -1380,44 +1443,53 @@ exports[`component render custom perPageOptions 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={false}
+            <ButtonBase
               aria-label="Go to last page"
-              className="pf-c-button pf-m-plain"
               data-action="last"
-              data-ouia-component-id="OUIA-Generated-Button-plain-38"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={false}
+              innerRef={null}
+              isDisabled={false}
               onClick={[Function]}
-              role={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={false}
+                aria-label="Go to last page"
+                className="pf-c-button pf-m-plain"
+                data-action="last"
+                data-ouia-component-id="OUIA-Generated-Button-plain-38"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={false}
+                onClick={[Function]}
+                role={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                  />
-                </svg>
-              </AngleDoubleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                    />
+                  </svg>
+                </AngleDoubleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
       </nav>
@@ -1976,44 +2048,53 @@ exports[`component render custom start end 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={false}
+            <ButtonBase
               aria-label="Go to first page"
-              className="pf-c-button pf-m-plain"
               data-action="first"
-              data-ouia-component-id="OUIA-Generated-Button-plain-47"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={false}
+              innerRef={null}
+              isDisabled={false}
               onClick={[Function]}
-              role={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={false}
+                aria-label="Go to first page"
+                className="pf-c-button pf-m-plain"
+                data-action="first"
+                data-ouia-component-id="OUIA-Generated-Button-plain-47"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={false}
+                onClick={[Function]}
+                role={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                  />
-                </svg>
-              </AngleDoubleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                    />
+                  </svg>
+                </AngleDoubleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -2026,44 +2107,53 @@ exports[`component render custom start end 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={false}
+            <ButtonBase
               aria-label="Go to previous page"
-              className="pf-c-button pf-m-plain"
               data-action="previous"
-              data-ouia-component-id="OUIA-Generated-Button-plain-48"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={false}
+              innerRef={null}
+              isDisabled={false}
               onClick={[Function]}
-              role={null}
-              type="button"
+              variant="plain"
             >
-              <AngleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={false}
+                aria-label="Go to previous page"
+                className="pf-c-button pf-m-plain"
+                data-action="previous"
+                data-ouia-component-id="OUIA-Generated-Button-plain-48"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={false}
+                onClick={[Function]}
+                role={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                  />
-                </svg>
-              </AngleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                    />
+                  </svg>
+                </AngleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -2098,44 +2188,53 @@ exports[`component render custom start end 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={false}
+            <ButtonBase
               aria-label="Go to next page"
-              className="pf-c-button pf-m-plain"
               data-action="next"
-              data-ouia-component-id="OUIA-Generated-Button-plain-49"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={false}
+              innerRef={null}
+              isDisabled={false}
               onClick={[Function]}
-              role={null}
-              type="button"
+              variant="plain"
             >
-              <AngleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={false}
+                aria-label="Go to next page"
+                className="pf-c-button pf-m-plain"
+                data-action="next"
+                data-ouia-component-id="OUIA-Generated-Button-plain-49"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={false}
+                onClick={[Function]}
+                role={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                  />
-                </svg>
-              </AngleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </AngleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -2148,44 +2247,53 @@ exports[`component render custom start end 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={false}
+            <ButtonBase
               aria-label="Go to last page"
-              className="pf-c-button pf-m-plain"
               data-action="last"
-              data-ouia-component-id="OUIA-Generated-Button-plain-50"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={false}
+              innerRef={null}
+              isDisabled={false}
               onClick={[Function]}
-              role={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={false}
+                aria-label="Go to last page"
+                className="pf-c-button pf-m-plain"
+                data-action="last"
+                data-ouia-component-id="OUIA-Generated-Button-plain-50"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={false}
+                onClick={[Function]}
+                role={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                  />
-                </svg>
-              </AngleDoubleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                    />
+                  </svg>
+                </AngleDoubleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
       </nav>
@@ -2399,45 +2507,54 @@ exports[`component render empty per page options 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to first page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="first"
-              data-ouia-component-id="OUIA-Generated-Button-plain-39"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to first page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="first"
+                data-ouia-component-id="OUIA-Generated-Button-plain-39"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                  />
-                </svg>
-              </AngleDoubleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                    />
+                  </svg>
+                </AngleDoubleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -2450,45 +2567,54 @@ exports[`component render empty per page options 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to previous page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="previous"
-              data-ouia-component-id="OUIA-Generated-Button-plain-40"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to previous page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="previous"
+                data-ouia-component-id="OUIA-Generated-Button-plain-40"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                  />
-                </svg>
-              </AngleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                    />
+                  </svg>
+                </AngleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -2523,44 +2649,53 @@ exports[`component render empty per page options 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={false}
+            <ButtonBase
               aria-label="Go to next page"
-              className="pf-c-button pf-m-plain"
               data-action="next"
-              data-ouia-component-id="OUIA-Generated-Button-plain-41"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={false}
+              innerRef={null}
+              isDisabled={false}
               onClick={[Function]}
-              role={null}
-              type="button"
+              variant="plain"
             >
-              <AngleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={false}
+                aria-label="Go to next page"
+                className="pf-c-button pf-m-plain"
+                data-action="next"
+                data-ouia-component-id="OUIA-Generated-Button-plain-41"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={false}
+                onClick={[Function]}
+                role={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                  />
-                </svg>
-              </AngleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </AngleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -2573,44 +2708,53 @@ exports[`component render empty per page options 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={false}
+            <ButtonBase
               aria-label="Go to last page"
-              className="pf-c-button pf-m-plain"
               data-action="last"
-              data-ouia-component-id="OUIA-Generated-Button-plain-42"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={false}
+              innerRef={null}
+              isDisabled={false}
               onClick={[Function]}
-              role={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={false}
+                aria-label="Go to last page"
+                className="pf-c-button pf-m-plain"
+                data-action="last"
+                data-ouia-component-id="OUIA-Generated-Button-plain-42"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={false}
+                onClick={[Function]}
+                role={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                  />
-                </svg>
-              </AngleDoubleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                    />
+                  </svg>
+                </AngleDoubleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
       </nav>
@@ -3169,44 +3313,53 @@ exports[`component render last page 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={false}
+            <ButtonBase
               aria-label="Go to first page"
-              className="pf-c-button pf-m-plain"
               data-action="first"
-              data-ouia-component-id="OUIA-Generated-Button-plain-31"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={false}
+              innerRef={null}
+              isDisabled={false}
               onClick={[Function]}
-              role={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={false}
+                aria-label="Go to first page"
+                className="pf-c-button pf-m-plain"
+                data-action="first"
+                data-ouia-component-id="OUIA-Generated-Button-plain-31"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={false}
+                onClick={[Function]}
+                role={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                  />
-                </svg>
-              </AngleDoubleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                    />
+                  </svg>
+                </AngleDoubleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -3219,44 +3372,53 @@ exports[`component render last page 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={false}
+            <ButtonBase
               aria-label="Go to previous page"
-              className="pf-c-button pf-m-plain"
               data-action="previous"
-              data-ouia-component-id="OUIA-Generated-Button-plain-32"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={false}
+              innerRef={null}
+              isDisabled={false}
               onClick={[Function]}
-              role={null}
-              type="button"
+              variant="plain"
             >
-              <AngleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={false}
+                aria-label="Go to previous page"
+                className="pf-c-button pf-m-plain"
+                data-action="previous"
+                data-ouia-component-id="OUIA-Generated-Button-plain-32"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={false}
+                onClick={[Function]}
+                role={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                  />
-                </svg>
-              </AngleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                    />
+                  </svg>
+                </AngleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -3291,45 +3453,54 @@ exports[`component render last page 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to next page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="next"
-              data-ouia-component-id="OUIA-Generated-Button-plain-33"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to next page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="next"
+                data-ouia-component-id="OUIA-Generated-Button-plain-33"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                  />
-                </svg>
-              </AngleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </AngleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -3342,45 +3513,54 @@ exports[`component render last page 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to last page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="last"
-              data-ouia-component-id="OUIA-Generated-Button-plain-34"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to last page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="last"
+                data-ouia-component-id="OUIA-Generated-Button-plain-34"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                  />
-                </svg>
-              </AngleDoubleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                    />
+                  </svg>
+                </AngleDoubleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
       </nav>
@@ -3939,45 +4119,54 @@ exports[`component render limited number of pages 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to first page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="first"
-              data-ouia-component-id="OUIA-Generated-Button-plain-23"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to first page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="first"
+                data-ouia-component-id="OUIA-Generated-Button-plain-23"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                  />
-                </svg>
-              </AngleDoubleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                    />
+                  </svg>
+                </AngleDoubleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -3990,45 +4179,54 @@ exports[`component render limited number of pages 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to previous page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="previous"
-              data-ouia-component-id="OUIA-Generated-Button-plain-24"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to previous page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="previous"
+                data-ouia-component-id="OUIA-Generated-Button-plain-24"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                  />
-                </svg>
-              </AngleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                    />
+                  </svg>
+                </AngleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -4063,45 +4261,54 @@ exports[`component render limited number of pages 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to next page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="next"
-              data-ouia-component-id="OUIA-Generated-Button-plain-25"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to next page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="next"
+                data-ouia-component-id="OUIA-Generated-Button-plain-25"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                  />
-                </svg>
-              </AngleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </AngleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -4114,45 +4321,54 @@ exports[`component render limited number of pages 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to last page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="last"
-              data-ouia-component-id="OUIA-Generated-Button-plain-26"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to last page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="last"
+                data-ouia-component-id="OUIA-Generated-Button-plain-26"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                  />
-                </svg>
-              </AngleDoubleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                    />
+                  </svg>
+                </AngleDoubleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
       </nav>
@@ -4714,45 +4930,54 @@ exports[`component render no items 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to first page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="first"
-              data-ouia-component-id="OUIA-Generated-Button-plain-43"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to first page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="first"
+                data-ouia-component-id="OUIA-Generated-Button-plain-43"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                  />
-                </svg>
-              </AngleDoubleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                    />
+                  </svg>
+                </AngleDoubleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -4765,45 +4990,54 @@ exports[`component render no items 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to previous page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="previous"
-              data-ouia-component-id="OUIA-Generated-Button-plain-44"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to previous page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="previous"
+                data-ouia-component-id="OUIA-Generated-Button-plain-44"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                  />
-                </svg>
-              </AngleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                    />
+                  </svg>
+                </AngleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -4838,45 +5072,54 @@ exports[`component render no items 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to next page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="next"
-              data-ouia-component-id="OUIA-Generated-Button-plain-45"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to next page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="next"
+                data-ouia-component-id="OUIA-Generated-Button-plain-45"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                  />
-                </svg>
-              </AngleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </AngleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -4889,45 +5132,54 @@ exports[`component render no items 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to last page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="last"
-              data-ouia-component-id="OUIA-Generated-Button-plain-46"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to last page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="last"
+                data-ouia-component-id="OUIA-Generated-Button-plain-46"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                  />
-                </svg>
-              </AngleDoubleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                    />
+                  </svg>
+                </AngleDoubleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
       </nav>
@@ -5462,45 +5714,54 @@ exports[`component render should render correctly bottom 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to first page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="first"
-              data-ouia-component-id="OUIA-Generated-Button-plain-5"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to first page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="first"
+                data-ouia-component-id="OUIA-Generated-Button-plain-5"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                  />
-                </svg>
-              </AngleDoubleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                    />
+                  </svg>
+                </AngleDoubleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -5513,45 +5774,54 @@ exports[`component render should render correctly bottom 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to previous page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="previous"
-              data-ouia-component-id="OUIA-Generated-Button-plain-6"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to previous page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="previous"
+                data-ouia-component-id="OUIA-Generated-Button-plain-6"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                  />
-                </svg>
-              </AngleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                    />
+                  </svg>
+                </AngleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -5586,44 +5856,53 @@ exports[`component render should render correctly bottom 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={false}
+            <ButtonBase
               aria-label="Go to next page"
-              className="pf-c-button pf-m-plain"
               data-action="next"
-              data-ouia-component-id="OUIA-Generated-Button-plain-7"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={false}
+              innerRef={null}
+              isDisabled={false}
               onClick={[Function]}
-              role={null}
-              type="button"
+              variant="plain"
             >
-              <AngleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={false}
+                aria-label="Go to next page"
+                className="pf-c-button pf-m-plain"
+                data-action="next"
+                data-ouia-component-id="OUIA-Generated-Button-plain-7"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={false}
+                onClick={[Function]}
+                role={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                  />
-                </svg>
-              </AngleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </AngleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -5636,44 +5915,53 @@ exports[`component render should render correctly bottom 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={false}
+            <ButtonBase
               aria-label="Go to last page"
-              className="pf-c-button pf-m-plain"
               data-action="last"
-              data-ouia-component-id="OUIA-Generated-Button-plain-8"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={false}
+              innerRef={null}
+              isDisabled={false}
               onClick={[Function]}
-              role={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={false}
+                aria-label="Go to last page"
+                className="pf-c-button pf-m-plain"
+                data-action="last"
+                data-ouia-component-id="OUIA-Generated-Button-plain-8"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={false}
+                onClick={[Function]}
+                role={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                  />
-                </svg>
-              </AngleDoubleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                    />
+                  </svg>
+                </AngleDoubleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
       </nav>
@@ -6208,45 +6496,54 @@ exports[`component render should render correctly bottom sticky 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to first page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="first"
-              data-ouia-component-id="OUIA-Generated-Button-plain-15"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to first page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="first"
+                data-ouia-component-id="OUIA-Generated-Button-plain-15"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                  />
-                </svg>
-              </AngleDoubleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                    />
+                  </svg>
+                </AngleDoubleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -6259,45 +6556,54 @@ exports[`component render should render correctly bottom sticky 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to previous page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="previous"
-              data-ouia-component-id="OUIA-Generated-Button-plain-16"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to previous page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="previous"
+                data-ouia-component-id="OUIA-Generated-Button-plain-16"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                  />
-                </svg>
-              </AngleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                    />
+                  </svg>
+                </AngleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -6332,44 +6638,53 @@ exports[`component render should render correctly bottom sticky 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={false}
+            <ButtonBase
               aria-label="Go to next page"
-              className="pf-c-button pf-m-plain"
               data-action="next"
-              data-ouia-component-id="OUIA-Generated-Button-plain-17"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={false}
+              innerRef={null}
+              isDisabled={false}
               onClick={[Function]}
-              role={null}
-              type="button"
+              variant="plain"
             >
-              <AngleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={false}
+                aria-label="Go to next page"
+                className="pf-c-button pf-m-plain"
+                data-action="next"
+                data-ouia-component-id="OUIA-Generated-Button-plain-17"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={false}
+                onClick={[Function]}
+                role={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                  />
-                </svg>
-              </AngleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </AngleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -6382,44 +6697,53 @@ exports[`component render should render correctly bottom sticky 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={false}
+            <ButtonBase
               aria-label="Go to last page"
-              className="pf-c-button pf-m-plain"
               data-action="last"
-              data-ouia-component-id="OUIA-Generated-Button-plain-18"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={false}
+              innerRef={null}
+              isDisabled={false}
               onClick={[Function]}
-              role={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={false}
+                aria-label="Go to last page"
+                className="pf-c-button pf-m-plain"
+                data-action="last"
+                data-ouia-component-id="OUIA-Generated-Button-plain-18"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={false}
+                onClick={[Function]}
+                role={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                  />
-                </svg>
-              </AngleDoubleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                    />
+                  </svg>
+                </AngleDoubleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
       </nav>
@@ -6978,45 +7302,54 @@ exports[`component render should render correctly compact 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to previous page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="previous"
-              data-ouia-component-id="OUIA-Generated-Button-plain-9"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to previous page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="previous"
+                data-ouia-component-id="OUIA-Generated-Button-plain-9"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                  />
-                </svg>
-              </AngleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                    />
+                  </svg>
+                </AngleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -7029,44 +7362,53 @@ exports[`component render should render correctly compact 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={false}
+            <ButtonBase
               aria-label="Go to next page"
-              className="pf-c-button pf-m-plain"
               data-action="next"
-              data-ouia-component-id="OUIA-Generated-Button-plain-10"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={false}
+              innerRef={null}
+              isDisabled={false}
               onClick={[Function]}
-              role={null}
-              type="button"
+              variant="plain"
             >
-              <AngleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={false}
+                aria-label="Go to next page"
+                className="pf-c-button pf-m-plain"
+                data-action="next"
+                data-ouia-component-id="OUIA-Generated-Button-plain-10"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={false}
+                onClick={[Function]}
+                role={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                  />
-                </svg>
-              </AngleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </AngleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
       </nav>
@@ -7628,45 +7970,54 @@ exports[`component render should render correctly disabled 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to first page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="first"
-              data-ouia-component-id="OUIA-Generated-Button-plain-19"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to first page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="first"
+                data-ouia-component-id="OUIA-Generated-Button-plain-19"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                  />
-                </svg>
-              </AngleDoubleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                    />
+                  </svg>
+                </AngleDoubleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -7679,45 +8030,54 @@ exports[`component render should render correctly disabled 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to previous page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="previous"
-              data-ouia-component-id="OUIA-Generated-Button-plain-20"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to previous page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="previous"
+                data-ouia-component-id="OUIA-Generated-Button-plain-20"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                  />
-                </svg>
-              </AngleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                    />
+                  </svg>
+                </AngleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -7752,45 +8112,54 @@ exports[`component render should render correctly disabled 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to next page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="next"
-              data-ouia-component-id="OUIA-Generated-Button-plain-21"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to next page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="next"
+                data-ouia-component-id="OUIA-Generated-Button-plain-21"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                  />
-                </svg>
-              </AngleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </AngleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -7803,45 +8172,54 @@ exports[`component render should render correctly disabled 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to last page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="last"
-              data-ouia-component-id="OUIA-Generated-Button-plain-22"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to last page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="last"
+                data-ouia-component-id="OUIA-Generated-Button-plain-22"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                  />
-                </svg>
-              </AngleDoubleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                    />
+                  </svg>
+                </AngleDoubleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
       </nav>
@@ -8400,45 +8778,54 @@ exports[`component render should render correctly sticky 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to first page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="first"
-              data-ouia-component-id="OUIA-Generated-Button-plain-11"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to first page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="first"
+                data-ouia-component-id="OUIA-Generated-Button-plain-11"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                  />
-                </svg>
-              </AngleDoubleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                    />
+                  </svg>
+                </AngleDoubleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -8451,45 +8838,54 @@ exports[`component render should render correctly sticky 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to previous page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="previous"
-              data-ouia-component-id="OUIA-Generated-Button-plain-12"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to previous page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="previous"
+                data-ouia-component-id="OUIA-Generated-Button-plain-12"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                  />
-                </svg>
-              </AngleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                    />
+                  </svg>
+                </AngleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -8524,44 +8920,53 @@ exports[`component render should render correctly sticky 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={false}
+            <ButtonBase
               aria-label="Go to next page"
-              className="pf-c-button pf-m-plain"
               data-action="next"
-              data-ouia-component-id="OUIA-Generated-Button-plain-13"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={false}
+              innerRef={null}
+              isDisabled={false}
               onClick={[Function]}
-              role={null}
-              type="button"
+              variant="plain"
             >
-              <AngleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={false}
+                aria-label="Go to next page"
+                className="pf-c-button pf-m-plain"
+                data-action="next"
+                data-ouia-component-id="OUIA-Generated-Button-plain-13"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={false}
+                onClick={[Function]}
+                role={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                  />
-                </svg>
-              </AngleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </AngleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -8574,44 +8979,53 @@ exports[`component render should render correctly sticky 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={false}
+            <ButtonBase
               aria-label="Go to last page"
-              className="pf-c-button pf-m-plain"
               data-action="last"
-              data-ouia-component-id="OUIA-Generated-Button-plain-14"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={false}
+              innerRef={null}
+              isDisabled={false}
               onClick={[Function]}
-              role={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={false}
+                aria-label="Go to last page"
+                className="pf-c-button pf-m-plain"
+                data-action="last"
+                data-ouia-component-id="OUIA-Generated-Button-plain-14"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={false}
+                onClick={[Function]}
+                role={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                  />
-                </svg>
-              </AngleDoubleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                    />
+                  </svg>
+                </AngleDoubleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
       </nav>
@@ -9170,45 +9584,54 @@ exports[`component render should render correctly top 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to first page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="first"
-              data-ouia-component-id="OUIA-Generated-Button-plain-1"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to first page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="first"
+                data-ouia-component-id="OUIA-Generated-Button-plain-1"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                  />
-                </svg>
-              </AngleDoubleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                    />
+                  </svg>
+                </AngleDoubleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -9221,45 +9644,54 @@ exports[`component render should render correctly top 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to previous page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="previous"
-              data-ouia-component-id="OUIA-Generated-Button-plain-2"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to previous page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="previous"
+                data-ouia-component-id="OUIA-Generated-Button-plain-2"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                  />
-                </svg>
-              </AngleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                    />
+                  </svg>
+                </AngleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -9294,44 +9726,53 @@ exports[`component render should render correctly top 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={false}
+            <ButtonBase
               aria-label="Go to next page"
-              className="pf-c-button pf-m-plain"
               data-action="next"
-              data-ouia-component-id="OUIA-Generated-Button-plain-3"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={false}
+              innerRef={null}
+              isDisabled={false}
               onClick={[Function]}
-              role={null}
-              type="button"
+              variant="plain"
             >
-              <AngleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={false}
+                aria-label="Go to next page"
+                className="pf-c-button pf-m-plain"
+                data-action="next"
+                data-ouia-component-id="OUIA-Generated-Button-plain-3"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={false}
+                onClick={[Function]}
+                role={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                  />
-                </svg>
-              </AngleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </AngleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -9344,44 +9785,53 @@ exports[`component render should render correctly top 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={false}
+            <ButtonBase
               aria-label="Go to last page"
-              className="pf-c-button pf-m-plain"
               data-action="last"
-              data-ouia-component-id="OUIA-Generated-Button-plain-4"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={false}
+              innerRef={null}
+              isDisabled={false}
               onClick={[Function]}
-              role={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={false}
+                aria-label="Go to last page"
+                className="pf-c-button pf-m-plain"
+                data-action="last"
+                data-ouia-component-id="OUIA-Generated-Button-plain-4"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={false}
+                onClick={[Function]}
+                role={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                  />
-                </svg>
-              </AngleDoubleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                    />
+                  </svg>
+                </AngleDoubleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
       </nav>
@@ -9931,45 +10381,54 @@ exports[`component render titles 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to first page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="first"
-              data-ouia-component-id="OUIA-Generated-Button-plain-51"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to first page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="first"
+                data-ouia-component-id="OUIA-Generated-Button-plain-51"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                  />
-                </svg>
-              </AngleDoubleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                    />
+                  </svg>
+                </AngleDoubleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -9982,45 +10441,54 @@ exports[`component render titles 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to previous page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="previous"
-              data-ouia-component-id="OUIA-Generated-Button-plain-52"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to previous page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="previous"
+                data-ouia-component-id="OUIA-Generated-Button-plain-52"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                  />
-                </svg>
-              </AngleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                    />
+                  </svg>
+                </AngleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -10055,44 +10523,53 @@ exports[`component render titles 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={false}
+            <ButtonBase
               aria-label="Go to next page"
-              className="pf-c-button pf-m-plain"
               data-action="next"
-              data-ouia-component-id="OUIA-Generated-Button-plain-53"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={false}
+              innerRef={null}
+              isDisabled={false}
               onClick={[Function]}
-              role={null}
-              type="button"
+              variant="plain"
             >
-              <AngleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={false}
+                aria-label="Go to next page"
+                className="pf-c-button pf-m-plain"
+                data-action="next"
+                data-ouia-component-id="OUIA-Generated-Button-plain-53"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={false}
+                onClick={[Function]}
+                role={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                  />
-                </svg>
-              </AngleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </AngleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -10105,44 +10582,53 @@ exports[`component render titles 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={false}
+            <ButtonBase
               aria-label="Go to last page"
-              className="pf-c-button pf-m-plain"
               data-action="last"
-              data-ouia-component-id="OUIA-Generated-Button-plain-54"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={false}
+              innerRef={null}
+              isDisabled={false}
               onClick={[Function]}
-              role={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={false}
+                aria-label="Go to last page"
+                className="pf-c-button pf-m-plain"
+                data-action="last"
+                data-ouia-component-id="OUIA-Generated-Button-plain-54"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={false}
+                onClick={[Function]}
+                role={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                  />
-                </svg>
-              </AngleDoubleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                    />
+                  </svg>
+                </AngleDoubleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
       </nav>
@@ -10702,45 +11188,54 @@ exports[`component render up drop direction 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to first page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="first"
-              data-ouia-component-id="OUIA-Generated-Button-plain-59"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to first page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="first"
+                data-ouia-component-id="OUIA-Generated-Button-plain-59"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                  />
-                </svg>
-              </AngleDoubleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                    />
+                  </svg>
+                </AngleDoubleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -10753,45 +11248,54 @@ exports[`component render up drop direction 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to previous page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="previous"
-              data-ouia-component-id="OUIA-Generated-Button-plain-60"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to previous page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="previous"
+                data-ouia-component-id="OUIA-Generated-Button-plain-60"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                  />
-                </svg>
-              </AngleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                    />
+                  </svg>
+                </AngleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -10826,44 +11330,53 @@ exports[`component render up drop direction 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={false}
+            <ButtonBase
               aria-label="Go to next page"
-              className="pf-c-button pf-m-plain"
               data-action="next"
-              data-ouia-component-id="OUIA-Generated-Button-plain-61"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={false}
+              innerRef={null}
+              isDisabled={false}
               onClick={[Function]}
-              role={null}
-              type="button"
+              variant="plain"
             >
-              <AngleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={false}
+                aria-label="Go to next page"
+                className="pf-c-button pf-m-plain"
+                data-action="next"
+                data-ouia-component-id="OUIA-Generated-Button-plain-61"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={false}
+                onClick={[Function]}
+                role={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                  />
-                </svg>
-              </AngleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </AngleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -10876,44 +11389,53 @@ exports[`component render up drop direction 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={false}
+            <ButtonBase
               aria-label="Go to last page"
-              className="pf-c-button pf-m-plain"
               data-action="last"
-              data-ouia-component-id="OUIA-Generated-Button-plain-62"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={false}
+              innerRef={null}
+              isDisabled={false}
               onClick={[Function]}
-              role={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={false}
+                aria-label="Go to last page"
+                className="pf-c-button pf-m-plain"
+                data-action="last"
+                data-ouia-component-id="OUIA-Generated-Button-plain-62"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={false}
+                onClick={[Function]}
+                role={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                  />
-                </svg>
-              </AngleDoubleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                    />
+                  </svg>
+                </AngleDoubleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
       </nav>
@@ -11475,45 +11997,54 @@ exports[`component render zero results 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to first page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="first"
-              data-ouia-component-id="OUIA-Generated-Button-plain-27"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to first page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="first"
+                data-ouia-component-id="OUIA-Generated-Button-plain-27"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                  />
-                </svg>
-              </AngleDoubleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                    />
+                  </svg>
+                </AngleDoubleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -11526,45 +12057,54 @@ exports[`component render zero results 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to previous page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="previous"
-              data-ouia-component-id="OUIA-Generated-Button-plain-28"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleLeftIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to previous page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="previous"
+                data-ouia-component-id="OUIA-Generated-Button-plain-28"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleLeftIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                  />
-                </svg>
-              </AngleLeftIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                    />
+                  </svg>
+                </AngleLeftIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -11599,45 +12139,54 @@ exports[`component render zero results 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to next page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="next"
-              data-ouia-component-id="OUIA-Generated-Button-plain-29"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to next page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="next"
+                data-ouia-component-id="OUIA-Generated-Button-plain-29"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 256 512"
-                  width="1em"
+                <AngleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                  />
-                </svg>
-              </AngleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </AngleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
         <div
@@ -11650,45 +12199,54 @@ exports[`component render zero results 1`] = `
             onClick={[Function]}
             variant="plain"
           >
-            <button
-              aria-disabled={true}
+            <ButtonBase
               aria-label="Go to last page"
-              className="pf-c-button pf-m-plain pf-m-disabled"
               data-action="last"
-              data-ouia-component-id="OUIA-Generated-Button-plain-30"
-              data-ouia-component-type="PF4/Button"
-              data-ouia-safe={true}
-              disabled={true}
+              innerRef={null}
+              isDisabled={true}
               onClick={[Function]}
-              role={null}
-              tabIndex={null}
-              type="button"
+              variant="plain"
             >
-              <AngleDoubleRightIcon
-                color="currentColor"
-                noVerticalAlign={false}
-                size="sm"
+              <button
+                aria-disabled={true}
+                aria-label="Go to last page"
+                className="pf-c-button pf-m-plain pf-m-disabled"
+                data-action="last"
+                data-ouia-component-id="OUIA-Generated-Button-plain-30"
+                data-ouia-component-type="PF4/Button"
+                data-ouia-safe={true}
+                disabled={true}
+                onClick={[Function]}
+                role={null}
+                tabIndex={null}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  aria-labelledby={null}
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style={
-                    Object {
-                      "verticalAlign": "-0.125em",
-                    }
-                  }
-                  viewBox="0 0 448 512"
-                  width="1em"
+                <AngleDoubleRightIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
                 >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                  />
-                </svg>
-              </AngleDoubleRightIcon>
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                    />
+                  </svg>
+                </AngleDoubleRightIcon>
+              </button>
+            </ButtonBase>
           </Button>
         </div>
       </nav>

--- a/packages/react-core/src/components/SearchInput/__tests__/__snapshots__/SearchInput.test.tsx.snap
+++ b/packages/react-core/src/components/SearchInput/__tests__/__snapshots__/SearchInput.test.tsx.snap
@@ -20,43 +20,51 @@ exports[`navigable search results 1`] = `
     onClick={[MockFunction]}
     variant="plain"
   >
-    <button
-      aria-disabled={false}
+    <ButtonBase
       aria-label="Previous"
-      className="pf-c-button pf-m-plain"
-      data-ouia-component-id="OUIA-Generated-Button-plain-7"
-      data-ouia-component-type="PF4/Button"
-      data-ouia-safe={true}
-      disabled={false}
+      innerRef={null}
+      isDisabled={false}
       onClick={[MockFunction]}
-      role={null}
-      type="button"
+      variant="plain"
     >
-      <AngleUpIcon
-        color="currentColor"
-        noVerticalAlign={false}
-        size="sm"
+      <button
+        aria-disabled={false}
+        aria-label="Previous"
+        className="pf-c-button pf-m-plain"
+        data-ouia-component-id="OUIA-Generated-Button-plain-7"
+        data-ouia-component-type="PF4/Button"
+        data-ouia-safe={true}
+        disabled={false}
+        onClick={[MockFunction]}
+        role={null}
+        type="button"
       >
-        <svg
-          aria-hidden={true}
-          aria-labelledby={null}
-          fill="currentColor"
-          height="1em"
-          role="img"
-          style={
-            Object {
-              "verticalAlign": "-0.125em",
-            }
-          }
-          viewBox="0 0 320 512"
-          width="1em"
+        <AngleUpIcon
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
         >
-          <path
-            d="M177 159.7l136 136c9.4 9.4 9.4 24.6 0 33.9l-22.6 22.6c-9.4 9.4-24.6 9.4-33.9 0L160 255.9l-96.4 96.4c-9.4 9.4-24.6 9.4-33.9 0L7 329.7c-9.4-9.4-9.4-24.6 0-33.9l136-136c9.4-9.5 24.6-9.5 34-.1z"
-          />
-        </svg>
-      </AngleUpIcon>
-    </button>
+          <svg
+            aria-hidden={true}
+            aria-labelledby={null}
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
+            viewBox="0 0 320 512"
+            width="1em"
+          >
+            <path
+              d="M177 159.7l136 136c9.4 9.4 9.4 24.6 0 33.9l-22.6 22.6c-9.4 9.4-24.6 9.4-33.9 0L160 255.9l-96.4 96.4c-9.4 9.4-24.6 9.4-33.9 0L7 329.7c-9.4-9.4-9.4-24.6 0-33.9l136-136c9.4-9.5 24.6-9.5 34-.1z"
+            />
+          </svg>
+        </AngleUpIcon>
+      </button>
+    </ButtonBase>
   </Button>
   <Button
     aria-label="Next"
@@ -64,43 +72,51 @@ exports[`navigable search results 1`] = `
     onClick={[MockFunction]}
     variant="plain"
   >
-    <button
-      aria-disabled={false}
+    <ButtonBase
       aria-label="Next"
-      className="pf-c-button pf-m-plain"
-      data-ouia-component-id="OUIA-Generated-Button-plain-8"
-      data-ouia-component-type="PF4/Button"
-      data-ouia-safe={true}
-      disabled={false}
+      innerRef={null}
+      isDisabled={false}
       onClick={[MockFunction]}
-      role={null}
-      type="button"
+      variant="plain"
     >
-      <AngleDownIcon
-        color="currentColor"
-        noVerticalAlign={false}
-        size="sm"
+      <button
+        aria-disabled={false}
+        aria-label="Next"
+        className="pf-c-button pf-m-plain"
+        data-ouia-component-id="OUIA-Generated-Button-plain-8"
+        data-ouia-component-type="PF4/Button"
+        data-ouia-safe={true}
+        disabled={false}
+        onClick={[MockFunction]}
+        role={null}
+        type="button"
       >
-        <svg
-          aria-hidden={true}
-          aria-labelledby={null}
-          fill="currentColor"
-          height="1em"
-          role="img"
-          style={
-            Object {
-              "verticalAlign": "-0.125em",
-            }
-          }
-          viewBox="0 0 320 512"
-          width="1em"
+        <AngleDownIcon
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
         >
-          <path
-            d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-          />
-        </svg>
-      </AngleDownIcon>
-    </button>
+          <svg
+            aria-hidden={true}
+            aria-labelledby={null}
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
+            viewBox="0 0 320 512"
+            width="1em"
+          >
+            <path
+              d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+            />
+          </svg>
+        </AngleDownIcon>
+      </button>
+    </ButtonBase>
   </Button>
 </span>
 `;

--- a/packages/react-core/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/packages/react-core/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
@@ -10470,46 +10470,56 @@ exports[`typeahead multi select renders selected successfully 1`] = `
                                 ouiaId="Remove"
                                 variant="plain"
                               >
-                                <button
-                                  aria-disabled={false}
+                                <ButtonBase
                                   aria-label="Remove"
                                   aria-labelledby="remove_pf-random-id-24 pf-random-id-24"
-                                  className="pf-c-button pf-m-plain"
-                                  data-ouia-component-id="Remove"
-                                  data-ouia-component-type="PF4/Button"
-                                  data-ouia-safe={true}
-                                  disabled={false}
                                   id="remove_pf-random-id-24"
+                                  innerRef={null}
                                   onClick={[Function]}
-                                  role={null}
-                                  type="button"
+                                  ouiaId="Remove"
+                                  variant="plain"
                                 >
-                                  <TimesIcon
-                                    aria-hidden="true"
-                                    color="currentColor"
-                                    noVerticalAlign={false}
-                                    size="sm"
+                                  <button
+                                    aria-disabled={false}
+                                    aria-label="Remove"
+                                    aria-labelledby="remove_pf-random-id-24 pf-random-id-24"
+                                    className="pf-c-button pf-m-plain"
+                                    data-ouia-component-id="Remove"
+                                    data-ouia-component-type="PF4/Button"
+                                    data-ouia-safe={true}
+                                    disabled={false}
+                                    id="remove_pf-random-id-24"
+                                    onClick={[Function]}
+                                    role={null}
+                                    type="button"
                                   >
-                                    <svg
+                                    <TimesIcon
                                       aria-hidden="true"
-                                      aria-labelledby={null}
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      style={
-                                        Object {
-                                          "verticalAlign": "-0.125em",
-                                        }
-                                      }
-                                      viewBox="0 0 352 512"
-                                      width="1em"
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      size="sm"
                                     >
-                                      <path
-                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                      />
-                                    </svg>
-                                  </TimesIcon>
-                                </button>
+                                      <svg
+                                        aria-hidden="true"
+                                        aria-labelledby={null}
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        style={
+                                          Object {
+                                            "verticalAlign": "-0.125em",
+                                          }
+                                        }
+                                        viewBox="0 0 352 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                        />
+                                      </svg>
+                                    </TimesIcon>
+                                  </button>
+                                </ButtonBase>
                               </Button>
                             </div>
                           </GenerateId>
@@ -10552,46 +10562,56 @@ exports[`typeahead multi select renders selected successfully 1`] = `
                                 ouiaId="Remove"
                                 variant="plain"
                               >
-                                <button
-                                  aria-disabled={false}
+                                <ButtonBase
                                   aria-label="Remove"
                                   aria-labelledby="remove_pf-random-id-25 pf-random-id-25"
-                                  className="pf-c-button pf-m-plain"
-                                  data-ouia-component-id="Remove"
-                                  data-ouia-component-type="PF4/Button"
-                                  data-ouia-safe={true}
-                                  disabled={false}
                                   id="remove_pf-random-id-25"
+                                  innerRef={null}
                                   onClick={[Function]}
-                                  role={null}
-                                  type="button"
+                                  ouiaId="Remove"
+                                  variant="plain"
                                 >
-                                  <TimesIcon
-                                    aria-hidden="true"
-                                    color="currentColor"
-                                    noVerticalAlign={false}
-                                    size="sm"
+                                  <button
+                                    aria-disabled={false}
+                                    aria-label="Remove"
+                                    aria-labelledby="remove_pf-random-id-25 pf-random-id-25"
+                                    className="pf-c-button pf-m-plain"
+                                    data-ouia-component-id="Remove"
+                                    data-ouia-component-type="PF4/Button"
+                                    data-ouia-safe={true}
+                                    disabled={false}
+                                    id="remove_pf-random-id-25"
+                                    onClick={[Function]}
+                                    role={null}
+                                    type="button"
                                   >
-                                    <svg
+                                    <TimesIcon
                                       aria-hidden="true"
-                                      aria-labelledby={null}
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      style={
-                                        Object {
-                                          "verticalAlign": "-0.125em",
-                                        }
-                                      }
-                                      viewBox="0 0 352 512"
-                                      width="1em"
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      size="sm"
                                     >
-                                      <path
-                                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                      />
-                                    </svg>
-                                  </TimesIcon>
-                                </button>
+                                      <svg
+                                        aria-hidden="true"
+                                        aria-labelledby={null}
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        style={
+                                          Object {
+                                            "verticalAlign": "-0.125em",
+                                          }
+                                        }
+                                        viewBox="0 0 352 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                        />
+                                      </svg>
+                                    </TimesIcon>
+                                  </button>
+                                </ButtonBase>
                               </Button>
                             </div>
                           </GenerateId>

--- a/packages/react-core/src/components/Slider/_tests_/__snapshots__/Slider.test.tsx.snap
+++ b/packages/react-core/src/components/Slider/_tests_/__snapshots__/Slider.test.tsx.snap
@@ -8581,13 +8581,13 @@ exports[`slider renders slider with input above thumb 1`] = `
 exports[`slider renders slider with input actions 1`] = `
 <Slider
   leftActions={
-    <Button
+    <ForwardRef(Button)
       aria-label="Minus"
       variant="plain"
     />
   }
   rightActions={
-    <Button
+    <ForwardRef(Button)
       aria-label="Plus"
       variant="plain"
     />
@@ -8609,17 +8609,23 @@ exports[`slider renders slider with input actions 1`] = `
         aria-label="Minus"
         variant="plain"
       >
-        <button
-          aria-disabled={false}
+        <ButtonBase
           aria-label="Minus"
-          className="pf-c-button pf-m-plain"
-          data-ouia-component-id="OUIA-Generated-Button-plain-1"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe={true}
-          disabled={false}
-          role={null}
-          type="button"
-        />
+          innerRef={null}
+          variant="plain"
+        >
+          <button
+            aria-disabled={false}
+            aria-label="Minus"
+            className="pf-c-button pf-m-plain"
+            data-ouia-component-id="OUIA-Generated-Button-plain-1"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={false}
+            role={null}
+            type="button"
+          />
+        </ButtonBase>
       </Button>
     </div>
     <div
@@ -10390,17 +10396,23 @@ exports[`slider renders slider with input actions 1`] = `
         aria-label="Plus"
         variant="plain"
       >
-        <button
-          aria-disabled={false}
+        <ButtonBase
           aria-label="Plus"
-          className="pf-c-button pf-m-plain"
-          data-ouia-component-id="OUIA-Generated-Button-plain-2"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe={true}
-          disabled={false}
-          role={null}
-          type="button"
-        />
+          innerRef={null}
+          variant="plain"
+        >
+          <button
+            aria-disabled={false}
+            aria-label="Plus"
+            className="pf-c-button pf-m-plain"
+            data-ouia-component-id="OUIA-Generated-Button-plain-2"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={false}
+            role={null}
+            type="button"
+          />
+        </ButtonBase>
       </Button>
     </div>
   </div>

--- a/packages/react-core/src/components/TreeView/__tests__/__snapshots__/TreeView.test.tsx.snap
+++ b/packages/react-core/src/components/TreeView/__tests__/__snapshots__/TreeView.test.tsx.snap
@@ -5716,7 +5716,7 @@ exports[`tree view renders individual flag options successfully 1`] = `
         "name": "ApplicationLauncher",
       },
       Object {
-        "action": <Button
+        "action": <ForwardRef(Button)
           aria-label="Folder action"
           variant="plain"
         >
@@ -5725,7 +5725,7 @@ exports[`tree view renders individual flag options successfully 1`] = `
             noVerticalAlign={false}
             size="sm"
           />
-        </Button>,
+        </ForwardRef(Button)>,
         "children": Array [
           Object {
             "children": Array [
@@ -6519,7 +6519,7 @@ exports[`tree view renders individual flag options successfully 1`] = `
           </TreeViewListItem>
           <TreeViewListItem
             action={
-              <Button
+              <ForwardRef(Button)
                 aria-label="Folder action"
                 variant="plain"
               >
@@ -6528,7 +6528,7 @@ exports[`tree view renders individual flag options successfully 1`] = `
                   noVerticalAlign={false}
                   size="sm"
                 />
-              </Button>
+              </ForwardRef(Button)>
             }
             activeItems={
               Array [
@@ -6555,7 +6555,7 @@ exports[`tree view renders individual flag options successfully 1`] = `
             id="Cost"
             itemData={
               Object {
-                "action": <Button
+                "action": <ForwardRef(Button)
                   aria-label="Folder action"
                   variant="plain"
                 >
@@ -6564,7 +6564,7 @@ exports[`tree view renders individual flag options successfully 1`] = `
                     noVerticalAlign={false}
                     size="sm"
                   />
-                </Button>,
+                </ForwardRef(Button)>,
                 "children": Array [
                   Object {
                     "children": Array [
@@ -6669,42 +6669,48 @@ exports[`tree view renders individual flag options successfully 1`] = `
                     aria-label="Folder action"
                     variant="plain"
                   >
-                    <button
-                      aria-disabled={false}
+                    <ButtonBase
                       aria-label="Folder action"
-                      className="pf-c-button pf-m-plain"
-                      data-ouia-component-id="OUIA-Generated-Button-plain-1"
-                      data-ouia-component-type="PF4/Button"
-                      data-ouia-safe={true}
-                      disabled={false}
-                      role={null}
-                      type="button"
+                      innerRef={null}
+                      variant="plain"
                     >
-                      <FolderIcon
-                        color="currentColor"
-                        noVerticalAlign={false}
-                        size="sm"
+                      <button
+                        aria-disabled={false}
+                        aria-label="Folder action"
+                        className="pf-c-button pf-m-plain"
+                        data-ouia-component-id="OUIA-Generated-Button-plain-1"
+                        data-ouia-component-type="PF4/Button"
+                        data-ouia-safe={true}
+                        disabled={false}
+                        role={null}
+                        type="button"
                       >
-                        <svg
-                          aria-hidden={true}
-                          aria-labelledby={null}
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          style={
-                            Object {
-                              "verticalAlign": "-0.125em",
-                            }
-                          }
-                          viewBox="0 0 512 512"
-                          width="1em"
+                        <FolderIcon
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
                         >
-                          <path
-                            d="M464 128H272l-64-64H48C21.49 64 0 85.49 0 112v288c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V176c0-26.51-21.49-48-48-48z"
-                          />
-                        </svg>
-                      </FolderIcon>
-                    </button>
+                          <svg
+                            aria-hidden={true}
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 512 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M464 128H272l-64-64H48C21.49 64 0 85.49 0 112v288c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V176c0-26.51-21.49-48-48-48z"
+                            />
+                          </svg>
+                        </FolderIcon>
+                      </button>
+                    </ButtonBase>
                   </Button>
                 </div>
               </div>

--- a/packages/react-inline-edit-extension/src/components/ConfirmButtons/__snapshots__/ConfirmButtons.test.js.snap
+++ b/packages/react-inline-edit-extension/src/components/ConfirmButtons/__snapshots__/ConfirmButtons.test.js.snap
@@ -47,43 +47,50 @@ exports[`ConfirmButtons renders correctly 1`] = `
         onMouseUp={[MockFunction]}
         variant="primary"
       >
-        <button
-          aria-disabled={false}
+        <ButtonBase
           aria-label="Confirm"
-          className="pf-c-button pf-m-primary"
-          data-ouia-component-id="OUIA-Generated-Button-primary-1"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe={true}
-          disabled={false}
+          innerRef={null}
           onMouseUp={[MockFunction]}
-          role={null}
-          type="button"
+          variant="primary"
         >
-          <CheckIcon
-            color="currentColor"
-            noVerticalAlign={false}
-            size="sm"
+          <button
+            aria-disabled={false}
+            aria-label="Confirm"
+            className="pf-c-button pf-m-primary"
+            data-ouia-component-id="OUIA-Generated-Button-primary-1"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={false}
+            onMouseUp={[MockFunction]}
+            role={null}
+            type="button"
           >
-            <svg
-              aria-hidden={true}
-              aria-labelledby={null}
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style={
-                Object {
-                  "verticalAlign": "-0.125em",
-                }
-              }
-              viewBox="0 0 512 512"
-              width="1em"
+            <CheckIcon
+              color="currentColor"
+              noVerticalAlign={false}
+              size="sm"
             >
-              <path
-                d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
-              />
-            </svg>
-          </CheckIcon>
-        </button>
+              <svg
+                aria-hidden={true}
+                aria-labelledby={null}
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style={
+                  Object {
+                    "verticalAlign": "-0.125em",
+                  }
+                }
+                viewBox="0 0 512 512"
+                width="1em"
+              >
+                <path
+                  d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
+                />
+              </svg>
+            </CheckIcon>
+          </button>
+        </ButtonBase>
       </Button>
     </ConfirmButton>
     <CancelButton
@@ -96,43 +103,50 @@ exports[`ConfirmButtons renders correctly 1`] = `
         onMouseUp={[MockFunction]}
         variant="plain"
       >
-        <button
-          aria-disabled={false}
+        <ButtonBase
           aria-label="Discard"
-          className="pf-c-button pf-m-plain"
-          data-ouia-component-id="OUIA-Generated-Button-plain-1"
-          data-ouia-component-type="PF4/Button"
-          data-ouia-safe={true}
-          disabled={false}
+          innerRef={null}
           onMouseUp={[MockFunction]}
-          role={null}
-          type="button"
+          variant="plain"
         >
-          <CloseIcon
-            color="currentColor"
-            noVerticalAlign={false}
-            size="sm"
+          <button
+            aria-disabled={false}
+            aria-label="Discard"
+            className="pf-c-button pf-m-plain"
+            data-ouia-component-id="OUIA-Generated-Button-plain-1"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={false}
+            onMouseUp={[MockFunction]}
+            role={null}
+            type="button"
           >
-            <svg
-              aria-hidden={true}
-              aria-labelledby={null}
-              fill="currentColor"
-              height="1em"
-              role="img"
-              style={
-                Object {
-                  "verticalAlign": "-0.125em",
-                }
-              }
-              viewBox="0 0 730 1024"
-              width="1em"
+            <CloseIcon
+              color="currentColor"
+              noVerticalAlign={false}
+              size="sm"
             >
-              <path
-                d="M725.499315,767.757345 L469.242169,511.500499 L725.499315,255.243653 C729.196254,251.545719 731.096195,247.248119 731,242.4498 C731,237.653479 728.997365,233.35588 725.299427,229.558002 L647.542773,151.701495 C643.743891,147.903617 639.446287,146 634.64996,146 C629.852635,146 625.55503,147.803673 621.857092,151.500607 L365.5,407.857398 L109.241857,151.500607 C105.544917,147.803673 101.246314,145.904733 96.4499876,146 C91.6526619,146.104622 87.3550577,148.002562 83.5571748,151.701495 L5.7005771,229.457058 C1.90269428,233.255936 0,237.553535 0,242.350855 C0,247.148175 1.80175055,251.444775 5.50068853,255.143709 L261.857779,511.500499 L5.50068853,767.757345 C1.80175055,771.454279 -0.0961914123,775.752878 0,779.750645 C0.103697157,784.547965 2.00263857,788.845564 5.7005771,792.642443 L83.4572306,871.299502 C87.2541139,875.096381 91.5527176,877 96.3500433,877 C101.147369,877 105.444973,875.197325 109.142912,871.499391 L365.400058,615.241545 L621.657203,871.499391 C625.355142,875.197325 629.652746,877.095265 634.449072,877 C639.246398,877 643.545002,874.997437 647.342885,871.299502 L725.099538,793.54294 C728.896421,789.745062 730.796362,785.446463 730.796362,780.649143 C731.096195,775.752878 729.196254,771.454279 725.499315,767.757345"
-              />
-            </svg>
-          </CloseIcon>
-        </button>
+              <svg
+                aria-hidden={true}
+                aria-labelledby={null}
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style={
+                  Object {
+                    "verticalAlign": "-0.125em",
+                  }
+                }
+                viewBox="0 0 730 1024"
+                width="1em"
+              >
+                <path
+                  d="M725.499315,767.757345 L469.242169,511.500499 L725.499315,255.243653 C729.196254,251.545719 731.096195,247.248119 731,242.4498 C731,237.653479 728.997365,233.35588 725.299427,229.558002 L647.542773,151.701495 C643.743891,147.903617 639.446287,146 634.64996,146 C629.852635,146 625.55503,147.803673 621.857092,151.500607 L365.5,407.857398 L109.241857,151.500607 C105.544917,147.803673 101.246314,145.904733 96.4499876,146 C91.6526619,146.104622 87.3550577,148.002562 83.5571748,151.701495 L5.7005771,229.457058 C1.90269428,233.255936 0,237.553535 0,242.350855 C0,247.148175 1.80175055,251.444775 5.50068853,255.143709 L261.857779,511.500499 L5.50068853,767.757345 C1.80175055,771.454279 -0.0961914123,775.752878 0,779.750645 C0.103697157,784.547965 2.00263857,788.845564 5.7005771,792.642443 L83.4572306,871.299502 C87.2541139,875.096381 91.5527176,877 96.3500433,877 C101.147369,877 105.444973,875.197325 109.142912,871.499391 L365.400058,615.241545 L621.657203,871.499391 C625.355142,875.197325 629.652746,877.095265 634.449072,877 C639.246398,877 643.545002,874.997437 647.342885,871.299502 L725.099538,793.54294 C728.896421,789.745062 730.796362,785.446463 730.796362,780.649143 C731.096195,775.752878 729.196254,771.454279 725.499315,767.757345"
+                />
+              </svg>
+            </CloseIcon>
+          </button>
+        </ButtonBase>
       </Button>
     </CancelButton>
   </div>

--- a/packages/react-integration/cypress/integration/duallistselectorbasic.spec.ts
+++ b/packages/react-integration/cypress/integration/duallistselectorbasic.spec.ts
@@ -106,6 +106,7 @@ describe('Dual List Selector BasicDemo Test', () => {
     cy.get('.pf-c-dual-list-selector__controls-item')
       .eq(1)
       .click();
+    cy.get('.pf-c-tooltip').should('exist');
     cy.get('.pf-c-dual-list-selector__list')
       .eq(0)
       .find('li')
@@ -123,6 +124,7 @@ describe('Dual List Selector BasicDemo Test', () => {
     cy.get('.pf-c-dual-list-selector__controls-item')
       .eq(3)
       .click();
+    cy.get('.pf-c-tooltip').should('exist');
     cy.get('.pf-c-dual-list-selector__list')
       .eq(0)
       .find('li')
@@ -137,6 +139,7 @@ describe('Dual List Selector BasicDemo Test', () => {
     cy.get('.pf-c-dual-list-selector__controls-item')
       .eq(0)
       .click();
+    cy.get('.pf-c-tooltip').should('exist');
     cy.get('.pf-c-dual-list-selector__list')
       .eq(0)
       .find('li')

--- a/packages/react-integration/demo-app-ts/src/components/demos/DualListSelector/DualListSelectorBasicDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DualListSelector/DualListSelectorBasicDemo.tsx
@@ -31,6 +31,14 @@ export class DualListSelectorBasicDemo extends React.Component<DualListSelectorP
         availableOptions={this.state.availableOptions}
         chosenOptions={this.state.chosenOptions}
         onListChange={this.onListChange}
+        addAllTooltip="Add all options"
+        addAllTooltipProps={{ position: 'top' }}
+        addSelectedTooltip="Add selected options"
+        addSelectedTooltipProps={{ position: 'right' }}
+        removeSelectedTooltip="Remove selected options"
+        removeSelectedTooltipProps={{ position: 'left' }}
+        removeAllTooltip="Remove all options"
+        removeAllTooltipProps={{ position: 'bottom' }}
       />
     );
   }

--- a/packages/react-topology/src/components/TopologyControlBar/__snapshots__/TopologyControlBar.test.tsx.snap
+++ b/packages/react-topology/src/components/TopologyControlBar/__snapshots__/TopologyControlBar.test.tsx.snap
@@ -174,7 +174,7 @@ exports[`TopologyControlBar should accept button options correctly 1`] = `
                               }
                             }
                             trigger={
-                              <Button
+                              <ForwardRef(Button)
                                 aria-disabled={false}
                                 className="pf-topology-control-bar__button"
                                 disabled={false}
@@ -190,7 +190,7 @@ exports[`TopologyControlBar should accept button options correctly 1`] = `
                                 >
                                   test-zoom-in-aria-label
                                 </span>
-                              </Button>
+                              </ForwardRef(Button)>
                             }
                             zIndex={9999}
                           >
@@ -205,28 +205,38 @@ exports[`TopologyControlBar should accept button options correctly 1`] = `
                                 onClick={[Function]}
                                 variant="tertiary"
                               >
-                                <button
+                                <ButtonBase
                                   aria-disabled={false}
-                                  aria-label={null}
-                                  className="pf-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                  data-ouia-component-id="OUIA-Generated-Button-tertiary-6"
-                                  data-ouia-component-type="PF4/Button"
-                                  data-ouia-safe={true}
+                                  className="pf-topology-control-bar__button"
                                   disabled={false}
                                   id="zoom-in"
+                                  innerRef={null}
                                   onClick={[Function]}
-                                  role={null}
-                                  type="button"
+                                  variant="tertiary"
                                 >
-                                  <span>
-                                    test zoom in
-                                  </span>
-                                  <span
-                                    className="sr-only"
+                                  <button
+                                    aria-disabled={false}
+                                    aria-label={null}
+                                    className="pf-c-button pf-m-tertiary pf-topology-control-bar__button"
+                                    data-ouia-component-id="OUIA-Generated-Button-tertiary-6"
+                                    data-ouia-component-type="PF4/Button"
+                                    data-ouia-safe={true}
+                                    disabled={false}
+                                    id="zoom-in"
+                                    onClick={[Function]}
+                                    role={null}
+                                    type="button"
                                   >
-                                    test-zoom-in-aria-label
-                                  </span>
-                                </button>
+                                    <span>
+                                      test zoom in
+                                    </span>
+                                    <span
+                                      className="sr-only"
+                                    >
+                                      test-zoom-in-aria-label
+                                    </span>
+                                  </button>
+                                </ButtonBase>
                               </Button>
                             </FindRefWrapper>
                           </Popper>
@@ -297,7 +307,7 @@ exports[`TopologyControlBar should accept button options correctly 1`] = `
                               }
                             }
                             trigger={
-                              <Button
+                              <ForwardRef(Button)
                                 aria-disabled={false}
                                 className="pf-topology-control-bar__button"
                                 disabled={false}
@@ -315,7 +325,7 @@ exports[`TopologyControlBar should accept button options correctly 1`] = `
                                 >
                                   Zoom Out
                                 </span>
-                              </Button>
+                              </ForwardRef(Button)>
                             }
                             zIndex={9999}
                           >
@@ -330,49 +340,59 @@ exports[`TopologyControlBar should accept button options correctly 1`] = `
                                 onClick={[Function]}
                                 variant="tertiary"
                               >
-                                <button
+                                <ButtonBase
                                   aria-disabled={false}
-                                  aria-label={null}
-                                  className="pf-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                  data-ouia-component-id="OUIA-Generated-Button-tertiary-7"
-                                  data-ouia-component-type="PF4/Button"
-                                  data-ouia-safe={true}
+                                  className="pf-topology-control-bar__button"
                                   disabled={false}
                                   id="zoom-out"
+                                  innerRef={null}
                                   onClick={[Function]}
-                                  role={null}
-                                  type="button"
+                                  variant="tertiary"
                                 >
-                                  <SearchMinusIcon
-                                    color="currentColor"
-                                    noVerticalAlign={false}
-                                    size="sm"
+                                  <button
+                                    aria-disabled={false}
+                                    aria-label={null}
+                                    className="pf-c-button pf-m-tertiary pf-topology-control-bar__button"
+                                    data-ouia-component-id="OUIA-Generated-Button-tertiary-7"
+                                    data-ouia-component-type="PF4/Button"
+                                    data-ouia-safe={true}
+                                    disabled={false}
+                                    id="zoom-out"
+                                    onClick={[Function]}
+                                    role={null}
+                                    type="button"
                                   >
-                                    <svg
-                                      aria-hidden={true}
-                                      aria-labelledby={null}
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      style={
-                                        Object {
-                                          "verticalAlign": "-0.125em",
-                                        }
-                                      }
-                                      viewBox="0 0 512 512"
-                                      width="1em"
+                                    <SearchMinusIcon
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      size="sm"
                                     >
-                                      <path
-                                        d="M304 192v32c0 6.6-5.4 12-12 12H124c-6.6 0-12-5.4-12-12v-32c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm201 284.7L476.7 505c-9.4 9.4-24.6 9.4-33.9 0L343 405.3c-4.5-4.5-7-10.6-7-17V372c-35.3 27.6-79.7 44-128 44C93.1 416 0 322.9 0 208S93.1 0 208 0s208 93.1 208 208c0 48.3-16.4 92.7-44 128h16.3c6.4 0 12.5 2.5 17 7l99.7 99.7c9.3 9.4 9.3 24.6 0 34zM344 208c0-75.2-60.8-136-136-136S72 132.8 72 208s60.8 136 136 136 136-60.8 136-136z"
-                                      />
-                                    </svg>
-                                  </SearchMinusIcon>
-                                  <span
-                                    className="sr-only"
-                                  >
-                                    Zoom Out
-                                  </span>
-                                </button>
+                                      <svg
+                                        aria-hidden={true}
+                                        aria-labelledby={null}
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        style={
+                                          Object {
+                                            "verticalAlign": "-0.125em",
+                                          }
+                                        }
+                                        viewBox="0 0 512 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M304 192v32c0 6.6-5.4 12-12 12H124c-6.6 0-12-5.4-12-12v-32c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm201 284.7L476.7 505c-9.4 9.4-24.6 9.4-33.9 0L343 405.3c-4.5-4.5-7-10.6-7-17V372c-35.3 27.6-79.7 44-128 44C93.1 416 0 322.9 0 208S93.1 0 208 0s208 93.1 208 208c0 48.3-16.4 92.7-44 128h16.3c6.4 0 12.5 2.5 17 7l99.7 99.7c9.3 9.4 9.3 24.6 0 34zM344 208c0-75.2-60.8-136-136-136S72 132.8 72 208s60.8 136 136 136 136-60.8 136-136z"
+                                        />
+                                      </svg>
+                                    </SearchMinusIcon>
+                                    <span
+                                      className="sr-only"
+                                    >
+                                      Zoom Out
+                                    </span>
+                                  </button>
+                                </ButtonBase>
                               </Button>
                             </FindRefWrapper>
                           </Popper>
@@ -443,7 +463,7 @@ exports[`TopologyControlBar should accept button options correctly 1`] = `
                               }
                             }
                             trigger={
-                              <Button
+                              <ForwardRef(Button)
                                 aria-disabled={true}
                                 className="pf-topology-control-bar__button pf-m-disabled"
                                 disabled={true}
@@ -461,7 +481,7 @@ exports[`TopologyControlBar should accept button options correctly 1`] = `
                                 >
                                   Reset View
                                 </span>
-                              </Button>
+                              </ForwardRef(Button)>
                             }
                             zIndex={9999}
                           >
@@ -476,49 +496,59 @@ exports[`TopologyControlBar should accept button options correctly 1`] = `
                                 onClick={[Function]}
                                 variant="tertiary"
                               >
-                                <button
-                                  aria-disabled={false}
-                                  aria-label={null}
-                                  className="pf-c-button pf-m-tertiary pf-topology-control-bar__button pf-m-disabled"
-                                  data-ouia-component-id="OUIA-Generated-Button-tertiary-8"
-                                  data-ouia-component-type="PF4/Button"
-                                  data-ouia-safe={true}
-                                  disabled={false}
+                                <ButtonBase
+                                  aria-disabled={true}
+                                  className="pf-topology-control-bar__button pf-m-disabled"
+                                  disabled={true}
                                   id="reset-view"
+                                  innerRef={null}
                                   onClick={[Function]}
-                                  role={null}
-                                  type="button"
+                                  variant="tertiary"
                                 >
-                                  <ExpandIcon
-                                    color="currentColor"
-                                    noVerticalAlign={false}
-                                    size="sm"
+                                  <button
+                                    aria-disabled={false}
+                                    aria-label={null}
+                                    className="pf-c-button pf-m-tertiary pf-topology-control-bar__button pf-m-disabled"
+                                    data-ouia-component-id="OUIA-Generated-Button-tertiary-8"
+                                    data-ouia-component-type="PF4/Button"
+                                    data-ouia-safe={true}
+                                    disabled={false}
+                                    id="reset-view"
+                                    onClick={[Function]}
+                                    role={null}
+                                    type="button"
                                   >
-                                    <svg
-                                      aria-hidden={true}
-                                      aria-labelledby={null}
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      style={
-                                        Object {
-                                          "verticalAlign": "-0.125em",
-                                        }
-                                      }
-                                      viewBox="0 0 448 512"
-                                      width="1em"
+                                    <ExpandIcon
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      size="sm"
                                     >
-                                      <path
-                                        d="M0 180V56c0-13.3 10.7-24 24-24h124c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12H64v84c0 6.6-5.4 12-12 12H12c-6.6 0-12-5.4-12-12zM288 44v40c0 6.6 5.4 12 12 12h84v84c0 6.6 5.4 12 12 12h40c6.6 0 12-5.4 12-12V56c0-13.3-10.7-24-24-24H300c-6.6 0-12 5.4-12 12zm148 276h-40c-6.6 0-12 5.4-12 12v84h-84c-6.6 0-12 5.4-12 12v40c0 6.6 5.4 12 12 12h124c13.3 0 24-10.7 24-24V332c0-6.6-5.4-12-12-12zM160 468v-40c0-6.6-5.4-12-12-12H64v-84c0-6.6-5.4-12-12-12H12c-6.6 0-12 5.4-12 12v124c0 13.3 10.7 24 24 24h124c6.6 0 12-5.4 12-12z"
-                                      />
-                                    </svg>
-                                  </ExpandIcon>
-                                  <span
-                                    className="sr-only"
-                                  >
-                                    Reset View
-                                  </span>
-                                </button>
+                                      <svg
+                                        aria-hidden={true}
+                                        aria-labelledby={null}
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        style={
+                                          Object {
+                                            "verticalAlign": "-0.125em",
+                                          }
+                                        }
+                                        viewBox="0 0 448 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M0 180V56c0-13.3 10.7-24 24-24h124c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12H64v84c0 6.6-5.4 12-12 12H12c-6.6 0-12-5.4-12-12zM288 44v40c0 6.6 5.4 12 12 12h84v84c0 6.6 5.4 12 12 12h40c6.6 0 12-5.4 12-12V56c0-13.3-10.7-24-24-24H300c-6.6 0-12 5.4-12 12zm148 276h-40c-6.6 0-12 5.4-12 12v84h-84c-6.6 0-12 5.4-12 12v40c0 6.6 5.4 12 12 12h124c13.3 0 24-10.7 24-24V332c0-6.6-5.4-12-12-12zM160 468v-40c0-6.6-5.4-12-12-12H64v-84c0-6.6-5.4-12-12-12H12c-6.6 0-12 5.4-12 12v124c0 13.3 10.7 24 24 24h124c6.6 0 12-5.4 12-12z"
+                                        />
+                                      </svg>
+                                    </ExpandIcon>
+                                    <span
+                                      className="sr-only"
+                                    >
+                                      Reset View
+                                    </span>
+                                  </button>
+                                </ButtonBase>
                               </Button>
                             </FindRefWrapper>
                           </Popper>
@@ -798,7 +828,7 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
                               }
                             }
                             trigger={
-                              <Button
+                              <ForwardRef(Button)
                                 aria-disabled={false}
                                 className="pf-topology-control-bar__button"
                                 disabled={false}
@@ -816,7 +846,7 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
                                 >
                                   Zoom In
                                 </span>
-                              </Button>
+                              </ForwardRef(Button)>
                             }
                             zIndex={9999}
                           >
@@ -831,49 +861,59 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
                                 onClick={[Function]}
                                 variant="tertiary"
                               >
-                                <button
+                                <ButtonBase
                                   aria-disabled={false}
-                                  aria-label={null}
-                                  className="pf-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                  data-ouia-component-id="OUIA-Generated-Button-tertiary-1"
-                                  data-ouia-component-type="PF4/Button"
-                                  data-ouia-safe={true}
+                                  className="pf-topology-control-bar__button"
                                   disabled={false}
                                   id="zoom-in"
+                                  innerRef={null}
                                   onClick={[Function]}
-                                  role={null}
-                                  type="button"
+                                  variant="tertiary"
                                 >
-                                  <SearchPlusIcon
-                                    color="currentColor"
-                                    noVerticalAlign={false}
-                                    size="sm"
+                                  <button
+                                    aria-disabled={false}
+                                    aria-label={null}
+                                    className="pf-c-button pf-m-tertiary pf-topology-control-bar__button"
+                                    data-ouia-component-id="OUIA-Generated-Button-tertiary-1"
+                                    data-ouia-component-type="PF4/Button"
+                                    data-ouia-safe={true}
+                                    disabled={false}
+                                    id="zoom-in"
+                                    onClick={[Function]}
+                                    role={null}
+                                    type="button"
                                   >
-                                    <svg
-                                      aria-hidden={true}
-                                      aria-labelledby={null}
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      style={
-                                        Object {
-                                          "verticalAlign": "-0.125em",
-                                        }
-                                      }
-                                      viewBox="0 0 512 512"
-                                      width="1em"
+                                    <SearchPlusIcon
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      size="sm"
                                     >
-                                      <path
-                                        d="M304 192v32c0 6.6-5.4 12-12 12h-56v56c0 6.6-5.4 12-12 12h-32c-6.6 0-12-5.4-12-12v-56h-56c-6.6 0-12-5.4-12-12v-32c0-6.6 5.4-12 12-12h56v-56c0-6.6 5.4-12 12-12h32c6.6 0 12 5.4 12 12v56h56c6.6 0 12 5.4 12 12zm201 284.7L476.7 505c-9.4 9.4-24.6 9.4-33.9 0L343 405.3c-4.5-4.5-7-10.6-7-17V372c-35.3 27.6-79.7 44-128 44C93.1 416 0 322.9 0 208S93.1 0 208 0s208 93.1 208 208c0 48.3-16.4 92.7-44 128h16.3c6.4 0 12.5 2.5 17 7l99.7 99.7c9.3 9.4 9.3 24.6 0 34zM344 208c0-75.2-60.8-136-136-136S72 132.8 72 208s60.8 136 136 136 136-60.8 136-136z"
-                                      />
-                                    </svg>
-                                  </SearchPlusIcon>
-                                  <span
-                                    className="sr-only"
-                                  >
-                                    Zoom In
-                                  </span>
-                                </button>
+                                      <svg
+                                        aria-hidden={true}
+                                        aria-labelledby={null}
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        style={
+                                          Object {
+                                            "verticalAlign": "-0.125em",
+                                          }
+                                        }
+                                        viewBox="0 0 512 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M304 192v32c0 6.6-5.4 12-12 12h-56v56c0 6.6-5.4 12-12 12h-32c-6.6 0-12-5.4-12-12v-56h-56c-6.6 0-12-5.4-12-12v-32c0-6.6 5.4-12 12-12h56v-56c0-6.6 5.4-12 12-12h32c6.6 0 12 5.4 12 12v56h56c6.6 0 12 5.4 12 12zm201 284.7L476.7 505c-9.4 9.4-24.6 9.4-33.9 0L343 405.3c-4.5-4.5-7-10.6-7-17V372c-35.3 27.6-79.7 44-128 44C93.1 416 0 322.9 0 208S93.1 0 208 0s208 93.1 208 208c0 48.3-16.4 92.7-44 128h16.3c6.4 0 12.5 2.5 17 7l99.7 99.7c9.3 9.4 9.3 24.6 0 34zM344 208c0-75.2-60.8-136-136-136S72 132.8 72 208s60.8 136 136 136 136-60.8 136-136z"
+                                        />
+                                      </svg>
+                                    </SearchPlusIcon>
+                                    <span
+                                      className="sr-only"
+                                    >
+                                      Zoom In
+                                    </span>
+                                  </button>
+                                </ButtonBase>
                               </Button>
                             </FindRefWrapper>
                           </Popper>
@@ -944,7 +984,7 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
                               }
                             }
                             trigger={
-                              <Button
+                              <ForwardRef(Button)
                                 aria-disabled={false}
                                 className="pf-topology-control-bar__button"
                                 disabled={false}
@@ -962,7 +1002,7 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
                                 >
                                   Zoom Out
                                 </span>
-                              </Button>
+                              </ForwardRef(Button)>
                             }
                             zIndex={9999}
                           >
@@ -977,49 +1017,59 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
                                 onClick={[Function]}
                                 variant="tertiary"
                               >
-                                <button
+                                <ButtonBase
                                   aria-disabled={false}
-                                  aria-label={null}
-                                  className="pf-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                  data-ouia-component-id="OUIA-Generated-Button-tertiary-2"
-                                  data-ouia-component-type="PF4/Button"
-                                  data-ouia-safe={true}
+                                  className="pf-topology-control-bar__button"
                                   disabled={false}
                                   id="zoom-out"
+                                  innerRef={null}
                                   onClick={[Function]}
-                                  role={null}
-                                  type="button"
+                                  variant="tertiary"
                                 >
-                                  <SearchMinusIcon
-                                    color="currentColor"
-                                    noVerticalAlign={false}
-                                    size="sm"
+                                  <button
+                                    aria-disabled={false}
+                                    aria-label={null}
+                                    className="pf-c-button pf-m-tertiary pf-topology-control-bar__button"
+                                    data-ouia-component-id="OUIA-Generated-Button-tertiary-2"
+                                    data-ouia-component-type="PF4/Button"
+                                    data-ouia-safe={true}
+                                    disabled={false}
+                                    id="zoom-out"
+                                    onClick={[Function]}
+                                    role={null}
+                                    type="button"
                                   >
-                                    <svg
-                                      aria-hidden={true}
-                                      aria-labelledby={null}
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      style={
-                                        Object {
-                                          "verticalAlign": "-0.125em",
-                                        }
-                                      }
-                                      viewBox="0 0 512 512"
-                                      width="1em"
+                                    <SearchMinusIcon
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      size="sm"
                                     >
-                                      <path
-                                        d="M304 192v32c0 6.6-5.4 12-12 12H124c-6.6 0-12-5.4-12-12v-32c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm201 284.7L476.7 505c-9.4 9.4-24.6 9.4-33.9 0L343 405.3c-4.5-4.5-7-10.6-7-17V372c-35.3 27.6-79.7 44-128 44C93.1 416 0 322.9 0 208S93.1 0 208 0s208 93.1 208 208c0 48.3-16.4 92.7-44 128h16.3c6.4 0 12.5 2.5 17 7l99.7 99.7c9.3 9.4 9.3 24.6 0 34zM344 208c0-75.2-60.8-136-136-136S72 132.8 72 208s60.8 136 136 136 136-60.8 136-136z"
-                                      />
-                                    </svg>
-                                  </SearchMinusIcon>
-                                  <span
-                                    className="sr-only"
-                                  >
-                                    Zoom Out
-                                  </span>
-                                </button>
+                                      <svg
+                                        aria-hidden={true}
+                                        aria-labelledby={null}
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        style={
+                                          Object {
+                                            "verticalAlign": "-0.125em",
+                                          }
+                                        }
+                                        viewBox="0 0 512 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M304 192v32c0 6.6-5.4 12-12 12H124c-6.6 0-12-5.4-12-12v-32c0-6.6 5.4-12 12-12h168c6.6 0 12 5.4 12 12zm201 284.7L476.7 505c-9.4 9.4-24.6 9.4-33.9 0L343 405.3c-4.5-4.5-7-10.6-7-17V372c-35.3 27.6-79.7 44-128 44C93.1 416 0 322.9 0 208S93.1 0 208 0s208 93.1 208 208c0 48.3-16.4 92.7-44 128h16.3c6.4 0 12.5 2.5 17 7l99.7 99.7c9.3 9.4 9.3 24.6 0 34zM344 208c0-75.2-60.8-136-136-136S72 132.8 72 208s60.8 136 136 136 136-60.8 136-136z"
+                                        />
+                                      </svg>
+                                    </SearchMinusIcon>
+                                    <span
+                                      className="sr-only"
+                                    >
+                                      Zoom Out
+                                    </span>
+                                  </button>
+                                </ButtonBase>
                               </Button>
                             </FindRefWrapper>
                           </Popper>
@@ -1090,7 +1140,7 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
                               }
                             }
                             trigger={
-                              <Button
+                              <ForwardRef(Button)
                                 aria-disabled={false}
                                 className="pf-topology-control-bar__button"
                                 disabled={false}
@@ -1108,7 +1158,7 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
                                 >
                                   Fit to Screen
                                 </span>
-                              </Button>
+                              </ForwardRef(Button)>
                             }
                             zIndex={9999}
                           >
@@ -1123,49 +1173,59 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
                                 onClick={[Function]}
                                 variant="tertiary"
                               >
-                                <button
+                                <ButtonBase
                                   aria-disabled={false}
-                                  aria-label={null}
-                                  className="pf-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                  data-ouia-component-id="OUIA-Generated-Button-tertiary-3"
-                                  data-ouia-component-type="PF4/Button"
-                                  data-ouia-safe={true}
+                                  className="pf-topology-control-bar__button"
                                   disabled={false}
                                   id="fit-to-screen"
+                                  innerRef={null}
                                   onClick={[Function]}
-                                  role={null}
-                                  type="button"
+                                  variant="tertiary"
                                 >
-                                  <ExpandArrowsAltIcon
-                                    color="currentColor"
-                                    noVerticalAlign={false}
-                                    size="sm"
+                                  <button
+                                    aria-disabled={false}
+                                    aria-label={null}
+                                    className="pf-c-button pf-m-tertiary pf-topology-control-bar__button"
+                                    data-ouia-component-id="OUIA-Generated-Button-tertiary-3"
+                                    data-ouia-component-type="PF4/Button"
+                                    data-ouia-safe={true}
+                                    disabled={false}
+                                    id="fit-to-screen"
+                                    onClick={[Function]}
+                                    role={null}
+                                    type="button"
                                   >
-                                    <svg
-                                      aria-hidden={true}
-                                      aria-labelledby={null}
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      style={
-                                        Object {
-                                          "verticalAlign": "-0.125em",
-                                        }
-                                      }
-                                      viewBox="0 0 448 512"
-                                      width="1em"
+                                    <ExpandArrowsAltIcon
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      size="sm"
                                     >
-                                      <path
-                                        d="M448 344v112a23.94 23.94 0 0 1-24 24H312c-21.39 0-32.09-25.9-17-41l36.2-36.2L224 295.6 116.77 402.9 153 439c15.09 15.1 4.39 41-17 41H24a23.94 23.94 0 0 1-24-24V344c0-21.4 25.89-32.1 41-17l36.19 36.2L184.46 256 77.18 148.7 41 185c-15.1 15.1-41 4.4-41-17V56a23.94 23.94 0 0 1 24-24h112c21.39 0 32.09 25.9 17 41l-36.2 36.2L224 216.4l107.23-107.3L295 73c-15.09-15.1-4.39-41 17-41h112a23.94 23.94 0 0 1 24 24v112c0 21.4-25.89 32.1-41 17l-36.19-36.2L263.54 256l107.28 107.3L407 327.1c15.1-15.2 41-4.5 41 16.9z"
-                                      />
-                                    </svg>
-                                  </ExpandArrowsAltIcon>
-                                  <span
-                                    className="sr-only"
-                                  >
-                                    Fit to Screen
-                                  </span>
-                                </button>
+                                      <svg
+                                        aria-hidden={true}
+                                        aria-labelledby={null}
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        style={
+                                          Object {
+                                            "verticalAlign": "-0.125em",
+                                          }
+                                        }
+                                        viewBox="0 0 448 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M448 344v112a23.94 23.94 0 0 1-24 24H312c-21.39 0-32.09-25.9-17-41l36.2-36.2L224 295.6 116.77 402.9 153 439c15.09 15.1 4.39 41-17 41H24a23.94 23.94 0 0 1-24-24V344c0-21.4 25.89-32.1 41-17l36.19 36.2L184.46 256 77.18 148.7 41 185c-15.1 15.1-41 4.4-41-17V56a23.94 23.94 0 0 1 24-24h112c21.39 0 32.09 25.9 17 41l-36.2 36.2L224 216.4l107.23-107.3L295 73c-15.09-15.1-4.39-41 17-41h112a23.94 23.94 0 0 1 24 24v112c0 21.4-25.89 32.1-41 17l-36.19-36.2L263.54 256l107.28 107.3L407 327.1c15.1-15.2 41-4.5 41 16.9z"
+                                        />
+                                      </svg>
+                                    </ExpandArrowsAltIcon>
+                                    <span
+                                      className="sr-only"
+                                    >
+                                      Fit to Screen
+                                    </span>
+                                  </button>
+                                </ButtonBase>
                               </Button>
                             </FindRefWrapper>
                           </Popper>
@@ -1236,7 +1296,7 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
                               }
                             }
                             trigger={
-                              <Button
+                              <ForwardRef(Button)
                                 aria-disabled={false}
                                 className="pf-topology-control-bar__button"
                                 disabled={false}
@@ -1254,7 +1314,7 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
                                 >
                                   Reset View
                                 </span>
-                              </Button>
+                              </ForwardRef(Button)>
                             }
                             zIndex={9999}
                           >
@@ -1269,49 +1329,59 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
                                 onClick={[Function]}
                                 variant="tertiary"
                               >
-                                <button
+                                <ButtonBase
                                   aria-disabled={false}
-                                  aria-label={null}
-                                  className="pf-c-button pf-m-tertiary pf-topology-control-bar__button"
-                                  data-ouia-component-id="OUIA-Generated-Button-tertiary-4"
-                                  data-ouia-component-type="PF4/Button"
-                                  data-ouia-safe={true}
+                                  className="pf-topology-control-bar__button"
                                   disabled={false}
                                   id="reset-view"
+                                  innerRef={null}
                                   onClick={[Function]}
-                                  role={null}
-                                  type="button"
+                                  variant="tertiary"
                                 >
-                                  <ExpandIcon
-                                    color="currentColor"
-                                    noVerticalAlign={false}
-                                    size="sm"
+                                  <button
+                                    aria-disabled={false}
+                                    aria-label={null}
+                                    className="pf-c-button pf-m-tertiary pf-topology-control-bar__button"
+                                    data-ouia-component-id="OUIA-Generated-Button-tertiary-4"
+                                    data-ouia-component-type="PF4/Button"
+                                    data-ouia-safe={true}
+                                    disabled={false}
+                                    id="reset-view"
+                                    onClick={[Function]}
+                                    role={null}
+                                    type="button"
                                   >
-                                    <svg
-                                      aria-hidden={true}
-                                      aria-labelledby={null}
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      style={
-                                        Object {
-                                          "verticalAlign": "-0.125em",
-                                        }
-                                      }
-                                      viewBox="0 0 448 512"
-                                      width="1em"
+                                    <ExpandIcon
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      size="sm"
                                     >
-                                      <path
-                                        d="M0 180V56c0-13.3 10.7-24 24-24h124c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12H64v84c0 6.6-5.4 12-12 12H12c-6.6 0-12-5.4-12-12zM288 44v40c0 6.6 5.4 12 12 12h84v84c0 6.6 5.4 12 12 12h40c6.6 0 12-5.4 12-12V56c0-13.3-10.7-24-24-24H300c-6.6 0-12 5.4-12 12zm148 276h-40c-6.6 0-12 5.4-12 12v84h-84c-6.6 0-12 5.4-12 12v40c0 6.6 5.4 12 12 12h124c13.3 0 24-10.7 24-24V332c0-6.6-5.4-12-12-12zM160 468v-40c0-6.6-5.4-12-12-12H64v-84c0-6.6-5.4-12-12-12H12c-6.6 0-12 5.4-12 12v124c0 13.3 10.7 24 24 24h124c6.6 0 12-5.4 12-12z"
-                                      />
-                                    </svg>
-                                  </ExpandIcon>
-                                  <span
-                                    className="sr-only"
-                                  >
-                                    Reset View
-                                  </span>
-                                </button>
+                                      <svg
+                                        aria-hidden={true}
+                                        aria-labelledby={null}
+                                        fill="currentColor"
+                                        height="1em"
+                                        role="img"
+                                        style={
+                                          Object {
+                                            "verticalAlign": "-0.125em",
+                                          }
+                                        }
+                                        viewBox="0 0 448 512"
+                                        width="1em"
+                                      >
+                                        <path
+                                          d="M0 180V56c0-13.3 10.7-24 24-24h124c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12H64v84c0 6.6-5.4 12-12 12H12c-6.6 0-12-5.4-12-12zM288 44v40c0 6.6 5.4 12 12 12h84v84c0 6.6 5.4 12 12 12h40c6.6 0 12-5.4 12-12V56c0-13.3-10.7-24-24-24H300c-6.6 0-12 5.4-12 12zm148 276h-40c-6.6 0-12 5.4-12 12v84h-84c-6.6 0-12 5.4-12 12v40c0 6.6 5.4 12 12 12h124c13.3 0 24-10.7 24-24V332c0-6.6-5.4-12-12-12zM160 468v-40c0-6.6-5.4-12-12-12H64v-84c0-6.6-5.4-12-12-12H12c-6.6 0-12 5.4-12 12v124c0 13.3 10.7 24 24 24h124c6.6 0 12-5.4 12-12z"
+                                        />
+                                      </svg>
+                                    </ExpandIcon>
+                                    <span
+                                      className="sr-only"
+                                    >
+                                      Reset View
+                                    </span>
+                                  </button>
+                                </ButtonBase>
                               </Button>
                             </FindRefWrapper>
                           </Popper>
@@ -1332,21 +1402,31 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
                           onClick={[Function]}
                           variant="tertiary"
                         >
-                          <button
+                          <ButtonBase
                             aria-disabled={false}
-                            aria-label={null}
-                            className="pf-c-button pf-m-tertiary pf-topology-control-bar__button"
-                            data-ouia-component-id="OUIA-Generated-Button-tertiary-5"
-                            data-ouia-component-type="PF4/Button"
-                            data-ouia-safe={true}
+                            className="pf-topology-control-bar__button"
                             disabled={false}
                             id="legend"
+                            innerRef={null}
                             onClick={[Function]}
-                            role={null}
-                            type="button"
+                            variant="tertiary"
                           >
-                            Legend
-                          </button>
+                            <button
+                              aria-disabled={false}
+                              aria-label={null}
+                              className="pf-c-button pf-m-tertiary pf-topology-control-bar__button"
+                              data-ouia-component-id="OUIA-Generated-Button-tertiary-5"
+                              data-ouia-component-type="PF4/Button"
+                              data-ouia-safe={true}
+                              disabled={false}
+                              id="legend"
+                              onClick={[Function]}
+                              role={null}
+                              type="button"
+                            >
+                              Legend
+                            </button>
+                          </ButtonBase>
                         </Button>
                       </div>
                     </ToolbarItem>

--- a/packages/react-topology/src/components/TopologySideBar/__snapshots__/TopologySideBar.test.tsx.snap
+++ b/packages/react-topology/src/components/TopologySideBar/__snapshots__/TopologySideBar.test.tsx.snap
@@ -52,43 +52,51 @@ exports[`TopologySideBar should display topology sidebar w/ close correctly 1`] 
       onClick={[MockFunction]}
       variant="plain"
     >
-      <button
-        aria-disabled={false}
+      <ButtonBase
         aria-label="Close"
-        className="pf-c-button pf-m-plain pf-topology-side-bar__dismiss"
-        data-ouia-component-id="OUIA-Generated-Button-plain-1"
-        data-ouia-component-type="PF4/Button"
-        data-ouia-safe={true}
-        disabled={false}
+        className="pf-topology-side-bar__dismiss"
+        innerRef={null}
         onClick={[MockFunction]}
-        role={null}
-        type="button"
+        variant="plain"
       >
-        <TimesIcon
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
+        <button
+          aria-disabled={false}
+          aria-label="Close"
+          className="pf-c-button pf-m-plain pf-topology-side-bar__dismiss"
+          data-ouia-component-id="OUIA-Generated-Button-plain-1"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe={true}
+          disabled={false}
+          onClick={[MockFunction]}
+          role={null}
+          type="button"
         >
-          <svg
-            aria-hidden={true}
-            aria-labelledby={null}
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style={
-              Object {
-                "verticalAlign": "-0.125em",
-              }
-            }
-            viewBox="0 0 352 512"
-            width="1em"
+          <TimesIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
           >
-            <path
-              d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-            />
-          </svg>
-        </TimesIcon>
-      </button>
+            <svg
+              aria-hidden={true}
+              aria-labelledby={null}
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
+              viewBox="0 0 352 512"
+              width="1em"
+            >
+              <path
+                d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+              />
+            </svg>
+          </TimesIcon>
+        </button>
+      </ButtonBase>
     </Button>
     <div
       className="pf-topology-side-bar__body"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5855

- Adds tooltip/tooltipProps properties for each move action control button.
- Updates `Button` to forward a `ref` (basically all of the snapshot updates are due to this change). This update is because Tooltip requires a `ref` set on the button that triggers the tooltip, but `Button` is a functional component that doesn't allow refs by default.