### PR TITLE
fix(Wizard): Update aria-current on wizard steps

### DIFF
--- a/packages/react-core/src/components/Wizard/WizardNavItem.tsx
+++ b/packages/react-core/src/components/Wizard/WizardNavItem.tsx
@@ -76,7 +76,7 @@ export const WizardNavItem: React.FunctionComponent<WizardNavItemProps> = ({
           isDisabled && styles.modifiers.disabled
         )}
         aria-disabled={isDisabled ? true : null}
-        aria-current={isCurrent && !children ? 'page' : false}
+        aria-current={isCurrent && !children ? 'step' : false}
         {...(isExpandable && { 'aria-expanded': isExpanded })}
       >
         {isExpandable ? (


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6361 

After talking to @jgiardino and @seanforyou23, I think the wizard steps should be set to `aria-current="step"`. I'm not sure there's a scenario with wizard that clicking the wizard's step would entirely change what current page you're on. I think that likely all use cases make the most sense with step, as you are moving through wizard steps. 