### PR TITLE
docs: refactor demos to use Masthead

### DIFF
--- a/packages/react-core/src/components/Page/PageToggleButton.tsx
+++ b/packages/react-core/src/components/Page/PageToggleButton.tsx
@@ -1,0 +1,41 @@
+/* eslint-disable no-console */
+import * as React from 'react';
+import { Button, ButtonProps, ButtonVariant } from '../../components/Button';
+import { PageContextConsumer, PageContextProps } from './Page';
+
+export interface PageToggleButtonProps extends ButtonProps {
+  /** Content of the page toggle button */
+  children?: React.ReactNode;
+  /** True if the side nav is shown  */
+  isNavOpen?: boolean;
+  /** Callback function to handle the side nav toggle button, managed by the Page component if the Page isManagedSidebar prop is set to true */
+  onNavToggle?: () => void;
+}
+
+export const PageToggleButton: React.FunctionComponent<PageToggleButtonProps> = ({
+  children,
+  isNavOpen = true,
+  onNavToggle = () => undefined as any,
+  ...props
+}: PageToggleButtonProps) => (
+  <PageContextConsumer>
+    {({ isManagedSidebar, onNavToggle: managedOnNavToggle, isNavOpen: managedIsNavOpen }: PageContextProps) => {
+      const navToggle = isManagedSidebar ? managedOnNavToggle : onNavToggle;
+      const navOpen = isManagedSidebar ? managedIsNavOpen : isNavOpen;
+
+      return (
+        <Button
+          id="nav-toggle"
+          onClick={navToggle}
+          aria-label="Side navigation toggle"
+          aria-expanded={navOpen ? 'true' : 'false'}
+          variant={ButtonVariant.plain}
+          {...props}
+        >
+          {children}
+        </Button>
+      );
+    }}
+  </PageContextConsumer>
+);
+PageToggleButton.displayName = 'PageToggleButton';

--- a/packages/react-core/src/components/Page/examples/Page.md
+++ b/packages/react-core/src/components/Page/examples/Page.md
@@ -14,6 +14,7 @@ propComponents:
     'PageGroup',
     'PageBreadcrumb',
     'PageNavigation',
+    'PageToggleButton',
   ]
 ---
 

--- a/packages/react-core/src/components/Page/index.ts
+++ b/packages/react-core/src/components/Page/index.ts
@@ -8,3 +8,4 @@ export * from './PageHeaderTools';
 export * from './PageHeaderToolsGroup';
 export * from './PageHeaderToolsItem';
 export * from './PageNavigation';
+export * from './PageToggleButton';

--- a/packages/react-core/src/demos/NotificationDrawer/NotificationDrawer.md
+++ b/packages/react-core/src/demos/NotificationDrawer/NotificationDrawer.md
@@ -5,14 +5,17 @@ section: components
 
 import BellIcon from '@patternfly/react-icons/dist/esm/icons/bell-icon';
 import CogIcon from '@patternfly/react-icons/dist/esm/icons/cog-icon';
+import BarsIcon from '@patternfly/react-icons/dist/js/icons/bars-icon';
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import imgBrand from '@patternfly/react-core/src/components/Brand/examples/pfLogo.svg';
 import imgAvatar from '@patternfly/react-core/src/components/Avatar/examples/avatarImg.svg';
+import AttentionBellIcon from '@patternfly/react-icons/dist/esm/icons/attention-bell-icon';
 
 ## Demos
 
 ### Basic
