### PR TITLE
fix(TreeView): console warning about uncontrolled inputs when checkbox swaps between determinate/indeterminate

### DIFF
--- a/packages/react-core/src/components/TreeView/TreeView.tsx
+++ b/packages/react-core/src/components/TreeView/TreeView.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { TreeViewList } from './TreeViewList';
-import { TreeViewListItem } from './TreeViewListItem';
+import { TreeViewCheckProps, TreeViewListItem } from './TreeViewListItem';
 import { TreeViewRoot } from './TreeViewRoot';
 
 export interface TreeViewDataItem {
@@ -19,7 +19,7 @@ export interface TreeViewDataItem {
   /** Flag indicating if a tree view item has a checkbox */
   hasCheck?: boolean;
   /** Additional properties of the tree view item checkbox */
-  checkProps?: any;
+  checkProps?: TreeViewCheckProps;
   /** Flag indicating if a tree view item has a badge */
   hasBadge?: boolean;
   /** Optional prop for custom badge */

--- a/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
+++ b/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
@@ -6,7 +6,7 @@ import { TreeViewDataItem } from './TreeView';
 import { Badge } from '../Badge';
 import { GenerateId } from '../../helpers/GenerateId/GenerateId';
 
-interface CheckProps extends Partial<React.InputHTMLAttributes<HTMLInputElement>> {
+export interface TreeViewCheckProps extends Partial<React.InputHTMLAttributes<HTMLInputElement>> {
   checked?: boolean | null;
 }
 
@@ -28,7 +28,7 @@ export interface TreeViewListItemProps {
   /** Flag indicating if a tree view item has a checkbox */
   hasCheck?: boolean;
   /** Additional properties of the tree view item checkbox */
-  checkProps?: CheckProps;
+  checkProps?: TreeViewCheckProps;
   /** Flag indicating if a tree view item has a badge */
   hasBadge?: boolean;
   /** Optional prop for custom badge */
@@ -140,6 +140,7 @@ export const TreeViewListItem: React.FunctionComponent<TreeViewListItemProps> = 
                     onClick={(evt: React.MouseEvent) => evt.stopPropagation()}
                     ref={elem => elem && (elem.indeterminate = checkProps.checked === null)}
                     {...checkProps}
+                    checked={checkProps.checked === null ? false : checkProps.checked}
                     id={randomId}
                     tabIndex={-1}
                   />


### PR DESCRIPTION
This fixes a bug I overlooked when I implemented https://github.com/patternfly/patternfly-react/pull/5150 last year.

In order to show an indeterminate (partially-checked) checkbox in the tree view, we allow a `null` value for the `checkProps.checked` property on a tree view item. We then [use a ref](https://github.com/patternfly/patternfly-react/blob/main/packages/react-core/src/components/TreeView/TreeViewListItem.tsx#L141) to set the `indeterminate` property on the DOM element if `checkProps.checked === null`. This was modeled after [similar behavior](https://github.com/patternfly/patternfly-react/blob/main/packages/react-core/src/components/Checkbox/Checkbox.tsx#L104) in the regular `Checkbox` component.

However, an `<input type="checkbox">` like these must always have a boolean (non-null) value for its `checked` attribute in order for React to recognize it as a [controlled component](https://reactjs.org/docs/uncontrolled-components.html). When this property goes from being a boolean to a null value or vice versa, we get this console warning:

![Screen Shot 2021-07-15 at 3 50 46 PM](https://user-images.githubusercontent.com/811963/125848842-1da56ceb-487e-4a8d-8aa2-92bbda4b4b92.png)

This can be reproduced in https://codesandbox.io/s/77px2 (taken unmodified from https://www.patternfly.org/v4/components/tree-view/#with-checkboxes) by simply checking the "Application 1" item and observing the console. The "Application launcher" parent checkbox goes from being false (controlled) to null (uncontrolled).

In the regular Checkbox component, this warning is avoided by [overriding the `checked` value we pass to the actual input](https://github.com/patternfly/patternfly-react/blob/main/packages/react-core/src/components/Checkbox/Checkbox.tsx#L93) to be `false` even if the `isChecked` prop is null so that even when the checkbox is indeterminate, React sees its value as controlled. I neglected to do that in the tree view version of this feature, so this PR corrects that. I also noticed that the type for `checkProps` in TreeView was `any`, which is inconsistent with the matching prop on TreeViewListItem, so I fixed that by exporting the interface (and giving it a TreeView-specific name in case anyone would try to import it elsewhere).

As an aside, the fact that we can't express an indeterminate checkbox with a simple HTML attribute is bananas.