### PR TITLE
fix(DualListSelector): respect initial chosen opts, select subfolders, reset selected button on all button

### DIFF
--- a/packages/react-core/src/components/DualListSelector/DualListSelector.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelector.tsx
@@ -138,7 +138,8 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
     removeSelectedAriaLabel: 'Remove selected',
     removeAllAriaLabel: 'Remove all'
   };
-  private originalCopy = this.props.availableOptions;
+  private originalAvailableCopy = this.props.availableOptions;
+  private originalChosenCopy = this.props.chosenOptions;
 
   constructor(props: DualListSelectorProps) {
     super(props);
@@ -228,7 +229,9 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
 
       return {
         chosenOptions: newChosen,
-        availableOptions: newAvailable
+        availableOptions: newAvailable,
+        chosenOptionsSelected: [],
+        availableOptionsSelected: []
       };
     });
   };
@@ -245,7 +248,11 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
 
       const currChosen = flattenTree(prevState.chosenOptions as DualListSelectorTreeItemData[]);
       const nextChosenOptions = currChosen.concat(movedOptions);
-      const newChosen = (this.originalCopy as DualListSelectorTreeItemData[])
+
+      const allOptions = (this.originalAvailableCopy as DualListSelectorTreeItemData[]).concat(
+        this.originalChosenCopy as DualListSelectorTreeItemData[]
+      );
+      const newChosen = allOptions
         .map(opt => Object.assign({}, opt))
         .filter(item => filterTreeItemsWithoutFolders(item as DualListSelectorTreeItemData, nextChosenOptions));
 
@@ -256,7 +263,11 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
         chosenOptions: newChosen,
         chosenFilteredOptions: newChosen,
         availableOptions: newAvailable,
-        availableFilteredOptions: newAvailable
+        availableFilteredOptions: newAvailable,
+        availableTreeOptionsSelected: [],
+        chosenTreeOptionsSelected: [],
+        availableTreeOptionsChecked: [],
+        chosenTreeOptionsChecked: []
       };
     });
   };
@@ -298,7 +309,10 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
       // Get next chosen options from current + new nodes and remap from base
       const currChosen = flattenTree(prevState.chosenOptions as DualListSelectorTreeItemData[]);
       const nextChosenOptions = currChosen.concat(prevState.availableTreeOptionsSelected);
-      const newChosen = (this.originalCopy as DualListSelectorTreeItemData[])
+      const allOptions = (this.originalAvailableCopy as DualListSelectorTreeItemData[]).concat(
+        this.originalChosenCopy as DualListSelectorTreeItemData[]
+      );
+      const newChosen = allOptions
         .map(opt => Object.assign({}, opt))
         .filter(item => filterTreeItemsWithoutFolders(item as DualListSelectorTreeItemData, nextChosenOptions));
 
@@ -335,7 +349,9 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
 
       return {
         chosenOptions: newChosen,
-        availableOptions: newAvailable
+        availableOptions: newAvailable,
+        chosenOptionsSelected: [],
+        availableOptionsSelected: []
       };
     });
   };
@@ -352,7 +368,10 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
       const currAvailable = flattenTree(prevState.availableOptions as DualListSelectorTreeItemData[]);
       const nextAvailableOptions = currAvailable.concat(movedOptions);
 
-      const newAvailable = (this.originalCopy as DualListSelectorTreeItemData[])
+      const allOptions = (this.originalAvailableCopy as DualListSelectorTreeItemData[]).concat(
+        this.originalChosenCopy as DualListSelectorTreeItemData[]
+      );
+      const newAvailable = allOptions
         .map(opt => Object.assign({}, opt))
         .filter(item => filterTreeItemsWithoutFolders(item as DualListSelectorTreeItemData, nextAvailableOptions));
 
@@ -361,7 +380,11 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
 
       return {
         chosenOptions: newChosen,
-        availableOptions: newAvailable
+        availableOptions: newAvailable,
+        availableTreeOptionsSelected: [],
+        chosenTreeOptionsSelected: [],
+        availableTreeOptionsChecked: [],
+        chosenTreeOptionsChecked: []
       };
     });
   };
@@ -401,7 +424,11 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
       // Get next chosen options from current and remap from base
       const currAvailable = flattenTree(prevState.availableOptions as DualListSelectorTreeItemData[]);
       const nextAvailableOptions = currAvailable.concat(prevState.chosenTreeOptionsSelected);
-      const newAvailable = (this.originalCopy as DualListSelectorTreeItemData[])
+
+      const allOptions = (this.originalAvailableCopy as DualListSelectorTreeItemData[]).concat(
+        this.originalChosenCopy as DualListSelectorTreeItemData[]
+      );
+      const newAvailable = allOptions
         .map(opt => Object.assign({}, opt))
         .filter(item => filterTreeItemsWithoutFolders(item as DualListSelectorTreeItemData, nextAvailableOptions));
 

--- a/packages/react-core/src/components/DualListSelector/examples/DualListSelector.md
+++ b/packages/react-core/src/components/DualListSelector/examples/DualListSelector.md
@@ -268,7 +268,40 @@ class TreeDualListSelector extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      chosenOptions: [],
+      chosenOptions: [
+        {
+          id: 'CF1',
+          text: 'Chosen Folder 1',
+          isChecked: false,
+          checkProps: { 'aria-label': 'Chosen Folder 1' },
+          hasBadge: true,
+          badgeProps: { isRead: true },
+          children: [
+            { id: 'CO1', text: 'Chosen Option 1', isChecked: false, checkProps: { 'aria-label': 'Chosen Option 1' } },
+            {
+              id: 'CF1A',
+              text: 'Chosen Folder 1A',
+              isChecked: false,
+              checkProps: { 'aria-label': 'Chosen Folder 1A' },
+              children: [
+                {
+                  id: 'CO2',
+                  text: 'Chosen Option 2',
+                  isChecked: false,
+                  checkProps: { 'aria-label': 'Chosen Option 2' }
+                },
+                {
+                  id: 'CO3',
+                  text: 'Chosen Option 3',
+                  isChecked: false,
+                  checkProps: { 'aria-label': 'Chosen Option 3' }
+                }
+              ]
+            },
+            { id: 'CO4', text: 'Chosen Option 4', isChecked: false, checkProps: { 'aria-label': 'Chosen Option 4' } }
+          ]
+        }
+      ],
       availableOptions: [
         {
           id: 'F1',

--- a/packages/react-core/src/components/DualListSelector/treeUtils.ts
+++ b/packages/react-core/src/components/DualListSelector/treeUtils.ts
@@ -45,9 +45,7 @@ export function filterTreeItems(item: DualListSelectorTreeItemData, inputList: s
     return (
       (item.children = item.children
         .map(opt => Object.assign({}, opt))
-        .filter(child =>
-          child.children ? filterTreeItemsWithoutFolders(child, inputList) : filterTreeItems(child, inputList)
-        )).length > 0
+        .filter(child => filterTreeItems(child, inputList))).length > 0
     );
   }
 }


### PR DESCRIPTION

<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6179, #6124, #5828

In this PR:
- Fix to respect initial chosen options while moving options between panes of tree DLS
- Fix to allow checking of tree DLS subfolders
- Fix to reset selected states when options are moved via add/remove all (leaving an empty pane + active move selected button). Only affected tree variant.
- Update tree DLS example to contain initial chosen options

@nicolethoen The fix for selecting subfolders is possibly a regression on #5763 but I was unable to reproduce the bug from that PR after changing the code (locally tested - selecting a child of a subfolder and then moving selected does not move other children of the same subfolder). 
