### PR TITLE
fix(various): tabIndex=0 if overflowscroll

### DIFF
--- a/packages/react-core/src/components/Page/PageBreadcrumb.tsx
+++ b/packages/react-core/src/components/Page/PageBreadcrumb.tsx
@@ -40,6 +40,7 @@ export const PageBreadcrumb = ({
       hasOverflowScroll && styles.modifiers.overflowScroll,
       className
     )}
+    tabIndex={hasOverflowScroll && 0}
     {...props}
   >
     {isWidthLimited && <div className={css(styles.pageMainBody)}>{children}</div>}

--- a/packages/react-core/src/components/Page/PageGroup.tsx
+++ b/packages/react-core/src/components/Page/PageGroup.tsx
@@ -27,7 +27,6 @@ export const PageGroup = ({
   ...props
 }: PageGroupProps) => (
   <div
-    {...props}
     className={css(
       styles.pageMainGroup,
       sticky === 'top' && styles.modifiers.stickyTop,
@@ -37,6 +36,8 @@ export const PageGroup = ({
       hasOverflowScroll && styles.modifiers.overflowScroll,
       className
     )}
+    tabIndex={hasOverflowScroll && 0}
+    {...props}
   >
     {children}
   </div>

--- a/packages/react-core/src/components/Page/PageNavigation.tsx
+++ b/packages/react-core/src/components/Page/PageNavigation.tsx
@@ -40,6 +40,7 @@ export const PageNavigation = ({
       hasOverflowScroll && styles.modifiers.overflowScroll,
       className
     )}
+    tabIndex={hasOverflowScroll && 0}
     {...props}
   >
     {isWidthLimited && <div className={css(styles.pageMainBody)}>{children}</div>}

--- a/packages/react-core/src/components/Page/PageSection.tsx
+++ b/packages/react-core/src/components/Page/PageSection.tsx
@@ -82,7 +82,6 @@ export const PageSection: React.FunctionComponent<PageSectionProps> = ({
   ...props
 }: PageSectionProps) => (
   <section
-    {...props}
     className={css(
       variantType[type],
       formatBreakpointMods(padding, styles),
@@ -97,6 +96,8 @@ export const PageSection: React.FunctionComponent<PageSectionProps> = ({
       hasOverflowScroll && styles.modifiers.overflowScroll,
       className
     )}
+    tabIndex={hasOverflowScroll && 0}
+    {...props}
   >
     {isWidthLimited && <div className={css(styles.pageMainBody)}>{children}</div>}
     {!isWidthLimited && children}


### PR DESCRIPTION
Draft PR to fix tabIndex issue on when an element overflows/scrolls.
