### PR TITLE
fix(LogViewer): Do not overestimate size for empty lines

### DIFF
--- a/packages/react-log-viewer/src/LogViewer/LogViewer.tsx
+++ b/packages/react-log-viewer/src/LogViewer/LogViewer.tsx
@@ -149,9 +149,9 @@ export const LogViewer: React.FunctionComponent<LogViewerProps> = memo(
     const guessRowHeight = (rowIndex: number) => {
       const rowText = parsedData[rowIndex];
       const textWidth = getTextWidth(rowText, 'Liberation Mono');
-      const numRows = Math.ceil(textWidth / currentWidth || 600);
+      const numRows = Math.ceil(textWidth / (currentWidth || 600));
 
-      return 60 * numRows;
+      return 60 * (numRows || 1);
     };
 
     const createList = (parsedData: string[]) => (

--- a/packages/react-log-viewer/src/LogViewer/examples/realTestData.js
+++ b/packages/react-log-viewer/src/LogViewer/examples/realTestData.js
@@ -1,5 +1,6 @@
 export const data = {
   data: `Copying system trust bundle
+
     Waiting for port :6443 to be released.
     I0223 20:04:25.084507       1 loader.go:379] Config loaded from file:  /etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-cert-syncer-kubeconfig/kubeconfig
     Copying termination logs to "/var/log/kube-apiserver/termination.log"


### PR DESCRIPTION
- Do not estimate 600 rows for empty lines => wrong priority for ‹||›
- After fixing previous bug, do not estimate 0 height for empty lines,
  i.e. there is always at least one row in the log

Signed-off-by: Matej Focko <mfocko@redhat.com>

<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Part of #6021

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
