### PR TITLE
fix(LogViewer): add required dependency

### DIFF
--- a/packages/react-log-viewer/package.json
+++ b/packages/react-log-viewer/package.json
@@ -32,7 +32,8 @@
     "@patternfly/react-core": "^4.152.7",
     "@patternfly/react-icons": "^4.11.15",
     "@patternfly/react-styles": "^4.11.14",
-    "memoize-one": "^5.1.0"
+    "memoize-one": "^5.1.0",
+    "resize-observer-polyfill": "^1.5.1"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",


### PR DESCRIPTION
Add dependency that needs to be included for successful build of log
viewer.

Signed-off-by: Matej Focko <mfocko@redhat.com>

<!-- What changes are being made? Please link the issue being addressed. -->
**What**: I tried to incorporate `@patternfly/react-log-viewer@4.5.1` into our dashboard, but I couldn't build it locally because of missing dependency, after adding it, builds fine.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: I'm going to commit changes on my side and verify that build is failing just because of the log viewer related changes, since I have upgraded multiple of your packages.

_Edit_: Yeah, it's that dependency, have no clue how it got built in the CI here though. :thinking: 