+
 ```js isFullscreen
 import React from 'react';
 import {
@@ -51,7 +54,6 @@ import {
   NotificationDrawerListItemBody,
   NotificationDrawerListItemHeader,
   Page,
-  PageHeader,
   PageSection,
   PageSectionVariants,
   PageSidebar,
@@ -59,14 +61,22 @@ import {
   TextContent,
   Text,
   Title,
-  PageHeaderTools,
-  PageHeaderToolsGroup,
-  PageHeaderToolsItem
+  PageToggleButton,
+  Masthead,
+  MastheadMain,
+  MastheadToggle,
+  MastheadContent,
+  MastheadBrand,
+  Toolbar,
+  ToolbarItem,
+  ToolbarGroup,
+  ToolbarContent
 } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import BellIcon from '@patternfly/react-icons/dist/esm/icons/bell-icon';
 import CogIcon from '@patternfly/react-icons/dist/esm/icons/cog-icon';
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
+import BarsIcon from '@patternfly/react-icons/dist/js/icons/bars-icon';
 import imgBrand from '@patternfly/react-core/src/components/Brand/examples/pfLogo.svg';
 import imgAvatar from '@patternfly/react-core/src/components/Avatar/examples/avatarImg.svg';
 import { Table, TableHeader, TableBody } from '@patternfly/react-table';
@@ -80,8 +90,8 @@ class BasicNotificationDrawer extends React.Component {
       activeItem: 0,
       isDrawerExpanded: false,
       isUnreadMap: {
-        "notification-1": true,
-        "notification-2": true
+        'notification-1': true,
+        'notification-2': true
       },
       showNotifications: true,
       isActionsMenuOpen: null
@@ -115,65 +125,65 @@ class BasicNotificationDrawer extends React.Component {
         activeItem: result.itemId
       });
     };
-    
+
     this.onCloseNotificationDrawer = () => {
       this.setState(prevState => {
         return {
           isDrawerExpanded: !prevState.isDrawerExpanded
-        }
+        };
       });
     };
-    
+
     this.onToggle = (id, isOpen) => {
       this.setState({
         isActionsMenuOpen: { [id]: isOpen }
       });
     };
-    
+
     this.onSelect = event => {
       this.setState({
         isActionsMenuOpen: null
       });
     };
-    
-    this.onListItemClick = (id) => {
+
+    this.onListItemClick = id => {
       this.setState(prevState => {
         if (!prevState.isUnreadMap) return;
         prevState.isUnreadMap[id] = false;
         return {
           isUnreadMap: prevState.isUnreadMap
-        }
+        };
       });
-    }
-    
+    };
+
     this.getNumberUnread = () => {
-      const { isUnreadMap } = this.state
+      const { isUnreadMap } = this.state;
       if (isUnreadMap === null) return 0;
       return Object.keys(isUnreadMap).reduce((count, id) => {
         return isUnreadMap[id] ? count + 1 : count;
       }, 0);
-    }
-    
+    };
+
     this.markAllRead = () => {
       this.setState({
         isUnreadMap: null
       });
-    }
-    
-    this.showNotifications = (showNotifications) => {
+    };
+
+    this.showNotifications = showNotifications => {
       this.setState({
         isUnreadMap: null,
         showNotifications: showNotifications
       });
-    }
+    };
   }
 
   render() {
-    const { 
-      isDropdownOpen, 
-      isKebabDropdownOpen, 
-      activeItem, 
-      res, 
+    const {
+      isDropdownOpen,
+      isKebabDropdownOpen,
+      activeItem,
+      res,
       isDrawerExpanded,
       isActionsMenuOpen,
       isUnreadMap,
@@ -218,64 +228,87 @@ class BasicNotificationDrawer extends React.Component {
         <DropdownItem key="group 2 logout">Logout</DropdownItem>
       </DropdownGroup>
     ];
-    const headerTools = (
-      <PageHeaderTools>
-        <PageHeaderToolsItem visibility={{default: 'visible'}} isSelected={isDrawerExpanded}>
-          <NotificationBadge variant={this.getNumberUnread() === 0 ? 'read' : 'unread'} onClick={this.onCloseNotificationDrawer} aria-label="Notifications">
-            <BellIcon />
-          </NotificationBadge>
-        </PageHeaderToolsItem>
-        <PageHeaderToolsGroup
-          visibility={{
-            default: 'hidden',
-            lg: 'visible'
-          }} /** the settings and help icon buttons are only visible on desktop sizes and replaced by a kebab dropdown for other sizes */
-        >
-          <PageHeaderToolsItem>
-            <Button aria-label="Settings actions" variant={ButtonVariant.plain}>
-              <CogIcon />
-            </Button>
-          </PageHeaderToolsItem>
-          <PageHeaderToolsItem>
-            <Button aria-label="Help actions" variant={ButtonVariant.plain}>
-              <HelpIcon />
-            </Button>
-          </PageHeaderToolsItem>
-        </PageHeaderToolsGroup>
-        <PageHeaderToolsGroup>
-          <PageHeaderToolsItem
-            visibility={{
-              lg: 'hidden'
-            }} /** this kebab dropdown replaces the icon buttons and is hidden for desktop sizes */
-          >
-            <Dropdown
-              isPlain
-              position="right"
-              onSelect={this.onKebabDropdownSelect}
-              toggle={<KebabToggle onToggle={this.onKebabDropdownToggle} />}
-              isOpen={isKebabDropdownOpen}
-              dropdownItems={kebabDropdownItems}
-            />
-          </PageHeaderToolsItem>
-          <PageHeaderToolsItem
-            visibility={{ default: 'hidden', md: 'visible' }} /** this user dropdown is hidden on mobile sizes */
-          >
-            <Dropdown
-              isPlain
-              position="right"
-              onSelect={this.onDropdownSelect}
-              isOpen={isDropdownOpen}
-              toggle={<DropdownToggle onToggle={this.onDropdownToggle}>John Smith</DropdownToggle>}
-              dropdownItems={userDropdownItems}
-            />
-          </PageHeaderToolsItem>
-        </PageHeaderToolsGroup>
-        <Avatar src={imgAvatar} alt="Avatar image" />
-      </PageHeaderTools>
+    const headerToolbar = (
+      <Toolbar>
+        <ToolbarContent>
+          <ToolbarGroup alignment={{ default: 'alignRight' }}>
+            <ToolbarGroup variant="icon-button-group">
+              <ToolbarItem visibility={{ default: 'visible' }} isSelected={isDrawerExpanded}>
+                <NotificationBadge
+                  variant={this.getNumberUnread() === 0 ? 'read' : 'unread'}
+                  onClick={this.onCloseNotificationDrawer}
+                  aria-label="Notifications"
+                >
+                  <BellIcon />
+                </NotificationBadge>
+              </ToolbarItem>
+              <ToolbarGroup
+                variant="icon-button-group"
+                visibility={{
+                  default: 'hidden',
+                  lg: 'visible'
+                }} /** the settings and help icon buttons are only visible on desktop sizes and replaced by a kebab dropdown for other sizes */
+              >
+                <ToolbarItem>
+                  <Button aria-label="Settings actions" variant={ButtonVariant.plain}>
+                    <CogIcon />
+                  </Button>
+                </ToolbarItem>
+                <ToolbarItem>
+                  <Button aria-label="Help actions" variant={ButtonVariant.plain}>
+                    <HelpIcon />
+                  </Button>
+                </ToolbarItem>
+              </ToolbarGroup>
+            </ToolbarGroup>
+            <ToolbarGroup>
+              <ToolbarItem
+                visibility={{
+                  lg: 'hidden'
+                }} /** this kebab dropdown replaces the icon buttons and is hidden for desktop sizes */
+              >
+                <Dropdown
+                  isPlain
+                  position="right"
+                  onSelect={this.onKebabDropdownSelect}
+                  toggle={<KebabToggle onToggle={this.onKebabDropdownToggle} />}
+                  isOpen={isKebabDropdownOpen}
+                  dropdownItems={kebabDropdownItems}
+                />
+              </ToolbarItem>
+              <ToolbarItem
+                visibility={{ default: 'hidden', md: 'visible' }} /** this user dropdown is hidden on mobile sizes */
+              >
+                <Dropdown
+                  isPlain
+                  position="right"
+                  onSelect={this.onDropdownSelect}
+                  isOpen={isDropdownOpen}
+                  toggle={<DropdownToggle onToggle={this.onDropdownToggle}>John Smith</DropdownToggle>}
+                  dropdownItems={userDropdownItems}
+                />
+              </ToolbarItem>
+            </ToolbarGroup>
+            <Avatar src={imgAvatar} alt="Avatar image" />
+          </ToolbarGroup>
+        </ToolbarContent>
+      </Toolbar>
     );
 
     const Header = (
-      <PageHeader logo={<Brand src={imgBrand} alt="Patternfly Logo" />} headerTools={headerTools} showNavToggle />
+      <Masthead>
+        <MastheadToggle>
+          <PageToggleButton variant="plain" aria-label="Global navigation">
+            <BarsIcon />
+          </PageToggleButton>
+        </MastheadToggle>
+        <MastheadMain>
+          <MastheadBrand>
+            <Brand src={imgBrand} alt="Patternfly logo" />
+          </MastheadBrand>
+        </MastheadMain>
+        <MastheadContent>{headerToolbar}</MastheadContent>
+      </Masthead>
     );
     const Sidebar = <PageSidebar nav={PageNav} />;
     const pageId = 'main-content-page-layout-default-nav';
@@ -291,9 +324,9 @@ class BasicNotificationDrawer extends React.Component {
         </BreadcrumbItem>
       </Breadcrumb>
     );
-    
-    const drawerContent = "Panel content";
-    
+
+    const drawerContent = 'Panel content';
+
     const notificationDrawerActions = [
       <DropdownItem key="markAllRead" onClick={this.markAllRead} component="button">
         Mark all read
@@ -301,14 +334,14 @@ class BasicNotificationDrawer extends React.Component {
       <DropdownItem key="clearAll" onClick={() => this.showNotifications(false)} component="button">
         Clear all
       </DropdownItem>,
-      <DropdownItem key="unclearLast" onClick={() => this.showNotifications(true)}component="button">
+      <DropdownItem key="unclearLast" onClick={() => this.showNotifications(true)} component="button">
         Unclear last
       </DropdownItem>,
       <DropdownItem key="settings" component="button">
         Settings
-      </DropdownItem>,
+      </DropdownItem>
     ];
-    
+
     const notificationDrawerDropdownItems = [
       <DropdownItem key="link">Link</DropdownItem>,
       <DropdownItem key="action" component="button">
@@ -319,7 +352,7 @@ class BasicNotificationDrawer extends React.Component {
         Disabled Link
       </DropdownItem>
     ];
-    
+
     const notificationDrawer = (
       <NotificationDrawer>
         <NotificationDrawerHeader count={this.getNumberUnread()} onClose={this.onCloseNotificationDrawer}>
@@ -336,7 +369,11 @@ class BasicNotificationDrawer extends React.Component {
         <NotificationDrawerBody>
           {showNotifications && (
             <NotificationDrawerList>
-              <NotificationDrawerListItem variant="info" onClick={() => this.onListItemClick("notification-1")} isRead={isUnreadMap === null || !isUnreadMap["notification-1"]}>
+              <NotificationDrawerListItem
+                variant="info"
+                onClick={() => this.onListItemClick('notification-1')}
+                isRead={isUnreadMap === null || !isUnreadMap['notification-1']}
+              >
                 <NotificationDrawerListItemHeader
                   variant="info"
                   title="Unread info notification title"
@@ -356,7 +393,11 @@ class BasicNotificationDrawer extends React.Component {
                   This is an info notification description.
                 </NotificationDrawerListItemBody>
               </NotificationDrawerListItem>
-              <NotificationDrawerListItem variant="danger" onClick={() => this.onListItemClick("notification-2")} isRead={isUnreadMap === null || !isUnreadMap["notification-2"]}>
+              <NotificationDrawerListItem
+                variant="danger"
+                onClick={() => this.onListItemClick('notification-2')}
+                isRead={isUnreadMap === null || !isUnreadMap['notification-2']}
+              >
                 <NotificationDrawerListItemHeader
                   variant="danger"
                   title="Unread danger notification title. This is a long title to show how the title will wrap if it is long and wraps to multiple lines."
@@ -373,11 +414,15 @@ class BasicNotificationDrawer extends React.Component {
                   />
                 </NotificationDrawerListItemHeader>
                 <NotificationDrawerListItemBody timestamp="10 minutes ago">
-                  This is a danger notification description. This is a long description to show how the title will wrap if
-                  it is long and wraps to multiple lines.
+                  This is a danger notification description. This is a long description to show how the title will wrap
+                  if it is long and wraps to multiple lines.
                 </NotificationDrawerListItemBody>
               </NotificationDrawerListItem>
-              <NotificationDrawerListItem variant="warning" onClick={() => this.onListItemClick("notification-3")} isRead={isUnreadMap === null || !isUnreadMap["notification-3"]}>
+              <NotificationDrawerListItem
+                variant="warning"
+                onClick={() => this.onListItemClick('notification-3')}
+                isRead={isUnreadMap === null || !isUnreadMap['notification-3']}
+              >
                 <NotificationDrawerListItemHeader
                   variant="warning"
                   title="Read warning notification title"
@@ -397,7 +442,11 @@ class BasicNotificationDrawer extends React.Component {
                   This is a warning notification description.
                 </NotificationDrawerListItemBody>
               </NotificationDrawerListItem>
-              <NotificationDrawerListItem variant="success" onClick={() => this.onListItemClick("notification-4")} isRead={isUnreadMap === null || !isUnreadMap["notification-4"]}>
+              <NotificationDrawerListItem
+                variant="success"
+                onClick={() => this.onListItemClick('notification-4')}
+                isRead={isUnreadMap === null || !isUnreadMap['notification-4']}
+              >
                 <NotificationDrawerListItemHeader
                   variant="success"
                   title="Read success notification title"
@@ -470,6 +519,7 @@ class BasicNotificationDrawer extends React.Component {
 ```
 
 ### Grouped
