### PR TITLE
Tbody, Thead: correct some copy-pasted prop comments

### DIFF
--- a/packages/react-table/src/components/TableComposable/Tbody.tsx
+++ b/packages/react-table/src/components/TableComposable/Tbody.tsx
@@ -3,9 +3,9 @@ import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 
 export interface TbodyProps extends React.HTMLProps<HTMLTableSectionElement> {
-  /** Content rendered inside the <tr> row */
+  /** Content rendered inside the <tbody> row group */
   children?: React.ReactNode;
-  /** Additional classes added to the <tr> row  */
+  /** Additional classes added to the <tbody> element  */
   className?: string;
   /** Modifies the body to allow for expandable rows */
   isExpanded?: boolean;

--- a/packages/react-table/src/components/TableComposable/Thead.tsx
+++ b/packages/react-table/src/components/TableComposable/Thead.tsx
@@ -3,9 +3,9 @@ import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 
 export interface TheadProps extends React.HTMLProps<HTMLTableSectionElement> {
-  /** Content rendered inside the <tr> row */
+  /** Content rendered inside the <thead> row group */
   children?: React.ReactNode;
-  /** Additional classes added to the <tr> row  */
+  /** Additional classes added to the <thead> element */
   className?: string;
   /** Won't wrap the table head if true */
   noWrap?: boolean;


### PR DESCRIPTION
**What**: a couple of props documentation comments on `Thead` and `Tbody` were incorrectly referring to `<tr>` (copy-pasted from `Tr` props).
