### PR TITLE
BreadCrumbItem: fix ts-lint errors

### DIFF
--- a/packages/react-core/src/components/Breadcrumb/BreadcrumbHeading.tsx
+++ b/packages/react-core/src/components/Breadcrumb/BreadcrumbHeading.tsx
@@ -21,8 +21,8 @@ export interface BreadcrumbHeadingProps extends React.HTMLProps<HTMLLIElement> {
 export const BreadcrumbHeading: React.FunctionComponent<BreadcrumbHeadingProps> = ({
   children = null,
   className = '',
-  to = null,
-  target = null,
+  to = undefined,
+  target = undefined,
   component = 'a',
   showDivider,
   ...props

--- a/packages/react-core/src/components/Breadcrumb/BreadcrumbItem.tsx
+++ b/packages/react-core/src/components/Breadcrumb/BreadcrumbItem.tsx
@@ -32,13 +32,13 @@ export interface BreadcrumbItemProps extends React.HTMLProps<HTMLLIElement> {
 export const BreadcrumbItem: React.FunctionComponent<BreadcrumbItemProps> = ({
   children = null,
   className: classNameProp = '',
-  to = null,
+  to = undefined,
   isActive = false,
   isDropdown = false,
   showDivider,
-  target = null,
+  target = undefined,
   component = 'a',
-  render = null,
+  render = undefined,
   ...props
 }: BreadcrumbItemProps) => {
   const Component = component;

--- a/packages/react-core/src/components/Breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/react-core/src/components/Breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -41,7 +41,6 @@ exports[`Breadcrumb component should render breadcrumb with children 1`] = `
           <a
             className="pf-c-breadcrumb__link"
             href="#"
-            target={null}
           >
             Item 1
           </a>
@@ -87,7 +86,6 @@ exports[`Breadcrumb component should render breadcrumb with children 1`] = `
           <a
             className="pf-c-breadcrumb__link"
             href="#"
-            target={null}
           >
             Item 1
           </a>

--- a/packages/react-core/src/components/Breadcrumb/__tests__/__snapshots__/BreadcrumbHeading.test.tsx.snap
+++ b/packages/react-core/src/components/Breadcrumb/__tests__/__snapshots__/BreadcrumbHeading.test.tsx.snap
@@ -67,7 +67,6 @@ exports[`BreadcrumbHeading component should render link breadcrumbTitle 1`] = `
       aria-current="page"
       className="pf-c-breadcrumb__link pf-m-current"
       href="/somewhere"
-      target={null}
     >
       Item
     </a>

--- a/packages/react-core/src/components/Breadcrumb/__tests__/__snapshots__/BreadcrumbItem.test.tsx.snap
+++ b/packages/react-core/src/components/Breadcrumb/__tests__/__snapshots__/BreadcrumbItem.test.tsx.snap
@@ -66,7 +66,6 @@ exports[`BreadcrumbItem component should render link breadcrumbItem 1`] = `
   <a
     className="pf-c-breadcrumb__link"
     href="/somewhere"
-    target={null}
   >
     Item
   </a>

--- a/packages/react-core/src/components/Page/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/packages/react-core/src/components/Page/__tests__/__snapshots__/Page.test.tsx.snap
@@ -363,7 +363,6 @@ exports[`Check page to verify breadcrumb is created - PageBreadcrumb syntax 1`] 
                     <a
                       className="pf-c-breadcrumb__link"
                       href="#"
-                      target={null}
                     >
                       Section Title
                     </a>
@@ -408,7 +407,6 @@ exports[`Check page to verify breadcrumb is created - PageBreadcrumb syntax 1`] 
                     <a
                       className="pf-c-breadcrumb__link"
                       href="#"
-                      target={null}
                     >
                       Section Title
                     </a>
@@ -455,7 +453,6 @@ exports[`Check page to verify breadcrumb is created - PageBreadcrumb syntax 1`] 
                       aria-current="page"
                       className="pf-c-breadcrumb__link pf-m-current"
                       href="#"
-                      target={null}
                     >
                       Section Landing
                     </a>
@@ -644,7 +641,6 @@ exports[`Check page to verify breadcrumb is created 1`] = `
                     <a
                       className="pf-c-breadcrumb__link"
                       href="#"
-                      target={null}
                     >
                       Section Title
                     </a>
@@ -689,7 +685,6 @@ exports[`Check page to verify breadcrumb is created 1`] = `
                     <a
                       className="pf-c-breadcrumb__link"
                       href="#"
-                      target={null}
                     >
                       Section Title
                     </a>
@@ -736,7 +731,6 @@ exports[`Check page to verify breadcrumb is created 1`] = `
                       aria-current="page"
                       className="pf-c-breadcrumb__link pf-m-current"
                       href="#"
-                      target={null}
                     >
                       Section Landing
                     </a>
@@ -930,7 +924,6 @@ exports[`Check page to verify grouped nav and breadcrumb - new components syntax
                         <a
                           className="pf-c-breadcrumb__link"
                           href="#"
-                          target={null}
                         >
                           Section Title
                         </a>
@@ -975,7 +968,6 @@ exports[`Check page to verify grouped nav and breadcrumb - new components syntax
                         <a
                           className="pf-c-breadcrumb__link"
                           href="#"
-                          target={null}
                         >
                           Section Title
                         </a>
@@ -1022,7 +1014,6 @@ exports[`Check page to verify grouped nav and breadcrumb - new components syntax
                           aria-current="page"
                           className="pf-c-breadcrumb__link pf-m-current"
                           href="#"
-                          target={null}
                         >
                           Section Landing
                         </a>
@@ -1681,7 +1672,6 @@ exports[`Check page to verify grouped nav and breadcrumb - old / props syntax 1`
                           <a
                             className="pf-c-breadcrumb__link"
                             href="#"
-                            target={null}
                           >
                             Section Title
                           </a>
@@ -1726,7 +1716,6 @@ exports[`Check page to verify grouped nav and breadcrumb - old / props syntax 1`
                           <a
                             className="pf-c-breadcrumb__link"
                             href="#"
-                            target={null}
                           >
                             Section Title
                           </a>
@@ -1773,7 +1762,6 @@ exports[`Check page to verify grouped nav and breadcrumb - old / props syntax 1`
                             aria-current="page"
                             className="pf-c-breadcrumb__link pf-m-current"
                             href="#"
-                            target={null}
                           >
                             Section Landing
                           </a>
@@ -2313,7 +2301,6 @@ exports[`Check page to verify skip to content points to main content region 1`] 
                   <a
                     className="pf-c-breadcrumb__link"
                     href="#"
-                    target={null}
                   >
                     Section Title
                   </a>
@@ -2358,7 +2345,6 @@ exports[`Check page to verify skip to content points to main content region 1`] 
                   <a
                     className="pf-c-breadcrumb__link"
                     href="#"
-                    target={null}
                   >
                     Section Title
                   </a>
@@ -2405,7 +2391,6 @@ exports[`Check page to verify skip to content points to main content region 1`] 
                     aria-current="page"
                     className="pf-c-breadcrumb__link pf-m-current"
                     href="#"
-                    target={null}
                   >
                     Section Landing
                   </a>


### PR DESCRIPTION
BreadcrumbItem.tsx:35:3 - error TS2322: Type 'null' is not assignable to type 'string'.
35   to = null,
     ~~
BreadcrumbItem.tsx:39:3 - error TS2322: Type 'null' is not assignable to type 'string'.
39   target = null,
     ~~~~~~
BreadcrumbItem.tsx:41:3 - error TS2322: Type 'null' is not assignable to type '(props: BreadcrumbItemRenderArgs) => ReactNode'.
41   render = null,
     ~~~~~~

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
