### PR TITLE
docs(Pagination): Export interfaces in md file so prop descriptions are documented

### DIFF
--- a/packages/react-core/src/components/Pagination/OptionsToggle.tsx
+++ b/packages/react-core/src/components/Pagination/OptionsToggle.tsx
@@ -9,7 +9,7 @@ import { DropdownToggle } from '../Dropdown';
 export interface OptionsToggleProps extends React.HTMLProps<HTMLDivElement> {
   /** The type or title of the items being paginated */
   itemsTitle?: string;
-  /** The text to be displayed on the Options Toggle */
+  /** Accessible label for the Options Toggle */
   optionsToggle?: string;
   /** The Title of the Pagination Options Menu */
   itemsPerPageTitle?: string;
@@ -40,7 +40,7 @@ export interface OptionsToggleProps extends React.HTMLProps<HTMLDivElement> {
 let toggleId = 0;
 export const OptionsToggle: React.FunctionComponent<OptionsToggleProps> = ({
   itemsTitle = 'items',
-  optionsToggle = 'Select',
+  optionsToggle = 'Items per page',
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   itemsPerPageTitle = 'Items per page',
   firstIndex = 0,

--- a/packages/react-core/src/components/Pagination/Pagination.tsx
+++ b/packages/react-core/src/components/Pagination/Pagination.tsx
@@ -33,22 +33,36 @@ const defaultPerPageOptions = [
 ];
 
 export interface PerPageOptions {
+  /** option title */
   title?: string;
+  /** option value */
   value?: number;
 }
 
 export interface PaginationTitles {
+  /** The title of a page displayed beside the page number */
   page?: string;
+  /** The type or title of the items being paginated */
   items?: string;
+  /** The Title of the Pagination Options Menu */
   itemsPerPage?: string;
+  /** The suffix to be displayed after each option on the Options Menu dropdown */
   perPageSuffix?: string;
+  /** Accessible label for the button which moves to the first page */
   toFirstPage?: string;
+  /** Accessible label for the button which moves to the previous page */
   toPreviousPage?: string;
+  /** Accessible label for the button which moves to the last page */
   toLastPage?: string;
+  /** Accessible label for the button which moves to the next page */
   toNextPage?: string;
+  /** Accessible label for the Options Toggle */
   optionsToggle?: string;
+  /** Accessible label for the input displaying the current page */
   currPage?: string;
+  /** Accessible label for the pagination component */
   paginationTitle?: string;
+  /** Accessible label for the English word "of" */
   ofWord?: string;
 }
 
@@ -87,7 +101,7 @@ export interface PaginationProps extends React.HTMLProps<HTMLDivElement>, OUIAPr
   isSticky?: boolean;
   /** Number of items per page. */
   perPage?: number;
-  /** Select from options to number of items per page. */
+  /** Array of the number of items per page  options. */
   perPageOptions?: PerPageOptions[];
   /** Indicate whether to show last full page of results when user selects perPage value greater than remaining rows */
   defaultToFullPage?: boolean;

--- a/packages/react-core/src/components/Pagination/PaginationOptionsMenu.tsx
+++ b/packages/react-core/src/components/Pagination/PaginationOptionsMenu.tsx
@@ -61,7 +61,7 @@ export class PaginationOptionsMenu extends React.Component<PaginationOptionsMenu
     perPageOptions: [] as PerPageOptions[],
     itemsPerPageTitle: 'Items per page',
     perPageSuffix: 'per page',
-    optionsToggle: 'Select',
+    optionsToggle: 'Items per page',
     perPage: 0,
     firstIndex: 0,
     lastIndex: 0,

--- a/packages/react-core/src/components/Pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/react-core/src/components/Pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -9935,7 +9935,7 @@ exports[`component render titles 1`] = `
       lastIndex={10}
       lastPage={4}
       onPerPageSelect={[Function]}
-      optionsToggle="Select"
+      optionsToggle="Items per page"
       page={1}
       perPage={10}
       perPageOptions={
@@ -10031,7 +10031,7 @@ exports[`component render titles 1`] = `
             itemsTitle="values"
             lastIndex={10}
             onToggle={[Function]}
-            optionsToggle="Select"
+            optionsToggle="Items per page"
             parentRef={null}
             showToggle={true}
             toggleTemplate={[Function]}
@@ -10059,7 +10059,7 @@ exports[`component render titles 1`] = `
             lastIndex={10}
             onEnter={[Function]}
             onToggle={[Function]}
-            optionsToggle="Select"
+            optionsToggle="Items per page"
             parentRef={
               Object {
                 "current": <div
@@ -10089,7 +10089,7 @@ exports[`component render titles 1`] = `
                     </span>
                     <button
                       aria-expanded="false"
-                      aria-label="Select"
+                      aria-label="Items per page"
                       class="  pf-c-options-menu__toggle-button"
                       data-ouia-component-id="OUIA-Generated-DropdownToggle-13"
                       data-ouia-component-type="PF4/DropdownToggle"
@@ -10151,7 +10151,7 @@ exports[`component render titles 1`] = `
                 </ToggleTemplate>
               </span>
               <DropdownToggle
-                aria-label="Select"
+                aria-label="Items per page"
                 className="pf-c-options-menu__toggle-button"
                 id="pagination-options-menu-toggle-12"
                 isDisabled={false}
@@ -10187,7 +10187,7 @@ exports[`component render titles 1`] = `
                         </span>
                         <button
                           aria-expanded="false"
-                          aria-label="Select"
+                          aria-label="Items per page"
                           class="  pf-c-options-menu__toggle-button"
                           data-ouia-component-id="OUIA-Generated-DropdownToggle-13"
                           data-ouia-component-type="PF4/DropdownToggle"
@@ -10219,7 +10219,7 @@ exports[`component render titles 1`] = `
                 }
               >
                 <Toggle
-                  aria-label="Select"
+                  aria-label="Items per page"
                   bubbleEvent={false}
                   className="pf-c-options-menu__toggle-button"
                   data-ouia-component-id="OUIA-Generated-DropdownToggle-13"
@@ -10264,7 +10264,7 @@ exports[`component render titles 1`] = `
                           </span>
                           <button
                             aria-expanded="false"
-                            aria-label="Select"
+                            aria-label="Items per page"
                             class="  pf-c-options-menu__toggle-button"
                             data-ouia-component-id="OUIA-Generated-DropdownToggle-13"
                             data-ouia-component-type="PF4/DropdownToggle"
@@ -10297,7 +10297,7 @@ exports[`component render titles 1`] = `
                 >
                   <button
                     aria-expanded={false}
-                    aria-label="Select"
+                    aria-label="Items per page"
                     className="  pf-c-options-menu__toggle-button"
                     data-ouia-component-id="OUIA-Generated-DropdownToggle-13"
                     data-ouia-component-type="PF4/DropdownToggle"

--- a/packages/react-core/src/components/Pagination/examples/Pagination.md
+++ b/packages/react-core/src/components/Pagination/examples/Pagination.md
@@ -2,7 +2,7 @@
 id: Pagination
 section: components
 cssPrefix: null
-propComponents: ['Pagination']
+propComponents: ['Pagination', PaginationTitles, PerPageOptions, ToggleTemplateProps]
 ouia: true
 ---
 


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #1882

Added the interfaces to the md file so that the props are documented for the user.  Updated a few prop descriptions @jessiehuff @jgiardino  the `titles.optionsToggle` is what sets the toggles aria label.
