### PR TITLE
feat(Form): add form group label info & docs(Form): add password strength demo

### DIFF
--- a/packages/react-core/src/components/Form/FormGroup.tsx
+++ b/packages/react-core/src/components/Form/FormGroup.tsx
@@ -11,6 +11,8 @@ export interface FormGroupProps extends Omit<React.HTMLProps<HTMLDivElement>, 'l
   className?: string;
   /** Label text before the field. */
   label?: React.ReactNode;
+  /** Additional label information displayed after the label. */
+  labelInfo?: React.ReactNode;
   /** Sets an icon for the label. For providing additional context. Host element for Popover  */
   labelIcon?: React.ReactElement;
   /** Sets the FormGroup required. */
@@ -45,6 +47,7 @@ export const FormGroup: React.FunctionComponent<FormGroupProps> = ({
   children = null,
   className = '',
   label,
+  labelInfo,
   labelIcon,
   isRequired = false,
   validated = 'default',
@@ -93,23 +96,40 @@ export const FormGroup: React.FunctionComponent<FormGroupProps> = ({
   const helperTextToDisplay =
     validated === ValidatedOptions.error && helperTextInvalid ? inValidHelperText : showValidHelperTxt(validated);
 
+  const labelContent = (
+    <React.Fragment>
+      <label className={css(styles.formLabel)} htmlFor={fieldId}>
+        <span className={css(styles.formLabelText)}>{label}</span>
+        {isRequired && (
+          <span className={css(styles.formLabelRequired)} aria-hidden="true">
+            {' '}
+            {ASTERISK}
+          </span>
+        )}
+      </label>{' '}
+      {React.isValidElement(labelIcon) && labelIcon}
+    </React.Fragment>
+  );
+
   return (
     <div {...props} className={css(styles.formGroup, className)}>
       {label && (
-        <div className={css(styles.formGroupLabel, hasNoPaddingTop && styles.modifiers.noPaddingTop)}>
-          <label className={css(styles.formLabel)} htmlFor={fieldId}>
-            <span className={css(styles.formLabelText)}>{label}</span>
-            {isRequired && (
-              <span className={css(styles.formLabelRequired)} aria-hidden="true">
-                {' '}
-                {ASTERISK}
-              </span>
-            )}
-          </label>{' '}
-          {React.isValidElement(labelIcon) && labelIcon}
+        <div
+          className={css(
+            styles.formGroupLabel,
+            labelInfo && styles.modifiers.info,
+            hasNoPaddingTop && styles.modifiers.noPaddingTop
+          )}
+        >
+          {labelInfo && (
+            <React.Fragment>
+              <div className={css(styles.formGroupLabelMain)}>{labelContent}</div>
+              <div className={css(styles.formGroupLabelInfo)}>{labelInfo}</div>
+            </React.Fragment>
+          )}
+          {!labelInfo && labelContent}
         </div>
       )}
-
       <div
         className={css(styles.formGroupControl, isInline && styles.modifiers.inline, isStack && styles.modifiers.stack)}
       >

--- a/packages/react-core/src/components/Form/FormHelperText.tsx
+++ b/packages/react-core/src/components/Form/FormHelperText.tsx
@@ -13,6 +13,8 @@ export interface FormHelperTextProps extends React.HTMLProps<HTMLDivElement> {
   className?: string;
   /** Icon displayed to the left of the helper text. */
   icon?: React.ReactNode;
+  /** Component type of the Form Helper Text */
+  component?: 'p' | 'div';
 }
 
 export const FormHelperText: React.FunctionComponent<FormHelperTextProps> = ({
@@ -21,19 +23,23 @@ export const FormHelperText: React.FunctionComponent<FormHelperTextProps> = ({
   isHidden = true,
   className = '',
   icon = null,
+  component = 'p',
   ...props
-}: FormHelperTextProps) => (
-  <p
-    className={css(
-      styles.formHelperText,
-      isError && styles.modifiers.error,
-      isHidden && styles.modifiers.hidden,
-      className
-    )}
-    {...props}
-  >
-    {icon && <span className={css(styles.formHelperTextIcon)}>{icon}</span>}
-    {children}
-  </p>
-);
+}: FormHelperTextProps) => {
+  const Component = component as any;
+  return (
+    <Component
+      className={css(
+        styles.formHelperText,
+        isError && styles.modifiers.error,
+        isHidden && styles.modifiers.hidden,
+        className
+      )}
+      {...props}
+    >
+      {icon && <span className={css(styles.formHelperTextIcon)}>{icon}</span>}
+      {children}
+    </Component>
+  );
+};
 FormHelperText.displayName = 'FormHelperText';

--- a/packages/react-core/src/components/Form/FormHelperText.tsx
+++ b/packages/react-core/src/components/Form/FormHelperText.tsx
@@ -13,7 +13,7 @@ export interface FormHelperTextProps extends React.HTMLProps<HTMLDivElement> {
   className?: string;
   /** Icon displayed to the left of the helper text. */
   icon?: React.ReactNode;
-  /** Component type of the Form Helper Text */
+  /** Component type of the form helper text */
   component?: 'p' | 'div';
 }
 

--- a/packages/react-core/src/components/Form/__tests__/FormGroup.test.tsx
+++ b/packages/react-core/src/components/Form/__tests__/FormGroup.test.tsx
@@ -53,6 +53,15 @@ describe('FormGroup component', () => {
     expect(view).toMatchSnapshot();
   });
 
+  test('should render form group with additonal label info', () => {
+    const view = mount(
+      <FormGroup fieldId="id" label={<h1>Header</h1>} labelInfo="more info">
+        <input aria-label="input" />
+      </FormGroup>
+    );
+    expect(view).toMatchSnapshot();
+  });
+
   test('should render form group variant with function label', () => {
     const view = mount(
       <FormGroup fieldId="id" label={returnFunction()}>

--- a/packages/react-core/src/components/Form/__tests__/__snapshots__/FormGroup.test.tsx.snap
+++ b/packages/react-core/src/components/Form/__tests__/__snapshots__/FormGroup.test.tsx.snap
@@ -517,6 +517,56 @@ exports[`FormGroup component should render form group variant without label 1`] 
 </FormGroup>
 `;
 
+exports[`FormGroup component should render form group with additonal label info 1`] = `
+<FormGroup
+  fieldId="id"
+  label={
+    <h1>
+      Header
+    </h1>
+  }
+  labelInfo="more info"
+>
+  <div
+    className="pf-c-form__group"
+  >
+    <div
+      className="pf-c-form__group-label pf-m-info"
+    >
+      <div
+        className="pf-c-form__group-label-main"
+      >
+        <label
+          className="pf-c-form__label"
+          htmlFor="id"
+        >
+          <span
+            className="pf-c-form__label-text"
+          >
+            <h1>
+              Header
+            </h1>
+          </span>
+        </label>
+         
+      </div>
+      <div
+        className="pf-c-form__group-label-info"
+      >
+        more info
+      </div>
+    </div>
+    <div
+      className="pf-c-form__group-control"
+    >
+      <input
+        aria-label="input"
+      />
+    </div>
+  </div>
+</FormGroup>
+`;
+
 exports[`FormGroup component should render helper text above input 1`] = `
 <Form
   isHorizontal={true}

--- a/packages/react-core/src/components/Form/examples/Form.md
+++ b/packages/react-core/src/components/Form/examples/Form.md
@@ -649,6 +649,91 @@ class HorizontalFormHelperTextOnTop extends React.Component {
 }
 ```
 
+### Form group with additional label info
+
+```js
+import React from 'react';
+import { Form, FormGroup, TextInput, Popover } from '@patternfly/react-core';
+import HelpIcon from '@patternfly/react-icons/dist/js/icons/help-icon';
+
+class FormGroupLabelInfo extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      value1: ''
+    };
+    this.handleTextInputChange1 = value1 => {
+      this.setState({ value1 });
+    };
+  }
+
+  render() {
+    const { value1 } = this.state;
+
+    return (
+      <Form>
+        <FormGroup
+          label="Name"
+          labelInfo="Additional label info"
+          labelIcon={
+            <Popover
+              headerContent={
+                <div>
+                  The{' '}
+                  <a href="https://schema.org/name" target="_blank">
+                    name
+                  </a>{' '}
+                  of a{' '}
+                  <a href="https://schema.org/Person" target="_blank">
+                    Person
+                  </a>
+                </div>
+              }
+              bodyContent={
+                <div>
+                  Often composed of{' '}
+                  <a href="https://schema.org/givenName" target="_blank">
+                    givenName
+                  </a>{' '}
+                  and{' '}
+                  <a href="https://schema.org/familyName" target="_blank">
+                    familyName
+                  </a>
+                  .
+                </div>
+              }
+            >
+              <button
+                type="button"
+                aria-label="More info for name field"
+                onClick={e => e.preventDefault()}
+                aria-describedby="form-group-label-info"
+                className="pf-c-form__group-label-help"
+              >
+                <HelpIcon noVerticalAlign />
+              </button>
+            </Popover>
+          }
+          isRequired
+          fieldId="form-group-label-info"
+          helperText="Please provide your full name"
+        >
+          <TextInput
+            isRequired
+            type="text"
+            id="form-group-label-info"
+            name="form-group-label-info"
+            aria-describedby="form-group-label-info-helper"
+            value={value1}
+            onChange={this.handleTextInputChange1}
+          />
+        </FormGroup>
+      </Form>
+    );
+  }
+}
+```
+
 ### Form Sections
 
 ```js
@@ -660,7 +745,7 @@ class FormSections extends React.Component {
     super(props);
     this.state = {
       value1: '',
-      value2: '',
+      value2: ''
     };
     this.handleTextInputChange1 = value1 => {
       this.setState({ value1 });
@@ -738,40 +823,35 @@ class SimpleForm extends React.Component {
       <Form>
         <Grid hasGutter md={6}>
           <GridItem span={12}>
-            <FormGroup
-              label="Name"
-              isRequired
-              fieldId="simple-form-name-01"
-              helperText="Please provide your full name"
-            >
+            <FormGroup label="Name" isRequired fieldId="grid-form-name-01" helperText="Please provide your full name">
               <TextInput
                 isRequired
                 type="text"
-                id="simple-form-name-01"
-                name="simple-form-name-01"
-                aria-describedby="simple-form-name-01-helper"
+                id="grid-form-name-01"
+                name="grid-form-name-01"
+                aria-describedby="grid-form-name-01-helper"
                 value={value1}
                 onChange={this.handleTextInputChange1}
               />
             </FormGroup>
           </GridItem>
-          <FormGroup label="Email" isRequired fieldId="simple-form-email-01">
+          <FormGroup label="Email" isRequired fieldId="grid-form-email-01">
             <TextInput
               isRequired
               type="email"
-              id="simple-form-email-01"
-              name="simple-form-email-01"
+              id="grid-form-email-01"
+              name="grid-form-email-01"
               value={value2}
               onChange={this.handleTextInputChange2}
             />
           </FormGroup>
-          <FormGroup label="Phone number" isRequired fieldId="simple-form-number-01">
+          <FormGroup label="Phone number" isRequired fieldId="grid-form-number-01">
             <TextInput
               isRequired
               type="tel"
-              id="simple-form-number-01"
+              id="grid-form-number-01"
               placeholder="555-555-5555"
-              name="simple-form-number-01"
+              name="grid-form-number-01"
               value={value3}
               onChange={this.handleTextInputChange3}
             />
@@ -787,7 +867,15 @@ class SimpleForm extends React.Component {
 
 ```js
 import React from 'react';
-import { Form, FormGroup, FormFieldGroup, FormFieldGroupExpandable, FormFieldGroupHeader, TextInput, Button } from '@patternfly/react-core';
+import {
+  Form,
+  FormGroup,
+  FormFieldGroup,
+  FormFieldGroupExpandable,
+  FormFieldGroupHeader,
+  TextInput,
+  Button
+} from '@patternfly/react-core';
 import TrashIcon from '@patternfly/react-icons/dist/js/icons/trash-icon';
 
 class FieldGroups extends React.Component {
@@ -877,7 +965,7 @@ class FieldGroups extends React.Component {
           toggleAriaLabel="Details"
           header={
             <FormFieldGroupHeader
-              titleText={{text: "Field group 1", id: "field-group1-titleText-id"}}
+              titleText={{ text: 'Field group 1', id: 'field-group1-titleText-id' }}
               titleDescription="Field group 1 description text."
               actions={
                 <>
@@ -892,7 +980,7 @@ class FieldGroups extends React.Component {
             toggleAriaLabel="Details"
             header={
               <FormFieldGroupHeader
-                titleText={{text: "Nested field group 1", id: "nested-field-group1-titleText-id"}}
+                titleText={{ text: 'Nested field group 1', id: 'nested-field-group1-titleText-id' }}
                 titleDescription="Nested field group 1 description text."
                 actions={
                   <Button variant="plain" aria-label="Remove">
@@ -929,7 +1017,7 @@ class FieldGroups extends React.Component {
             toggleAriaLabel="Details"
             header={
               <FormFieldGroupHeader
-                titleText={{text: "Nested field group 2", id: "nested-field-group2-titleText-id"}}
+                titleText={{ text: 'Nested field group 2', id: 'nested-field-group2-titleText-id' }}
                 actions={
                   <Button variant="plain" aria-label="Remove">
                     <TrashIcon />
@@ -965,7 +1053,7 @@ class FieldGroups extends React.Component {
             toggleAriaLabel="Details"
             header={
               <FormFieldGroupHeader
-                titleText={{text: "Nested field group 3", id: "nested-field-group3-titleText-id"}}
+                titleText={{ text: 'Nested field group 3', id: 'nested-field-group3-titleText-id' }}
                 titleDescription="Field group 3 description text."
                 actions={
                   <Button variant="plain" aria-label="Remove">
@@ -1020,7 +1108,7 @@ class FieldGroups extends React.Component {
           >
             <TextInput
               isRequired
-            id="form-expandable-field-groupsform-expandable-field-groups-field-group1-label2"
+              id="form-expandable-field-groupsform-expandable-field-groups-field-group1-label2"
               name="form-expandable-field-groupsform-expandable-field-groups-field-group1-label2"
               value={value10}
               onChange={value => {
@@ -1033,7 +1121,7 @@ class FieldGroups extends React.Component {
           toggleAriaLabel="Details"
           header={
             <FormFieldGroupHeader
-              titleText={{text: "Field group 2", id: "field-group2-titleText-id"}}
+              titleText={{ text: 'Field group 2', id: 'field-group2-titleText-id' }}
               titleDescription="Field group 2 description text."
               actions={
                 <>
@@ -1069,7 +1157,12 @@ class FieldGroups extends React.Component {
         <FormFieldGroupExpandable
           isExpanded
           toggleAriaLabel="Details"
-          header={<FormFieldGroupHeader titleText={{text: "Field group 3", id: "field-group3-titleText-id"}} titleDescription="Field group 3 description text." />}
+          header={
+            <FormFieldGroupHeader
+              titleText={{ text: 'Field group 3', id: 'field-group3-titleText-id' }}
+              titleDescription="Field group 3 description text."
+            />
+          }
         >
           <FormGroup label="Label 1" isRequired fieldId="form-expandable-field-group3-label1">
             <TextInput
@@ -1093,7 +1186,16 @@ class FieldGroups extends React.Component {
               }}
             />
           </FormGroup>
-          <FormFieldGroup header={<FormFieldGroupHeader titleText={{text: "Nested field group 1 (non-expandable)", id: "nested-field-group1-non-expandable-titleText-id"}} />}>
+          <FormFieldGroup
+            header={
+              <FormFieldGroupHeader
+                titleText={{
+                  text: 'Nested field group 1 (non-expandable)',
+                  id: 'nested-field-group1-non-expandable-titleText-id'
+                }}
+              />
+            }
+          >
             <FormGroup label="Label 1" isRequired fieldId="form-expandable-field-groups-field-group7-label1">
               <TextInput
                 isRequired
@@ -1120,7 +1222,10 @@ class FieldGroups extends React.Component {
           <FormFieldGroup
             header={
               <FormFieldGroupHeader
-                titleText={{text: "Nested field group 2 (non-expandable)", id: "nested-field-group2-non-expandable-titleText-id"}}
+                titleText={{
+                  text: 'Nested field group 2 (non-expandable)',
+                  id: 'nested-field-group2-non-expandable-titleText-id'
+                }}
                 titleDescription="Field group 2 description text."
               />
             }
@@ -1152,7 +1257,7 @@ class FieldGroups extends React.Component {
         <FormFieldGroup
           header={
             <FormFieldGroupHeader
-              titleText={{text: "Field group 4 (non-expandable)", id: "field-group4-non-expandable-titleText-id"}}
+              titleText={{ text: 'Field group 4 (non-expandable)', id: 'field-group4-non-expandable-titleText-id' }}
               titleDescription="Field group 4 description text."
               actions={
                 <>
@@ -1162,7 +1267,11 @@ class FieldGroups extends React.Component {
             />
           }
         >
-          <FormGroup label="Label 1" isRequired fieldId="form-expandable-field-groupsform-expandable-field-groups-field-group10-label1">
+          <FormGroup
+            label="Label 1"
+            isRequired
+            fieldId="form-expandable-field-groupsform-expandable-field-groups-field-group10-label1"
+          >
             <TextInput
               isRequired
               id="form-expandable-field-groupsform-expandable-field-groups-field-group10-label1"
@@ -1173,7 +1282,11 @@ class FieldGroups extends React.Component {
               }}
             />
           </FormGroup>
-          <FormGroup label="Label 2" isRequired fieldId="form-expandable-field-groupsform-expandable-field-groups-field-group10-label2">
+          <FormGroup
+            label="Label 2"
+            isRequired
+            fieldId="form-expandable-field-groupsform-expandable-field-groups-field-group10-label2"
+          >
             <TextInput
               isRequired
               id="form-expandable-field-groupsform-expandable-field-groups-field-group10-label2"

--- a/packages/react-core/src/components/TextInput/TextInput.tsx
+++ b/packages/react-core/src/components/TextInput/TextInput.tsx
@@ -203,7 +203,7 @@ export class TextInputBase extends React.Component<TextInputProps, TextInputStat
         onChange={this.handleChange}
         type={type}
         value={value}
-        aria-invalid={validated === ValidatedOptions.error}
+        aria-invalid={props['aria-invalid'] ? props['aria-invalid'] : validated === ValidatedOptions.error}
         required={isRequired}
         disabled={isDisabled}
         readOnly={isReadOnly}

--- a/packages/react-core/src/demos/PasswordStrength.md
+++ b/packages/react-core/src/demos/PasswordStrength.md
@@ -12,6 +12,8 @@ import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-
 
 ### Basic validation
 
+Note, the validation and password strength rules are only examples, demonstrating the changes in the UI when certain conditions are met. Currently the password strength is determined by how often validation rules are met.
+
 ```js
 import React from 'react';
 import {

--- a/packages/react-core/src/demos/PasswordStrength.md
+++ b/packages/react-core/src/demos/PasswordStrength.md
@@ -12,7 +12,7 @@ import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-
 
 ### Basic validation
 
-Note, the validation and password strength rules are only examples, demonstrating the changes in the UI when certain conditions are met. Currently the password strength is determined by how often validation rules are met.
+Note, the validation and password strength rules are only examples, demonstrating the changes in the UI when certain conditions are met. We expect consumers will substitute their own, more robust, validation algorithm. In this demo the password strength is determined by how often validation rules are met. A good open-source password strength estimator, recommended by InfoSec, can be found here: https://github.com/dropbox/zxcvbn
 
 ```js
 import React from 'react';

--- a/packages/react-core/src/demos/PasswordStrength.md
+++ b/packages/react-core/src/demos/PasswordStrength.md
@@ -146,21 +146,24 @@ class PasswordStrengthDemo extends React.Component {
             id="password-field"
             name="password-field"
             aria-describedby="password-field-helper"
+            aria-invalid={ruleLength === 'error' || ruleContent === 'error' || ruleCharacters === 'error'}
             value={password}
             onChange={this.handlePasswordInput}
           />
           <FormHelperText isHidden={false} component="div">
-            <HelperText component="ul">
-              <HelperTextItem isDynamic variant={ruleLength} component="li">
-                Must be at least 14 characters
-              </HelperTextItem>
-              <HelperTextItem isDynamic variant={ruleContent} component="li">
-                Cannot contain the word "redhat"
-              </HelperTextItem>
-              <HelperTextItem isDynamic variant={ruleCharacters} component="li">
-                Must include at least 3 of the following: lowercase letter, uppercase letters, numbers, symbols
-              </HelperTextItem>
-            </HelperText>
+            <div aria-live="polite">
+              <HelperText component="ul" id="password-field-helper">
+                <HelperTextItem isDynamic variant={ruleLength} component="li">
+                  Must be at least 14 characters
+                </HelperTextItem>
+                <HelperTextItem isDynamic variant={ruleContent} component="li">
+                  Cannot contain the word "redhat"
+                </HelperTextItem>
+                <HelperTextItem isDynamic variant={ruleCharacters} component="li">
+                  Must include at least 3 of the following: lowercase letter, uppercase letters, numbers, symbols
+                </HelperTextItem>
+              </HelperText>
+            </div>
           </FormHelperText>
         </FormGroup>
       </Form>

--- a/packages/react-core/src/demos/PasswordStrength.md
+++ b/packages/react-core/src/demos/PasswordStrength.md
@@ -1,0 +1,166 @@
+---
+id: Password strength
+section: demos
+---
+
+import HelpIcon from '@patternfly/react-icons/dist/js/icons/help-icon';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
+import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
+
+## Demos
+
+### Basic validation
+
+```js
+import React from 'react';
+import {
+  Form,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  Popover,
+  HelperTextItem,
+  TextInput
+} from '@patternfly/react-core';
+import HelpIcon from '@patternfly/react-icons/dist/js/icons/help-icon';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
+import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
+
+class PasswordStrengthDemo extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      password: '',
+      ruleLength: 'indeterminate',
+      ruleContent: 'indeterminate',
+      ruleCharacters: 'indeterminate',
+      passStrength: { variant: 'error', icon: <ExclamationCircleIcon />, text: 'Weak' }
+    };
+
+    this.handlePasswordInput = password => {
+      this.setState({ password });
+      this.validate(password);
+    };
+
+    this.validate = password => {
+      if (password === '') {
+        this.setState({
+          ruleLength: 'indeterminate',
+          ruleContent: 'indeterminate',
+          ruleCharacters: 'indeterminate'
+        });
+        return;
+      }
+
+      if (password.length < 14) {
+        this.setState({ ruleLength: 'error' });
+      } else {
+        this.setState({ ruleLength: 'success' });
+      }
+
+      if (/redhat/gi.test(password) || /red/gi.test(password) || /hat/gi.test(password) || /rh/gi.test(password)) {
+        this.setState({ ruleContent: 'error' });
+      } else {
+        this.setState({ ruleContent: 'success' });
+      }
+
+      let rulesCount = 0;
+      let strCount = 0;
+      if (/[a-z]/g.test(password)) {
+        rulesCount++;
+      }
+      if (/[A-Z]/g.test(password)) {
+        strCount += password.match(/[A-Z]/g).length;
+        rulesCount++;
+      }
+      if (/\d/g.test(password)) {
+        strCount += password.match(/\d/g).length;
+        rulesCount++;
+      }
+      if (/\W/g.test(password)) {
+        strCount += password.match(/\W/g).length;
+        rulesCount++;
+      }
+
+      if (rulesCount < 3) {
+        this.setState({ ruleCharacters: 'error' });
+      } else {
+        this.setState({ ruleCharacters: 'success' });
+      }
+
+      if (strCount < 3) {
+        this.setState({ passStrength: { variant: 'error', icon: <ExclamationCircleIcon />, text: 'Weak' } });
+      } else if (strCount < 5) {
+        this.setState({ passStrength: { variant: 'warning', icon: <ExclamationTriangleIcon />, text: 'Medium' } });
+      } else {
+        this.setState({ passStrength: { variant: 'success', icon: <CheckCircleIcon />, text: 'Strong' } });
+      }
+    };
+  }
+
+  render() {
+    const { password, ruleLength, ruleContent, ruleCharacters, passStrength } = this.state;
+
+    const iconPopover = (
+      <Popover headerContent={<div>Password Requirements</div>} bodyContent={<div>Password rules</div>}>
+        <button
+          type="button"
+          aria-label="More info for name field"
+          onClick={e => e.preventDefault()}
+          aria-describedby="password-field"
+          className="pf-c-form__group-label-help"
+        >
+          <HelpIcon noVerticalAlign />
+        </button>
+      </Popover>
+    );
+
+    let passStrLabel = (
+      <HelperTextItem variant={passStrength.variant} icon={passStrength.icon}>
+        {passStrength.text}
+      </HelperTextItem>
+    );
+
+    return (
+      <Form>
+        <FormGroup
+          label="Password"
+          labelIcon={iconPopover}
+          isRequired
+          fieldId="password-field"
+          {...(ruleLength === 'success' &&
+            ruleContent === 'success' &&
+            ruleCharacters === 'success' && {
+              labelInfo: passStrLabel
+            })}
+        >
+          <TextInput
+            isRequired
+            type="text"
+            id="password-field"
+            name="password-field"
+            aria-describedby="password-field-helper"
+            value={password}
+            onChange={this.handlePasswordInput}
+          />
+          <FormHelperText isHidden={false}>
+            <HelperText component="ul">
+              <HelperTextItem isDynamic variant={ruleLength} component="li">
+                Must be at least 14 characters
+              </HelperTextItem>
+              <HelperTextItem isDynamic variant={ruleContent} component="li">
+                Cannot contain any variation of the word "redhat"
+              </HelperTextItem>
+              <HelperTextItem isDynamic variant={ruleCharacters} component="li">
+                Must include at least 3 of the following: lowercase letter, uppercase letters, numbers, symbols
+              </HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        </FormGroup>
+      </Form>
+    );
+  }
+}
+```

--- a/packages/react-core/src/demos/PasswordStrength.md
+++ b/packages/react-core/src/demos/PasswordStrength.md
@@ -155,7 +155,7 @@ class PasswordStrengthDemo extends React.Component {
                 Must be at least 14 characters
               </HelperTextItem>
               <HelperTextItem isDynamic variant={ruleContent} component="li">
-                Cannot contain any the word "redhat"
+                Cannot contain the word "redhat"
               </HelperTextItem>
               <HelperTextItem isDynamic variant={ruleCharacters} component="li">
                 Must include at least 3 of the following: lowercase letter, uppercase letters, numbers, symbols

--- a/packages/react-core/src/demos/PasswordStrength.md
+++ b/packages/react-core/src/demos/PasswordStrength.md
@@ -62,7 +62,7 @@ class PasswordStrengthDemo extends React.Component {
         this.setState({ ruleLength: 'success' });
       }
 
-      if (/redhat/gi.test(password) || /red/gi.test(password) || /hat/gi.test(password) || /rh/gi.test(password)) {
+      if (/redhat/gi.test(password)) {
         this.setState({ ruleContent: 'error' });
       } else {
         this.setState({ ruleContent: 'success' });
@@ -155,7 +155,7 @@ class PasswordStrengthDemo extends React.Component {
                 Must be at least 14 characters
               </HelperTextItem>
               <HelperTextItem isDynamic variant={ruleContent} component="li">
-                Cannot contain any variation of the word "redhat"
+                Cannot contain any the word "redhat"
               </HelperTextItem>
               <HelperTextItem isDynamic variant={ruleCharacters} component="li">
                 Must include at least 3 of the following: lowercase letter, uppercase letters, numbers, symbols

--- a/packages/react-core/src/demos/PasswordStrength.md
+++ b/packages/react-core/src/demos/PasswordStrength.md
@@ -118,9 +118,11 @@ class PasswordStrengthDemo extends React.Component {
     );
 
     let passStrLabel = (
-      <HelperTextItem variant={passStrength.variant} icon={passStrength.icon}>
-        {passStrength.text}
-      </HelperTextItem>
+      <HelperText>
+        <HelperTextItem variant={passStrength.variant} icon={passStrength.icon}>
+          {passStrength.text}
+        </HelperTextItem>
+      </HelperText>
     );
 
     return (
@@ -145,7 +147,7 @@ class PasswordStrengthDemo extends React.Component {
             value={password}
             onChange={this.handlePasswordInput}
           />
-          <FormHelperText isHidden={false}>
+          <FormHelperText isHidden={false} component="div">
             <HelperText component="ul">
               <HelperTextItem isDynamic variant={ruleLength} component="li">
                 Must be at least 14 characters

--- a/packages/react-core/src/demos/PasswordStrength.md
+++ b/packages/react-core/src/demos/PasswordStrength.md
@@ -151,19 +151,17 @@ class PasswordStrengthDemo extends React.Component {
             onChange={this.handlePasswordInput}
           />
           <FormHelperText isHidden={false} component="div">
-            <div aria-live="polite">
-              <HelperText component="ul" id="password-field-helper">
-                <HelperTextItem isDynamic variant={ruleLength} component="li">
-                  Must be at least 14 characters
-                </HelperTextItem>
-                <HelperTextItem isDynamic variant={ruleContent} component="li">
-                  Cannot contain the word "redhat"
-                </HelperTextItem>
-                <HelperTextItem isDynamic variant={ruleCharacters} component="li">
-                  Must include at least 3 of the following: lowercase letter, uppercase letters, numbers, symbols
-                </HelperTextItem>
-              </HelperText>
-            </div>
+            <HelperText component="ul" aria-live="polite" id="password-field-helper">
+              <HelperTextItem isDynamic variant={ruleLength} component="li">
+                Must be at least 14 characters
+              </HelperTextItem>
+              <HelperTextItem isDynamic variant={ruleContent} component="li">
+                Cannot contain the word "redhat"
+              </HelperTextItem>
+              <HelperTextItem isDynamic variant={ruleCharacters} component="li">
+                Must include at least 3 of the following: lowercase letter, uppercase letters, numbers, symbols
+              </HelperTextItem>
+            </HelperText>
           </FormHelperText>
         </FormGroup>
       </Form>

--- a/packages/react-integration/cypress/integration/form.spec.ts
+++ b/packages/react-integration/cypress/integration/form.spec.ts
@@ -11,6 +11,12 @@ describe('Form Demo Test', () => {
       .should('have.value', 'Five');
   });
 
+  it('Verify labelInfo structure', () => {
+    cy.get('#form-group-age .pf-c-form__group-label.pf-m-info').should('exist');
+    cy.get('#form-group-age .pf-c-form__group-label-main').should('exist');
+    cy.get('#form-group-age .pf-c-form__group-label-info').should('exist');
+  });
+
   it('Verify form allows correct input', () => {
     cy.get('#age')
       .first()

--- a/packages/react-integration/demo-app-ts/src/components/demos/FormDemo/FormDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/FormDemo/FormDemo.tsx
@@ -108,7 +108,9 @@ export class FormDemo extends Component<FormProps, FormState> {
       <React.Fragment>
         <Form id="form-demo-1">
           <FormGroup
+            id="form-group-age"
             label="Age"
+            labelInfo="Age info"
             labelIcon={
               <Popover
                 headerContent={<div>The age of a person</div>}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6002 & #5819

Adds `labelInfo` property to `FormGroup`.
Adds new unit test, example and integration test.
Also updates some duplicate ids in the examples.

Update: Adds password strength demo