### PR TITLE
[ISSUE-6350] - allow onSelect to prevent the default behavior of toggling node collapse

### DIFF
--- a/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
+++ b/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
@@ -23,7 +23,7 @@ export interface TreeViewListItemProps {
   defaultExpanded?: boolean;
   /** Child nodes of a tree view item */
   children?: React.ReactNode;
-  /** Callback for item selection */
+  /** Callback for item selection. Note: calling event.preventDefault() will prevent the node from toggling. */
   onSelect?: (event: React.MouseEvent, item: TreeViewDataItem, parent: TreeViewDataItem) => void;
   /** Callback for item checkbox selection */
   onCheck?: (event: React.ChangeEvent, item: TreeViewDataItem, parent: TreeViewDataItem) => void;

--- a/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
+++ b/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
@@ -186,10 +186,10 @@ export const TreeViewListItem: React.FunctionComponent<TreeViewListItemProps> = 
               )}
               onClick={(evt: React.MouseEvent) => {
                 if (!hasCheck) {
-                  if (children) {
+                  onSelect && onSelect(evt, itemData, parentItem);
+                  if (children && evt.isDefaultPrevented() !== true) {
                     setIsExpanded(!internalIsExpanded);
                   }
-                  onSelect && onSelect(evt, itemData, parentItem);
                 }
               }}
               {...(!children && { role: 'treeitem' })}


### PR DESCRIPTION
The proposed usage would allow for the onSelect method to call `evt.preventDefault()` to prevent the nodes from toggling. This is useful for determining programmatically whether a node should be collapsed. Further, it allows for the tree to be expanded and locked by the integrator.

<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6350 

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: None
