### PR TITLE
fix(FileUpload): Improving events in the FileUpload

### DIFF
--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -38,7 +38,7 @@
     "@patternfly/react-styles": "^4.19.3",
     "@patternfly/react-tokens": "^4.21.3",
     "focus-trap": "6.2.2",
-    "react-dropzone": "11.3.4",
+    "react-dropzone": "10.2.2",
     "tippy.js": "5.1.2",
     "tslib": "^2.0.0"
   },

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -38,7 +38,7 @@
     "@patternfly/react-styles": "^4.19.3",
     "@patternfly/react-tokens": "^4.21.3",
     "focus-trap": "6.2.2",
-    "react-dropzone": "9.0.0",
+    "react-dropzone": "11.3.4",
     "tippy.js": "5.1.2",
     "tslib": "^2.0.0"
   },

--- a/packages/react-core/src/components/FileUpload/FileUpload.tsx
+++ b/packages/react-core/src/components/FileUpload/FileUpload.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import Dropzone, { DropzoneProps, DropEvent, DropzoneInputProps, FileWithPath } from 'react-dropzone';
+import Dropzone, { DropzoneProps, DropEvent, DropzoneInputProps } from 'react-dropzone';
 import { FileUploadField, FileUploadFieldProps } from './FileUploadField';
 import { readFile, fileReaderType } from '../../helpers/fileUtils';
-import { fromEvent } from 'file-selector'
+import { fromEvent } from 'file-selector';
 export interface FileUploadProps
   extends Omit<
