### PR TITLE
fix(Slider): update slider to respect min/max constraints

### DIFF
--- a/packages/react-core/src/components/Slider/Slider.tsx
+++ b/packages/react-core/src/components/Slider/Slider.tsx
@@ -49,7 +49,11 @@ export interface SliderProps extends Omit<React.HTMLProps<HTMLDivElement>, 'onCh
   /** Position of the input */
   inputPosition?: 'aboveThumb' | 'right';
   /** Value change callback. This is called when the slider value changes */
-  onChange?: (value: number, inputValue?: number) => void;
+  onChange?: (
+    value: number,
+    inputValue?: number,
+    setLocalInputValue?: React.Dispatch<React.SetStateAction<number>>
+  ) => void;
   /** Actions placed to the left of the slider */
   leftActions?: React.ReactNode;
   /** Actions placed to the right of the slider */
@@ -109,7 +113,7 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
     if (event.key === 'Enter') {
       event.preventDefault();
       if (onChange) {
-        onChange(localValue, localInputValue);
+        onChange(localValue, localInputValue, setLocalInputValue);
       }
     }
   };
@@ -124,7 +128,7 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
 
   const onBlur = () => {
     if (onChange) {
-      onChange(localValue, localInputValue);
+      onChange(localValue, localInputValue, setLocalInputValue);
     }
   };
 

--- a/packages/react-core/src/components/Slider/examples/Slider.md
+++ b/packages/react-core/src/components/Slider/examples/Slider.md
@@ -190,7 +190,7 @@ class ValueInput extends React.Component {
       { value: 100, label: '100%' }
     ];
 
