### PR TITLE
feat(Dropdown): Allow for tooltips on aria-disabled items

### DIFF
--- a/packages/react-core/src/components/ApplicationLauncher/__tests__/__snapshots__/ApplicationLauncher.test.tsx.snap
+++ b/packages/react-core/src/components/ApplicationLauncher/__tests__/__snapshots__/ApplicationLauncher.test.tsx.snap
@@ -536,6 +536,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
                     "onKeyPress",
                   ]
                 }
+                isAriaDisabled={false}
                 isDisabled={false}
                 isHovered={false}
                 isPlainText={false}
@@ -607,6 +608,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
                     "onKeyPress",
                   ]
                 }
+                isAriaDisabled={false}
                 isDisabled={false}
                 isHovered={false}
                 isPlainText={false}
@@ -680,6 +682,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
                     "onKeyPress",
                   ]
                 }
+                isAriaDisabled={false}
                 isDisabled={true}
                 isHovered={false}
                 isPlainText={false}
@@ -755,6 +758,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
                     "onKeyPress",
                   ]
                 }
+                isAriaDisabled={false}
                 isDisabled={true}
                 isHovered={false}
                 isPlainText={false}
@@ -888,6 +892,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
                     "onKeyPress",
                   ]
                 }
+                isAriaDisabled={false}
                 isDisabled={false}
                 isHovered={false}
                 isPlainText={false}
@@ -959,6 +964,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
                     "onKeyPress",
                   ]
                 }
+                isAriaDisabled={false}
                 isDisabled={false}
                 isHovered={false}
                 isPlainText={false}
@@ -2089,6 +2095,7 @@ exports[`ApplicationLauncher expanded 1`] = `
                     "onKeyPress",
                   ]
                 }
+                isAriaDisabled={false}
                 isDisabled={false}
                 isHovered={false}
                 isPlainText={false}
@@ -2160,6 +2167,7 @@ exports[`ApplicationLauncher expanded 1`] = `
                     "onKeyPress",
                   ]
                 }
+                isAriaDisabled={false}
                 isDisabled={false}
                 isHovered={false}
                 isPlainText={false}
@@ -2233,6 +2241,7 @@ exports[`ApplicationLauncher expanded 1`] = `
                     "onKeyPress",
                   ]
                 }
+                isAriaDisabled={false}
                 isDisabled={true}
                 isHovered={false}
                 isPlainText={false}
@@ -2308,6 +2317,7 @@ exports[`ApplicationLauncher expanded 1`] = `
                     "onKeyPress",
                   ]
                 }
+                isAriaDisabled={false}
                 isDisabled={true}
                 isHovered={false}
                 isPlainText={false}
@@ -2441,6 +2451,7 @@ exports[`ApplicationLauncher expanded 1`] = `
                     "onKeyPress",
                   ]
                 }
+                isAriaDisabled={false}
                 isDisabled={false}
                 isHovered={false}
                 isPlainText={false}
@@ -2512,6 +2523,7 @@ exports[`ApplicationLauncher expanded 1`] = `
                     "onKeyPress",
                   ]
                 }
+                isAriaDisabled={false}
                 isDisabled={false}
                 isHovered={false}
                 isPlainText={false}

