### PR TITLE
fix(dragdrop): remove React.createPortal, add noWrap

### DIFF
--- a/packages/react-core/src/components/DataList/DataList.tsx
+++ b/packages/react-core/src/components/DataList/DataList.tsx
@@ -27,15 +27,15 @@ export interface DataListProps extends Omit<React.HTMLProps<HTMLUListElement>, '
   className?: string;
   /** Adds accessible text to the DataList list */
   'aria-label': string;
-  /** Optional callback to make DataList selectable, fired when DataListItem selected */
+  /** @deprecated Optional callback to make DataList selectable, fired when DataListItem selected */
   onSelectDataListItem?: (id: string) => void;
-  /** Optional callback to make DataList draggable, fired when dragging ends */
+  /** @deprecated Optional callback to make DataList draggable, fired when dragging ends */
   onDragFinish?: (newItemOrder: string[]) => void;
-  /** Optional informational callback for dragging, fired when dragging starts */
+  /** @deprecated Optional informational callback for dragging, fired when dragging starts */
   onDragStart?: (id: string) => void;
-  /** Optional informational callback for dragging, fired when an item moves */
+  /** @deprecated Optional informational callback for dragging, fired when an item moves */
   onDragMove?: (oldIndex: number, newIndex: number) => void;
-  /** Optional informational callback for dragging, fired when dragging is cancelled */
+  /** @deprecated Optional informational callback for dragging, fired when dragging is cancelled */
   onDragCancel?: () => void;
   /** Id of DataList item currently selected */
   selectedDataListItemId?: string;
@@ -45,7 +45,7 @@ export interface DataListProps extends Omit<React.HTMLProps<HTMLUListElement>, '
   gridBreakpoint?: 'none' | 'always' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
   /** Determines which wrapping modifier to apply to the DataList */
   wrapModifier?: DataListWrapModifier | 'nowrap' | 'truncate' | 'breakWord';
-  /** Order of items in a draggable DataList */
+  /** @deprecated Order of items in a draggable DataList */
   itemOrder?: string[];
 }
 

--- a/packages/react-core/src/components/DataList/DataList.tsx
+++ b/packages/react-core/src/components/DataList/DataList.tsx
@@ -93,6 +93,7 @@ export class DataList extends React.Component<DataListProps, DataListState> {
     wrapModifier: null
   };
   dragFinished: boolean = false;
+  html5DragDrop: boolean = false;
   arrayCopy: React.ReactElement[] = React.Children.toArray(this.props.children) as React.ReactElement[];
   ref = React.createRef<HTMLUListElement>();
 
