### PR TITLE
Fix menu crash if current menuRef value is not found.

### DIFF
--- a/packages/react-core/src/components/Menu/Menu.tsx
+++ b/packages/react-core/src/components/Menu/Menu.tsx
@@ -90,11 +90,12 @@ class MenuBase extends React.Component<MenuProps, MenuState> {
 
   allowTabFirstItem() {
     // Allow tabbing to first menu item
-    const first = this.menuRef.current.querySelector('ul').querySelector('button, a') as
-      | HTMLButtonElement
-      | HTMLAnchorElement;
-    if (first) {
-      first.tabIndex = 0;
+    const current = this.menuRef.current;
+    if (current) {
+      const first = current.querySelector('ul button, ul a') as HTMLButtonElement | HTMLAnchorElement;
+      if (first) {
+        first.tabIndex = 0;
+      }
     }
   }
 
@@ -122,12 +123,12 @@ class MenuBase extends React.Component<MenuProps, MenuState> {
   }
 
   handleDrilldownTransition = (event: TransitionEvent) => {
-    const ref = this.menuRef;
+    const current = this.menuRef.current;
 
     if (
-      !ref.current ||
-      (ref.current !== (event.target as HTMLElement).closest('.pf-c-menu') &&
-        !Array.from(ref.current.getElementsByClassName('pf-c-menu')).includes(
+      !current ||
+      (current !== (event.target as HTMLElement).closest('.pf-c-menu') &&
+        !Array.from(current.getElementsByClassName('pf-c-menu')).includes(
           (event.target as HTMLElement).closest('.pf-c-menu')
         ))
     ) {
@@ -138,7 +139,7 @@ class MenuBase extends React.Component<MenuProps, MenuState> {
       this.state.transitionMoveTarget.focus();
       this.setState({ transitionMoveTarget: null });
     } else {
-      const nextMenu = ref.current.querySelector('#' + this.props.activeMenu) || ref.current || null;
+      const nextMenu = current.querySelector('#' + this.props.activeMenu) || current || null;
       const nextTarget = Array.from(nextMenu.getElementsByTagName('UL')[0].children).filter(
         el => !(el.classList.contains('pf-m-disabled') || el.classList.contains('pf-c-divider'))
       )[0].firstChild;


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6151

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
Blocks https://github.com/openshift/console/pull/9279, see https://github.com/openshift/console/pull/9767#issuecomment-895607590

This PR fixes that `Menu` component can crash if menuRef is null. Other code in `handleDrilldownTransition` already checks if the current value is set. The new `allowTabFirstItem` function does this with this PR as well.

Crash and call stack:
```
TypeError
Cannot read property 'querySelector' of null
Call Stack
 MenuBase.allowTabFirstItem
 MenuBase.componentDidUpdate
```
