### PR TITLE
feat(DescriptionList): add compact and fluid modifiers

### DIFF
--- a/packages/react-core/src/components/DescriptionList/DescriptionList.tsx
+++ b/packages/react-core/src/components/DescriptionList/DescriptionList.tsx
@@ -24,6 +24,10 @@ export interface DescriptionListProps extends Omit<React.HTMLProps<HTMLDListElem
   isAutoColumnWidths?: boolean;
   /** Modifies the description list display to inline-grid. */
   isInlineGrid?: boolean;
+  /** Sets the description list to compact styling. */
+  isCompact?: boolean;
+  /** Sets a horizontal description list to have fluid styling. */
+  isFluid?: boolean;
   /** Sets the number of columns on the description list */
   columnModifier?: {
     default?: '1Col' | '2Col' | '3Col';
@@ -68,6 +72,8 @@ export const DescriptionList: React.FunctionComponent<DescriptionListProps> = ({
   isAutoColumnWidths,
   isAutoFit,
   isInlineGrid,
+  isCompact,
+  isFluid,
   columnModifier,
   autoFitMinModifier,
   orientation,
@@ -77,12 +83,14 @@ export const DescriptionList: React.FunctionComponent<DescriptionListProps> = ({
   <dl
     className={css(
       styles.descriptionList,
-      isHorizontal && styles.modifiers.horizontal,
+      (isHorizontal || isFluid) && styles.modifiers.horizontal,
       isAutoColumnWidths && styles.modifiers.autoColumnWidths,
       isAutoFit && styles.modifiers.autoFit,
       formatBreakpointMods(columnModifier, styles),
       formatBreakpointMods(orientation, styles),
       isInlineGrid && styles.modifiers.inlineGrid,
+      isCompact && styles.modifiers.compact,
+      isFluid && styles.modifiers.fluid,
       className
     )}
     style={

--- a/packages/react-core/src/components/DescriptionList/__tests__/DescriptionList.test.tsx
+++ b/packages/react-core/src/components/DescriptionList/__tests__/DescriptionList.test.tsx
@@ -39,6 +39,21 @@ describe('Description List', () => {
     expect(view).toMatchSnapshot();
   });
 
+  test('Compact Description List', () => {
+    const view = shallow(<DescriptionList isCompact />);
+    expect(view).toMatchSnapshot();
+  });
+
+  test('Compact Horizontal Description List', () => {
+    const view = shallow(<DescriptionList isCompact isHorizontal />);
+    expect(view).toMatchSnapshot();
+  });
+
+  test('Fluid Horizontal Description List', () => {
+    const view = shallow(<DescriptionList isFluid isHorizontal />);
+    expect(view).toMatchSnapshot();
+  });
+
   test('alignment breakpoints', () => {
     const view = mount(
       <DescriptionList

--- a/packages/react-core/src/components/DescriptionList/__tests__/__snapshots__/DescriptionList.test.tsx.snap
+++ b/packages/react-core/src/components/DescriptionList/__tests__/__snapshots__/DescriptionList.test.tsx.snap
@@ -44,6 +44,18 @@ exports[`Description List Auto fit with responsive grid Description List 1`] = `
 />
 `;
 
+exports[`Description List Compact Description List 1`] = `
+<dl
+  className="pf-c-description-list pf-m-compact"
+/>
+`;
+
+exports[`Description List Compact Horizontal Description List 1`] = `
+<dl
+  className="pf-c-description-list pf-m-horizontal pf-m-compact"
+/>
+`;
+
 exports[`Description List Description 1`] = `
 <dd
   aria-labelledby="description-1"
@@ -55,6 +67,12 @@ exports[`Description List Description 1`] = `
     test
   </div>
 </dd>
+`;
+
+exports[`Description List Fluid Horizontal Description List 1`] = `
+<dl
+  className="pf-c-description-list pf-m-horizontal pf-m-fluid"
+/>
 `;
 
 exports[`Description List Group 1`] = `

--- a/packages/react-core/src/components/DescriptionList/examples/DescriptionList.md
+++ b/packages/react-core/src/components/DescriptionList/examples/DescriptionList.md
@@ -352,6 +352,135 @@ import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-i
 </DescriptionList>;
 ```
 
+### Compact
+
+```js
+import React from 'react';
+import {
+  Button,
+  DescriptionList,
+  DescriptionListTerm,
+  DescriptionListGroup,
+  DescriptionListDescription
+} from '@patternfly/react-core';
+import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+
+<DescriptionList isCompact>
+  <DescriptionListGroup>
+    <DescriptionListTerm>Name</DescriptionListTerm>
+    <DescriptionListDescription>Example</DescriptionListDescription>
+  </DescriptionListGroup>
+  <DescriptionListGroup>
+    <DescriptionListTerm>Namespace</DescriptionListTerm>
+    <DescriptionListDescription>
+      <a href="#">mary-test</a>
+    </DescriptionListDescription>
+  </DescriptionListGroup>
+  <DescriptionListGroup>
+    <DescriptionListTerm>Labels</DescriptionListTerm>
+    <DescriptionListDescription>example</DescriptionListDescription>
+  </DescriptionListGroup>
+  <DescriptionListGroup>
+    <DescriptionListTerm>Pod selector</DescriptionListTerm>
+    <DescriptionListDescription>
+      <Button variant="link" isInline icon={<PlusCircleIcon />}>
+        app=MyApp
+      </Button>
+    </DescriptionListDescription>
+  </DescriptionListGroup>
+  <DescriptionListGroup>
+    <DescriptionListTerm>Annotation</DescriptionListTerm>
+    <DescriptionListDescription>2 Annotations</DescriptionListDescription>
+  </DescriptionListGroup>
+</DescriptionList>;
+```
+
+### Compact horizontal
+
+```js
+import React from 'react';
+import {
+  Button,
+  DescriptionList,
+  DescriptionListTerm,
+  DescriptionListGroup,
+  DescriptionListDescription
+} from '@patternfly/react-core';
+import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+
+<DescriptionList isCompact isHorizontal>
+  <DescriptionListGroup>
+    <DescriptionListTerm>Name</DescriptionListTerm>
+    <DescriptionListDescription>Example</DescriptionListDescription>
+  </DescriptionListGroup>
+  <DescriptionListGroup>
+    <DescriptionListTerm>Namespace</DescriptionListTerm>
+    <DescriptionListDescription>
+      <a href="#">mary-test</a>
+    </DescriptionListDescription>
+  </DescriptionListGroup>
+  <DescriptionListGroup>
+    <DescriptionListTerm>Labels</DescriptionListTerm>
+    <DescriptionListDescription>example</DescriptionListDescription>
+  </DescriptionListGroup>
+  <DescriptionListGroup>
+    <DescriptionListTerm>Pod selector</DescriptionListTerm>
+    <DescriptionListDescription>
+      <Button variant="link" isInline icon={<PlusCircleIcon />}>
+        app=MyApp
+      </Button>
+    </DescriptionListDescription>
+  </DescriptionListGroup>
+  <DescriptionListGroup>
+    <DescriptionListTerm>Annotation</DescriptionListTerm>
+    <DescriptionListDescription>2 Annotations</DescriptionListDescription>
+  </DescriptionListGroup>
+</DescriptionList>;
+```
+
+### Fluid horizontal
+
+```js
+import React from 'react';
+import {
+  Button,
+  DescriptionList,
+  DescriptionListTerm,
+  DescriptionListGroup,
+  DescriptionListDescription
+} from '@patternfly/react-core';
+import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+
+<DescriptionList isHorizontal isFluid>
+  <DescriptionListGroup>
+    <DescriptionListTerm>Name</DescriptionListTerm>
+    <DescriptionListDescription>Example</DescriptionListDescription>
+  </DescriptionListGroup>
+  <DescriptionListGroup>
+    <DescriptionListTerm>Namespace</DescriptionListTerm>
+    <DescriptionListDescription>
+      <a href="#">mary-test</a>
+    </DescriptionListDescription>
+  </DescriptionListGroup>
+  <DescriptionListGroup>
+    <DescriptionListTerm>Labels</DescriptionListTerm>
+    <DescriptionListDescription>example</DescriptionListDescription>
+  </DescriptionListGroup>
+  <DescriptionListGroup>
+    <DescriptionListTerm>Pod selector</DescriptionListTerm>
+    <DescriptionListDescription>
+      <Button variant="link" isInline icon={<PlusCircleIcon />}>
+        app=MyApp
+      </Button>
+    </DescriptionListDescription>
+  </DescriptionListGroup>
+  <DescriptionListGroup>
+    <DescriptionListTerm>Annotation</DescriptionListTerm>
+    <DescriptionListDescription>2 Annotations</DescriptionListDescription>
+  </DescriptionListGroup>
+</DescriptionList>;
+```
+
 ## Responsive column definitions
 
 ### Default responsive columns

--- a/packages/react-integration/cypress/integration/descriptionlist.spec.ts
+++ b/packages/react-integration/cypress/integration/descriptionlist.spec.ts
@@ -60,4 +60,12 @@ describe('Description List Demo Test', () => {
     ).click();
     cy.get('.pf-c-popover__content').should('exist');
   });
+
+  it('Verify compact list', () => {
+    cy.get('#compact-description-list').should('have.class', 'pf-m-compact');
+  });
+
+  it('Verify fluid list', () => {
+    cy.get('#fluid-description-list').should('have.class', 'pf-m-fluid');
+  });
 });

--- a/packages/react-integration/demo-app-ts/src/components/demos/DescriptionListDemo/DescriptionListDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DescriptionListDemo/DescriptionListDemo.tsx
@@ -385,6 +385,88 @@ export class DescriptionListDemo extends Component {
       </StackItem>
     );
   }
+  renderCompactDescriptionList() {
+    return (
+      <StackItem isFilled>
+        <Title headingLevel="h2" size="2xl">
+          Compact Description List
+        </Title>
+        <Divider component="div" />
+        <br />
+        <div className="example">
+          <DescriptionList id="compact-description-list" isCompact>
+            <DescriptionListGroup>
+              <DescriptionListTerm>Name</DescriptionListTerm>
+              <DescriptionListDescription>Example</DescriptionListDescription>
+            </DescriptionListGroup>
+            <DescriptionListGroup>
+              <DescriptionListTerm>Namespace</DescriptionListTerm>
+              <DescriptionListDescription>
+                <a href="#">mary-test</a>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+            <DescriptionListGroup>
+              <DescriptionListTerm>Labels</DescriptionListTerm>
+              <DescriptionListDescription>example</DescriptionListDescription>
+            </DescriptionListGroup>
+            <DescriptionListGroup>
+              <DescriptionListTerm>Pod selector</DescriptionListTerm>
+              <DescriptionListDescription>
+                <Button variant="link" isInline icon={<PlusCircleIcon />}>
+                  app=MyApp
+                </Button>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+            <DescriptionListGroup>
+              <DescriptionListTerm>Annotation</DescriptionListTerm>
+              <DescriptionListDescription>2 Annotations</DescriptionListDescription>
+            </DescriptionListGroup>
+          </DescriptionList>
+        </div>
+      </StackItem>
+    );
+  }
+  renderFluidDescriptionList() {
+    return (
+      <StackItem isFilled>
+        <Title headingLevel="h2" size="2xl">
+          Compact Description List
+        </Title>
+        <Divider component="div" />
+        <br />
+        <div className="example">
+          <DescriptionList id="fluid-description-list" isFluid isHorizontal>
+            <DescriptionListGroup>
+              <DescriptionListTerm>Name</DescriptionListTerm>
+              <DescriptionListDescription>Example</DescriptionListDescription>
+            </DescriptionListGroup>
+            <DescriptionListGroup>
+              <DescriptionListTerm>Namespace</DescriptionListTerm>
+              <DescriptionListDescription>
+                <a href="#">mary-test</a>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+            <DescriptionListGroup>
+              <DescriptionListTerm>Labels</DescriptionListTerm>
+              <DescriptionListDescription>example</DescriptionListDescription>
+            </DescriptionListGroup>
+            <DescriptionListGroup>
+              <DescriptionListTerm>Pod selector</DescriptionListTerm>
+              <DescriptionListDescription>
+                <Button variant="link" isInline icon={<PlusCircleIcon />}>
+                  app=MyApp
+                </Button>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+            <DescriptionListGroup>
+              <DescriptionListTerm>Annotation</DescriptionListTerm>
+              <DescriptionListDescription>2 Annotations</DescriptionListDescription>
+            </DescriptionListGroup>
+          </DescriptionList>
+        </div>
+      </StackItem>
+    );
+  }
   render() {
     return (
       <Stack hasGutter>
@@ -395,6 +477,8 @@ export class DescriptionListDemo extends Component {
         {this.renderAutoColumnWidthsDescriptionList()}
         {this.renderInlineGridDescriptionList()}
         {this.renderAutoFitDescriptionList()}
+        {this.renderCompactDescriptionList()}
+        {this.renderFluidDescriptionList()}
       </Stack>
     );
   }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6181

In this PR:
- Adds `isCompact` property to `DescriptionList`
- Adds `isFluid` property to `DescriptionList`. The property description indicates this only applies to horizontal description lists, but I've also made it so that if only `isFluid` is passed to `DescriptionList`, the `isHorizontal` styling is also applied.
