### PR TITLE
fix: wrapper nav should have hrefs

### DIFF
--- a/packages/react-core/src/demos/examples/DashboardWrapper.js
+++ b/packages/react-core/src/demos/examples/DashboardWrapper.js
@@ -42,19 +42,19 @@ export default class DashboardWrapper extends React.Component {
     const PageNav = (
       <Nav onSelect={this.onNavSelect} aria-label="Nav">
         <NavList>
-          <NavItem itemId={0} isActive={activeItem === 0}>
+          <NavItem itemId={0} isActive={activeItem === 0} to="#system-panel">
             System Panel
           </NavItem>
-          <NavItem itemId={1} isActive={activeItem === 1}>
+          <NavItem itemId={1} isActive={activeItem === 1} to="#policy">
             Policy
           </NavItem>
-          <NavItem itemId={2} isActive={activeItem === 2}>
+          <NavItem itemId={2} isActive={activeItem === 2} to="#auth">
             Authentication
           </NavItem>
-          <NavItem itemId={3} isActive={activeItem === 3}>
+          <NavItem itemId={3} isActive={activeItem === 3} to="#network">
             Network Services
           </NavItem>
-          <NavItem itemId={4} isActive={activeItem === 4}>
+          <NavItem itemId={4} isActive={activeItem === 4} to="#server">
             Server
           </NavItem>
         </NavList>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #

Adds hrefs to `Nav` in `DashboardWrapper` to make it tabbable.
