### PR TITLE
fix(datepicker): change default parse format to y-m-d from y(-m)?(-d)?

### DIFF
--- a/packages/react-core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-core/src/components/DatePicker/DatePicker.tsx
@@ -53,7 +53,7 @@ export const DatePicker: React.FunctionComponent<DatePickerProps> = ({
   className,
   locale = undefined,
   dateFormat = yyyyMMddFormat,
-  dateParse = (val: string) => new Date(`${val}T00:00:00`),
+  dateParse = (val: string) => val.split('-').length === 3 && new Date(`${val}T00:00:00`),
   isDisabled = false,
   placeholder = 'yyyy-MM-dd',
   value: valueProp = '',


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6036

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