@@ -106,7 +107,8 @@ export class DataList extends React.Component<DataListProps, DataListState> {
   constructor(props: DataListProps) {
     super(props);
 
-    if (props.onDragFinish || props.onDragStart || props.onDragMove || props.onDragCancel) {
+    this.html5DragDrop = Boolean(props.onDragFinish || props.onDragStart || props.onDragMove || props.onDragCancel);
+    if (this.html5DragDrop) {
       // eslint-disable-next-line no-console
       console.warn("DataList's onDrag API is deprecated. Use DragDrop instead.");
     }
@@ -251,13 +253,7 @@ export class DataList extends React.Component<DataListProps, DataListState> {
 
   handleDragButtonKeys = (evt: React.KeyboardEvent) => {
     const { dragging } = this.state;
-    if (
-      evt.key !== ' ' &&
-      evt.key !== 'Escape' &&
-      evt.key !== 'Enter' &&
-      evt.key !== 'ArrowUp' &&
-      evt.key !== 'ArrowDown'
-    ) {
+    if (![' ', 'Escape', 'Enter', 'ArrowUp', 'ArrowDown'].includes(evt.key) || !this.html5DragDrop) {
       if (dragging) {
         evt.preventDefault();
       }
@@ -317,13 +313,12 @@ export class DataList extends React.Component<DataListProps, DataListState> {
     } = this.props;
     const { dragging } = this.state;
     const isSelectable = onSelectDataListItem !== undefined;
-    const isDraggable = onDragFinish !== undefined;
 
     const updateSelectedDataListItem = (id: string) => {
       onSelectDataListItem(id);
     };
 
-    const dragProps = isDraggable && {
+    const dragProps = this.html5DragDrop && {
       onDragOver: this.dragOver,
       onDrop: this.dragOver,
       onDragLeave: this.dragLeave
@@ -335,7 +330,7 @@ export class DataList extends React.Component<DataListProps, DataListState> {
           isSelectable,
           selectedDataListItemId,
           updateSelectedDataListItem,
-          isDraggable,
+          isDraggable: this.html5DragDrop,
           dragStart: this.dragStart,
           dragEnd: this.dragEnd,
           drop: this.drop,

--- a/packages/react-core/src/components/DataList/DataList.tsx
+++ b/packages/react-core/src/components/DataList/DataList.tsx
@@ -27,7 +27,7 @@ export interface DataListProps extends Omit<React.HTMLProps<HTMLUListElement>, '
   className?: string;
   /** Adds accessible text to the DataList list */
   'aria-label': string;
-  /** @deprecated Optional callback to make DataList selectable, fired when DataListItem selected */
+  /** Optional callback to make DataList selectable, fired when DataListItem selected */
   onSelectDataListItem?: (id: string) => void;
   /** @deprecated Optional callback to make DataList draggable, fired when dragging ends */
   onDragFinish?: (newItemOrder: string[]) => void;
@@ -102,6 +102,15 @@ export class DataList extends React.Component<DataListProps, DataListState> {
     draggingToItemIndex: null,
     dragging: false
   };
+
+  constructor(props: DataListProps) {
+    super(props);
+
+    if (props.onDragFinish || props.onDragStart || props.onDragMove || props.onDragCancel) {
+      // eslint-disable-next-line no-console
+      console.warn("DataList's onDrag API is deprecated. Use DragDrop instead.");
+    }
+  }
 
   componentDidUpdate(oldProps: DataListProps) {
     if (this.dragFinished) {

--- a/packages/react-core/src/components/DataList/examples/DataList.md
+++ b/packages/react-core/src/components/DataList/examples/DataList.md
@@ -1160,6 +1160,21 @@ const reorder = (list, startIndex, endIndex) => {
 
 DraggableDataList = () => {
   const [items, setItems] = React.useState(getItems(10));
+  const [liveText, setLiveText] = React.useState('');
+
+  function onDrag(source) {
+    setLiveText(`Started dragging ${items[source.index].content}`);
+    return true;
+  }
+
+  function onDragMove(source, dest) {
+    const newText = dest
+      ? `Move ${items[source.index].content} to ${items[dest.index].content}`
+      : 'Invalid drop zone';
+    if (newText !== liveText) {
+      setLiveText(newText);
+    }
+  }
 
   function onDrop(source, dest) {
     if (dest) {
@@ -1170,12 +1185,15 @@ DraggableDataList = () => {
       );
       setItems(newItems);
 
+      setLiveText('Dragging finished.');
       return true;
+    } else {
+      setLiveText('Dragging cancelled. List unchanged.');
     }
   }
 
   return (
-    <DragDrop onDrop={onDrop}>
+    <DragDrop onDrag={onDrag} onDragMove={onDragMove} onDrop={onDrop}>
       <Droppable noWrap>
         <DataList aria-label="draggable data list example" isCompact>
           {items.map(({id, content}) =>
@@ -1204,6 +1222,9 @@ DraggableDataList = () => {
           )}
         </DataList>
       </Droppable>
+      <div className="pf-screen-reader" aria-live="assertive">
+        {liveText}
+      </div>
     </DragDrop>
   );
 };

--- a/packages/react-core/src/components/DataList/examples/DataList.md
+++ b/packages/react-core/src/components/DataList/examples/DataList.md
@@ -1194,10 +1194,10 @@ DraggableDataList = () => {
 
   return (
     <DragDrop onDrag={onDrag} onDragMove={onDragMove} onDrop={onDrop}>
-      <Droppable noWrap>
+      <Droppable noWrapper>
         <DataList aria-label="draggable data list example" isCompact>
           {items.map(({id, content}) =>
-            <Draggable key={id} noWrap>
+            <Draggable key={id} noWrapper>
               <DataListItem aria-labelledby={id} ref={React.createRef()}>
                 <DataListItemRow>
                   <DataListControl>

--- a/packages/react-core/src/components/DataList/examples/DataList.md
+++ b/packages/react-core/src/components/DataList/examples/DataList.md
@@ -1164,6 +1164,7 @@ DraggableDataList = () => {
 
   function onDrag(source) {
     setLiveText(`Started dragging ${items[source.index].content}`);
+    // Return true to allow drag
     return true;
   }
 

--- a/packages/react-core/src/components/DataList/examples/DataList.md
+++ b/packages/react-core/src/components/DataList/examples/DataList.md
@@ -1125,6 +1125,10 @@ import {
 
 ### Draggable
 
+Draggable data lists used to have their own HTML5 API based drag and drop. Upon initial implementation we thought this implementation sufficient for all future drag and drop functionality. We were wrong.
+
+Since then we've written generic new `DragDrop`, `Draggable`, and `Droppable` components for this purpose. This should be used instead of the old deprecated (and buggy!) HTML5-based API.
+
 ```js
 import React from 'react';
 import {
@@ -1135,129 +1139,72 @@ import {
   DataListCheck,
   DataListControl,
   DataListDragButton,
-  DataListItemCells
+  DataListItemCells,
+  DragDrop,
+  Draggable,
+  Droppable
 } from '@patternfly/react-core';
 
+const getItems = count =>
+  Array.from({ length: count }, (v, k) => k).map(k => ({
+    id: `item-${k}`,
+    content: `item ${k} `.repeat(k === 4 ? 20 : 1)
+  }));
+
+const reorder = (list, startIndex, endIndex) => {
+  const result = Array.from(list);
+  const [removed] = result.splice(startIndex, 1);
+  result.splice(endIndex, 0, removed);
+  return result;
+};
+
 DraggableDataList = () => {
-  const [ liveText, setLiveText ] = React.useState('');
-  const [ id, setId ] = React.useState('');
-  const [ itemOrder, setItemOrder ] = React.useState(['data1', 'data2', 'data3', 'data4']);
+  const [items, setItems] = React.useState(getItems(10));
 
-  const onDragStart = newId => {
-    setId(newId)
-    setLiveText(`Dragging tarted for item id: ${newId}.`);
-  };
+  function onDrop(source, dest) {
+    if (dest) {
+      const newItems = reorder(
+        items,
+        source.index,
+        dest.index
+      );
+      setItems(newItems);
 
-  const onDragMove = (oldIndex, newIndex) => {
-    setLiveText(`Dragging item ${id}.  Item with index ${oldIndex} in now ${newIndex}.`);
-  };
-
-  const onDragCancel = () => {
-    setLiveText('Dragging cancelled. List is unchanged.');
-  };
-
-  const onDragFinish = newItemOrder => {
-    setLiveText('Dragging finsihed');
-    setItemOrder(newItemOrder);
-  };
+      return true;
+    }
+  }
 
   return (
-    <>
-      <DataList
-        aria-label="draggable data list example"
-        isCompact
-        onDragFinish={onDragFinish}
-        onDragStart={onDragStart}
-        onDragMove={onDragMove}
-        onDragCancel={onDragCancel}
-        itemOrder={itemOrder}
-      >
-        <DataListItem aria-labelledby="simple-item1" id="data1" key="1">
-          <DataListItemRow>
-            <DataListControl>
-              <DataListDragButton
-                aria-label="Reorder"
-                aria-labelledby="simple-item1"
-                aria-describedby="Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
-                aria-pressed="false"
-                isDisabled
-              />
-              <DataListCheck aria-labelledby="simple-item1" name="check1" otherControls />
-            </DataListControl>
-            <DataListItemCells
-              dataListCells={[
-                <DataListCell key="item1">
-                  <span id="simple-item1">Item 1</span>
-                </DataListCell>
-              ]}
-            />
-          </DataListItemRow>
-        </DataListItem>
-        <DataListItem aria-labelledby="simple-item2" id="data2" key="2">
-          <DataListItemRow>
-            <DataListControl>
-              <DataListDragButton
-                aria-label="Reorder"
-                aria-labelledby="simple-item2"
-                aria-describedby="Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
-                aria-pressed="false"
-              />
-              <DataListCheck aria-labelledby="simple-item2" name="check2" otherControls />
-            </DataListControl>
-            <DataListItemCells
-              dataListCells={[
-                <DataListCell key="item2">
-                  <span id="simple-item2">Item 2</span>
-                </DataListCell>
-              ]}
-            />
-          </DataListItemRow>
-        </DataListItem>
-        <DataListItem aria-labelledby="simple-item3" id="data3" key="3">
-          <DataListItemRow>
-            <DataListControl>
-              <DataListDragButton
-                aria-label="Reorder"
-                aria-labelledby="simple-item3"
-                aria-describedby="Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
-                aria-pressed="false"
-              />
-              <DataListCheck aria-labelledby="simple-item3" name="check3" otherControls />
-            </DataListControl>
-            <DataListItemCells
-              dataListCells={[
-                <DataListCell key="item3">
-                  <span id="simple-item3">Item 3</span>
-                </DataListCell>
-              ]}
-            />
-          </DataListItemRow>
-        </DataListItem>
-        <DataListItem aria-labelledby="simple-item4" id="data4" key="4">
-          <DataListItemRow>
-            <DataListControl>
-              <DataListDragButton
-                aria-label="Reorder"
-                aria-labelledby="simple-item4"
-                aria-describedby="Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
-                aria-pressed="false"
-              />
-              <DataListCheck aria-labelledby="simple-item4" name="check4" otherControls />
-            </DataListControl>
-            <DataListItemCells
-              dataListCells={[
-                <DataListCell key="item4">
-                  <span id="simple-item4">Item 4</span>
-                </DataListCell>
-              ]}
-            />
-          </DataListItemRow>
-        </DataListItem>
-      </DataList>
-      <div className="pf-screen-reader" aria-live="assertive">
-        {liveText}
-      </div>
-    </>
+    <DragDrop onDrop={onDrop}>
+      <Droppable noWrap>
+        <DataList aria-label="draggable data list example" isCompact>
+          {items.map(({id, content}) =>
+            <Draggable key={id} noWrap>
+              <DataListItem aria-labelledby={id} ref={React.createRef()}>
+                <DataListItemRow>
+                  <DataListControl>
+                    <DataListDragButton
+                      aria-label="Reorder"
+                      aria-labelledby={id}
+                      aria-describedby="Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
+                      aria-pressed="false"
+                    />
+                    <DataListCheck aria-labelledby={id} name={id} otherControls />
+                  </DataListControl>
+                  <DataListItemCells
+                    dataListCells={[
+                      <DataListCell key={id}>
+                        <span id={id}>{content}</span>
+                      </DataListCell>
+                    ]}
+                  />
+                </DataListItemRow>
+              </DataListItem>
+            </Draggable>
+          )}
+        </DataList>
+      </Droppable>
+    </DragDrop>
   );
 };
 ```

--- a/packages/react-core/src/components/DataList/examples/DataList.md
+++ b/packages/react-core/src/components/DataList/examples/DataList.md
@@ -1125,7 +1125,7 @@ import {
 
 ### Draggable
 
-Draggable data lists used to have their own HTML5 API based drag and drop. Upon initial implementation we thought this implementation sufficient for all future drag and drop functionality. We were wrong.
+Draggable data lists used to have their own HTML5 API based drag and drop. This was unable to fulfill requirements like custom styling on items as they are being dragged.
 
 Since then we've written generic new `DragDrop`, `Draggable`, and `Droppable` components for this purpose. This should be used instead of the old deprecated (and buggy!) HTML5-based API.
 
@@ -1186,7 +1186,7 @@ DraggableDataList = () => {
       setItems(newItems);
 
       setLiveText('Dragging finished.');
-      return true;
+      return true; // Signal that this is a valid drop and not to animate the item returning home.
     } else {
       setLiveText('Dragging cancelled. List unchanged.');
     }

--- a/packages/react-core/src/components/DataList/examples/DataList.md
+++ b/packages/react-core/src/components/DataList/examples/DataList.md
@@ -1195,10 +1195,10 @@ DraggableDataList = () => {
 
   return (
     <DragDrop onDrag={onDrag} onDragMove={onDragMove} onDrop={onDrop}>
-      <Droppable noWrapper>
+      <Droppable hasNoWrapper>
         <DataList aria-label="draggable data list example" isCompact>
           {items.map(({id, content}) =>
-            <Draggable key={id} noWrapper>
+            <Draggable key={id} hasNoWrapper>
               <DataListItem aria-labelledby={id} ref={React.createRef()}>
                 <DataListItemRow>
                   <DataListControl>

--- a/packages/react-core/src/components/DataList/examples/DataList.md
+++ b/packages/react-core/src/components/DataList/examples/DataList.md
@@ -1125,7 +1125,7 @@ import {
 
 ### Draggable
 
-Draggable data lists used to have their own HTML5 API based drag and drop. This was unable to fulfill requirements like custom styling on items as they are being dragged.
+Draggable data lists used to have their own HTML5-based API for drag and drop. This was unable to fulfill requirements like custom styling on items as they are being dragged.
 
 Since then we've written generic new `DragDrop`, `Draggable`, and `Droppable` components for this purpose. This should be used instead of the old deprecated (and buggy!) HTML5-based API.
 

--- a/packages/react-core/src/components/DataList/examples/DataList.md
+++ b/packages/react-core/src/components/DataList/examples/DataList.md
@@ -1125,9 +1125,7 @@ import {
 
 ### Draggable
 
-Draggable data lists used to have their own HTML5-based API for drag and drop. This was unable to fulfill requirements like custom styling on items as they are being dragged.
-
-Since then we've written generic new `DragDrop`, `Draggable`, and `Droppable` components for this purpose. This should be used instead of the old deprecated (and buggy!) HTML5-based API.
+Draggable data lists used to have their own HTML5-based API for drag and drop, which wasn't able to fulfill requirements such as custom styling on items being dragged. So we wrote generic `DragDrop`, `Draggable`, and `Droppable` components for this purpose. Use those new components instead of the deprecated (and buggy!) HTML5-based API.
 
 ```js
 import React from 'react';

--- a/packages/react-core/src/components/DragDrop/DragDrop.tsx
+++ b/packages/react-core/src/components/DragDrop/DragDrop.tsx
@@ -9,6 +9,7 @@ interface DraggableItemPosition {
 
 export const DragDropContext = React.createContext({
   onDrag: (_source: DraggableItemPosition) => true as boolean,
+  onDragMove: (_source: DraggableItemPosition, _dest?: DraggableItemPosition) => {},
   onDrop: (_source: DraggableItemPosition, _dest?: DraggableItemPosition) => false as boolean
 });
 
@@ -17,6 +18,8 @@ interface DragDropProps {
   children?: React.ReactNode;
   /** Callback for drag event. Return true to allow drag, false to disallow. */
   onDrag?: (source: DraggableItemPosition) => boolean;
+  /** Callback for drag event. */
+  onDragMove?: (source: DraggableItemPosition, dest?: DraggableItemPosition) => void;
   /** Callback for drop event. Return true to allow drop, false to disallow. */
   onDrop?: (source: DraggableItemPosition, dest?: DraggableItemPosition) => boolean;
 }
@@ -24,6 +27,9 @@ interface DragDropProps {
 export const DragDrop: React.FunctionComponent<DragDropProps> = ({
   children,
   onDrag = () => true,
+  onDragMove = () => {},
   onDrop = () => false
-}: DragDropProps) => <DragDropContext.Provider value={{ onDrag, onDrop }}>{children}</DragDropContext.Provider>;
+}: DragDropProps) => (
+  <DragDropContext.Provider value={{ onDrag, onDragMove, onDrop }}>{children}</DragDropContext.Provider>
+);
 DragDrop.displayName = 'DragDrop';

--- a/packages/react-core/src/components/DragDrop/DragDrop.tsx
+++ b/packages/react-core/src/components/DragDrop/DragDrop.tsx
@@ -18,7 +18,7 @@ interface DragDropProps {
   children?: React.ReactNode;
   /** Callback for drag event. Return true to allow drag, false to disallow. */
   onDrag?: (source: DraggableItemPosition) => boolean;
-  /** Callback for drag event. */
+  /** Callback on mouse move while dragging. */
   onDragMove?: (source: DraggableItemPosition, dest?: DraggableItemPosition) => void;
   /** Callback for drop event. Return true to allow drop, false to disallow. */
   onDrop?: (source: DraggableItemPosition, dest?: DraggableItemPosition) => boolean;

--- a/packages/react-core/src/components/DragDrop/Draggable.tsx
+++ b/packages/react-core/src/components/DragDrop/Draggable.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { createPortal } from 'react-dom';
 import { DroppableContext } from './DroppableContext';
 import { DragDropContext } from './DragDrop';
 
@@ -74,7 +73,7 @@ function overlaps(ev: MouseEvent, rect: DOMRect) {
 export const Draggable: React.FunctionComponent<DraggableProps> = ({
   className,
   children,
-  style: styleProp,
+  style: styleProp = {},
   ...props
 }: DraggableProps) => {
   /* eslint-disable prefer-const */
@@ -240,7 +239,8 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
         node: cur,
         rect: cur.getBoundingClientRect(),
         isDraggingHost,
-        draggableNodes,
+        // We don't want styles to apply to the left behind div in onMouseMoveWhileDragging
+        draggableNodes: draggableNodes.map(node => (node === ref.current ? node.cloneNode(false) : node)),
         draggableNodesRects: draggableNodes.map(node => node.getBoundingClientRect())
       };
       acc.push(droppableItem);
@@ -275,24 +275,8 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
     document.addEventListener('mousemove', mouseMoveListener);
     document.addEventListener('mouseup', mouseUpListener);
     // Comment out this line to debug while dragging by right clicking
-    document.addEventListener('contextmenu', mouseUpListener);
+    // document.addEventListener('contextmenu', mouseUpListener);
   };
-
-  const div = (
-    <div
-      data-pf-draggable-zone={isDragging ? null : zone}
-      draggable
-      role="button"
-      className={className}
-      onDragStart={onDragStart}
-      onTransitionEnd={onTransitionEnd}
-      style={style}
-      ref={ref}
-      {...props}
-    >
-      {children}
-    </div>
-  );
 
   return (
     <React.Fragment>
@@ -302,8 +286,19 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
           {children}
         </div>
       )}
-      {/* Move dragging part into portal to appear above top and side nav */}
-      {isDragging ? createPortal(div, document.body) : div}
+      <div
+        data-pf-draggable-zone={isDragging ? null : zone}
+        draggable
+        role="button"
+        className={className}
+        onDragStart={onDragStart}
+        onTransitionEnd={onTransitionEnd}
+        style={style}
+        ref={ref}
+        {...props}
+      >
+        {children}
+      </div>
     </React.Fragment>
   );
 };

--- a/packages/react-core/src/components/DragDrop/Draggable.tsx
+++ b/packages/react-core/src/components/DragDrop/Draggable.tsx
@@ -6,7 +6,7 @@ export interface DraggableProps extends React.HTMLProps<HTMLDivElement> {
   /** Content rendered inside DragDrop */
   children?: React.ReactNode;
   /** Don't wrap the component in a div. Requires passing a single child. */
-  noWrapper?: boolean;
+  hasNoWrapper?: boolean;
   /** Class to add to outer div */
   className?: string;
 }
@@ -76,7 +76,7 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
   className,
   children,
   style: styleProp = {},
-  noWrapper = false,
+  hasNoWrapper = false,
   ...props
 }: DraggableProps) => {
   /* eslint-disable prefer-const */
@@ -307,7 +307,7 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
           {children}
         </div>
       )}
-      {noWrapper ? React.cloneElement(children as React.ReactElement, childProps) : <div>{children}</div>}
+      {hasNoWrapper ? React.cloneElement(children as React.ReactElement, childProps) : <div>{children}</div>}
     </React.Fragment>
   );
 };

--- a/packages/react-core/src/components/DragDrop/Draggable.tsx
+++ b/packages/react-core/src/components/DragDrop/Draggable.tsx
@@ -307,7 +307,11 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
           {children}
         </div>
       )}
-      {hasNoWrapper ? React.cloneElement(children as React.ReactElement, childProps) : <div>{children}</div>}
+      {hasNoWrapper ? (
+        React.cloneElement(children as React.ReactElement, childProps)
+      ) : (
+        <div {...childProps}>{children}</div>
+      )}
     </React.Fragment>
   );
 };

--- a/packages/react-core/src/components/DragDrop/Draggable.tsx
+++ b/packages/react-core/src/components/DragDrop/Draggable.tsx
@@ -6,7 +6,7 @@ export interface DraggableProps extends React.HTMLProps<HTMLDivElement> {
   /** Content rendered inside DragDrop */
   children?: React.ReactNode;
   /** Don't wrap the component in a div. Requires passing a single child. */
-  noWrap?: boolean;
+  noWrapper?: boolean;
   /** Class to add to outer div */
   className?: string;
 }
@@ -76,7 +76,7 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
   className,
   children,
   style: styleProp = {},
-  noWrap = false,
+  noWrapper = false,
   ...props
 }: DraggableProps) => {
   /* eslint-disable prefer-const */
@@ -307,7 +307,7 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
           {children}
         </div>
       )}
-      {noWrap ? React.cloneElement(children as React.ReactElement, childProps) : <div>{children}</div>}
+      {noWrapper ? React.cloneElement(children as React.ReactElement, childProps) : <div>{children}</div>}
     </React.Fragment>
   );
 };

--- a/packages/react-core/src/components/DragDrop/Droppable.tsx
+++ b/packages/react-core/src/components/DragDrop/Droppable.tsx
@@ -31,7 +31,11 @@ export const Droppable: React.FunctionComponent<DroppableProps> = ({
 
   return (
     <DroppableContext.Provider value={{ zone, droppableId }}>
-      {hasNoWrapper ? React.cloneElement(children as React.ReactElement, childProps) : <div>{children}</div>}
+      {hasNoWrapper ? (
+        React.cloneElement(children as React.ReactElement, childProps)
+      ) : (
+        <div {...childProps}>{children}</div>
+      )}
     </DroppableContext.Provider>
   );
 };

--- a/packages/react-core/src/components/DragDrop/Droppable.tsx
+++ b/packages/react-core/src/components/DragDrop/Droppable.tsx
@@ -10,6 +10,8 @@ interface DroppableProps extends React.HTMLProps<HTMLDivElement> {
   zone?: string;
   /** Id to be passed back on drop events */
   droppableId?: string;
+  /** Don't wrap the component in a div. Requires passing a single child. */
+  noWrap?: boolean;
 }
 
 export const Droppable: React.FunctionComponent<DroppableProps> = ({
@@ -17,12 +19,20 @@ export const Droppable: React.FunctionComponent<DroppableProps> = ({
   children,
   zone = 'defaultZone',
   droppableId = 'defaultId',
+  noWrap = false,
   ...props
-}: DroppableProps) => (
-  <DroppableContext.Provider value={{ zone, droppableId }}>
-    <div data-pf-droppable={zone} data-pf-droppableid={droppableId} className={className} {...props}>
-      {children}
-    </div>
-  </DroppableContext.Provider>
-);
+}: DroppableProps) => {
+  const childProps = {
+    'data-pf-droppable': zone,
+    'data-pf-droppableid': droppableId,
+    className,
+    ...props
+  };
+
+  return (
+    <DroppableContext.Provider value={{ zone, droppableId }}>
+      {noWrap ? React.cloneElement(children as React.ReactElement, childProps) : <div>{children}</div>}
+    </DroppableContext.Provider>
+  );
+};
 Droppable.displayName = 'Droppable';

--- a/packages/react-core/src/components/DragDrop/Droppable.tsx
+++ b/packages/react-core/src/components/DragDrop/Droppable.tsx
@@ -11,7 +11,7 @@ interface DroppableProps extends React.HTMLProps<HTMLDivElement> {
   /** Id to be passed back on drop events */
   droppableId?: string;
   /** Don't wrap the component in a div. Requires passing a single child. */
-  noWrap?: boolean;
+  noWrapper?: boolean;
 }
 
 export const Droppable: React.FunctionComponent<DroppableProps> = ({
@@ -19,7 +19,7 @@ export const Droppable: React.FunctionComponent<DroppableProps> = ({
   children,
   zone = 'defaultZone',
   droppableId = 'defaultId',
-  noWrap = false,
+  noWrapper = false,
   ...props
 }: DroppableProps) => {
   const childProps = {
@@ -31,7 +31,7 @@ export const Droppable: React.FunctionComponent<DroppableProps> = ({
 
   return (
     <DroppableContext.Provider value={{ zone, droppableId }}>
-      {noWrap ? React.cloneElement(children as React.ReactElement, childProps) : <div>{children}</div>}
+      {noWrapper ? React.cloneElement(children as React.ReactElement, childProps) : <div>{children}</div>}
     </DroppableContext.Provider>
   );
 };

--- a/packages/react-core/src/components/DragDrop/Droppable.tsx
+++ b/packages/react-core/src/components/DragDrop/Droppable.tsx
@@ -11,7 +11,7 @@ interface DroppableProps extends React.HTMLProps<HTMLDivElement> {
   /** Id to be passed back on drop events */
   droppableId?: string;
   /** Don't wrap the component in a div. Requires passing a single child. */
-  noWrapper?: boolean;
+  hasNoWrapper?: boolean;
 }
 
 export const Droppable: React.FunctionComponent<DroppableProps> = ({
@@ -19,7 +19,7 @@ export const Droppable: React.FunctionComponent<DroppableProps> = ({
   children,
   zone = 'defaultZone',
   droppableId = 'defaultId',
-  noWrapper = false,
+  hasNoWrapper = false,
   ...props
 }: DroppableProps) => {
   const childProps = {
@@ -31,7 +31,7 @@ export const Droppable: React.FunctionComponent<DroppableProps> = ({
 
   return (
     <DroppableContext.Provider value={{ zone, droppableId }}>
-      {noWrapper ? React.cloneElement(children as React.ReactElement, childProps) : <div>{children}</div>}
+      {hasNoWrapper ? React.cloneElement(children as React.ReactElement, childProps) : <div>{children}</div>}
     </DroppableContext.Provider>
   );
 };

--- a/packages/react-core/src/components/DragDrop/__tests__/__snapshots__/DragDrop.test.tsx.snap
+++ b/packages/react-core/src/components/DragDrop/__tests__/__snapshots__/DragDrop.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`renders some divs 1`] = `
   value={
     Object {
       "onDrag": [Function],
+      "onDragMove": [Function],
       "onDrop": [Function],
     }
   }

--- a/packages/react-integration/cypress/integration/drawer.spec.ts
+++ b/packages/react-integration/cypress/integration/drawer.spec.ts
@@ -45,6 +45,6 @@ describe('Drawer Demo Test', () => {
 
   it('Verify that focus gets sent to drawer', () => {
     cy.get('#toggleButton').click();
-    setTimeout(() => cy.focused().contains('drawer-panel'), 1000);
+    cy.wrap(() => cy.focused().contains('drawer-panel'), { timeout: 1000 });
   });
 });


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Putting data list rows (or any arbitrary list items that expect style based on a parent) leads to a situation where when moved into a portal it's styled completely differently. For this reason dragging from the main content to Sidebars, Drawers, and PageHeaders has been removed.

The `noWrap` prop was also added so that `<div>`s need not wrap the component. This was accomplished by using event targets instead of refs to the div and passing event handlers via `React.cloneElement`.

Towards https://github.com/patternfly/patternfly/issues/4376

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
