### PR TITLE
feat(AlertGroup): Make dynamic alerts more accessible

### DIFF
--- a/packages/react-core/src/components/Alert/examples/Alert.md
+++ b/packages/react-core/src/components/Alert/examples/Alert.md
@@ -194,7 +194,7 @@ class StaticLiveRegionAlert extends React.Component {
 ### Dynamic live region alert
 ```js
 import React from 'react';
-import { Alert, InputGroup } from '@patternfly/react-core';
+import { Alert, AlertGroup, InputGroup } from '@patternfly/react-core';
 
 class DynamicLiveRegionAlert extends React.Component {
   constructor() {
@@ -213,7 +213,6 @@ class DynamicLiveRegionAlert extends React.Component {
       addAlert({
         title: 'Single Success Alert',
         variant: 'success',
-        isLiveRegion: true,
         key: getUniqueId()
       });
     };
@@ -221,9 +220,6 @@ class DynamicLiveRegionAlert extends React.Component {
       addAlert({
         title: 'Single Info Alert',
         variant: 'info',
-        ariaLive: 'polite',
-        ariaRelevant: 'additions text',
-        ariaAtomic: 'false',
         key: getUniqueId()
       });
     };
@@ -231,9 +227,6 @@ class DynamicLiveRegionAlert extends React.Component {
       addAlert({
         title: 'Single Danger Alert',
         variant: 'danger',
-        ariaLive: 'assertive',
-        ariaRelevant: 'additions text',
-        ariaAtomic: 'false',
         key: getUniqueId()
       });
     };
@@ -251,17 +244,15 @@ class DynamicLiveRegionAlert extends React.Component {
             Add Single Danger Alert
           </button>
         </InputGroup>
+        <AlertGroup isLiveRegion aria-live="polite" aria-relevant="additions text" aria-atomic="false">
         {this.state.alerts.map(({ title, variant, isLiveRegion, ariaLive, ariaRelevant, ariaAtomic, key }) => (
           <Alert
             variant={variant}
             title={title}
-            isLiveRegion={isLiveRegion}
-            aria-live={ariaLive}
-            aria-relevant={ariaRelevant}
-            aria-atomic={ariaAtomic}
             key={key}
           />
         ))}
+        </AlertGroup>
       </React.Fragment>
     );
   }
@@ -271,7 +262,7 @@ class DynamicLiveRegionAlert extends React.Component {
 ### Async live region alert
 ```js
 import React from 'react';
-import { Alert, InputGroup } from '@patternfly/react-core';
+import { Alert, AlertGroup, InputGroup } from '@patternfly/react-core';
 
 class AsyncLiveRegionAlert extends React.Component {
   constructor() {
@@ -297,7 +288,6 @@ class AsyncLiveRegionAlert extends React.Component {
         addAlert({
           title: `This is a async alert number ${this.state.alerts.length + 1}`,
           variant: 'info',
-          isLiveRegion: true,
           key: getUniqueId()
         });
       }, 1500);
@@ -314,9 +304,11 @@ class AsyncLiveRegionAlert extends React.Component {
             Stop Async Info Alerts
           </button>
         </InputGroup>
-        {this.state.alerts.map(({ title, variant, isLiveRegion, key }) => (
-          <Alert variant={variant} title={title} isLiveRegion={isLiveRegion} key={key} />
+        <AlertGroup isLiveRegion aria-live="polite" aria-relevant="additions text" aria-atomic="false">
+        {this.state.alerts.map(({ title, variant, key }) => (
+          <Alert variant={variant} title={title} key={key} />
         ))}
+        </AlertGroup>
       </React.Fragment>
     );
   }
@@ -326,7 +318,7 @@ class AsyncLiveRegionAlert extends React.Component {
 ### Alert timeout
 ```js
 import React from 'react';
-import { Alert, AlertActionLink, Button } from '@patternfly/react-core';
+import { Alert, AlertActionLink, AlertGroup, Button } from '@patternfly/react-core';
 
 class AlertTimeout extends React.Component {
   constructor() {
@@ -355,7 +347,9 @@ class AlertTimeout extends React.Component {
       <React.Fragment>
         <Button variant="secondary" onClick={this.onClick}>Add alert</Button>
         <Button variant="secondary" onClick={() => this.setState({ alerts: [] })}>Remove all alerts</Button>
+        <AlertGroup isLiveRegion>
         {this.state.alerts}
+        </AlertGroup>
       </React.Fragment>
     );
   }

--- a/packages/react-core/src/components/Alert/examples/Alert.md
+++ b/packages/react-core/src/components/Alert/examples/Alert.md
@@ -192,6 +192,7 @@ class StaticLiveRegionAlert extends React.Component {
 ```
 
 ### Dynamic live region alert
+Alerts asynchronously appended into dynamic AlertGroups with isLiveRegion will be announced to assistive technology at the moment the change happens, following the strategy used for aria-atomic, which defaults to false. This means only changes of type "addition" will be announced.
 ```js
 import React from 'react';
 import { Alert, AlertGroup, InputGroup } from '@patternfly/react-core';
@@ -260,6 +261,7 @@ class DynamicLiveRegionAlert extends React.Component {
 ```
 
 ### Async live region alert
+This shows how an alert could be triggered by an asynchronous event in the application. Note that you can customize how the alert will be announced to assistive technology. See the alert accessibility tab for more information.
 ```js
 import React from 'react';
 import { Alert, AlertGroup, InputGroup } from '@patternfly/react-core';
@@ -290,7 +292,7 @@ class AsyncLiveRegionAlert extends React.Component {
           variant: 'info',
           key: getUniqueId()
         });
-      }, 1500);
+      }, 4500);
       this.setState({ timer: timerValue });
     };
     const btnClasses = ['pf-c-button', 'pf-m-secondary'].join(' ');
@@ -304,7 +306,7 @@ class AsyncLiveRegionAlert extends React.Component {
             Stop Async Info Alerts
           </button>
         </InputGroup>
-        <AlertGroup isLiveRegion aria-live="polite" aria-relevant="additions text" aria-atomic="false">
+        <AlertGroup isLiveRegion>
         {this.state.alerts.map(({ title, variant, key }) => (
           <Alert variant={variant} title={title} key={key} />
         ))}

--- a/packages/react-core/src/components/AlertGroup/AlertGroup.tsx
+++ b/packages/react-core/src/components/AlertGroup/AlertGroup.tsx
@@ -10,6 +10,8 @@ export interface AlertGroupProps extends Omit<React.HTMLProps<HTMLUListElement>,
   children?: React.ReactNode;
   /** Toast notifications are positioned at the top right corner of the viewport */
   isToast?: boolean;
+  /** Dyanmic alerts need to be rendered in pre-existing live region */
+  isDynamic?: boolean;
   /** Determine where the alert is appended to */
   appendTo?: HTMLElement | (() => HTMLElement);
 }
@@ -47,9 +49,9 @@ export class AlertGroup extends React.Component<AlertGroupProps, AlertGroupState
   }
 
   render() {
-    const { className, children, isToast, ...props } = this.props;
+    const { className, children, isToast, isDynamic, ...props } = this.props;
     const alertGroup = (
-      <AlertGroupInline className={className} isToast={isToast} {...props}>
+      <AlertGroupInline className={className} isToast={isToast} isDynamic={isDynamic} {...props}>
         {children}
       </AlertGroupInline>
     );

--- a/packages/react-core/src/components/AlertGroup/AlertGroup.tsx
+++ b/packages/react-core/src/components/AlertGroup/AlertGroup.tsx
@@ -10,8 +10,8 @@ export interface AlertGroupProps extends Omit<React.HTMLProps<HTMLUListElement>,
   children?: React.ReactNode;
   /** Toast notifications are positioned at the top right corner of the viewport */
   isToast?: boolean;
-  /** Dyanmic alerts need to be rendered in pre-existing live region */
-  isDynamic?: boolean;
+  /** Turns the container into a live region so that changes to content within the AlertGroup, such as appending an Alert, are reliably announced to assistive technology. */
+  isLiveRegion?: boolean;
   /** Determine where the alert is appended to */
   appendTo?: HTMLElement | (() => HTMLElement);
 }
@@ -49,9 +49,9 @@ export class AlertGroup extends React.Component<AlertGroupProps, AlertGroupState
   }
 
   render() {
-    const { className, children, isToast, isDynamic, ...props } = this.props;
+    const { className, children, isToast, isLiveRegion, ...props } = this.props;
     const alertGroup = (
-      <AlertGroupInline className={className} isToast={isToast} isDynamic={isDynamic} {...props}>
+      <AlertGroupInline className={className} isToast={isToast} isLiveRegion={isLiveRegion} {...props}>
         {children}
       </AlertGroupInline>
     );

--- a/packages/react-core/src/components/AlertGroup/AlertGroupInline.tsx
+++ b/packages/react-core/src/components/AlertGroup/AlertGroupInline.tsx
@@ -7,11 +7,12 @@ export const AlertGroupInline: React.FunctionComponent<AlertGroupProps> = ({
   className,
   children,
   isToast,
-  isDynamic,
+  isLiveRegion,
   ...rest
 }: AlertGroupProps) => (
   <ul
-    aria-live={isDynamic ? 'polite' : null}
+    aria-live={isLiveRegion ? 'polite' : null}
+    aria-atomic={isLiveRegion ? false : null}
     className={css(styles.alertGroup, className, isToast ? styles.modifiers.toast : '')}
     {...rest}
   >

--- a/packages/react-core/src/components/AlertGroup/AlertGroupInline.tsx
+++ b/packages/react-core/src/components/AlertGroup/AlertGroupInline.tsx
@@ -7,9 +7,14 @@ export const AlertGroupInline: React.FunctionComponent<AlertGroupProps> = ({
   className,
   children,
   isToast,
+  isDynamic,
   ...rest
 }: AlertGroupProps) => (
-  <ul className={css(styles.alertGroup, className, isToast ? styles.modifiers.toast : '')} {...rest}>
+  <ul
+    aria-live={isDynamic ? 'polite' : null}
+    className={css(styles.alertGroup, className, isToast ? styles.modifiers.toast : '')}
+    {...rest}
+  >
     {React.Children.toArray(children).map((Alert: React.ReactNode, index: number) => (
       <li key={index}>{Alert}</li>
     ))}

--- a/packages/react-core/src/components/AlertGroup/__tests__/Generated/__snapshots__/AlertGroupInline.test.tsx.snap
+++ b/packages/react-core/src/components/AlertGroup/__tests__/Generated/__snapshots__/AlertGroupInline.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`AlertGroupInline should match snapshot (auto-generated) 1`] = `
 <ul
+  aria-live={null}
   className="pf-c-alert-group"
 />
 `;

--- a/packages/react-core/src/components/AlertGroup/__tests__/Generated/__snapshots__/AlertGroupInline.test.tsx.snap
+++ b/packages/react-core/src/components/AlertGroup/__tests__/Generated/__snapshots__/AlertGroupInline.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`AlertGroupInline should match snapshot (auto-generated) 1`] = `
 <ul
+  aria-atomic={null}
   aria-live={null}
   className="pf-c-alert-group"
 />

--- a/packages/react-core/src/components/AlertGroup/__tests__/__snapshots__/AlertGroup.test.tsx.snap
+++ b/packages/react-core/src/components/AlertGroup/__tests__/__snapshots__/AlertGroup.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`Standard Alert Group is not a toast alert group 1`] = `
 <AlertGroup>
   <AlertGroupInline>
     <ul
+      aria-atomic={null}
       aria-live={null}
       className="pf-c-alert-group"
     >
@@ -132,6 +133,7 @@ exports[`Toast Alert Group contains expected modifier class 1`] = `
       isToast={true}
     >
       <ul
+        aria-atomic={null}
         aria-live={null}
         className="pf-c-alert-group pf-m-toast"
       >
@@ -670,6 +672,7 @@ exports[`alertgroup closes when alerts are closed 1`] = `
             </div>
           </body>
         }
+        aria-atomic={null}
         aria-live={null}
         className="pf-c-alert-group pf-m-toast"
       >

--- a/packages/react-core/src/components/AlertGroup/__tests__/__snapshots__/AlertGroup.test.tsx.snap
+++ b/packages/react-core/src/components/AlertGroup/__tests__/__snapshots__/AlertGroup.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`Standard Alert Group is not a toast alert group 1`] = `
 <AlertGroup>
   <AlertGroupInline>
     <ul
+      aria-live={null}
       className="pf-c-alert-group"
     >
       <li
@@ -131,6 +132,7 @@ exports[`Toast Alert Group contains expected modifier class 1`] = `
       isToast={true}
     >
       <ul
+        aria-live={null}
         className="pf-c-alert-group pf-m-toast"
       >
         <li
@@ -668,6 +670,7 @@ exports[`alertgroup closes when alerts are closed 1`] = `
             </div>
           </body>
         }
+        aria-live={null}
         className="pf-c-alert-group pf-m-toast"
       >
         <li

--- a/packages/react-core/src/components/AlertGroup/examples/AlertGroup.md
+++ b/packages/react-core/src/components/AlertGroup/examples/AlertGroup.md
@@ -7,7 +7,7 @@ propComponents: ['Alert', 'AlertGroup', 'AlertActionCloseButton', 'AlertActionLi
 
 ## Examples
 ### Static alert group
-These alerts are discoverable from within the normal page content flow, and will not be announced individually/explicitly to assistive technology.
+These alerts appear on page load and are discoverable from within the normal page content flow, and will not be announced individually/explicitly to assistive technology.
 ```js
 import React from 'react';
 import { Alert, AlertGroup } from '@patternfly/react-core';
@@ -79,6 +79,7 @@ class ToastAlertGroup extends React.Component {
 ```
 
 ### Singular dynamic alert group
+This alert will appear in the page, most likely in response to a user action.
 ```js
 import React from 'react';
 import { Alert, AlertGroup, AlertVariant, AlertActionCloseButton, InputGroup } from '@patternfly/react-core';
@@ -131,6 +132,7 @@ class SingularAdditiveAlertGroup extends React.Component {
 ```
 
 ### Multiple dynamic alert group
+These alerts will appear in the page, most likely in response to a user action.
 ```js
 import React from 'react';
 import { Alert, AlertGroup, AlertVariant, AlertActionCloseButton, InputGroup } from '@patternfly/react-core';
@@ -186,6 +188,7 @@ class MultipleAdditiveAlertGroup extends React.Component {
 ```
 
 ### Async alert group
+This shows how an alert could be triggered by an asynchronous event in the application. Note how you can customize how the alert will be announced to assistive technology. See the alert group accessibility tab for more information.
 ```js
 import React from 'react';
 import { Alert, AlertGroup, AlertActionCloseButton, AlertVariant, InputGroup } from '@patternfly/react-core';
@@ -211,11 +214,11 @@ class AsyncAdditiveAlertGroup extends React.Component {
         addAlerts([
           {
             title: `Async Notification ${this.state.alerts.length + 1} was added to the queue.`,
-            variant: 'info',
+            variant: 'danger',
             key: getUniqueId()
           }
         ])
-      }, 1500);
+      }, 4500);
       this.setState({timer: timerValue});
     };
     return (
@@ -224,7 +227,7 @@ class AsyncAdditiveAlertGroup extends React.Component {
           <button onClick={startAsyncAlerts} type="button" className={btnClasses}>Start Async Alerts</button>
           <button onClick={this.stopAsyncAlerts} type="button" className={btnClasses}>Stop Async Alerts</button>
         </InputGroup>
-        <AlertGroup isToast isLiveRegion>
+        <AlertGroup isToast isLiveRegion aria-live="assertive">
           {this.state.alerts.map(({ title, variant, key }) => (
             <Alert
               variant={AlertVariant[variant]}

--- a/packages/react-core/src/components/AlertGroup/examples/AlertGroup.md
+++ b/packages/react-core/src/components/AlertGroup/examples/AlertGroup.md
@@ -7,6 +7,7 @@ propComponents: ['Alert', 'AlertGroup', 'AlertActionCloseButton', 'AlertActionLi
 
 ## Examples
 ### Static alert group
+These alerts are discoverable from within the normal page content flow, and will not be announced individually/explicitly to assistive technology.
 ```js
 import React from 'react';
 import { Alert, AlertGroup } from '@patternfly/react-core';
@@ -26,6 +27,7 @@ class StaticAlertGroup extends React.Component {
 ```
 
 ### Toast alert group
+Alerts asynchronously appended into dynamic AlertGroups with `isLiveRegion` will be announced to assistive technology at the moment the change happens, following the strategy used for aria-atomic, which defaults to false. This means only changes of type "addition" will be announced.
 ```js
 import React from 'react';
 import { Alert, AlertGroup, AlertActionCloseButton, AlertVariant, InputGroup } from '@patternfly/react-core';
@@ -55,10 +57,9 @@ class ToastAlertGroup extends React.Component {
           <button onClick={addDangerAlert} type="button" className={btnClasses}>Add Toast Danger Alert</button>
           <button onClick={addInfoAlert} type="button" className={btnClasses}>Add Toast Info Alert</button>
         </InputGroup>
-        <AlertGroup isToast isDynamic>
+        <AlertGroup isToast isLiveRegion>
           {this.state.alerts.map(({key, variant, title}) => (
             <Alert
-              isLiveRegion
               variant={AlertVariant[variant]}
               title={title}
               actionClose={
@@ -107,11 +108,10 @@ class SingularAdditiveAlertGroup extends React.Component {
           <button onClick={addDangerAlert} type="button" className={btnClasses}>Add Single Danger Alert</button>
           <button onClick={addInfoAlert} type="button" className={btnClasses}>Add Single Info Alert</button>
         </InputGroup>
-        <AlertGroup isDynamic>
+        <AlertGroup isLiveRegion>
           {this.state.alerts.map(({ title, variant, key }) => (
             <Alert
               isInline
-              isLiveRegion
               variant={AlertVariant[variant]}
               title={title}
               key={key}
@@ -164,10 +164,9 @@ class MultipleAdditiveAlertGroup extends React.Component {
         <InputGroup style={{ marginBottom: '16px' }}>
           <button onClick={addAlertCollection} type="button" className={btnClasses}>Add Alert Collection</button>
         </InputGroup>
-        <AlertGroup isToast isDynamic>
+        <AlertGroup isToast isLiveRegion>
           {this.state.alerts.map(({ title, variant, key, action }) => (
             <Alert
-              isLiveRegion
               variant={AlertVariant[variant]}
               title={title}
               key={key}
@@ -225,10 +224,9 @@ class AsyncAdditiveAlertGroup extends React.Component {
           <button onClick={startAsyncAlerts} type="button" className={btnClasses}>Start Async Alerts</button>
           <button onClick={this.stopAsyncAlerts} type="button" className={btnClasses}>Stop Async Alerts</button>
         </InputGroup>
-        <AlertGroup isToast isDynamic>
+        <AlertGroup isToast isLiveRegion>
           {this.state.alerts.map(({ title, variant, key }) => (
             <Alert
-              isLiveRegion
               variant={AlertVariant[variant]}
               title={title}
               key={key}

--- a/packages/react-core/src/components/AlertGroup/examples/AlertGroup.md
+++ b/packages/react-core/src/components/AlertGroup/examples/AlertGroup.md
@@ -55,7 +55,7 @@ class ToastAlertGroup extends React.Component {
           <button onClick={addDangerAlert} type="button" className={btnClasses}>Add Toast Danger Alert</button>
           <button onClick={addInfoAlert} type="button" className={btnClasses}>Add Toast Info Alert</button>
         </InputGroup>
-        <AlertGroup isToast>
+        <AlertGroup isToast isDynamic>
           {this.state.alerts.map(({key, variant, title}) => (
             <Alert
               isLiveRegion
@@ -107,7 +107,7 @@ class SingularAdditiveAlertGroup extends React.Component {
           <button onClick={addDangerAlert} type="button" className={btnClasses}>Add Single Danger Alert</button>
           <button onClick={addInfoAlert} type="button" className={btnClasses}>Add Single Info Alert</button>
         </InputGroup>
-        <AlertGroup>
+        <AlertGroup isDynamic>
           {this.state.alerts.map(({ title, variant, key }) => (
             <Alert
               isInline
@@ -164,7 +164,7 @@ class MultipleAdditiveAlertGroup extends React.Component {
         <InputGroup style={{ marginBottom: '16px' }}>
           <button onClick={addAlertCollection} type="button" className={btnClasses}>Add Alert Collection</button>
         </InputGroup>
-        <AlertGroup isToast>
+        <AlertGroup isToast isDynamic>
           {this.state.alerts.map(({ title, variant, key, action }) => (
             <Alert
               isLiveRegion
@@ -225,7 +225,7 @@ class AsyncAdditiveAlertGroup extends React.Component {
           <button onClick={startAsyncAlerts} type="button" className={btnClasses}>Start Async Alerts</button>
           <button onClick={this.stopAsyncAlerts} type="button" className={btnClasses}>Stop Async Alerts</button>
         </InputGroup>
-        <AlertGroup isToast>
+        <AlertGroup isToast isDynamic>
           {this.state.alerts.map(({ title, variant, key }) => (
             <Alert
               isLiveRegion


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Alternative approach/attempt to PR#5773
Closes #5731

This PR/POC is meant to test an alternative approach to making dynamic alerts more accessible. It turns AlertGroup into a pre-existing live region for screen readers to be notified that alerts will be rendered inside of it.