### PR TITLE
feat(Progress): allow node titles

### DIFF
--- a/packages/react-core/src/components/Progress/Progress.tsx
+++ b/packages/react-core/src/components/Progress/Progress.tsx
@@ -34,7 +34,7 @@ export interface ProgressProps extends Omit<React.HTMLProps<HTMLDivElement>, 'si
   max?: number;
   /** Accessible text description of current progress value, for when value is not a percentage. Use with label. */
   valueText?: string;
-  /** Indicate whether to truncate the title */
+  /** Indicate whether to truncate the string title */
   isTitleTruncated?: boolean;
   /** Position of the tooltip which is displayed if title is truncated */
   tooltipPosition?: 'auto' | 'top' | 'bottom' | 'left' | 'right';

--- a/packages/react-core/src/components/Progress/ProgressContainer.tsx
+++ b/packages/react-core/src/components/Progress/ProgressContainer.tsx
@@ -35,7 +35,7 @@ export interface ProgressContainerProps extends Omit<React.HTMLProps<HTMLDivElem
   measureLocation?: 'outside' | 'inside' | 'top' | 'none';
   /** Actual progress value. */
   value: number;
-  /** Whether title should be truncated */
+  /** Whether string title should be truncated */
   isTitleTruncated?: boolean;
   /** Position of the tooltip which is displayed if title is truncated */
   tooltipPosition?: 'auto' | 'top' | 'bottom' | 'left' | 'right';


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5276

Allows Progress `title` to be a node and updated its description. A node's truncation must be handled manually by the user. String title truncation remains the same.