### PR TITLE
feat(Breadcrumb): Spread props over custom component passed to BreadcrumbItem

### DIFF
--- a/packages/react-core/src/components/Breadcrumb/BreadcrumbItem.tsx
+++ b/packages/react-core/src/components/Breadcrumb/BreadcrumbItem.tsx
@@ -59,7 +59,7 @@ export const BreadcrumbItem: React.FunctionComponent<BreadcrumbItemProps> = ({
       {isDropdown && <span className={css(styles.breadcrumbDropdown)}>{children}</span>}
       {render && render({ className, ariaCurrent })}
       {to && !render && (
-        <Component {...props} href={to} target={target} className={className} aria-current={ariaCurrent}>
+        <Component href={to} target={target} className={className} aria-current={ariaCurrent} {...props}>
           {children}
         </Component>
       )}

--- a/packages/react-core/src/components/Breadcrumb/BreadcrumbItem.tsx
+++ b/packages/react-core/src/components/Breadcrumb/BreadcrumbItem.tsx
@@ -59,7 +59,7 @@ export const BreadcrumbItem: React.FunctionComponent<BreadcrumbItemProps> = ({
       {isDropdown && <span className={css(styles.breadcrumbDropdown)}>{children}</span>}
       {render && render({ className, ariaCurrent })}
       {to && !render && (
-        <Component href={to} target={target} className={className} aria-current={ariaCurrent}>
+        <Component {...props} href={to} target={target} className={className} aria-current={ariaCurrent}>
           {children}
         </Component>
       )}


### PR DESCRIPTION
Allows other props to be passed to the `BreadcrumbItem` for example when using a React Router link:

```tsx
import { BreadcrumbItem } from '@patternfly/react-core'
import { Link } from 'react-router-dom'

<BreadcrumbItem component={Link} to={toMyRoute()} />
```