### PR TITLE
TreeView: react to default expansion state change

### DIFF
--- a/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
+++ b/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
@@ -82,6 +82,12 @@ export const TreeViewListItem: React.FunctionComponent<TreeViewListItemProps> = 
     }
   }, [isExpanded]);
 
+  useEffect(() => {
+    if (defaultExpanded !== undefined && defaultExpanded !== null) {
+      setIsExpanded(internalIsExpanded || defaultExpanded);
+    }
+  }, [defaultExpanded]);
+
   const Component = hasCheck ? 'div' : 'button';
   const ToggleComponent = hasCheck ? 'button' : 'div';
   return (


### PR DESCRIPTION
While it was possible to render a TreeView with a subset of nodes
expanded, it was not possible to programmatically change the default
expansion of nodes (as in response to a search) as the underlying node
did not react to changes on the default expansion state. This patch adds
that functionality.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

fixes https://github.com/patternfly/patternfly-react/issues/6093