--- a/packages/react-core/src/components/ApplicationLauncher/examples/ApplicationLauncher.md
+++ b/packages/react-core/src/components/ApplicationLauncher/examples/ApplicationLauncher.md
@@ -343,8 +343,6 @@ class TooltipApplicationLauncher extends React.Component {
 import React from 'react';
 import {
   ApplicationLauncher,
-  ApplicationLauncherIcon,
-  ApplicationLauncherText,
   ApplicationLauncherItem,
   ApplicationLauncherGroup,
   ApplicationLauncherSeparator

--- a/packages/react-core/src/components/Dropdown/DropdownItem.tsx
+++ b/packages/react-core/src/components/Dropdown/DropdownItem.tsx
@@ -23,6 +23,8 @@ export interface DropdownItemProps extends InternalDropdownItemProps, OUIAProps 
   styleChildren?: boolean;
   /** Render dropdown item as disabled option */
   isDisabled?: boolean;
+  /** Render dropdown item as aria-disabled option */
+  isAriaDisabled?: boolean;
   /** Render dropdown item as non-interactive item */
   isPlainText?: boolean;
   /** Forces display of the hover state of the element */
@@ -52,6 +54,7 @@ export const DropdownItem: React.FunctionComponent<DropdownItemProps> = ({
   className,
   component = 'a',
   isDisabled = false,
+  isAriaDisabled = false,
   isPlainText = false,
   isHovered = false,
   href,
@@ -83,6 +86,7 @@ export const DropdownItem: React.FunctionComponent<DropdownItemProps> = ({
           className={className}
           component={component}
           isDisabled={isDisabled}
+          isAriaDisabled={isAriaDisabled}
           isPlainText={isPlainText}
           isHovered={isHovered}
           href={href}

--- a/packages/react-core/src/components/Dropdown/InternalDropdownItem.tsx
+++ b/packages/react-core/src/components/Dropdown/InternalDropdownItem.tsx
@@ -267,11 +267,9 @@ export class InternalDropdownItem extends React.Component<InternalDropdownItemPr
               role={role}
               onKeyDown={this.onKeyDown}
               onClick={(event: any) => {
-                if (!isDisabled) {
+                if (!isDisabled || !isAriaDisabled) {
                   onClick(event);
-                  if (!isAriaDisabled) {
-                    onSelect(event);
-                  }
+                  onSelect(event);
                 }
               }}
               id={id}

--- a/packages/react-core/src/components/Dropdown/InternalDropdownItem.tsx
+++ b/packages/react-core/src/components/Dropdown/InternalDropdownItem.tsx
@@ -267,9 +267,11 @@ export class InternalDropdownItem extends React.Component<InternalDropdownItemPr
               role={role}
               onKeyDown={this.onKeyDown}
               onClick={(event: any) => {
-                if (!isDisabled || !isAriaDisabled) {
+                if (!isDisabled) {
                   onClick(event);
-                  onSelect(event);
+                  if (!isAriaDisabled) {
+                    onSelect(event);
+                  }
                 }
               }}
               id={id}

--- a/packages/react-core/src/components/Dropdown/InternalDropdownItem.tsx
+++ b/packages/react-core/src/components/Dropdown/InternalDropdownItem.tsx
@@ -267,7 +267,7 @@ export class InternalDropdownItem extends React.Component<InternalDropdownItemPr
               role={role}
               onKeyDown={this.onKeyDown}
               onClick={(event: any) => {
-                if (!isDisabled && !isAriaDisabled) {
+                if (!isDisabled || !isAriaDisabled) {
                   onClick(event);
                   onSelect(event);
                 }

--- a/packages/react-core/src/components/Dropdown/InternalDropdownItem.tsx
+++ b/packages/react-core/src/components/Dropdown/InternalDropdownItem.tsx
@@ -21,6 +21,8 @@ export interface InternalDropdownItemProps extends React.HTMLProps<HTMLAnchorEle
   role?: string;
   /** Render dropdown item as disabled option */
   isDisabled?: boolean;
+  /** Render dropdown item as aria disabled option */
+  isAriaDisabled?: boolean;
   /** Render dropdown item as a non-interactive item */
   isPlainText?: boolean;
   /** Forces display of the hover state of the element */
@@ -163,6 +165,7 @@ export class InternalDropdownItem extends React.Component<InternalDropdownItemPr
       component,
       role,
       isDisabled,
+      isAriaDisabled,
       isPlainText,
       index,
       href,
@@ -182,12 +185,12 @@ export class InternalDropdownItem extends React.Component<InternalDropdownItemPr
       ...additionalProps
     } = this.props;
     /* eslint-enable @typescript-eslint/no-unused-vars */
-    let classes = css(icon && styles.modifiers.icon, className);
+    let classes = css(icon && styles.modifiers.icon, isAriaDisabled && styles.modifiers.ariaDisabled, className);
 
     if (component === 'a') {
-      additionalProps['aria-disabled'] = isDisabled;
+      additionalProps['aria-disabled'] = isDisabled || isAriaDisabled;
     } else if (component === 'button') {
-      additionalProps['aria-disabled'] = isDisabled;
+      additionalProps['aria-disabled'] = isDisabled || isAriaDisabled;
       additionalProps.type = additionalProps.type || 'button';
     }
     const renderWithTooltip = (childNode: React.ReactNode) =>
@@ -264,7 +267,7 @@ export class InternalDropdownItem extends React.Component<InternalDropdownItemPr
               role={role}
               onKeyDown={this.onKeyDown}
               onClick={(event: any) => {
-                if (!isDisabled) {
+                if (!isDisabled && !isAriaDisabled) {
                   onClick(event);
                   onSelect(event);
                 }

--- a/packages/react-core/src/components/Dropdown/InternalDropdownItem.tsx
+++ b/packages/react-core/src/components/Dropdown/InternalDropdownItem.tsx
@@ -267,7 +267,7 @@ export class InternalDropdownItem extends React.Component<InternalDropdownItemPr
               role={role}
               onKeyDown={this.onKeyDown}
               onClick={(event: any) => {
-                if (!isDisabled || !isAriaDisabled) {
+                if (!isDisabled && !isAriaDisabled) {
                   onClick(event);
                   onSelect(event);
                 }

--- a/packages/react-core/src/components/Dropdown/InternalDropdownItem.tsx
+++ b/packages/react-core/src/components/Dropdown/InternalDropdownItem.tsx
@@ -231,7 +231,7 @@ export class InternalDropdownItem extends React.Component<InternalDropdownItemPr
       return (
         <Component
           {...additionalProps}
-          {...(isDisabled ? preventedEvents(inoperableEvents) : null)}
+          {...(isDisabled || isAriaDisabled ? preventedEvents(inoperableEvents) : null)}
           href={href}
           ref={this.ref}
           className={classes}

--- a/packages/react-core/src/components/Dropdown/__tests__/InternalDropdownItem.test.tsx
+++ b/packages/react-core/src/components/Dropdown/__tests__/InternalDropdownItem.test.tsx
@@ -49,6 +49,21 @@ describe('dropdown items', () => {
     });
   });
 
+  describe('aria-disabled', () => {
+    test('a', () => {
+      const view = shallow(<InternalDropdownItem isAriaDisabled>Something</InternalDropdownItem>);
+      expect(view).toMatchSnapshot();
+    });
+    test('button', () => {
+      const view = shallow(
+        <InternalDropdownItem isAriaDisabled component="button">
+          Something
+        </InternalDropdownItem>
+      );
+      expect(view).toMatchSnapshot();
+    });
+  });
+
   describe('description', () => {
     test('a', () => {
       const view = shallow(

--- a/packages/react-core/src/components/Dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/react-core/src/components/Dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
@@ -1686,7 +1686,6 @@ exports[`KebabToggle expanded 1`] = `
                   role="none"
                 >
                   <a
-                    aria-disabled="false"
                     class="pf-c-dropdown__menu-item"
                   >
                     Link
@@ -1696,7 +1695,6 @@ exports[`KebabToggle expanded 1`] = `
                   role="none"
                 >
                   <button
-                    aria-disabled="false"
                     class="pf-c-dropdown__menu-item"
                     type="button"
                   >
@@ -1736,7 +1734,6 @@ exports[`KebabToggle expanded 1`] = `
                   role="none"
                 >
                   <a
-                    aria-disabled="false"
                     class="pf-c-dropdown__menu-item"
                   >
                     Separated Link
@@ -1746,7 +1743,6 @@ exports[`KebabToggle expanded 1`] = `
                   role="none"
                 >
                   <button
-                    aria-disabled="false"
                     class="pf-c-dropdown__menu-item"
                     type="button"
                   >
@@ -1812,7 +1808,6 @@ exports[`KebabToggle expanded 1`] = `
                     role="none"
                   >
                     <a
-                      aria-disabled="false"
                       class="pf-c-dropdown__menu-item"
                     >
                       Link
@@ -1822,7 +1817,6 @@ exports[`KebabToggle expanded 1`] = `
                     role="none"
                   >
                     <button
-                      aria-disabled="false"
                       class="pf-c-dropdown__menu-item"
                       type="button"
                     >
@@ -1862,7 +1856,6 @@ exports[`KebabToggle expanded 1`] = `
                     role="none"
                   >
                     <a
-                      aria-disabled="false"
                       class="pf-c-dropdown__menu-item"
                     >
                       Separated Link
@@ -1872,7 +1865,6 @@ exports[`KebabToggle expanded 1`] = `
                     role="none"
                   >
                     <button
-                      aria-disabled="false"
                       class="pf-c-dropdown__menu-item"
                       type="button"
                     >
@@ -1975,7 +1967,6 @@ exports[`KebabToggle expanded 1`] = `
               role="none"
             >
               <a
-                aria-disabled={false}
                 className="pf-c-dropdown__menu-item"
               >
                 Link
@@ -2017,7 +2008,6 @@ exports[`KebabToggle expanded 1`] = `
               role="none"
             >
               <button
-                aria-disabled={false}
                 className="pf-c-dropdown__menu-item"
                 type="button"
               >
@@ -2205,7 +2195,6 @@ exports[`KebabToggle expanded 1`] = `
               role="none"
             >
               <a
-                aria-disabled={false}
                 className="pf-c-dropdown__menu-item"
               >
                 Separated Link
@@ -2247,7 +2236,6 @@ exports[`KebabToggle expanded 1`] = `
               role="none"
             >
               <button
-                aria-disabled={false}
                 className="pf-c-dropdown__menu-item"
                 type="button"
               >
@@ -4290,7 +4278,6 @@ exports[`dropdown alignment breakpoints 1`] = `
                   role="none"
                 >
                   <a
-                    aria-disabled="false"
                     class="pf-c-dropdown__menu-item"
                   >
                     Link
@@ -4300,7 +4287,6 @@ exports[`dropdown alignment breakpoints 1`] = `
                   role="none"
                 >
                   <button
-                    aria-disabled="false"
                     class="pf-c-dropdown__menu-item"
                     type="button"
                   >
@@ -4340,7 +4326,6 @@ exports[`dropdown alignment breakpoints 1`] = `
                   role="none"
                 >
                   <a
-                    aria-disabled="false"
                     class="pf-c-dropdown__menu-item"
                   >
                     Separated Link
@@ -4350,7 +4335,6 @@ exports[`dropdown alignment breakpoints 1`] = `
                   role="none"
                 >
                   <button
-                    aria-disabled="false"
                     class="pf-c-dropdown__menu-item"
                     type="button"
                   >
@@ -4429,7 +4413,6 @@ exports[`dropdown alignment breakpoints 1`] = `
                     role="none"
                   >
                     <a
-                      aria-disabled="false"
                       class="pf-c-dropdown__menu-item"
                     >
                       Link
@@ -4439,7 +4422,6 @@ exports[`dropdown alignment breakpoints 1`] = `
                     role="none"
                   >
                     <button
-                      aria-disabled="false"
                       class="pf-c-dropdown__menu-item"
                       type="button"
                     >
@@ -4479,7 +4461,6 @@ exports[`dropdown alignment breakpoints 1`] = `
                     role="none"
                   >
                     <a
-                      aria-disabled="false"
                       class="pf-c-dropdown__menu-item"
                     >
                       Separated Link
@@ -4489,7 +4470,6 @@ exports[`dropdown alignment breakpoints 1`] = `
                     role="none"
                   >
                     <button
-                      aria-disabled="false"
                       class="pf-c-dropdown__menu-item"
                       type="button"
                     >
@@ -4612,7 +4592,6 @@ exports[`dropdown alignment breakpoints 1`] = `
               role="none"
             >
               <a
-                aria-disabled={false}
                 className="pf-c-dropdown__menu-item"
               >
                 Link
@@ -4654,7 +4633,6 @@ exports[`dropdown alignment breakpoints 1`] = `
               role="none"
             >
               <button
-                aria-disabled={false}
                 className="pf-c-dropdown__menu-item"
                 type="button"
               >
@@ -4842,7 +4820,6 @@ exports[`dropdown alignment breakpoints 1`] = `
               role="none"
             >
               <a
-                aria-disabled={false}
                 className="pf-c-dropdown__menu-item"
               >
                 Separated Link
@@ -4884,7 +4861,6 @@ exports[`dropdown alignment breakpoints 1`] = `
               role="none"
             >
               <button
-                aria-disabled={false}
                 className="pf-c-dropdown__menu-item"
                 type="button"
               >
@@ -6717,7 +6693,6 @@ exports[`dropdown expanded 1`] = `
                   role="none"
                 >
                   <a
-                    aria-disabled="false"
                     class="pf-c-dropdown__menu-item"
                   >
                     Link
@@ -6727,7 +6702,6 @@ exports[`dropdown expanded 1`] = `
                   role="none"
                 >
                   <button
-                    aria-disabled="false"
                     class="pf-c-dropdown__menu-item"
                     type="button"
                   >
@@ -6767,7 +6741,6 @@ exports[`dropdown expanded 1`] = `
                   role="none"
                 >
                   <a
-                    aria-disabled="false"
                     class="pf-c-dropdown__menu-item"
                   >
                     Separated Link
@@ -6777,7 +6750,6 @@ exports[`dropdown expanded 1`] = `
                   role="none"
                 >
                   <button
-                    aria-disabled="false"
                     class="pf-c-dropdown__menu-item"
                     type="button"
                   >
@@ -6856,7 +6828,6 @@ exports[`dropdown expanded 1`] = `
                     role="none"
                   >
                     <a
-                      aria-disabled="false"
                       class="pf-c-dropdown__menu-item"
                     >
                       Link
@@ -6866,7 +6837,6 @@ exports[`dropdown expanded 1`] = `
                     role="none"
                   >
                     <button
-                      aria-disabled="false"
                       class="pf-c-dropdown__menu-item"
                       type="button"
                     >
@@ -6906,7 +6876,6 @@ exports[`dropdown expanded 1`] = `
                     role="none"
                   >
                     <a
-                      aria-disabled="false"
                       class="pf-c-dropdown__menu-item"
                     >
                       Separated Link
@@ -6916,7 +6885,6 @@ exports[`dropdown expanded 1`] = `
                     role="none"
                   >
                     <button
-                      aria-disabled="false"
                       class="pf-c-dropdown__menu-item"
                       type="button"
                     >
@@ -7030,7 +6998,6 @@ exports[`dropdown expanded 1`] = `
               role="none"
             >
               <a
-                aria-disabled={false}
                 className="pf-c-dropdown__menu-item"
               >
                 Link
@@ -7072,7 +7039,6 @@ exports[`dropdown expanded 1`] = `
               role="none"
             >
               <button
-                aria-disabled={false}
                 className="pf-c-dropdown__menu-item"
                 type="button"
               >
@@ -7260,7 +7226,6 @@ exports[`dropdown expanded 1`] = `
               role="none"
             >
               <a
-                aria-disabled={false}
                 className="pf-c-dropdown__menu-item"
               >
                 Separated Link
@@ -7302,7 +7267,6 @@ exports[`dropdown expanded 1`] = `
               role="none"
             >
               <button
-                aria-disabled={false}
                 className="pf-c-dropdown__menu-item"
                 type="button"
               >

--- a/packages/react-core/src/components/Dropdown/__tests__/__snapshots__/InternalDropdownItem.test.tsx.snap
+++ b/packages/react-core/src/components/Dropdown/__tests__/__snapshots__/InternalDropdownItem.test.tsx.snap
@@ -6,6 +6,18 @@ exports[`dropdown items a 1`] = `
 </ContextConsumer>
 `;
 
+exports[`dropdown items aria-disabled a 1`] = `
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
+`;
+
+exports[`dropdown items aria-disabled button 1`] = `
+<ContextConsumer>
+  <Component />
+</ContextConsumer>
+`;
+
 exports[`dropdown items button 1`] = `
 <ContextConsumer>
   <Component />

--- a/packages/react-core/src/components/Dropdown/examples/Dropdown.md
+++ b/packages/react-core/src/components/Dropdown/examples/Dropdown.md
@@ -27,11 +27,7 @@ import {
   DropdownToggle,
   DropdownItem,
   DropdownSeparator,
-  DropdownPosition,
-  DropdownDirection,
-  KebabToggle
 } from '@patternfly/react-core';
-import ThIcon from '@patternfly/react-icons/dist/js/icons/th-icon';
 import CaretDownIcon from '@patternfly/react-icons/dist/js/icons/caret-down-icon';
 
 class SimpleDropdown extends React.Component {
@@ -67,7 +63,13 @@ class SimpleDropdown extends React.Component {
       <DropdownItem key="disabled link" isDisabled href="www.google.com">
         Disabled Link
       </DropdownItem>,
-      <DropdownItem key="disabled action" isDisabled component="button">
+      <DropdownItem 
+        key="disabled action" 
+        isAriaDisabled 
+        component="button"
+        tooltip="Tooltip for disabled item" 
+        tooltipProps={{position:"top"}}
+      >
         Disabled Action
       </DropdownItem>,
       <DropdownSeparator key="separator" />,
@@ -100,12 +102,8 @@ import {
   Dropdown,
   DropdownToggle,
   DropdownItem,
-  DropdownSeparator,
-  DropdownPosition,
-  DropdownDirection,
-  KebabToggle
+  DropdownSeparator
 } from '@patternfly/react-core';
-import ThIcon from '@patternfly/react-icons/dist/js/icons/th-icon';
 
 class IntialSelectionDropdown extends React.Component {
   constructor(props) {
@@ -170,7 +168,7 @@ class IntialSelectionDropdown extends React.Component {
 
 ```js
 import React from 'react';
-import { Dropdown, DropdownToggle, DropdownGroup, DropdownItem, DropdownSeparator } from '@patternfly/react-core';
+import { Dropdown, DropdownToggle, DropdownGroup, DropdownItem } from '@patternfly/react-core';
 
 class GroupedDropdown extends React.Component {
   constructor(props) {
@@ -242,12 +240,8 @@ import {
   Dropdown,
   DropdownToggle,
   DropdownItem,
-  DropdownSeparator,
-  DropdownPosition,
-  DropdownDirection,
-  KebabToggle
+  DropdownSeparator
 } from '@patternfly/react-core';
-import ThIcon from '@patternfly/react-icons/dist/js/icons/th-icon';
 
 class DisabledDropdown extends React.Component {
   constructor(props) {
@@ -310,11 +304,8 @@ import {
   Dropdown,
   DropdownToggle,
   DropdownItem,
-  DropdownSeparator,
-  DropdownPosition,
-  DropdownDirection
+  DropdownSeparator
 } from '@patternfly/react-core';
-import ThIcon from '@patternfly/react-icons/dist/js/icons/th-icon';
 import CaretDownIcon from '@patternfly/react-icons/dist/js/icons/caret-down-icon';
 
 class PrimaryDropdown extends React.Component {
@@ -384,11 +375,8 @@ import {
   DropdownToggle,
   DropdownItem,
   DropdownSeparator,
-  DropdownPosition,
-  DropdownDirection,
-  KebabToggle
+  DropdownPosition
 } from '@patternfly/react-core';
-import ThIcon from '@patternfly/react-icons/dist/js/icons/th-icon';
 
 class PositionRightDropdown extends React.Component {
   constructor(props) {
@@ -453,12 +441,8 @@ import {
   Dropdown,
   DropdownToggle,
   DropdownItem,
-  DropdownSeparator,
-  DropdownPosition,
-  DropdownDirection,
-  KebabToggle
+  DropdownSeparator
 } from '@patternfly/react-core';
-import ThIcon from '@patternfly/react-icons/dist/js/icons/th-icon';
 
 class AlignmentsDropdown extends React.Component {
   constructor(props) {
@@ -530,11 +514,8 @@ import {
   DropdownToggle,
   DropdownItem,
   DropdownSeparator,
-  DropdownPosition,
-  DropdownDirection,
-  KebabToggle
+  DropdownDirection
 } from '@patternfly/react-core';
-import ThIcon from '@patternfly/react-icons/dist/js/icons/th-icon';
 
 class DirectionUpDropdown extends React.Component {
   constructor(props) {
@@ -596,14 +577,10 @@ class DirectionUpDropdown extends React.Component {
 import React from 'react';
 import {
   Dropdown,
-  DropdownToggle,
   DropdownItem,
   DropdownSeparator,
-  DropdownPosition,
-  DropdownDirection,
   KebabToggle
 } from '@patternfly/react-core';
-import ThIcon from '@patternfly/react-icons/dist/js/icons/th-icon';
 
 class KebabDropdown extends React.Component {
   constructor(props) {
@@ -666,15 +643,9 @@ class KebabDropdown extends React.Component {
 import React from 'react';
 import {
   Dropdown,
-  DropdownToggle,
   DropdownItem,
-  DropdownSeparator,
-  DropdownPosition,
-  DropdownDirection,
   BadgeToggle
 } from '@patternfly/react-core';
-import ThIcon from '@patternfly/react-icons/dist/js/icons/th-icon';
-import CaretDownIcon from '@patternfly/react-icons/dist/js/icons/caret-down-icon';
 import AngleLeftIcon from '@patternfly/react-icons/dist/js/icons/angle-left-icon';
 
 class BadgeDropdown extends React.Component {
@@ -737,10 +708,7 @@ import {
   Dropdown,
   DropdownToggle,
   DropdownItem,
-  DropdownSeparator,
-  DropdownPosition,
-  DropdownDirection,
-  KebabToggle
+  DropdownSeparator
 } from '@patternfly/react-core';
 import ThIcon from '@patternfly/react-icons/dist/js/icons/th-icon';
 
@@ -812,12 +780,8 @@ import {
   DropdownToggle,
   DropdownToggleCheckbox,
   DropdownItem,
-  DropdownSeparator,
-  DropdownPosition,
-  DropdownDirection,
-  KebabToggle
+  DropdownSeparator
 } from '@patternfly/react-core';
-import ThIcon from '@patternfly/react-icons/dist/js/icons/th-icon';
 
 class SplitButtonDropdown extends React.Component {
   constructor(props) {
@@ -890,12 +854,8 @@ import {
   DropdownToggle,
   DropdownToggleCheckbox,
   DropdownItem,
-  DropdownSeparator,
-  DropdownPosition,
-  DropdownDirection,
-  KebabToggle
+  DropdownSeparator
 } from '@patternfly/react-core';
-import ThIcon from '@patternfly/react-icons/dist/js/icons/th-icon';
 
 class SplitButtonDropdown extends React.Component {
   constructor(props) {
@@ -964,12 +924,8 @@ import {
   DropdownToggle,
   DropdownToggleCheckbox,
   DropdownItem,
-  DropdownSeparator,
-  DropdownPosition,
-  DropdownDirection,
-  KebabToggle
+  DropdownSeparator
 } from '@patternfly/react-core';
-import ThIcon from '@patternfly/react-icons/dist/js/icons/th-icon';
 class SplitButtonDropdown extends React.Component {
   constructor(props) {
     super(props);
@@ -1046,12 +1002,8 @@ import {
   DropdownToggle,
   DropdownToggleCheckbox,
   DropdownItem,
-  DropdownSeparator,
-  DropdownPosition,
-  DropdownDirection,
-  KebabToggle
+  DropdownSeparator
 } from '@patternfly/react-core';
-import ThIcon from '@patternfly/react-icons/dist/js/icons/th-icon';
 
 class SplitButtonDisabledDropdown extends React.Component {
   constructor(props) {
@@ -1123,13 +1075,8 @@ import {
   Dropdown,
   DropdownToggle,
   DropdownToggleAction,
-  DropdownItem,
-  DropdownSeparator,
-  DropdownPosition,
-  DropdownDirection,
-  KebabToggle
+  DropdownItem
 } from '@patternfly/react-core';
-import ThIcon from '@patternfly/react-icons/dist/js/icons/th-icon';
 import CogIcon from '@patternfly/react-icons/dist/js/icons/cog-icon';
 import BellIcon from '@patternfly/react-icons/dist/js/icons/bell-icon';
 import CubesIcon from '@patternfly/react-icons/dist/js/icons/cubes-icon';
@@ -1239,14 +1186,8 @@ class SplitButtonActionDropdown extends React.Component {
 import React from 'react';
 import {
   Dropdown,
-  DropdownToggle,
-  DropdownItem,
-  DropdownSeparator,
-  DropdownPosition,
-  DropdownDirection,
-  KebabToggle
+  DropdownToggle
 } from '@patternfly/react-core';
-import ThIcon from '@patternfly/react-icons/dist/js/icons/th-icon';
 
 class DropdownPanel extends React.Component {
   constructor(props) {
@@ -1286,17 +1227,11 @@ class DropdownPanel extends React.Component {
 ```js
 import React from 'react';
 import {
-  Button,
   Dropdown,
   DropdownToggle,
-  DropdownItem,
-  DropdownSeparator,
-  DropdownPosition,
-  DropdownDirection,
-  KebabToggle
+  DropdownItem
 } from '@patternfly/react-core';
 import { Link } from '@reach/router';
-import ThIcon from '@patternfly/react-icons/dist/js/icons/th-icon';
 import CaretDownIcon from '@patternfly/react-icons/dist/js/icons/caret-down-icon';
 
 class RouterDropdown extends React.Component {
@@ -1427,13 +1362,8 @@ import React from 'react';
 import {
   Dropdown,
   DropdownToggle,
-  DropdownItem,
-  DropdownSeparator,
-  DropdownPosition,
-  DropdownDirection,
-  KebabToggle
+  DropdownItem
 } from '@patternfly/react-core';
-import ThIcon from '@patternfly/react-icons/dist/js/icons/th-icon';
 import CaretDownIcon from '@patternfly/react-icons/dist/js/icons/caret-down-icon';
 
 class MenuOnDocumentBodyDropdown extends React.Component {
@@ -1488,11 +1418,7 @@ import React from 'react';
 import {
   Dropdown,
   DropdownToggle,
-  DropdownItem,
-  DropdownSeparator,
-  DropdownPosition,
-  DropdownDirection,
-  KebabToggle
+  DropdownItem
 } from '@patternfly/react-core';
 import BellIcon from '@patternfly/react-icons/dist/js/icons/bell-icon';
 import CaretDownIcon from '@patternfly/react-icons/dist/js/icons/caret-down-icon';

--- a/packages/react-core/src/components/OptionsMenu/__tests__/__snapshots__/OptionsMenu.test.tsx.snap
+++ b/packages/react-core/src/components/OptionsMenu/__tests__/__snapshots__/OptionsMenu.test.tsx.snap
@@ -814,6 +814,7 @@ exports[`optionsMenu expanded 1`] = `
                           "onKeyPress",
                         ]
                       }
+                      isAriaDisabled={false}
                       isDisabled={false}
                       isHovered={false}
                       isPlainText={false}
@@ -876,6 +877,7 @@ exports[`optionsMenu expanded 1`] = `
                           "onKeyPress",
                         ]
                       }
+                      isAriaDisabled={false}
                       isDisabled={false}
                       isHovered={false}
                       isPlainText={false}
@@ -942,6 +944,7 @@ exports[`optionsMenu expanded 1`] = `
                           "onKeyPress",
                         ]
                       }
+                      isAriaDisabled={false}
                       isDisabled={true}
                       isHovered={false}
                       isPlainText={false}
@@ -1006,6 +1009,7 @@ exports[`optionsMenu expanded 1`] = `
                           "onKeyPress",
                         ]
                       }
+                      isAriaDisabled={false}
                       isDisabled={false}
                       isHovered={false}
                       isPlainText={false}
@@ -1105,6 +1109,7 @@ exports[`optionsMenu expanded 1`] = `
                           "onKeyPress",
                         ]
                       }
+                      isAriaDisabled={false}
                       isDisabled={false}
                       isHovered={false}
                       isPlainText={false}
@@ -1167,6 +1172,7 @@ exports[`optionsMenu expanded 1`] = `
                           "onKeyPress",
                         ]
                       }
+                      isAriaDisabled={false}
                       isDisabled={false}
                       isHovered={false}
                       isPlainText={false}

--- a/packages/react-integration/demo-app-ts/src/components/demos/DropdownDemo/DropdownDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DropdownDemo/DropdownDemo.tsx
@@ -168,11 +168,13 @@ export class DropdownDemo extends React.Component<{}, DropdownState> {
       </DropdownItem>,
       <DropdownItem
         key="disabled action"
-        isDisabled
+        isAriaDisabled
         component="button"
         onClick={this.incrementCounter}
         onKeyPress={this.incrementCounter}
         id="disabled-button"
+        tooltip="Tooltip for disabled item"
+        tooltipProps={{ position: 'top' }}
       >
         Disabled Action
         {this.state.counter}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5826 

You can see it working in the very first example - one of the disabled items is now using aria-disabled with a simple tooltip.