### PR TITLE
fix(Select): check the values of the children for possible changes on componentDidUpdate

### DIFF
--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -237,7 +237,12 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
       }
     }
 
-    if (prevProps.children !== this.props.children) {
+    if (
+      prevProps.children.length !== this.props.children.length ||
+      prevProps.children.some(
+        (child: React.ReactElement, index: number) => child.props.value !== this.props.children[index].props.value
+      )
+    ) {
       this.updateTypeAheadFilteredChildren(prevState.typeaheadInputValue || '', null);
     }
 


### PR DESCRIPTION
Select's `children` property is a collection of ReactElements and
therefore a pure JS '===' is not accurate. For this reason let's do a
one by one value comparison for the SelectOption children, to make sure
that actual changes took place. We need this in order to avoid falsely
updating the filtered list, having the assumption that children changed
when they did not.

Note:
Before this commit one could get a JS error:

'Uncaught InternalError: too much recursion
    getNextIndex ...index.js

on the following scenario.

Crash Scenario:

Imagine that children on the consumer side do not need to be a constant.
The SelectOptions list can be prepared on the fly before rendering the Select component.
In this case, when the componentDidUpdate will run,
`prevProps.children !== this.props.children` would be truthy even when
children did not really change. In turn this will let the
`updateTypeAheadFilteredChildren` get called with the new typeahead input value,
which would cause later in the code sequence the crash described above.