-    this.onChangeDiscrete = (value, inputValue) => {
+    this.onChangeDiscrete = (value, inputValue, setLocalInputValue) => {
 
       let newValue;
       let newInputValue;
@@ -204,19 +204,28 @@ class ValueInput extends React.Component {
         const maxValue =  Number(this.stepsDiscrete[this.stepsDiscrete.length -1].label);
         if (inputValue > maxValue) {
           newValue = Number(this.stepsDiscrete[this.stepsDiscrete.length -1].value);
-          newInputValue =  maxValue
+          newInputValue =  maxValue;
+          setLocalInputValue(maxValue);
         } else {
-          const stepIndex = this.stepsDiscrete.findIndex(step => Number(step.label) >= inputValue);
-          if (Number(this.stepsDiscrete[stepIndex].label) === inputValue) {
-            newValue = this.stepsDiscrete[stepIndex].value;
+          const minValue =  Number(this.stepsDiscrete[0].label);
+          if (inputValue < minValue) {
+            newValue = Number(this.stepsDiscrete[0].value);
+            newInputValue =  minValue;
+            setLocalInputValue(minValue);
           } else {
-            const midpoint = (Number(this.stepsDiscrete[stepIndex].label) + Number(this.stepsDiscrete[stepIndex - 1].label)) / 2;
-            if (midpoint > inputValue) {
-              newValue = this.stepsDiscrete[stepIndex - 1].value;
-              newInputValue = Number(this.stepsDiscrete[stepIndex - 1].label);
-            } else {
+            const stepIndex = this.stepsDiscrete.findIndex(step => Number(step.label) >= inputValue);
+            if (Number(this.stepsDiscrete[stepIndex].label) === inputValue) {
               newValue = this.stepsDiscrete[stepIndex].value;
-              newInputValue = Number(this.stepsDiscrete[stepIndex].label);
+              newInputValue = inputValue;
+            } else {
+              const midpoint = (Number(this.stepsDiscrete[stepIndex].label) + Number(this.stepsDiscrete[stepIndex - 1].label)) / 2;
+              if (midpoint > inputValue) {
+                newValue = this.stepsDiscrete[stepIndex - 1].value;
+                newInputValue = Number(this.stepsDiscrete[stepIndex - 1].label);
+              } else {
+                newValue = this.stepsDiscrete[stepIndex].value;
+                newInputValue = Number(this.stepsDiscrete[stepIndex].label);
+              }
             }
           }
         }
@@ -228,7 +237,7 @@ class ValueInput extends React.Component {
       });
     };
 
-    this.onChangePercent = (value, inputValue) => {
+    this.onChangePercent = (value, inputValue, setLocalInputValue) => {
       let newValue;
       let newInputValue;
 
@@ -237,23 +246,31 @@ class ValueInput extends React.Component {
         newInputValue = step ? step.label.slice(0, -1) : 0;
         newInputValue = Number(newInputValue);
         newValue = value;
-      }  else {
+      } else {
         const maxValue =  Number(this.stepsPercent[this.stepsPercent.length -1].label.slice(0, -1));
         if (inputValue > maxValue) {
           newValue = Number(this.stepsPercent[this.stepsPercent.length -1].value);
           newInputValue =  maxValue;
+          setLocalInputValue(maxValue);
         } else {
-          const stepIndex = this.stepsPercent.findIndex(step => Number(step.label.slice(0, -1)) >= inputValue);
-          if (Number(this.stepsPercent[stepIndex].label.slice(0, -1)) === inputValue) {
-            newValue = this.stepsPercent[stepIndex].value;
+          const minValue =  Number(this.stepsPercent[0].label.slice(0, -1));
+          if (inputValue < minValue) {
+            newValue = minValue;
+            setLocalInputValue(minValue);
           } else {
-            const midpoint = (Number(this.stepsPercent[stepIndex].label.slice(0, -1)) + Number(this.stepsPercent[stepIndex - 1].label.slice(0, -1))) / 2;
-            if (midpoint > inputValue) {
-              newValue = this.stepsPercent[stepIndex - 1].value;
-              newInputValue = Number(this.stepsPercent[stepIndex - 1].label.slice(0, -1));
-            } else {
+            const stepIndex = this.stepsPercent.findIndex(step => Number(step.label.slice(0, -1)) >= inputValue);
+            if (Number(this.stepsPercent[stepIndex].label.slice(0, -1)) === inputValue) {
               newValue = this.stepsPercent[stepIndex].value;
-              newInputValue = Number(this.stepsPercent[stepIndex].label.slice(0, -1));
+              newInputValue = inputValue;
+            } else {
+              const midpoint = (Number(this.stepsPercent[stepIndex].label.slice(0, -1)) + Number(this.stepsPercent[stepIndex - 1].label.slice(0, -1))) / 2;
+              if (midpoint > inputValue) {
+                newValue = this.stepsPercent[stepIndex - 1].value;
+                newInputValue = Number(this.stepsPercent[stepIndex - 1].label.slice(0, -1));
+              } else {
+                newValue = this.stepsPercent[stepIndex].value;
+                newInputValue = Number(this.stepsPercent[stepIndex].label.slice(0, -1));
+              }
             }
           }
         }
@@ -265,12 +282,20 @@ class ValueInput extends React.Component {
       });
     };
 
-    this.onChangeContinuous = (value, inputValue) => { 
+    this.onChangeContinuous = (value, inputValue, setLocalInputValue) => { 
       let newValue;
       if (inputValue === undefined) { 
         newValue = Math.floor(value);
       } else {
-        newValue = inputValue > 100 ? 100 : Math.floor(inputValue);
+        if (inputValue > 100) {
+          newValue = 100;
+          setLocalInputValue(100);
+        } else if (inputValue < 0) {
+          newValue = 0;
+          setLocalInputValue(0);
+        } else {
+          newValue = Math.floor(inputValue);
+        }
       }
       this.setState({
         inputValueContinuous: newValue,
@@ -326,12 +351,20 @@ class ThumbValueInput extends React.Component {
       inputValue: 50
     };
 
-    this.onChange = (value, inputValue) => { 
+    this.onChange = (value, inputValue, setLocalInputValue) => { 
       let newValue;
       if (inputValue === undefined) { 
         newValue = Number(value).toFixed(2);
       } else {
-        newValue = inputValue > 100 ? 100 : Math.floor(inputValue);
+        if (inputValue > 100) {
+          newValue = 100;
+          setLocalInputValue(100);
+        } else if (inputValue < 0) {
+          newValue = 0;
+          setLocalInputValue(0);
+        } else {
+          newValue = Math.floor(inputValue);
+        }
       }
       this.setState({
         value: newValue,
@@ -382,12 +415,20 @@ class SliderActions extends React.Component {
       });
     };
 
-    this.onChange2 =(value, inputValue) => { 
+    this.onChange2 =(value, inputValue, setLocalInputValue) => { 
       let newValue;
       if (inputValue === undefined) { 
         newValue = Math.floor(Number(value));
       } else {
-        newValue = inputValue > 100 ? 100 : Math.floor(inputValue);
+        if (inputValue > 100) {
+          newValue = 100;
+          setLocalInputValue(100);
+        } else if (inputValue < 0) {
+          newValue = 0;
+          setLocalInputValue(0);
+        } else {
+          newValue = Math.floor(inputValue);
+        }
       }
       this.setState({
         value2: newValue,


### PR DESCRIPTION
Closes #5893 
Closes #5707 

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: Related issue #5833 

This PR fixes the issue of being able to enter a value outside slider's min/max via the text input, by passing `setLocalInputValue` to the user through `onChange`.
Steps to recreate issue:
- Set a slider either to max value, or above-max value using the text input.
- `value` and `inputValue` are correctly set to the max value, component state updates & internally updates `localInputValue` variable which controls the value displayed in the text input.
- Immediately enter another value above the max, `value` and `inputValue` remain at the max value so `setState` has no effect and the `localInputValue` is not updated causing above-max value to remain.

This PR also fixes the issue of tabbing through the first two "Value input" examples causes the text input to change to 0, and tabbing through a second time causes the slider to reflect this 0 value, by adding missing `newInputValue` assignment in example code.