### PR TITLE
docs: Move some repeated demo code to wrapper

### DIFF
--- a/packages/react-core/src/demos/Card/Card.md
+++ b/packages/react-core/src/demos/Card/Card.md
@@ -3,11 +3,8 @@ id: Card view
 section: demos
 ---
 
-import BellIcon from '@patternfly/react-icons/dist/js/icons/bell-icon';
-import CogIcon from '@patternfly/react-icons/dist/js/icons/cog-icon';
 import FilterIcon from '@patternfly/react-icons/dist/js/icons/filter-icon';
 import TrashIcon from '@patternfly/react-icons/dist/js/icons/trash-icon';
-import HelpIcon from '@patternfly/react-icons/dist/js/icons/help-icon';
 import PlusCircleIcon from '@patternfly/react-icons/dist/js/icons/plus-circle-icon';
 import imgBrand from '@patternfly/react-core/src/components/Brand/examples/pfLogo.svg';
 import imgAvatar from '@patternfly/react-core/src/components/Avatar/examples/avatarImg.svg';
@@ -21,9 +18,6 @@ import sparkIcon from './camel-spark_200x150.png';
 import swaggerIcon from './camel-swagger-java_200x150.png';
 import azureIcon from './FuseConnector_Icons_AzureServices.png';
 import restIcon from './FuseConnector_Icons_REST.png';
-import InfoCircleIcon from '@patternfly/react-icons/dist/js/icons/info-circle-icon';
-import ArrowRightIcon from '@patternfly/react-icons/dist/js/icons/arrow-right-icon';
-import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 
 ## Demos
 
@@ -34,11 +28,8 @@ This demonstrates how you can assemble a full page view that contains a grid of 
 ```js isFullscreen
 import React from 'react';
 import {
-  Avatar,
-  Brand,
   Bullseye,
   Button,
-  ButtonVariant,
   Card,
   CardHeader,
   CardActions,
@@ -46,55 +37,38 @@ import {
   CardBody,
   Checkbox,
   Dropdown,
-  DropdownGroup,
   DropdownToggle,
   DropdownItem,
   DropdownSeparator,
   DropdownPosition,
-  DropdownDirection,
   DropdownToggleCheckbox,
   EmptyState,
   EmptyStateIcon,
   EmptyStateVariant,
   EmptyStateSecondaryActions,
   Gallery,
-  GalleryItem,
   KebabToggle,
-  Nav,
-  NavItem,
-  NavList,
   OverflowMenu,
   OverflowMenuControl,
   OverflowMenuDropdownItem,
   OverflowMenuItem,
-  Page,
-  PageHeader,
-  PageHeaderTools,
-  PageHeaderToolsGroup,
-  PageHeaderToolsItem,
   PageSection,
   PageSectionVariants,
-  PageSidebar,
   Pagination,
   Select,
   SelectOption,
   SelectVariant,
-  SkipToContent,
   TextContent,
   Text,
   Title,
   Toolbar,
-  ToolbarGroup,
   ToolbarItem,
   ToolbarFilter,
   ToolbarContent,
-  ToolbarToggleGroup
+  DashboardWrapper
 } from '@patternfly/react-core';
-import BellIcon from '@patternfly/react-icons/dist/js/icons/bell-icon';
-import CogIcon from '@patternfly/react-icons/dist/js/icons/cog-icon';
 import FilterIcon from '@patternfly/react-icons/dist/js/icons/filter-icon';
 import TrashIcon from '@patternfly/react-icons/dist/js/icons/trash-icon';
-import HelpIcon from '@patternfly/react-icons/dist/js/icons/help-icon';
 import PlusCircleIcon from '@patternfly/react-icons/dist/js/icons/plus-circle-icon';
 import imgBrand from '@patternfly/react-core/src/components/Brand/examples/pfLogo.svg';
 import imgAvatar from '@patternfly/react-core/src/components/Avatar/examples/avatarImg.svg';
@@ -120,9 +94,9 @@ class CardViewBasic extends React.Component {
         products: []
       },
       res: [],
+      isChecked: false,
       selectedItems: [],
       areAllSelected: false,
-      itemsCheckedByDefault: false,
       isUpperToolbarDropdownOpen: false,
       isUpperToolbarKebabDropdownOpen: false,
       isLowerToolbarDropdownOpen: false,
@@ -135,40 +109,10 @@ class CardViewBasic extends React.Component {
       totalItemCount: 10
     };
 
-    this.onPageDropdownToggle = isUpperToolbarDropdownOpen => {
-      this.setState({
-        isUpperToolbarDropdownOpen
-      });
-    };
-
-    this.onPageDropdownSelect = event => {
-      this.setState({
-        isUpperToolbarDropdownOpen: !this.state.isUpperToolbarDropdownOpen
-      });
-    };
-
-    this.onPageToolbarDropdownToggle = isPageToolbarDropdownOpen => {
-      this.setState({
-        isPageToolbarDropdownOpen
-      });
-    };
-
-    this.onPageToolbarKebabDropdownToggle = isUpperToolbarKebabDropdownOpen => {
-      this.setState({
-        isUpperToolbarKebabDropdownOpen
-      });
-    };
-
     this.onToolbarDropdownToggle = isLowerToolbarDropdownOpen => {
       this.setState(prevState => ({
         isLowerToolbarDropdownOpen
       }));
-    };
-
-    this.onToolbarDropdownSelect = event => {
-      this.setState({
-        isLowerToolbarDropdownOpen: !this.state.isLowerToolbarDropdownOpen
-      });
     };
 
     this.onToolbarKebabDropdownToggle = isLowerToolbarKebabDropdownOpen => {
@@ -192,12 +136,6 @@ class CardViewBasic extends React.Component {
     this.onCardKebabDropdownSelect = (key, event) => {
       this.setState({
         [key]: !this.state[key]
-      });
-    };
-
-    this.onNavSelect = result => {
-      this.setState({
-        activeItem: result.itemId
       });
     };
 
@@ -526,7 +464,6 @@ class CardViewBasic extends React.Component {
       res,
       checked,
       selectedItems,
-      itemsCheckedByDefault,
       areAllSelected,
       isChecked,
       page,
@@ -554,9 +491,7 @@ class CardViewBasic extends React.Component {
     const toolbarItems = (
       <React.Fragment>
         <ToolbarItem variant="bulk-select">{this.buildSelectDropdown()}</ToolbarItem>
-        <ToolbarItem toggleIcon={<FilterIcon />} breakpoint="xl">
-          {this.buildFilterDropdown()}
-        </ToolbarItem>
+        <ToolbarItem breakpoint="xl">{this.buildFilterDropdown()}</ToolbarItem>
         <ToolbarItem variant="overflow-menu">
           <OverflowMenu breakpoint="md">
             <OverflowMenuItem>
@@ -578,103 +513,6 @@ class CardViewBasic extends React.Component {
         </ToolbarItem>
       </React.Fragment>
     );
-
-    const PageNav = (
-      <Nav onSelect={this.onNavSelect} aria-label="Nav">
-        <NavList>
-          <NavItem itemId={0} isActive={activeItem === 0}>
-            System Panel
-          </NavItem>
-          <NavItem itemId={1} isActive={activeItem === 1}>
-            Policy
-          </NavItem>
-          <NavItem itemId={2} isActive={activeItem === 2}>
-            Authentication
-          </NavItem>
-          <NavItem itemId={3} isActive={activeItem === 3}>
-            Network Services
-          </NavItem>
-          <NavItem itemId={4} isActive={activeItem === 4}>
-            Server
-          </NavItem>
-        </NavList>
-      </Nav>
-    );
-
-    const kebabDropdownItems = [
-      <DropdownItem key="kebab-settings">
-        <CogIcon /> Settings
-      </DropdownItem>,
-      <DropdownItem key="kebab-help">
-        <HelpIcon /> Help
-      </DropdownItem>
-    ];
-    const userDropdownItems = [
-      <DropdownGroup key="group 2">
-        <DropdownItem key="group 2 profile">My profile</DropdownItem>
-        <DropdownItem key="group 2 user" component="button">
-          User management
-        </DropdownItem>
-        <DropdownItem key="group 2 logout">Logout</DropdownItem>
-      </DropdownGroup>
-    ];
-    const headerTools = (
-      <PageHeaderTools>
-        <PageHeaderToolsGroup
-          visibility={{
-            default: 'hidden',
-            lg: 'visible'
-          }} /** the settings and help icon buttons are only visible on desktop sizes and replaced by a kebab dropdown for other sizes */
-        >
-          <PageHeaderToolsItem>
-            <Button aria-label="Settings actions" variant={ButtonVariant.plain}>
-              <CogIcon />
-            </Button>
-          </PageHeaderToolsItem>
-          <PageHeaderToolsItem>
-            <Button aria-label="Help actions" variant={ButtonVariant.plain}>
-              <HelpIcon />
-            </Button>
-          </PageHeaderToolsItem>
-        </PageHeaderToolsGroup>
-        <PageHeaderToolsGroup>
-          <PageHeaderToolsItem
-            visibility={{
-              lg: 'hidden'
-            }} /** this kebab dropdown replaces the icon buttons and is hidden for desktop sizes */
-          >
-            <Dropdown
-              isPlain
-              position="right"
-              onSelect={this.onKebabDropdownSelect}
-              toggle={<KebabToggle onToggle={this.onPageToolbarKebabDropdownToggle} />}
-              isOpen={isUpperToolbarKebabDropdownOpen}
-              dropdownItems={kebabDropdownItems}
-            />
-          </PageHeaderToolsItem>
-          <PageHeaderToolsItem
-            visibility={{ default: 'hidden', md: 'visible' }} /** this user dropdown is hidden on mobile sizes */
-          >
-            <Dropdown
-              isPlain
-              position="right"
-              onSelect={this.onPageDropdownSelect}
-              isOpen={isUpperToolbarDropdownOpen}
-              toggle={<DropdownToggle onToggle={this.onPageDropdownToggle}>John Smith</DropdownToggle>}
-              dropdownItems={userDropdownItems}
-            />
-          </PageHeaderToolsItem>
-        </PageHeaderToolsGroup>
-        <Avatar src={imgAvatar} alt="Avatar image" />
-      </PageHeaderTools>
-    );
-
-    const Header = (
-      <PageHeader logo={<Brand src={imgBrand} alt="Patternfly Logo" />} headerTools={headerTools} showNavToggle />
-    );
-    const Sidebar = <PageSidebar nav={PageNav} />;
-    const pageId = 'main-content-card-view-default-nav';
-    const PageSkipToContent = <SkipToContent href={`#${pageId}`}>Skip to Content</SkipToContent>;
 
     const filtered =
       filters.products.length > 0
