### PR TITLE
SearchInput: allow hasWordAttrLabel to be React.ReactNode as well

### DIFF
--- a/packages/react-core/src/components/SearchInput/SearchInput.tsx
+++ b/packages/react-core/src/components/SearchInput/SearchInput.tsx
@@ -33,7 +33,7 @@ export interface SearchInputProps extends Omit<React.HTMLProps<HTMLDivElement>, 
    * The new form elements can be wrapped in a FormGroup component for automatic formatting */
   formAdditionalItems?: React.ReactNode;
   /** Attribute label for strings unassociated with one of the provided listed attributes */
-  hasWordsAttrLabel?: string | React.ReactNode;
+  hasWordsAttrLabel?: React.ReactNode;
   /** Delimiter in the query string for pairing attributes with search values.
    * Required whenever attributes are passed as props */
   advancedSearchDelimiter?: string;

--- a/packages/react-core/src/components/SearchInput/SearchInput.tsx
+++ b/packages/react-core/src/components/SearchInput/SearchInput.tsx
@@ -33,7 +33,7 @@ export interface SearchInputProps extends Omit<React.HTMLProps<HTMLDivElement>, 
    * The new form elements can be wrapped in a FormGroup component for automatic formatting */
   formAdditionalItems?: React.ReactNode;
   /** Attribute label for strings unassociated with one of the provided listed attributes */
-  hasWordsAttrLabel?: string;
+  hasWordsAttrLabel?: string | React.ReactNode;
   /** Delimiter in the query string for pairing attributes with search values.
    * Required whenever attributes are passed as props */
   advancedSearchDelimiter?: string;
@@ -206,7 +206,7 @@ const SearchInputBase: React.FunctionComponent<SearchInputProps> = ({
     let updatedValue = '';
     Object.entries(newMap).forEach(([k, v]) => {
       if (v.trim() !== '') {
-        if (k !== hasWordsAttrLabel.replace(' ', '').toLowerCase()) {
+        if (k !== 'haswords') {
           updatedValue = `${updatedValue} ${k}${advancedSearchDelimiter}${v}`;
         } else {
           updatedValue = `${updatedValue} ${v}`;


### PR DESCRIPTION
In cockpit we want to use this component variant, but the 'Has words' field needs explanation. For this reason we want to use a helpicon popover as seen in the screenshot.

![search-box-label](https://user-images.githubusercontent.com/14921356/125819467-3a3a4691-48f9-45a3-938a-8d782e2f6f1f.jpg)
