### PR TITLE
fix(TimePicker): small fixes

### DIFF
--- a/packages/react-core/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react-core/src/components/TimePicker/TimePicker.tsx
@@ -30,7 +30,7 @@ export interface TimePickerProps
   /** True if the time is 24 hour time. False if the time is 12 hour time */
   is24Hour?: boolean;
   /** Optional event handler called each time the value in the time picker input changes. */
-  onChange?: (time: string, hour?: number, minute?: number) => void;
+  onChange?: (time: string, hour?: number, minute?: number, isValid?: boolean) => void;
   /** Optional validator can be provided to override the internal time validator. */
   validateTime?: (time: string) => boolean;
   /** Id of the time picker */
@@ -296,7 +296,12 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
 
   onInputChange = (newTime: string) => {
     if (this.props.onChange) {
-      this.props.onChange(newTime, getHours(newTime, this.state.timeRegex), getMinutes(newTime, this.state.timeRegex));
+      this.props.onChange(
+        newTime,
+        getHours(newTime, this.state.timeRegex),
+        getMinutes(newTime, this.state.timeRegex),
+        this.isValid(newTime)
+      );
     }
     this.scrollToSelection(newTime);
     this.setState({

--- a/packages/react-core/src/components/TimePicker/TimePickerUtils.tsx
+++ b/packages/react-core/src/components/TimePicker/TimePickerUtils.tsx
@@ -84,9 +84,9 @@ export const validateTime = (time: string, timeRegex: RegExp, delimiter: string,
   if (!isNaN(date.getDate()) && time.includes('T')) {
     return true;
   }
-  // hours only valid if they are [0-23] or [0-12]
+  // hours only valid if they are [0-23] or [1-12]
   const hours = parseInt(time.split(delimiter)[0]);
-  const validHours = hours >= 0 && hours <= (is12Hour ? 12 : 23);
+  const validHours = hours >= (is12Hour ? 1 : 0) && hours <= (is12Hour ? 12 : 23);
   // minutes verified by timeRegex
 
   // empty string is valid

--- a/packages/react-core/src/components/TimePicker/__tests__/TimePicker.test.tsx
+++ b/packages/react-core/src/components/TimePicker/__tests__/TimePicker.test.tsx
@@ -15,7 +15,7 @@ describe('test timepicker onChange method with valid values', () => {
     act(() => {
       view.find('input').prop('onChange')(event);
     })
-    expect(onChange).toBeCalledWith(input.value, expects.hour, expects.minutes);
+    expect(onChange).toBeCalledWith(input.value, expects.hour, expects.minutes, true);
   }
 
   test('should return the correct value using the AM/PM pattern - midnight', () => {

--- a/packages/react-core/src/components/TimePicker/examples/TimePicker.md
+++ b/packages/react-core/src/components/TimePicker/examples/TimePicker.md
@@ -15,8 +15,11 @@ import React from 'react';
 import { TimePicker } from '@patternfly/react-core';
 
 SimpleTimePicker = () => {
-  const onChange = (time) => {
-    console.log(time);
+  const onChange = (time, hour, minute, isValid) => {
+    console.log("time", time);
+    console.log("hour", hour);
+    console.log("minute", minute);
+    console.log("isValid", isValid);
   };
   
   return <TimePicker time="3:35 AM" onChange={onChange}/>;


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5539 & #5898 

- onChange handler returns flag indicating if current time value is valid
- 0 & 00 are no longer a valid hour values in 12 hour time.