@@ -698,12 +536,11 @@ class CardViewBasic extends React.Component {
 
     return (
       <React.Fragment>
-        <Page
-          header={Header}
-          sidebar={Sidebar}
-          isManagedSidebar
-          skipToContent={PageSkipToContent}
-          mainContainerId={pageId}
+        <DashboardWrapper
+          mainContainerId="main-content-card-view-default-nav"
+          breadcrumb={null}
+          imgBrand={imgBrand}
+          imgAvatar={imgAvatar}
         >
           <PageSection variant={PageSectionVariants.light}>
             <TextContent>
@@ -758,7 +595,6 @@ class CardViewBasic extends React.Component {
                         value={product.id}
                         onChange={this.handleCheckboxClick}
                         isChecked={selectedItems.includes(product.id)}
-                        defaultChecked={this.state.itemsCheckedByDefault}
                         aria-label="card checkbox example"
                         id={`check-${product.id}`}
                       />
@@ -781,7 +617,7 @@ class CardViewBasic extends React.Component {
               variant="bottom"
             />
           </PageSection>
-        </Page>
+        </DashboardWrapper>
       </React.Fragment>
     );
   }

--- a/packages/react-core/src/demos/PrimaryDetail.md
+++ b/packages/react-core/src/demos/PrimaryDetail.md
@@ -3,10 +3,8 @@ id: Primary-detail
 section: demos
 ---
 
-import BellIcon from '@patternfly/react-icons/dist/js/icons/bell-icon';
 import CodeBranchIcon from '@patternfly/react-icons/dist/js/icons/code-branch-icon';
 import CodeIcon from '@patternfly/react-icons/dist/js/icons/code-icon';
-import CogIcon from '@patternfly/react-icons/dist/js/icons/cog-icon';
 import CubeIcon from '@patternfly/react-icons/dist/js/icons/cube-icon';
 import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
@@ -30,18 +28,12 @@ import restIcon from './Card/FuseConnector_Icons_REST.png';
 ## Demos
 
 ### Primary-detail full page
+
 ```js isFullscreen
 import React from 'react';
 import {
-  Avatar,
-  Brand,
-  Breadcrumb,
-  BreadcrumbItem,
   Button,
   ButtonVariant,
-  Dropdown,
-  Card,
-  CardBody,
   DataList,
   DataListAction,
   DataListCell,
@@ -62,40 +54,25 @@ import {
   DrawerHead,
   DrawerPanelBody,
   DrawerPanelContent,
-  DropdownToggle,
-  DropdownItem,
-  DropdownSeparator,
   Flex,
   FlexItem,
-  Gallery,
-  GalleryItem,
   InputGroup,
-  KebabToggle,
-  Nav,
-  NavItem,
-  NavList,
-  Page,
-  PageHeader,
   PageSection,
   PageSectionVariants,
-  PageSidebar,
   Progress,
   Select,
   SelectOption,
   SelectVariant,
-  SkipToContent,
   Stack,
   StackItem,
   Text,
   TextContent,
   TextInput,
-  Title
+  Title,
+  DashboardWrapper
 } from '@patternfly/react-core';
-
-import BellIcon from '@patternfly/react-icons/dist/js/icons/bell-icon';
 import CodeBranchIcon from '@patternfly/react-icons/dist/js/icons/code-branch-icon';
 import CodeIcon from '@patternfly/react-icons/dist/js/icons/code-icon';
-import CogIcon from '@patternfly/react-icons/dist/js/icons/cog-icon';
 import CubeIcon from '@patternfly/react-icons/dist/js/icons/cube-icon';
 import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
@@ -120,36 +97,6 @@ class PrimaryDetailFullPage extends React.Component {
       riskIsExpanded: false,
       riskSelected: null,
       selectedDataListItemId: ''
-    };
-
-    this.onDropdownToggle = isDropdownOpen => {
-      this.setState({
-        isDropdownOpen
-      });
-    };
-
-    this.onDropdownSelect = event => {
-      this.setState({
-        isDropdownOpen: !this.state.isDropdownOpen
-      });
-    };
-
-    this.onKebabDropdownToggle = isKebabDropdownOpen => {
-      this.setState({
-        isKebabDropdownOpen
-      });
-    };
-
-    this.onKebabDropdownSelect = event => {
-      this.setState({
-        isKebabDropdownOpen: !this.state.isKebabDropdownOpen
-      });
-    };
-
-    this.onNavSelect = result => {
-      this.setState({
-        activeItem: result.itemId
-      });
     };
 
     this.statusOptions = [
@@ -243,71 +190,6 @@ class PrimaryDetailFullPage extends React.Component {
       riskSelected,
       selectedDataListItemId
     } = this.state;
-
-    const PageNav = (
-      <Nav onSelect={this.onNavSelect} aria-label="Nav">
-        <NavList>
-          <NavItem itemId={0} isActive={activeItem === 0}>
-            System Panel
-          </NavItem>
-          <NavItem itemId={1} isActive={activeItem === 1}>
-            Policy
-          </NavItem>
-          <NavItem itemId={2} isActive={activeItem === 2}>
-            Authentication
-          </NavItem>
-          <NavItem itemId={3} isActive={activeItem === 3}>
-            Network Services
-          </NavItem>
-          <NavItem itemId={4} isActive={activeItem === 4}>
-            Server
-          </NavItem>
-        </NavList>
-      </Nav>
-    );
-    const kebabDropdownItems = [
-      <DropdownItem>
-        <BellIcon /> Notifications
-      </DropdownItem>,
-      <DropdownItem>
-        <CogIcon /> Settings
-      </DropdownItem>
-    ];
-    const userDropdownItems = [
-      <DropdownItem>Link</DropdownItem>,
-      <DropdownItem component="button">Action</DropdownItem>,
-      <DropdownItem isDisabled>Disabled link</DropdownItem>,
-      <DropdownItem isDisabled component="button">
-        Disabled action
-      </DropdownItem>,
-      <DropdownSeparator />,
-      <DropdownItem>Separated link</DropdownItem>,
-      <DropdownItem component="button">Separated action</DropdownItem>
-    ];
-    const PageToolbar = <div>need to implement new toolbar</div>;
-
-    const Header = (
-      <PageHeader
-        logo={<Brand src={imgBrand} alt="Patternfly Logo" />}
-        toolbar={PageToolbar}
-        avatar={<Avatar src={imgAvatar} alt="Avatar image" />}
-        showNavToggle
-      />
-    );
-    const Sidebar = <PageSidebar nav={PageNav} />;
-    const pageId = 'main-content-page-layout-default-nav';
-    const PageSkipToContent = <SkipToContent href={`#${pageId}`}>Skip to content</SkipToContent>;
-
-    const PageBreadcrumb = (
-      <Breadcrumb>
-        <BreadcrumbItem>Section home</BreadcrumbItem>
-        <BreadcrumbItem to="#">Section title</BreadcrumbItem>
-        <BreadcrumbItem to="#">Section title</BreadcrumbItem>
-        <BreadcrumbItem to="#" isActive>
-          Section landing
-        </BreadcrumbItem>
-      </Breadcrumb>
-    );
 
     const toggleGroupItems = (
       <React.Fragment>
@@ -583,52 +465,41 @@ class PrimaryDetailFullPage extends React.Component {
     );
 
     return (
-      <React.Fragment>
-        <Page
-          header={Header}
-          sidebar={Sidebar}
-          isManagedSidebar
-          skipToContent={PageSkipToContent}
-          breadcrumb={PageBreadcrumb}
-          mainContainerId={pageId}
-        >
-          <PageSection variant={PageSectionVariants.light}>
-            <TextContent>
-              <Text component="h1">Main title</Text>
-              <Text component="p">
-                Body text should be Overpass Regular at 16px. It should have leading of 24px because <br />
-                of it’s relative line height of 1.5.
-              </Text>
-            </TextContent>
-          </PageSection>
-          <Divider component="div" />
-          <PageSection variant={PageSectionVariants.light} padding={{ default: 'noPadding' }}>
-            <Drawer isExpanded={isDrawerExpanded}>
-              <DrawerContent panelContent={panelContent}>
-                <DrawerContentBody>{drawerContent}</DrawerContentBody>
-              </DrawerContent>
-            </Drawer>
-          </PageSection>
-        </Page>
-      </React.Fragment>
+      <DashboardWrapper
+        mainContainerId="main-content-page-layout-default-nav"
+        imgBrand={imgBrand}
+        imgAvatar={imgAvatar}
+      >
+        <PageSection variant={PageSectionVariants.light}>
+          <TextContent>
+            <Text component="h1">Main title</Text>
+            <Text component="p">
+              Body text should be Overpass Regular at 16px. It should have leading of 24px because <br />
+              of it’s relative line height of 1.5.
+            </Text>
+          </TextContent>
+        </PageSection>
+        <Divider component="div" />
+        <PageSection variant={PageSectionVariants.light} padding={{ default: 'noPadding' }}>
+          <Drawer isExpanded={isDrawerExpanded}>
+            <DrawerContent panelContent={panelContent}>
+              <DrawerContentBody>{drawerContent}</DrawerContentBody>
+            </DrawerContent>
+          </Drawer>
+        </PageSection>
+      </DashboardWrapper>
     );
   }
 }
 ```
 
 ### Primary-detail content padding
+
 ```js isFullscreen
 import React from 'react';
 import {
-  Avatar,
-  Brand,
-  Breadcrumb,
-  BreadcrumbItem,
   Button,
   ButtonVariant,
-  Dropdown,
-  Card,
-  CardBody,
   DataList,
   DataListAction,
   DataListCell,
@@ -649,40 +520,25 @@ import {
   DrawerHead,
   DrawerPanelBody,
   DrawerPanelContent,
-  DropdownToggle,
-  DropdownItem,
-  DropdownSeparator,
   Flex,
   FlexItem,
-  Gallery,
-  GalleryItem,
   InputGroup,
-  KebabToggle,
-  Nav,
-  NavItem,
-  NavList,
-  Page,
-  PageHeader,
   PageSection,
   PageSectionVariants,
-  PageSidebar,
   Progress,
   Select,
   SelectOption,
   SelectVariant,
-  SkipToContent,
   Stack,
   StackItem,
   Text,
   TextContent,
   TextInput,
-  Title
+  Title,
+  DashboardWrapper
 } from '@patternfly/react-core';
-
-import BellIcon from '@patternfly/react-icons/dist/js/icons/bell-icon';
 import CodeBranchIcon from '@patternfly/react-icons/dist/js/icons/code-branch-icon';
 import CodeIcon from '@patternfly/react-icons/dist/js/icons/code-icon';
-import CogIcon from '@patternfly/react-icons/dist/js/icons/cog-icon';
 import CubeIcon from '@patternfly/react-icons/dist/js/icons/cube-icon';
 import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
@@ -707,36 +563,6 @@ class PrimaryDetailContentPadding extends React.Component {
       riskIsExpanded: false,
       riskSelected: null,
       selectedDataListItemId: ''
-    };
-
-    this.onDropdownToggle = isDropdownOpen => {
-      this.setState({
-        isDropdownOpen
-      });
-    };
-
-    this.onDropdownSelect = event => {
-      this.setState({
-        isDropdownOpen: !this.state.isDropdownOpen
-      });
-    };
-
-    this.onKebabDropdownToggle = isKebabDropdownOpen => {
-      this.setState({
-        isKebabDropdownOpen
-      });
-    };
-
-    this.onKebabDropdownSelect = event => {
-      this.setState({
-        isKebabDropdownOpen: !this.state.isKebabDropdownOpen
-      });
-    };
-
-    this.onNavSelect = result => {
-      this.setState({
-        activeItem: result.itemId
-      });
     };
 
     this.statusOptions = [
@@ -830,71 +656,6 @@ class PrimaryDetailContentPadding extends React.Component {
       riskSelected,
       selectedDataListItemId
     } = this.state;
-
-    const PageNav = (
-      <Nav onSelect={this.onNavSelect} aria-label="Nav">
-        <NavList>
-          <NavItem itemId={0} isActive={activeItem === 0}>
-            System Panel
-          </NavItem>
-          <NavItem itemId={1} isActive={activeItem === 1}>
-            Policy
-          </NavItem>
-          <NavItem itemId={2} isActive={activeItem === 2}>
-            Authentication
-          </NavItem>
-          <NavItem itemId={3} isActive={activeItem === 3}>
-            Network Services
-          </NavItem>
-          <NavItem itemId={4} isActive={activeItem === 4}>
-            Server
-          </NavItem>
-        </NavList>
-      </Nav>
-    );
-    const kebabDropdownItems = [
-      <DropdownItem>
-        <BellIcon /> Notifications
-      </DropdownItem>,
-      <DropdownItem>
-        <CogIcon /> Settings
-      </DropdownItem>
-    ];
-    const userDropdownItems = [
-      <DropdownItem>Link</DropdownItem>,
-      <DropdownItem component="button">Action</DropdownItem>,
-      <DropdownItem isDisabled>Disabled link</DropdownItem>,
-      <DropdownItem isDisabled component="button">
-        Disabled action
-      </DropdownItem>,
-      <DropdownSeparator />,
-      <DropdownItem>Separated link</DropdownItem>,
-      <DropdownItem component="button">Separated action</DropdownItem>
-    ];
-    const PageToolbar = <div>need to implement new toolbar</div>;
-
-    const Header = (
-      <PageHeader
-        logo={<Brand src={imgBrand} alt="Patternfly Logo" />}
-        toolbar={PageToolbar}
-        avatar={<Avatar src={imgAvatar} alt="Avatar image" />}
-        showNavToggle
-      />
-    );
-    const Sidebar = <PageSidebar nav={PageNav} />;
-    const pageId = 'main-content-page-layout-default-nav';
-    const PageSkipToContent = <SkipToContent href={`#${pageId}`}>Skip to content</SkipToContent>;
-
-    const PageBreadcrumb = (
-      <Breadcrumb>
-        <BreadcrumbItem>Section home</BreadcrumbItem>
-        <BreadcrumbItem to="#">Section title</BreadcrumbItem>
-        <BreadcrumbItem to="#">Section title</BreadcrumbItem>
-        <BreadcrumbItem to="#" isActive>
-          Section landing
-        </BreadcrumbItem>
-      </Breadcrumb>
-    );
 
     const toggleGroupItems = (
       <React.Fragment>
@@ -1171,61 +932,44 @@ class PrimaryDetailContentPadding extends React.Component {
     );
 
     return (
-      <React.Fragment>
-        <Page
-          header={Header}
-          sidebar={Sidebar}
-          isManagedSidebar
-          skipToContent={PageSkipToContent}
-          breadcrumb={PageBreadcrumb}
-          mainContainerId={pageId}
-        >
-          <PageSection variant={PageSectionVariants.light}>
-            <TextContent>
-              <Text component="h1">Main title</Text>
-              <Text component="p">
-                Body text should be Overpass Regular at 16px. It should have leading of 24px because <br />
-                of it’s relative line height of 1.5.
-              </Text>
-            </TextContent>
-          </PageSection>
-          <Divider component="div" />
-          <PageSection padding={{ default: 'noPadding' }}>
-            <Drawer isExpanded={isDrawerExpanded}>
-              <DrawerContent panelContent={panelContent} className={'pf-m-no-background'}>
-                <DrawerContentBody hasPadding>{drawerContent}</DrawerContentBody>
-              </DrawerContent>
-            </Drawer>
-          </PageSection>
-        </Page>
-      </React.Fragment>
+      <DashboardWrapper imgBrand={imgBrand} imgAvatar={imgAvatar}>
+        <PageSection variant={PageSectionVariants.light}>
+          <TextContent>
+            <Text component="h1">Main title</Text>
+            <Text component="p">
+              Body text should be Overpass Regular at 16px. It should have leading of 24px because <br />
+              of it’s relative line height of 1.5.
+            </Text>
+          </TextContent>
+        </PageSection>
+        <Divider component="div" />
+        <PageSection padding={{ default: 'noPadding' }}>
+          <Drawer isExpanded={isDrawerExpanded}>
+            <DrawerContent panelContent={panelContent} className={'pf-m-no-background'}>
+              <DrawerContentBody hasPadding>{drawerContent}</DrawerContentBody>
+            </DrawerContent>
+          </Drawer>
+        </PageSection>
+      </DashboardWrapper>
     );
   }
 }
 ```
 
 ### Primary-detail card view
+
 ```js isFullscreen
 import React from 'react';
 import {
-  Avatar,
-  Brand,
   Button,
-  ButtonVariant,
   Card,
-  CardActions,
   CardHeader,
   CardBody,
   CardTitle,
-  Checkbox,
   Divider,
   Dropdown,
-  DropdownToggle,
   DropdownItem,
   DropdownSeparator,
-  DropdownPosition,
-  DropdownDirection,
-  DropdownToggleCheckbox,
   Drawer,
   DrawerActions,
   DrawerPanelBody,
@@ -1238,27 +982,17 @@ import {
   Flex,
   FlexItem,
   Gallery,
-  GalleryItem,
   KebabToggle,
-  Nav,
-  NavItem,
-  NavList,
-  NavVariants,
   OverflowMenu,
   OverflowMenuControl,
-  OverflowMenuGroup,
   OverflowMenuItem,
-  Page,
-  PageHeader,
   PageSection,
   PageSectionVariants,
-  PageSidebar,
   Pagination,
   Progress,
   Select,
   SelectOption,
   SelectVariant,
-  SkipToContent,
   TextContent,
   Text,
   Title,
@@ -1266,13 +1000,9 @@ import {
   ToolbarItem,
   ToolbarContent,
   ToolbarFilter,
-  ToolbarToggleGroup
+  ToolbarToggleGroup,
+  DashboardWrapper
 } from '@patternfly/react-core';
-
-import BellIcon from '@patternfly/react-icons/dist/js/icons/bell-icon';
-import CogIcon from '@patternfly/react-icons/dist/js/icons/cog-icon';
-import FilterIcon from '@patternfly/react-icons/dist/js/icons/filter-icon';
-import TrashIcon from '@patternfly/react-icons/dist/js/icons/trash-icon';
 import imgBrand from '@patternfly/react-core/src/components/Brand/examples/pfLogo.svg';
 import imgAvatar from '@patternfly/react-core/src/components/Avatar/examples/avatarImg.svg';
 import pfIcon from './pf-logo-small.svg';
@@ -1307,30 +1037,6 @@ class PrimaryDetailCardView extends React.Component {
       activeItem: 0
     };
 
-    this.onPageDropdownToggle = isUpperToolbarDropdownOpen => {
-      this.setState({
-        isUpperToolbarDropdownOpen
-      });
-    };
-
-    this.onPageDropdownSelect = event => {
-      this.setState({
-        isUpperToolbarDropdownOpen: !this.state.isUpperToolbarDropdownOpen
-      });
-    };
-
-    this.onPageToolbarDropdownToggle = isPageToolbarDropdownOpen => {
-      this.setState({
-        isPageToolbarDropdownOpen
-      });
-    };
-
-    this.onPageToolbarKebabDropdownToggle = isUpperToolbarKebabDropdownOpen => {
-      this.setState({
-        isUpperToolbarKebabDropdownOpen
-      });
-    };
-
     this.onToolbarDropdownToggle = isLowerToolbarDropdownOpen => {
       this.setState(prevState => ({
         isLowerToolbarDropdownOpen
@@ -1352,12 +1058,6 @@ class PrimaryDetailCardView extends React.Component {
     this.onToolbarKebabDropdownSelect = event => {
       this.setState({
         isLowerToolbarKebabDropdownOpen: !this.state.isLowerToolbarKebabDropdownOpen
-      });
-    };
-
-    this.onNavSelect = result => {
-      this.setState({
-        activeItem: result.itemId
       });
     };
 
@@ -1433,12 +1133,12 @@ class PrimaryDetailCardView extends React.Component {
     };
 
     this.onPerPageSelect = (_evt, perPage) => {
-      this.setState({ page: 1, perPage })
-    }
+      this.setState({ page: 1, perPage });
+    };
 
     this.onSetPage = (_evt, page) => {
-      this.setState({ page })
-    }
+      this.setState({ page });
+    };
   }
 
   getAllItems() {
@@ -1539,7 +1239,9 @@ class PrimaryDetailCardView extends React.Component {
             <OverflowMenuControl hasAdditionalOptions>
               <Dropdown
                 onSelect={this.onToolbarKebabDropdownSelect}
-                toggle={<KebabToggle onToggle={this.onToolbarKebabDropdownToggle} id="card-view-data-toolbar-dropdown" />}
+                toggle={
+                  <KebabToggle onToggle={this.onToolbarKebabDropdownToggle} id="card-view-data-toolbar-dropdown" />
+                }
                 isOpen={isLowerToolbarKebabDropdownOpen}
                 isPlain
                 dropdownItems={toolbarKebabDropdownItems}
@@ -1549,54 +1251,6 @@ class PrimaryDetailCardView extends React.Component {
         </ToolbarItem>
       </React.Fragment>
     );
-
-    const PageNav = (
-      <Nav onSelect={this.onNavSelect} aria-label="Nav">
-        <NavList>
-          <NavItem itemId={0} isActive={activeItem === 0}>
-            System Panel
-          </NavItem>
-          <NavItem itemId={1} isActive={activeItem === 1}>
-            Policy
-          </NavItem>
-          <NavItem itemId={2} isActive={activeItem === 2}>
-            Authentication
-          </NavItem>
-          <NavItem itemId={3} isActive={activeItem === 3}>
-            Network Services
-          </NavItem>
-          <NavItem itemId={4} isActive={activeItem === 4}>
-            Server
-          </NavItem>
-        </NavList>
-      </Nav>
-    );
-
-    const userDropdownItems = [
-      <DropdownItem>Link</DropdownItem>,
-      <DropdownItem component="button">Action</DropdownItem>,
-      <DropdownItem isDisabled>Disabled Link</DropdownItem>,
-      <DropdownItem isDisabled component="button">
-        Disabled Action
-      </DropdownItem>,
-      <DropdownSeparator />,
-      <DropdownItem>Separated Link</DropdownItem>,
-      <DropdownItem component="button">Separated Action</DropdownItem>
-    ];
-
-    const PageToolbar = <div>need to implement new toolbar</div>;
-
-    const Header = (
-      <PageHeader
-        logo={<Brand src={imgBrand} alt="Patternfly Logo" />}
-        toolbar={PageToolbar}
-        avatar={<Avatar src={imgAvatar} alt="Avatar image" />}
-        showNavToggle
-      />
-    );
-    const Sidebar = <PageSidebar nav={PageNav} />;
-    const pageId = 'main-content-card-view-default-nav';
-    const PageSkipToContent = <SkipToContent href={`#${pageId}`}>Skip to Content</SkipToContent>;
 
     const filtered =
       filters.products.length > 0
@@ -1673,68 +1327,54 @@ class PrimaryDetailCardView extends React.Component {
     );
 
     return (
-      <React.Fragment>
-        <Page
-          header={Header}
-          sidebar={Sidebar}
-          isManagedSidebar
-          skipToContent={PageSkipToContent}
-          mainContainerId={pageId}
-        >
-          <PageSection variant={PageSectionVariants.light}>
-            <TextContent>
-              <Text component="h1">Projects</Text>
-              <Text component="p">This is a demo that showcases Patternfly Cards.</Text>
-            </TextContent>
-          </PageSection>
-          <PageSection isFilled padding={{default: "noPadding"}}>
-            <Drawer isExpanded={isDrawerExpanded} className={'pf-m-inline-on-2xl'}>
-              <DrawerSection>
-                <Toolbar id="card-view-data-toolbar-group-types" usePageInsets clearAllFilters={this.onDelete}>
-                  <ToolbarContent>{toolbarItems}</ToolbarContent>
-                </Toolbar>
-                <Divider component="div" />
-              </DrawerSection>
-              <DrawerContent panelContent={panelContent} className={'pf-m-no-background'}>
-                <DrawerContentBody hasPadding>{drawerContent}</DrawerContentBody>
-              </DrawerContent>
-            </Drawer>
-          </PageSection>
-          <PageSection isFilled={false} sticky="bottom" padding={{default: "noPadding"}} variant="light">
-            <Pagination
-              itemCount={filtered.length}
-              page={this.state.page}
-              perPage={this.state.perPage}
-              onPerPageSelect={this.onPerPageSelect}
-              onSetPage={this.onSetPage}
-              variant="bottom"
-            />
-          </PageSection>
-        </Page>
-      </React.Fragment>
+      <DashboardWrapper
+        mainContainerId="main-content-card-view-default-nav"
+        breadcrumb={null}
+        imgBrand={imgBrand}
+        imgAvatar={imgAvatar}
+      >
+        <PageSection variant={PageSectionVariants.light}>
+          <TextContent>
+            <Text component="h1">Projects</Text>
+            <Text component="p">This is a demo that showcases Patternfly Cards.</Text>
+          </TextContent>
+        </PageSection>
+        <PageSection isFilled padding={{ default: 'noPadding' }}>
+          <Drawer isExpanded={isDrawerExpanded} className={'pf-m-inline-on-2xl'}>
+            <DrawerSection>
+              <Toolbar id="card-view-data-toolbar-group-types" usePageInsets clearAllFilters={this.onDelete}>
+                <ToolbarContent>{toolbarItems}</ToolbarContent>
+              </Toolbar>
+              <Divider component="div" />
+            </DrawerSection>
+            <DrawerContent panelContent={panelContent} className={'pf-m-no-background'}>
+              <DrawerContentBody hasPadding>{drawerContent}</DrawerContentBody>
+            </DrawerContent>
+          </Drawer>
+        </PageSection>
+        <PageSection isFilled={false} sticky="bottom" padding={{ default: 'noPadding' }} variant="light">
+          <Pagination
+            itemCount={filtered.length}
+            page={this.state.page}
+            perPage={this.state.perPage}
+            onPerPageSelect={this.onPerPageSelect}
+            onSetPage={this.onSetPage}
+            variant="bottom"
+          />
+        </PageSection>
+      </DashboardWrapper>
     );
   }
 }
 ```
 
 ### Primary-detail simple list in card
+
 ```js isFullscreen
 import React from 'react';
 import {
-  Avatar,
-  Brand,
-  Breadcrumb,
-  BreadcrumbItem,
-  Button,
-  ButtonVariant,
-  Dropdown,
   Card,
   CardBody,
-  DataList,
-  DataListAction,
-  DataListItem,
-  DataListItemCells,
-  DataListItemRow,
   Divider,
   Drawer,
   DrawerActions,
@@ -1744,38 +1384,20 @@ import {
   DrawerHead,
   DrawerPanelBody,
   DrawerPanelContent,
-  DropdownToggle,
   Flex,
   FlexItem,
-  KebabToggle,
-  Nav,
-  NavItem,
-  NavList,
-  Page,
-  PageHeader,
   PageSection,
   PageSectionVariants,
-  PageSidebar,
   Progress,
-  Select,
-  SelectOption,
   SimpleList,
   SimpleListGroup,
   SimpleListItem,
-  SkipToContent,
   Text,
   TextContent,
   TextInput,
   Title,
-  Toolbar,
-  ToolbarGroup,
-  ToolbarItem
+  DashboardWrapper
 } from '@patternfly/react-core';
-
-import BellIcon from '@patternfly/react-icons/dist/js/icons/bell-icon';
-import CogIcon from '@patternfly/react-icons/dist/js/icons/cog-icon';
-import FilterIcon from '@patternfly/react-icons/dist/js/icons/filter-icon';
-import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon';
 import imgBrand from '@patternfly/react-core/src/components/Brand/examples/pfLogo.svg';
 import imgAvatar from '@patternfly/react-core/src/components/Avatar/examples/avatarImg.svg';
 
@@ -1801,59 +1423,12 @@ class PrimaryDetailSimpleListInCard extends React.Component {
     this.onClose = () => {
       this.setState({
         isExpanded: false
-      })
-    }
+      });
+    };
   }
 
   render() {
     const { drawerPanelBodyContent, selectedListItemId, activeItem, isExpanded } = this.state;
-
-    const PageNav = (
-      <Nav onSelect={this.onNavSelect} aria-label="Nav">
-        <NavList>
-          <NavItem itemId={0} isActive={activeItem === 0}>
-            System Panel
-          </NavItem>
-          <NavItem itemId={1} isActive={activeItem === 1}>
-            Policy
-          </NavItem>
-          <NavItem itemId={2} isActive={activeItem === 2}>
-            Authentication
-          </NavItem>
-          <NavItem itemId={3} isActive={activeItem === 3}>
-            Network Services
-          </NavItem>
-          <NavItem itemId={4} isActive={activeItem === 4}>
-            Server
-          </NavItem>
-        </NavList>
-      </Nav>
-    );
-
-    const PageToolbar = <div>need to implement new toolbar</div>;
-
-    const Header = (
-      <PageHeader
-        logo={<Brand src={imgBrand} alt="Patternfly Logo" />}
-        toolbar={PageToolbar}
-        avatar={<Avatar src={imgAvatar} alt="Avatar image" />}
-        showNavToggle
-      />
-    );
-    const Sidebar = <PageSidebar nav={PageNav} />;
-    const pageId = 'main-content-page-layout-default-nav';
-    const PageSkipToContent = <SkipToContent href={`#${pageId}`}>Skip to content</SkipToContent>;
-
-    const PageBreadcrumb = (
-      <Breadcrumb>
-        <BreadcrumbItem>Section home</BreadcrumbItem>
-        <BreadcrumbItem to="#">Section title</BreadcrumbItem>
-        <BreadcrumbItem to="#">Section title</BreadcrumbItem>
-        <BreadcrumbItem to="#" isActive>
-          Section landing
-        </BreadcrumbItem>
-      </Breadcrumb>
-    );
 
     const panelContent = (
       <DrawerPanelContent widthOnXl={75}>
@@ -1924,55 +1499,39 @@ class PrimaryDetailSimpleListInCard extends React.Component {
     );
 
     return (
-      <React.Fragment>
-        <Page
-          header={Header}
-          sidebar={Sidebar}
-          isManagedSidebar
-          skipToContent={PageSkipToContent}
-          breadcrumb={PageBreadcrumb}
-          mainContainerId={pageId}
-        >
-          <PageSection variant={PageSectionVariants.light}>
-            <TextContent>
-              <Text component="h1">Main title</Text>
-              <Text component="p">
-                Body text should be Overpass Regular at 16px. It should have leading of 24px because <br />
-                of it’s relative line height of 1.5.
-              </Text>
-            </TextContent>
-          </PageSection>
-          <Divider component="div" />
-          <PageSection>
-            <Card>
-              <Drawer isStatic isExpanded={isExpanded}>
-                <DrawerContent panelContent={panelContent}>
-                  <DrawerContentBody>{drawerContent}</DrawerContentBody>
-                </DrawerContent>
-              </Drawer>
-            </Card>
-          </PageSection>
-        </Page>
-      </React.Fragment>
+      <DashboardWrapper imgBrand={imgBrand} imgAvatar={imgAvatar}>
+        <PageSection variant={PageSectionVariants.light}>
+          <TextContent>
+            <Text component="h1">Main title</Text>
+            <Text component="p">
+              Body text should be Overpass Regular at 16px. It should have leading of 24px because <br />
+              of it’s relative line height of 1.5.
+            </Text>
+          </TextContent>
+        </PageSection>
+        <Divider component="div" />
+        <PageSection>
+          <Card>
+            <Drawer isStatic isExpanded={isExpanded}>
+              <DrawerContent panelContent={panelContent}>
+                <DrawerContentBody>{drawerContent}</DrawerContentBody>
+              </DrawerContent>
+            </Drawer>
+          </Card>
+        </PageSection>
+      </DashboardWrapper>
     );
   }
 }
 ```
 
 ### Primary-detail data list in card
+
 ```js isFullscreen
 import React from 'react';
 import {
-  Avatar,
-  Brand,
-  Breadcrumb,
-  BreadcrumbItem,
-  Button,
-  ButtonVariant,
   Card,
-  CardBody,
   DataList,
-  DataListAction,
   DataListCell,
   DataListItem,
   DataListItemCells,
@@ -1994,32 +1553,14 @@ import {
   DropdownItem,
   Flex,
   FlexItem,
-  KebabToggle,
-  Link,
-  Nav,
-  NavItem,
-  NavList,
-  Page,
-  PageHeader,
   PageSection,
   PageSectionVariants,
-  PageSidebar,
   Progress,
-  Select,
-  SelectOption,
-  SimpleList,
-  SimpleListItem,
-  SkipToContent,
   Text,
   TextContent,
-  TextInput,
-  Title
+  Title,
+  DashboardWrapper
 } from '@patternfly/react-core';
-import accessibleStyles from '@patternfly/react-styles/css/utilities/Accessibility/accessibility';
-import BellIcon from '@patternfly/react-icons/dist/js/icons/bell-icon';
-import CogIcon from '@patternfly/react-icons/dist/js/icons/cog-icon';
-import FilterIcon from '@patternfly/react-icons/dist/js/icons/filter-icon';
-import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon';
 import CaretDownIcon from '@patternfly/react-icons/dist/js/icons/caret-down-icon';
 import imgBrand from '@patternfly/react-core/src/components/Brand/examples/pfLogo.svg';
 import imgAvatar from '@patternfly/react-core/src/components/Avatar/examples/avatarImg.svg';
@@ -2061,8 +1602,8 @@ class PrimaryDetailDataListInCard extends React.Component {
     this.onClose = () => {
       this.setState({
         isExpanded: false
-      })
-    }
+      });
+    };
   }
 
   render() {
@@ -2074,53 +1615,6 @@ class PrimaryDetailDataListInCard extends React.Component {
       selectedDataListItemId,
       isExpanded
     } = this.state;
-
-    const PageNav = (
-      <Nav onSelect={this.onNavSelect} aria-label="Nav">
-        <NavList>
-          <NavItem itemId={0} isActive={activeItem === 0}>
-            System Panel
-          </NavItem>
-          <NavItem itemId={1} isActive={activeItem === 1}>
-            Policy
-          </NavItem>
-          <NavItem itemId={2} isActive={activeItem === 2}>
-            Authentication
-          </NavItem>
-          <NavItem itemId={3} isActive={activeItem === 3}>
-            Network Services
-          </NavItem>
-          <NavItem itemId={4} isActive={activeItem === 4}>
-            Server
-          </NavItem>
-        </NavList>
-      </Nav>
-    );
-
-    const PageToolbar = <div>need to implement new toolbar</div>;
-
-    const Header = (
-      <PageHeader
-        logo={<Brand src={imgBrand} alt="Patternfly Logo" />}
-        toolbar={PageToolbar}
-        avatar={<Avatar src={imgAvatar} alt="Avatar image" />}
-        showNavToggle
-      />
-    );
-    const Sidebar = <PageSidebar nav={PageNav} />;
-    const pageId = 'main-content-page-layout-default-nav';
-    const PageSkipToContent = <SkipToContent href={`#${pageId}`}>Skip to content</SkipToContent>;
-
-    const PageBreadcrumb = (
-      <Breadcrumb>
-        <BreadcrumbItem>Section home</BreadcrumbItem>
-        <BreadcrumbItem to="#">Section title</BreadcrumbItem>
-        <BreadcrumbItem to="#">Section title</BreadcrumbItem>
-        <BreadcrumbItem to="#" isActive>
-          Section landing
-        </BreadcrumbItem>
-      </Breadcrumb>
-    );
 
     const panelContent = (
       <DrawerPanelContent widthOn2Xl={75}>
@@ -2249,54 +1743,39 @@ class PrimaryDetailDataListInCard extends React.Component {
     );
 
     return (
-      <React.Fragment>
-        <Page
-          header={Header}
-          sidebar={Sidebar}
-          isManagedSidebar
-          skipToContent={PageSkipToContent}
-          breadcrumb={PageBreadcrumb}
-          mainContainerId={pageId}
-        >
-          <PageSection variant={PageSectionVariants.light}>
-            <TextContent>
-              <Text component="h1">Main title</Text>
-              <Text component="p">
-                Body text should be Overpass Regular at 16px. It should have leading of 24px because <br />
-                of it’s relative line height of 1.5.
-              </Text>
-            </TextContent>
-          </PageSection>
-          <Divider component="div" />
-          <PageSection>
-            <Card>
-              <Drawer isStatic isExpanded={isExpanded}>
-                <DrawerContent panelContent={panelContent}>
-                  <DrawerContentBody>{drawerContent}</DrawerContentBody>
-                </DrawerContent>
-              </Drawer>
-            </Card>
-          </PageSection>
-        </Page>
-      </React.Fragment>
+      <DashboardWrapper imgBrand={imgBrand} imgAvatar={imgAvatar}>
+        <PageSection variant={PageSectionVariants.light}>
+          <TextContent>
+            <Text component="h1">Main title</Text>
+            <Text component="p">
+              Body text should be Overpass Regular at 16px. It should have leading of 24px because <br />
+              of it’s relative line height of 1.5.
+            </Text>
+          </TextContent>
+        </PageSection>
+        <Divider component="div" />
+        <PageSection>
+          <Card>
+            <Drawer isStatic isExpanded={isExpanded}>
+              <DrawerContent panelContent={panelContent}>
+                <DrawerContentBody>{drawerContent}</DrawerContentBody>
+              </DrawerContent>
+            </Drawer>
+          </Card>
+        </PageSection>
+      </DashboardWrapper>
     );
   }
 }
 ```
 
 ### Primary-detail inline modifier
+
 ```js isFullscreen
 import React from 'react';
 import {
-  Avatar,
-  Brand,
-  Breadcrumb,
-  BreadcrumbItem,
   Button,
   ButtonVariant,
-  Dropdown,
-  Card,
-  CardBody,
   DataList,
   DataListAction,
   DataListCell,
@@ -2317,40 +1796,25 @@ import {
   DrawerHead,
   DrawerPanelBody,
   DrawerPanelContent,
-  DropdownToggle,
-  DropdownItem,
-  DropdownSeparator,
   Flex,
   FlexItem,
-  Gallery,
-  GalleryItem,
   InputGroup,
-  KebabToggle,
-  Nav,
-  NavItem,
-  NavList,
-  Page,
-  PageHeader,
   PageSection,
   PageSectionVariants,
-  PageSidebar,
   Progress,
   Select,
   SelectOption,
   SelectVariant,
-  SkipToContent,
   Stack,
   StackItem,
   Text,
   TextContent,
   TextInput,
-  Title
+  Title,
+  DashboardWrapper
 } from '@patternfly/react-core';
-
-import BellIcon from '@patternfly/react-icons/dist/js/icons/bell-icon';
 import CodeBranchIcon from '@patternfly/react-icons/dist/js/icons/code-branch-icon';
 import CodeIcon from '@patternfly/react-icons/dist/js/icons/code-icon';
-import CogIcon from '@patternfly/react-icons/dist/js/icons/cog-icon';
 import CubeIcon from '@patternfly/react-icons/dist/js/icons/cube-icon';
 import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
@@ -2375,36 +1839,6 @@ class PrimaryDetailInlineModifier extends React.Component {
       riskIsExpanded: false,
       riskSelected: null,
       selectedDataListItemId: ''
-    };
-
-    this.onDropdownToggle = isDropdownOpen => {
-      this.setState({
-        isDropdownOpen
-      });
-    };
-
-    this.onDropdownSelect = event => {
-      this.setState({
-        isDropdownOpen: !this.state.isDropdownOpen
-      });
-    };
-
-    this.onKebabDropdownToggle = isKebabDropdownOpen => {
-      this.setState({
-        isKebabDropdownOpen
-      });
-    };
-
-    this.onKebabDropdownSelect = event => {
-      this.setState({
-        isKebabDropdownOpen: !this.state.isKebabDropdownOpen
-      });
-    };
-
-    this.onNavSelect = result => {
-      this.setState({
-        activeItem: result.itemId
-      });
     };
 
     this.statusOptions = [
@@ -2498,71 +1932,6 @@ class PrimaryDetailInlineModifier extends React.Component {
       riskSelected,
       selectedDataListItemId
     } = this.state;
-
-    const PageNav = (
-      <Nav onSelect={this.onNavSelect} aria-label="Nav">
-        <NavList>
-          <NavItem itemId={0} isActive={activeItem === 0}>
-            System Panel
-          </NavItem>
-          <NavItem itemId={1} isActive={activeItem === 1}>
-            Policy
-          </NavItem>
-          <NavItem itemId={2} isActive={activeItem === 2}>
-            Authentication
-          </NavItem>
-          <NavItem itemId={3} isActive={activeItem === 3}>
-            Network Services
-          </NavItem>
-          <NavItem itemId={4} isActive={activeItem === 4}>
-            Server
-          </NavItem>
-        </NavList>
-      </Nav>
-    );
-    const kebabDropdownItems = [
-      <DropdownItem>
-        <BellIcon /> Notifications
-      </DropdownItem>,
-      <DropdownItem>
-        <CogIcon /> Settings
-      </DropdownItem>
-    ];
-    const userDropdownItems = [
-      <DropdownItem>Link</DropdownItem>,
-      <DropdownItem component="button">Action</DropdownItem>,
-      <DropdownItem isDisabled>Disabled link</DropdownItem>,
-      <DropdownItem isDisabled component="button">
-        Disabled action
-      </DropdownItem>,
-      <DropdownSeparator />,
-      <DropdownItem>Separated link</DropdownItem>,
-      <DropdownItem component="button">Separated action</DropdownItem>
-    ];
-    const PageToolbar = <div>need to implement new toolbar</div>;
-
-    const Header = (
-      <PageHeader
-        logo={<Brand src={imgBrand} alt="Patternfly Logo" />}
-        toolbar={PageToolbar}
-        avatar={<Avatar src={imgAvatar} alt="Avatar image" />}
-        showNavToggle
-      />
-    );
-    const Sidebar = <PageSidebar nav={PageNav} />;
-    const pageId = 'main-content-page-layout-default-nav';
-    const PageSkipToContent = <SkipToContent href={`#${pageId}`}>Skip to content</SkipToContent>;
-
-    const PageBreadcrumb = (
-      <Breadcrumb>
-        <BreadcrumbItem>Section home</BreadcrumbItem>
-        <BreadcrumbItem to="#">Section title</BreadcrumbItem>
-        <BreadcrumbItem to="#">Section title</BreadcrumbItem>
-        <BreadcrumbItem to="#" isActive>
-          Section landing
-        </BreadcrumbItem>
-      </Breadcrumb>
-    );
 
     const toggleGroupItems = (
       <React.Fragment>
@@ -2838,34 +2207,25 @@ class PrimaryDetailInlineModifier extends React.Component {
     );
 
     return (
-      <React.Fragment>
-        <Page
-          header={Header}
-          sidebar={Sidebar}
-          isManagedSidebar
-          skipToContent={PageSkipToContent}
-          breadcrumb={PageBreadcrumb}
-          mainContainerId={pageId}
-        >
-          <PageSection variant={PageSectionVariants.light}>
-            <TextContent>
-              <Text component="h1">Main title</Text>
-              <Text component="p">
-                Body text should be Overpass Regular at 16px. It should have leading of 24px because <br />
-                of it’s relative line height of 1.5.
-              </Text>
-            </TextContent>
-          </PageSection>
-          <Divider component="div" />
-          <PageSection variant={PageSectionVariants.light} padding={{ default: 'noPadding' }}>
-            <Drawer isExpanded={isDrawerExpanded} isInline>
-              <DrawerContent panelContent={panelContent}>
-                <DrawerContentBody>{drawerContent}</DrawerContentBody>
-              </DrawerContent>
-            </Drawer>
-          </PageSection>
-        </Page>
-      </React.Fragment>
+      <DashboardWrapper imgBrand={imgBrand} imgAvatar={imgAvatar}>
+        <PageSection variant={PageSectionVariants.light}>
+          <TextContent>
+            <Text component="h1">Main title</Text>
+            <Text component="p">
+              Body text should be Overpass Regular at 16px. It should have leading of 24px because <br />
+              of it’s relative line height of 1.5.
+            </Text>
+          </TextContent>
+        </PageSection>
+        <Divider component="div" />
+        <PageSection variant={PageSectionVariants.light} padding={{ default: 'noPadding' }}>
+          <Drawer isExpanded={isDrawerExpanded} isInline>
+            <DrawerContent panelContent={panelContent}>
+              <DrawerContentBody>{drawerContent}</DrawerContentBody>
+            </DrawerContent>
+          </Drawer>
+        </PageSection>
+      </DashboardWrapper>
     );
   }
 }

--- a/packages/react-core/src/helpers/DashboardWrapper.tsx
+++ b/packages/react-core/src/helpers/DashboardWrapper.tsx
@@ -1,0 +1,215 @@
+import React from 'react';
+import {
+  Avatar,
+  Brand,
+  Breadcrumb,
+  BreadcrumbItem,
+  Button,
+  ButtonVariant,
+  Dropdown,
+  DropdownGroup,
+  DropdownToggle,
+  DropdownItem,
+  KebabToggle,
+  Nav,
+  NavItem,
+  NavList,
+  Page,
+  PageHeader,
+  PageSidebar,
+  SkipToContent,
+  PageHeaderTools,
+  PageHeaderToolsGroup,
+  PageHeaderToolsItem
+} from '../components';
+import CogIcon from '@patternfly/react-icons/dist/js/icons/cog-icon';
+import HelpIcon from '@patternfly/react-icons/dist/js/icons/help-icon';
+
+export interface DashboardWrapperProps {
+  /** Content rendered inside of Page */
+  children?: React.ReactNode;
+  /** ID of the Page */
+  mainContainerId?: string;
+  /** Custom breadcrumb of the Page */
+  breadcrumb?: React.ReactNode;
+  /** Custom header of the Page */
+  header?: React.ReactNode;
+  /** Custom sidebar of the Page */
+  sidebar?: React.ReactNode;
+  /** Brand image of the Page Header */
+  imgBrand?: string;
+  /** Avatar image of the Page Header */
+  imgAvatar?: string;
+}
+
+export interface DashboardWrapperState {
+  isDropdownOpen: boolean;
+  isKebabDropdownOpen: boolean;
+  activeItem: number;
+}
+
+export class DashboardWrapper extends React.Component<DashboardWrapperProps, DashboardWrapperState> {
+  static displayName = 'DashboardWrapper';
+  static defaultProps = {
+    pageId: 'main-content-page-layout-default-nav'
+  };
+
+  state = {
+    isDropdownOpen: false,
+    isKebabDropdownOpen: false,
+    activeItem: 0
+  };
+
+  onDropdownToggle = (isDropdownOpen: boolean) => {
+    this.setState({
+      isDropdownOpen
+    });
+  };
+
+  onDropdownSelect = () => {
+    this.setState({
+      isDropdownOpen: !this.state.isDropdownOpen
+    });
+  };
+
+  onKebabDropdownToggle = (isKebabDropdownOpen: boolean) => {
+    this.setState({
+      isKebabDropdownOpen
+    });
+  };
+
+  onKebabDropdownSelect = () => {
+    this.setState({
+      isKebabDropdownOpen: !this.state.isKebabDropdownOpen
+    });
+  };
+
+  onNavSelect = (result: any) => {
+    this.setState({
+      activeItem: result.itemId
+    });
+  };
+
+  render() {
+    const { isDropdownOpen, isKebabDropdownOpen, activeItem } = this.state;
+    const { children, mainContainerId, breadcrumb, header, sidebar, imgBrand, imgAvatar } = this.props;
+
+    const PageNav = (
+      <Nav onSelect={this.onNavSelect} aria-label="Nav">
+        <NavList>
+          <NavItem itemId={0} isActive={activeItem === 0}>
+            System Panel
+          </NavItem>
+          <NavItem itemId={1} isActive={activeItem === 1}>
+            Policy
+          </NavItem>
+          <NavItem itemId={2} isActive={activeItem === 2}>
+            Authentication
+          </NavItem>
+          <NavItem itemId={3} isActive={activeItem === 3}>
+            Network Services
+          </NavItem>
+          <NavItem itemId={4} isActive={activeItem === 4}>
+            Server
+          </NavItem>
+        </NavList>
+      </Nav>
+    );
+    const kebabDropdownItems = [
+      <DropdownItem key="kebab-1">
+        <CogIcon /> Settings
+      </DropdownItem>,
+      <DropdownItem key="kebab-2">
+        <HelpIcon /> Help
+      </DropdownItem>
+    ];
+    const userDropdownItems = [
+      <DropdownGroup key="group 2">
+        <DropdownItem key="group 2 profile">My profile</DropdownItem>
+        <DropdownItem key="group 2 user" component="button">
+          User management
+        </DropdownItem>
+        <DropdownItem key="group 2 logout">Logout</DropdownItem>
+      </DropdownGroup>
+    ];
+    const headerTools = (
+      <PageHeaderTools>
+        <PageHeaderToolsGroup
+          visibility={{
+            default: 'hidden',
+            lg: 'visible'
+          }} /** the settings and help icon buttons are only visible on desktop sizes and replaced by a kebab dropdown for other sizes */
+        >
+          <PageHeaderToolsItem>
+            <Button aria-label="Settings actions" variant={ButtonVariant.plain}>
+              <CogIcon />
+            </Button>
+          </PageHeaderToolsItem>
+          <PageHeaderToolsItem>
+            <Button aria-label="Help actions" variant={ButtonVariant.plain}>
+              <HelpIcon />
+            </Button>
+          </PageHeaderToolsItem>
+        </PageHeaderToolsGroup>
+        <PageHeaderToolsGroup>
+          <PageHeaderToolsItem
+            visibility={{
+              lg: 'hidden'
+            }} /** this kebab dropdown replaces the icon buttons and is hidden for desktop sizes */
+          >
+            <Dropdown
+              isPlain
+              position="right"
+              onSelect={this.onKebabDropdownSelect}
+              toggle={<KebabToggle onToggle={this.onKebabDropdownToggle} />}
+              isOpen={isKebabDropdownOpen}
+              dropdownItems={kebabDropdownItems}
+            />
+          </PageHeaderToolsItem>
+          <PageHeaderToolsItem
+            visibility={{ default: 'hidden', md: 'visible' }} /** this user dropdown is hidden on mobile sizes */
+          >
+            <Dropdown
+              isPlain
+              position="right"
+              onSelect={this.onDropdownSelect}
+              isOpen={isDropdownOpen}
+              toggle={<DropdownToggle onToggle={this.onDropdownToggle}>John Smith</DropdownToggle>}
+              dropdownItems={userDropdownItems}
+            />
+          </PageHeaderToolsItem>
+        </PageHeaderToolsGroup>
+        <Avatar src={imgAvatar} alt="Avatar image" />
+      </PageHeaderTools>
+    );
+
+    const _header = (
+      <PageHeader logo={<Brand src={imgBrand} alt="Patternfly Logo" />} headerTools={headerTools} showNavToggle />
+    );
+    const _sidebar = <PageSidebar nav={PageNav} />;
+    const PageSkipToContent = <SkipToContent href={`#${mainContainerId}`}>Skip to content</SkipToContent>;
+    const _breadcrumb = (
+      <Breadcrumb>
+        <BreadcrumbItem>Section home</BreadcrumbItem>
+        <BreadcrumbItem to="#">Section title</BreadcrumbItem>
+        <BreadcrumbItem to="#">Section title</BreadcrumbItem>
+        <BreadcrumbItem to="#" isActive>
+          Section landing
+        </BreadcrumbItem>
+      </Breadcrumb>
+    );
+
+    return (
+      <Page
+        header={header !== undefined ? header : _header}
+        sidebar={sidebar !== undefined ? sidebar : _sidebar}
+        isManagedSidebar
+        skipToContent={PageSkipToContent}
+        breadcrumb={breadcrumb !== undefined ? breadcrumb : _breadcrumb}
+        mainContainerId={mainContainerId}
+      >
+        {children}
+      </Page>
+    );
+  }
+}

--- a/packages/react-core/src/helpers/index.ts
+++ b/packages/react-core/src/helpers/index.ts
@@ -7,3 +7,4 @@ export * from './OUIA/ouia';
 export * from './util';
 export * from './Popper/Popper';
 export * from './useIsomorphicLayout';
+export * from './DashboardWrapper';


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5865

Moves repeated demo code (Page, PageHeader, PageSidebar, Nav) to a wrapper/helper component to reduce the bulk of some full page demos that are not showcasing these components. Shown in PrimaryDetail and CardView demos for the moment. If it looks all right I will continue refactoring.

@redallen I would love to import the Brand/Avatar images directly into the wrapper component but I was having trouble getting the code to work/recognize the svg files (tried through import and require). Is there a good way to import svgs directly into a tsx file? Otherwise I've got them passed via properties, so it's not a huge deal.