-  FileUploadFieldProps,
-  'children' | 'onBrowseButtonClick' | 'onClearButtonClick' | 'isDragActive' | 'containerRef'
+    FileUploadFieldProps,
+    'children' | 'onBrowseButtonClick' | 'onClearButtonClick' | 'isDragActive' | 'containerRef'
   > {
   /** Unique id for the TextArea, also used to generate ids for accessible labels. */
   id: string;
@@ -18,19 +18,19 @@ export interface FileUploadProps
   value?: string | File;
   /** Value to be shown in the read-only filename field. */
   filename?: string;
-  /** A callback for when the file contents change. */
+  /** *(deprecated)* A callback for when the file contents change. Please use rather the individual events. */
   onChange?: (
     value: string | File,
     filename: string,
     event:
-      | React.MouseEvent<HTMLButtonElement, MouseEvent> // Clear button was clicked (deprecated)
-      | React.DragEvent<HTMLElement> // User dragged/dropped a file (deprecated)
-      | React.ChangeEvent<HTMLElement> // User typed in the TextArea (deprecated)
+      | React.MouseEvent<HTMLButtonElement, MouseEvent> // Clear button was clicked
+      | React.DragEvent<HTMLElement> // User dragged/dropped a file
+      | React.ChangeEvent<HTMLElement> // User typed in the TextArea
       | DragEvent
       | Event
   ) => void;
   /** Change event emitted from the \<input\> field associated with the component  */
-  onInputChange?: (event: React.ChangeEvent<HTMLInputElement> | DropEvent, file: File) => void
+  onInputChange?: (event: React.ChangeEvent<HTMLInputElement> | DropEvent, file: File) => void;
   /** Callback for clicking on the FileUploadField text area. By default, prevents a click in the text area from opening file dialog. */
   onClick?: (event: React.MouseEvent) => void;
   /** Additional classes added to the FileUpload container element. */
@@ -92,11 +92,11 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
   value = type === fileReaderType.text || type === fileReaderType.dataURL ? '' : null,
   filename = '',
   children = null,
-  onChange = () => { },
+  onChange = () => {},
   onInputChange = null,
-  onReadStarted = () => { },
-  onReadFinished = () => { },
-  onReadFailed = () => { },
+  onReadStarted = () => {},
+  onReadFinished = () => {},
+  onReadFailed = () => {},
   onClearClicked,
   onClick = event => event.preventDefault(),
   onTextChanged,
@@ -107,7 +107,9 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
   const onDropAccepted = (acceptedFiles: File[], event: DropEvent) => {
     if (acceptedFiles.length > 0) {
       const fileHandle = acceptedFiles[0];
-      if (event.type === "drop") onInputChange?.(event, fileHandle);
+      if (event.type === 'drop') {
+        onInputChange?.(event, fileHandle);
+      }
       if (type === fileReaderType.text || type === fileReaderType.dataURL) {
         onChange('', fileHandle.name, event); // Show the filename while reading
         onReadStarted(fileHandle);
@@ -163,8 +165,9 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
         inputProps.onChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
           oldInputChange?.(e);
           const files = await fromEvent(e.nativeEvent);
-          if (files.length === 1)
-            onInputChange?.(e, (files[0] as File));
+          if (files.length === 1) {
+            onInputChange?.(e, files[0] as File);
+          }
         };
 
         return (

--- a/packages/react-core/src/components/FileUpload/FileUpload.tsx
+++ b/packages/react-core/src/components/FileUpload/FileUpload.tsx
@@ -30,7 +30,7 @@ export interface FileUploadProps
       | Event
   ) => void;
   /** Change event emitted from the \<input\> field associated with the component  */
-  onInputChange?: (event: React.ChangeEvent<HTMLInputElement>, items?: (FileWithPath | DataTransferItem)[]) => void
+  onInputChange?: (event: React.ChangeEvent<HTMLInputElement>, file: File) => void
   /** Callback for clicking on the FileUploadField text area. By default, prevents a click in the text area from opening file dialog. */
   onClick?: (event: React.MouseEvent) => void;
   /** Additional classes added to the FileUpload container element. */
@@ -162,7 +162,8 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
         inputProps.onChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
           oldInputChange?.(e);
           const files = await fromEvent(e.nativeEvent);
-          onInputChange?.(e, files);
+          if (files.length === 1)
+            onInputChange?.(e, (files[0] as File));
         };
 
         return (

--- a/packages/react-core/src/components/FileUpload/FileUpload.tsx
+++ b/packages/react-core/src/components/FileUpload/FileUpload.tsx
@@ -18,7 +18,7 @@ export interface FileUploadProps
   value?: string | File;
   /** Value to be shown in the read-only filename field. */
   filename?: string;
-  /** *(deprecated)* A callback for when the file contents change. Please use rather the individual events. */
+  /** *(deprecated)* A callback for when the file contents change. Please instead use onFileInputChange, onTextChange, onDataChange, onClearClick individually.  */
   onChange?: (
     value: string | File,
     filename: string,

--- a/packages/react-core/src/components/FileUpload/FileUpload.tsx
+++ b/packages/react-core/src/components/FileUpload/FileUpload.tsx
@@ -139,9 +139,9 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
     dropzoneProps.onDropRejected && dropzoneProps.onDropRejected(rejectedFiles, event);
   };
 
-  let textInput: any;
+  const fileInputRef = React.useRef<HTMLInputElement>();
   const setFileValue = (filename: string) => {
-    textInput.current.value = filename;
+    fileInputRef.current.value = filename;
   };
 
   const onClearButtonClick = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
@@ -159,14 +159,15 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
       noClick={true}
     >
       {({ getRootProps, getInputProps, isDragActive, open }) => {
-        const inputProps: DropzoneInputProps & { ref: React.Ref<HTMLInputElement> } = { ref: null, ...getInputProps() };
-        textInput = inputProps.ref;
-        const oldInputChange = inputProps.onChange;
-        inputProps.onChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-          oldInputChange?.(e);
-          const files = await fromEvent(e.nativeEvent);
-          if (files.length === 1) {
-            onInputChange?.(e, files[0] as File);
+        const oldInputProps = getInputProps();
+        const inputProps: DropzoneInputProps = {
+          ...oldInputProps,
+          onChange: async (e: React.ChangeEvent<HTMLInputElement>) => {
+            oldInputProps.onChange?.(e);
+            const files = await fromEvent(e.nativeEvent);
+            if (files.length === 1) {
+              onInputChange?.(e, files[0] as File);
+            }
           }
         };
 
@@ -189,7 +190,7 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
             onTextAreaClick={onClick}
             onTextChanged={onTextChanged}
           >
-            <input {...inputProps} ref={textInput} /* hidden, necessary for react-dropzone */ />
+            <input {...inputProps} ref={fileInputRef} /* hidden, necessary for react-dropzone */ />
             {children}
           </FileUploadField>
         );

--- a/packages/react-core/src/components/FileUpload/FileUpload.tsx
+++ b/packages/react-core/src/components/FileUpload/FileUpload.tsx
@@ -29,8 +29,8 @@ export interface FileUploadProps
       | DragEvent
       | Event
   ) => void;
-  /** Change event emitted from the \<input\> field associated with the component  */
-  onInputChange?: (event: React.ChangeEvent<HTMLInputElement> | DropEvent, file: File) => void;
+  /** Change event emitted from the hidden \<input type="file" \> field associated with the component  */
+  onFileInputChange?: (event: React.ChangeEvent<HTMLInputElement> | DropEvent, file: File) => void;
   /** Callback for clicking on the FileUploadField text area. By default, prevents a click in the text area from opening file dialog. */
   onClick?: (event: React.MouseEvent) => void;
   /** Additional classes added to the FileUpload container element. */
@@ -93,7 +93,7 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
   filename = '',
   children = null,
   onChange = () => {},
-  onInputChange = null,
+  onFileInputChange = null,
   onReadStarted = () => {},
   onReadFinished = () => {},
   onReadFailed = () => {},
@@ -108,7 +108,7 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
     if (acceptedFiles.length > 0) {
       const fileHandle = acceptedFiles[0];
       if (event.type === 'drop') {
-        onInputChange?.(event, fileHandle);
+        onFileInputChange?.(event, fileHandle);
       }
       if (type === fileReaderType.text || type === fileReaderType.dataURL) {
         onChange('', fileHandle.name, event); // Show the filename while reading
@@ -166,7 +166,7 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
             oldInputProps.onChange?.(e);
             const files = await fromEvent(e.nativeEvent);
             if (files.length === 1) {
-              onInputChange?.(e, files[0] as File);
+              onFileInputChange?.(e, files[0] as File);
             }
           }
         };

--- a/packages/react-core/src/components/FileUpload/FileUpload.tsx
+++ b/packages/react-core/src/components/FileUpload/FileUpload.tsx
@@ -30,7 +30,7 @@ export interface FileUploadProps
       | Event
   ) => void;
   /** Change event emitted from the \<input\> field associated with the component  */
-  onInputChange?: (event: React.ChangeEvent<HTMLInputElement>, file: File) => void
+  onInputChange?: (event: React.ChangeEvent<HTMLInputElement> | DropEvent, file: File) => void
   /** Callback for clicking on the FileUploadField text area. By default, prevents a click in the text area from opening file dialog. */
   onClick?: (event: React.MouseEvent) => void;
   /** Additional classes added to the FileUpload container element. */
@@ -81,7 +81,7 @@ export interface FileUploadProps
   /** Clear button was clicked */
   onClearClicked?: React.MouseEventHandler<HTMLButtonElement>;
   /** Text area text changed */
-  onTextChanged?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onTextChanged?: (text: string) => void;
   /** On data changed - if type='text' or type='dataURL' and file was loaded it will call this method */
   onDataChanged?: (data: string) => void;
 }
@@ -99,7 +99,7 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
   onReadFailed = () => { },
   onClearClicked,
   onClick = event => event.preventDefault(),
-  onTextChanged = () => { },
+  onTextChanged,
   onDataChanged,
   dropzoneProps = {},
   ...props
@@ -107,6 +107,7 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
   const onDropAccepted = (acceptedFiles: File[], event: DropEvent) => {
     if (acceptedFiles.length > 0) {
       const fileHandle = acceptedFiles[0];
+      if (event.type === "drop") onInputChange?.(event, fileHandle);
       if (type === fileReaderType.text || type === fileReaderType.dataURL) {
         onChange('', fileHandle.name, event); // Show the filename while reading
         onReadStarted(fileHandle);
@@ -129,9 +130,9 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
     dropzoneProps.onDropAccepted && dropzoneProps.onDropAccepted(acceptedFiles, event);
   };
 
-  const onDropRejected = (rejectedFiles: any[], event: DropEvent) => {
+  const onDropRejected = (rejectedFiles: File[], event: DropEvent) => {
     if (rejectedFiles.length > 0) {
-      onChange('', rejectedFiles[0].file.name, event);
+      onChange('', rejectedFiles[0].name, event);
     }
     dropzoneProps.onDropRejected && dropzoneProps.onDropRejected(rejectedFiles, event);
   };

--- a/packages/react-core/src/components/FileUpload/FileUpload.tsx
+++ b/packages/react-core/src/components/FileUpload/FileUpload.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import Dropzone, { DropzoneProps, DropEvent, DropzoneInputProps, FileWithPath } from 'react-dropzone';
 import { FileUploadField, FileUploadFieldProps } from './FileUploadField';
 import { readFile, fileReaderType } from '../../helpers/fileUtils';
-import { MouseEventHandler } from 'react';
 import { fromEvent } from 'file-selector'
 export interface FileUploadProps
   extends Omit<
@@ -80,7 +79,7 @@ export interface FileUploadProps
   /** Optional extra props to customize react-dropzone. */
   dropzoneProps?: DropzoneProps;
   /** Clear button was clicked */
-  onClearClicked?: MouseEventHandler<HTMLButtonElement>;
+  onClearClicked?: React.MouseEventHandler<HTMLButtonElement>;
   /** Text area text changed */
   onTextChanged?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
   /** On data changed - if type='text' or type='dataURL' and file was loaded it will call this method */

--- a/packages/react-core/src/components/FileUpload/FileUpload.tsx
+++ b/packages/react-core/src/components/FileUpload/FileUpload.tsx
@@ -79,7 +79,7 @@ export interface FileUploadProps
   /** Optional extra props to customize react-dropzone. */
   dropzoneProps?: DropzoneProps;
   /** Clear button was clicked */
-  onClearClicked?: React.MouseEventHandler<HTMLButtonElement>;
+  onClearClick?: React.MouseEventHandler<HTMLButtonElement>;
   /** Text area text changed */
   onTextChange?: (text: string) => void;
   /** On data changed - if type='text' or type='dataURL' and file was loaded it will call this method */
@@ -97,7 +97,7 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
   onReadStarted = () => {},
   onReadFinished = () => {},
   onReadFailed = () => {},
-  onClearClicked,
+  onClearClick,
   onClick = event => event.preventDefault(),
   onTextChange,
   onDataChange,
@@ -146,7 +146,7 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
 
   const onClearButtonClick = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     onChange('', '', event);
-    onClearClicked?.(event);
+    onClearClick?.(event);
     setFileValue(null);
   };
 

--- a/packages/react-core/src/components/FileUpload/FileUpload.tsx
+++ b/packages/react-core/src/components/FileUpload/FileUpload.tsx
@@ -81,9 +81,9 @@ export interface FileUploadProps
   /** Clear button was clicked */
   onClearClicked?: React.MouseEventHandler<HTMLButtonElement>;
   /** Text area text changed */
-  onTextChanged?: (text: string) => void;
+  onTextChange?: (text: string) => void;
   /** On data changed - if type='text' or type='dataURL' and file was loaded it will call this method */
-  onDataChanged?: (data: string) => void;
+  onDataChange?: (data: string) => void;
 }
 
 export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
@@ -99,8 +99,8 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
   onReadFailed = () => {},
   onClearClicked,
   onClick = event => event.preventDefault(),
-  onTextChanged,
-  onDataChanged,
+  onTextChange,
+  onDataChange,
   dropzoneProps = {},
   ...props
 }: FileUploadProps) => {
@@ -117,13 +117,13 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
           .then(data => {
             onReadFinished(fileHandle);
             onChange(data as string, fileHandle.name, event);
-            onDataChanged?.(data as string);
+            onDataChange?.(data as string);
           })
           .catch((error: DOMException) => {
             onReadFailed(error, fileHandle);
             onReadFinished(fileHandle);
             onChange('', '', event); // Clear the filename field on a failure
-            onDataChanged?.('');
+            onDataChange?.('');
           });
       } else {
         onChange(fileHandle, fileHandle.name, event);
@@ -188,7 +188,7 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
             onBrowseButtonClick={open}
             onClearButtonClick={onClearButtonClick}
             onTextAreaClick={onClick}
-            onTextChanged={onTextChanged}
+            onTextChange={onTextChange}
           >
             <input {...inputProps} ref={fileInputRef} /* hidden, necessary for react-dropzone */ />
             {children}

--- a/packages/react-core/src/components/FileUpload/FileUploadField.tsx
+++ b/packages/react-core/src/components/FileUpload/FileUploadField.tsx
@@ -87,7 +87,7 @@ export const FileUploadField: React.FunctionComponent<FileUploadFieldProps> = ({
   filename = '',
   onChange = () => { },
   onBrowseButtonClick = () => { },
-  onClearButtonClick = () => { },
+  onClearButtonClick = () => { },  
   onTextAreaClick,
   onTextChanged,
   className = '',

--- a/packages/react-core/src/components/FileUpload/FileUploadField.tsx
+++ b/packages/react-core/src/components/FileUpload/FileUploadField.tsx
@@ -85,9 +85,9 @@ export const FileUploadField: React.FunctionComponent<FileUploadFieldProps> = ({
   type,
   value = '',
   filename = '',
-  onChange = () => { },
-  onBrowseButtonClick = () => { },
-  onClearButtonClick = () => { },  
+  onChange = () => {},
+  onBrowseButtonClick = () => {},
+  onClearButtonClick = () => {},
   onTextAreaClick,
   onTextChanged,
   className = '',
@@ -113,7 +113,7 @@ export const FileUploadField: React.FunctionComponent<FileUploadFieldProps> = ({
 }: FileUploadFieldProps) => {
   const onTextAreaChange = (newValue: string, event: React.ChangeEvent<HTMLTextAreaElement>) => {
     onChange(newValue, filename, event);
-    onTextChanged?.(newValue)
+    onTextChanged?.(newValue);
   };
   return (
     <div

--- a/packages/react-core/src/components/FileUpload/FileUploadField.tsx
+++ b/packages/react-core/src/components/FileUpload/FileUploadField.tsx
@@ -77,7 +77,7 @@ export interface FileUploadFieldProps extends Omit<React.HTMLProps<HTMLDivElemen
   /** A reference object to attach to the FileUploadField container element. */
   containerRef?: React.Ref<HTMLDivElement>;
   /** Text area text changed */
-  onTextChanged?: (text: string) => void;
+  onTextChange?: (text: string) => void;
 }
 
 export const FileUploadField: React.FunctionComponent<FileUploadFieldProps> = ({
@@ -89,7 +89,7 @@ export const FileUploadField: React.FunctionComponent<FileUploadFieldProps> = ({
   onBrowseButtonClick = () => {},
   onClearButtonClick = () => {},
   onTextAreaClick,
-  onTextChanged,
+  onTextChange,
   className = '',
   isDisabled = false,
   isReadOnly = false,
@@ -113,7 +113,7 @@ export const FileUploadField: React.FunctionComponent<FileUploadFieldProps> = ({
 }: FileUploadFieldProps) => {
   const onTextAreaChange = (newValue: string, event: React.ChangeEvent<HTMLTextAreaElement>) => {
     onChange(newValue, filename, event);
-    onTextChanged?.(newValue);
+    onTextChange?.(newValue);
   };
   return (
     <div

--- a/packages/react-core/src/components/FileUpload/FileUploadField.tsx
+++ b/packages/react-core/src/components/FileUpload/FileUploadField.tsx
@@ -76,6 +76,8 @@ export interface FileUploadFieldProps extends Omit<React.HTMLProps<HTMLDivElemen
   isDragActive?: boolean;
   /** A reference object to attach to the FileUploadField container element. */
   containerRef?: React.Ref<HTMLDivElement>;
+  /** Text area text changed */
+  onTextChanged?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void
 }
 
 export const FileUploadField: React.FunctionComponent<FileUploadFieldProps> = ({
@@ -83,10 +85,11 @@ export const FileUploadField: React.FunctionComponent<FileUploadFieldProps> = ({
   type,
   value = '',
   filename = '',
-  onChange = () => {},
-  onBrowseButtonClick = () => {},
-  onClearButtonClick = () => {},
+  onChange = () => { },
+  onBrowseButtonClick = () => { },
+  onClearButtonClick = () => { },
   onTextAreaClick,
+  onTextChanged,
   className = '',
   isDisabled = false,
   isReadOnly = false,
@@ -105,10 +108,12 @@ export const FileUploadField: React.FunctionComponent<FileUploadFieldProps> = ({
   allowEditingUploadedText = false,
   hideDefaultPreview = false,
   children = null,
+
   ...props
 }: FileUploadFieldProps) => {
   const onTextAreaChange = (newValue: string, event: React.ChangeEvent<HTMLTextAreaElement>) => {
     onChange(newValue, filename, event);
+    onTextChanged(event)
   };
   return (
     <div

--- a/packages/react-core/src/components/FileUpload/FileUploadField.tsx
+++ b/packages/react-core/src/components/FileUpload/FileUploadField.tsx
@@ -77,7 +77,7 @@ export interface FileUploadFieldProps extends Omit<React.HTMLProps<HTMLDivElemen
   /** A reference object to attach to the FileUploadField container element. */
   containerRef?: React.Ref<HTMLDivElement>;
   /** Text area text changed */
-  onTextChanged?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void
+  onTextChanged?: (text: string) => void;
 }
 
 export const FileUploadField: React.FunctionComponent<FileUploadFieldProps> = ({
@@ -113,7 +113,7 @@ export const FileUploadField: React.FunctionComponent<FileUploadFieldProps> = ({
 }: FileUploadFieldProps) => {
   const onTextAreaChange = (newValue: string, event: React.ChangeEvent<HTMLTextAreaElement>) => {
     onChange(newValue, filename, event);
-    onTextChanged(event)
+    onTextChanged?.(newValue)
   };
   return (
     <div

--- a/packages/react-core/src/components/FileUpload/__tests__/__snapshots__/FileUpload.test.tsx.snap
+++ b/packages/react-core/src/components/FileUpload/__tests__/__snapshots__/FileUpload.test.tsx.snap
@@ -1,16 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`simple fileupload 1`] = `
-<t
-  disabled={false}
-  getDataTransferItems={[Function]}
-  maxSize={Infinity}
-  minSize={0}
+<Dropzone
   multiple={false}
+  noClick={true}
   onDropAccepted={[Function]}
   onDropRejected={[Function]}
-  preventDropOnDocument={true}
 >
   <Component />
-</t>
+</Dropzone>
 `;

--- a/packages/react-core/src/components/FileUpload/examples/FileUpload.md
+++ b/packages/react-core/src/components/FileUpload/examples/FileUpload.md
@@ -25,9 +25,8 @@ class SimpleTextFileUpload extends React.Component {
   constructor(props) {
     super(props);
     this.state = { value: '', filename: '', isLoading: false };
-    this.handleFileChanged = (event, file, filename) => this.setState({ filename });
-    this.handleDataChanged = value => { this.setState({ value });
-    console.log("onDataChanged",value);};
+    this.handleInputChange = (event, file) => this.setState({ filename: file.name });
+    this.handleTextChanged = value => { this.setState({ value });
     this.handleFileReadStarted = fileHandle => this.setState({ isLoading: true });
     this.handleFileReadFinished = fileHandle => this.setState({ isLoading: false });
     this.handleClear = event => this.setState({ filename: '', value: '' });
@@ -42,8 +41,8 @@ class SimpleTextFileUpload extends React.Component {
         value={value}
         filename={filename}
         filenamePlaceholder="Drag and drop a file or upload one"
-        onFileChanged={this.handleFileChanged}
-        onDataChanged={this.handleDataChanged}
+        onInputChange={this.handleInputChange}
+        onTextChanged={this.handleDataChanged}
         onReadStarted={this.handleFileReadStarted}
         onReadFinished={this.handleFileReadFinished}
         onClearButtonClick={this.handleClear}
@@ -67,7 +66,7 @@ class TextFileWithEditsAllowed extends React.Component {
   constructor(props) {
     super(props);
     this.state = { value: '', filename: '', isLoading: false };
-    this.handleFileChange = (value, filename, event) => this.setState({ value, filename });
+    this.handleInputChange = (event,file) => this.setState({ value, file.name });
     this.handleFileReadStarted = fileHandle => this.setState({ isLoading: true });
     this.handleFileReadFinished = fileHandle => this.setState({ isLoading: false });
   }
@@ -111,8 +110,8 @@ class TextFileUploadWithRestrictions extends React.Component {
   constructor(props) {
     super(props);
     this.state = { value: '', filename: '', isLoading: false, isRejected: false };
-    this.handleFileChange = (value, filename, event) => {
-      this.setState({ value, filename, isRejected: false });
+    this.handleInputChange = (event,file) => {
+      this.setState({ value, file.name, isRejected: false });
     };
     this.handleFileRejected = (rejectedFiles, event) => this.setState({ isRejected: true });
     this.handleFileReadStarted = fileHandle => this.setState({ isLoading: true });
@@ -168,12 +167,14 @@ class SimpleFileUpload extends React.Component {
   constructor(props) {
     super(props);
     this.state = { value: null, filename: '' };
-    this.handleFileChange = (value, filename, event) => this.setState({ value, filename });
+    this.handleInputChange = (event,file) => {
+      this.setState({ value, file.name});
+    };
   }
 
   render() {
     const { value, filename } = this.state;
-    return <FileUpload id="simple-file" value={value} filename={filename} filenamePlaceholder="Drag and drop a file or upload one" browseButtonText="Upload" onChange={this.handleFileChange} />;
+    return <FileUpload id="simple-file" value={value} filename={filename} filenamePlaceholder="Drag and drop a file or upload one" browseButtonText="Upload" onInputChange={this.handleInputChange} />;
   }
 }
 ```
@@ -193,7 +194,9 @@ class CustomPreviewFileUpload extends React.Component {
   constructor(props) {
     super(props);
     this.state = { value: null, filename: '' };
-    this.handleFileChange = (value, filename, event) => this.setState({ value, filename });
+    this.handleInputChange = (event,file) => {
+      this.setState({ value, file.name });
+    };
   }
 
   render() {
@@ -203,8 +206,8 @@ class CustomPreviewFileUpload extends React.Component {
         id="customized-preview-file"
         value={value}
         filename={filename}
-        filenamePlaceholder="Drag and drop a file or upload one"
-        onChange={this.handleFileChange}
+        filenamePlaceholder="Drag and drop a file or upload one"      
+        onInputChange={this.handleInputChange}
         hideDefaultPreview
         browseButtonText="Upload"
       >

--- a/packages/react-core/src/components/FileUpload/examples/FileUpload.md
+++ b/packages/react-core/src/components/FileUpload/examples/FileUpload.md
@@ -16,6 +16,7 @@ The basic `FileUpload` component can accept a file via browse or drag-and-drop, 
 If `type="text"` is passed (and `hideDefaultPreview` is not), a `TextArea` preview will be rendered underneath the filename bar. When a file is selected, its contents will be read into memory and passed to the `onChange` prop as a string (along with its filename). Typing/pasting text in the box will also call `onChange` with a string, and a string value is expected for the `value` prop.
 
 ### Simple text file
+
 ```js
 import React from 'react';
 import { FileUpload } from '@patternfly/react-core';
@@ -24,9 +25,12 @@ class SimpleTextFileUpload extends React.Component {
   constructor(props) {
     super(props);
     this.state = { value: '', filename: '', isLoading: false };
-    this.handleFileChange = (value, filename, event) => this.setState({ value, filename });
+    this.handleFileChanged = (event, file, filename) => this.setState({ filename });
+    this.handleDataChanged = value => { this.setState({ value });
+    console.log("onDataChanged",value);};
     this.handleFileReadStarted = fileHandle => this.setState({ isLoading: true });
     this.handleFileReadFinished = fileHandle => this.setState({ isLoading: false });
+    this.handleClear = event => this.setState({ filename: '', value: '' });
   }
 
   render() {
@@ -38,9 +42,11 @@ class SimpleTextFileUpload extends React.Component {
         value={value}
         filename={filename}
         filenamePlaceholder="Drag and drop a file or upload one"
-        onChange={this.handleFileChange}
+        onFileChanged={this.handleFileChanged}
+        onDataChanged={this.handleDataChanged}
         onReadStarted={this.handleFileReadStarted}
         onReadFinished={this.handleFileReadFinished}
+        onClearButtonClick={this.handleClear}
         isLoading={isLoading}
         browseButtonText="Upload"
       />
@@ -52,6 +58,7 @@ class SimpleTextFileUpload extends React.Component {
 A user can always type instead of selecting a file, but by default, once a user selects a text file from their disk they are not allowed to edit it (to prevent unintended changes to a format-sensitive file). This behavior can be changed with the `allowEditingUploadedText` prop:
 
 ### Text file with edits allowed
+
 ```js
 import React from 'react';
 import { FileUpload } from '@patternfly/react-core';
@@ -95,6 +102,7 @@ Any [props accepted by `react-dropzone`'s `Dropzone` component](https://react-dr
 Restricting file sizes and types in this way is for user convenience only, and it cannot prevent a malicious user from submitting anything to your server. As with any user input, your application should also validate, sanitize and/or reject restricted files on the server side.
 
 ### Text file with restrictions
+
 ```js
 import React from 'react';
 import { FileUpload, Form, FormGroup } from '@patternfly/react-core';
@@ -151,6 +159,7 @@ class TextFileUploadWithRestrictions extends React.Component {
 If no `type` prop is specified, the component will not read files directly. When a file is selected, a [`File` object](https://developer.mozilla.org/en-US/docs/Web/API/File) will be passed to `onChange` and your application will be responsible for reading from it (e.g. by using the [FileReader API](https://developer.mozilla.org/en-US/docs/Web/API/FileReader) or attaching it to a [FormData object](https://developer.mozilla.org/en-US/docs/Web/API/FormData/Using_FormData_Objects)). A `File` object will also be expected for the `value` prop instead of a string, and no preview of the file contents will be shown by default. The `onReadStarted` and `onReadFinished` callbacks will also not be called since the component is not reading the file.
 
 ### Simple file of any format
+
 ```js
 import React from 'react';
 import { FileUpload } from '@patternfly/react-core';
@@ -174,6 +183,7 @@ class SimpleFileUpload extends React.Component {
 Regardless of `type`, the preview area (the TextArea, or any future implementations of default previews for other types) can be removed by passing `hideDefaultPreview`, and a custom one can be rendered by passing `children`.
 
 ### Custom file preview
+
 ```js
 import React from 'react';
 import { FileUpload } from '@patternfly/react-core';
@@ -216,6 +226,7 @@ class CustomPreviewFileUpload extends React.Component {
 Note that the `isLoading` prop is styled to position the spinner dead center above the entire component, so it should not be used with `hideDefaultPreview` unless a custom empty-state preview is provided via `children`. The below example prevents `isLoading` and `hideDefaultPreview` from being used at the same time. You can always provide your own spinner as part of the `children`!
 
 ### Custom file upload
+
 ```js
 import React from 'react';
 import { FileUploadField, Checkbox } from '@patternfly/react-core';

--- a/packages/react-core/src/components/FileUpload/examples/FileUpload.md
+++ b/packages/react-core/src/components/FileUpload/examples/FileUpload.md
@@ -9,11 +9,12 @@ import FileUploadIcon from '@patternfly/react-icons/dist/esm/icons/file-upload-i
 
 ## Examples
 
-The basic `FileUpload` component can accept a file via browse or drag-and-drop, and behaves like a standard form field with its `value` and `onChange` props. The `type` prop determines how the `FileUpload` component behaves upon accepting a file, what type of value it passes to its `onChange` prop, and what type it expects for its `value` prop.
+The basic `FileUpload` component can accept a file via browse or drag-and-drop, and behaves like a standard form field with its `value` and `onInputChange` event that is similar to `<input onChange="...">` prop. The `type` prop determines how the `FileUpload` component behaves upon accepting a file, what type of value it passes to its `onDataChanged` event.
 
 ### Text files
 
-If `type="text"` is passed (and `hideDefaultPreview` is not), a `TextArea` preview will be rendered underneath the filename bar. When a file is selected, its contents will be read into memory and passed to the `onChange` prop as a string (along with its filename). Typing/pasting text in the box will also call `onChange` with a string, and a string value is expected for the `value` prop.
+If `type="text"` is passed (and `hideDefaultPreview` is not), a `TextArea` preview will be rendered underneath the filename bar. When a file is selected, its contents will be read into memory and passed to the `onDataChanged` event as a string. Every filename change is passed to `onInputChange` same as it would do with the `<input>` element. 
+Pressing *Clear* button triggers `onClearClicked` event.
 
 ### Simple text file
 
@@ -54,7 +55,8 @@ class SimpleTextFileUpload extends React.Component {
 }
 ```
 
-A user can always type instead of selecting a file, but by default, once a user selects a text file from their disk they are not allowed to edit it (to prevent unintended changes to a format-sensitive file). This behavior can be changed with the `allowEditingUploadedText` prop:
+A user can always type instead of selecting a file, but by default, once a user selects a text file from their disk they are not allowed to edit it (to prevent unintended changes to a format-sensitive file). This behavior can be changed with the `allowEditingUploadedText` prop.
+Typing/pasting text in the box will call `onTextChanged` with a string, and a string value is expected for the `value` prop. :
 
 ### Text file with edits allowed
 
@@ -163,7 +165,7 @@ class TextFileUploadWithRestrictions extends React.Component {
 
 ### Other file types
 
-If no `type` prop is specified, the component will not read files directly. When a file is selected, a [`File` object](https://developer.mozilla.org/en-US/docs/Web/API/File) will be passed to `onChange` and your application will be responsible for reading from it (e.g. by using the [FileReader API](https://developer.mozilla.org/en-US/docs/Web/API/FileReader) or attaching it to a [FormData object](https://developer.mozilla.org/en-US/docs/Web/API/FormData/Using_FormData_Objects)). A `File` object will also be expected for the `value` prop instead of a string, and no preview of the file contents will be shown by default. The `onReadStarted` and `onReadFinished` callbacks will also not be called since the component is not reading the file.
+If no `type` prop is specified, the component will not read files directly. When a file is selected, a [`File` object](https://developer.mozilla.org/en-US/docs/Web/API/File) will be passed as a second argument to `onInputChange` and your application will be responsible for reading from it (e.g. by using the [FileReader API](https://developer.mozilla.org/en-US/docs/Web/API/FileReader) or attaching it to a [FormData object](https://developer.mozilla.org/en-US/docs/Web/API/FormData/Using_FormData_Objects)). A `File` object will also be expected for the `value` prop instead of a string, and no preview of the file contents will be shown by default. The `onReadStarted` and `onReadFinished` callbacks will also not be called since the component is not reading the file.
 
 ### Simple file of any format
 
@@ -309,7 +311,7 @@ class CustomFileUpload extends React.Component {
           type="text"
           value={value}
           filename={filename ? 'example-filename.txt' : ''}
-          onChange={this.handleTextAreaChange}
+          onTextChanged={this.handleTextAreaChange}
           filenamePlaceholder="Do something custom with this!"
           onBrowseButtonClick={() => alert('Browse button clicked!')}
           onClearButtonClick={() => alert('Clear button clicked!')}

--- a/packages/react-core/src/components/FileUpload/examples/FileUpload.md
+++ b/packages/react-core/src/components/FileUpload/examples/FileUpload.md
@@ -26,10 +26,10 @@ class SimpleTextFileUpload extends React.Component {
     super(props);
     this.state = { value: '', filename: '', isLoading: false };
     this.handleInputChange = (event, file) => this.setState({ filename: file.name });
-    this.handleTextChanged = value => { this.setState({ value });
+    this.handleDataChanged = value => this.setState({ value });
+    this.handleClear = event => this.setState({ filename: '', value: '' });
     this.handleFileReadStarted = fileHandle => this.setState({ isLoading: true });
     this.handleFileReadFinished = fileHandle => this.setState({ isLoading: false });
-    this.handleClear = event => this.setState({ filename: '', value: '' });
   }
 
   render() {
@@ -42,10 +42,10 @@ class SimpleTextFileUpload extends React.Component {
         filename={filename}
         filenamePlaceholder="Drag and drop a file or upload one"
         onInputChange={this.handleInputChange}
-        onTextChanged={this.handleDataChanged}
+        onDataChanged={this.handleDataChanged}
         onReadStarted={this.handleFileReadStarted}
         onReadFinished={this.handleFileReadFinished}
-        onClearButtonClick={this.handleClear}
+        onClearClicked={this.handleClear}
         isLoading={isLoading}
         browseButtonText="Upload"
       />
@@ -66,7 +66,9 @@ class TextFileWithEditsAllowed extends React.Component {
   constructor(props) {
     super(props);
     this.state = { value: '', filename: '', isLoading: false };
-    this.handleInputChange = (event,file) => this.setState({ value, file.name });
+    this.handleInputChange = (event, file) => this.setState({ filename: file.name });
+    this.handleTextOrDataChanged = value => this.setState({ value });
+    this.handleClear = event => this.setState({ filename: '', value: '' });
     this.handleFileReadStarted = fileHandle => this.setState({ isLoading: true });
     this.handleFileReadFinished = fileHandle => this.setState({ isLoading: false });
   }
@@ -80,7 +82,10 @@ class TextFileWithEditsAllowed extends React.Component {
         value={value}
         filename={filename}
         filenamePlaceholder="Drag and drop a file or upload one"
-        onChange={this.handleFileChange}
+        onInputChange={this.handleInputChange}
+        onDataChanged={this.handleTextOrDataChanged}
+        onClearClicked={this.handleClear}
+        onTextChanged={this.handleTextOrDataChanged}
         onReadStarted={this.handleFileReadStarted}
         onReadFinished={this.handleFileReadFinished}
         isLoading={isLoading}
@@ -110,9 +115,9 @@ class TextFileUploadWithRestrictions extends React.Component {
   constructor(props) {
     super(props);
     this.state = { value: '', filename: '', isLoading: false, isRejected: false };
-    this.handleInputChange = (event,file) => {
-      this.setState({ value, file.name, isRejected: false });
-    };
+    this.handleInputChange = (event, file) => this.setState({ filename: file.name });
+    this.handleTextOrDataChanged = value => this.setState({ value });
+    this.handleClear = event => this.setState({ filename: '', value: '', isRejected: false });
     this.handleFileRejected = (rejectedFiles, event) => this.setState({ isRejected: true });
     this.handleFileReadStarted = fileHandle => this.setState({ isLoading: true });
     this.handleFileReadFinished = fileHandle => this.setState({ isLoading: false });
@@ -134,7 +139,10 @@ class TextFileUploadWithRestrictions extends React.Component {
             value={value}
             filename={filename}
             filenamePlaceholder="Drag and drop a file or upload one"
-            onChange={this.handleFileChange}
+            onInputChange={this.handleInputChange}
+            onDataChanged={this.handleTextOrDataChanged}
+            onTextChanged={this.handleTextOrDataChanged}
+            onClearClicked={this.handleClear}
             onReadStarted={this.handleFileReadStarted}
             onReadFinished={this.handleFileReadFinished}
             isLoading={isLoading}
@@ -167,14 +175,25 @@ class SimpleFileUpload extends React.Component {
   constructor(props) {
     super(props);
     this.state = { value: null, filename: '' };
-    this.handleInputChange = (event,file) => {
-      this.setState({ value, file.name});
+    this.handleInputChange = (event, file) => {
+      this.setState({ filename: file.name });
     };
+    this.handleClear = event => this.setState({ filename: '', value: ''});
   }
 
   render() {
     const { value, filename } = this.state;
-    return <FileUpload id="simple-file" value={value} filename={filename} filenamePlaceholder="Drag and drop a file or upload one" browseButtonText="Upload" onInputChange={this.handleInputChange} />;
+    return (
+      <FileUpload
+        id="simple-file"
+        value={value}
+        filename={filename}
+        filenamePlaceholder="Drag and drop a file or upload one"
+        browseButtonText="Upload"
+        onInputChange={this.handleInputChange}
+        onClearClicked={this.handleClear}
+      />
+    );
   }
 }
 ```
@@ -194,9 +213,10 @@ class CustomPreviewFileUpload extends React.Component {
   constructor(props) {
     super(props);
     this.state = { value: null, filename: '' };
-    this.handleInputChange = (event,file) => {
-      this.setState({ value, file.name });
+    this.handleInputChange = (event, file) => {
+      this.setState({ value: file, filename: file.name });
     };
+    this.handleClear = event => this.setState({ filename: '', value: ''});
   }
 
   render() {
@@ -206,8 +226,9 @@ class CustomPreviewFileUpload extends React.Component {
         id="customized-preview-file"
         value={value}
         filename={filename}
-        filenamePlaceholder="Drag and drop a file or upload one"      
+        filenamePlaceholder="Drag and drop a file or upload one"
         onInputChange={this.handleInputChange}
+        onClearClicked={this.handleClear}
         hideDefaultPreview
         browseButtonText="Upload"
       >

--- a/packages/react-core/src/components/FileUpload/examples/FileUpload.md
+++ b/packages/react-core/src/components/FileUpload/examples/FileUpload.md
@@ -9,12 +9,12 @@ import FileUploadIcon from '@patternfly/react-icons/dist/esm/icons/file-upload-i
 
 ## Examples
 
-The basic `FileUpload` component can accept a file via browse or drag-and-drop, and behaves like a standard form field with its `value` and `onInputChange` event that is similar to `<input onChange="...">` prop. The `type` prop determines how the `FileUpload` component behaves upon accepting a file, what type of value it passes to its `onDataChanged` event.
+The basic `FileUpload` component can accept a file via browse or drag-and-drop, and behaves like a standard form field with its `value` and `onFileInputChange` event that is similar to `<input onChange="...">` prop. The `type` prop determines how the `FileUpload` component behaves upon accepting a file, what type of value it passes to its `onDataChange` event.
 
 ### Text files
 
-If `type="text"` is passed (and `hideDefaultPreview` is not), a `TextArea` preview will be rendered underneath the filename bar. When a file is selected, its contents will be read into memory and passed to the `onDataChanged` event as a string. Every filename change is passed to `onInputChange` same as it would do with the `<input>` element. 
-Pressing *Clear* button triggers `onClearClicked` event.
+If `type="text"` is passed (and `hideDefaultPreview` is not), a `TextArea` preview will be rendered underneath the filename bar. When a file is selected, its contents will be read into memory and passed to the `onDataChange` event as a string. Every filename change is passed to `onFileInputChange` same as it would do with the `<input>` element.
+Pressing _Clear_ button triggers `onClearClick` event.
 
 ### Simple text file
 
@@ -26,8 +26,8 @@ class SimpleTextFileUpload extends React.Component {
   constructor(props) {
     super(props);
     this.state = { value: '', filename: '', isLoading: false };
-    this.handleInputChange = (event, file) => this.setState({ filename: file.name });
-    this.handleDataChanged = value => this.setState({ value });
+    this.handleFileInputChange = (event, file) => this.setState({ filename: file.name });
+    this.handleDataChange = value => this.setState({ value });
     this.handleClear = event => this.setState({ filename: '', value: '' });
     this.handleFileReadStarted = fileHandle => this.setState({ isLoading: true });
     this.handleFileReadFinished = fileHandle => this.setState({ isLoading: false });
@@ -42,11 +42,11 @@ class SimpleTextFileUpload extends React.Component {
         value={value}
         filename={filename}
         filenamePlaceholder="Drag and drop a file or upload one"
-        onInputChange={this.handleInputChange}
-        onDataChanged={this.handleDataChanged}
+        onFileInputChange={this.handleFileInputChange}
+        onDataChange={this.handleDataChange}
         onReadStarted={this.handleFileReadStarted}
         onReadFinished={this.handleFileReadFinished}
-        onClearClicked={this.handleClear}
+        onClearClick={this.handleClear}
         isLoading={isLoading}
         browseButtonText="Upload"
       />
@@ -56,7 +56,7 @@ class SimpleTextFileUpload extends React.Component {
 ```
 
 A user can always type instead of selecting a file, but by default, once a user selects a text file from their disk they are not allowed to edit it (to prevent unintended changes to a format-sensitive file). This behavior can be changed with the `allowEditingUploadedText` prop.
-Typing/pasting text in the box will call `onTextChanged` with a string, and a string value is expected for the `value` prop. :
+Typing/pasting text in the box will call `onTextChange` with a string, and a string value is expected for the `value` prop. :
 
 ### Text file with edits allowed
 
@@ -68,8 +68,8 @@ class TextFileWithEditsAllowed extends React.Component {
   constructor(props) {
     super(props);
     this.state = { value: '', filename: '', isLoading: false };
-    this.handleInputChange = (event, file) => this.setState({ filename: file.name });
-    this.handleTextOrDataChanged = value => this.setState({ value });
+    this.handleFileInputChange = (event, file) => this.setState({ filename: file.name });
+    this.handleTextOrDataChange = value => this.setState({ value });
     this.handleClear = event => this.setState({ filename: '', value: '' });
     this.handleFileReadStarted = fileHandle => this.setState({ isLoading: true });
     this.handleFileReadFinished = fileHandle => this.setState({ isLoading: false });
@@ -84,10 +84,10 @@ class TextFileWithEditsAllowed extends React.Component {
         value={value}
         filename={filename}
         filenamePlaceholder="Drag and drop a file or upload one"
-        onInputChange={this.handleInputChange}
-        onDataChanged={this.handleTextOrDataChanged}
-        onClearClicked={this.handleClear}
-        onTextChanged={this.handleTextOrDataChanged}
+        onFileInputChange={this.handleFileInputChange}
+        onDataChange={this.handleTextOrDataChange}
+        onClearClick={this.handleClear}
+        onTextChange={this.handleTextOrDataChange}
         onReadStarted={this.handleFileReadStarted}
         onReadFinished={this.handleFileReadFinished}
         isLoading={isLoading}
@@ -117,8 +117,8 @@ class TextFileUploadWithRestrictions extends React.Component {
   constructor(props) {
     super(props);
     this.state = { value: '', filename: '', isLoading: false, isRejected: false };
-    this.handleInputChange = (event, file) => this.setState({ filename: file.name });
-    this.handleTextOrDataChanged = value => this.setState({ value });
+    this.handleFileInputChange = (event, file) => this.setState({ filename: file.name });
+    this.handleTextOrDataChange = value => this.setState({ value });
     this.handleClear = event => this.setState({ filename: '', value: '', isRejected: false });
     this.handleFileRejected = (rejectedFiles, event) => this.setState({ isRejected: true });
     this.handleFileReadStarted = fileHandle => this.setState({ isLoading: true });
@@ -141,10 +141,10 @@ class TextFileUploadWithRestrictions extends React.Component {
             value={value}
             filename={filename}
             filenamePlaceholder="Drag and drop a file or upload one"
-            onInputChange={this.handleInputChange}
-            onDataChanged={this.handleTextOrDataChanged}
-            onTextChanged={this.handleTextOrDataChanged}
-            onClearClicked={this.handleClear}
+            onFileInputChange={this.handleFileInputChange}
+            onDataChange={this.handleTextOrDataChange}
+            onTextChange={this.handleTextOrDataChange}
+            onClearClick={this.handleClear}
             onReadStarted={this.handleFileReadStarted}
             onReadFinished={this.handleFileReadFinished}
             isLoading={isLoading}
@@ -165,7 +165,7 @@ class TextFileUploadWithRestrictions extends React.Component {
 
 ### Other file types
 
-If no `type` prop is specified, the component will not read files directly. When a file is selected, a [`File` object](https://developer.mozilla.org/en-US/docs/Web/API/File) will be passed as a second argument to `onInputChange` and your application will be responsible for reading from it (e.g. by using the [FileReader API](https://developer.mozilla.org/en-US/docs/Web/API/FileReader) or attaching it to a [FormData object](https://developer.mozilla.org/en-US/docs/Web/API/FormData/Using_FormData_Objects)). A `File` object will also be expected for the `value` prop instead of a string, and no preview of the file contents will be shown by default. The `onReadStarted` and `onReadFinished` callbacks will also not be called since the component is not reading the file.
+If no `type` prop is specified, the component will not read files directly. When a file is selected, a [`File` object](https://developer.mozilla.org/en-US/docs/Web/API/File) will be passed as a second argument to `onFileInputChange` and your application will be responsible for reading from it (e.g. by using the [FileReader API](https://developer.mozilla.org/en-US/docs/Web/API/FileReader) or attaching it to a [FormData object](https://developer.mozilla.org/en-US/docs/Web/API/FormData/Using_FormData_Objects)). A `File` object will also be expected for the `value` prop instead of a string, and no preview of the file contents will be shown by default. The `onReadStarted` and `onReadFinished` callbacks will also not be called since the component is not reading the file.
 
 ### Simple file of any format
 
@@ -177,10 +177,10 @@ class SimpleFileUpload extends React.Component {
   constructor(props) {
     super(props);
     this.state = { value: null, filename: '' };
-    this.handleInputChange = (event, file) => {
+    this.handleFileInputChange = (event, file) => {
       this.setState({ filename: file.name });
     };
-    this.handleClear = event => this.setState({ filename: '', value: ''});
+    this.handleClear = event => this.setState({ filename: '', value: '' });
   }
 
   render() {
@@ -192,8 +192,8 @@ class SimpleFileUpload extends React.Component {
         filename={filename}
         filenamePlaceholder="Drag and drop a file or upload one"
         browseButtonText="Upload"
-        onInputChange={this.handleInputChange}
-        onClearClicked={this.handleClear}
+        onFileInputChange={this.handleFileInputChange}
+        onClearClick={this.handleClear}
       />
     );
   }
@@ -215,10 +215,10 @@ class CustomPreviewFileUpload extends React.Component {
   constructor(props) {
     super(props);
     this.state = { value: null, filename: '' };
-    this.handleInputChange = (event, file) => {
+    this.handleFileInputChange = (event, file) => {
       this.setState({ value: file, filename: file.name });
     };
-    this.handleClear = event => this.setState({ filename: '', value: ''});
+    this.handleClear = event => this.setState({ filename: '', value: '' });
   }
 
   render() {
@@ -229,8 +229,8 @@ class CustomPreviewFileUpload extends React.Component {
         value={value}
         filename={filename}
         filenamePlaceholder="Drag and drop a file or upload one"
-        onInputChange={this.handleInputChange}
-        onClearClicked={this.handleClear}
+        onFileInputChange={this.handleFileInputChange}
+        onClearClick={this.handleClear}
         hideDefaultPreview
         browseButtonText="Upload"
       >
@@ -311,7 +311,7 @@ class CustomFileUpload extends React.Component {
           type="text"
           value={value}
           filename={filename ? 'example-filename.txt' : ''}
-          onTextChanged={this.handleTextAreaChange}
+          onTextChange={this.handleTextAreaChange}
           filenamePlaceholder="Do something custom with this!"
           onBrowseButtonClick={() => alert('Browse button clicked!')}
           onClearButtonClick={() => alert('Clear button clicked!')}

--- a/packages/react-integration/demo-app-ts/src/components/demos/FileUploadDemo/FileUploadDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/FileUploadDemo/FileUploadDemo.tsx
@@ -10,7 +10,14 @@ export class FileUploadDemo extends React.Component {
   handleFileChange = (...args: any[]) => {
     const [value, filename] = args
     this.setState({ value, filename })
-    console.log(args)
+    console.log("onChange",args)
+  }
+  handleInputChange= (...args: any[])=> {
+    console.log("onInputChange",args);
+  }
+
+  handleInputChange2= (...args: any[])=> {
+    console.log("onInputChange2",args);
   }
   /* eslint-disable @typescript-eslint/no-unused-vars */
   handleFileReadStarted = (fileHandle: File) => this.setState({ isLoading: true });
@@ -26,12 +33,12 @@ export class FileUploadDemo extends React.Component {
         value={value}
         filename={filename}
         onChange={this.handleFileChange}
+        onInputChange={this.handleInputChange}
         onReadStarted={this.handleFileReadStarted}
         onReadFinished={this.handleFileReadFinished}
         onClick={this.handleClick}
         onClearClicked={(e) => console.log("clear clicked", e)}
         onTextChanged={(e) => console.log("text changed", e)}
-        onFileChanged={(...args) => console.log("file changed", args)}
         isLoading={isLoading}
       >
         <TextInput value={value}>
@@ -39,6 +46,7 @@ export class FileUploadDemo extends React.Component {
         </TextInput>
       </FileUpload>
       <br></br>
+      <input type="file" onChange={this.handleInputChange2} />
     </>
     );
   }

--- a/packages/react-integration/demo-app-ts/src/components/demos/FileUploadDemo/FileUploadDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/FileUploadDemo/FileUploadDemo.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { FileUpload } from '@patternfly/react-core';
+import React, { ChangeEvent } from 'react';
+import { FileUpload, TextArea, TextInput } from '@patternfly/react-core';
 
 export class FileUploadDemo extends React.Component {
   static displayName = 'FileUploadDemo';
@@ -7,7 +7,11 @@ export class FileUploadDemo extends React.Component {
   state = { value: '', filename: '', isLoading: false };
   /* eslint-disable-next-line no-console */
   handleClick = (evt: React.MouseEvent) => console.log('clicked', evt.target);
-  handleFileChange = (value: string | File, filename: string) => this.setState({ value, filename });
+  handleFileChange = (...args: any[]) => {
+    const [value, filename] = args
+    this.setState({ value, filename })
+    console.log(args)
+  }
   /* eslint-disable @typescript-eslint/no-unused-vars */
   handleFileReadStarted = (fileHandle: File) => this.setState({ isLoading: true });
   handleFileReadFinished = (fileHandle: File) => this.setState({ isLoading: false });
@@ -15,7 +19,7 @@ export class FileUploadDemo extends React.Component {
 
   render() {
     const { value, filename, isLoading } = this.state;
-    return (
+    return (<>
       <FileUpload
         id="simple-text-file"
         type="text"
@@ -25,8 +29,17 @@ export class FileUploadDemo extends React.Component {
         onReadStarted={this.handleFileReadStarted}
         onReadFinished={this.handleFileReadFinished}
         onClick={this.handleClick}
+        onClearClicked={(e) => console.log("clear clicked", e)}
+        onTextChanged={(e) => console.log("text changed", e)}
+        onFileChanged={(...args) => console.log("file changed", args)}
         isLoading={isLoading}
-      />
+      >
+        <TextInput value={value}>
+
+        </TextInput>
+      </FileUpload>
+      <br></br>
+    </>
     );
   }
 }

--- a/packages/react-integration/demo-app-ts/src/components/demos/FileUploadDemo/FileUploadDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/FileUploadDemo/FileUploadDemo.tsx
@@ -1,24 +1,14 @@
-import React, { ChangeEvent } from 'react';
-import { FileUpload, TextArea, TextInput } from '@patternfly/react-core';
+import React from 'react';
+import { FileUpload } from '@patternfly/react-core';
 
 export class FileUploadDemo extends React.Component {
   static displayName = 'FileUploadDemo';
 
   state = { value: '', filename: '', isLoading: false };
   /* eslint-disable-next-line no-console */
-  handleClick = (evt: React.MouseEvent) => console.log('clicked', evt.target);
-  handleFileChange = (...args: any[]) => {
-    const [value, filename] = args
-    this.setState({ value, filename })
-    console.log("onChange",args)
-  }
-  handleInputChange= (...args: any[])=> {
-    console.log("onInputChange",args);
-  }
-
-  handleInputChange2= (...args: any[])=> {
-    console.log("onInputChange2",args);
-  }
+  handleInputChange = (event: React.ChangeEvent<HTMLInputElement>, file: File) =>
+    this.setState({ value: file, filename: file.name });
+  handleDataChanged = (value: string) => this.setState({ value });
   /* eslint-disable @typescript-eslint/no-unused-vars */
   handleFileReadStarted = (fileHandle: File) => this.setState({ isLoading: true });
   handleFileReadFinished = (fileHandle: File) => this.setState({ isLoading: false });
@@ -26,28 +16,18 @@ export class FileUploadDemo extends React.Component {
 
   render() {
     const { value, filename, isLoading } = this.state;
-    return (<>
+    return (
       <FileUpload
         id="simple-text-file"
         type="text"
         value={value}
         filename={filename}
-        onChange={this.handleFileChange}
         onInputChange={this.handleInputChange}
+        onDataChanged={this.handleDataChanged}
         onReadStarted={this.handleFileReadStarted}
         onReadFinished={this.handleFileReadFinished}
-        onClick={this.handleClick}
-        onClearClicked={(e) => console.log("clear clicked", e)}
-        onTextChanged={(e) => console.log("text changed", e)}
         isLoading={isLoading}
-      >
-        <TextInput value={value}>
-
-        </TextInput>
-      </FileUpload>
-      <br></br>
-      <input type="file" onChange={this.handleInputChange2} />
-    </>
+      />
     );
   }
 }

--- a/packages/react-integration/demo-app-ts/src/components/demos/FileUploadDemo/FileUploadDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/FileUploadDemo/FileUploadDemo.tsx
@@ -6,9 +6,9 @@ export class FileUploadDemo extends React.Component {
 
   state = { value: '', filename: '', isLoading: false };
   /* eslint-disable-next-line no-console */
-  handleInputChange = (event: React.ChangeEvent<HTMLInputElement>, file: File) =>
+  handleFileInputChange = (event: React.ChangeEvent<HTMLInputElement>, file: File) =>
     this.setState({ value: file, filename: file.name });
-  handleDataChanged = (value: string) => this.setState({ value });
+  handleDataChange = (value: string) => this.setState({ value });
   /* eslint-disable @typescript-eslint/no-unused-vars */
   handleFileReadStarted = (fileHandle: File) => this.setState({ isLoading: true });
   handleFileReadFinished = (fileHandle: File) => this.setState({ isLoading: false });
@@ -22,8 +22,8 @@ export class FileUploadDemo extends React.Component {
         type="text"
         value={value}
         filename={filename}
-        onInputChange={this.handleInputChange}
-        onDataChanged={this.handleDataChanged}
+        onFileInputChange={this.handleFileInputChange}
+        onDataChange={this.handleDataChange}
         onReadStarted={this.handleFileReadStarted}
         onReadFinished={this.handleFileReadFinished}
         isLoading={isLoading}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4585,6 +4585,15 @@ attr-accept@^1.1.3:
   dependencies:
     core-js "^2.5.0"
 
+attr-accept@^2.2.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-2.2.2.tgz#646613809660110749e92f2c10833b70968d929b"
+  integrity sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==
+
+author-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/author-regex/-/author-regex-1.0.0.tgz#d08885be6b9bbf9439fe087c76287245f0a81450"
+
 autoprefixer@^9.8.6:
   version "9.8.6"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.8.6.tgz#3b73594ca1bf9266320c5acf1588d74dea74210f"
@@ -8152,6 +8161,21 @@ file-selector@^0.1.8:
   resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-0.1.12.tgz#fe726547be219a787a9dcc640575a04a032b1fd0"
   dependencies:
     tslib "^1.9.0"
+
+file-selector@^0.2.2:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-0.2.4.tgz#7b98286f9dbb9925f420130ea5ed0a69238d4d80"
+  integrity sha512-ZDsQNbrv6qRi1YTDOEWzf5J2KjZ9KMI1Q2SGeTkCJmNNW25Jg4TW4UMcmoqcg4WrAyKRcpBXdbWRxkfrOzVRbA==
+  dependencies:
+    tslib "^2.0.3"
+
+file-type@^3.1.0, file-type@^3.8.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-3.9.0.tgz#257a078384d1db8087bc449d107d52a52672b9e9"
+
+file-type@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-9.0.0.tgz#a68d5ad07f486414dfb2c8866f73161946714a18"
 
 file-uri-to-path@1.0.0:
   version "1.0.0"
@@ -13641,6 +13665,15 @@ react-dom@^17.0.0:
     object-assign "^4.1.1"
     scheduler "^0.20.1"
 
+react-dropzone@11.3.4:
+  version "11.3.4"
+  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-11.3.4.tgz#aeb098df5c4491e165042c9f0b5e2e7185484740"
+  integrity sha512-B1nzNRZ4F1cnrfEC0T6KXeBN1mCPinu4JCoTrp7NjB+442KSPxqfDrw41QIA2kAwlYs1+wj/0BTedeM5hc2+xw==
+  dependencies:
+    attr-accept "^2.2.1"
+    file-selector "^0.2.2"
+    prop-types "^15.7.2"
+
 react-dropzone@9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-9.0.0.tgz#4f5223cdcb4d3bd8a66e3298c4041eb0c75c4634"
@@ -15996,6 +16029,11 @@ tslib@^2.0.0:
 tslib@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
+
+tslib@^2.0.3:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
+  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
 tsscmp@1.0.6:
   version "1.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4585,7 +4585,7 @@ attr-accept@^1.1.3:
   dependencies:
     core-js "^2.5.0"
 
-attr-accept@^2.2.1:
+attr-accept@^2.0.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-2.2.2.tgz#646613809660110749e92f2c10833b70968d929b"
   integrity sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==
@@ -8156,18 +8156,18 @@ file-saver@^1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-1.3.8.tgz#e68a30c7cb044e2fb362b428469feb291c2e09d8"
 
+file-selector@^0.1.12:
+  version "0.1.19"
+  resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-0.1.19.tgz#8ecc9d069a6f544f2e4a096b64a8052e70ec8abf"
+  integrity sha512-kCWw3+Aai8Uox+5tHCNgMFaUdgidxvMnLWO6fM5sZ0hA2wlHP5/DHGF0ECe84BiB95qdJbKNEJhWKVDvMN+JDQ==
+  dependencies:
+    tslib "^2.0.1"
+
 file-selector@^0.1.8:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-0.1.12.tgz#fe726547be219a787a9dcc640575a04a032b1fd0"
   dependencies:
     tslib "^1.9.0"
-
-file-selector@^0.2.2:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-0.2.4.tgz#7b98286f9dbb9925f420130ea5ed0a69238d4d80"
-  integrity sha512-ZDsQNbrv6qRi1YTDOEWzf5J2KjZ9KMI1Q2SGeTkCJmNNW25Jg4TW4UMcmoqcg4WrAyKRcpBXdbWRxkfrOzVRbA==
-  dependencies:
-    tslib "^2.0.3"
 
 file-type@^3.1.0, file-type@^3.8.0:
   version "3.9.0"
@@ -13665,13 +13665,13 @@ react-dom@^17.0.0:
     object-assign "^4.1.1"
     scheduler "^0.20.1"
 
-react-dropzone@11.3.4:
-  version "11.3.4"
-  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-11.3.4.tgz#aeb098df5c4491e165042c9f0b5e2e7185484740"
-  integrity sha512-B1nzNRZ4F1cnrfEC0T6KXeBN1mCPinu4JCoTrp7NjB+442KSPxqfDrw41QIA2kAwlYs1+wj/0BTedeM5hc2+xw==
+react-dropzone@10.2.2:
+  version "10.2.2"
+  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-10.2.2.tgz#67b4db7459589a42c3b891a82eaf9ade7650b815"
+  integrity sha512-U5EKckXVt6IrEyhMMsgmHQiWTGLudhajPPG77KFSvgsMqNEHSyGpqWvOMc5+DhEah/vH4E1n+J5weBNLd5VtyA==
   dependencies:
-    attr-accept "^2.2.1"
-    file-selector "^0.2.2"
+    attr-accept "^2.0.0"
+    file-selector "^0.1.12"
     prop-types "^15.7.2"
 
 react-dropzone@9.0.0:
@@ -16029,11 +16029,6 @@ tslib@^2.0.0:
 tslib@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
-
-tslib@^2.0.3:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
-  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
 tsscmp@1.0.6:
   version "1.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4590,10 +4590,6 @@ attr-accept@^2.0.0:
   resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-2.2.2.tgz#646613809660110749e92f2c10833b70968d929b"
   integrity sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==
 
-author-regex@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/author-regex/-/author-regex-1.0.0.tgz#d08885be6b9bbf9439fe087c76287245f0a81450"
-
 autoprefixer@^9.8.6:
   version "9.8.6"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.8.6.tgz#3b73594ca1bf9266320c5acf1588d74dea74210f"
@@ -8168,14 +8164,6 @@ file-selector@^0.1.8:
   resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-0.1.12.tgz#fe726547be219a787a9dcc640575a04a032b1fd0"
   dependencies:
     tslib "^1.9.0"
-
-file-type@^3.1.0, file-type@^3.8.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/file-type/-/file-type-3.9.0.tgz#257a078384d1db8087bc449d107d52a52672b9e9"
-
-file-type@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/file-type/-/file-type-9.0.0.tgz#a68d5ad07f486414dfb2c8866f73161946714a18"
 
 file-uri-to-path@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5545

# What changes?
* `onChange` is now split in more events, old event remain there for the compatibility
* `onTextChange` - when text area changes (@mturley edit: renamed from `onTextChanged`)
* `onFileInputChange` - called when internal `<input>` field emits its own `onChange` DOM event (@mturley edit: renamed from `onInputChange`)
* `onDataChange` - when data is loaded in the component (@mturley edit: renamed from `onDataChanged`)
* `onClearClick` - when clear button is clicked (@mturley edit: renamed from `onClearClicked`)
* react-dropzone upgraded to the `10.2.2`
