### PR TITLE
fix(Select): Ignore arrow keys when typeahead options are empty

### DIFF
--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -578,6 +578,9 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
           this.onToggle(false);
         }
       } else if (!tabbedIntoFavoritesMenu) {
+        if (this.refCollection[0][0] === null) {
+          return;
+        }
         let nextIndex;
         if (typeaheadCurrIndex === -1 && position === 'down') {
           nextIndex = 0;


### PR DESCRIPTION
**What**: Closes #5952 

To note, the "maximum stack exceeded" could possibly still happen in other components but fixing that is not necessary for this issue.