### PR TITLE
fix(Table): Account for `disableSelection` in `areAllRowsSelected` method of legacy Table

### DIFF
--- a/packages/react-table/src/components/Table/Table.tsx
+++ b/packages/react-table/src/components/Table/Table.tsx
@@ -152,7 +152,9 @@ export class Table extends React.Component<TableProps, {}> {
     if (rows === undefined || rows.length === 0) {
       return false;
     }
-    return rows.every(row => this.isSelected(row) || (row.hasOwnProperty('parent') && !row.showSelect));
+    return rows.every(
+      row => this.isSelected(row) || row.disableSelection || (row.hasOwnProperty('parent') && !row.showSelect)
+    );
   };
 
   render() {

--- a/packages/react-table/src/components/Table/examples/Table.md
+++ b/packages/react-table/src/components/Table/examples/Table.md
@@ -556,7 +556,9 @@ class SelectableTable extends React.Component {
     let rows;
     if (rowId === -1) {
       rows = this.state.rows.map(oneRow => {
-        oneRow.selected = isSelected;
+        if (!oneRow.disableSelection) {
+          oneRow.selected = isSelected;
+        }
         return oneRow;
       });
     } else {


### PR DESCRIPTION
Fixes #6436. See issue for details.

Also fixes the Selectable with Checkbox example so its behavior matches the composable example. This will conflict with #6186, but I figured I might as well fix it here first to showcase the `areAllRowsSelected` fix.