### PR TITLE
Improve IAction type

### DIFF
--- a/packages/react-table/src/components/Table/ActionsColumn.tsx
+++ b/packages/react-table/src/components/Table/ActionsColumn.tsx
@@ -10,7 +10,14 @@ import {
   DropdownPosition
 } from '@patternfly/react-core/dist/esm/components/Dropdown/dropdownConstants';
 
-import { IAction, IExtraData, IRowData } from './TableTypes';
+import {
+  IAction,
+  IActionDropdownItem,
+  IActionOutsideItemButton,
+  IActionOutsideItemCustom,
+  IExtraData,
+  IRowData
+} from './TableTypes';
 
 export interface CustomActionsToggleProps {
   onToggle: (isOpen: boolean) => void;
@@ -82,10 +89,16 @@ export class ActionsColumn extends React.Component<ActionsColumnProps, ActionsCo
       <KebabToggle isDisabled={isDisabled} onToggle={this.onToggle} />
     );
 
+    const outsideDropdownItems = items.filter(a => a.isOutsideDropdown) as (
+      | IActionOutsideItemButton
+      | IActionOutsideItemCustom
+    )[];
+
+    const dropdownItems = items.filter(a => !a.isOutsideDropdown) as IActionDropdownItem[];
+
     return (
       <React.Fragment>
-        {items
-          .filter(item => item.isOutsideDropdown)
+        {outsideDropdownItems
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           .map(({ title, itemKey, onClick, isOutsideDropdown, ...props }, key) =>
             typeof title === 'string' ? (
@@ -107,26 +120,24 @@ export class ActionsColumn extends React.Component<ActionsColumnProps, ActionsCo
           position={dropdownPosition}
           direction={dropdownDirection}
           isOpen={isOpen}
-          dropdownItems={items
-            .filter(item => !item.isOutsideDropdown)
-            .map(({ title, itemKey, onClick, isSeparator, ...props }, key) =>
-              isSeparator ? (
-                <DropdownSeparator {...props} key={itemKey || key} data-key={itemKey || key} />
-              ) : (
-                <DropdownItem
-                  component="button"
-                  onClick={event => {
-                    this.onClick(event, onClick);
-                    this.onToggle(!isOpen);
-                  }}
-                  {...props}
-                  key={itemKey || key}
-                  data-key={itemKey || key}
-                >
-                  {title}
-                </DropdownItem>
-              )
-            )}
+          dropdownItems={dropdownItems.map(({ title, itemKey, onClick, isSeparator, ...props }, key) =>
+            isSeparator ? (
+              <DropdownSeparator {...props} key={itemKey || key} data-key={itemKey || key} />
+            ) : (
+              <DropdownItem
+                component="button"
+                onClick={event => {
+                  this.onClick(event, onClick);
+                  this.onToggle(!isOpen);
+                }}
+                {...props}
+                key={itemKey || key}
+                data-key={itemKey || key}
+              >
+                {title}
+              </DropdownItem>
+            )
+          )}
           isPlain
           {...(rowData && rowData.actionProps)}
         />

--- a/packages/react-table/src/components/Table/TableTypes.tsx
+++ b/packages/react-table/src/components/Table/TableTypes.tsx
@@ -146,22 +146,54 @@ export interface ISortBy {
   defaultDirection?: 'asc' | 'desc';
 }
 
-export interface IAction extends Omit<DropdownItemProps, 'title' | 'onClick'>, Pick<ButtonProps, 'variant'> {
+export interface ISeparator {
   /** Flag indicating an item on actions menu is a separator, rather than an action */
-  isSeparator?: boolean;
-  /** Key of actions menu item */
-  itemKey?: string;
-  /** Content to display in the actions menu item */
-  title?: string | React.ReactNode;
-  /** Click handler for the actions menu item */
-  onClick?: (event: React.MouseEvent, rowIndex: number, rowData: IRowData, extraData: IExtraData) => void;
-  /** Flag indicating this action should be placed outside the actions menu, beside the toggle */
-  isOutsideDropdown?: boolean;
+  isSeparator: true;
 }
 
-export interface ISeparator extends IAction {
-  isSeparator: boolean;
+export interface IActionSeparator extends ISeparator {
+  isOutsideDropdown?: false;
 }
+
+interface IActionClickable {
+  /** Click handler for the actions menu item */
+  onClick?: (event: React.MouseEvent, rowIndex: number, rowData: IRowData, extraData: IExtraData) => void;
+}
+
+export type IActionOutsideItemBase = IActionClickable & {
+  /** Flag indicating this action should be placed outside the actions menu, beside the toggle */
+  isOutsideDropdown: true;
+  /** Flag indicating an item on actions menu is not a separator, added to make it easy to distinguish */
+  isSeparator?: false;
+  /** Key of actions menu item */
+  itemKey?: undefined;
+};
+
+export type IActionOutsideItemButton = IActionOutsideItemBase &
+  Omit<ButtonProps, 'onClick'> & {
+    title: string;
+    /** Key of actions menu item */
+    itemKey?: string;
+  };
+
+export type IActionOutsideItemCustom = IActionOutsideItemBase & {
+  title: Exclude<React.ReactNode, string>;
+  [key: string]: any;
+};
+
+export type IActionDropdownItem = Omit<DropdownItemProps, 'title' | 'onClick'> &
+  IActionClickable & {
+    /** Flag indicating an item on actions menu is not a separator, added to make it easy to distinguish */
+    isSeparator?: false;
+    /** Flag indicating this action should be placed outside the actions menu, beside the toggle */
+    isOutsideDropdown?: false;
+    /** Key of actions menu item */
+    itemKey?: string;
+    /** Content to display in the actions menu item */
+    title: React.ReactNode;
+  };
+
+export type IAction = IActionSeparator | IActionDropdownItem | IActionOutsideItemButton | IActionOutsideItemCustom;
 
 export type IActions = (IAction | ISeparator)[];
 export type IActionsResolver = (rowData: IRowData, extraData: IExtraData) => (IAction | ISeparator)[];

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
@@ -163,6 +163,9 @@ This example demonstrates adding actions as the last column. The header's last c
 
 To make a cell an action cell, render an `ActionsColumn` component inside a row's last `Td` and pass an array of `IAction` objects via the `items` prop of `ActionsColumn`.
 
+Look [here](https://github.com/patternfly/patternfly-react/blob/main/packages/react-table/src/components/Table/TableTypes.tsx)
+for the `IAction` type to see what it looks like.
+
 ```ts file="ComposableTableActions.tsx"
 ```
 


### PR DESCRIPTION
`IAction` type is hard to use if you haven't seen the code (I don't think I found a lot of documentation regarding it as well).

Reason is that it cover 4 different things:
- An action Separator, where the `isSeparator` property is always true. 
- DropdownItem
- Button
- Custom component

I tried making it easier to consume by split into 4 different types (with the main features of each one) so that the types don't mix and is clear what properties will be used.

- `IActionSeparator` where `isSeparator` is *always* true (always false or undefined on the other types). 
- `IActionDropdownItem` where the `title` is a `ReactNode`, has the `onClick` and any property from `DropdownItemProps`
- `IActionOutsideItemButton` where the `title` is a string, has the `onClick`, `isOutsideDropdown` is true (false and undefined on others) and any property from `ButtonProps`
- `IActionOutsideItemCustom` `title` is a `ReactNode` minus `string` (to avoid overlap with previos) , has `onClick` and `isOutsideDropdown` as true and anything else you want (This could probably be worked to be a generic). 

All of these together are the `IAction` type.

I inspected the code and the usage seems more or less like that, there where a couple of castings as `any` that I'm removing now with this structure.
