### PR TITLE
Add Support for disabled state tabs

### DIFF
--- a/packages/react-core/src/components/Tabs/Tab.tsx
+++ b/packages/react-core/src/components/Tabs/Tab.tsx
@@ -18,6 +18,12 @@ export interface TabProps extends Omit<React.HTMLProps<HTMLAnchorElement | HTMLB
   tabContentRef?: React.RefObject<any>;
   /** whether to render the tab or not */
   isHidden?: boolean;
+  /** Adds disabled styling and disables the button using the disabled html attribute */
+  isDisabled?: boolean;
+  /** Adds disabled styling and communicates that the button is disabled using the aria-disabled html attribute */
+  isAriaDisabled?: boolean;
+  /** Events to prevent when the button is in an aria-disabled state */
+  inoperableEvents?: string[];
 }
 
 /** The parent <Tabs> component accecesses this component's propeties directly in order to present each Tab */

--- a/packages/react-core/src/components/Tabs/Tab.tsx
+++ b/packages/react-core/src/components/Tabs/Tab.tsx
@@ -61,6 +61,14 @@ const TabBase: React.FunctionComponent<TabProps> = ({
   if ((mountOnEnter || unmountOnExit) && eventKey !== localActiveKey) {
     ariaControls = undefined;
   }
+  const isButtonElement = href !== null;
+  const getDefaultTabIdx = () => {
+    if (isDisabled) {
+      return isButtonElement ? null : -1;
+    } else if (isAriaDisabled) {
+      return -1;
+    }
+  };
   return (
     <li
       className={css(styles.tabsItem, eventKey === localActiveKey && styles.modifiers.current, childClassName)}
@@ -72,8 +80,9 @@ const TabBase: React.FunctionComponent<TabProps> = ({
           isDisabled && href && styles.modifiers.disabled,
           isAriaDisabled && styles.modifiers.ariaDisabled
         )}
-        disabled={isDisabled}
-        aria-disabled={isAriaDisabled}
+        disabled={isButtonElement ? isDisabled : null}
+        aria-disabled={!isButtonElement && isAriaDisabled}
+        tabIndex={getDefaultTabIdx()}
         onClick={(event: any) => handleTabClick(event, eventKey, tabContentRef)}
         {...(isAriaDisabled ? preventedEvents : null)}
         id={`pf-tab-${eventKey}-${childId || uniqueId}`}

--- a/packages/react-core/src/components/Tabs/Tab.tsx
+++ b/packages/react-core/src/components/Tabs/Tab.tsx
@@ -61,12 +61,12 @@ const TabBase: React.FunctionComponent<TabProps> = ({
   if ((mountOnEnter || unmountOnExit) && eventKey !== localActiveKey) {
     ariaControls = undefined;
   }
-  const isButtonElement = href !== null;
+  const isButtonElement = Boolean(!href);
   const getDefaultTabIdx = () => {
     if (isDisabled) {
       return isButtonElement ? null : -1;
     } else if (isAriaDisabled) {
-      return -1;
+      return null;
     }
   };
   return (
@@ -81,7 +81,7 @@ const TabBase: React.FunctionComponent<TabProps> = ({
           isAriaDisabled && styles.modifiers.ariaDisabled
         )}
         disabled={isButtonElement ? isDisabled : null}
-        aria-disabled={!isButtonElement && isAriaDisabled}
+        aria-disabled={isDisabled || isAriaDisabled}
         tabIndex={getDefaultTabIdx()}
         onClick={(event: any) => handleTabClick(event, eventKey, tabContentRef)}
         {...(isAriaDisabled ? preventedEvents : null)}

--- a/packages/react-core/src/components/Tabs/Tab.tsx
+++ b/packages/react-core/src/components/Tabs/Tab.tsx
@@ -73,7 +73,7 @@ const TabBase: React.FunctionComponent<TabProps> = ({
           isAriaDisabled && styles.modifiers.ariaDisabled
         )}
         disabled={isDisabled}
-        aria-disabled={isDisabled || isAriaDisabled}
+        aria-disabled={isAriaDisabled}
         onClick={(event: any) => handleTabClick(event, eventKey, tabContentRef)}
         {...(isAriaDisabled ? preventedEvents : null)}
         id={`pf-tab-${eventKey}-${childId || uniqueId}`}

--- a/packages/react-core/src/components/Tabs/Tab.tsx
+++ b/packages/react-core/src/components/Tabs/Tab.tsx
@@ -80,6 +80,7 @@ const TabBase: React.FunctionComponent<TabProps> = ({
         aria-controls={ariaControls}
         tabContentRef={tabContentRef}
         ouiaId={childOuiaId}
+        href={href}
         {...props}
       >
         {title}

--- a/packages/react-core/src/components/Tabs/Tabs.tsx
+++ b/packages/react-core/src/components/Tabs/Tabs.tsx
@@ -314,12 +314,25 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
                 ouiaId: childOuiaId,
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 isHidden,
+                isDisabled,
+                isAriaDisabled,
+                inoperableEvents = ['onClick', 'onKeyPress'],
+                href,
                 ...rest
               } = child.props;
               let ariaControls = tabContentId ? `${tabContentId}` : `pf-tab-section-${eventKey}-${childId || uniqueId}`;
               if ((mountOnEnter || unmountOnExit) && eventKey !== localActiveKey) {
                 ariaControls = undefined;
               }
+              const preventedEvents = inoperableEvents.reduce(
+                (handlers, eventToPrevent) => ({
+                  ...handlers,
+                  [eventToPrevent]: (event: React.SyntheticEvent<HTMLButtonElement>) => {
+                    event.preventDefault();
+                  }
+                }),
+                {}
+              );
               return (
                 <li
                   key={index}
@@ -330,8 +343,15 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
                   )}
                 >
                   <TabButton
-                    className={css(styles.tabsLink)}
+                    className={css(
+                      styles.tabsLink,
+                      isDisabled && href && styles.modifiers.disabled,
+                      isAriaDisabled && styles.modifiers.ariaDisabled
+                    )}
+                    disabled={isDisabled}
+                    aria-disabled={isDisabled || isAriaDisabled}
                     onClick={(event: any) => this.handleTabClick(event, eventKey, tabContentRef, mountOnEnter)}
+                    {...(isAriaDisabled ? preventedEvents : null)}
                     id={`pf-tab-${eventKey}-${childId || uniqueId}`}
                     aria-controls={ariaControls}
                     tabContentRef={tabContentRef}

--- a/packages/react-core/src/components/Tabs/Tabs.tsx
+++ b/packages/react-core/src/components/Tabs/Tabs.tsx
@@ -114,6 +114,8 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
     eventKey: number | string,
     tabContentRef: React.RefObject<any>
   ) {
+    // When tab is an achor tag with href, cancel navigation event
+    event.preventDefault();
     const { shownKeys } = this.state;
     const { onSelect, defaultActiveKey } = this.props;
     // if defaultActiveKey Tabs are uncontrolled, set new active key internally

--- a/packages/react-core/src/components/Tabs/Tabs.tsx
+++ b/packages/react-core/src/components/Tabs/Tabs.tsx
@@ -6,7 +6,6 @@ import { PickOptional } from '../../helpers/typeUtils';
 import AngleLeftIcon from '@patternfly/react-icons/dist/esm/icons/angle-left-icon';
 import AngleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-right-icon';
 import { getUniqueId, isElementInView, formatBreakpointMods } from '../../helpers/util';
-import { TabButton } from './TabButton';
 import { TabContent } from './TabContent';
 import { TabProps } from './Tab';
 import { TabsContextProvider } from './TabsContext';
@@ -113,8 +112,7 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
   handleTabClick(
     event: React.MouseEvent<HTMLElement, MouseEvent>,
     eventKey: number | string,
-    tabContentRef: React.RefObject<any>,
-    mountOnEnter: boolean
+    tabContentRef: React.RefObject<any>
   ) {
     const { shownKeys } = this.state;
     const { onSelect, defaultActiveKey } = this.props;
@@ -138,7 +136,7 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
         tabContentRef.current.hidden = false;
       }
     }
-    if (mountOnEnter) {
+    if (this.props.mountOnEnter) {
       this.setState({
         shownKeys: shownKeys.concat(eventKey)
       });
@@ -274,7 +272,16 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
     const localActiveKey = defaultActiveKey !== undefined ? uncontrolledActiveKey : activeKey;
 
     return (
-      <TabsContextProvider value={{ variant }}>
+      <TabsContextProvider
+        value={{
+          variant,
+          mountOnEnter,
+          unmountOnExit,
+          localActiveKey,
+          uniqueId,
+          handleTabClick: (...args) => this.handleTabClick(...args)
+        }}
+      >
         <Component
           aria-label={ariaLabel}
           className={css(
@@ -303,66 +310,7 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
             <AngleLeftIcon />
           </button>
           <ul className={css(styles.tabsList)} ref={this.tabList} onScroll={this.handleScrollButtons}>
-            {filteredChildren.map((child, index) => {
-              const {
-                title,
-                eventKey,
-                tabContentRef,
-                id: childId,
-                tabContentId,
-                className: childClassName = '',
-                ouiaId: childOuiaId,
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                isHidden,
-                isDisabled,
-                isAriaDisabled,
-                inoperableEvents = ['onClick', 'onKeyPress'],
-                href,
-                ...rest
-              } = child.props;
-              let ariaControls = tabContentId ? `${tabContentId}` : `pf-tab-section-${eventKey}-${childId || uniqueId}`;
-              if ((mountOnEnter || unmountOnExit) && eventKey !== localActiveKey) {
-                ariaControls = undefined;
-              }
-              const preventedEvents = inoperableEvents.reduce(
-                (handlers, eventToPrevent) => ({
-                  ...handlers,
-                  [eventToPrevent]: (event: React.SyntheticEvent<HTMLButtonElement>) => {
-                    event.preventDefault();
-                  }
-                }),
-                {}
-              );
-              return (
-                <li
-                  key={index}
-                  className={css(
-                    styles.tabsItem,
-                    eventKey === localActiveKey && styles.modifiers.current,
-                    childClassName
-                  )}
-                >
-                  <TabButton
-                    className={css(
-                      styles.tabsLink,
-                      isDisabled && href && styles.modifiers.disabled,
-                      isAriaDisabled && styles.modifiers.ariaDisabled
-                    )}
-                    disabled={isDisabled}
-                    aria-disabled={isDisabled || isAriaDisabled}
-                    onClick={(event: any) => this.handleTabClick(event, eventKey, tabContentRef, mountOnEnter)}
-                    {...(isAriaDisabled ? preventedEvents : null)}
-                    id={`pf-tab-${eventKey}-${childId || uniqueId}`}
-                    aria-controls={ariaControls}
-                    tabContentRef={tabContentRef}
-                    ouiaId={childOuiaId}
-                    {...rest}
-                  >
-                    {title}
-                  </TabButton>
-                </li>
-              );
-            })}
+            {filteredChildren}
           </ul>
           <button
             className={css(styles.tabsScrollButton, isSecondary && buttonStyles.modifiers.secondary)}

--- a/packages/react-core/src/components/Tabs/TabsContext.ts
+++ b/packages/react-core/src/components/Tabs/TabsContext.ts
@@ -2,10 +2,24 @@ import * as React from 'react';
 
 export interface TabsContextProps {
   variant: 'default' | 'light300';
+  mountOnEnter: boolean;
+  unmountOnExit: boolean;
+  localActiveKey: string | number;
+  uniqueId: string;
+  handleTabClick: (
+    event: React.MouseEvent<HTMLElement, MouseEvent>,
+    eventKey: number | string,
+    tabContentRef: React.RefObject<any>
+  ) => void;
 }
 
-const TabsContext = React.createContext<TabsContextProps>({
-  variant: 'default'
+export const TabsContext = React.createContext<TabsContextProps>({
+  variant: 'default',
+  mountOnEnter: false,
+  unmountOnExit: false,
+  localActiveKey: '',
+  uniqueId: '',
+  handleTabClick: () => null
 });
 
 export const TabsContextProvider = TabsContext.Provider;

--- a/packages/react-core/src/components/Tabs/__tests__/Generated/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/react-core/src/components/Tabs/__tests__/Generated/__snapshots__/Tabs.test.tsx.snap
@@ -4,6 +4,11 @@ exports[`Tabs should match snapshot (auto-generated) 1`] = `
 <ContextProvider
   value={
     Object {
+      "handleTabClick": [Function],
+      "localActiveKey": 0,
+      "mountOnEnter": false,
+      "uniqueId": "string",
+      "unmountOnExit": false,
       "variant": "div",
     }
   }
@@ -34,17 +39,11 @@ exports[`Tabs should match snapshot (auto-generated) 1`] = `
       className="pf-c-tabs__list"
       onScroll={[Function]}
     >
-      <li
-        className="pf-c-tabs__item"
-        key="0"
+      <div
+        key=".0"
       >
-        <TabButton
-          aria-controls="pf-tab-section-undefined-string"
-          className="pf-c-tabs__link"
-          id="pf-tab-undefined-string"
-          onClick={[Function]}
-        />
-      </li>
+        ReactNode
+      </div>
     </ul>
     <button
       aria-hidden={false}

--- a/packages/react-core/src/components/Tabs/__tests__/__snapshots__/Tab.test.tsx.snap
+++ b/packages/react-core/src/components/Tabs/__tests__/__snapshots__/Tab.test.tsx.snap
@@ -8,5 +8,43 @@ exports[`should not render anything 1`] = `
       "Tab item 1"
     </TabTitleText>
   }
-/>
+>
+  <TabBase
+    eventKey={0}
+    innerRef={null}
+    title={
+      <TabTitleText>
+        "Tab item 1"
+      </TabTitleText>
+    }
+  >
+    <li
+      className="pf-c-tabs__item"
+    >
+      <TabButton
+        aria-controls="pf-tab-section-0-"
+        className="pf-c-tabs__link"
+        id="pf-tab-0-"
+        onClick={[Function]}
+      >
+        <button
+          aria-controls="pf-tab-section-0-"
+          className="pf-c-tabs__link"
+          data-ouia-component-type="PF4/TabButton"
+          data-ouia-safe={true}
+          id="pf-tab-0-"
+          onClick={[Function]}
+        >
+          <TabTitleText>
+            <span
+              className="pf-c-tabs__item-text"
+            >
+              "Tab item 1"
+            </span>
+          </TabTitleText>
+        </button>
+      </TabButton>
+    </li>
+  </TabBase>
+</Tab>
 `;

--- a/packages/react-core/src/components/Tabs/__tests__/__snapshots__/Tab.test.tsx.snap
+++ b/packages/react-core/src/components/Tabs/__tests__/__snapshots__/Tab.test.tsx.snap
@@ -23,12 +23,14 @@ exports[`should not render anything 1`] = `
     >
       <TabButton
         aria-controls="pf-tab-section-0-"
+        aria-disabled={false}
         className="pf-c-tabs__link"
         id="pf-tab-0-"
         onClick={[Function]}
       >
         <button
           aria-controls="pf-tab-section-0-"
+          aria-disabled={false}
           className="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe={true}

--- a/packages/react-core/src/components/Tabs/__tests__/__snapshots__/Tab.test.tsx.snap
+++ b/packages/react-core/src/components/Tabs/__tests__/__snapshots__/Tab.test.tsx.snap
@@ -23,14 +23,12 @@ exports[`should not render anything 1`] = `
     >
       <TabButton
         aria-controls="pf-tab-section-0-"
-        aria-disabled={false}
         className="pf-c-tabs__link"
         id="pf-tab-0-"
         onClick={[Function]}
       >
         <button
           aria-controls="pf-tab-section-0-"
-          aria-disabled={false}
           className="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe={true}

--- a/packages/react-core/src/components/Tabs/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/react-core/src/components/Tabs/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -37,7 +37,6 @@ Array [
       >
         <a
           aria-controls="pf-tab-section-0-tab1"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -56,7 +55,6 @@ Array [
       >
         <a
           aria-controls="pf-tab-section-1-tab2"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -75,7 +73,6 @@ Array [
       >
         <a
           aria-controls="pf-tab-section-2-tab3"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -184,7 +181,6 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-0-tab1"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -202,7 +198,6 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-1-tab2"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -220,7 +215,6 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-2-tab3"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -238,7 +232,6 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-3-tab4"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -367,7 +360,6 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-0-tab1"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -385,7 +377,6 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-1-tab2"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -403,7 +394,6 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-2-tab3"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -511,7 +501,6 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-0-tab1"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -529,7 +518,6 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-1-tab2"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -547,7 +535,6 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-2-tab3"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -655,7 +642,6 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-0-primarieTabs"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -673,7 +659,6 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-1-tab2"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -691,7 +676,6 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-2-tab3"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -768,7 +752,6 @@ Array [
         >
           <button
             aria-controls="pf-tab-section-10-secondary tab1"
-            aria-disabled="false"
             class="pf-c-tabs__link"
             data-ouia-component-type="PF4/TabButton"
             data-ouia-safe="true"
@@ -786,7 +769,6 @@ Array [
         >
           <button
             aria-controls="pf-tab-section-11-secondary tab2"
-            aria-disabled="false"
             class="pf-c-tabs__link"
             data-ouia-component-type="PF4/TabButton"
             data-ouia-safe="true"
@@ -804,7 +786,6 @@ Array [
         >
           <button
             aria-controls="pf-tab-section-12-secondary tab3"
-            aria-disabled="false"
             class="pf-c-tabs__link"
             data-ouia-component-type="PF4/TabButton"
             data-ouia-safe="true"
@@ -938,7 +919,6 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-0-tab1"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -956,7 +936,6 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-1-tab2"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -974,7 +953,6 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-2-tab3"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -992,7 +970,6 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-3-tab4"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -1121,7 +1098,6 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-one-tab1"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -1139,7 +1115,6 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-two-tab2"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -1157,7 +1132,6 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-three-tab3"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -1266,7 +1240,6 @@ Array [
       >
         <button
           aria-controls="refTab1Section"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -1284,7 +1257,6 @@ Array [
       >
         <button
           aria-controls="refTab2Section"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -1302,7 +1274,6 @@ Array [
       >
         <button
           aria-controls="refTab3Section"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -1411,7 +1382,6 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-0-tab1"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -1429,7 +1399,6 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-1-tab2"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -1447,7 +1416,6 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-2-tab3"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -1465,7 +1433,6 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-3-tab4"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -1594,7 +1561,6 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-0-tab1"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -1612,7 +1578,6 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-1-tab2"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -1630,7 +1595,6 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-2-tab3"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -1648,7 +1612,6 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-3-tab4"
-          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"

--- a/packages/react-core/src/components/Tabs/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/react-core/src/components/Tabs/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -37,6 +37,7 @@ Array [
       >
         <a
           aria-controls="pf-tab-section-0-tab1"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -55,6 +56,7 @@ Array [
       >
         <a
           aria-controls="pf-tab-section-1-tab2"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -73,6 +75,7 @@ Array [
       >
         <a
           aria-controls="pf-tab-section-2-tab3"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -181,6 +184,7 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-0-tab1"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -198,6 +202,7 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-1-tab2"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -215,6 +220,7 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-2-tab3"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -232,6 +238,7 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-3-tab4"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -360,6 +367,7 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-0-tab1"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -377,6 +385,7 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-1-tab2"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -394,6 +403,7 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-2-tab3"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -501,6 +511,7 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-0-tab1"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -518,6 +529,7 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-1-tab2"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -535,6 +547,7 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-2-tab3"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -642,6 +655,7 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-0-primarieTabs"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -659,6 +673,7 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-1-tab2"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -676,6 +691,7 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-2-tab3"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -752,6 +768,7 @@ Array [
         >
           <button
             aria-controls="pf-tab-section-10-secondary tab1"
+            aria-disabled="false"
             class="pf-c-tabs__link"
             data-ouia-component-type="PF4/TabButton"
             data-ouia-safe="true"
@@ -769,6 +786,7 @@ Array [
         >
           <button
             aria-controls="pf-tab-section-11-secondary tab2"
+            aria-disabled="false"
             class="pf-c-tabs__link"
             data-ouia-component-type="PF4/TabButton"
             data-ouia-safe="true"
@@ -786,6 +804,7 @@ Array [
         >
           <button
             aria-controls="pf-tab-section-12-secondary tab3"
+            aria-disabled="false"
             class="pf-c-tabs__link"
             data-ouia-component-type="PF4/TabButton"
             data-ouia-safe="true"
@@ -919,6 +938,7 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-0-tab1"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -936,6 +956,7 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-1-tab2"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -953,6 +974,7 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-2-tab3"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -970,6 +992,7 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-3-tab4"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -1098,6 +1121,7 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-one-tab1"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -1115,6 +1139,7 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-two-tab2"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -1132,6 +1157,7 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-three-tab3"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -1240,6 +1266,7 @@ Array [
       >
         <button
           aria-controls="refTab1Section"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -1257,6 +1284,7 @@ Array [
       >
         <button
           aria-controls="refTab2Section"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -1274,6 +1302,7 @@ Array [
       >
         <button
           aria-controls="refTab3Section"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -1382,6 +1411,7 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-0-tab1"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -1399,6 +1429,7 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-1-tab2"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -1416,6 +1447,7 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-2-tab3"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -1433,6 +1465,7 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-3-tab4"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -1561,6 +1594,7 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-0-tab1"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -1578,6 +1612,7 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-1-tab2"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -1595,6 +1630,7 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-2-tab3"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"
@@ -1612,6 +1648,7 @@ Array [
       >
         <button
           aria-controls="pf-tab-section-3-tab4"
+          aria-disabled="false"
           class="pf-c-tabs__link"
           data-ouia-component-type="PF4/TabButton"
           data-ouia-safe="true"

--- a/packages/react-core/src/components/Tabs/examples/Tabs.md
+++ b/packages/react-core/src/components/Tabs/examples/Tabs.md
@@ -801,11 +801,11 @@ class TabsNav extends React.Component {
         <Tab eventKey={2} title={<TabTitleText>Database</TabTitleText>} href="#">
           Database
         </Tab>
-        <Tab eventKey={3} title={<TabTitleText>Server</TabTitleText>} href="#">
-          Server
+        <Tab eventKey={3} title={<TabTitleText>Disabled</TabTitleText>} isDisabled href="#">
+          Disabled
         </Tab>
-        <Tab eventKey={4} title={<TabTitleText>System</TabTitleText>} href="#">
-          System
+        <Tab eventKey={4} title={<TabTitleText>ARIA Disabled</TabTitleText>} isAriaDisabled href="#">
+          ARIA Disabled
         </Tab>
         <Tab eventKey={6} title={<TabTitleText>Network</TabTitleText>} href="#">
           Network
@@ -861,23 +861,23 @@ class SecondaryTabsNav extends React.Component {
             aria-label="Local secondary"
             component={TabsComponent.nav}
           >
-            <Tab eventKey={20} title={<TabTitleText>Secondary tab item 1</TabTitleText>} href="#">
-              Secondary tab item 1 item section
+            <Tab eventKey={20} title={<TabTitleText>Item 1</TabTitleText>} href="#">
+              Item 1 item section
             </Tab>
-            <Tab eventKey={21} title={<TabTitleText>Secondary tab item 2</TabTitleText>} href="#">
-              Secondary tab item 2 section
+            <Tab eventKey={21} title={<TabTitleText>Item 2</TabTitleText>} href="#">
+              Item 2 section
             </Tab>
-            <Tab eventKey={22} title={<TabTitleText>Secondary tab item 3</TabTitleText>} href="#">
-              Secondary tab item 3 section
+            <Tab eventKey={22} title={<TabTitleText>Item 3</TabTitleText>} href="#">
+              Item 3 section
             </Tab>
-            <Tab eventKey={23} title={<TabTitleText>Secondary tab item 4</TabTitleText>}href="#" >
-              Secondary tab item 4 section
+            <Tab eventKey={3} title={<TabTitleText>Disabled</TabTitleText>} isDisabled href="#">
+              Disabled
             </Tab>
-            <Tab eventKey={24} title={<TabTitleText>Secondary tab item 5</TabTitleText>} href="#">
-              Secondary tab item 5 section
+            <Tab eventKey={4} title={<TabTitleText>ARIA Disabled</TabTitleText>} isAriaDisabled href="#">
+              ARIA Disabled
             </Tab>
-            <Tab eventKey={25} title={<TabTitleText>Secondary tab item 6</TabTitleText>} href="#">
-              Secondary tab item 6 section
+            <Tab eventKey={25} title={<TabTitleText>Item 6</TabTitleText>} href="#">
+              Item 6 section
             </Tab>
           </Tabs>
         </Tab>
@@ -887,11 +887,11 @@ class SecondaryTabsNav extends React.Component {
         <Tab eventKey={2} title={<TabTitleText>Database</TabTitleText>} href="#">
           Database
         </Tab>
-        <Tab eventKey={3} title={<TabTitleText>Server</TabTitleText>} href="#">
-          Server
+        <Tab eventKey={3} title={<TabTitleText>Disabled</TabTitleText>} isDisabled href="#">
+          Disabled
         </Tab>
-        <Tab eventKey={4} title={<TabTitleText>System</TabTitleText>} href="#">
-          System
+        <Tab eventKey={4} title={<TabTitleText>ARIA Disabled</TabTitleText>} isAriaDisabled href="#">
+          ARIA Disabled
         </Tab>
         <Tab eventKey={6} title={<TabTitleText>Network</TabTitleText>} href="#">
           Network

--- a/packages/react-core/src/components/Tabs/examples/Tabs.md
+++ b/packages/react-core/src/components/Tabs/examples/Tabs.md
@@ -17,6 +17,75 @@ The Tabs items background can be also toggled with 'Tab light variation' checkbo
 Similarly the 'Tab content light variation' checkbox affects the TabContent background.
 
 ## Examples
+### Disabled Tabs
+```js
+import React from 'react';
+import { Tabs, Tab, TabTitleText, Checkbox, Tooltip } from '@patternfly/react-core';
+
+class DisabledTabs extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      activeTabKey: 0,
+      isBox: false,
+    };
+    // Toggle currently active tab
+    this.handleTabClick = (event, tabIndex) => {
+      this.setState({
+        activeTabKey: tabIndex
+      });
+    };
+
+    this.toggleBox = checked => {
+      this.setState({
+        isBox: checked
+      });
+    };
+  }
+
+  render() {
+    const {activeTabKey, isBox } = this.state;
+    const tooltipRef = React.createRef();
+    return (
+      <div>
+        <Tabs activeKey={activeTabKey} onSelect={this.handleTabClick} isBox={isBox}>
+          <Tab eventKey={0} title={<TabTitleText>Users</TabTitleText>}>
+            Users
+          </Tab>
+          <Tab eventKey={1} title={<TabTitleText>Containers</TabTitleText>}>
+            Containers
+          </Tab>
+          <Tab eventKey={2} title={<TabTitleText>Database</TabTitleText>}>
+            Database
+          </Tab>
+          <Tab eventKey={3} title={<TabTitleText>Server</TabTitleText>}>
+            Server
+          </Tab>
+          <Tab eventKey={4} title={<TabTitleText>System</TabTitleText>} isDisabled>
+            System
+          </Tab>
+          <Tab eventKey={6} title={<TabTitleText>Network</TabTitleText>} isAriaDisabled>
+            Network
+          </Tab>
+          <Tab eventKey={6} title={<TabTitleText>AriaDisabled</TabTitleText>} isAriaDisabled ref={tooltipRef}>
+            Aria Disabled
+          </Tab>
+        </Tabs>
+        <div style={{marginTop: "20px"}}>
+          <Checkbox
+              label="isBox"
+              isChecked={isBox}
+              onChange={this.toggleBox}
+              aria-label="show box variation checkbox"
+              id="toggle-box"
+              name="toggle-box"
+            />
+        </div>
+      </div>
+    );
+  }
+}
+```
 ### Default
 ```js
 import React from 'react';

--- a/packages/react-core/src/components/Tabs/examples/Tabs.md
+++ b/packages/react-core/src/components/Tabs/examples/Tabs.md
@@ -17,79 +17,11 @@ The Tabs items background can be also toggled with 'Tab light variation' checkbo
 Similarly the 'Tab content light variation' checkbox affects the TabContent background.
 
 ## Examples
-### Disabled Tabs
-```js
-import React from 'react';
-import { Tabs, Tab, TabTitleText, Checkbox, Tooltip } from '@patternfly/react-core';
 
-class DisabledTabs extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      activeTabKey: 0,
-      isBox: false,
-    };
-    // Toggle currently active tab
-    this.handleTabClick = (event, tabIndex) => {
-      this.setState({
-        activeTabKey: tabIndex
-      });
-    };
-
-    this.toggleBox = checked => {
-      this.setState({
-        isBox: checked
-      });
-    };
-  }
-
-  render() {
-    const {activeTabKey, isBox } = this.state;
-    const tooltipRef = React.createRef();
-    return (
-      <div>
-        <Tabs activeKey={activeTabKey} onSelect={this.handleTabClick} isBox={isBox}>
-          <Tab eventKey={0} title={<TabTitleText>Users</TabTitleText>}>
-            Users
-          </Tab>
-          <Tab eventKey={1} title={<TabTitleText>Containers</TabTitleText>}>
-            Containers
-          </Tab>
-          <Tab eventKey={2} title={<TabTitleText>Database</TabTitleText>}>
-            Database
-          </Tab>
-          <Tab eventKey={3} title={<TabTitleText>Server</TabTitleText>}>
-            Server
-          </Tab>
-          <Tab eventKey={4} title={<TabTitleText>System</TabTitleText>} isDisabled>
-            System
-          </Tab>
-          <Tab eventKey={6} title={<TabTitleText>Network</TabTitleText>} isAriaDisabled>
-            Network
-          </Tab>
-          <Tab eventKey={6} title={<TabTitleText>AriaDisabled</TabTitleText>} isAriaDisabled ref={tooltipRef}>
-            Aria Disabled
-          </Tab>
-        </Tabs>
-        <div style={{marginTop: "20px"}}>
-          <Checkbox
-              label="isBox"
-              isChecked={isBox}
-              onChange={this.toggleBox}
-              aria-label="show box variation checkbox"
-              id="toggle-box"
-              name="toggle-box"
-            />
-        </div>
-      </div>
-    );
-  }
-}
-```
 ### Default
 ```js
 import React from 'react';
-import { Tabs, Tab, TabTitleText, Checkbox } from '@patternfly/react-core';
+import { Tabs, Tab, TabTitleText, Checkbox, Tooltip } from '@patternfly/react-core';
 
 class SimpleTabs extends React.Component {
   constructor(props) {
@@ -127,15 +59,17 @@ class SimpleTabs extends React.Component {
           <Tab eventKey={2} title={<TabTitleText>Database</TabTitleText>}>
             Database
           </Tab>
-          <Tab eventKey={3} title={<TabTitleText>Server</TabTitleText>}>
-            Server
+          <Tab eventKey={3} title={<TabTitleText>Disabled</TabTitleText>} isDisabled>
+            Disabled
           </Tab>
-          <Tab eventKey={4} title={<TabTitleText>System</TabTitleText>}>
-            System
+          <Tab eventKey={4} title={<TabTitleText>ARIA Disabled</TabTitleText>} isAriaDisabled>
+            ARIA Disabled
           </Tab>
-          <Tab eventKey={6} title={<TabTitleText>Network</TabTitleText>}>
-            Network
-          </Tab>
+          <Tooltip content="Aria-disabled tabs are like disabled tabs, but focusable. Allows for tooltip support.">
+            <Tab eventKey={5} title={<TabTitleText>ARIA Disabled (Tooltip)</TabTitleText>} isAriaDisabled>
+              ARIA Disabled (Tooltip)
+            </Tab>
+          </Tooltip>
         </Tabs>
         <div style={{marginTop: "20px"}}>
           <Checkbox
@@ -156,7 +90,7 @@ class SimpleTabs extends React.Component {
 ### Uncontrolled
 ```js
 import React from 'react';
-import { Tabs, Tab, TabTitleText, Checkbox } from '@patternfly/react-core';
+import { Tabs, Tab, TabTitleText, Checkbox, Tooltip } from '@patternfly/react-core';
 
 class UncontrolledSimpleTabs extends React.Component {
 
@@ -173,15 +107,17 @@ class UncontrolledSimpleTabs extends React.Component {
         <Tab eventKey={2} title={<TabTitleText>Database</TabTitleText>}>
           Database
         </Tab>
-        <Tab eventKey={3} title={<TabTitleText>Server</TabTitleText>}>
-          Server
+        <Tab eventKey={3} title={<TabTitleText>Disabled</TabTitleText>} isDisabled>
+            Disabled
         </Tab>
-        <Tab eventKey={4} title={<TabTitleText>System</TabTitleText>}>
-          System
+        <Tab eventKey={4} title={<TabTitleText>ARIA Disabled</TabTitleText>} isAriaDisabled>
+          ARIA Disabled
         </Tab>
-        <Tab eventKey={6} title={<TabTitleText>Network</TabTitleText>}>
-          Network
-        </Tab>
+        <Tooltip content="Aria-disabled tabs are like disabled tabs, but focusable. Allows for tooltip support.">
+          <Tab eventKey={5} title={<TabTitleText>ARIA Disabled (Tooltip)</TabTitleText>} isAriaDisabled>
+            ARIA Disabled (Tooltip)
+          </Tab>
+        </Tooltip>
       </Tabs>
     );
   }
@@ -191,7 +127,7 @@ class UncontrolledSimpleTabs extends React.Component {
 ### Box light variation
 ```js
 import React from 'react';
-import { Tabs, Tab, TabTitleText, Checkbox } from '@patternfly/react-core';
+import { Tabs, Tab, TabTitleText, Checkbox, Tooltip } from '@patternfly/react-core';
 
 class SimpleTabs extends React.Component {
   constructor(props) {
@@ -229,15 +165,17 @@ class SimpleTabs extends React.Component {
           <Tab eventKey={2} title={<TabTitleText>Database</TabTitleText>}>
             Database
           </Tab>
-          <Tab eventKey={3} title={<TabTitleText>Server</TabTitleText>}>
-            Server
+          <Tab eventKey={3} title={<TabTitleText>Disabled</TabTitleText>} isDisabled>
+            Disabled
           </Tab>
-          <Tab eventKey={4} title={<TabTitleText>System</TabTitleText>}>
-            System
+          <Tab eventKey={4} title={<TabTitleText>ARIA Disabled</TabTitleText>} isAriaDisabled>
+            ARIA Disabled
           </Tab>
-          <Tab eventKey={6} title={<TabTitleText>Network</TabTitleText>}>
-            Network
-          </Tab>
+          <Tooltip content="Aria-disabled tabs are like disabled tabs, but focusable. Allows for tooltip support.">
+            <Tab eventKey={6} title={<TabTitleText>ARIA Disabled (Tooltip)</TabTitleText>} isAriaDisabled>
+              ARIA Disabled (Tooltip)
+            </Tab>
+          </Tooltip>
         </Tabs>
         <div style={{marginTop: "20px"}}>
           <Checkbox
@@ -340,7 +278,7 @@ class ScrollButtonsPrimaryTabs extends React.Component {
 ### Vertical
 ```js
 import React from 'react';
-import { Tabs, Tab, TabTitleText, Checkbox } from '@patternfly/react-core';
+import { Tabs, Tab, TabTitleText, Checkbox, Tooltip } from '@patternfly/react-core';
 
 class VerticalTabs extends React.Component {
   constructor(props) {
@@ -377,15 +315,17 @@ class VerticalTabs extends React.Component {
           <Tab eventKey={2} title={<TabTitleText>Database</TabTitleText>}>
             Database
           </Tab>
-          <Tab eventKey={3} title={<TabTitleText>Server</TabTitleText>}>
-            Server
+          <Tab eventKey={3} title={<TabTitleText>Disabled</TabTitleText>} isDisabled>
+            Disabled
           </Tab>
-          <Tab eventKey={4} title={<TabTitleText>System</TabTitleText>}>
-            System
+          <Tab eventKey={4} title={<TabTitleText>ARIA Disabled</TabTitleText>} isAriaDisabled>
+            ARIA Disabled
           </Tab>
-          <Tab eventKey={6} title={<TabTitleText>Network</TabTitleText>}>
-            Network
-          </Tab>
+          <Tooltip content="Aria-disabled tabs are like disabled tabs, but focusable. Allows for tooltip support." position="right">
+            <Tab eventKey={6} title={<TabTitleText>ARIA Disabled (Tooltip)</TabTitleText>} isAriaDisabled>
+              ARIA Disabled (Tooltip)
+            </Tab>
+          </Tooltip>
         </Tabs>
         <div style={{marginTop: "20px"}}>
           <Checkbox

--- a/packages/react-core/src/components/Tabs/examples/Tabs.md
+++ b/packages/react-core/src/components/Tabs/examples/Tabs.md
@@ -46,6 +46,7 @@ class SimpleTabs extends React.Component {
 
   render() {
     const {activeTabKey, isBox } = this.state;
+    const tooltipRef = React.createRef();
 
     return (
       <div>
@@ -65,12 +66,11 @@ class SimpleTabs extends React.Component {
           <Tab eventKey={4} title={<TabTitleText>ARIA Disabled</TabTitleText>} isAriaDisabled>
             ARIA Disabled
           </Tab>
-          <Tooltip content="Aria-disabled tabs are like disabled tabs, but focusable. Allows for tooltip support.">
-            <Tab eventKey={5} title={<TabTitleText>ARIA Disabled (Tooltip)</TabTitleText>} isAriaDisabled>
-              ARIA Disabled (Tooltip)
-            </Tab>
-          </Tooltip>
+          <Tab eventKey={5} title={<TabTitleText>ARIA Disabled (Tooltip)</TabTitleText>} isAriaDisabled ref={tooltipRef}>
+            ARIA Disabled (Tooltip)
+          </Tab>
         </Tabs>
+        <Tooltip content="Aria-disabled tabs are like disabled tabs, but focusable. Allows for tooltip support." reference={tooltipRef} />
         <div style={{marginTop: "20px"}}>
           <Checkbox
               label="isBox"
@@ -95,30 +95,32 @@ import { Tabs, Tab, TabTitleText, Checkbox, Tooltip } from '@patternfly/react-co
 class UncontrolledSimpleTabs extends React.Component {
 
   render() {
+    const tooltipRef = React.createRef();
 
     return (
-      <Tabs defaultActiveKey={0}>
-        <Tab eventKey={0} title={<TabTitleText>Users</TabTitleText>}>
-          Users
-        </Tab>
-        <Tab eventKey={1} title={<TabTitleText>Containers</TabTitleText>}>
-          Containers
-        </Tab>
-        <Tab eventKey={2} title={<TabTitleText>Database</TabTitleText>}>
-          Database
-        </Tab>
-        <Tab eventKey={3} title={<TabTitleText>Disabled</TabTitleText>} isDisabled>
-            Disabled
-        </Tab>
-        <Tab eventKey={4} title={<TabTitleText>ARIA Disabled</TabTitleText>} isAriaDisabled>
-          ARIA Disabled
-        </Tab>
-        <Tooltip content="Aria-disabled tabs are like disabled tabs, but focusable. Allows for tooltip support.">
-          <Tab eventKey={5} title={<TabTitleText>ARIA Disabled (Tooltip)</TabTitleText>} isAriaDisabled>
+      <>
+        <Tabs defaultActiveKey={0}>
+          <Tab eventKey={0} title={<TabTitleText>Users</TabTitleText>}>
+            Users
+          </Tab>
+          <Tab eventKey={1} title={<TabTitleText>Containers</TabTitleText>}>
+            Containers
+          </Tab>
+          <Tab eventKey={2} title={<TabTitleText>Database</TabTitleText>}>
+            Database
+          </Tab>
+          <Tab eventKey={3} title={<TabTitleText>Disabled</TabTitleText>} isDisabled>
+              Disabled
+          </Tab>
+          <Tab eventKey={4} title={<TabTitleText>ARIA Disabled</TabTitleText>} isAriaDisabled>
+            ARIA Disabled
+          </Tab>
+          <Tab eventKey={5} title={<TabTitleText>ARIA Disabled (Tooltip)</TabTitleText>} isAriaDisabled ref={tooltipRef}>
             ARIA Disabled (Tooltip)
           </Tab>
-        </Tooltip>
-      </Tabs>
+        </Tabs>
+        <Tooltip content="Aria-disabled tabs are like disabled tabs, but focusable. Allows for tooltip support." reference={tooltipRef} />
+      </>
     );
   }
 }
@@ -152,6 +154,7 @@ class SimpleTabs extends React.Component {
 
   render() {
     const {activeTabKey, isBox, isTabsLightScheme } = this.state;
+    const tooltipRef = React.createRef();
 
     return (
       <div>
@@ -171,12 +174,11 @@ class SimpleTabs extends React.Component {
           <Tab eventKey={4} title={<TabTitleText>ARIA Disabled</TabTitleText>} isAriaDisabled>
             ARIA Disabled
           </Tab>
-          <Tooltip content="Aria-disabled tabs are like disabled tabs, but focusable. Allows for tooltip support.">
-            <Tab eventKey={6} title={<TabTitleText>ARIA Disabled (Tooltip)</TabTitleText>} isAriaDisabled>
-              ARIA Disabled (Tooltip)
-            </Tab>
-          </Tooltip>
+          <Tab eventKey={5} title={<TabTitleText>ARIA Disabled (Tooltip)</TabTitleText>} isAriaDisabled ref={tooltipRef}>
+            ARIA Disabled (Tooltip)
+          </Tab>
         </Tabs>
+        <Tooltip content="Aria-disabled tabs are like disabled tabs, but focusable. Allows for tooltip support." reference={tooltipRef} />
         <div style={{marginTop: "20px"}}>
           <Checkbox
               label="Tabs light variation"
@@ -303,6 +305,7 @@ class VerticalTabs extends React.Component {
 
   render() {
     const {activeTabKey, isBox} = this.state;
+    const tooltipRef = React.createRef();
     return (
       <div>
         <Tabs activeKey={activeTabKey} onSelect={this.handleTabClick} isVertical isBox={isBox}>
@@ -321,12 +324,11 @@ class VerticalTabs extends React.Component {
           <Tab eventKey={4} title={<TabTitleText>ARIA Disabled</TabTitleText>} isAriaDisabled>
             ARIA Disabled
           </Tab>
-          <Tooltip content="Aria-disabled tabs are like disabled tabs, but focusable. Allows for tooltip support." position="right">
-            <Tab eventKey={6} title={<TabTitleText>ARIA Disabled (Tooltip)</TabTitleText>} isAriaDisabled>
-              ARIA Disabled (Tooltip)
-            </Tab>
-          </Tooltip>
+          <Tab eventKey={5} title={<TabTitleText>ARIA Disabled (Tooltip)</TabTitleText>} isAriaDisabled ref={tooltipRef}>
+            ARIA Disabled (Tooltip)
+          </Tab>
         </Tabs>
+        <Tooltip content="Aria-disabled tabs are like disabled tabs, but focusable. Allows for tooltip support." reference={tooltipRef} position="right" />
         <div style={{marginTop: "20px"}}>
           <Checkbox
                 label="isBox"

--- a/packages/react-integration/cypress/integration/tabdisbleddemo.spec.ts
+++ b/packages/react-integration/cypress/integration/tabdisbleddemo.spec.ts
@@ -1,0 +1,47 @@
+describe('Disabled Tab Demo Test', () => {
+  it('Navigate to demo section', () => {
+    cy.visit('http://localhost:3000/');
+    cy.get('#tabs-disabled-demo-nav-item-link').click();
+    cy.url().should('eq', 'http://localhost:3000/tabs-disabled-demo-nav-link');
+  });
+
+  const tabIds = {
+    notDisabled: {
+      button: '#pf-tab-0-not-disabled',
+      content: '#pf-tab-section-0-not-disabled'
+    },
+    disabled: {
+      button: '#pf-tab-1-is-disabled',
+      content: '#pf-tab-section-1-is-disabled'
+    },
+    ariaDisabled: {
+      button: '#pf-tab-2-is-aria-disabled',
+      content: '#pf-tab-section-2-is-aria-disabled'
+    },
+    withTooltip: {
+      button: '#pf-tab-3-with-tooltip',
+      content: '#pf-tab-section-3-with-tooltip'
+    }
+  };
+  const { notDisabled, disabled, ariaDisabled, withTooltip } = tabIds;
+
+  it('Verify disabled tabs', () => {
+    cy.get('#disabledTabs').within(() => {
+      cy.get(notDisabled.content).should('not.have.a.property', 'hidden');
+      cy.get(disabled.button).click({ force: true });
+      cy.get(disabled.content).should('not.exist');
+      cy.get(notDisabled.content).should('not.have.a.property', 'hidden');
+      cy.get(ariaDisabled.button).click({ force: true });
+      cy.get(ariaDisabled.content).should('not.exist');
+      cy.get(notDisabled.content).should('not.have.a.property', 'hidden');
+      cy.get(withTooltip.button).click({ force: true });
+      cy.get(withTooltip.content).should('not.exist');
+      cy.get(notDisabled.content).should('not.have.a.property', 'hidden');
+    });
+  });
+
+  it('Verify aria-disabled with tooltip', () => {
+    cy.get(withTooltip.button).trigger('mouseover');
+    cy.get('.pf-c-tooltip').should('be.visible');
+  });
+});

--- a/packages/react-integration/demo-app-ts/src/Demos.ts
+++ b/packages/react-integration/demo-app-ts/src/Demos.ts
@@ -722,6 +722,11 @@ export const Demos: DemoInterface[] = [
     componentType: Examples.TabsInsetDemo
   },
   {
+    id: 'tabs-disabled-demo',
+    name: 'Tabs Disabled Demo',
+    componentType: Examples.TabsDisabledDemo
+  },
+  {
     id: 'table-actions-demo',
     name: 'Table Actions Demo',
     componentType: Examples.TableActionsDemo

--- a/packages/react-integration/demo-app-ts/src/components/demos/TabsDemo/TabsDisabledDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TabsDemo/TabsDisabledDemo.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Tabs, Tab, TabTitleText, Tooltip } from '@patternfly/react-core';
+
+export class TabsDisabledDemo extends React.Component {
+  static displayName = 'TabsDisabledDemo';
+  state = {
+    activeTabKey: 0,
+    isBox: false
+  };
+
+  constructor(props: {}) {
+    super(props);
+  }
+
+  private handleTabClick = (_event: React.MouseEvent<HTMLElement, MouseEvent>, tabIndex: number | string) => {
+    this.setState({
+      activeTabKey: tabIndex
+    });
+  };
+
+  render() {
+    const { activeTabKey } = this.state;
+    const tooltipRef = React.createRef();
+
+    return (
+      <>
+        <Tabs id="disabledTabs" activeKey={activeTabKey} onSelect={this.handleTabClick}>
+          <Tab eventKey={0} title={<TabTitleText>Users</TabTitleText>} id="not-disabled">
+            <div id="not-disabled-content">Users</div>
+          </Tab>
+          <Tab eventKey={1} title={<TabTitleText>Disabled</TabTitleText>} isDisabled id="is-disabled">
+            <div id="is-disabled-content">Disabled</div>
+          </Tab>
+          <Tab eventKey={2} title={<TabTitleText>ARIA Disabled</TabTitleText>} isAriaDisabled id="is-aria-disabled">
+            <div id="is-aira-disabled-content">ARIA Disabled</div>
+          </Tab>
+          <Tab
+            eventKey={3}
+            title={<TabTitleText>ARIA Disabled (Tooltip)</TabTitleText>}
+            isAriaDisabled
+            ref={tooltipRef}
+            id="with-tooltip"
+          >
+            <div id="with-tooltip-content">ARIA Disabled (Tooltip)</div>
+          </Tab>
+        </Tabs>
+        <Tooltip
+          content={
+            <div id="tooltip-content">
+              Aria-disabled tabs are like disabled tabs, but focusable. Allows for tooltip support."
+            </div>
+          }
+          reference={tooltipRef}
+        />
+      </>
+    );
+  }
+}

--- a/packages/react-integration/demo-app-ts/src/components/demos/index.ts
+++ b/packages/react-integration/demo-app-ts/src/components/demos/index.ts
@@ -166,6 +166,7 @@ export * from './TabsDemo/TabsDemo';
 export * from './TabsDemo/TabsInsetDemo';
 export * from './TabsDemo/TabsStringEventKeyDemo';
 export * from './TabsDemo/TabsUncontrolledDemo';
+export * from './TabsDemo/TabsDisabledDemo';
 export * from './TextAreaDemo/TextAreaDemo';
 export * from './TextDemo/TextDemo';
 export * from './TextInputDemo/TextInputDemo';


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6162 

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
- Refactored Tab into it's own component in order to forwardRef for `Tooltip` in `aria-disabled` case re: [Original Request](https://github.com/patternfly/patternfly-design/issues/1066)
- Added disabled state examples to match core PR for same issue