+
 ```js isFullscreen
 import React from 'react';
 import {
@@ -510,7 +560,6 @@ import {
   NotificationDrawerListItemBody,
   NotificationDrawerListItemHeader,
   Page,
-  PageHeader,
   PageSection,
   PageSectionVariants,
   PageSidebar,
@@ -518,13 +567,22 @@ import {
   Title,
   TextContent,
   Text,
-  PageHeaderTools,
-  PageHeaderToolsGroup,
-  PageHeaderToolsItem
+  PageToggleButton,
+  Masthead,
+  MastheadMain,
+  MastheadToggle,
+  MastheadContent,
+  MastheadBrand,
+  Toolbar,
+  ToolbarItem,
+  ToolbarGroup,
+  ToolbarContent
 } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import BellIcon from '@patternfly/react-icons/dist/esm/icons/bell-icon';
 import CogIcon from '@patternfly/react-icons/dist/esm/icons/cog-icon';
+import AttentionBellIcon from '@patternfly/react-icons/dist/esm/icons/attention-bell-icon';
+import BarsIcon from '@patternfly/react-icons/dist/esm/icons/bars-icon';
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 import imgBrand from '@patternfly/react-core/src/components/Brand/examples/pfLogo.svg';
 import imgAvatar from '@patternfly/react-core/src/components/Avatar/examples/avatarImg.svg';
@@ -544,15 +602,15 @@ class GroupedNotificationDrawer extends React.Component {
       isActionsMenuOpen: null,
       showNotifications: true,
       isUnreadMap: {
-        "group-1": {
-          "notification-5": true,
-          "notification-6": true
+        'group-1': {
+          'notification-5': true,
+          'notification-6': true
         },
-        "group-2": {
-          "notification-9": true,
-          "notification-10": true 
+        'group-2': {
+          'notification-9': true,
+          'notification-10': true
         },
-        "group-3": null
+        'group-3': null
       }
     };
     this.onDropdownToggle = isDropdownOpen => {
@@ -584,27 +642,27 @@ class GroupedNotificationDrawer extends React.Component {
         activeItem: result.itemId
       });
     };
-    
+
     this.onCloseNotificationDrawer = () => {
       this.setState(prevState => {
         return {
           isDrawerExpanded: !prevState.isDrawerExpanded
-        }
+        };
       });
     };
-    
+
     this.onToggle = (id, isOpen) => {
       this.setState({
         isActionsMenuOpen: { [id]: isOpen }
       });
     };
-    
+
     this.onSelect = event => {
       this.setState({
         isActionsMenuOpen: null
       });
     };
-    
+
     this.onListItemClick = (groupId, id) => {
       this.setState(prevState => {
         if (!prevState.isUnreadMap || !prevState.isUnreadMap[groupId]) return;
@@ -612,62 +670,61 @@ class GroupedNotificationDrawer extends React.Component {
         prevState.isUnreadMap[groupId][id] = false;
         return {
           isUnreadMap: prevState.isUnreadMap
-        }
+        };
       });
-    }
-    
+    };
+
     this.isUnread = (groupId, id) => {
-      const { isUnreadMap } = this.state
+      const { isUnreadMap } = this.state;
       return isUnreadMap && isUnreadMap[groupId] && isUnreadMap[groupId][id];
-    }
-    
-    this.getNumberUnread = (groupId) => {
-      const { isUnreadMap } = this.state
-      if (isUnreadMap === null) return 0
-      
+    };
+
+    this.getNumberUnread = groupId => {
+      const { isUnreadMap } = this.state;
+      if (isUnreadMap === null) return 0;
+
       if (groupId) {
         if (isUnreadMap[groupId] === null) return 0;
-        
+
         return Object.keys(isUnreadMap[groupId]).reduce((count, id) => {
           return isUnreadMap[groupId][id] ? count + 1 : count;
         }, 0);
       }
-      
+
       return Object.keys(isUnreadMap).reduce((count, groupId) => {
         if (isUnreadMap[groupId] === null) return count;
-                
+
         return Object.keys(isUnreadMap[groupId]).reduce((groupCount, id) => {
           return isUnreadMap[groupId][id] ? groupCount + 1 : groupCount;
         }, count);
-        
       }, 0);
-    }
-    
+    };
+
     this.markAllRead = () => {
       this.setState({
         isUnreadMap: null
       });
-    }
-    
-    this.showNotifications = (showNotifications) => {
+    };
+
+    this.showNotifications = showNotifications => {
       this.setState({
         isUnreadMap: null,
         showNotifications: showNotifications
       });
-    }
-    
+    };
+
     this.toggleFirstDrawer = (event, value) => {
       this.setState({
         firstDrawerGroupExpanded: value
       });
     };
-    
+
     this.toggleSecondDrawer = (event, value) => {
       this.setState({
         secondDrawerGroupExpanded: value
       });
     };
-    
+
     this.toggleThirdDrawer = (event, value) => {
       this.setState({
         thirdDrawerGroupExpanded: value
@@ -676,20 +733,20 @@ class GroupedNotificationDrawer extends React.Component {
   }
 
   render() {
-    const { 
-      isDropdownOpen, 
-      isKebabDropdownOpen, 
-      activeItem, 
-      res, 
+    const {
+      isDropdownOpen,
+      isKebabDropdownOpen,
+      activeItem,
+      res,
       isDrawerExpanded,
       isActionsMenuOpen,
-      isUnreadMap, 
+      isUnreadMap,
       showNotifications,
-      firstDrawerGroupExpanded, 
-      secondDrawerGroupExpanded, 
+      firstDrawerGroupExpanded,
+      secondDrawerGroupExpanded,
       thirdDrawerGroupExpanded
     } = this.state;
-    
+
     const PageNav = (
       <Nav onSelect={this.onNavSelect} aria-label="Nav">
         <NavList>
@@ -728,64 +785,87 @@ class GroupedNotificationDrawer extends React.Component {
         <DropdownItem key="group 2 logout">Logout</DropdownItem>
       </DropdownGroup>
     ];
-    const headerTools = (
-      <PageHeaderTools>
-        <PageHeaderToolsItem visibility={{default: 'visible'}} isSelected={isDrawerExpanded}>
-          <NotificationBadge variant={this.getNumberUnread() === 0 ? 'read' : 'unread'} onClick={this.onCloseNotificationDrawer} aria-label="Notifications">
-            <BellIcon />
-          </NotificationBadge>
-        </PageHeaderToolsItem>
-        <PageHeaderToolsGroup
-          visibility={{
-            default: 'hidden',
-            lg: 'visible'
-          }} /** the notificaitons, settings, and help icon buttons are only visible on desktop sizes and replaced by a kebab dropdown for other sizes */
-        >
-          <PageHeaderToolsItem>
-            <Button aria-label="Settings actions" variant={ButtonVariant.plain}>
-              <CogIcon />
-            </Button>
-          </PageHeaderToolsItem>
-          <PageHeaderToolsItem>
-            <Button aria-label="Help actions" variant={ButtonVariant.plain}>
-              <HelpIcon />
-            </Button>
-          </PageHeaderToolsItem>
-        </PageHeaderToolsGroup>
-        <PageHeaderToolsGroup>
-          <PageHeaderToolsItem
-            visibility={{
-              lg: 'hidden'
-            }} /** this kebab dropdown replaces the icon buttons and is hidden for desktop sizes */
-          >
-            <Dropdown
-              isPlain
-              position="right"
-              onSelect={this.onKebabDropdownSelect}
-              toggle={<KebabToggle onToggle={this.onKebabDropdownToggle} />}
-              isOpen={isKebabDropdownOpen}
-              dropdownItems={kebabDropdownItems}
-            />
-          </PageHeaderToolsItem>
-          <PageHeaderToolsItem
-            visibility={{ default: 'hidden', md: 'visible' }} /** this user dropdown is hidden on mobile sizes */
-          >
-            <Dropdown
-              isPlain
-              position="right"
-              onSelect={this.onDropdownSelect}
-              isOpen={isDropdownOpen}
-              toggle={<DropdownToggle onToggle={this.onDropdownToggle}>John Smith</DropdownToggle>}
-              dropdownItems={userDropdownItems}
-            />
-          </PageHeaderToolsItem>
-        </PageHeaderToolsGroup>
-        <Avatar src={imgAvatar} alt="Avatar image" />
-      </PageHeaderTools>
+    const headerToolbar = (
+      <Toolbar>
+        <ToolbarContent>
+          <ToolbarGroup alignment={{ default: 'alignRight' }}>
+            <ToolbarGroup variant="icon-button-group">
+              <ToolbarItem visibility={{ default: 'visible' }} isSelected={isDrawerExpanded}>
+                <NotificationBadge
+                  variant={this.getNumberUnread() === 0 ? 'read' : 'unread'}
+                  onClick={this.onCloseNotificationDrawer}
+                  aria-label="Notifications"
+                >
+                  <BellIcon />
+                </NotificationBadge>
+              </ToolbarItem>
+              <ToolbarGroup
+                variant="icon-button-group"
+                visibility={{
+                  default: 'hidden',
+                  lg: 'visible'
+                }} /** the settings and help icon buttons are only visible on desktop sizes and replaced by a kebab dropdown for other sizes */
+              >
+                <ToolbarItem>
+                  <Button aria-label="Settings actions" variant={ButtonVariant.plain}>
+                    <CogIcon />
+                  </Button>
+                </ToolbarItem>
+                <ToolbarItem>
+                  <Button aria-label="Help actions" variant={ButtonVariant.plain}>
+                    <HelpIcon />
+                  </Button>
+                </ToolbarItem>
+              </ToolbarGroup>
+            </ToolbarGroup>
+            <ToolbarGroup>
+              <ToolbarItem
+                visibility={{
+                  lg: 'hidden'
+                }} /** this kebab dropdown replaces the icon buttons and is hidden for desktop sizes */
+              >
+                <Dropdown
+                  isPlain
+                  position="right"
+                  onSelect={this.onKebabDropdownSelect}
+                  toggle={<KebabToggle onToggle={this.onKebabDropdownToggle} />}
+                  isOpen={isKebabDropdownOpen}
+                  dropdownItems={kebabDropdownItems}
+                />
+              </ToolbarItem>
+              <ToolbarItem
+                visibility={{ default: 'hidden', md: 'visible' }} /** this user dropdown is hidden on mobile sizes */
+              >
+                <Dropdown
+                  isPlain
+                  position="right"
+                  onSelect={this.onDropdownSelect}
+                  isOpen={isDropdownOpen}
+                  toggle={<DropdownToggle onToggle={this.onDropdownToggle}>John Smith</DropdownToggle>}
+                  dropdownItems={userDropdownItems}
+                />
+              </ToolbarItem>
+            </ToolbarGroup>
+            <Avatar src={imgAvatar} alt="Avatar image" />
+          </ToolbarGroup>
+        </ToolbarContent>
+      </Toolbar>
     );
 
     const Header = (
-      <PageHeader logo={<Brand src={imgBrand} alt="Patternfly Logo" />} headerTools={headerTools} showNavToggle />
+      <Masthead>
+        <MastheadToggle>
+          <PageToggleButton variant="plain" aria-label="Global navigation">
+            <BarsIcon />
+          </PageToggleButton>
+        </MastheadToggle>
+        <MastheadMain>
+          <MastheadBrand>
+            <Brand src={imgBrand} alt="Patternfly logo" />
+          </MastheadBrand>
+        </MastheadMain>
+        <MastheadContent>{headerToolbar}</MastheadContent>
+      </Masthead>
     );
     const Sidebar = <PageSidebar nav={PageNav} />;
     const pageId = 'main-content-page-layout-default-nav';
@@ -801,9 +881,9 @@ class GroupedNotificationDrawer extends React.Component {
         </BreadcrumbItem>
       </Breadcrumb>
     );
-    
-    const drawerContent = "Panel content";
-    
+
+    const drawerContent = 'Panel content';
+
     const notificationDrawerDropdownItems = [
       <DropdownItem key="link">Link</DropdownItem>,
       <DropdownItem key="action" component="button">
@@ -814,7 +894,7 @@ class GroupedNotificationDrawer extends React.Component {
         Disabled Link
       </DropdownItem>
     ];
-    
+
     const notificationDrawerActions = [
       <DropdownItem key="markAllRead" onClick={this.markAllRead} component="button">
         Mark all read
@@ -822,14 +902,14 @@ class GroupedNotificationDrawer extends React.Component {
       <DropdownItem key="clearAll" onClick={() => this.showNotifications(false)} component="button">
         Clear all
       </DropdownItem>,
-      <DropdownItem key="unclearLast" onClick={() => this.showNotifications(true)}component="button">
+      <DropdownItem key="unclearLast" onClick={() => this.showNotifications(true)} component="button">
         Unclear last
       </DropdownItem>,
       <DropdownItem key="settings" component="button">
         Settings
-      </DropdownItem>,
+      </DropdownItem>
     ];
-    
+
     const notificationDrawer = (
       <NotificationDrawer>
         <NotificationDrawerHeader count={this.getNumberUnread()} onClose={this.onCloseNotificationDrawer}>
@@ -849,11 +929,15 @@ class GroupedNotificationDrawer extends React.Component {
               <NotificationDrawerGroup
                 title="First notification group"
                 isExpanded={firstDrawerGroupExpanded}
-                count={this.getNumberUnread("group-1")}
+                count={this.getNumberUnread('group-1')}
                 onExpand={this.toggleFirstDrawer}
               >
                 <NotificationDrawerList isHidden={!firstDrawerGroupExpanded}>
-                  <NotificationDrawerListItem variant="info" onClick={() => this.onListItemClick("group-1", "notification-5")} isRead={!this.isUnread("group-1","notification-5")}>
+                  <NotificationDrawerListItem
+                    variant="info"
+                    onClick={() => this.onListItemClick('group-1', 'notification-5')}
+                    isRead={!this.isUnread('group-1', 'notification-5')}
+                  >
                     <NotificationDrawerListItemHeader
                       variant="info"
                       title="Unread info notification title"
@@ -875,7 +959,11 @@ class GroupedNotificationDrawer extends React.Component {
                       This is an info notification description.
                     </NotificationDrawerListItemBody>
                   </NotificationDrawerListItem>
-                  <NotificationDrawerListItem variant="danger" onClick={() => this.onListItemClick("group-1", "notification-6")} isRead={!this.isUnread("group-1","notification-6")}>
+                  <NotificationDrawerListItem
+                    variant="danger"
+                    onClick={() => this.onListItemClick('group-1', 'notification-6')}
+                    isRead={!this.isUnread('group-1', 'notification-6')}
+                  >
                     <NotificationDrawerListItemHeader
                       variant="danger"
                       title="Unread danger notification title. This is a long title to show how the title will wrap if it is long and wraps to multiple lines."
@@ -898,7 +986,11 @@ class GroupedNotificationDrawer extends React.Component {
                       wrap if it is long and wraps to multiple lines.
                     </NotificationDrawerListItemBody>
                   </NotificationDrawerListItem>
-                  <NotificationDrawerListItem variant="warning" onClick={() => this.onListItemClick("group-1", "notification-7")} isRead={!this.isUnread("group-1","notification-7")}>
+                  <NotificationDrawerListItem
+                    variant="warning"
+                    onClick={() => this.onListItemClick('group-1', 'notification-7')}
+                    isRead={!this.isUnread('group-1', 'notification-7')}
+                  >
                     <NotificationDrawerListItemHeader
                       variant="warning"
                       title="Read warning notification title"
@@ -920,7 +1012,11 @@ class GroupedNotificationDrawer extends React.Component {
                       This is a warning notification description.
                     </NotificationDrawerListItemBody>
                   </NotificationDrawerListItem>
-                  <NotificationDrawerListItem variant="success" onClick={() => this.onListItemClick("group-1", "notification-8")} isRead={!this.isUnread("group-1","notification-8")}>
+                  <NotificationDrawerListItem
+                    variant="success"
+                    onClick={() => this.onListItemClick('group-1', 'notification-8')}
+                    isRead={!this.isUnread('group-1', 'notification-8')}
+                  >
                     <NotificationDrawerListItemHeader
                       variant="success"
                       title="Read success notification title"
@@ -948,11 +1044,15 @@ class GroupedNotificationDrawer extends React.Component {
               <NotificationDrawerGroup
                 title="Second notification group"
                 isExpanded={secondDrawerGroupExpanded}
-                count={this.getNumberUnread("group-2")}
+                count={this.getNumberUnread('group-2')}
                 onExpand={this.toggleSecondDrawer}
               >
                 <NotificationDrawerList isHidden={!secondDrawerGroupExpanded}>
-                  <NotificationDrawerListItem variant="info" onClick={() => this.onListItemClick("group-2", "notification-9")} isRead={!this.isUnread("group-2","notification-9")}>
+                  <NotificationDrawerListItem
+                    variant="info"
+                    onClick={() => this.onListItemClick('group-2', 'notification-9')}
+                    isRead={!this.isUnread('group-2', 'notification-9')}
+                  >
                     <NotificationDrawerListItemHeader
                       variant="info"
                       title="Unread info notification title"
@@ -974,7 +1074,11 @@ class GroupedNotificationDrawer extends React.Component {
                       This is an info notification description.
                     </NotificationDrawerListItemBody>
                   </NotificationDrawerListItem>
-                  <NotificationDrawerListItem variant="danger" onClick={() => this.onListItemClick("group-2", "notification-10")} isRead={!this.isUnread("group-2","notification-10")}>
+                  <NotificationDrawerListItem
+                    variant="danger"
+                    onClick={() => this.onListItemClick('group-2', 'notification-10')}
+                    isRead={!this.isUnread('group-2', 'notification-10')}
+                  >
                     <NotificationDrawerListItemHeader
                       variant="danger"
                       title="Unread danger notification title. This is a long title to show how the title will wrap if it is long and wraps to multiple lines."
@@ -997,7 +1101,11 @@ class GroupedNotificationDrawer extends React.Component {
                       wrap if it is long and wraps to multiple lines.
                     </NotificationDrawerListItemBody>
                   </NotificationDrawerListItem>
-                  <NotificationDrawerListItem variant="warning" onClick={() => this.onListItemClick("group-2", "notification-11")} isRead={!this.isUnread("group-2","notification-11")}>
+                  <NotificationDrawerListItem
+                    variant="warning"
+                    onClick={() => this.onListItemClick('group-2', 'notification-11')}
+                    isRead={!this.isUnread('group-2', 'notification-11')}
+                  >
                     <NotificationDrawerListItemHeader
                       variant="warning"
                       title="Read warning notification title"
@@ -1019,7 +1127,11 @@ class GroupedNotificationDrawer extends React.Component {
                       This is a warning notification description.
                     </NotificationDrawerListItemBody>
                   </NotificationDrawerListItem>
-                  <NotificationDrawerListItem variant="success" onClick={() => this.onListItemClick("group-2", "notification-12")} isRead={!this.isUnread("group-2","notification-12")}>
+                  <NotificationDrawerListItem
+                    variant="success"
+                    onClick={() => this.onListItemClick('group-2', 'notification-12')}
+                    isRead={!this.isUnread('group-2', 'notification-12')}
+                  >
                     <NotificationDrawerListItemHeader
                       variant="success"
                       title="Read success notification title"
@@ -1047,7 +1159,7 @@ class GroupedNotificationDrawer extends React.Component {
               <NotificationDrawerGroup
                 title="Third notification group"
                 isExpanded={thirdDrawerGroupExpanded}
-                count={this.getNumberUnread("group-3")}
+                count={this.getNumberUnread('group-3')}
                 onExpand={this.toggleThirdDrawer}
               >
                 <NotificationDrawerList isHidden={!thirdDrawerGroupExpanded}>
@@ -1083,7 +1195,7 @@ class GroupedNotificationDrawer extends React.Component {
             </EmptyState>
           )}
         </NotificationDrawerBody>
-    </  NotificationDrawer>
+      </NotificationDrawer>
     );
 
     return (

--- a/packages/react-core/src/demos/NotificationDrawer/NotificationDrawer.md
+++ b/packages/react-core/src/demos/NotificationDrawer/NotificationDrawer.md
@@ -231,7 +231,7 @@ class BasicNotificationDrawer extends React.Component {
     const headerToolbar = (
       <Toolbar>
         <ToolbarContent>
-          <ToolbarGroup alignment={{ default: 'alignRight' }}>
+          <ToolbarGroup spaceItems={{ default: 'spacerNone' }} alignment={{ default: 'alignRight' }}>
             <ToolbarGroup variant="icon-button-group">
               <ToolbarItem visibility={{ default: 'visible' }} isSelected={isDrawerExpanded}>
                 <NotificationBadge
@@ -280,16 +280,18 @@ class BasicNotificationDrawer extends React.Component {
                 visibility={{ default: 'hidden', md: 'visible' }} /** this user dropdown is hidden on mobile sizes */
               >
                 <Dropdown
-                  isPlain
                   position="right"
                   onSelect={this.onDropdownSelect}
                   isOpen={isDropdownOpen}
-                  toggle={<DropdownToggle onToggle={this.onDropdownToggle}>John Smith</DropdownToggle>}
+                  toggle={
+                    <DropdownToggle icon={<Avatar src={imgAvatar} alt="Avatar" />} onToggle={this.onDropdownToggle}>
+                      John Smith
+                    </DropdownToggle>
+                  }
                   dropdownItems={userDropdownItems}
                 />
               </ToolbarItem>
             </ToolbarGroup>
-            <Avatar src={imgAvatar} alt="Avatar image" />
           </ToolbarGroup>
         </ToolbarContent>
       </Toolbar>
@@ -788,7 +790,7 @@ class GroupedNotificationDrawer extends React.Component {
     const headerToolbar = (
       <Toolbar>
         <ToolbarContent>
-          <ToolbarGroup alignment={{ default: 'alignRight' }}>
+          <ToolbarGroup spaceItems={{ default: 'spacerNone' }} alignment={{ default: 'alignRight' }}>
             <ToolbarGroup variant="icon-button-group">
               <ToolbarItem visibility={{ default: 'visible' }} isSelected={isDrawerExpanded}>
                 <NotificationBadge
@@ -837,16 +839,18 @@ class GroupedNotificationDrawer extends React.Component {
                 visibility={{ default: 'hidden', md: 'visible' }} /** this user dropdown is hidden on mobile sizes */
               >
                 <Dropdown
-                  isPlain
                   position="right"
                   onSelect={this.onDropdownSelect}
                   isOpen={isDropdownOpen}
-                  toggle={<DropdownToggle onToggle={this.onDropdownToggle}>John Smith</DropdownToggle>}
+                  toggle={
+                    <DropdownToggle icon={<Avatar src={imgAvatar} alt="Avatar" />} onToggle={this.onDropdownToggle}>
+                      John Smith
+                    </DropdownToggle>
+                  }
                   dropdownItems={userDropdownItems}
                 />
               </ToolbarItem>
             </ToolbarGroup>
-            <Avatar src={imgAvatar} alt="Avatar image" />
           </ToolbarGroup>
         </ToolbarContent>
       </Toolbar>

--- a/packages/react-core/src/demos/Wizard/WizardDemo.md
+++ b/packages/react-core/src/demos/Wizard/WizardDemo.md
@@ -3,29 +3,30 @@ id: Wizard
 section: components
 ---
 
-import { 
- Brand,
- Breadcrumb,
- BreadcrumbItem,
- Modal,
- ModalVariant,
- Nav,
- NavItem,
- NavList,
- Page,
- PageHeader,
- PageSection,
- PageSectionTypes,
- PageSectionVariants,
- PageSidebar,
- Progress,
- SkipToContent,
- Text,
- TextContent,
- Title,
- Wizard
+import {
+Brand,
+Breadcrumb,
+BreadcrumbItem,
+Modal,
+ModalVariant,
+Nav,
+NavItem,
+NavList,
+Page,
+PageToggleButton,
+PageSection,
+PageSectionTypes,
+PageSectionVariants,
+PageSidebar,
+Progress,
+SkipToContent,
+Text,
+TextContent,
+Title,
+Wizard
 } from '@patternfly/react-core';
 import imgBrand from './imgBrand.svg';
+import BarsIcon from '@patternfly/react-icons/dist/js/icons/bars-icon';
 
 ## Demos
 
@@ -39,22 +40,22 @@ class BasicWizardDemo extends React.Component {
   render() {
     const steps = [
       { id: 0, name: 'Information', component: <p>Step 1 content</p> },
-      { 
+      {
         id: 1,
-        name: 'Configuration', 
+        name: 'Configuration',
         steps: [
           {
             id: 2,
             name: 'Substep A',
             component: <p>Configuration substep A</p>
           },
-          { 
-            id: 3, 
-            name: 'Substep B', 
+          {
+            id: 3,
+            name: 'Substep B',
             component: <p>Configuration substep B</p>
           }
         ],
-        component: <p>Step 2 content</p> 
+        component: <p>Step 2 content</p>
       },
       { id: 4, name: 'Additional', component: <p>Step 3 content</p> },
       { id: 5, name: 'Review', component: <p>Review step content</p>, nextButtonText: 'Finish' }
@@ -83,7 +84,6 @@ class BasicWizardDemo extends React.Component {
     );
   }
 }
-
 ```
 
 ### In Page
