### PR TITLE
feat(SearchInput): Allow passing custom form elements after the attributes

### DIFF
--- a/packages/react-core/src/components/SearchInput/SearchInput.tsx
+++ b/packages/react-core/src/components/SearchInput/SearchInput.tsx
@@ -29,6 +29,9 @@ export interface SearchInputProps extends Omit<React.HTMLProps<HTMLDivElement>, 
   value?: string;
   /** Array of attribute values */
   attributes?: string[] | SearchAttribute[];
+  /* Additional elements added after the attributes in the form.
+   * The new form elements can be wrapped in a FormGroup component for automatic formatting */
+  formAdditionalItems?: React.ReactNode;
   /** Attribute label for strings unassociated with one of the provided listed attributes */
   hasWordsAttrLabel?: string;
   /** Delimiter in the query string for pairing attributes with search values.
@@ -71,6 +74,7 @@ const SearchInputBase: React.FunctionComponent<SearchInputProps> = ({
   className,
   value = '',
   attributes = [] as string[],
+  formAdditionalItems,
   hasWordsAttrLabel = 'Has words',
   advancedSearchDelimiter,
   placeholder,
@@ -350,6 +354,7 @@ const SearchInputBase: React.FunctionComponent<SearchInputProps> = ({
           <div className={styles.searchInputMenuBody}>
             <Form>
               {buildFormGroups()}
+              {formAdditionalItems ? formAdditionalItems : null}
               <ActionGroup>
                 <Button variant="primary" type="submit" onClick={onSearchHandler}>
                   {submitSearchButtonLabel}

--- a/packages/react-core/src/components/SearchInput/__tests__/SearchInput.test.tsx
+++ b/packages/react-core/src/components/SearchInput/__tests__/SearchInput.test.tsx
@@ -52,6 +52,7 @@ test('advanced search', () => {
   const view = mount(
     <SearchInput
       attributes={[{attr:"username", display:"Username"}, {attr: "firstname", display: "First name"}]}
+      advancedSearchDelimiter=":"
       value='username:player firstname:john'
       onChange={props.onChange}
       onSearch={props.onSearch}
@@ -67,6 +68,7 @@ test('advanced search with custom attributes', () => {
   const view = mount(
     <SearchInput
       attributes={[{attr:"username", display:"Username"}, {attr: "firstname", display: "First name"}]}
+      advancedSearchDelimiter=":"
       formAdditionalItems={<FormGroup><Button variant="link" isInline icon={<ExternalLinkSquareAltIcon />} iconPosition="right">Link</Button></FormGroup>}
       value='username:player firstname:john'
       onChange={props.onChange}

--- a/packages/react-core/src/components/SearchInput/__tests__/SearchInput.test.tsx
+++ b/packages/react-core/src/components/SearchInput/__tests__/SearchInput.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { SearchInput } from '../SearchInput';
+import { SearchInput, FormGroup, Button, ExternalLinkSquareAltIcon } from '../SearchInput';
 
 
 const props = {
@@ -63,5 +63,18 @@ test('advanced search', () => {
   expect(view.find('input')).toMatchSnapshot();
 });
 
-
-
+test('advanced search with custom attributes', () => {
+  const view = mount(
+    <SearchInput
+      attributes={[{attr:"username", display:"Username"}, {attr: "firstname", display: "First name"}]}
+      formAdditionalItems={<FormGroup><Button variant="link" isInline icon={<ExternalLinkSquareAltIcon />} iconPosition="right">Link</Button></FormGroup>}
+      value='username:player firstname:john'
+      onChange={props.onChange}
+      onSearch={props.onSearch}
+      onClear={props.onClear}
+    />
+  );
+  view.find('.pf-c-button').at(2).simulate('click', {});
+  expect(props.onSearch).toBeCalled();
+  expect(view.find('input')).toMatchSnapshot();
+});

--- a/packages/react-core/src/components/SearchInput/__tests__/__snapshots__/SearchInput.test.tsx.snap
+++ b/packages/react-core/src/components/SearchInput/__tests__/__snapshots__/SearchInput.test.tsx.snap
@@ -10,6 +10,16 @@ exports[`advanced search 1`] = `
 />
 `;
 
+exports[`advanced search with custom attributes 1`] = `
+<input
+  aria-label="Search input"
+  className="pf-c-search-input__text-input"
+  disabled={false}
+  onChange={[Function]}
+  value="username:player firstname:john"
+/>
+`;
+
 exports[`navigable search results 1`] = `
 <span
   className="pf-c-search-input__nav"

--- a/packages/react-core/src/components/SearchInput/examples/SearchInput.md
+++ b/packages/react-core/src/components/SearchInput/examples/SearchInput.md
@@ -6,6 +6,7 @@ propComponents: ['SearchInput', 'SearchAttribute']
 beta: true
 ---
 import { SearchInput } from '@patternfly/react-core';
+import { ExternalLinkSquareAltIcon } from '@patternfly/react-icons';
 
 ## Examples
 ### Basic
@@ -97,14 +98,14 @@ class SearchInputWithNavigableOptions extends React.Component {
       resultsCount: 0,
       currentResult: 1
     };
-  
+
     this.onChange = (value, event) => {
       this.setState({
         value: value,
         resultsCount: 3
       });
     };
-    
+
     this.onClear = (event) => {
       this.setState({
         value: '',
@@ -112,26 +113,26 @@ class SearchInputWithNavigableOptions extends React.Component {
         currentResult: 1
       });
     }
-    
+
     this.onNext = (event) => {
       this.setState(prevState => {
         const newCurrentResult = prevState.currentResult + 1;
         return {
           currentResult: newCurrentResult <= prevState.resultsCount ? newCurrentResult : prevState.resultsCount
-        } 
+        }
       });
     }
-    
+
     this.onPrevious = (event) => {
       this.setState(prevState => {
         const newCurrentResult = prevState.currentResult - 1;
         return {
-          currentResult: newCurrentResult > 0 ? newCurrentResult : 1 
+          currentResult: newCurrentResult > 0 ? newCurrentResult : 1
         }
       });
     }
   }
-  
+
   render() {
     return (
       <SearchInput
@@ -173,63 +174,51 @@ TextInputSelectAll = () => {
 ### Advanced
 ```js
 import React from 'react';
-import { Checkbox, SearchInput } from '@patternfly/react-core';
+import { Button, Checkbox, FormGroup, SearchInput } from '@patternfly/react-core';
+import ExternalLinkSquareAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-square-alt-icon';
 
-class AdvancedSearchInput extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      value: 'username:player firstname:john',
-      useEqualsAsDelimiter: false,
-    };
-    
-    this.toggleDelimiter = checked => {
-      this.setState(prevState => {
-        const newValue = prevState.value.replace(/:|=/g, checked ? "=" : ':' );
-        return {
-          useEqualsAsDelimiter: checked,
-          value: newValue
-          }
-      });
-    };
+AdvancedSearchInput = () => {
+  const [value, setValue] = React.useState('username:player firstname:john');
+  const [useEqualsAsDelimiter, setUseEqualsAsDelimiter] = React.useState(false);
+  const [showLink, setShowLink] = React.useState(false);
+  const [useCustomFooter, setUseCustomFooter] = React.useState(false);
 
-    this.onChange = (value) => {
-      this.setState({
-        value: value
-      });
-    };
-    
-    this.onSearch = (value, event, attrValueMap) => {
-      this.setState({
-        value: value
-      });
-      console.log(attrValueMap);
-    }
-  }
+  const toggleDelimiter = checked => {
+      const newValue = value.replace(/:|=/g, checked ? "=" : ':' );
+      setUseEqualsAsDelimiter(checked);
+      setValue(newValue);
+  };
 
-  render() {
-    return (
-      <>
-        <Checkbox
-          label="Use equal sign as search attribute delimiter"
-          isChecked={this.state.useEqualsAsDelimiter}
-          onChange={this.toggleDelimiter}
-          aria-label="change delimiter checkbox"
-          id="toggle-delimiter"
-          name="toggle-delimiter"
-        /> 
-        <br />
-        <SearchInput
-          attributes={[{attr:"username", display:"Username"}, {attr: "firstname", display: "First name"}]}
-          advancedSearchDelimiter={this.state.useEqualsAsDelimiter ? '=' : ':'}
-          value={this.state.value}
-          onChange={this.onChange}
-          onSearch={this.onSearch}
-          onClear={(evt) => this.onChange('', evt)}
-        />
-      </>
-    );
-  }
-}
+  return (
+    <>
+      <Checkbox
+        label="Use equal sign as search attribute delimiter"
+        isChecked={useEqualsAsDelimiter}
+        onChange={toggleDelimiter}
+        aria-label="change delimiter checkbox"
+        id="toggle-delimiter"
+        name="toggle-delimiter"
+      />
+      <Checkbox
+        label="Add custom footer element after the attributes in the menu"
+        isChecked={useCustomFooter}
+        onChange={value => setUseCustomFooter(value)}
+        aria-label="change use custom footer checkbox"
+        id="toggle-custom-footer"
+        name="toggle-custom-footer"
+      />
+      <br />
+      <SearchInput
+        attributes={[{attr:"username", display:"Username"}, {attr: "firstname", display: "First name"}]}
+        advancedSearchDelimiter={useEqualsAsDelimiter ? '=' : ':'}
+        value={value}
+        onChange={setValue}
+        onSearch={setValue}
+        onClear={() => setValue('')}
+        formAdditionalItems={useCustomFooter ? <FormGroup><Button variant="link" isInline icon={<ExternalLinkSquareAltIcon />} iconPosition="right">Link</Button></FormGroup> : null}
+      />
+    </>
+  );
+};
 
 ```


### PR DESCRIPTION
Can be used to link to docs pages for example.

This is for cockpit, we want to use it like this:
![Screen Shot 2021-07-16 at 10 17 08](https://user-images.githubusercontent.com/14921356/125915917-994cae95-e2e8-4fe6-9c1f-6a2472c7db55.png)

See the last item, it's basically the docs link and and CopyClipboard with the CLI command equivalent generated by the user's input.