### PR TITLE
fix(Table): fix broken links in table's empty state demo

### DIFF
--- a/packages/react-table/src/demos/Table.md
+++ b/packages/react-table/src/demos/Table.md
@@ -2765,7 +2765,7 @@ class PageLayoutDefaultNav extends React.Component {
 
 ## Empty states
 
-These examples demonstrate the use of an [Empty State component](/documentation/react/components/emptystate) inside of a [Table](/documentation/react/components/table). Empty states are useful in a table when a filter returns no results, while data is loading, or when any type of error or exception condition occurs.
+These examples demonstrate the use of an [Empty State component](/components/empty-state) inside of a [Table](/components/table). Empty states are useful in a table when a filter returns no results, while data is loading, or when any type of error or exception condition occurs.
 
 ### Empty
 


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6275 

This PR fixes the "Empty state component" and "Table" links in the ["Empty states" table demo](https://www.patternfly.org/v4/components/table/react-demos#empty-states).
