### PR TITLE
fix(jumplinks): improve perf

### DIFF
--- a/packages/react-core/src/components/JumpLinks/JumpLinks.tsx
+++ b/packages/react-core/src/components/JumpLinks/JumpLinks.tsx
@@ -104,47 +104,50 @@ export const JumpLinks: React.FunctionComponent<JumpLinksProps> = ({
   React.useEffect(() => setIsExpanded(isExpandedProp), [isExpandedProp]);
   const navRef = React.useRef<HTMLElement>();
 
-  if (hasScrollSpy) {
-    React.useEffect(() => {
-      if (!canUseDOM) {
-        return;
+  const scrollSpy = React.useCallback(() => {
+    if (!canUseDOM || !hasScrollSpy) {
+      return;
+    }
+    const scrollableElement = document.querySelector(scrollableSelector) as HTMLElement;
+    if (!(scrollableElement instanceof HTMLElement)) {
+      return;
+    }
+    const scrollPosition = Math.ceil(scrollableElement.scrollTop + offset);
+    window.requestAnimationFrame(() => {
+      let newScrollItems = scrollItems;
+      // Items might have rendered after this component. Do a quick refresh.
+      if (!newScrollItems[0] || newScrollItems.includes(null)) {
+        newScrollItems = getScrollItems(children, []);
+        setScrollItems(newScrollItems);
       }
-      const scrollableElement = document.querySelector(scrollableSelector) as HTMLElement;
-      if (!(scrollableElement instanceof HTMLElement)) {
-        return;
+      const scrollElements = newScrollItems
+        .map((e, index) => ({
+          y: e ? e.offsetTop : null,
+          index
+        }))
+        .filter(({ y }) => y !== null)
+        .sort((e1, e2) => e2.y - e1.y);
+      for (const { y, index } of scrollElements) {
+        if (scrollPosition >= y) {
+          return setActiveIndex(index);
+        }
       }
+    });
+  }, [scrollItems, hasScrollSpy, scrollableSelector]);
 
-      function scrollSpy() {
-        const scrollPosition = Math.ceil(scrollableElement.scrollTop + offset);
-        window.requestAnimationFrame(() => {
-          let newScrollItems = scrollItems;
-          // Items might have rendered after this component. Do a quick refresh.
-          if (!newScrollItems[0] || newScrollItems.includes(null) || newScrollItems[0].offsetParent !== null) {
-            newScrollItems = getScrollItems(children, []);
-            setScrollItems(newScrollItems);
-          }
-          const scrollElements = newScrollItems
-            .map((e, index) => ({
-              y: e ? e.offsetTop : null,
-              index
-            }))
-            .filter(({ y }) => y !== null)
-            .sort((e1, e2) => e2.y - e1.y);
-          for (const { y, index } of scrollElements) {
-            if (scrollPosition >= y) {
-              return setActiveIndex(index);
-            }
-          }
-        });
-      }
-      if (scrollableElement) {
-        scrollSpy();
-        scrollableElement.addEventListener('scroll', scrollSpy);
-      }
+  React.useEffect(() => {
+    const scrollableElement = document.querySelector(scrollableSelector) as HTMLElement;
+    if (!(scrollableElement instanceof HTMLElement)) {
+      return;
+    }
+    scrollableElement.addEventListener('scroll', scrollSpy);
 
-      return () => scrollableElement.removeEventListener('scroll', scrollSpy);
-    }, [scrollItems, hasScrollSpy]);
-  }
+    return () => scrollableElement.removeEventListener('scroll', scrollSpy);
+  }, [scrollableSelector, scrollSpy]);
+
+  React.useEffect(() => {
+    scrollSpy();
+  }, []);
 
   let jumpLinkIndex = 0;
   const cloneChildren = (children: React.ReactNode): React.ReactNode =>

--- a/packages/react-core/src/components/JumpLinks/JumpLinks.tsx
+++ b/packages/react-core/src/components/JumpLinks/JumpLinks.tsx
@@ -104,12 +104,10 @@ export const JumpLinks: React.FunctionComponent<JumpLinksProps> = ({
   React.useEffect(() => setIsExpanded(isExpandedProp), [isExpandedProp]);
   const navRef = React.useRef<HTMLElement>();
 
+  let scrollableElement: HTMLElement;
+
   const scrollSpy = React.useCallback(() => {
-    if (!canUseDOM || !hasScrollSpy) {
-      return;
-    }
-    const scrollableElement = document.querySelector(scrollableSelector) as HTMLElement;
-    if (!(scrollableElement instanceof HTMLElement)) {
+    if (!canUseDOM || !hasScrollSpy || !(scrollableElement instanceof HTMLElement)) {
       return;
     }
     const scrollPosition = Math.ceil(scrollableElement.scrollTop + offset);
@@ -133,10 +131,10 @@ export const JumpLinks: React.FunctionComponent<JumpLinksProps> = ({
         }
       }
     });
-  }, [scrollItems, hasScrollSpy, scrollableSelector]);
+  }, [scrollItems, hasScrollSpy, scrollableElement]);
 
   React.useEffect(() => {
-    const scrollableElement = document.querySelector(scrollableSelector) as HTMLElement;
+    scrollableElement = document.querySelector(scrollableSelector) as HTMLElement;
     if (!(scrollableElement instanceof HTMLElement)) {
       return;
     }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Fixes #6127

![smooth-scrollspy](https://user-images.githubusercontent.com/47335686/128362137-b82141a2-7051-4d7e-bdda-a442dd2c5186.gif)


<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: `|| newScrollItems[0].offsetParent !== null` was the big offender which was always true and caused a render loop. A possible solution could be to flip the condition ([per MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent) it's null when we can't track `offsetTop` anyway) but a similar performance penalty would be incurred for hidden elements. I've removed the condition for now.