### PR TITLE
feat(LogViewer): add onScroll and footer props

### DIFF
--- a/packages/react-log-viewer/src/LogViewer/LogViewer.tsx
+++ b/packages/react-log-viewer/src/LogViewer/LogViewer.tsx
@@ -31,7 +31,26 @@ interface LogViewerProps {
   /** Number of rows to display in the log viewer */
   itemCount?: number;
   /** Component rendered in the log viewer console window header */
-  headerComponent?: React.ReactNode;
+  header?: React.ReactNode;
+  /** Component rendered in the log viewer console window footer */
+  footer?: React.ReactNode;
+  /** Callback function when scrolling the window.
+   * scrollDirection is the direction of scroll, could be 'forward'|'backward'.
+   * scrollOffset and scrollOffsetToBottom are the offset of the current position to the top or the bottom.
+   * scrollUpdateWasRequested is false when the scroll event is cause by the user interaction in the browser, else it's true.
+   * @example onScroll={({scrollDirection, scrollOffset, scrollOffsetToBottom, scrollUpdateWasRequested})=>{}}
+   */
+  onScroll?: ({
+    scrollDirection,
+    scrollOffset,
+    scrollOffsetToBottom,
+    scrollUpdateWasRequested
+  }: {
+    scrollDirection: 'forward' | 'backward';
+    scrollOffset: number;
+    scrollOffsetToBottom: number;
+    scrollUpdateWasRequested: boolean;
+  }) => void;
 }
 
 export const LogViewer: React.FunctionComponent<LogViewerProps> = memo(
@@ -46,7 +65,9 @@ export const LogViewer: React.FunctionComponent<LogViewerProps> = memo(
     theme = 'light',
     scrollToRow = 0,
     itemCount = undefined,
-    headerComponent,
+    header,
+    footer,
+    onScroll,
     ...props
   }: LogViewerProps) => {
     const [searchedInput, setSearchedInput] = useState<string | null>('');
@@ -61,8 +82,8 @@ export const LogViewer: React.FunctionComponent<LogViewerProps> = memo(
     const [loading, setLoading] = useState(true);
     const [firstMount, setFirstMount] = useState(true);
 
-    const logViewerRef = React.createRef<any>();
-    const containerRef = React.createRef<any>();
+    const logViewerRef = React.useRef<any>();
+    const containerRef = React.useRef<any>();
     let resizeTimer = null as any;
 
     React.useEffect(() => {
@@ -152,6 +173,10 @@ export const LogViewer: React.FunctionComponent<LogViewerProps> = memo(
       logViewerRef.current.scrollToItem(searchedRowIndex, 'center');
     };
 
+    const scrollToBottom = () => {
+      logViewerRef.current.scrollToBottom();
+    };
+
     const createList = (parsedData: string[]) => (
       <List
         className={css(styles.logViewerList)}
@@ -161,6 +186,7 @@ export const LogViewer: React.FunctionComponent<LogViewerProps> = memo(
         itemData={dataToRender}
         ref={logViewerRef}
         overscanCount={overScanCount}
+        onScroll={onScroll}
       >
         {LogViewerRow}
       </List>
@@ -170,7 +196,8 @@ export const LogViewer: React.FunctionComponent<LogViewerProps> = memo(
       <LogViewerContext.Provider
         value={{
           parsedData,
-          searchedInput
+          searchedInput,
+          scrollToBottom
         }}
       >
         <div
@@ -198,10 +225,11 @@ export const LogViewer: React.FunctionComponent<LogViewerProps> = memo(
               <div className={css(styles.logViewerHeader)}>{toolbar}</div>
             </LogViewerToolbarContext.Provider>
           )}
-          {headerComponent}
+          {header}
           <div className={css(styles.logViewerMain)} ref={containerRef}>
             {loading ? <div style={{ height }}>{loadingContent}</div> : createList(parsedData)}
           </div>
+          {footer}
         </div>
       </LogViewerContext.Provider>
     );

--- a/packages/react-log-viewer/src/LogViewer/LogViewer.tsx
+++ b/packages/react-log-viewer/src/LogViewer/LogViewer.tsx
@@ -137,7 +137,7 @@ export const LogViewer: React.FunctionComponent<LogViewerProps> = memo(
       if (scrollToRow && parsedData.length) {
         setRowInFocus(parsedData.length - 1);
         if (logViewerRef && logViewerRef.current) {
-          logViewerRef.current.scrollToItem(scrollToRow, 'center');
+          logViewerRef.current.scrollToItem(scrollToRow, 'auto');
         }
       }
     }, [parsedData, scrollToRow]);

--- a/packages/react-log-viewer/src/LogViewer/LogViewerContext.tsx
+++ b/packages/react-log-viewer/src/LogViewer/LogViewerContext.tsx
@@ -5,6 +5,7 @@ export const useLogViewerContext = () => useContext(LogViewerContext);
 export interface LogViewerContextInterface {
   parsedData: string[];
   searchedInput: string;
+  scrollToBottom: () => void;
 }
 
 export const LogViewerContext = createContext<LogViewerContextInterface | null>(null);

--- a/packages/react-log-viewer/src/LogViewer/LogViewerRow.tsx
+++ b/packages/react-log-viewer/src/LogViewer/LogViewerRow.tsx
@@ -1,9 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, memo } from 'react';
 import { LOGGER_LINE_NUMBER_INDEX_DELTA } from './utils/constants';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/LogViewer/log-viewer';
 import { LogViewerContext } from './LogViewerContext';
-import { forwardRef } from 'react';
 
 interface LogViewerRowProps {
   index?: number;
@@ -15,9 +14,10 @@ interface LogViewerRowProps {
     highlightedRowIndexes: number[];
     setHighlightedRowIndexes: (indexes: number[]) => void;
   };
+  innerRef?: React.Ref<any>;
 }
 
-export const LogViewerRow: React.FunctionComponent<LogViewerRowProps> = forwardRef(({ index, style, data }, ref) => {
+const LogViewerRowBase: React.FunctionComponent<LogViewerRowProps> = memo(({ index, style, data, innerRef }) => {
   const { parsedData, highlightedRowIndexes, searchedWordIndexes, setHighlightedRowIndexes, rowInFocus } = data;
   const [clickCounter, setClickCounter] = useState(0);
   const [isHiglighted, setIsHiglighted] = useState(false);
@@ -87,7 +87,7 @@ export const LogViewerRow: React.FunctionComponent<LogViewerRowProps> = forwardR
   return (
     <div
       key={index}
-      ref={ref as any}
+      ref={innerRef}
       style={style}
       className={css(styles.logViewerListItem)}
       onClick={() => handleHighlightRow()}
@@ -99,4 +99,9 @@ export const LogViewerRow: React.FunctionComponent<LogViewerRowProps> = forwardR
     </div>
   );
 });
+
+export const LogViewerRow = React.forwardRef((props: LogViewerRowProps, ref: React.Ref<HTMLButtonElement>) => (
+  <LogViewerRowBase {...props} innerRef={ref} />
+));
+
 LogViewerRow.displayName = 'LogViewerRow';

--- a/packages/react-log-viewer/src/LogViewer/demos/LogViewer.md
+++ b/packages/react-log-viewer/src/LogViewer/demos/LogViewer.md
@@ -4,22 +4,23 @@ beta: true
 section: extensions
 ---
 
-import { LogViewer, LogViewerSearch } from '@patternfly/react-log-viewer';
+import { LogViewer, LogViewerSearch, LogViewerContext } from '@patternfly/react-log-viewer';
 import {
-  Badge,
-  Button,
-  Select,
-  SelectOption,
-  PageSection,
-  PageSectionVariants,
-  Tooltip,
-  Toolbar, 
-  ToolbarContent, 
-  ToolbarGroup, 
-  ToolbarItem, 
-  ToolbarToggleGroup
+Badge,
+Button,
+Select,
+SelectOption,
+PageSection,
+PageSectionVariants,
+Tooltip,
+Toolbar,
+ToolbarContent,
+ToolbarGroup,
+ToolbarItem,
+ToolbarToggleGroup
 } from '@patternfly/react-core';
 import { data } from '../examples/realTestData.js';
+import { OutlinedPlayCircleIcon } from '@patternfly/react-icons';
 import ExpandIcon from '@patternfly/react-icons/dist/esm/icons/expand-icon';
 import PauseIcon from '@patternfly/react-icons/dist/esm/icons/pause-icon';
 import DownloadIcon from '@patternfly/react-icons/dist/esm/icons/download-icon';
@@ -31,19 +32,20 @@ import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-ico
 ```js
 import React from 'react';
 import { data } from './realTestData';
-import { LogViewer, LogViewerSearch } from '@patternfly/react-log-viewer';
+import { LogViewer, LogViewerSearch, LogViewerContext } from '@patternfly/react-log-viewer';
 import {
   Badge,
   Button,
   Select,
   SelectOption,
   Tooltip,
-  Toolbar, 
-  ToolbarContent, 
-  ToolbarGroup, 
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
   ToolbarItem,
   ToolbarToggleGroup
 } from '@patternfly/react-core';
+import OutlinedPlayCircleIcon from '@patternfly/react-icons/dist/esm/icons/outlined-play-circle-icon';
 import ExpandIcon from '@patternfly/react-icons/dist/esm/icons/expand-icon';
 import PauseIcon from '@patternfly/react-icons/dist/esm/icons/pause-icon';
 import PlayIcon from '@patternfly/react-icons/dist/esm/icons/play-icon';
@@ -54,62 +56,65 @@ ComplexToolbarLogViewer = () => {
   const [isPaused, setIsPaused] = React.useState(false);
   const [isFullScreen, setIsFullScreen] = React.useState(false);
   const [currentItemCount, setCurrentItemCount] = React.useState(0);
-  const [selectedDataSource, setSelectedDataSource] = React.useState("container-1");
+  const [selectedDataSource, setSelectedDataSource] = React.useState('container-1');
   const [selectDataSourceOpen, setSelectDataSourceOpen] = React.useState(false);
   const [timer, setTimer] = React.useState(null);
-  
-  const dataSources = {                    
-    'container-1': { type: 'C', id: "data1" },   
-    'container-2': { type: 'D', id: "data2" },   
-    'container-3': { type: 'E', id: "data3" }    
-  };    
-  
+
+  const dataSources = {
+    'container-1': { type: 'C', id: 'data1' },
+    'container-2': { type: 'D', id: 'data2' },
+    'container-3': { type: 'E', id: 'data3' }
+  };
+
   React.useEffect(() => {
     if (!isPaused) {
-      setTimer(window.setInterval(() => {
-          setCurrentItemCount((currentItemCount) => currentItemCount + 1);
-      }, 1000));
+      setTimer(
+        window.setInterval(() => {
+          setCurrentItemCount(currentItemCount => currentItemCount + 1);
+        }, 1000)
+      );
     } else {
       timer && window.clearInterval(timer);
     }
     return () => {
-      window.clearInterval(timer)
-    }
+      window.clearInterval(timer);
+    };
   }, [isPaused]);
-  
+
   React.useEffect(() => {
     if (currentItemCount > 29) {
       window.clearInterval(timer);
     }
   }, [currentItemCount]);
-  
+
   const onExpandClick = event => {
     const element = document.querySelector('#complex-toolbar-demo');
 
     if (!isFullScreen) {
       if (element.requestFullscreen) {
-          element.requestFullscreen();
+        element.requestFullscreen();
       } else if (element.mozRequestFullScreen) {
-          element.mozRequestFullScreen();
+        element.mozRequestFullScreen();
       } else if (element.webkitRequestFullScreen) {
-          element.webkitRequestFullScreen(Element.ALLOW_KEYBOARD_INPUT);
+        element.webkitRequestFullScreen(Element.ALLOW_KEYBOARD_INPUT);
       }
       setIsFullScreen(true);
     } else {
       if (document.exitFullscreen) {
         document.exitFullscreen();
-      } else if (document.webkitExitFullscreen) { /* Safari */
+      } else if (document.webkitExitFullscreen) {
+        /* Safari */
         document.webkitExitFullscreen();
-      } else if (document.msExitFullscreen) { /* IE11 */
+      } else if (document.msExitFullscreen) {
+        /* IE11 */
         document.msExitFullscreen();
       }
       setIsFullScreen(false);
     }
-    
   };
-  
+
   const onDownloadClick = () => {
-    const element = document.createElement("a");
+    const element = document.createElement('a');
     const dataToDownload = [data[dataSources[selectedDataSource].id]];
     const file = new Blob(dataToDownload, { type: 'text/plain' });
     element.href = URL.createObjectURL(file);
@@ -118,7 +123,17 @@ ComplexToolbarLogViewer = () => {
     element.click();
     document.body.removeChild(element);
   };
-  
+
+  const onScroll = ({ scrollOffsetToBottom, scrollUpdateWasRequested }) => {
+    if (!scrollUpdateWasRequested) {
+      if (scrollOffsetToBottom > 0) {
+        setIsPaused(true);
+      } else {
+        setIsPaused(false);
+      }
+    }
+  };
+
   const selectDataSourceMenu = Object.entries(dataSources).map(([value, { type }]) => (
     <SelectOption
       key={value}
@@ -130,17 +145,35 @@ ComplexToolbarLogViewer = () => {
       {` ${value}`}
     </SelectOption>
   ));
-  
+
   const selectDataSourcePlaceholder = (
     <React.Fragment>
       <Badge>{dataSources[selectedDataSource].type}</Badge>
       {` ${selectedDataSource}`}
     </React.Fragment>
   );
-  
+
+  const ControlButton = () => {
+    const { scrollToBottom } = React.useContext(LogViewerContext);
+    return (
+      <Button
+        variant={isPaused ? 'plain' : 'link'}
+        onClick={() => {
+          if (isPaused) {
+            scrollToBottom();
+          }
+          setIsPaused(!isPaused);
+        }}
+      >
+        {isPaused ? <PlayIcon /> : <PauseIcon />}
+        {isPaused ? ` Resume Log` : ` Pause Log`}
+      </Button>
+    );
+  };
+
   const leftAlignedToolbarGroup = (
     <React.Fragment>
-    <ToolbarToggleGroup toggleIcon={<EllipsisVIcon />} breakpoint="md">
+      <ToolbarToggleGroup toggleIcon={<EllipsisVIcon />} breakpoint="md">
         <ToolbarItem variant="search-filter">
           <Select
             onToggle={isOpen => setSelectDataSourceOpen(isOpen)}
@@ -157,14 +190,11 @@ ComplexToolbarLogViewer = () => {
           </Select>
         </ToolbarItem>
         <ToolbarItem variant="search-filter">
-          <LogViewerSearch placeholder="Search" />
+          <LogViewerSearch onFocus={e => setIsPaused(true)} placeholder="Search" />
         </ToolbarItem>
       </ToolbarToggleGroup>
       <ToolbarItem>
-        <Button variant={isPaused ? 'plain' : 'link'} onClick={() => setIsPaused(!isPaused)}>
-          {isPaused ? <PlayIcon /> : <PauseIcon />}
-          {isPaused ? ` Resume Log` : ` Pause Log`}
-        </Button>
+        <ControlButton />
       </ToolbarItem>
     </React.Fragment>
   );
@@ -190,6 +220,20 @@ ComplexToolbarLogViewer = () => {
     </React.Fragment>
   );
 
+  const FooterButton = () => {
+    const { scrollToBottom } = React.useContext(LogViewerContext);
+    const handleClick = e => {
+      setIsPaused(false);
+      scrollToBottom();
+    };
+    return (
+      <Button onClick={handleClick} isBlock>
+        <OutlinedPlayCircleIcon />
+        resume
+      </Button>
+    );
+  };
+
   return (
     <LogViewer
       data={data[dataSources[selectedDataSource].id]}
@@ -204,6 +248,8 @@ ComplexToolbarLogViewer = () => {
           </ToolbarContent>
         </Toolbar>
       }
+      footer={isPaused && <FooterButton />}
+      onScroll={onScroll}
     />
   );
 };

--- a/packages/react-log-viewer/src/LogViewer/examples/LogViewer.md
+++ b/packages/react-log-viewer/src/LogViewer/examples/LogViewer.md
@@ -5,7 +5,7 @@ section: extensions
 propComponents: [LogViewer, LogViewerSearch]
 ---
 
-import { LogViewer, LogViewerSearch } from '@patternfly/react-log-viewer';
+import { LogViewer, LogViewerSearch, LogViewerContext } from '@patternfly/react-log-viewer';
 import { Button, Checkbox, Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
 import { data } from './realTestData.js';
 
@@ -124,8 +124,33 @@ HeaderComponentLogViewer = () => {
         height={300}
         data={data.data}
         theme="dark"
-        headerComponent={<Banner>{data.data.length} lines</Banner>}
+        header={<Banner>5019 lines</Banner>}
       />
+    </React.Fragment>
+  );
+};
+```
+
+### With footer component
+
+```js
+import React from 'react';
+import { data } from './realTestData.js';
+import { LogViewer, LogViewerContext } from '@patternfly/react-log-viewer';
+import { Button } from '@patternfly/react-core';
+
+FooterComponentLogViewer = () => {
+  const FooterButton = () => {
+    const { scrollToBottom } = React.useContext(LogViewerContext);
+    const handleClick = e => {
+      scrollToBottom();
+    };
+    return <Button onClick={handleClick}>Jump to the bottom</Button>;
+  };
+
+  return (
+    <React.Fragment>
+      <LogViewer hasLineNumbers={false} height={300} data={data.data} theme="dark" footer={<FooterButton />} />
     </React.Fragment>
   );
 };

--- a/packages/react-log-viewer/src/LogViewer/index.ts
+++ b/packages/react-log-viewer/src/LogViewer/index.ts
@@ -1,3 +1,4 @@
 export * from './LogViewer';
 export * from './LogViewerContext';
 export * from './LogViewerSearch';
+export * from './LogViewerContext';


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6237 

This PR includes:
1. Add a prop named `onScroll`, users could pass a callback function into it which takes 4 parameters: `scrollDirection`, `scrollOffset`, `scrollOffsetToBottom`, `scrollUpdateWasRequested`, the callback function will be called when scrolling the log window.
2. Add a prop named `footer` to allow users to set a footer at the bottom of the log viewer window and add an example about how to use the `footer` prop.
3. Update the demo, show how to use `onScroll` callback function and how to use the context of the log viewer to scroll to the bottom.
