### PR TITLE
feat(Page): Add tabs PageSection variant

### DIFF
--- a/packages/react-core/src/components/Page/PageSection.tsx
+++ b/packages/react-core/src/components/Page/PageSection.tsx
@@ -13,6 +13,7 @@ export enum PageSectionVariants {
 export enum PageSectionTypes {
   default = 'default',
   nav = 'nav',
+  tabs = 'tabs',
   wizard = 'wizard'
 }
 
@@ -24,7 +25,7 @@ export interface PageSectionProps extends React.HTMLProps<HTMLDivElement> {
   /** Section background color variant */
   variant?: 'default' | 'light' | 'dark' | 'darker';
   /** Section type variant */
-  type?: 'default' | 'nav' | 'wizard';
+  type?: 'default' | 'nav' | 'tabs' | 'wizard';
   /** Enables the page section to fill the available vertical space */
   isFilled?: boolean;
   /** Limits the width of the section */
@@ -51,6 +52,7 @@ export interface PageSectionProps extends React.HTMLProps<HTMLDivElement> {
 const variantType = {
   [PageSectionTypes.default]: styles.pageMainSection,
   [PageSectionTypes.nav]: styles.pageMainNav,
+  [PageSectionTypes.tabs]: styles.pageMainTabs,
   [PageSectionTypes.wizard]: styles.pageMainWizard
 };
 

--- a/packages/react-core/src/components/Page/__tests__/PageSection.test.tsx
+++ b/packages/react-core/src/components/Page/__tests__/PageSection.test.tsx
@@ -16,6 +16,12 @@ test('Check page section with limited width', () => {
   expect(view).toMatchSnapshot();
 });
 
+test('Check page main tabs section against snapshot', () => {
+  const Section = <PageSection type={PageSectionTypes.tabs} />;
+  const view = mount(Section);
+  expect(view).toMatchSnapshot();
+});
+
 test('Check page main nav section against snapshot', () => {
   const Section = <PageSection type={PageSectionTypes.nav} />;
   const view = mount(Section);

--- a/packages/react-core/src/components/Page/__tests__/__snapshots__/PageSection.test.tsx.snap
+++ b/packages/react-core/src/components/Page/__tests__/__snapshots__/PageSection.test.tsx.snap
@@ -10,6 +10,16 @@ exports[`Check page main nav section against snapshot 1`] = `
 </PageSection>
 `;
 
+exports[`Check page main tabs section against snapshot 1`] = `
+<PageSection
+  type="tabs"
+>
+  <section
+    className="pf-c-page__main-tabs"
+  />
+</PageSection>
+`;
+
 exports[`Check page section with fill and no padding example against snapshot 1`] = `
 <PageSection
   isFilled={true}


### PR DESCRIPTION
This change adds a PageSection variant for tabs as demoed in the PatternFly HTML version. See https://www.patternfly.org/v4/components/tabs/html-demos#open-tabs.

I am trying to rebuild part of this tab demo in React, but currently it does not have a PageSectionVariant for tabs, so I am unable to properly reproduce the demo without using HTML components.

Fixes #6034