### PR TITLE
Add Drag and Drop

### DIFF
--- a/packages/react-core/src/components/DragDrop/DragDrop.tsx
+++ b/packages/react-core/src/components/DragDrop/DragDrop.tsx
@@ -8,22 +8,37 @@ export const DragDropContext = React.createContext({
   draggingZone: '',
   setDraggingZone: (_zone: string) => {},
   draggableZoneNodes: {} as ZoneNodes,
-  setDraggableZoneNodes: (_nodes: ZoneNodes) => {}
+  setDraggableZoneNodes: (_nodes: ZoneNodes) => {},
+  onDrop: (
+    _sourceDroppableIndex: number,
+    _sourceDraggableIndex: number,
+    _destDroppableIndex: number,
+    _destDraggableIndex: number
+  ) => {}
 });
 
 interface DragDropProps {
   /** Potentially Droppable and Draggable children */
   children?: React.ReactNode;
+  /** Callback for drop event */
+  onDrop?: (
+    sourceDroppableIndex: number,
+    sourceDraggableIndex: number,
+    destDroppableIndex: number,
+    destDraggableIndex: number
+  ) => void;
 }
 
-export const DragDrop: React.FunctionComponent<DragDropProps> = ({ children }: DragDropProps) => {
+export const DragDrop: React.FunctionComponent<DragDropProps> = ({ children, onDrop = () => {} }: DragDropProps) => {
   // Used for highlighting Droppable
   const [draggingZone, setDraggingZone] = React.useState('');
   // Used for reordering
   const [draggableZoneNodes, setDraggableZoneNodes] = React.useState({});
 
   return (
-    <DragDropContext.Provider value={{ draggingZone, setDraggingZone, draggableZoneNodes, setDraggableZoneNodes }}>
+    <DragDropContext.Provider
+      value={{ draggingZone, setDraggingZone, draggableZoneNodes, setDraggableZoneNodes, onDrop }}
+    >
       {children}
     </DragDropContext.Provider>
   );

--- a/packages/react-core/src/components/DragDrop/DragDrop.tsx
+++ b/packages/react-core/src/components/DragDrop/DragDrop.tsx
@@ -1,8 +1,14 @@
 import * as React from 'react';
 
+interface ZoneNodes {
+  [zone: string]: HTMLElement[];
+}
+
 export const DragDropContext = React.createContext({
   draggingZone: '',
-  setDraggingZone: (_zone: string) => {}
+  setDraggingZone: (_zone: string) => {},
+  draggableZoneNodes: {} as ZoneNodes,
+  setDraggableZoneNodes: (_nodes: ZoneNodes) => {}
 });
 
 interface DragDropProps {
@@ -11,8 +17,15 @@ interface DragDropProps {
 }
 
 export const DragDrop: React.FunctionComponent<DragDropProps> = ({ children }: DragDropProps) => {
+  // Used for highlighting Droppable
   const [draggingZone, setDraggingZone] = React.useState('');
+  // Used for reordering
+  const [draggableZoneNodes, setDraggableZoneNodes] = React.useState({});
 
-  return <DragDropContext.Provider value={{ draggingZone, setDraggingZone }}>{children}</DragDropContext.Provider>;
+  return (
+    <DragDropContext.Provider value={{ draggingZone, setDraggingZone, draggableZoneNodes, setDraggableZoneNodes }}>
+      {children}
+    </DragDropContext.Provider>
+  );
 };
 DragDrop.displayName = 'DragDrop';

--- a/packages/react-core/src/components/DragDrop/DragDrop.tsx
+++ b/packages/react-core/src/components/DragDrop/DragDrop.tsx
@@ -5,8 +5,6 @@ interface ZoneNodes {
 }
 
 export const DragDropContext = React.createContext({
-  draggingZone: '',
-  setDraggingZone: (_zone: string) => {},
   draggableZoneNodes: {} as ZoneNodes,
   setDraggableZoneNodes: (_nodes: ZoneNodes) => {},
   onDrop: (
@@ -30,15 +28,11 @@ interface DragDropProps {
 }
 
 export const DragDrop: React.FunctionComponent<DragDropProps> = ({ children, onDrop = () => {} }: DragDropProps) => {
-  // Used for highlighting Droppable
-  const [draggingZone, setDraggingZone] = React.useState('');
   // Used for reordering
   const [draggableZoneNodes, setDraggableZoneNodes] = React.useState({});
 
   return (
-    <DragDropContext.Provider
-      value={{ draggingZone, setDraggingZone, draggableZoneNodes, setDraggableZoneNodes, onDrop }}
-    >
+    <DragDropContext.Provider value={{ draggableZoneNodes, setDraggableZoneNodes, onDrop }}>
       {children}
     </DragDropContext.Provider>
   );

--- a/packages/react-core/src/components/DragDrop/DragDrop.tsx
+++ b/packages/react-core/src/components/DragDrop/DragDrop.tsx
@@ -10,10 +10,10 @@ export const DragDropContext = React.createContext({
   draggableZoneNodes: {} as ZoneNodes,
   setDraggableZoneNodes: (_nodes: ZoneNodes) => {},
   onDrop: (
-    _sourceDroppableIndex: number,
-    _sourceDraggableIndex: number,
-    _destDroppableIndex: number,
-    _destDraggableIndex: number
+    _sourceDroppableKey: string | number,
+    _sourceDraggableKey: string | number,
+    _destDroppableKey: string | number | null,
+    _destDraggableKey: string | number | null
   ) => {}
 });
 
@@ -22,10 +22,10 @@ interface DragDropProps {
   children?: React.ReactNode;
   /** Callback for drop event */
   onDrop?: (
-    sourceDroppableIndex: number,
-    sourceDraggableIndex: number,
-    destDroppableIndex: number,
-    destDraggableIndex: number
+    sourceDroppableKey: string | number,
+    sourceDraggableKey: string | number,
+    destDroppableKey: string | number | null,
+    destDraggableKey: string | number | null
   ) => void;
 }
 

--- a/packages/react-core/src/components/DragDrop/DragDrop.tsx
+++ b/packages/react-core/src/components/DragDrop/DragDrop.tsx
@@ -1,40 +1,29 @@
 import * as React from 'react';
 
-interface ZoneNodes {
-  [zone: string]: HTMLElement[];
+interface DraggableItemPosition {
+  /** Parent droppableId */
+  droppableId: string;
+  /** Index of item in parent Droppable */
+  index: number;
 }
 
 export const DragDropContext = React.createContext({
-  draggableZoneNodes: {} as ZoneNodes,
-  setDraggableZoneNodes: (_nodes: ZoneNodes) => {},
-  onDrop: (
-    _sourceDroppableKey: string | number,
-    _sourceDraggableKey: string | number,
-    _destDroppableKey: string | number | null,
-    _destDraggableKey: string | number | null
-  ) => false as boolean
+  onDrag: (_source: DraggableItemPosition) => true as boolean,
+  onDrop: (_source: DraggableItemPosition, _dest?: DraggableItemPosition) => false as boolean
 });
 
 interface DragDropProps {
   /** Potentially Droppable and Draggable children */
   children?: React.ReactNode;
-  /** Callback for drop event */
-  onDrop?: (
-    sourceDroppableKey: string | number,
-    sourceDraggableKey: string | number,
-    destDroppableKey: string | number | null,
-    destDraggableKey: string | number | null
-  ) => boolean;
+  /** Callback for drag event. Return true to allow drag, false to disallow. */
+  onDrag?: (source: DraggableItemPosition) => boolean;
+  /** Callback for drop event. Return true to allow drop, false to disallow. */
+  onDrop?: (source: DraggableItemPosition, dest?: DraggableItemPosition) => boolean;
 }
 
-export const DragDrop: React.FunctionComponent<DragDropProps> = ({ children, onDrop = () => false }: DragDropProps) => {
-  // Used for reordering
-  const [draggableZoneNodes, setDraggableZoneNodes] = React.useState({});
-
-  return (
-    <DragDropContext.Provider value={{ draggableZoneNodes, setDraggableZoneNodes, onDrop }}>
-      {children}
-    </DragDropContext.Provider>
-  );
-};
+export const DragDrop: React.FunctionComponent<DragDropProps> = ({
+  children,
+  onDrag = () => true,
+  onDrop = () => false
+}: DragDropProps) => <DragDropContext.Provider value={{ onDrag, onDrop }}>{children}</DragDropContext.Provider>;
 DragDrop.displayName = 'DragDrop';

--- a/packages/react-core/src/components/DragDrop/DragDrop.tsx
+++ b/packages/react-core/src/components/DragDrop/DragDrop.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+export const DragDropContext = React.createContext({
+  draggingZone: '',
+  setDraggingZone: (_zone: string) => {}
+});
+
+interface DragDropProps {
+  /** Potentially Droppable and Draggable children */
+  children?: React.ReactNode;
+}
+
+export const DragDrop: React.FunctionComponent<DragDropProps> = ({ children }: DragDropProps) => {
+  const [draggingZone, setDraggingZone] = React.useState('');
+
+  return <DragDropContext.Provider value={{ draggingZone, setDraggingZone }}>{children}</DragDropContext.Provider>;
+};
+DragDrop.displayName = 'DragDrop';

--- a/packages/react-core/src/components/DragDrop/DragDrop.tsx
+++ b/packages/react-core/src/components/DragDrop/DragDrop.tsx
@@ -12,7 +12,7 @@ export const DragDropContext = React.createContext({
     _sourceDraggableKey: string | number,
     _destDroppableKey: string | number | null,
     _destDraggableKey: string | number | null
-  ) => {}
+  ) => false as boolean
 });
 
 interface DragDropProps {
@@ -24,10 +24,10 @@ interface DragDropProps {
     sourceDraggableKey: string | number,
     destDroppableKey: string | number | null,
     destDraggableKey: string | number | null
-  ) => void;
+  ) => boolean;
 }
 
-export const DragDrop: React.FunctionComponent<DragDropProps> = ({ children, onDrop = () => {} }: DragDropProps) => {
+export const DragDrop: React.FunctionComponent<DragDropProps> = ({ children, onDrop = () => false }: DragDropProps) => {
   // Used for reordering
   const [draggableZoneNodes, setDraggableZoneNodes] = React.useState({});
 

--- a/packages/react-core/src/components/DragDrop/Draggable.tsx
+++ b/packages/react-core/src/components/DragDrop/Draggable.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import { createPortal } from 'react-dom';
+import { DroppableContext } from './Droppable';
+import { DragDropContext } from './DragDrop';
 
 interface DraggableProps extends React.HTMLProps<HTMLDivElement> {
   /** Content rendered inside DragDrop */
@@ -18,6 +20,8 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
   // eslint-disable-next-line prefer-const
   let [style, setStyle] = React.useState(styleProp);
   const [isDragging, setIsDragging] = React.useState(false);
+  const { zone } = React.useContext(DroppableContext);
+  const { setDraggingZone } = React.useContext(DragDropContext);
   let startX = 0;
   let startY = 0;
 
@@ -28,16 +32,16 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
     setStyle(styleProp);
   };
 
-  const onMouseUp = (ev: MouseEvent) => {
-    if (ev.button === 0) {
-      setStyle({
-        ...style,
-        transition: 'transform 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0s, opacity 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0s',
-        transform: ''
-      });
-      document.removeEventListener('mousemove', onMouseMove);
-      document.removeEventListener('mouseup', onMouseUp);
-    }
+  const onMouseUp = (_ev: MouseEvent) => {
+    setStyle({
+      ...style,
+      transition: 'transform 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0s, opacity 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0s',
+      transform: '',
+      background: styleProp.background
+    });
+    document.removeEventListener('mousemove', onMouseMove);
+    document.removeEventListener('mouseup', onMouseUp);
+    setDraggingZone('');
   };
 
   const onMouseMove = (ev: MouseEvent) => {
@@ -50,6 +54,10 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
 
   const onDragStart = (ev: React.DragEvent<HTMLDivElement>) => {
     ev.preventDefault();
+    if (isDragging) {
+      // still in animation
+      return;
+    }
     onDragStartProp(ev);
     const boundingClientRect = ref.current.getBoundingClientRect();
     style = {
@@ -68,6 +76,7 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
     startX = ev.pageX;
     startY = ev.pageY;
     setIsDragging(true);
+    setDraggingZone(zone);
   };
 
   const div = (

--- a/packages/react-core/src/components/DragDrop/Draggable.tsx
+++ b/packages/react-core/src/components/DragDrop/Draggable.tsx
@@ -1,13 +1,35 @@
 import * as React from 'react';
 import { createPortal } from 'react-dom';
-import { DroppableContext } from './Droppable';
+import { DroppableContext } from './DroppableContext';
 import { DragDropContext } from './DragDrop';
 
-interface DraggableProps extends React.HTMLProps<HTMLDivElement> {
+export interface DraggableProps extends React.HTMLProps<HTMLDivElement> {
   /** Content rendered inside DragDrop */
   children?: React.ReactNode;
   /** Class to add to outer div */
   className?: string;
+}
+
+// They really like being different from each other.
+function getDefaultBackground() {
+  const div = document.createElement('div');
+  document.head.appendChild(div);
+  const bg = window.getComputedStyle(div).backgroundColor;
+  document.head.removeChild(div);
+  return bg;
+}
+
+function getInheritedBackgroundColor(el: HTMLElement): string {
+  const defaultStyle = getDefaultBackground();
+  const backgroundColor = window.getComputedStyle(el).backgroundColor;
+
+  if (backgroundColor !== defaultStyle) {
+    return backgroundColor;
+  } else if (!el.parentElement) {
+    return defaultStyle;
+  }
+
+  return getInheritedBackgroundColor(el.parentElement);
 }
 
 export const Draggable: React.FunctionComponent<DraggableProps> = ({
@@ -24,6 +46,11 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
   const { setDraggingZone } = React.useContext(DragDropContext);
   let startX = 0;
   let startY = 0;
+  let mouseMoveListener: EventListener;
+  let mouseUpListener: EventListener;
+  let draggableNodes = [] as HTMLDivElement[];
+  let blankDivPos = -1;
+  let blankDivHeight = 0;
 
   const ref = React.createRef<HTMLDivElement>();
 
@@ -32,23 +59,40 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
     setStyle(styleProp);
   };
 
-  const onMouseUp = (_ev: MouseEvent) => {
+  const onMouseUpWhileDragging = (draggableNodes: HTMLDivElement[]) => {
     setStyle({
       ...style,
       transition: 'transform 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0s, opacity 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0s',
       transform: '',
-      background: styleProp.background
+      background: styleProp.background,
+      boxShadow: styleProp.boxShadow
     });
-    document.removeEventListener('mousemove', onMouseMove);
-    document.removeEventListener('mouseup', onMouseUp);
+    document.removeEventListener('mousemove', mouseMoveListener);
+    document.removeEventListener('mouseup', mouseUpListener);
     setDraggingZone('');
+    draggableNodes.forEach(node => (node.style.transform = ''));
   };
 
-  const onMouseMove = (ev: MouseEvent) => {
-    ev.preventDefault();
+  const onMouseMoveWhileDragging = (
+    ev: MouseEvent,
+    draggableNodes: HTMLDivElement[],
+    blankDivPos: number,
+    blankDivHeight: number
+  ) => {
     setStyle({
       ...style,
       transform: `translate(${ev.pageX - startX}px, ${ev.pageY - startY}px)`
+    });
+    draggableNodes.forEach((node, i) => {
+      if (i !== blankDivPos) {
+        const boundingClientRect = node.getBoundingClientRect();
+        const halfway = boundingClientRect.y + boundingClientRect.height / 2;
+        if (ev.pageY > halfway) {
+          node.style.transform = `translate(0, -${blankDivHeight}px`;
+        } else {
+          node.style.transform = '';
+        }
+      }
     });
   };
 
@@ -67,12 +111,18 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
       left: boundingClientRect.x,
       width: boundingClientRect.width,
       height: boundingClientRect.height,
-      background: 'green',
+      background: getInheritedBackgroundColor(ref.current),
+      boxShadow: '0px 0px 0px 1px blue, 0px 2px 5px rgba(0, 0, 0, 0.2)',
       zIndex: 5000
     };
     setStyle(style);
-    document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('mouseup', onMouseUp);
+    draggableNodes = Array.from(document.querySelectorAll(`[data-pf-dropzone="${zone}"]`));
+    blankDivPos = draggableNodes.indexOf(ref.current);
+    blankDivHeight = ref.current.getBoundingClientRect().height;
+    mouseMoveListener = ev => onMouseMoveWhileDragging(ev as MouseEvent, draggableNodes, blankDivPos, blankDivHeight);
+    mouseUpListener = () => onMouseUpWhileDragging(draggableNodes);
+    document.addEventListener('mousemove', mouseMoveListener);
+    document.addEventListener('mouseup', mouseUpListener);
     startX = ev.pageX;
     startY = ev.pageY;
     setIsDragging(true);
@@ -81,6 +131,7 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
 
   const div = (
     <div
+      data-pf-dropzone={isDragging ? null : zone}
       draggable
       role="button"
       className={className}
@@ -94,11 +145,18 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
     </div>
   );
 
+  const blankDiv = React.useMemo(() => React.cloneElement(div, { style: { ...styleProp, visibility: 'hidden' } }), [
+    zone,
+    className,
+    styleProp,
+    children
+  ]);
+
   return (
     <React.Fragment>
       {/* Leave behind blank spot per-design */}
-      {isDragging && React.cloneElement(div, { style: { ...styleProp, visibility: 'hidden' } })}
-      {/* Move dragging part into portal to appear above side/top nav */}
+      {isDragging && blankDiv}
+      {/* Move dragging part into portal to appear above top and side nav */}
       {isDragging ? createPortal(div, document.body) : div}
     </React.Fragment>
   );

--- a/packages/react-core/src/components/DragDrop/Draggable.tsx
+++ b/packages/react-core/src/components/DragDrop/Draggable.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import { createPortal } from 'react-dom';
+import { css } from '@patternfly/react-styles';
+
+interface DraggableProps extends React.HTMLProps<HTMLDivElement> {
+  /** Content rendered inside DragDrop */
+  children?: React.ReactNode;
+  /** Class to add to outer div */
+  className?: string;
+}
+
+export const Draggable: React.FunctionComponent<DraggableProps> = ({
+  className,
+  children,
+  onDragStart: onDragStartProp = () => {},
+  style: styleProp,
+  ...props
+}: DraggableProps) => {
+  let [style, setStyle] = React.useState(styleProp);
+  const [isDragging, setIsDragging] = React.useState(false);
+  let startX = 0, startY = 0;
+
+  const ref = React.createRef<HTMLDivElement>();
+
+  const onMouseUp = (ev: MouseEvent) => {
+    if (ev.button === 0) {
+      setStyle(styleProp);
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+      setIsDragging(false);
+    }
+  };
+
+  const onMouseMove = (ev: MouseEvent) => {
+    ev.preventDefault();
+    setStyle({
+      ...style,
+      transform: `translate(${ev.pageX - startX}px, ${ev.pageY - startY}px)`
+    });
+  };
+
+  const onDragStart = (ev: React.DragEvent<HTMLDivElement>) => {
+    ev.preventDefault();
+    onDragStartProp(ev);
+    const boundingClientRect = ref.current.getBoundingClientRect();
+    style = {
+      ...style,
+      position: 'fixed',
+      top: boundingClientRect.y,
+      left: boundingClientRect.x,
+      width: ref.current.clientWidth,
+      height: ref.current.clientHeight,
+      background: 'green',
+      zIndex: 5000,
+      transition: 'opacity 0.2s cubic-bezier(0.2, 0, 0, 1) 0s',
+    };
+    setStyle(style);
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+    startX = ev.pageX;
+    startY = ev.pageY;
+    setIsDragging(true);
+  };
+
+  const div = (
+    <div
+      draggable
+      role="button"
+      className={className}
+      onDragStart={onDragStart}
+      onDragEnd={() => console.log('onDragEnd')}
+      style={style}
+      ref={ref}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+
+  return isDragging ? createPortal(div, document.body) : div;
+}
+Draggable.displayName = 'Draggable';
+

--- a/packages/react-core/src/components/DragDrop/Droppable.tsx
+++ b/packages/react-core/src/components/DragDrop/Droppable.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { DragDropContext } from './DragDrop';
 import { DroppableContext } from './DroppableContext';
 
 interface DroppableProps extends React.HTMLProps<HTMLDivElement> {
@@ -16,39 +15,11 @@ export const Droppable: React.FunctionComponent<DroppableProps> = ({
   children,
   zone = 'defaultZone',
   ...props
-}: DroppableProps) => {
-  const { draggingZone } = React.useContext(DragDropContext);
-  const ref = React.useRef<HTMLDivElement>();
-  const [isCursorInside, setIsCursorInside] = React.useState(true);
-
-  return (
-    <DroppableContext.Provider value={{ zone }}>
-      <div
-        className={className}
-        style={
-          draggingZone === zone
-            ? { boxShadow: `0px 0px 0px 1px ${isCursorInside ? 'blue' : 'red'}, 0px 2px 5px rgba(0, 0, 0, 0.2)` }
-            : {}
-        }
-        ref={ref}
-        onMouseMove={ev => {
-          const rect = ref.current.getBoundingClientRect();
-          if (
-            ev.clientX > rect.x &&
-            ev.clientX < rect.x + rect.width &&
-            ev.clientY > rect.y &&
-            ev.clientY < rect.y + rect.height
-          ) {
-            setIsCursorInside(true);
-          } else {
-            setIsCursorInside(false);
-          }
-        }}
-        {...props}
-      >
-        {children}
-      </div>
-    </DroppableContext.Provider>
-  );
-};
+}: DroppableProps) => (
+  <DroppableContext.Provider value={{ zone }}>
+    <div data-pf-droppable={zone} className={className} {...props}>
+      {children}
+    </div>
+  </DroppableContext.Provider>
+);
 Droppable.displayName = 'Droppable';

--- a/packages/react-core/src/components/DragDrop/Droppable.tsx
+++ b/packages/react-core/src/components/DragDrop/Droppable.tsx
@@ -9,18 +9,18 @@ interface DroppableProps extends React.HTMLProps<HTMLDivElement> {
   /** Name of zone that items can be dragged between */
   zone?: string;
   /** Id to be passed back on drop events */
-  key?: string | number | null;
+  droppableId?: string;
 }
 
 export const Droppable: React.FunctionComponent<DroppableProps> = ({
   className,
   children,
   zone = 'defaultZone',
-  key,
+  droppableId = 'defaultId',
   ...props
 }: DroppableProps) => (
-  <DroppableContext.Provider value={{ zone, key }}>
-    <div data-pf-droppable={zone} data-pf-droppable-key={key} className={className} {...props}>
+  <DroppableContext.Provider value={{ zone, droppableId }}>
+    <div data-pf-droppable={zone} data-pf-droppableid={droppableId} className={className} {...props}>
       {children}
     </div>
   </DroppableContext.Provider>

--- a/packages/react-core/src/components/DragDrop/Droppable.tsx
+++ b/packages/react-core/src/components/DragDrop/Droppable.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { css } from '@patternfly/react-styles';
+
+interface DroppableProps extends React.HTMLProps<HTMLDivElement> {
+  /** Content rendered inside DragDrop */
+  children?: React.ReactNode;
+  /** Class to add to outer div */
+  className?: string;
+}
+
+export const Droppable: React.FunctionComponent<DroppableProps> = ({
+  className,
+  children,
+  onDragOver: onDragOverProp = () => {},
+  onDrop: onDropProp = () => {},
+  ...props
+}: DroppableProps) => {
+  const onDragOver = (ev: React.DragEvent<HTMLDivElement>) => {
+    ev.preventDefault();
+    ev.dataTransfer.dropEffect = 'move';
+    onDragOverProp(ev);
+  };
+  const onDrop = (ev: React.DragEvent<HTMLDivElement>) => {
+    ev.preventDefault();
+    onDropProp(ev);
+  };
+
+  return (
+    <div
+      className={className}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+Droppable.displayName = 'Droppable';
+

--- a/packages/react-core/src/components/DragDrop/Droppable.tsx
+++ b/packages/react-core/src/components/DragDrop/Droppable.tsx
@@ -6,7 +6,7 @@ interface DroppableProps extends React.HTMLProps<HTMLDivElement> {
   children?: React.ReactNode;
   /** Class to add to outer div */
   className?: string;
-  /** Name of zone that items can be dragged between */
+  /** Name of zone that items can be dragged between. Should specify if there is more than one Droppable on the page. */
   zone?: string;
   /** Id to be passed back on drop events */
   droppableId?: string;

--- a/packages/react-core/src/components/DragDrop/Droppable.tsx
+++ b/packages/react-core/src/components/DragDrop/Droppable.tsx
@@ -1,9 +1,6 @@
 import * as React from 'react';
 import { DragDropContext } from './DragDrop';
-
-export const DroppableContext = React.createContext({
-  zone: 'defaultZone'
-});
+import { DroppableContext } from './DroppableContext';
 
 interface DroppableProps extends React.HTMLProps<HTMLDivElement> {
   /** Content rendered inside DragDrop */
@@ -24,7 +21,11 @@ export const Droppable: React.FunctionComponent<DroppableProps> = ({
 
   return (
     <DroppableContext.Provider value={{ zone }}>
-      <div className={className} style={draggingZone === zone ? { background: 'blue' } : {}} {...props}>
+      <div
+        className={className}
+        style={draggingZone === zone ? { boxShadow: '0px 0px 0px 1px blue, 0px 2px 5px rgba(0, 0, 0, 0.2)' } : {}}
+        {...props}
+      >
         {children}
       </div>
     </DroppableContext.Provider>

--- a/packages/react-core/src/components/DragDrop/Droppable.tsx
+++ b/packages/react-core/src/components/DragDrop/Droppable.tsx
@@ -1,40 +1,33 @@
 import * as React from 'react';
-import { css } from '@patternfly/react-styles';
+import { DragDropContext } from './DragDrop';
+
+export const DroppableContext = React.createContext({
+  zone: 'defaultZone'
+});
 
 interface DroppableProps extends React.HTMLProps<HTMLDivElement> {
   /** Content rendered inside DragDrop */
   children?: React.ReactNode;
   /** Class to add to outer div */
   className?: string;
+  /** Name of zone that items can be dragged between */
+  zone?: string;
 }
 
 export const Droppable: React.FunctionComponent<DroppableProps> = ({
   className,
   children,
-  onDragOver: onDragOverProp = () => {},
-  onDrop: onDropProp = () => {},
+  zone = 'defaultZone',
   ...props
 }: DroppableProps) => {
-  const onDragOver = (ev: React.DragEvent<HTMLDivElement>) => {
-    ev.preventDefault();
-    ev.dataTransfer.dropEffect = 'move';
-    onDragOverProp(ev);
-  };
-  const onDrop = (ev: React.DragEvent<HTMLDivElement>) => {
-    ev.preventDefault();
-    onDropProp(ev);
-  };
+  const { draggingZone } = React.useContext(DragDropContext);
 
   return (
-    <div
-      className={className}
-      onDragOver={onDragOver}
-      onDrop={onDrop}
-      {...props}
-    >
-      {children}
-    </div>
+    <DroppableContext.Provider value={{ zone }}>
+      <div className={className} style={draggingZone === zone ? { background: 'blue' } : {}} {...props}>
+        {children}
+      </div>
+    </DroppableContext.Provider>
   );
-}
+};
 Droppable.displayName = 'Droppable';
-

--- a/packages/react-core/src/components/DragDrop/Droppable.tsx
+++ b/packages/react-core/src/components/DragDrop/Droppable.tsx
@@ -8,16 +8,19 @@ interface DroppableProps extends React.HTMLProps<HTMLDivElement> {
   className?: string;
   /** Name of zone that items can be dragged between */
   zone?: string;
+  /** Id to be passed back on drop events */
+  key?: string | number | null;
 }
 
 export const Droppable: React.FunctionComponent<DroppableProps> = ({
   className,
   children,
   zone = 'defaultZone',
+  key,
   ...props
 }: DroppableProps) => (
-  <DroppableContext.Provider value={{ zone }}>
-    <div data-pf-droppable={zone} className={className} {...props}>
+  <DroppableContext.Provider value={{ zone, key }}>
+    <div data-pf-droppable={zone} data-pf-droppable-key={key} className={className} {...props}>
       {children}
     </div>
   </DroppableContext.Provider>

--- a/packages/react-core/src/components/DragDrop/Droppable.tsx
+++ b/packages/react-core/src/components/DragDrop/Droppable.tsx
@@ -18,12 +18,32 @@ export const Droppable: React.FunctionComponent<DroppableProps> = ({
   ...props
 }: DroppableProps) => {
   const { draggingZone } = React.useContext(DragDropContext);
+  const ref = React.useRef<HTMLDivElement>();
+  const [isCursorInside, setIsCursorInside] = React.useState(true);
 
   return (
     <DroppableContext.Provider value={{ zone }}>
       <div
         className={className}
-        style={draggingZone === zone ? { boxShadow: '0px 0px 0px 1px blue, 0px 2px 5px rgba(0, 0, 0, 0.2)' } : {}}
+        style={
+          draggingZone === zone
+            ? { boxShadow: `0px 0px 0px 1px ${isCursorInside ? 'blue' : 'red'}, 0px 2px 5px rgba(0, 0, 0, 0.2)` }
+            : {}
+        }
+        ref={ref}
+        onMouseMove={ev => {
+          const rect = ref.current.getBoundingClientRect();
+          if (
+            ev.clientX > rect.x &&
+            ev.clientX < rect.x + rect.width &&
+            ev.clientY > rect.y &&
+            ev.clientY < rect.y + rect.height
+          ) {
+            setIsCursorInside(true);
+          } else {
+            setIsCursorInside(false);
+          }
+        }}
         {...props}
       >
         {children}

--- a/packages/react-core/src/components/DragDrop/DroppableContext.ts
+++ b/packages/react-core/src/components/DragDrop/DroppableContext.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
 export const DroppableContext = React.createContext({
-  zone: 'defaultZone'
+  zone: 'defaultZone',
+  key: null as string | number | null
 });

--- a/packages/react-core/src/components/DragDrop/DroppableContext.ts
+++ b/packages/react-core/src/components/DragDrop/DroppableContext.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
 export const DroppableContext = React.createContext({
-  zone: 'defaultZone',
-  droppableId: 'defaultId'
+  zone: 'defaultDroppableZone',
+  droppableId: 'defaultDroppableId'
 });

--- a/packages/react-core/src/components/DragDrop/DroppableContext.ts
+++ b/packages/react-core/src/components/DragDrop/DroppableContext.ts
@@ -2,5 +2,5 @@ import * as React from 'react';
 
 export const DroppableContext = React.createContext({
   zone: 'defaultZone',
-  key: null as string | number | null
+  droppableId: 'defaultId'
 });

--- a/packages/react-core/src/components/DragDrop/DroppableContext.ts
+++ b/packages/react-core/src/components/DragDrop/DroppableContext.ts
@@ -1,0 +1,5 @@
+import * as React from 'react';
+
+export const DroppableContext = React.createContext({
+  zone: 'defaultZone'
+});

--- a/packages/react-core/src/components/DragDrop/__tests__/DragDrop.test.tsx
+++ b/packages/react-core/src/components/DragDrop/__tests__/DragDrop.test.tsx
@@ -1,9 +1,19 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import DragDrop from './DragDrop';
+import { DragDrop, Draggable, Droppable } from '../';
 
-test('basic', () => {
-  const view = shallow(<DragDrop />);
-  // Add a useful assertion here.
-  expect(view).toBe(false);
+test('renders some divs', () => {
+  const view = shallow(
+    <DragDrop>
+      <Droppable droppableId="dropzone">
+        <Draggable draggableId="draggable1">
+          item 1
+        </Draggable>
+        <Draggable draggableId="draggable2">
+          item 2
+        </Draggable>
+      </Droppable>
+    </DragDrop>
+  );
+  expect(view).toMatchSnapshot();
 });

--- a/packages/react-core/src/components/DragDrop/__tests__/DragDrop.test.tsx
+++ b/packages/react-core/src/components/DragDrop/__tests__/DragDrop.test.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import DragDrop from './DragDrop';
+
+test('basic', () => {
+  const view = shallow(<DragDrop />);
+  // Add a useful assertion here.
+  expect(view).toBe(false);
+});

--- a/packages/react-core/src/components/DragDrop/__tests__/__snapshots__/DragDrop.test.tsx.snap
+++ b/packages/react-core/src/components/DragDrop/__tests__/__snapshots__/DragDrop.test.tsx.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders some divs 1`] = `
+<ContextProvider
+  value={
+    Object {
+      "draggableZoneNodes": Object {},
+      "onDrop": [Function],
+      "setDraggableZoneNodes": [Function],
+    }
+  }
+>
+  <Droppable
+    droppableId="dropzone"
+  >
+    <Draggable
+      draggableId="draggable1"
+    >
+      item 1
+    </Draggable>
+    <Draggable
+      draggableId="draggable2"
+    >
+      item 2
+    </Draggable>
+  </Droppable>
+</ContextProvider>
+`;

--- a/packages/react-core/src/components/DragDrop/__tests__/__snapshots__/DragDrop.test.tsx.snap
+++ b/packages/react-core/src/components/DragDrop/__tests__/__snapshots__/DragDrop.test.tsx.snap
@@ -4,9 +4,8 @@ exports[`renders some divs 1`] = `
 <ContextProvider
   value={
     Object {
-      "draggableZoneNodes": Object {},
+      "onDrag": [Function],
       "onDrop": [Function],
-      "setDraggableZoneNodes": [Function],
     }
   }
 >

--- a/packages/react-core/src/components/DragDrop/examples/DragDrop.md
+++ b/packages/react-core/src/components/DragDrop/examples/DragDrop.md
@@ -4,12 +4,32 @@ section: components
 propComponents: [
   DragDrop,
   Draggable,
-  Droppable
+  Droppable,
+  DraggableItemPosition
 ]
 beta: true
 ---
 
-You can use Draggable and Droppable components to move items in or between lists.
+You can use `DragDrop` to move items in or between lists. `DragDrop`s should contain `Droppable`s which contain `Draggable`s.
+
+```js noLive
+import React from 'react';
+import { DragDrop, Draggable, Droppable } from '@patternfly/react-core';
+
+<DragDrop> {/* DragDrop houses the context for dragging and dropping */}
+  <Droppable>
+    <Draggable>
+      You can put anything here! It will be wrapped in a styled div.
+    </Draggable>
+    <Draggable>
+      You can have as many Draggables as you like.
+    </Draggable>
+  </Droppable>
+  <Droppable> {/* You can also have many droppables! */}
+    <Draggable />
+  </Droppable>
+</DragDrop>
+```
 
 ## Examples
 ### Basic
@@ -34,14 +54,12 @@ const reorder = (list, startIndex, endIndex) => {
 Basic = () => {
   const [items, setItems] = React.useState(getItems(10));
 
-  function onDrop(_sourceDroppableId, sourceDraggableId, destDroppableId, destDraggableId) {
-    if (destDroppableId) {
-      const sourceIndex = items.findIndex(item => item.id === sourceDraggableId);
-      const destIndex = items.findIndex(item => item.id === destDraggableId);
+  function onDrop(source, dest) {
+    if (dest) {
       const newItems = reorder(
         items,
-        sourceIndex,
-        destIndex
+        source.index,
+        dest.index
       );
       setItems(newItems);
 
@@ -51,9 +69,9 @@ Basic = () => {
 
   return (
     <DragDrop onDrop={onDrop}>
-      <Droppable zone="basic">
-        {items.map(({ id, content }) =>
-          <Draggable key={id} draggableId={id} style={{ padding: '8px' }}>
+      <Droppable>
+        {items.map(({ id, content }, i) =>
+          <Draggable key={i} style={{ padding: '8px' }}>
             {content}
           </Draggable>
         )}
@@ -96,18 +114,16 @@ MultiList = () => {
     items2: getItems(5, 10)
   });
 
-  function onDrop(sourceDroppableId, sourceDraggableId, destDroppableId, destDraggableId) {
-    console.log(sourceDroppableId, sourceDraggableId, destDroppableId, destDraggableId);
-    if (destDroppableId) {
-      const sourceIndex = items[sourceDroppableId].findIndex(item => item.id === sourceDraggableId);
-      const destIndex = items[destDroppableId].findIndex(item => item.id === destDraggableId) + 1;
-      if (sourceDroppableId === destDroppableId) {
+  function onDrop(source, dest) {
+    console.log(source, dest);
+    if (dest) {
+      if (source.droppableId === dest.droppableId) {
         const newItems = reorder(
-          sourceDroppableId === 'items1' ? items.items1 : items.items2,
-          sourceIndex,
-          destIndex
+          source.droppableId === 'items1' ? items.items1 : items.items2,
+          source.index,
+          dest.index
         );
-        if (sourceDroppableId === 'items1') {
+        if (source.droppableId === 'items1') {
           setItems({
             items1: newItems,
             items2: items.items2
@@ -120,14 +136,14 @@ MultiList = () => {
         }
       } else {
         const [newItems1, newItems2] = move(
-          sourceDroppableId === 'items1' ? items.items1 : items.items2,
-          destDroppableId   === 'items1' ? items.items1 : items.items2,
-          sourceIndex,
-          destIndex
+          source.droppableId === 'items1' ? items.items1 : items.items2,
+          dest.droppableId   === 'items1' ? items.items1 : items.items2,
+          source.index,
+          dest.index
         );
         setItems({
-          items1: sourceDroppableId === 'items1' ? newItems1 : newItems2,
-          items2: destDroppableId   === 'items1' ? newItems1 : newItems2
+          items1: source.droppableId === 'items1' ? newItems1 : newItems2,
+          items2: dest.droppableId   === 'items1' ? newItems1 : newItems2
         });
       }
       return true;
@@ -140,8 +156,8 @@ MultiList = () => {
         {Object.entries(items).map(([key, subitems]) =>
           <SplitItem key={key} style={{ flex: 1 }}>
             <Droppable zone="multizone" droppableId={key}>
-              {subitems.map(({ id, content }) =>
-                <Draggable key={key + id} draggableId={id} style={{ padding: '8px' }}>
+              {subitems.map(({ id, content }, i) =>
+                <Draggable key={id} style={{ padding: '8px' }}>
                   {content}
                 </Draggable>
               )}

--- a/packages/react-core/src/components/DragDrop/examples/DragDrop.md
+++ b/packages/react-core/src/components/DragDrop/examples/DragDrop.md
@@ -21,7 +21,7 @@ import { DragDrop, Draggable, Droppable } from '@patternfly/react-core';
 const getItems = count =>
   Array.from({ length: count }, (v, k) => k).map(k => ({
     id: `item-${k}`,
-    content: `item ${k}`
+    content: `item ${k} `.repeat(k === 5 ? 20 : 1)
   }));
 
 Basic = () => {
@@ -35,7 +35,7 @@ Basic = () => {
     <DragDrop onDrop={onDrop}>
       <Droppable zone="basic">
         {items.map(({ id, content }) =>
-          <Draggable key={id} style={{ padding: '8px' }}>
+          <Draggable key={id} draggableId={id} style={{ padding: '8px' }}>
             {content}
           </Draggable>
         )}
@@ -54,7 +54,7 @@ import { DragDrop, Draggable, Droppable, Split, SplitItem } from '@patternfly/re
 const getItems = (count, start) =>
   Array.from({ length: count }, (v, k) => k).map(k => ({
     id: `item-${k + start}`,
-    content: `item ${k + start}`
+    content: `item ${k + start} `.repeat(k === 5 ? 20 : 1)
   }));
 
 Basic = () => {
@@ -65,18 +65,18 @@ Basic = () => {
     <DragDrop>
       <Split hasGutter>
         <SplitItem>
-          <Droppable zone="multizone">
+          <Droppable zone="multizone" droppableId="items1">
             {items1.map(({ id, content }) =>
-              <Draggable key={id} style={{ padding: '8px' }}>
+              <Draggable key={id} draggableId={id} style={{ padding: '8px' }}>
                 {content}
               </Draggable>
             )}
           </Droppable>
         </SplitItem>
         <SplitItem>
-          <Droppable zone="multizone">
+          <Droppable zone="multizone" droppableId="items2">
             {items2.map(({ id, content }) =>
-              <Draggable key={id} style={{ padding: '8px' }}>
+              <Draggable key={id} draggableId={id} style={{ padding: '8px' }}>
                 {content}
               </Draggable>
             )}

--- a/packages/react-core/src/components/DragDrop/examples/DragDrop.md
+++ b/packages/react-core/src/components/DragDrop/examples/DragDrop.md
@@ -6,6 +6,7 @@ propComponents: [
   Draggable,
   Droppable
 ]
+beta: true
 ---
 
 You can use Draggable and Droppable components to move items in or between lists.
@@ -26,8 +27,12 @@ const getItems = count =>
 Basic = () => {
   const [items, setItems] = React.useState(getItems(10));
 
+  function onDrop(sourceDroppableIndex, sourceDraggableIndex, destDroppableIndex, destDraggableIndex) {
+    console.log('onDrop', arguments);
+  }
+
   return (
-    <DragDrop>
+    <DragDrop onDrop={onDrop}>
       <Droppable zone="basic">
         {items.map(({ id, content }) =>
           <Draggable key={id} style={{ padding: '8px' }}>
@@ -46,21 +51,22 @@ Basic = () => {
 import React from 'react';
 import { DragDrop, Draggable, Droppable, Split, SplitItem } from '@patternfly/react-core';
 
-const getItems = count =>
+const getItems = (count, start) =>
   Array.from({ length: count }, (v, k) => k).map(k => ({
-    id: `item-${k}`,
-    content: `item ${k}`
+    id: `item-${k + start}`,
+    content: `item ${k + start}`
   }));
 
 Basic = () => {
-  const [items, setItems] = React.useState(getItems(10));
+  const [items1, setItems1] = React.useState(getItems(10, 0));
+  const [items2, setItems2] = React.useState(getItems(10, 10));
 
   return (
     <DragDrop>
       <Split hasGutter>
         <SplitItem>
           <Droppable zone="multizone">
-            {items.map(({ id, content }) =>
+            {items1.map(({ id, content }) =>
               <Draggable key={id} style={{ padding: '8px' }}>
                 {content}
               </Draggable>
@@ -69,7 +75,7 @@ Basic = () => {
         </SplitItem>
         <SplitItem>
           <Droppable zone="multizone">
-            {items.map(({ id, content }) =>
+            {items2.map(({ id, content }) =>
               <Draggable key={id} style={{ padding: '8px' }}>
                 {content}
               </Draggable>

--- a/packages/react-core/src/components/DragDrop/examples/DragDrop.md
+++ b/packages/react-core/src/components/DragDrop/examples/DragDrop.md
@@ -95,13 +95,12 @@ MultiList = () => {
     items1: getItems(10, 0),
     items2: getItems(5, 10)
   });
-  console.log('items', items);
 
   function onDrop(sourceDroppableId, sourceDraggableId, destDroppableId, destDraggableId) {
     console.log(sourceDroppableId, sourceDraggableId, destDroppableId, destDraggableId);
     if (destDroppableId) {
       const sourceIndex = items[sourceDroppableId].findIndex(item => item.id === sourceDraggableId);
-      const destIndex = items[destDroppableId].findIndex(item => item.id === destDraggableId);
+      const destIndex = items[destDroppableId].findIndex(item => item.id === destDraggableId) + 1;
       if (sourceDroppableId === destDroppableId) {
         const newItems = reorder(
           sourceDroppableId === 'items1' ? items.items1 : items.items2,
@@ -127,8 +126,8 @@ MultiList = () => {
           destIndex
         );
         setItems({
-          items1: newItems1,
-          items2: newItems2
+          items1: sourceDroppableId === 'items1' ? newItems1 : newItems2,
+          items2: destDroppableId   === 'items1' ? newItems1 : newItems2
         });
       }
       return true;

--- a/packages/react-core/src/components/DragDrop/examples/DragDrop.md
+++ b/packages/react-core/src/components/DragDrop/examples/DragDrop.md
@@ -1,0 +1,35 @@
+---
+id: Drag and drop
+section: components
+---
+
+You can use Draggable and Droppable components to move items in or between lists.
+
+## Examples
+### Basic
+
+```js
+import React from 'react';
+import { Draggable, Droppable } from '@patternfly/react-core';
+
+const getItems = count =>
+  Array.from({ length: count }, (v, k) => k).map(k => ({
+    id: `item-${k}`,
+    content: `item ${k}`
+  }));
+
+Basic = () => {
+  const [items, setItems] = React.useState(getItems(10));
+
+  return (
+    <Droppable id="todolist">
+      {items.map(({ id, content }) =>
+        <Draggable key={id} style={{ padding: '8px' }}>
+          {content}
+        </Draggable>
+      )}
+    </Droppable>
+  );
+}
+```
+

--- a/packages/react-core/src/components/DragDrop/examples/DragDrop.md
+++ b/packages/react-core/src/components/DragDrop/examples/DragDrop.md
@@ -1,6 +1,11 @@
 ---
 id: Drag and drop
 section: components
+propComponents: [
+  DragDrop,
+  Draggable,
+  Droppable
+]
 ---
 
 You can use Draggable and Droppable components to move items in or between lists.
@@ -23,7 +28,7 @@ Basic = () => {
 
   return (
     <DragDrop>
-      <Droppable id="todolist">
+      <Droppable zone="basic">
         {items.map(({ id, content }) =>
           <Draggable key={id} style={{ padding: '8px' }}>
             {content}
@@ -54,7 +59,7 @@ Basic = () => {
     <DragDrop>
       <Split hasGutter>
         <SplitItem>
-          <Droppable id="todolist">
+          <Droppable zone="multizone">
             {items.map(({ id, content }) =>
               <Draggable key={id} style={{ padding: '8px' }}>
                 {content}
@@ -63,7 +68,7 @@ Basic = () => {
           </Droppable>
         </SplitItem>
         <SplitItem>
-          <Droppable id="todolist">
+          <Droppable zone="multizone">
             {items.map(({ id, content }) =>
               <Draggable key={id} style={{ padding: '8px' }}>
                 {content}

--- a/packages/react-core/src/components/DragDrop/examples/DragDrop.md
+++ b/packages/react-core/src/components/DragDrop/examples/DragDrop.md
@@ -10,7 +10,7 @@ You can use Draggable and Droppable components to move items in or between lists
 
 ```js
 import React from 'react';
-import { Draggable, Droppable } from '@patternfly/react-core';
+import { DragDrop, Draggable, Droppable } from '@patternfly/react-core';
 
 const getItems = count =>
   Array.from({ length: count }, (v, k) => k).map(k => ({
@@ -22,13 +22,57 @@ Basic = () => {
   const [items, setItems] = React.useState(getItems(10));
 
   return (
-    <Droppable id="todolist">
-      {items.map(({ id, content }) =>
-        <Draggable key={id} style={{ padding: '8px' }}>
-          {content}
-        </Draggable>
-      )}
-    </Droppable>
+    <DragDrop>
+      <Droppable id="todolist">
+        {items.map(({ id, content }) =>
+          <Draggable key={id} style={{ padding: '8px' }}>
+            {content}
+          </Draggable>
+        )}
+      </Droppable>
+    </DragDrop>
+  );
+}
+```
+
+### Multiple lists
+
+```js
+import React from 'react';
+import { DragDrop, Draggable, Droppable, Split, SplitItem } from '@patternfly/react-core';
+
+const getItems = count =>
+  Array.from({ length: count }, (v, k) => k).map(k => ({
+    id: `item-${k}`,
+    content: `item ${k}`
+  }));
+
+Basic = () => {
+  const [items, setItems] = React.useState(getItems(10));
+
+  return (
+    <DragDrop>
+      <Split hasGutter>
+        <SplitItem>
+          <Droppable id="todolist">
+            {items.map(({ id, content }) =>
+              <Draggable key={id} style={{ padding: '8px' }}>
+                {content}
+              </Draggable>
+            )}
+          </Droppable>
+        </SplitItem>
+        <SplitItem>
+          <Droppable id="todolist">
+            {items.map(({ id, content }) =>
+              <Draggable key={id} style={{ padding: '8px' }}>
+                {content}
+              </Draggable>
+            )}
+          </Droppable>
+        </SplitItem>
+      </Split>
+    </DragDrop>
   );
 }
 ```

--- a/packages/react-core/src/components/DragDrop/examples/DragDrop.md
+++ b/packages/react-core/src/components/DragDrop/examples/DragDrop.md
@@ -59,7 +59,7 @@ const getItems = (count, start) =>
 
 Basic = () => {
   const [items1, setItems1] = React.useState(getItems(10, 0));
-  const [items2, setItems2] = React.useState(getItems(10, 10));
+  const [items2, setItems2] = React.useState(getItems(5, 10));
 
   return (
     <DragDrop>

--- a/packages/react-core/src/components/DragDrop/examples/DragDrop.md
+++ b/packages/react-core/src/components/DragDrop/examples/DragDrop.md
@@ -21,14 +21,32 @@ import { DragDrop, Draggable, Droppable } from '@patternfly/react-core';
 const getItems = count =>
   Array.from({ length: count }, (v, k) => k).map(k => ({
     id: `item-${k}`,
-    content: `item ${k} `.repeat(k === 5 ? 20 : 1)
+    content: `item ${k} `.repeat(k === 4 ? 20 : 1)
   }));
+
+const reorder = (list, startIndex, endIndex) => {
+  const result = Array.from(list);
+  const [removed] = result.splice(startIndex, 1);
+  result.splice(endIndex, 0, removed);
+  return result;
+};
 
 Basic = () => {
   const [items, setItems] = React.useState(getItems(10));
 
-  function onDrop(sourceDroppableIndex, sourceDraggableIndex, destDroppableIndex, destDraggableIndex) {
-    console.log('onDrop', arguments);
+  function onDrop(_sourceDroppableId, sourceDraggableId, destDroppableId, destDraggableId) {
+    if (destDroppableId) {
+      const sourceIndex = items.findIndex(item => item.id === sourceDraggableId);
+      const destIndex = items.findIndex(item => item.id === destDraggableId);
+      const newItems = reorder(
+        items,
+        sourceIndex,
+        destIndex
+      );
+      setItems(newItems);
+
+      return true;
+    }
   }
 
   return (
@@ -54,34 +72,83 @@ import { DragDrop, Draggable, Droppable, Split, SplitItem } from '@patternfly/re
 const getItems = (count, start) =>
   Array.from({ length: count }, (v, k) => k).map(k => ({
     id: `item-${k + start}`,
-    content: `item ${k + start} `.repeat(k === 5 ? 20 : 1)
+    content: `item ${k + start} `.repeat(k === 4 ? 20 : 1)
   }));
 
-Basic = () => {
-  const [items1, setItems1] = React.useState(getItems(10, 0));
-  const [items2, setItems2] = React.useState(getItems(5, 10));
+const reorder = (list, startIndex, endIndex) => {
+  const result = Array.from(list);
+  const [removed] = result.splice(startIndex, 1);
+  result.splice(endIndex, 0, removed);
+  return result;
+};
+
+const move = (source, destination, sourceIndex, destIndex) => {
+  const sourceClone = Array.from(source);
+  const destClone = Array.from(destination);
+  const [removed] = sourceClone.splice(sourceIndex, 1);
+  destClone.splice(destIndex, 0, removed);
+  return [sourceClone, destClone];
+};
+
+MultiList = () => {
+  const [items, setItems] = React.useState({
+    items1: getItems(10, 0),
+    items2: getItems(5, 10)
+  });
+  console.log('items', items);
+
+  function onDrop(sourceDroppableId, sourceDraggableId, destDroppableId, destDraggableId) {
+    console.log(sourceDroppableId, sourceDraggableId, destDroppableId, destDraggableId);
+    if (destDroppableId) {
+      const sourceIndex = items[sourceDroppableId].findIndex(item => item.id === sourceDraggableId);
+      const destIndex = items[destDroppableId].findIndex(item => item.id === destDraggableId);
+      if (sourceDroppableId === destDroppableId) {
+        const newItems = reorder(
+          sourceDroppableId === 'items1' ? items.items1 : items.items2,
+          sourceIndex,
+          destIndex
+        );
+        if (sourceDroppableId === 'items1') {
+          setItems({
+            items1: newItems,
+            items2: items.items2
+          });
+        } else {
+          setItems({
+            items1: items.items1,
+            items2: newItems
+          });
+        }
+      } else {
+        const [newItems1, newItems2] = move(
+          sourceDroppableId === 'items1' ? items.items1 : items.items2,
+          destDroppableId   === 'items1' ? items.items1 : items.items2,
+          sourceIndex,
+          destIndex
+        );
+        setItems({
+          items1: newItems1,
+          items2: newItems2
+        });
+      }
+      return true;
+    }
+  }
 
   return (
-    <DragDrop>
+    <DragDrop onDrop={onDrop}>
       <Split hasGutter>
-        <SplitItem>
-          <Droppable zone="multizone" droppableId="items1">
-            {items1.map(({ id, content }) =>
-              <Draggable key={id} draggableId={id} style={{ padding: '8px' }}>
-                {content}
-              </Draggable>
-            )}
-          </Droppable>
-        </SplitItem>
-        <SplitItem>
-          <Droppable zone="multizone" droppableId="items2">
-            {items2.map(({ id, content }) =>
-              <Draggable key={id} draggableId={id} style={{ padding: '8px' }}>
-                {content}
-              </Draggable>
-            )}
-          </Droppable>
-        </SplitItem>
+        {Object.entries(items).map(([key, subitems]) =>
+          <SplitItem key={key} style={{ flex: 1 }}>
+            <Droppable zone="multizone" droppableId={key}>
+              {subitems.map(({ id, content }) =>
+                <Draggable key={key + id} draggableId={id} style={{ padding: '8px' }}>
+                  {content}
+                </Draggable>
+              )}
+            </Droppable>
+          </SplitItem>
+        )}
       </Split>
     </DragDrop>
   );

--- a/packages/react-core/src/components/DragDrop/index.ts
+++ b/packages/react-core/src/components/DragDrop/index.ts
@@ -1,0 +1,2 @@
+export * from './Draggable';
+export * from './Droppable';

--- a/packages/react-core/src/components/DragDrop/index.ts
+++ b/packages/react-core/src/components/DragDrop/index.ts
@@ -1,2 +1,3 @@
+export * from './DragDrop';
 export * from './Draggable';
 export * from './Droppable';

--- a/packages/react-core/src/components/index.ts
+++ b/packages/react-core/src/components/index.ts
@@ -76,3 +76,4 @@ export * from './Tooltip';
 export * from './NumberInput';
 export * from './TreeView';
 export * from './Wizard';
+export * from './DragDrop';

--- a/scripts/generators/patternfly-4-component/templates/component/component.md.hbs
+++ b/scripts/generators/patternfly-4-component/templates/component/component.md.hbs
@@ -1,9 +1,11 @@
 ---
-title: {{componentName}}
+id: {{componentName}}
+section: {{typeDir}}
 ---
 {{componentName}} is used for ...
 
-## Basic
+## Examples
+### Basic
 
 ```js
 import React from 'react';

--- a/scripts/generators/patternfly-4-component/templates/component/component.tsx.hbs
+++ b/scripts/generators/patternfly-4-component/templates/component/component.tsx.hbs
@@ -2,7 +2,7 @@ import * as React from 'react';
 import styles from '@patternfly/react-styles/css/{{typeDir}}/{{componentName}}';
 import { css } from '@patternfly/react-styles';
 
-interface {{ componentName }}Props {
+interface {{ componentName }}Props extends React.HTMLProps<HTMLDivElement> {
   /** Content rendered inside {{ componentName }} */
   children?: React.ReactNode;
   /** Class to add to outer div */
@@ -11,7 +11,8 @@ interface {{ componentName }}Props {
 
 export const {{componentName}}: React.FunctionComponent<{{componentName}}Props> = ({
   className,
-  children
+  children,
+  ...props
 }: {{ componentName }}Props) => {
   return (
     <div className={css(styles.{{ camelCase componentName }}, className)} {...props}>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Reimplement the parts we're interested in from react-beautiful-dnd while applying our own styling. Closes #6167

What this does:
- Adds `DragDrop`, `Draggable`, and `Droppable` components
- Animates dropping in invalid zone
- Add styles for hovering over invalid zone
- Animates items moving out of the way for draggable item
- Allow draggable item to be dropped into other lists
- Natural movement offset by where item is picked up
- Provides drop API for moving dropped items

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: Will need integration tests and to be used in Draggable datalist