@@ -98,7 +98,6 @@ import {
   NavItem,
   NavList,
   Page,
-  PageHeader,
   PageSection,
   PageSectionTypes,
   PageSectionVariants,
@@ -108,15 +107,21 @@ import {
   Text,
   TextContent,
   Title,
-  Wizard
+  Wizard,
+  Masthead,
+  PageToggleButton,
+  MastheadToggle,
+  MastheadMain,
+  MastheadBrand
 } from '@patternfly/react-core';
 import imgBrand from './imgBrand.svg';
+import BarsIcon from '@patternfly/react-icons/dist/js/icons/bars-icon';
 
 class FullPageWizard extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      activeItem: 0,
+      activeItem: 0
     };
     this.onNavSelect = result => {
       this.setState({
@@ -125,9 +130,7 @@ class FullPageWizard extends React.Component {
     };
   }
   render() {
-    const {
-      activeItem
-    } = this.state;
+    const { activeItem } = this.state;
     const PageNav = (
       <Nav onSelect={this.onNavSelect} aria-label="Nav">
         <NavList>
@@ -150,10 +153,18 @@ class FullPageWizard extends React.Component {
       </Nav>
     );
     const Header = (
-      <PageHeader
-        logo={<Brand src={imgBrand} alt="Patternfly Logo" />}
-        showNavToggle
-      />
+      <Masthead id="basic">
+        <MastheadToggle>
+          <PageToggleButton variant="plain" aria-label="Global navigation">
+            <BarsIcon />
+          </PageToggleButton>
+        </MastheadToggle>
+        <MastheadMain>
+          <MastheadBrand>
+            <Brand src={imgBrand} alt="Patternfly logo" />
+          </MastheadBrand>
+        </MastheadMain>
+      </Masthead>
     );
     const Sidebar = <PageSidebar nav={PageNav} />;
     const pageId = 'main-content-page-layout-default-nav';
@@ -168,31 +179,31 @@ class FullPageWizard extends React.Component {
         </BreadcrumbItem>
       </Breadcrumb>
     );
-    
+
     const steps = [
       { id: 0, name: 'Information', component: <p>Step 1 content</p> },
-      { 
+      {
         id: 1,
-        name: 'Configuration', 
+        name: 'Configuration',
         steps: [
           {
             id: 2,
             name: 'Substep A',
             component: <p>Configuration substep A</p>
           },
-          { 
-            id: 3, 
-            name: 'Substep B', 
+          {
+            id: 3,
+            name: 'Substep B',
             component: <p>Configuration substep B</p>
           }
         ],
-        component: <p>Step 2 content</p> 
+        component: <p>Step 2 content</p>
       },
       { id: 4, name: 'Additional', component: <p>Step 3 content</p> },
       { id: 5, name: 'Review', component: <p>Review step content</p>, nextButtonText: 'Finish' }
     ];
     const title = 'Basic wizard';
-    
+
     return (
       <React.Fragment>
         <Page
@@ -206,22 +217,15 @@ class FullPageWizard extends React.Component {
           <PageSection variant={PageSectionVariants.light}>
             <TextContent>
               <Text component="h1">Main title</Text>
-              <Text component="p">
-                A demo of a wizard in a page.
-              </Text>
+              <Text component="p">A demo of a wizard in a page.</Text>
             </TextContent>
           </PageSection>
           <PageSection type={PageSectionTypes.wizard} variant={PageSectionVariants.light}>
-            <Wizard
-              navAriaLabel={`${title} steps`}
-              mainAriaLabel={`${title} content`}
-              steps={steps}
-            />
+            <Wizard navAriaLabel={`${title} steps`} mainAriaLabel={`${title} content`} steps={steps} />
           </PageSection>
         </Page>
       </React.Fragment>
     );
   }
 }
-
 ```

--- a/packages/react-core/src/demos/examples/DashboardHeader.js
+++ b/packages/react-core/src/demos/examples/DashboardHeader.js
@@ -9,13 +9,22 @@ import {
   DropdownToggle,
   DropdownItem,
   KebabToggle,
-  PageHeader,
-  PageHeaderTools,
-  PageHeaderToolsGroup,
-  PageHeaderToolsItem
+  Masthead,
+  MastheadToggle,
+  MastheadMain,
+  MastheadBrand,
+  MastheadContent,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+  PageContextConsumer,
+  Divider
 } from '@patternfly/react-core';
+import BarsIcon from '@patternfly/react-icons/dist/esm/icons/bars-icon';
 import CogIcon from '@patternfly/react-icons/dist/esm/icons/cog-icon';
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
+import AttentionBellIcon from '@patternfly/react-icons/dist/esm/icons/attention-bell-icon';
 import imgBrand from './pfColorLogo.svg';
 import imgAvatar from '@patternfly/react-core/src/components/Avatar/examples/avatarImg.svg';
 
@@ -25,6 +34,7 @@ export default class DashboardHeader extends React.Component {
     this.state = {
       isDropdownOpen: false,
       isKebabDropdownOpen: false,
+      isFullKebabDropdownOpen: false,
       activeItem: 0
     };
 
@@ -51,10 +61,22 @@ export default class DashboardHeader extends React.Component {
         isKebabDropdownOpen: !this.state.isKebabDropdownOpen
       });
     };
+
+    this.onFullKebabToggle = isFullKebabDropdownOpen => {
+      this.setState({
+        isFullKebabDropdownOpen
+      });
+    };
+
+    this.onFullKebabSelect = () => {
+      this.setState({
+        isFullKebabDropdownOpen: !this.state.isFullKebabDropdownOpen
+      });
+    };
   }
 
   render() {
-    const { isDropdownOpen, isKebabDropdownOpen } = this.state;
+    const { isDropdownOpen, isKebabDropdownOpen, isFullKebabDropdownOpen } = this.state;
 
     const kebabDropdownItems = [
       <DropdownItem key="kebab-1">
@@ -73,61 +95,116 @@ export default class DashboardHeader extends React.Component {
         <DropdownItem key="group 2 logout">Logout</DropdownItem>
       </DropdownGroup>
     ];
-    const headerTools = (
-      <PageHeaderTools>
-        <PageHeaderToolsGroup
-          visibility={{
-            default: 'hidden',
-            lg: 'visible'
-          }} /** the settings and help icon buttons are only visible on desktop sizes and replaced by a kebab dropdown for other sizes */
-        >
-          <PageHeaderToolsItem>
-            <Button aria-label="Settings actions" variant={ButtonVariant.plain}>
-              <CogIcon />
-            </Button>
-          </PageHeaderToolsItem>
-          <PageHeaderToolsItem>
-            <Button aria-label="Help actions" variant={ButtonVariant.plain}>
-              <HelpIcon />
-            </Button>
-          </PageHeaderToolsItem>
-        </PageHeaderToolsGroup>
-        <PageHeaderToolsGroup>
-          <PageHeaderToolsItem
-            visibility={{
-              lg: 'hidden'
-            }} /** this kebab dropdown replaces the icon buttons and is hidden for desktop sizes */
-          >
-            <Dropdown
-              isPlain
-              position="right"
-              onSelect={this.onKebabDropdownSelect}
-              toggle={<KebabToggle onToggle={this.onKebabDropdownToggle} />}
-              isOpen={isKebabDropdownOpen}
-              dropdownItems={kebabDropdownItems}
-            />
-          </PageHeaderToolsItem>
-          <PageHeaderToolsItem
-            visibility={{ default: 'hidden', md: 'visible' }} /** this user dropdown is hidden on mobile sizes */
-          >
-            <Dropdown
-              isPlain
-              position="right"
-              onSelect={this.onDropdownSelect}
-              isOpen={isDropdownOpen}
-              toggle={<DropdownToggle onToggle={this.onDropdownToggle}>John Smith</DropdownToggle>}
-              dropdownItems={userDropdownItems}
-            />
-          </PageHeaderToolsItem>
-        </PageHeaderToolsGroup>
-        <Avatar src={imgAvatar} alt="Avatar image" />
-      </PageHeaderTools>
-    );
 
-    const _header = (
-      <PageHeader logo={<Brand src={imgBrand} alt="Patternfly Logo" />} headerTools={headerTools} showNavToggle />
-    );
+    const fullKebabItems = [
+      <DropdownGroup key="group 2">
+        <DropdownItem key="group 2 profile">My profile</DropdownItem>
+        <DropdownItem key="group 2 user" component="button">
+          User management
+        </DropdownItem>
+        <DropdownItem key="group 2 logout">Logout</DropdownItem>
+      </DropdownGroup>,
+      <Divider key="divider" />,
+      <DropdownItem key="kebab-1">
+        <CogIcon /> Settings
+      </DropdownItem>,
+      <DropdownItem key="kebab-2">
+        <HelpIcon /> Help
+      </DropdownItem>
+    ];
 
-    return _header;
+    return (
+      <PageContextConsumer>
+        {({ onNavToggle: managedOnNavToggle, isNavOpen: managedIsNavOpen }) => {
+          const headerToolbar = (
+            <Toolbar id="toolbar" isFullHeight isStatic>
+              <ToolbarContent>
+                <ToolbarGroup
+                  variant="icon-button-group"
+                  alignment={{ default: 'alignRight' }}
+                  spacer={{ default: 'spacerNone', md: 'spacerMd' }}
+                >
+                  <ToolbarItem>
+                    <Button aria-label="Notifications" variant={ButtonVariant.plain}>
+                      <AttentionBellIcon />
+                    </Button>
+                  </ToolbarItem>
+                  <ToolbarGroup variant="icon-button-group" visibility={{ default: 'hidden', lg: 'visible' }}>
+                    <ToolbarItem>
+                      <Button aria-label="Settings actions" variant={ButtonVariant.plain}>
+                        <CogIcon />
+                      </Button>
+                    </ToolbarItem>
+                    <ToolbarItem>
+                      <Button aria-label="Help actions" variant={ButtonVariant.plain}>
+                        <HelpIcon />
+                      </Button>
+                    </ToolbarItem>
+                  </ToolbarGroup>
+                </ToolbarGroup>
+                <ToolbarItem visibility={{ default: 'hidden', md: 'visible', lg: 'hidden' }}>
+                  <Dropdown
+                    isPlain
+                    position="right"
+                    onSelect={this.onKebabDropdownSelect}
+                    toggle={<KebabToggle onToggle={this.onKebabDropdownToggle} />}
+                    isOpen={isKebabDropdownOpen}
+                    dropdownItems={kebabDropdownItems}
+                  />
+                </ToolbarItem>
+                <ToolbarItem
+                  visibility={{ default: 'visible', md: 'hidden', lg: 'hidden', xl: 'hidden', '2xl': 'hidden' }}
+                >
+                  <Dropdown
+                    isPlain
+                    position="right"
+                    onSelect={this.onFullKebabSelect}
+                    toggle={<KebabToggle onToggle={this.onFullKebabToggle} />}
+                    isOpen={isFullKebabDropdownOpen}
+                    dropdownItems={fullKebabItems}
+                  />
+                </ToolbarItem>
+                <ToolbarItem visibility={{ default: 'hidden', md: 'visible' }}>
+                  <Dropdown
+                    position="right"
+                    onSelect={this.onDropdownSelect}
+                    isOpen={isDropdownOpen}
+                    toggle={
+                      <DropdownToggle icon={<Avatar src={imgAvatar} alt="Avatar" />} onToggle={this.onDropdownToggle}>
+                        John Smith
+                      </DropdownToggle>
+                    }
+                    dropdownItems={userDropdownItems}
+                  />
+                </ToolbarItem>
+              </ToolbarContent>
+            </Toolbar>
+          );
+
+          const masthead = (
+            <Masthead id="basic">
+              <MastheadToggle>
+                <Button
+                  variant="plain"
+                  onClick={managedOnNavToggle}
+                  aria-label="Global navigation"
+                  aria-expanded={managedIsNavOpen ? 'true' : 'false'}
+                >
+                  <BarsIcon />
+                </Button>
+              </MastheadToggle>
+              <MastheadMain>
+                <MastheadBrand>
+                  <Brand src={imgBrand} alt="Patternfly logo" />
+                </MastheadBrand>
+              </MastheadMain>
+              <MastheadContent>{headerToolbar}</MastheadContent>
+            </Masthead>
+          );
+
+          return masthead;
+        }}
+      </PageContextConsumer>
+    );
   }
 }

--- a/packages/react-core/src/demos/examples/DashboardHeader.js
+++ b/packages/react-core/src/demos/examples/DashboardHeader.js
@@ -18,7 +18,7 @@ import {
   ToolbarContent,
   ToolbarGroup,
   ToolbarItem,
-  PageContextConsumer,
+  PageToggleButton,
   Divider
 } from '@patternfly/react-core';
 import BarsIcon from '@patternfly/react-icons/dist/esm/icons/bars-icon';
@@ -113,98 +113,85 @@ export default class DashboardHeader extends React.Component {
       </DropdownItem>
     ];
 
-    return (
-      <PageContextConsumer>
-        {({ onNavToggle: managedOnNavToggle, isNavOpen: managedIsNavOpen }) => {
-          const headerToolbar = (
-            <Toolbar id="toolbar" isFullHeight isStatic>
-              <ToolbarContent>
-                <ToolbarGroup
-                  variant="icon-button-group"
-                  alignment={{ default: 'alignRight' }}
-                  spacer={{ default: 'spacerNone', md: 'spacerMd' }}
-                >
-                  <ToolbarItem>
-                    <Button aria-label="Notifications" variant={ButtonVariant.plain}>
-                      <AttentionBellIcon />
-                    </Button>
-                  </ToolbarItem>
-                  <ToolbarGroup variant="icon-button-group" visibility={{ default: 'hidden', lg: 'visible' }}>
-                    <ToolbarItem>
-                      <Button aria-label="Settings actions" variant={ButtonVariant.plain}>
-                        <CogIcon />
-                      </Button>
-                    </ToolbarItem>
-                    <ToolbarItem>
-                      <Button aria-label="Help actions" variant={ButtonVariant.plain}>
-                        <HelpIcon />
-                      </Button>
-                    </ToolbarItem>
-                  </ToolbarGroup>
-                </ToolbarGroup>
-                <ToolbarItem visibility={{ default: 'hidden', md: 'visible', lg: 'hidden' }}>
-                  <Dropdown
-                    isPlain
-                    position="right"
-                    onSelect={this.onKebabDropdownSelect}
-                    toggle={<KebabToggle onToggle={this.onKebabDropdownToggle} />}
-                    isOpen={isKebabDropdownOpen}
-                    dropdownItems={kebabDropdownItems}
-                  />
-                </ToolbarItem>
-                <ToolbarItem
-                  visibility={{ default: 'visible', md: 'hidden', lg: 'hidden', xl: 'hidden', '2xl': 'hidden' }}
-                >
-                  <Dropdown
-                    isPlain
-                    position="right"
-                    onSelect={this.onFullKebabSelect}
-                    toggle={<KebabToggle onToggle={this.onFullKebabToggle} />}
-                    isOpen={isFullKebabDropdownOpen}
-                    dropdownItems={fullKebabItems}
-                  />
-                </ToolbarItem>
-                <ToolbarItem visibility={{ default: 'hidden', md: 'visible' }}>
-                  <Dropdown
-                    position="right"
-                    onSelect={this.onDropdownSelect}
-                    isOpen={isDropdownOpen}
-                    toggle={
-                      <DropdownToggle icon={<Avatar src={imgAvatar} alt="Avatar" />} onToggle={this.onDropdownToggle}>
-                        John Smith
-                      </DropdownToggle>
-                    }
-                    dropdownItems={userDropdownItems}
-                  />
-                </ToolbarItem>
-              </ToolbarContent>
-            </Toolbar>
-          );
-
-          const masthead = (
-            <Masthead id="basic">
-              <MastheadToggle>
-                <Button
-                  variant="plain"
-                  onClick={managedOnNavToggle}
-                  aria-label="Global navigation"
-                  aria-expanded={managedIsNavOpen ? 'true' : 'false'}
-                >
-                  <BarsIcon />
+    const headerToolbar = (
+      <Toolbar id="toolbar" isFullHeight isStatic>
+        <ToolbarContent>
+          <ToolbarGroup
+            variant="icon-button-group"
+            alignment={{ default: 'alignRight' }}
+            spacer={{ default: 'spacerNone', md: 'spacerMd' }}
+          >
+            <ToolbarItem>
+              <Button aria-label="Notifications" variant={ButtonVariant.plain}>
+                <AttentionBellIcon />
+              </Button>
+            </ToolbarItem>
+            <ToolbarGroup variant="icon-button-group" visibility={{ default: 'hidden', lg: 'visible' }}>
+              <ToolbarItem>
+                <Button aria-label="Settings actions" variant={ButtonVariant.plain}>
+                  <CogIcon />
                 </Button>
-              </MastheadToggle>
-              <MastheadMain>
-                <MastheadBrand>
-                  <Brand src={imgBrand} alt="Patternfly logo" />
-                </MastheadBrand>
-              </MastheadMain>
-              <MastheadContent>{headerToolbar}</MastheadContent>
-            </Masthead>
-          );
-
-          return masthead;
-        }}
-      </PageContextConsumer>
+              </ToolbarItem>
+              <ToolbarItem>
+                <Button aria-label="Help actions" variant={ButtonVariant.plain}>
+                  <HelpIcon />
+                </Button>
+              </ToolbarItem>
+            </ToolbarGroup>
+          </ToolbarGroup>
+          <ToolbarItem visibility={{ default: 'hidden', md: 'visible', lg: 'hidden' }}>
+            <Dropdown
+              isPlain
+              position="right"
+              onSelect={this.onKebabDropdownSelect}
+              toggle={<KebabToggle onToggle={this.onKebabDropdownToggle} />}
+              isOpen={isKebabDropdownOpen}
+              dropdownItems={kebabDropdownItems}
+            />
+          </ToolbarItem>
+          <ToolbarItem visibility={{ default: 'visible', md: 'hidden', lg: 'hidden', xl: 'hidden', '2xl': 'hidden' }}>
+            <Dropdown
+              isPlain
+              position="right"
+              onSelect={this.onFullKebabSelect}
+              toggle={<KebabToggle onToggle={this.onFullKebabToggle} />}
+              isOpen={isFullKebabDropdownOpen}
+              dropdownItems={fullKebabItems}
+            />
+          </ToolbarItem>
+          <ToolbarItem visibility={{ default: 'hidden', md: 'visible' }}>
+            <Dropdown
+              position="right"
+              onSelect={this.onDropdownSelect}
+              isOpen={isDropdownOpen}
+              toggle={
+                <DropdownToggle icon={<Avatar src={imgAvatar} alt="Avatar" />} onToggle={this.onDropdownToggle}>
+                  John Smith
+                </DropdownToggle>
+              }
+              dropdownItems={userDropdownItems}
+            />
+          </ToolbarItem>
+        </ToolbarContent>
+      </Toolbar>
     );
+
+    const masthead = (
+      <Masthead>
+        <MastheadToggle>
+          <PageToggleButton variant="plain" aria-label="Global navigation">
+            <BarsIcon />
+          </PageToggleButton>
+        </MastheadToggle>
+        <MastheadMain>
+          <MastheadBrand>
+            <Brand src={imgBrand} alt="Patternfly logo" />
+          </MastheadBrand>
+        </MastheadMain>
+        <MastheadContent>{headerToolbar}</MastheadContent>
+      </Masthead>
+    );
+
+    return masthead;
   }
 }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6174

Refactors:
- [x] DashboardHeader
- [ ] Page
- [ ] Nav
- [x] NotificationDrawer
- [x] Wizard

`PageHeader` is integrated with a `Page` context to provide the managed nav toggle trigger / aria-expanded state. To maintain this functionality I added a `PageToggleButton` component that extends our `Button` component and contains the context consumer.