### PR TITLE
feat(Table): Add hoverable and selectable rows

### DIFF
--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableRowClickDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableRowClickDemo.tsx
@@ -24,13 +24,19 @@ export class TableRowClickDemo extends React.Component<TableProps, ITableRowClic
       columns: [{ title: 'Repositories' }, 'Branches', { title: 'Pull requests' }, 'Workspaces'],
       rows: [
         {
-          cells: ['Repositories one', 'Branches one', 'Pull requests one', 'Workspaces one']
+          cells: ['Repositories one', 'Branches one', 'Pull requests one', 'Workspaces one'],
+          isHoverable: true,
+          isSelected: true
         },
         {
-          cells: ['Repositories two', 'Branches two', 'Pull requests two', 'Workspaces two']
+          cells: ['Repositories two', 'Branches two', 'Pull requests two', 'Workspaces two'],
+          isHoverable: true,
+          isSelected: false
         },
         {
-          cells: ['Repositories three', 'Branches three', 'Pull requests three', 'Workspaces three']
+          cells: ['Repositories three', 'Branches three', 'Pull requests three', 'Workspaces three'],
+          isHoverable: true,
+          isSelected: false
         }
       ]
     };

--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableRowClickDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableRowClickDemo.tsx
@@ -26,17 +26,17 @@ export class TableRowClickDemo extends React.Component<TableProps, ITableRowClic
         {
           cells: ['Repositories one', 'Branches one', 'Pull requests one', 'Workspaces one'],
           isHoverable: true,
-          isSelected: true
+          isRowSelected: true
         },
         {
           cells: ['Repositories two', 'Branches two', 'Pull requests two', 'Workspaces two'],
           isHoverable: true,
-          isSelected: false
+          isRowSelected: false
         },
         {
           cells: ['Repositories three', 'Branches three', 'Pull requests three', 'Workspaces three'],
           isHoverable: true,
-          isSelected: false
+          isRowSelected: false
         }
       ]
     };

