### PR TITLE
fix(TreeView): isExpanded should override defaultExpanded

### DIFF
--- a/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
+++ b/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
@@ -85,14 +85,10 @@ export const TreeViewListItem: React.FunctionComponent<TreeViewListItemProps> = 
   useEffect(() => {
     if (isExpanded !== undefined && isExpanded !== null) {
       setIsExpanded(isExpanded);
-    }
-  }, [isExpanded]);
-
-  useEffect(() => {
-    if (defaultExpanded !== undefined && defaultExpanded !== null) {
+    } else if (defaultExpanded !== undefined && defaultExpanded !== null) {
       setIsExpanded(internalIsExpanded || defaultExpanded);
     }
-  }, [defaultExpanded]);
+  }, [isExpanded, defaultExpanded]);
 
   const Component = hasCheck ? 'div' : 'button';
   const ToggleComponent = hasCheck ? 'button' : 'div';


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6314, #4395

`allExpanded` (TreeView) and `isExpanded` (TreeViewListItem) should override `defaultAllExpanded`/`defaultExpanded`. 