### PR TITLE
fix(slider): respect props in useCallback

### DIFF
--- a/packages/react-core/src/components/Slider/Slider.tsx
+++ b/packages/react-core/src/components/Slider/Slider.tsx
@@ -239,8 +239,8 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
     }
   };
 
-  const callbackThumbMove = React.useCallback(handleThumbMove, []);
-  const callbackThumbUp = React.useCallback(handleThumbDragEnd, []);
+  const callbackThumbMove = React.useCallback(handleThumbMove, [min, max, customSteps, onChange]);
+  const callbackThumbUp = React.useCallback(handleThumbDragEnd, [min, max, customSteps, onChange]);
 
   const handleThumbKeys = (e: React.KeyboardEvent) => {
     const key = e.key;


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5968

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: Try the following code in an example:
```tsx
class DiscreteInput extends React.Component {
  constructor(props) {
    super(props);
    this.state = {
      value: 50,
      max: 100
    };

    this.onChange = (value) => {
      this.setState({
        value: value
      });
    };
  }

  render() {
    return (
      <React.Fragment>
        <TextInput
          onChange={(value) => this.setState({ max: value })}
          value={this.state.max}
        />
        <Text component={TextVariants.small}>
          (min = -25, max = {this.state.max}, step = 10, boundaries shown, ticks
          not shown){" "}
        </Text>
        <Slider
        isInputVisible
          value={this.state.value}
          onChange={this.onChange}
          min={-25}
          max={this.state.max}
          step={1}
        />
      </React.Fragment>
    );
  }
}
```