--- a/packages/react-table/src/components/Table/Body.tsx
+++ b/packages/react-table/src/components/Table/Body.tsx
@@ -28,14 +28,14 @@ export interface TableBodyProps {
   rows?: IRow[];
   /** @hide This prop should not be set manually  */
   rowKey?: RowKeyType;
-  /** @hide This prop should not be set manually  */
+  /** An click handler for the row  */
   onRowClick?: OnRowClick;
   /** @hide This prop should not be set manually  */
   onRow?: Function;
 }
 
 const flagVisibility = (rows: IRow[]) => {
-  const visibleRows = (rows as []).filter((oneRow: IRow) => !oneRow.parent || oneRow.isExpanded) as IRow[];
+  const visibleRows = (rows as IRow[]).filter((oneRow: IRow) => !oneRow.parent || oneRow.isExpanded) as IRow[];
   if (visibleRows.length > 0) {
     visibleRows[0].isFirstVisible = true;
     visibleRows[visibleRows.length - 1].isLastVisible = true;
@@ -56,13 +56,22 @@ class ContextBody extends React.Component<TableBodyProps, {}> {
     return {
       row,
       rowProps: extendedRowProps,
-      onMouseDown: (event: React.MouseEvent) => {
+      onClick: (event: React.MouseEvent) => {
         const computedData = {
           isInput: (event.target as HTMLElement).tagName !== 'INPUT',
           isButton: (event.target as HTMLElement).tagName !== 'BUTTON'
         };
 
         onRowClick(event, row, rowProps, computedData);
+      },
+      onKeyDown: (event: React.KeyboardEvent) => {
+        if (event.key === 'Enter') {
+          const computedData = {
+            isInput: (event.target as HTMLElement).tagName !== 'INPUT',
+            isButton: (event.target as HTMLElement).tagName !== 'BUTTON'
+          };
+          onRowClick(undefined as React.MouseEvent, row, rowProps, computedData);
+        }
       }
     };
   };
@@ -128,7 +137,7 @@ class ContextBody extends React.Component<TableBodyProps, {}> {
 
     let mappedRows: IRow[];
     if (headerData.length > 0) {
-      mappedRows = (rows as []).map((oneRow: IRow, oneRowKey: number) => ({
+      mappedRows = (rows as IRow[]).map((oneRow: IRow, oneRowKey: number) => ({
         ...oneRow,
         ...this.mapCells(headerData, oneRow, oneRowKey),
         isExpanded: isRowExpanded(oneRow, rows),

--- a/packages/react-table/src/components/Table/Body.tsx
+++ b/packages/react-table/src/components/Table/Body.tsx
@@ -28,7 +28,7 @@ export interface TableBodyProps {
   rows?: IRow[];
   /** @hide This prop should not be set manually  */
   rowKey?: RowKeyType;
-  /** An click handler for the row  */
+  /** A click handler for the row  */
   onRowClick?: OnRowClick;
   /** @hide This prop should not be set manually  */
   onRow?: Function;

--- a/packages/react-table/src/components/Table/Body.tsx
+++ b/packages/react-table/src/components/Table/Body.tsx
@@ -11,7 +11,7 @@ export interface IComputedData {
 }
 
 export type OnRowClick = (
-  event: React.MouseEvent,
+  event: React.KeyboardEvent | React.MouseEvent,
   row: IRow,
   rowProps: IExtraRowData,
   computedData: IComputedData
@@ -70,7 +70,7 @@ class ContextBody extends React.Component<TableBodyProps, {}> {
             isInput: (event.target as HTMLElement).tagName !== 'INPUT',
             isButton: (event.target as HTMLElement).tagName !== 'BUTTON'
           };
-          onRowClick(undefined as React.MouseEvent, row, rowProps, computedData);
+          onRowClick(event, row, rowProps, computedData);
           event.preventDefault();
         }
       }
@@ -174,7 +174,12 @@ export const TableBody = ({
   rowKey = 'secretTableRowKeyId' as string,
   /* eslint-disable @typescript-eslint/no-unused-vars */
   onRow = (...args: any) => ({}),
-  onRowClick = (event: React.MouseEvent, row: IRow, rowProps: IExtraRowData, computedData: IComputedData) =>
+  onRowClick = (
+    event: React.MouseEvent | React.KeyboardEvent,
+    row: IRow,
+    rowProps: IExtraRowData,
+    computedData: IComputedData
+  ) =>
     /* eslint-enable @typescript-eslint/no-unused-vars */
     undefined as OnRowClick,
   ...props

--- a/packages/react-table/src/components/Table/Body.tsx
+++ b/packages/react-table/src/components/Table/Body.tsx
@@ -65,12 +65,13 @@ class ContextBody extends React.Component<TableBodyProps, {}> {
         onRowClick(event, row, rowProps, computedData);
       },
       onKeyDown: (event: React.KeyboardEvent) => {
-        if (event.key === 'Enter') {
+        if (event.key === 'Enter' || event.key === ' ') {
           const computedData = {
             isInput: (event.target as HTMLElement).tagName !== 'INPUT',
             isButton: (event.target as HTMLElement).tagName !== 'BUTTON'
           };
           onRowClick(undefined as React.MouseEvent, row, rowProps, computedData);
+          event.preventDefault();
         }
       }
     };

--- a/packages/react-table/src/components/Table/RowWrapper.tsx
+++ b/packages/react-table/src/components/Table/RowWrapper.tsx
@@ -91,7 +91,7 @@ export class RowWrapper extends React.Component<RowWrapperProps> {
       /* eslint-disable @typescript-eslint/no-unused-vars */
       onScroll,
       onResize,
-      row: { isExpanded, isEditable },
+      row: { isExpanded, isEditable, isHoverable, isSelected },
       rowProps,
       /* eslint-enable @typescript-eslint/no-unused-vars */
       trRef,
@@ -108,6 +108,8 @@ export class RowWrapper extends React.Component<RowWrapperProps> {
         isEditable={isEditable}
         className={className}
         ouiaId={ouiaId}
+        isHoverable={isHoverable}
+        isSelected={isSelected}
       />
     );
   }

--- a/packages/react-table/src/components/Table/RowWrapper.tsx
+++ b/packages/react-table/src/components/Table/RowWrapper.tsx
@@ -91,7 +91,7 @@ export class RowWrapper extends React.Component<RowWrapperProps> {
       /* eslint-disable @typescript-eslint/no-unused-vars */
       onScroll,
       onResize,
-      row: { isExpanded, isEditable, isHoverable, isSelected },
+      row: { isExpanded, isEditable, isHoverable, isRowSelected },
       rowProps,
       /* eslint-enable @typescript-eslint/no-unused-vars */
       trRef,
@@ -109,7 +109,7 @@ export class RowWrapper extends React.Component<RowWrapperProps> {
         className={className}
         ouiaId={ouiaId}
         isHoverable={isHoverable}
-        isSelected={isSelected}
+        isRowSelected={isRowSelected}
       />
     );
   }

--- a/packages/react-table/src/components/Table/TableTypes.ts
+++ b/packages/react-table/src/components/Table/TableTypes.ts
@@ -228,7 +228,7 @@ export interface IRow extends RowType {
   isOpen?: boolean;
   isEditable?: boolean;
   isHoverable?: boolean;
-  isSelectable?: boolean;
+  isRowSelected?: boolean;
   isValid?: boolean;
   /** An array of validation functions to run against every cell for a given row */
   rowEditValidationRules?: IValidatorDef[];

--- a/packages/react-table/src/components/Table/TableTypes.ts
+++ b/packages/react-table/src/components/Table/TableTypes.ts
@@ -227,6 +227,8 @@ export interface IRow extends RowType {
   cells?: (React.ReactNode | IRowCell)[];
   isOpen?: boolean;
   isEditable?: boolean;
+  isHoverable?: boolean;
+  isSelectable?: boolean;
   isValid?: boolean;
   /** An array of validation functions to run against every cell for a given row */
   rowEditValidationRules?: IValidatorDef[];

--- a/packages/react-table/src/components/Table/examples/Table.md
+++ b/packages/react-table/src/components/Table/examples/Table.md
@@ -245,7 +245,11 @@ class RowClickTable extends React.Component {
         }
       ],
       rows: [
-        ['Repository one', 'Branch one', 'PR one', 'Workspace one', 'Commit one'],
+        {
+          cells: ['Repository one', 'Branch one', 'PR one', 'Workspace one', 'Commit one'],
+          isHoverable: true,
+          isSelected: false
+        },
         {
           cells: [
             {
@@ -254,7 +258,9 @@ class RowClickTable extends React.Component {
             },
             'four - 2',
             'five - 2'
-          ]
+          ],
+          isHoverable: true,
+          isSelected: false
         },
         {
           cells: [
@@ -266,13 +272,31 @@ class RowClickTable extends React.Component {
               title: 'five - 3 (not centered)',
               props: { textCenter: false }
             }
-          ]
+          ],
+          isHoverable: true,
+          isSelected: false
         }
       ]
     };
-    this.rowClickHandler = (event, row) => {
-      console.log('handle row click', row);
-    };
+    
+    this.rowClickHandler = (event, row, rowProps) => {
+      console.log(event);
+      this.setState(prevState => {
+        const updatedRows = [...prevState.rows];
+        updatedRows[rowProps.rowIndex].isSelected = !prevState.rows[rowProps.rowIndex].isSelected;
+        return {
+          rows: updatedRows
+        }
+      });
+    }
+  }
+  
+  componentDidUpdate(prevProps, prevState) {
+    if (prevState.selectedRow != this.state.selectedRow) {
+      this.setState(() => {
+        
+      });
+    }
   }
 
   render() {

--- a/packages/react-table/src/components/Table/examples/Table.md
+++ b/packages/react-table/src/components/Table/examples/Table.md
@@ -248,7 +248,7 @@ class RowClickTable extends React.Component {
         {
           cells: ['Repository one', 'Branch one', 'PR one', 'Workspace one', 'Commit one'],
           isHoverable: true,
-          isSelected: false
+          isRowSelected: false
         },
         {
           cells: [
@@ -260,7 +260,7 @@ class RowClickTable extends React.Component {
             'five - 2'
           ],
           isHoverable: true,
-          isSelected: false
+          isRowSelected: false
         },
         {
           cells: [
@@ -274,7 +274,7 @@ class RowClickTable extends React.Component {
             }
           ],
           isHoverable: true,
-          isSelected: false
+          isRowSelected: false
         }
       ]
     };
@@ -282,18 +282,10 @@ class RowClickTable extends React.Component {
     this.rowClickHandler = (event, row, rowProps) => {
       this.setState(prevState => {
         const updatedRows = [...prevState.rows];
-        updatedRows[rowProps.rowIndex].isSelected = !prevState.rows[rowProps.rowIndex].isSelected;
+        updatedRows[rowProps.rowIndex].isRowSelected = !prevState.rows[rowProps.rowIndex].isRowSelected;
         return {
           rows: updatedRows
         }
-      });
-    }
-  }
-  
-  componentDidUpdate(prevProps, prevState) {
-    if (prevState.selectedRow != this.state.selectedRow) {
-      this.setState(() => {
-        
       });
     }
   }

--- a/packages/react-table/src/components/Table/examples/Table.md
+++ b/packages/react-table/src/components/Table/examples/Table.md
@@ -195,7 +195,7 @@ class SimpleTable extends React.Component {
 }
 ```
 
-### Row click handler and header cell tooltips/popovers
+### Hoverable rows, selectable rows, and header cell tooltips/popovers
 
 ```js
 import React from 'react';

--- a/packages/react-table/src/components/Table/examples/Table.md
+++ b/packages/react-table/src/components/Table/examples/Table.md
@@ -195,114 +195,6 @@ class SimpleTable extends React.Component {
 }
 ```
 
-### Hoverable rows, selectable rows, and header cell tooltips/popovers
-
-```js
-import React from 'react';
-import { Table, TableHeader, TableBody, textCenter } from '@patternfly/react-table';
-import styles from '@patternfly/react-styles/css/components/Table/table';
-
-class RowClickTable extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      columns: [
-        {
-          title: 'Repositories',
-          transforms: [
-            info({
-              tooltip: 'More information about repositories',
-              className: 'repositories-info-tip',
-              tooltipProps: {
-                isContentLeftAligned: true
-              }
-            })
-          ]
-        },
-        'Branches',
-        {
-          title: 'Pull requests',
-          transforms: [
-            info({
-              popover: (
-                <div>
-                  More <strong>information</strong> on pull requests
-                </div>
-              ),
-              ariaLabel: 'More information on pull requests',
-              popoverProps: {
-                headerContent: 'Pull requests',
-                footerContent: <a href="">Click here for even more info</a>
-              }
-            })
-          ]
-        },
-        'Workspaces',
-        {
-          title: 'Last commit',
-          transforms: [textCenter],
-          cellTransforms: [textCenter]
-        }
-      ],
-      rows: [
-        {
-          cells: ['Repository one', 'Branch one', 'PR one', 'Workspace one', 'Commit one'],
-          isHoverable: true,
-          isRowSelected: false
-        },
-        {
-          cells: [
-            {
-              title: <div>one - 2</div>,
-              props: { title: 'hover title', colSpan: 3 }
-            },
-            'four - 2',
-            'five - 2'
-          ],
-          isHoverable: true,
-          isRowSelected: false
-        },
-        {
-          cells: [
-            'one - 3',
-            'two - 3',
-            'three - 3',
-            'four - 3',
-            {
-              title: 'five - 3 (not centered)',
-              props: { textCenter: false }
-            }
-          ],
-          isHoverable: true,
-          isRowSelected: false
-        }
-      ]
-    };
-    
-    this.rowClickHandler = (event, row, rowProps) => {
-      this.setState(prevState => {
-        const updatedRows = [...prevState.rows];
-        updatedRows[rowProps.rowIndex].isRowSelected = !prevState.rows[rowProps.rowIndex].isRowSelected;
-        return {
-          rows: updatedRows
-        }
-      });
-    }
-  }
-
-  render() {
-    const { columns, rows } = this.state;
-
-    return (
-      <Table caption="Row click handler table" cells={columns} rows={rows}>
-        <TableHeader className={styles.modifiers.nowrap} />
-        <TableBody onRowClick={this.rowClickHandler} />
-      </Table>
-    );
-  }
-}
-```
-
 ### Custom row wrapper
 
 Custom row wrappers are passed to the `Table` component via the `rowWrapper` prop.
@@ -473,7 +365,7 @@ class SortableTable extends React.Component {
 }
 ```
 
-### Selectable
+### Selectable with checkbox
 
 To enable row selection, set the `onSelect` callback prop on the Table.
 
@@ -646,6 +538,116 @@ class SelectableTable extends React.Component {
       >
         <TableHeader />
         <TableBody />
+      </Table>
+    );
+  }
+}
+```
+
+### Hoverable rows, selectable rows, and header cell tooltips/popovers
+
+This selectable rows feature is intended for use when a table is used to present a list of objects in a Primary-detail view.
+
+```js
+import React from 'react';
+import { Table, TableHeader, TableBody, textCenter } from '@patternfly/react-table';
+import styles from '@patternfly/react-styles/css/components/Table/table';
+
+class RowClickTable extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      columns: [
+        {
+          title: 'Repositories',
+          transforms: [
+            info({
+              tooltip: 'More information about repositories',
+              className: 'repositories-info-tip',
+              tooltipProps: {
+                isContentLeftAligned: true
+              }
+            })
+          ]
+        },
+        'Branches',
+        {
+          title: 'Pull requests',
+          transforms: [
+            info({
+              popover: (
+                <div>
+                  More <strong>information</strong> on pull requests
+                </div>
+              ),
+              ariaLabel: 'More information on pull requests',
+              popoverProps: {
+                headerContent: 'Pull requests',
+                footerContent: <a href="">Click here for even more info</a>
+              }
+            })
+          ]
+        },
+        'Workspaces',
+        {
+          title: 'Last commit',
+          transforms: [textCenter],
+          cellTransforms: [textCenter]
+        }
+      ],
+      rows: [
+        {
+          cells: ['Repository one', 'Branch one', 'PR one', 'Workspace one', 'Commit one'],
+          isHoverable: true,
+          isRowSelected: false
+        },
+        {
+          cells: [
+            {
+              title: <div>one - 2</div>,
+              props: { title: 'hover title', colSpan: 3 }
+            },
+            'four - 2',
+            'five - 2'
+          ],
+          isHoverable: true,
+          isRowSelected: false
+        },
+        {
+          cells: [
+            'one - 3',
+            'two - 3',
+            'three - 3',
+            'four - 3',
+            {
+              title: 'five - 3 (not centered)',
+              props: { textCenter: false }
+            }
+          ],
+          isHoverable: true,
+          isRowSelected: false
+        }
+      ]
+    };
+    
+    this.rowClickHandler = (event, row, rowProps) => {
+      this.setState(prevState => {
+        const updatedRows = [...prevState.rows];
+        updatedRows[rowProps.rowIndex].isRowSelected = !prevState.rows[rowProps.rowIndex].isRowSelected;
+        return {
+          rows: updatedRows
+        }
+      });
+    }
+  }
+
+  render() {
+    const { columns, rows } = this.state;
+
+    return (
+      <Table caption="Row click handler table" cells={columns} rows={rows}>
+        <TableHeader className={styles.modifiers.nowrap} />
+        <TableBody onRowClick={this.rowClickHandler} />
       </Table>
     );
   }

--- a/packages/react-table/src/components/Table/examples/Table.md
+++ b/packages/react-table/src/components/Table/examples/Table.md
@@ -280,7 +280,6 @@ class RowClickTable extends React.Component {
     };
     
     this.rowClickHandler = (event, row, rowProps) => {
-      console.log(event);
       this.setState(prevState => {
         const updatedRows = [...prevState.rows];
         updatedRows[rowProps.rowIndex].isSelected = !prevState.rows[rowProps.rowIndex].isSelected;

--- a/packages/react-table/src/components/Table/utils/decorators/treeRow.tsx
+++ b/packages/react-table/src/components/Table/utils/decorators/treeRow.tsx
@@ -26,9 +26,15 @@ export const treeRow = (
   } = rowData.props;
   const content = value.title || value;
   const text = (
-    <div className={css(stylesTreeView.tableTreeViewText)}>
-      {icon && <span className={css(stylesTreeView.tableTreeViewIcon)}>{icon}</span>}
-      <span className="pf-c-table__text">{content}</span>
+    <div className={css(stylesTreeView.tableTreeViewText)} key="tree-view-text">
+      {icon && (
+        <span className={css(stylesTreeView.tableTreeViewIcon)} key="tree-view-text-icon">
+          {icon}
+        </span>
+      )}
+      <span className="pf-c-table__text" key="table-text">
+        {content}
+      </span>
     </div>
   );
   const onChange = (isChecked: boolean, event: React.FormEvent<HTMLInputElement>) => {
@@ -41,7 +47,7 @@ export const treeRow = (
       level !== undefined ? (
         <div className={css(stylesTreeView.tableTreeViewMain)}>
           {setsize > 0 && (
-            <span className={css(stylesTreeView.tableToggle)}>
+            <span className={css(stylesTreeView.tableToggle)} key="table-toggle">
               <Button
                 variant="plain"
                 onClick={event => onCollapse && onCollapse(event, rowIndex, content, rowData)}
@@ -56,7 +62,7 @@ export const treeRow = (
             </span>
           )}
           {!!onCheckChange && (
-            <span className={css(stylesTreeView.tableCheck)}>
+            <span className={css(stylesTreeView.tableCheck)} key="table-check">
               <Checkbox
                 id={checkboxId || `checkbox_${rowIndex}`}
                 aria-label={checkAriaLabel || `Row ${rowIndex} checkbox`}
@@ -67,7 +73,7 @@ export const treeRow = (
           )}
           {text}
           {!!onToggleRowDetails && (
-            <span className={css(stylesTreeView.tableTreeViewDetailsToggle)}>
+            <span className={css(stylesTreeView.tableTreeViewDetailsToggle)} key="view-details-toggle">
               <Button
                 variant="plain"
                 aria-expanded={isDetailsExpanded}

--- a/packages/react-table/src/components/TableComposable/Tr.tsx
+++ b/packages/react-table/src/components/TableComposable/Tr.tsx
@@ -17,6 +17,10 @@ export interface TrProps extends React.HTMLProps<HTMLTableRowElement>, OUIAProps
   isExpanded?: boolean;
   /** Only applicable to Tr within the Tbody: Whether the row is editable */
   isEditable?: boolean;
+  /** */
+  isHoverable?: boolean;
+  /** */
+  isSelected?: boolean;
 }
 
 const TrBase: React.FunctionComponent<TrProps> = ({
@@ -25,6 +29,8 @@ const TrBase: React.FunctionComponent<TrProps> = ({
   isExpanded,
   isEditable,
   isHidden = false,
+  isHoverable = false,
+  isSelected = false,
   innerRef,
   ouiaId,
   ouiaSafe = true,
@@ -37,9 +43,12 @@ const TrBase: React.FunctionComponent<TrProps> = ({
         className,
         isExpanded !== undefined && styles.tableExpandableRow,
         isExpanded && styles.modifiers.expanded,
-        isEditable && inlineStyles.modifiers.inlineEditable
+        isEditable && inlineStyles.modifiers.inlineEditable,
+        isHoverable && styles.modifiers.hoverable,
+        isSelected && styles.modifiers.selected
       )}
       hidden={isHidden || (isExpanded !== undefined && !isExpanded)}
+      {...(isHoverable && { tabIndex: 0 })}
       ref={innerRef}
       {...ouiaProps}
       {...props}

--- a/packages/react-table/src/components/TableComposable/Tr.tsx
+++ b/packages/react-table/src/components/TableComposable/Tr.tsx
@@ -21,6 +21,8 @@ export interface TrProps extends React.HTMLProps<HTMLTableRowElement>, OUIAProps
   isHoverable?: boolean;
   /** */
   isSelected?: boolean;
+  /** */
+  onRowClick?: (event?: React.KeyboardEvent | React.MouseEvent) => void;
 }
 
 const TrBase: React.FunctionComponent<TrProps> = ({
@@ -34,9 +36,21 @@ const TrBase: React.FunctionComponent<TrProps> = ({
   innerRef,
   ouiaId,
   ouiaSafe = true,
+  onRowClick,
   ...props
 }: TrProps) => {
   const ouiaProps = useOUIAProps('TableRow', ouiaId, ouiaSafe);
+
+  let onKeyDown = null;
+  if (onRowClick) {
+    onKeyDown = (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        onRowClick(e);
+        e.preventDefault();
+      }
+    };
+  }
+
   return (
     <tr
       className={css(
@@ -50,6 +64,7 @@ const TrBase: React.FunctionComponent<TrProps> = ({
       hidden={isHidden || (isExpanded !== undefined && !isExpanded)}
       {...(isHoverable && { tabIndex: 0 })}
       ref={innerRef}
+      {...(onRowClick && { onClick: onRowClick, onKeyDown })}
       {...ouiaProps}
       {...props}
     >

--- a/packages/react-table/src/components/TableComposable/Tr.tsx
+++ b/packages/react-table/src/components/TableComposable/Tr.tsx
@@ -17,11 +17,11 @@ export interface TrProps extends React.HTMLProps<HTMLTableRowElement>, OUIAProps
   isExpanded?: boolean;
   /** Only applicable to Tr within the Tbody: Whether the row is editable */
   isEditable?: boolean;
-  /** */
+  /** Flag which adds hover styles for the table row */
   isHoverable?: boolean;
-  /** */
-  isSelected?: boolean;
-  /** */
+  /** Flag indicating the row is selected - adds selected styling */
+  isRowSelected?: boolean;
+  /** An event handler for the row */
   onRowClick?: (event?: React.KeyboardEvent | React.MouseEvent) => void;
 }
 
@@ -32,7 +32,7 @@ const TrBase: React.FunctionComponent<TrProps> = ({
   isEditable,
   isHidden = false,
   isHoverable = false,
-  isSelected = false,
+  isRowSelected = false,
   innerRef,
   ouiaId,
   ouiaSafe = true,
@@ -59,7 +59,7 @@ const TrBase: React.FunctionComponent<TrProps> = ({
         isExpanded && styles.modifiers.expanded,
         isEditable && inlineStyles.modifiers.inlineEditable,
         isHoverable && styles.modifiers.hoverable,
-        isSelected && styles.modifiers.selected
+        isRowSelected && styles.modifiers.selected
       )}
       hidden={isHidden || (isExpanded !== undefined && !isExpanded)}
       {...(isHoverable && { tabIndex: 0 })}

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
@@ -240,68 +240,6 @@ ComposableTableMisc = () => {
 };
 ```
 
-### Composable: Row click handler, hoverable & selected rows
-
-```js
-import React from 'react';
-import { TableComposable, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
-
-ComposableTableHoverable = () => {
-  const columns = ['Repositories', 'Branches', 'Pull requests', 'Workspaces', 'Last commit'];
-  const [rows, setRows] = React.useState([
-    { cells: ['one', 'two', 'a', 'four', 'five'], isRowSelected: false},
-    { cells: ['a', 'two', 'k', 'four', 'five'], isRowSelected: false},
-    { cells: ['p', 'two', 'b', 'four', 'five'], isRowSelected: false}
-  ]);
-  const onRowClick = (event, rowIndex, row) => {
-    const updatedRows = [...rows];
-    updatedRows[rowIndex].isRowSelected = !rows[rowIndex].isRowSelected;
-    setRows(updatedRows); 
-  };
-  
-  return (
-    <TableComposable aria-label="Misc table">
-      <Thead noWrap>
-        <Tr>
-          <Th>
-            {columns[0]}
-          </Th>
-          <Th>{columns[1]}</Th>
-          <Th>
-            {columns[2]}
-          </Th>
-          <Th>{columns[3]}</Th>
-          <Th>{columns[4]}</Th>
-        </Tr>
-      </Thead>
-      <Tbody>
-        {rows.map((row, rowIndex) => {
-          return (
-            <Tr
-              key={rowIndex}
-              onRowClick={event => onRowClick(event, rowIndex, row.cells)}
-              isHoverable
-              isRowSelected={row.isRowSelected}
-            >
-              {row.cells.map((cell, cellIndex) => {
-                return (
-                  <Td
-                    key={`${rowIndex}_${cellIndex}`}
-                    dataLabel={columns[cellIndex]}
-                  >
-                    {cell}
-                  </Td>
-                );
-              })}
-            </Tr>
-          );
-        })}
-      </Tbody>
-    </TableComposable>
-  );
-};
-```
-
 ### Composable: Sortable & wrapping headers
 
 To make a column sortable, pass a `ThSortType` object via the `sort` prop on a column's `Th`.
@@ -615,6 +553,70 @@ ComposableTableSelectableRadio = () => {
             })}
           </Tr>
         ))}
+      </Tbody>
+    </TableComposable>
+  );
+};
+```
+
+### Composable: Row click handler, hoverable & selected rows
+
+This selectable rows feature is intended for use when a table is used to present a list of objects in a Primary-detail view.
+
+```js
+import React from 'react';
+import { TableComposable, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+
+ComposableTableHoverable = () => {
+  const columns = ['Repositories', 'Branches', 'Pull requests', 'Workspaces', 'Last commit'];
+  const [rows, setRows] = React.useState([
+    { cells: ['one', 'two', 'a', 'four', 'five'], isRowSelected: false},
+    { cells: ['a', 'two', 'k', 'four', 'five'], isRowSelected: false},
+    { cells: ['p', 'two', 'b', 'four', 'five'], isRowSelected: false}
+  ]);
+  const onRowClick = (event, rowIndex, row) => {
+    const updatedRows = [...rows];
+    updatedRows[rowIndex].isRowSelected = !rows[rowIndex].isRowSelected;
+    setRows(updatedRows); 
+  };
+  
+  return (
+    <TableComposable aria-label="Misc table">
+      <Thead noWrap>
+        <Tr>
+          <Th>
+            {columns[0]}
+          </Th>
+          <Th>{columns[1]}</Th>
+          <Th>
+            {columns[2]}
+          </Th>
+          <Th>{columns[3]}</Th>
+          <Th>{columns[4]}</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {rows.map((row, rowIndex) => {
+          return (
+            <Tr
+              key={rowIndex}
+              onRowClick={event => onRowClick(event, rowIndex, row.cells)}
+              isHoverable
+              isRowSelected={row.isRowSelected}
+            >
+              {row.cells.map((cell, cellIndex) => {
+                return (
+                  <Td
+                    key={`${rowIndex}_${cellIndex}`}
+                    dataLabel={columns[cellIndex]}
+                  >
+                    {cell}
+                  </Td>
+                );
+              })}
+            </Tr>
+          );
+        })}
       </Tbody>
     </TableComposable>
   );

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
@@ -139,11 +139,11 @@ ComposableTableBasic = () => {
 };
 ```
 
-### Composable: Row click handler, custom row wrapper, header tooltips & popovers
+### Composable: Custom row wrapper, header tooltips & popovers
 
 - If you add the `noWrap` prop to `Thead`, it won't wrap it if there is no space
 - You can add the `textCenter` prop to `Th` or `Td` to center the contents
-- You can pass `onClick`, `className`, `style` and more to `Tr`
+- You can pass `className`, `style` and more to `Tr`
 
 To add a header tooltip or popover to `Th`, pass a `ThInfoType` object via the `info` prop.
 
@@ -152,15 +152,14 @@ import React from 'react';
 import { TableComposable, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 
 ComposableTableMisc = () => {
+  const [selectedRow, setSelectedRow] = React.useState(null);
   const columns = ['Repositories', 'Branches', 'Pull requests', 'Workspaces', 'Last commit'];
   const rows = [
     ['one', 'two', 'three', 'four', 'five'],
     [{ title: 'one - 2', colSpan: 3 }, null, null, 'four - 2', 'five - 2'],
     ['one - 3', 'two - 3', 'three - 3', 'four - 3', { title: 'five - 3 (not centered)', textCenter: false }]
   ];
-  const onRowClick = (event, rowIndex, row) => {
-    console.log(`handle row click ${rowIndex}`, row);
-  };
+  
   return (
     <TableComposable aria-label="Misc table">
       <Thead noWrap>
@@ -206,9 +205,10 @@ ComposableTableMisc = () => {
           return (
             <Tr
               key={rowIndex}
-              onClick={event => onRowClick(event, rowIndex, row)}
               className={isOddRow ? 'odd-row-class' : 'even-row-class'}
               style={isOddRow ? customStyle : {}}
+              isHoverable
+              isSelected={selectedRow === rowIndex}
             >
               {row.map((cell, cellIndex) => {
                 if (!cell) {
@@ -231,6 +231,68 @@ ComposableTableMisc = () => {
                     {...rest}
                   >
                     {title}
+                  </Td>
+                );
+              })}
+            </Tr>
+          );
+        })}
+      </Tbody>
+    </TableComposable>
+  );
+};
+```
+
+### Composable: Row click handler, hoverable & selected rows
+
+```js
+import React from 'react';
+import { TableComposable, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+
+ComposableTableHoverable = () => {
+  const columns = ['Repositories', 'Branches', 'Pull requests', 'Workspaces', 'Last commit'];
+  const [rows, setRows] = React.useState([
+    { cells: ['one', 'two', 'a', 'four', 'five'], isSelected: false},
+    { cells: ['a', 'two', 'k', 'four', 'five'], isSelected: false},
+    { cells: ['p', 'two', 'b', 'four', 'five'], isSelected: false}
+  ]);
+  const onRowClick = (event, rowIndex, row) => {
+    const updatedRows = [...rows];
+    updatedRows[rowIndex].isSelected = !rows[rowIndex].isSelected;
+    setRows(updatedRows); 
+  };
+  
+  return (
+    <TableComposable aria-label="Misc table">
+      <Thead noWrap>
+        <Tr>
+          <Th>
+            {columns[0]}
+          </Th>
+          <Th>{columns[1]}</Th>
+          <Th>
+            {columns[2]}
+          </Th>
+          <Th>{columns[3]}</Th>
+          <Th>{columns[4]}</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {rows.map((row, rowIndex) => {
+          return (
+            <Tr
+              key={rowIndex}
+              onClick={event => onRowClick(event, rowIndex, row.cells)}
+              isHoverable
+              isSelected={row.isSelected}
+            >
+              {row.cells.map((cell, cellIndex) => {
+                return (
+                  <Td
+                    key={`${rowIndex}_${cellIndex}`}
+                    dataLabel={columns[cellIndex]}
+                  >
+                    {cell}
                   </Td>
                 );
               })}
@@ -354,7 +416,7 @@ ComposableTableSortable = () => {
 };
 ```
 
-### Composable: Selectable
+### Composable: Selectable with checkbox
 
 To make a row selectable, the table needs a selection column.
 The selection column is just another column, but with selection specific props added. 

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
@@ -152,7 +152,6 @@ import React from 'react';
 import { TableComposable, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 
 ComposableTableMisc = () => {
-  const [selectedRow, setSelectedRow] = React.useState(null);
   const columns = ['Repositories', 'Branches', 'Pull requests', 'Workspaces', 'Last commit'];
   const rows = [
     ['one', 'two', 'three', 'four', 'five'],
@@ -207,8 +206,6 @@ ComposableTableMisc = () => {
               key={rowIndex}
               className={isOddRow ? 'odd-row-class' : 'even-row-class'}
               style={isOddRow ? customStyle : {}}
-              isHoverable
-              isSelected={selectedRow === rowIndex}
             >
               {row.map((cell, cellIndex) => {
                 if (!cell) {
@@ -282,7 +279,7 @@ ComposableTableHoverable = () => {
           return (
             <Tr
               key={rowIndex}
-              onClick={event => onRowClick(event, rowIndex, row.cells)}
+              onRowClick={event => onRowClick(event, rowIndex, row.cells)}
               isHoverable
               isSelected={row.isSelected}
             >

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
@@ -249,13 +249,13 @@ import { TableComposable, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-tab
 ComposableTableHoverable = () => {
   const columns = ['Repositories', 'Branches', 'Pull requests', 'Workspaces', 'Last commit'];
   const [rows, setRows] = React.useState([
-    { cells: ['one', 'two', 'a', 'four', 'five'], isSelected: false},
-    { cells: ['a', 'two', 'k', 'four', 'five'], isSelected: false},
-    { cells: ['p', 'two', 'b', 'four', 'five'], isSelected: false}
+    { cells: ['one', 'two', 'a', 'four', 'five'], isRowSelected: false},
+    { cells: ['a', 'two', 'k', 'four', 'five'], isRowSelected: false},
+    { cells: ['p', 'two', 'b', 'four', 'five'], isRowSelected: false}
   ]);
   const onRowClick = (event, rowIndex, row) => {
     const updatedRows = [...rows];
-    updatedRows[rowIndex].isSelected = !rows[rowIndex].isSelected;
+    updatedRows[rowIndex].isRowSelected = !rows[rowIndex].isRowSelected;
     setRows(updatedRows); 
   };
   
@@ -281,7 +281,7 @@ ComposableTableHoverable = () => {
               key={rowIndex}
               onRowClick={event => onRowClick(event, rowIndex, row.cells)}
               isHoverable
-              isSelected={row.isSelected}
+              isRowSelected={row.isRowSelected}
             >
               {row.cells.map((cell, cellIndex) => {
                 return (


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5444 

Changes:

- I removed the rowClickHandler piece from a different TableComposable example
- I added a new `Composable: Row click handler, hoverable & selected rows` example to TableComposable
- I updated the Legacy Table's `Row click handler and header cell tooltips/popovers` example to include hoverable/selectable features.
- I added keyboard handling to the `onRowClick` prop so that the event can be triggered using keyboard and not just mouse click