### PR TITLE
feat(HelperText): update default icons for success/error

### DIFF
--- a/packages/react-core/src/components/HelperText/HelperTextItem.tsx
+++ b/packages/react-core/src/components/HelperText/HelperTextItem.tsx
@@ -3,8 +3,8 @@ import styles from '@patternfly/react-styles/css/components/HelperText/helper-te
 import { css } from '@patternfly/react-styles';
 import MinusIcon from '@patternfly/react-icons/dist/js/icons/minus-icon';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
-import CheckIcon from '@patternfly/react-icons/dist/js/icons/check-icon';
-import TimesIcon from '@patternfly/react-icons/dist/js/icons/times-icon';
+import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
 
 export interface HelperTextItemProps extends React.HTMLProps<HTMLDivElement | HTMLLIElement> {
   /** Content rendered inside the helper text item. */
@@ -56,8 +56,8 @@ export const HelperTextItem: React.FunctionComponent<HelperTextItemProps> = ({
         <span className={css(styles.helperTextItemIcon)} aria-hidden>
           {(variant === 'default' || variant === 'indeterminate') && <MinusIcon />}
           {variant === 'warning' && <ExclamationTriangleIcon />}
-          {variant === 'success' && <CheckIcon />}
-          {variant === 'error' && <TimesIcon />}
+          {variant === 'success' && <CheckCircleIcon />}
+          {variant === 'error' && <ExclamationCircleIcon />}
         </span>
       )}
       <span className={css(styles.helperTextItemText)}>{children}</span>

--- a/packages/react-core/src/components/HelperText/examples/HelperText.md
+++ b/packages/react-core/src/components/HelperText/examples/HelperText.md
@@ -8,9 +8,9 @@ beta: true
 
 import InfoIcon from '@patternfly/react-icons/dist/js/icons/info-icon';
 import QuestionIcon from '@patternfly/react-icons/dist/js/icons/question-icon';
-import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
-import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
-import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
+import CheckIcon from '@patternfly/react-icons/dist/js/icons/check-icon';
+import TimesIcon from '@patternfly/react-icons/dist/js/icons/times-icon';
+import ExclamationIcon from '@patternfly/react-icons/dist/js/icons/exclamation-icon';
 
 ## Examples
 
@@ -84,9 +84,9 @@ import React from 'react';
 import { HelperText, HelperTextItem } from '@patternfly/react-core';
 import InfoIcon from '@patternfly/react-icons/dist/js/icons/info-icon';
 import QuestionIcon from '@patternfly/react-icons/dist/js/icons/question-icon';
-import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
-import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
-import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
+import ExclamationIcon from '@patternfly/react-icons/dist/js/icons/exclamation-icon';
+import CheckIcon from '@patternfly/react-icons/dist/js/icons/check-icon';
+import TimesIcon from '@patternfly/react-icons/dist/js/icons/times-icon';
 
 <React.Fragment>
   <HelperText>
@@ -98,17 +98,17 @@ import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclama
     </HelperTextItem>
   </HelperText>
   <HelperText>
-    <HelperTextItem variant="warning" icon={<ExclamationTriangleIcon />}>
+    <HelperTextItem variant="warning" icon={<ExclamationIcon />}>
       This is warning helper text
     </HelperTextItem>
   </HelperText>
   <HelperText>
-    <HelperTextItem variant="success" icon={<CheckCircleIcon />}>
+    <HelperTextItem variant="success" icon={<CheckIcon />}>
       This is success helper text
     </HelperTextItem>
   </HelperText>
   <HelperText>
-    <HelperTextItem variant="error" icon={<ExclamationCircleIcon />}>
+    <HelperTextItem variant="error" icon={<TimesIcon />}>
       This is error helper text
     </HelperTextItem>
   </HelperText>
@@ -133,7 +133,7 @@ import { HelperText, HelperTextItem } from '@patternfly/react-core';
 ```js
 import React from 'react';
 import { HelperText, HelperTextItem } from '@patternfly/react-core';
-import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
+import TimesIcon from '@patternfly/react-icons/dist/js/icons/times-icon';
 
 <React.Fragment>
   <HelperText>
@@ -160,7 +160,7 @@ import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclama
     </HelperTextItem>
   </HelperText>
   <HelperText>
-    <HelperTextItem isDynamic variant="error" icon={<ExclamationCircleIcon />}>
+    <HelperTextItem isDynamic variant="error" icon={<TimesIcon />}>
       This is error helper text with a custom icon
     </HelperTextItem>
   </HelperText>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6083

In this PR:
- Updates default icons for `success` and `error` variants of `HelperText`
- Updates custom icons used in examples to differ from new defaults
