### PR TITLE
fix(Select): fixed issues in Select typeaheadmulti

### DIFF
--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -408,16 +408,26 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
     if (typeaheadFilteredChildren.length === 0) {
       !isCreatable &&
         typeaheadFilteredChildren.push(
-          <SelectOption isDisabled key={0} value={noResultsFoundText} isNoResultsOption />
+          <SelectOption isDisabled key="no-results" value={noResultsFoundText} isNoResultsOption />
         );
     }
     if (isCreatable && typeaheadInputValue !== '') {
       const newValue = typeaheadInputValue;
-      typeaheadFilteredChildren.push(
-        <SelectOption key={0} value={newValue} onClick={() => onCreateOption && onCreateOption(newValue)}>
-          {createText} "{newValue}"
-        </SelectOption>
-      );
+      if (
+        !typeaheadFilteredChildren.find(
+          (i: React.ReactElement) => i.props.value.toLowerCase() === newValue.toLowerCase()
+        )
+      ) {
+        typeaheadFilteredChildren.push(
+          <SelectOption
+            key={`create ${newValue}`}
+            value={newValue}
+            onClick={() => onCreateOption && onCreateOption(newValue)}
+          >
+            {createText} "{newValue}"
+          </SelectOption>
+        );
+      }
     }
 
     this.setState({


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes https://github.com/patternfly/patternfly-react/issues/6243

- added string value to key instead of `0` for the `No Results found` & `Create <text>` Select options
- added check for duplicate entries. If the option already exists for the entered text then the Create option will not be shown

GIF:
![select_fix](https://user-images.githubusercontent.com/22490998/131380890-062e6f49-d100-44b6-b27b-a13a720d1fcf.gif)

