### PR TITLE
feat(Label): add editable label

### DIFF
--- a/packages/react-core/src/components/Label/Label.tsx
+++ b/packages/react-core/src/components/Label/Label.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
+import { useState } from 'react';
 import styles from '@patternfly/react-styles/css/components/Label/label';
+import labelGrpStyles from '@patternfly/react-styles/css/components/LabelGroup/label-group';
+import inlineEditStyles from '@patternfly/react-styles/css/components/InlineEdit/inline-edit';
 import { Button } from '../Button';
 import { Tooltip } from '../Tooltip';
 import { css } from '@patternfly/react-styles';
@@ -15,6 +18,14 @@ export interface LabelProps extends React.HTMLProps<HTMLSpanElement> {
   color?: 'blue' | 'cyan' | 'green' | 'orange' | 'purple' | 'red' | 'grey';
   /** Variant of the label. */
   variant?: 'outline' | 'filled';
+  /** Flag indicating the label is editable. */
+  isEditable?: boolean;
+  /** Additional props passed to the editable label text div. Optionally passing onInput and onBlur callbacks will allow finer custom text input control. */
+  editableProps?: any;
+  /** Callback when an editable label completes an edit. */
+  onEditComplete?: (newText: string) => void;
+  /** Callback when an editable label cancels an edit. */
+  onEditCancel?: (previousText: string) => void;
   /** Flag indicating the label text should be truncated. */
   isTruncated?: boolean;
   /** Position of the tooltip which is displayed if text is truncated */
@@ -58,10 +69,14 @@ export const Label: React.FunctionComponent<LabelProps> = ({
   className = '',
   color = 'grey',
   variant = 'filled',
+  isEditable = false,
+  editableProps,
   isTruncated = false,
   tooltipPosition,
   icon,
   onClose,
+  onEditCancel,
+  onEditComplete,
   closeBtn,
   closeBtnProps,
   href,
@@ -69,6 +84,67 @@ export const Label: React.FunctionComponent<LabelProps> = ({
   render,
   ...props
 }: LabelProps) => {
+  const [isEditableActive, setIsEditableActive] = useState(false);
+  const editableDivRef = React.createRef<HTMLDivElement>();
+
+  React.useEffect(() => {
+    document.addEventListener('click', onDocClick);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('click', onDocClick);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  });
+
+  const onDocClick = (event: MouseEvent) => {
+    if (
+      isEditableActive &&
+      editableDivRef &&
+      editableDivRef.current &&
+      !editableDivRef.current.contains(event.target as Node)
+    ) {
+      onEditComplete && onEditComplete(editableDivRef.current.textContent);
+      setIsEditableActive(false);
+    }
+  };
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    const key = event.key;
+
+    if (!editableDivRef || !editableDivRef.current || !editableDivRef.current.contains(event.target as Node)) {
+      return;
+    }
+
+    if (isEditableActive && (key === 'Enter' || key === 'Tab')) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      onEditComplete && onEditComplete(editableDivRef.current.textContent);
+      setIsEditableActive(false);
+    }
+    if (isEditableActive && key === 'Escape') {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      // Reset div text to initial children prop - pre-edit
+      editableDivRef.current.textContent = children as string;
+      onEditCancel && onEditCancel(children as string);
+      setIsEditableActive(false);
+    }
+    if (!isEditableActive && key === 'Enter') {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      setIsEditableActive(true);
+
+      // Set cursor position to end of text
+      const el = event.target as HTMLElement;
+      const range = document.createRange();
+      const sel = window.getSelection();
+      range.selectNodeContents(el);
+      range.collapse(false);
+      sel.removeAllRanges();
+      sel.addRange(range);
+    }
+  };
+
   const LabelComponent = (isOverflowLabel ? 'button' : 'span') as any;
   const Component = href ? 'a' : 'span';
   const button = closeBtn ? (
@@ -90,8 +166,8 @@ export const Label: React.FunctionComponent<LabelProps> = ({
   useIsomorphicLayoutEffect(() => {
     setIsTooltipVisible(textRef.current && textRef.current.offsetWidth < textRef.current.scrollWidth);
   }, []);
-  const content = (
-    <>
+  let content = (
+    <React.Fragment>
       {icon && <span className={css(styles.labelIcon)}>{icon}</span>}
       {isTruncated && (
         <span ref={textRef} className={css(styles.labelText)}>
@@ -99,24 +175,45 @@ export const Label: React.FunctionComponent<LabelProps> = ({
         </span>
       )}
       {!isTruncated && children}
-    </>
+    </React.Fragment>
   );
+
+  if (isEditable) {
+    content = (
+      <React.Fragment>
+        <div className={css(inlineEditStyles.inlineEdit)}>
+          <div
+            tabIndex={0}
+            ref={editableDivRef}
+            className={css(inlineEditStyles.inlineEditEditableText)}
+            role="textbox"
+            {...(isEditableActive && { contentEditable: true })}
+            suppressContentEditableWarning
+            {...editableProps}
+          >
+            {children}
+          </div>
+        </div>
+      </React.Fragment>
+    );
+  }
 
   let labelComponentChild = (
     <Component className={css(styles.labelContent)} {...(href && { href })}>
       {content}
     </Component>
   );
+
   if (render) {
     labelComponentChild = (
-      <>
+      <React.Fragment>
         {isTooltipVisible && <Tooltip reference={componentRef} content={children} position={tooltipPosition} />}
         {render({
           className: styles.labelContent,
           content,
           componentRef
         })}
-      </>
+      </React.Fragment>
     );
   } else if (isTooltipVisible) {
     labelComponentChild = (
@@ -136,8 +233,16 @@ export const Label: React.FunctionComponent<LabelProps> = ({
         colorStyles[color],
         variant === 'outline' && styles.modifiers.outline,
         isOverflowLabel && styles.modifiers.overflow,
+        isEditable && labelGrpStyles.modifiers.editable,
+        isEditableActive && styles.modifiers.editableActive,
         className
       )}
+      {...(isEditable && {
+        onClick: () => {
+          setIsEditableActive(true);
+          editableDivRef.current.focus();
+        }
+      })}
     >
       {labelComponentChild}
       {onClose && button}

--- a/packages/react-core/src/components/Label/Label.tsx
+++ b/packages/react-core/src/components/Label/Label.tsx
@@ -238,7 +238,11 @@ export const Label: React.FunctionComponent<LabelProps> = ({
         className
       )}
       {...(isEditable && {
-        onClick: () => {
+        onClick: (evt: MouseEvent) => {
+          const isEvtFromButton = (evt.target as HTMLElement).closest('button');
+          if (isEvtFromButton !== null) {
+            return;
+          }
           setIsEditableActive(true);
           editableDivRef.current.focus();
         }

--- a/packages/react-core/src/components/Label/examples/Label.md
+++ b/packages/react-core/src/components/Label/examples/Label.md
@@ -156,7 +156,7 @@ import InfoCircleIcon from '@patternfly/react-icons/dist/js/icons/info-circle-ic
   <Label color="cyan" icon={<InfoCircleIcon />} onClose={Function.prototype} isTruncated>
     Cyan label with icon that overflows
   </Label>
-</React.Fragment>
+</React.Fragment>;
 ```
 
 ### Outline
@@ -324,10 +324,11 @@ import InfoCircleIcon from '@patternfly/react-icons/dist/js/icons/info-circle-ic
   <Label variant="outline" color="cyan" icon={<InfoCircleIcon />} onClose={Function.prototype} isTruncated>
     Cyan label with icon that overflows
   </Label>
-</React.Fragment>
+</React.Fragment>;
 ```
 
 ### Router link
+
 ```js
 import React from 'react';
 import { Label } from '@patternfly/react-core';
@@ -339,16 +340,56 @@ import { Link } from '@reach/router';
   icon={<InfoCircleIcon />}
   onClose={Function.prototype}
   isTruncated
-  render={({
-    className, 
-    content,
-    componentRef 
-  }) => (
+  render={({ className, content, componentRef }) => (
     <Link to="/" className={className} innerRef={componentRef}>
       {content}
     </Link>
   )}
 >
   Blue label router link with icon that overflows
-</Label>
+</Label>;
+```
+
+### Editable
+
+```js
+import React from 'react';
+import { Label } from '@patternfly/react-core';
+
+class EditableLabel extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      text: 'Editable label'
+    };
+    this.onEditCancel = prevText => {
+      this.setState({
+        text: prevText
+      });
+    };
+    this.onEditComplete = newText => {
+      this.setState({
+        text: newText
+      });
+    };
+  }
+
+  render() {
+    return (
+      <Label
+        color="blue"
+        onClose={Function.prototype}
+        onEditCancel={this.onEditCancel}
+        onEditComplete={this.onEditComplete}
+        isEditable
+        editableProps={{
+          'aria-label': 'Editable text',
+          id: 'editable-label'
+        }}
+      >
+        {this.state.text}
+      </Label>
+    );
+  }
+}
 ```

--- a/packages/react-core/src/components/Label/examples/Label.md
+++ b/packages/react-core/src/components/Label/examples/Label.md
@@ -352,6 +352,8 @@ import { Link } from '@reach/router';
 
 ### Editable
 
+Click or press either enter or space to begin editing a label. After editing, click outside the label or press enter again to complete the edit. To cancel an edit, press escape.
+
 ```js
 import React from 'react';
 import { Label } from '@patternfly/react-core';

--- a/packages/react-core/src/components/LabelGroup/LabelGroup.tsx
+++ b/packages/react-core/src/components/LabelGroup/LabelGroup.tsx
@@ -170,7 +170,7 @@ export class LabelGroup extends React.Component<LabelGroupProps, LabelGroupState
                 </Label>
               </li>
             )}
-            {hasEditableTextArea && (
+            {isEditable && hasEditableTextArea && (
               <li className={css(styles.labelGroupListItem, styles.modifiers.textarea)}>
                 <textarea className={css(styles.labelGroupTextarea)} rows={1} tabIndex={0} {...editableTextAreaProps} />
               </li>

--- a/packages/react-core/src/components/LabelGroup/LabelGroup.tsx
+++ b/packages/react-core/src/components/LabelGroup/LabelGroup.tsx
@@ -35,6 +35,12 @@ export interface LabelGroupProps extends React.HTMLProps<HTMLUListElement> {
   tooltipPosition?: 'auto' | 'top' | 'bottom' | 'left' | 'right';
   /** Flag to implement a vertical layout */
   isVertical?: boolean;
+  /** Flag indicating contained labels are editable. Allows spacing for a text input after the labels. */
+  isEditable?: boolean;
+  /** Flag indicating the editable label group should be appended with a textarea. */
+  hasEditableTextArea?: boolean;
+  /** Additional props passed to the editable textarea. */
+  editableTextAreaProps?: any;
 }
 
 interface LabelGroupState {
@@ -65,7 +71,9 @@ export class LabelGroup extends React.Component<LabelGroupProps, LabelGroupState
     closeBtnAriaLabel: 'Close label group',
     tooltipPosition: 'top',
     'aria-label': 'Label group category',
-    isVertical: false
+    isVertical: false,
+    isEditable: false,
+    hasEditableTextArea: false
   };
 
   componentDidMount() {
@@ -123,6 +131,9 @@ export class LabelGroup extends React.Component<LabelGroupProps, LabelGroupState
       defaultIsOpen,
       tooltipPosition,
       isVertical,
+      isEditable,
+      hasEditableTextArea,
+      editableTextAreaProps,
       /* eslint-enable @typescript-eslint/no-unused-vars */
       ...rest
     } = this.props;
@@ -159,6 +170,11 @@ export class LabelGroup extends React.Component<LabelGroupProps, LabelGroupState
                 </Label>
               </li>
             )}
+            {hasEditableTextArea && (
+              <li className={css(styles.labelGroupListItem, styles.modifiers.textarea)}>
+                <textarea className={css(styles.labelGroupTextarea)} rows={1} tabIndex={0} {...editableTextAreaProps} />
+              </li>
+            )}
           </ul>
         </React.Fragment>
       );
@@ -183,7 +199,8 @@ export class LabelGroup extends React.Component<LabelGroupProps, LabelGroupState
             styles.labelGroup,
             className,
             categoryName && styles.modifiers.category,
-            isVertical && styles.modifiers.vertical
+            isVertical && styles.modifiers.vertical,
+            isEditable && styles.modifiers.editable
           )}
         >
           {<div className={css(styles.labelGroupMain)}>{content}</div>}

--- a/packages/react-core/src/components/LabelGroup/examples/LabelGroup.md
+++ b/packages/react-core/src/components/LabelGroup/examples/LabelGroup.md
@@ -160,7 +160,7 @@ class EditableLabelGroup extends React.Component {
 
   render() {
     return (
-      <LabelGroup numLabels={5} isEditable hasEditableTextArea editableTextAreaProps={{ 'aria-label': 'New label' }}>
+      <LabelGroup numLabels={5} isEditable>
         <Label
           color="blue"
           onClose={Function.prototype}

--- a/packages/react-core/src/components/LabelGroup/examples/LabelGroup.md
+++ b/packages/react-core/src/components/LabelGroup/examples/LabelGroup.md
@@ -10,7 +10,9 @@ ouia: true
 import InfoCircleIcon from '@patternfly/react-icons/dist/js/icons/info-circle-icon';
 
 ## Examples
+
 ### Basic
+
 ```js
 import React from 'react';
 import { Label, LabelGroup } from '@patternfly/react-core';
@@ -18,12 +20,17 @@ import InfoCircleIcon from '@patternfly/react-icons/dist/js/icons/info-circle-ic
 
 <LabelGroup>
   <Label icon={<InfoCircleIcon />}>Label 1</Label>
-  <Label icon={<InfoCircleIcon />} color="blue">Label 2</Label>
-  <Label icon={<InfoCircleIcon />} color="green">Label 3</Label>
-</LabelGroup>
+  <Label icon={<InfoCircleIcon />} color="blue">
+    Label 2
+  </Label>
+  <Label icon={<InfoCircleIcon />} color="green">
+    Label 3
+  </Label>
+</LabelGroup>;
 ```
 
 ### Overflow
+
 ```js
 import React from 'react';
 import { Label, LabelGroup } from '@patternfly/react-core';
@@ -31,15 +38,26 @@ import InfoCircleIcon from '@patternfly/react-icons/dist/js/icons/info-circle-ic
 
 <LabelGroup>
   <Label icon={<InfoCircleIcon />}>Label 1</Label>
-  <Label icon={<InfoCircleIcon />} color="blue">Label 2</Label>
-  <Label icon={<InfoCircleIcon />} color="green">Label 3</Label>
-  <Label icon={<InfoCircleIcon />} color="orange">Label 4</Label>
-  <Label icon={<InfoCircleIcon />} color="red">Label 5</Label>
-  <Label icon={<InfoCircleIcon />} color="purple">Label 6</Label>
-</LabelGroup>
+  <Label icon={<InfoCircleIcon />} color="blue">
+    Label 2
+  </Label>
+  <Label icon={<InfoCircleIcon />} color="green">
+    Label 3
+  </Label>
+  <Label icon={<InfoCircleIcon />} color="orange">
+    Label 4
+  </Label>
+  <Label icon={<InfoCircleIcon />} color="red">
+    Label 5
+  </Label>
+  <Label icon={<InfoCircleIcon />} color="purple">
+    Label 6
+  </Label>
+</LabelGroup>;
 ```
 
 ### Category
+
 ```js
 import React from 'react';
 import { Label, LabelGroup } from '@patternfly/react-core';
@@ -47,12 +65,17 @@ import InfoCircleIcon from '@patternfly/react-icons/dist/js/icons/info-circle-ic
 
 <LabelGroup categoryName="Group label">
   <Label icon={<InfoCircleIcon />}>Label 1</Label>
-  <Label icon={<InfoCircleIcon />} color="blue">Label 2</Label>
-  <Label icon={<InfoCircleIcon />} color="green">Label 3</Label>
-</LabelGroup>
+  <Label icon={<InfoCircleIcon />} color="blue">
+    Label 2
+  </Label>
+  <Label icon={<InfoCircleIcon />} color="green">
+    Label 3
+  </Label>
+</LabelGroup>;
 ```
 
 ### Category removable
+
 ```js
 import React from 'react';
 import { Label, LabelGroup } from '@patternfly/react-core';
@@ -76,11 +99,12 @@ CategoryLabelGroupRemovable = () => {
         </Label>
       ))}
     </LabelGroup>
-  )
-}
+  );
+};
 ```
 
 ### Vertical category overflow removable
+
 ```js
 import React from 'react';
 import { Label, LabelGroup } from '@patternfly/react-core';
@@ -104,6 +128,81 @@ VerticalCategoryLabelGroupOverflowRemovable = () => {
         </Label>
       ))}
     </LabelGroup>
-  )
+  );
+};
+```
+
+### Editable labels
+
+```js
+import React from 'react';
+import { LabelGroup, Label, TextArea } from '@patternfly/react-core';
+
+class EditableLabelGroup extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      label1: 'Editable label',
+      label2: 'Editable label 2',
+      label3: 'Editable label 3'
+    };
+    this.onEditCancel = (prevText, label) => {
+      this.setState({
+        [label]: prevText
+      });
+    };
+    this.onEditComplete = (newText, label) => {
+      this.setState({
+        [label]: newText
+      });
+    };
+  }
+
+  render() {
+    return (
+      <LabelGroup numLabels={5} isEditable hasEditableTextArea editableTextAreaProps={{ 'aria-label': 'New label' }}>
+        <Label
+          color="blue"
+          onClose={Function.prototype}
+          onEditCancel={prevText => this.onEditCancel(prevText, 'label1')}
+          onEditComplete={newText => this.onEditComplete(newText, 'label1')}
+          isEditable
+          editableProps={{
+            'aria-label': 'Editable text',
+            id: 'editable-label-1'
+          }}
+        >
+          {this.state.label1}
+        </Label>
+        <Label color="green">Static label</Label>
+        <Label
+          color="blue"
+          onClose={Function.prototype}
+          onEditCancel={prevText => this.onEditCancel(prevText, 'label2')}
+          onEditComplete={newText => this.onEditComplete(newText, 'label2')}
+          isEditable
+          editableProps={{
+            'aria-label': 'Editable text 2',
+            id: 'editable-label-2'
+          }}
+        >
+          {this.state.label2}
+        </Label>
+        <Label
+          color="blue"
+          onClose={Function.prototype}
+          onEditCancel={prevText => this.onEditCancel(prevText, 'label3')}
+          onEditComplete={newText => this.onEditComplete(newText, 'label3')}
+          isEditable
+          editableProps={{
+            'aria-label': 'Editable text 3',
+            id: 'editable-label-3'
+          }}
+        >
+          {this.state.label3}
+        </Label>
+      </LabelGroup>
+    );
+  }
 }
 ```

--- a/packages/react-integration/cypress/integration/label.spec.ts
+++ b/packages/react-integration/cypress/integration/label.spec.ts
@@ -11,6 +11,12 @@ describe('Label Demo Test', () => {
       .contains('Grey');
   });
 
+  it('Verify editable label', () => {
+    cy.get('.pf-m-editable')
+      .contains('Edit')
+      .should('exist');
+  });
+
   it('Verify isTruncated label and no tooltip on short text', () => {
     cy.get('#truncated-no-tooltip .pf-c-label__content span')
       .last()

--- a/packages/react-integration/cypress/integration/labelgroupeditable.spec.ts
+++ b/packages/react-integration/cypress/integration/labelgroupeditable.spec.ts
@@ -1,0 +1,38 @@
+describe('Label Group Editable Demo Test', () => {
+  it('Navigate to demo section', () => {
+    cy.visit('http://localhost:3000/');
+    cy.get('#labelgroup-editable-demo-nav-item-link').click();
+    cy.url().should('eq', 'http://localhost:3000/labelgroup-editable-demo-nav-link');
+  });
+
+  it('Verify editing first label', () => {
+    cy.get('#editable-label-1').contains('Editable label');
+    cy.get('#editable-label-1')
+      .focus()
+      .type('{enter}test{enter}');
+    cy.get('#editable-label-1').contains('Editable labeltest');
+  });
+
+  it('Verify cancelling edit on second label', () => {
+    cy.get('#editable-label-2').contains('Editable label 2');
+    cy.get('#editable-label-2')
+      .focus()
+      .type('{enter}testcancel{esc}');
+    cy.get('#editable-label-2').contains('Editable label 2');
+  });
+
+  it('Verify editing third label with click off', () => {
+    cy.get('#editable-label-3').contains('Editable label 3');
+    cy.get('#editable-label-3')
+      .focus()
+      .type('{enter}testclick');
+    cy.get('#editable-label-3')
+      .closest('.pf-c-label')
+      .should('have.class', 'pf-c-label pf-m-blue pf-m-editable pf-m-editable-active');
+    cy.get('.pf-c-page__header').click();
+    cy.get('#editable-label-3')
+      .closest('.pf-c-label')
+      .should('have.class', 'pf-c-label pf-m-blue pf-m-editable');
+    cy.get('#editable-label-3').contains('Editable label 3testclick');
+  });
+});

--- a/packages/react-integration/demo-app-ts/src/Demos.ts
+++ b/packages/react-integration/demo-app-ts/src/Demos.ts
@@ -452,6 +452,11 @@ export const Demos: DemoInterface[] = [
     componentType: Examples.LabelGroupDemo
   },
   {
+    id: 'labelgroup-editable-demo',
+    name: 'LabelGroup Editable Demo',
+    componentType: Examples.LabelGroupEditableDemo
+  },
+  {
     id: 'labelgroup-default-is-open-demo',
     name: 'LabelGroup Default is Open Demo',
     componentType: Examples.LabelGroupDefaultIsOpenDemo

--- a/packages/react-integration/demo-app-ts/src/components/demos/LabelDemo/LabelDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/LabelDemo/LabelDemo.tsx
@@ -61,6 +61,16 @@ export class LabelDemo extends Component {
         >
           Blue label fake router link with icon that overflows
         </Label>
+        <Label
+          color="blue"
+          isEditable
+          editableProps={{
+            'aria-label': 'Editable text',
+            id: 'editable-label'
+          }}
+        >
+          Edit
+        </Label>
       </React.Fragment>
     );
   }

--- a/packages/react-integration/demo-app-ts/src/components/demos/LabelGroupDemo/LabelGroupEditableDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/LabelGroupDemo/LabelGroupEditableDemo.tsx
@@ -1,0 +1,79 @@
+import { Label, LabelGroup } from '@patternfly/react-core';
+import React, { Component } from 'react';
+
+interface LabelState {
+  label1: string;
+  label2: string;
+  label3: string;
+}
+
+export class LabelGroupEditableDemo extends Component<{}, LabelState> {
+  state = {
+    label1: 'Editable label',
+    label2: 'Editable label 2',
+    label3: 'Editable label 3'
+  };
+
+  componentDidMount() {
+    window.scrollTo(0, 0);
+  }
+
+  onEditCancel = (prevText: string, label: string) => {
+    this.setState({
+      [label]: prevText
+    } as Pick<LabelState, keyof LabelState>);
+  };
+
+  onEditComplete = (newText: string, label: string) => {
+    this.setState({
+      [label]: newText
+    } as Pick<LabelState, keyof LabelState>);
+  };
+
+  render() {
+    return (
+      <LabelGroup numLabels={5} isEditable hasEditableTextArea editableTextAreaProps={{ 'aria-label': 'New label' }}>
+        <Label
+          color="blue"
+          onClose={() => {}}
+          onEditCancel={prevText => this.onEditCancel(prevText, 'label1')}
+          onEditComplete={newText => this.onEditComplete(newText, 'label1')}
+          isEditable
+          editableProps={{
+            'aria-label': 'Editable text',
+            id: 'editable-label-1'
+          }}
+        >
+          {this.state.label1}
+        </Label>
+        <Label color="green">Static label</Label>
+        <Label
+          color="blue"
+          onClose={() => {}}
+          onEditCancel={prevText => this.onEditCancel(prevText, 'label2')}
+          onEditComplete={newText => this.onEditComplete(newText, 'label2')}
+          isEditable
+          editableProps={{
+            'aria-label': 'Editable text 2',
+            id: 'editable-label-2'
+          }}
+        >
+          {this.state.label2}
+        </Label>
+        <Label
+          color="blue"
+          onClose={() => {}}
+          onEditCancel={prevText => this.onEditCancel(prevText, 'label3')}
+          onEditComplete={newText => this.onEditComplete(newText, 'label3')}
+          isEditable
+          editableProps={{
+            'aria-label': 'Editable text 3',
+            id: 'editable-label-3'
+          }}
+        >
+          {this.state.label3}
+        </Label>
+      </LabelGroup>
+    );
+  }
+}

--- a/packages/react-integration/demo-app-ts/src/components/demos/index.ts
+++ b/packages/react-integration/demo-app-ts/src/components/demos/index.ts
@@ -89,6 +89,7 @@ export * from './InputGroupDemo/InputGroupDemo';
 export * from './LabelDemo/LabelDemo';
 export * from './LabelGroupDemo/LabelGroupDefaultIsOpenDemo';
 export * from './LabelGroupDemo/LabelGroupDemo';
+export * from './LabelGroupDemo/LabelGroupEditableDemo';
 export * from './LabelGroupDemo/LabelGroupVerticalDemo';
 export * from './LabelGroupDemo/LabelGroupWithCategoryDemo';
 export * from './LevelDemo/LevelDemo';


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5875

Label:
- Adds `isEditable`, `onEditComplete`, `onEditCancel`, `editableProps`
- `onEditComplete` is triggered when `Enter`, `Tab` is pressed while on an active editable div, or when the mouse clicks outside of an active editable div
- `onEditCancel` is triggered when `Escape` is pressed while on on active editable div. This will also reset the editable div text to the initially passed children. The callback also passes back the previous text as a property (but it isn't be required to set the text state in this callback). 
- Optionally, passing `onInput` and/or `onBlur` to `editableProps` can let users hook directly into the changing text div

LabelGroup:
- Adds `isEditable`, `hasEditableTextArea`, `editableTextAreaProps`
- `hasEditableTextArea` will append a text area to the end of the label group list. This is in preparation for a future demo featuring creating a label from text.
