### PR TITLE
Type improvements on Select.onFilter

### DIFF
--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -111,7 +111,7 @@ export interface SelectProps
   /** Callback for typeahead clear button */
   onClear?: (event: React.MouseEvent) => void;
   /** Optional callback for custom filtering */
-  onFilter?: (e: React.ChangeEvent<HTMLInputElement>, value: string) => React.ReactElement[];
+  onFilter?: (e: React.ChangeEvent<HTMLInputElement> | null, value: string) => React.ReactElement[] | undefined;
   /** Optional callback for newly created options */
   onCreateOption?: (newOptionValue: string) => void;
   /** Optional event handler called each time the value in the typeahead input changes. */


### PR DESCRIPTION
- Allow Select.onFilter to return undefined 
- Allow Select.onFilter have a `null` event as input

`onFilter` function supports ([here](https://github.com/patternfly/patternfly-react/blob/main/packages/react-core/src/components/Select/Select.tsx#L338)) to return undefined (or any falsy value) to say that we want to keep rendering the children. 
In this case `onFilter` function is responsible of updating whatever logic to ensure the children are updated.

`onFilter` function first argument can be null as seen [here](https://github.com/patternfly/patternfly-react/blob/main/packages/react-core/src/components/Select/Select.tsx#L252) (`updateTypeAheadFilteredChildren` function calls `onFilter` with the second argument) 

closes: #6105 