### PR TITLE
chore(charts): Add custom labels example for bullet chart

### DIFF
--- a/packages/react-charts/src/components/ChartBullet/examples/ChartBullet.md
+++ b/packages/react-charts/src/components/ChartBullet/examples/ChartBullet.md
@@ -429,6 +429,46 @@ import { ChartBullet } from '@patternfly/react-charts';
 </div>
 ```
 
+### Custom labels
+```js
+import React from 'react';
+import { ChartAxis, ChartBullet } from '@patternfly/react-charts';
+
+<div style={{ height: '150px', width: '600px' }}>
+  <ChartBullet
+    ariaDesc="Storage capacity"
+    ariaTitle="Bullet chart example"
+    axisComponent={
+      <ChartAxis 
+        tickValues={[0, 25, 50, 75, 100]}
+        tickFormat={val => {
+          switch (val) {
+            case 0:
+              return 'New';
+            case 25:
+              return 'Beginner';
+            case 50:
+              return 'Intermediate';
+            case 75:
+              return 'Advanced';
+            case 100:
+              return 'Expert';
+          }
+        }}
+      />
+    }
+    comparativeWarningMeasureData={[{ name: 'Warning', y: 88 }]}
+    constrainToVisibleArea
+    height={150}
+    labels={({ datum }) => `${datum.name}: ${datum.y}`}
+    maxDomain={{y: 100}}
+    primarySegmentedMeasureData={[{ name: 'Measure', y: 60 }]}
+    qualitativeRangeData={[{ name: 'Range', y: 50 }, { name: 'Range', y: 75 }]}
+    width={600}
+  />
+</div>
+```
+
 ### Custom size
 ```js
 import React from 'react';


### PR DESCRIPTION
A user recently asked how to override the labels for a bullet chart. We have several bullet chart examples, but nothing to show how to customize your labels.

Fixes https://github.com/patternfly/patternfly-react/issues/6355

<img width="860" alt="Screen Shot 2021-09-24 at 2 22 22 PM" src="https://user-images.githubusercontent.com/17481322/134722963-ab6cdb4b-7d14-48e3-9a72-9ae4e952f9ad.png">

