### PR TITLE
fix(table): Avoid Object constructor

### DIFF
--- a/packages/react-table/src/components/Table/Body.tsx
+++ b/packages/react-table/src/components/Table/Body.tsx
@@ -163,7 +163,7 @@ export const TableBody = ({
   children = null as React.ReactNode,
   rowKey = 'secretTableRowKeyId' as string,
   /* eslint-disable @typescript-eslint/no-unused-vars */
-  onRow = (...args: any) => Object,
+  onRow = (...args: any) => ({}),
   onRowClick = (event: React.MouseEvent, row: IRow, rowProps: IExtraRowData, computedData: IComputedData) =>
     /* eslint-enable @typescript-eslint/no-unused-vars */
     undefined as OnRowClick,

--- a/packages/react-table/src/components/Table/base/body-row.tsx
+++ b/packages/react-table/src/components/Table/base/body-row.tsx
@@ -25,7 +25,7 @@ export class BodyRow extends React.Component<BodyRowProps, {}> {
   static displayName = 'BodyRow';
   static defaultProps = {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    onRow: (...args: any) => Object
+    onRow: (...args: any) => ({})
   };
 
   shouldComponentUpdate(nextProps: BodyRowProps) {

--- a/packages/react-table/src/components/Table/base/body.tsx
+++ b/packages/react-table/src/components/Table/base/body.tsx
@@ -24,7 +24,7 @@ export interface BodyProps {
 class BaseBody extends React.Component<BodyProps, {}> {
   static defaultProps = {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    onRow: (...args: any) => Object
+    onRow: (...args: any) => ({})
   };
 
   shouldComponentUpdate(nextProps: BodyProps) {

--- a/packages/react-table/src/components/Table/base/header-row.tsx
+++ b/packages/react-table/src/components/Table/base/header-row.tsx
@@ -22,7 +22,7 @@ export const HeaderRow: React.FunctionComponent<HeaderRowProps> = ({
   rowData,
   rowIndex,
   renderers,
-  onRow = () => Object
+  onRow = () => ({})
 }: HeaderRowProps) =>
   React.createElement(
     renderers.row as createElementType,


### PR DESCRIPTION
This change updates the @patternfly/react-table package to remove the use of the `Object` constructor. This was used as a replacement for an empty dictionary. However, Dart libraries such as dart-sass might pollute the Object constructor, which in turn causes issues with React.

Fixes #5320
