### PR TITLE
fix(code-editor): remove uneeded peer dep

### DIFF
--- a/packages/react-code-editor/package.json
+++ b/packages/react-code-editor/package.json
@@ -37,7 +37,6 @@
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "monaco-editor": "^0.21.3",
     "monaco-editor-webpack-plugin": "^2.1.0",
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0",


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6240. [react-monaco-editor](https://www.npmjs.com/package/react-monaco-editor) already depends on [monaco-editor](https://www.npmjs.com/package/monaco-editor), so we don't need to ask consumers to specify it manually.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
