### PR TITLE
fix(Label): Make editable label more screen reader accessible

### DIFF
--- a/packages/react-core/src/components/Label/Label.tsx
+++ b/packages/react-core/src/components/Label/Label.tsx
@@ -131,7 +131,7 @@ export const Label: React.FunctionComponent<LabelProps> = ({
       event.preventDefault();
       event.stopImmediatePropagation();
       if (editableInputRef.current.value) {
-        onEditComplete && onEditComplete(editableInputRef.current.value); // for some reason this isn't getting passed, how to get this to save
+        onEditComplete && onEditComplete(editableInputRef.current.value);
       }
       setIsEditableActive(false);
     }
@@ -209,7 +209,11 @@ export const Label: React.FunctionComponent<LabelProps> = ({
     return;
   });
 
-  const [currValue] = useState(children);
+  const [currValue, setCurrValue] = useState(children);
+
+  const updateVal = () => {
+    setCurrValue(editableInputRef.current.value);
+  };
 
   if (isEditable) {
     content = (
@@ -232,7 +236,8 @@ export const Label: React.FunctionComponent<LabelProps> = ({
               type="text"
               id="editable-input"
               ref={editableInputRef}
-              defaultValue={currValue}
+              value={currValue}
+              onChange={updateVal}
               {...isEditableActive}
               {...editableProps}
             ></input>

--- a/packages/react-core/src/components/Label/Label.tsx
+++ b/packages/react-core/src/components/Label/Label.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { useState } from 'react';
 import styles from '@patternfly/react-styles/css/components/Label/label';
 import labelGrpStyles from '@patternfly/react-styles/css/components/LabelGroup/label-group';
-import inlineEditStyles from '@patternfly/react-styles/css/components/InlineEdit/inline-edit';
 import { Button } from '../Button';
 import { Tooltip } from '../Tooltip';
 import { css } from '@patternfly/react-styles';
@@ -217,33 +216,16 @@ export const Label: React.FunctionComponent<LabelProps> = ({
 
   if (isEditable) {
     content = (
-      <React.Fragment>
-        <div className={css(inlineEditStyles.inlineEdit)}>
-          {!isEditableActive && (
-            <button
-              ref={editableDivRef}
-              className={css(inlineEditStyles.inlineEditEditableText)}
-              onClick={event => onEditClick(event, isEditableActive)}
-              currvalue={currValue}
-              {...isEditableActive}
-              {...editableProps}
-            >
-              {children}
-            </button>
-          )}
-          {isEditableActive && (
-            <input
-              type="text"
-              id="editable-input"
-              ref={editableInputRef}
-              value={currValue}
-              onChange={updateVal}
-              {...isEditableActive}
-              {...editableProps}
-            ></input>
-          )}
-        </div>
-      </React.Fragment>
+      <button
+        ref={editableDivRef}
+        className={css(styles.labelEditableText)}
+        onClick={event => onEditClick(event, isEditableActive)}
+        currvalue={currValue}
+        {...isEditableActive}
+        {...editableProps}
+      >
+        {children}
+      </button>
     );
   }
 
@@ -287,18 +269,20 @@ export const Label: React.FunctionComponent<LabelProps> = ({
         isEditableActive && styles.modifiers.editableActive,
         className
       )}
-      {...(isEditable && {
-        onClick: (evt: MouseEvent) => {
-          const isEvtFromButton = (evt.target as HTMLElement).closest('button');
-          if (isEvtFromButton !== null) {
-            return;
-          }
-          setIsEditableActive(true);
-        }
-      })}
     >
-      {labelComponentChild}
-      {onClose && button}
+      {!isEditableActive && labelComponentChild}
+      {!isEditableActive && onClose && button}
+      {isEditableActive && (
+        <input
+          className={css(styles.labelEditableText)}
+          type="text"
+          id="editable-input"
+          ref={editableInputRef}
+          value={currValue}
+          onChange={updateVal}
+          {...editableProps}
+        />
+      )}
     </LabelComponent>
   );
 };

--- a/packages/react-core/src/components/Label/Label.tsx
+++ b/packages/react-core/src/components/Label/Label.tsx
@@ -90,8 +90,9 @@ export const Label: React.FunctionComponent<LabelProps> = ({
   ...props
 }: LabelProps) => {
   const [isEditableActive, setIsEditableActive] = useState(false);
-  const editableDivRef = React.createRef<HTMLButtonElement>();
-  const editableInputRef = React.createRef<HTMLInputElement>();
+  const [currValue, setCurrValue] = useState(children);
+  const editableButtonRef = React.useRef<HTMLButtonElement>();
+  const editableInputRef = React.useRef<HTMLInputElement>();
 
   React.useEffect(() => {
     document.addEventListener('click', onDocClick);
@@ -120,7 +121,9 @@ export const Label: React.FunctionComponent<LabelProps> = ({
     const key = event.key;
     if (
       (!isEditableActive &&
-        (!editableDivRef || !editableDivRef.current || !editableDivRef.current.contains(event.target as Node))) ||
+        (!editableButtonRef ||
+          !editableButtonRef.current ||
+          !editableButtonRef.current.contains(event.target as Node))) ||
       (isEditableActive &&
         (!editableInputRef || !editableInputRef.current || !editableInputRef.current.contains(event.target as Node)))
     ) {
@@ -194,21 +197,11 @@ export const Label: React.FunctionComponent<LabelProps> = ({
     </React.Fragment>
   );
 
-  const onEditClick = (event: any, isEditableActive: boolean) => {
-    if (!isEditableActive) {
-      setIsEditableActive(true);
-    }
-    return;
-  };
-
   React.useEffect(() => {
     if (isEditableActive && editableInputRef) {
       editableInputRef.current && editableInputRef.current.focus();
     }
-    return;
-  });
-
-  const [currValue, setCurrValue] = useState(children);
+  }, [editableInputRef, isEditableActive]);
 
   const updateVal = () => {
     setCurrValue(editableInputRef.current.value);
@@ -217,11 +210,12 @@ export const Label: React.FunctionComponent<LabelProps> = ({
   if (isEditable) {
     content = (
       <button
-        ref={editableDivRef}
+        ref={editableButtonRef}
         className={css(styles.labelEditableText)}
-        onClick={event => onEditClick(event, isEditableActive)}
-        currvalue={currValue}
-        {...isEditableActive}
+        onClick={e => {
+          setIsEditableActive(true);
+          e.stopPropagation();
+        }}
         {...editableProps}
       >
         {children}

--- a/packages/react-core/src/components/Label/__tests__/Label.test.tsx
+++ b/packages/react-core/src/components/Label/__tests__/Label.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { Label } from '../Label';
 
 test('label', () => {
@@ -7,6 +7,8 @@ test('label', () => {
   expect(view).toMatchSnapshot();
   const outline = shallow(<Label variant="outline">Something</Label>);
   expect(outline).toMatchSnapshot();
+  const compact = shallow(<Label isCompact>Something</Label>);
+  expect(compact).toMatchSnapshot();
 });
 
 test('label with href', () => {
@@ -61,5 +63,21 @@ test('label with additional class name and props', () => {
 
 test('label with truncation', () => {
   const view = shallow(<Label isTruncated>Something very very very very very long that should be truncated</Label>);
+  expect(view).toMatchSnapshot();
+});
+
+test('editable label', () => {
+  const view = mount(
+    <Label onClose={jest.fn()}
+           onEditCancel={jest.fn()}
+           onEditComplete={jest.fn()}
+           isEditable>Something</Label>);
+  const button = view.find('button.pf-c-label__editable-text');
+  expect(button.length).toBe(1);
+  expect(view).toMatchSnapshot();
+
+  button.simulate('click');
+  const clickedButton = view.find('button.pf-c-label__editable-text');
+  expect(clickedButton.length).toBe(0);
   expect(view).toMatchSnapshot();
 });

--- a/packages/react-core/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
+++ b/packages/react-core/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
@@ -15,7 +15,6 @@ exports[`editable label 1`] = `
     >
       <button
         className="pf-c-label__editable-text"
-        currvalue="Something"
         onClick={[Function]}
       >
         Something

--- a/packages/react-core/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
+++ b/packages/react-core/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
@@ -1,5 +1,103 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`editable label 1`] = `
+<Label
+  isEditable={true}
+  onClose={[MockFunction]}
+  onEditCancel={[MockFunction]}
+  onEditComplete={[MockFunction]}
+>
+  <span
+    className="pf-c-label pf-m-editable"
+  >
+    <span
+      className="pf-c-label__content"
+    >
+      <button
+        className="pf-c-label__editable-text"
+        currvalue="Something"
+        onClick={[Function]}
+      >
+        Something
+      </button>
+    </span>
+    <Button
+      aria-label="Close Something"
+      onClick={[MockFunction]}
+      type="button"
+      variant="plain"
+    >
+      <ButtonBase
+        aria-label="Close Something"
+        innerRef={null}
+        onClick={[MockFunction]}
+        type="button"
+        variant="plain"
+      >
+        <button
+          aria-disabled={false}
+          aria-label="Close Something"
+          className="pf-c-button pf-m-plain"
+          data-ouia-component-id="OUIA-Generated-Button-plain-1"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe={true}
+          disabled={false}
+          onClick={[MockFunction]}
+          role={null}
+          type="button"
+        >
+          <TimesIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
+          >
+            <svg
+              aria-hidden={true}
+              aria-labelledby={null}
+              fill="currentColor"
+              height="1em"
+              role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
+              viewBox="0 0 352 512"
+              width="1em"
+            >
+              <path
+                d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+              />
+            </svg>
+          </TimesIcon>
+        </button>
+      </ButtonBase>
+    </Button>
+  </span>
+</Label>
+`;
+
+exports[`editable label 2`] = `
+<Label
+  isEditable={true}
+  onClose={[MockFunction]}
+  onEditCancel={[MockFunction]}
+  onEditComplete={[MockFunction]}
+>
+  <span
+    className="pf-c-label pf-m-editable pf-m-editable-active"
+  >
+    <input
+      className="pf-c-label__editable-text"
+      id="editable-input"
+      onChange={[Function]}
+      type="text"
+      value="Something"
+    />
+  </span>
+</Label>
+`;
+
 exports[`label 1`] = `
 <span
   className="pf-c-label"
@@ -15,6 +113,18 @@ exports[`label 1`] = `
 exports[`label 2`] = `
 <span
   className="pf-c-label pf-m-outline"
+>
+  <span
+    className="pf-c-label__content"
+  >
+    Something
+  </span>
+</span>
+`;
+
+exports[`label 3`] = `
+<span
+  className="pf-c-label pf-m-compact"
 >
   <span
     className="pf-c-label__content"

--- a/packages/react-core/src/components/Label/examples/Label.md
+++ b/packages/react-core/src/components/Label/examples/Label.md
@@ -386,45 +386,5 @@ Click or press either enter or space to begin editing a label. After editing, cl
 
 You can also customize any Label's close button aria-label as this example shows with `closeBtnAriaLabel`.
 
-```js isBeta
-import React from 'react';
-import { Label } from '@patternfly/react-core';
-
-class EditableLabel extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      text: 'Editable label'
-    };
-    this.onEditCancel = prevText => {
-      this.setState({
-        text: prevText
-      });
-    };
-    this.onEditComplete = newText => {
-      this.setState({
-        text: newText
-      });
-    };
-  }
-
-  render() {
-    return (
-      <Label
-        color="blue"
-        onClose={Function.prototype}
-        closeBtnAriaLabel="Custom close button for editable label"
-        onEditCancel={this.onEditCancel}
-        onEditComplete={this.onEditComplete}
-        isEditable
-        editableProps={{
-          'aria-label': 'Editable text',
-          id: 'editable-label'
-        }}
-      >
-        {this.state.text}
-      </Label>
-    );
-  }
-}
+```js file="LabelEditable.tsx" isBeta 
 ```

--- a/packages/react-core/src/components/Label/examples/LabelEditable.tsx
+++ b/packages/react-core/src/components/Label/examples/LabelEditable.tsx
@@ -25,8 +25,7 @@ export const LabelEditable: React.FunctionComponent = () => {
     <React.Fragment>
       <Label
         color="blue"
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        onClose={(event: React.MouseEvent) => {}}
+        onClose={() => {}}
         closeBtnAriaLabel="Custom close button for editable label"
         onEditCancel={onEditCancel}
         onEditComplete={onEditComplete}
@@ -41,8 +40,7 @@ export const LabelEditable: React.FunctionComponent = () => {
       <Label
         color="grey"
         isCompact
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        onClose={(event: React.MouseEvent) => {}}
+        onClose={() => {}}
         closeBtnAriaLabel="Custom close button for compact editable label"
         onEditCancel={onCompactEditCancel}
         onEditComplete={onCompactEditComplete}

--- a/packages/react-core/src/components/Label/examples/LabelEditable.tsx
+++ b/packages/react-core/src/components/Label/examples/LabelEditable.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Label } from '@patternfly/react-core';
+
+export const LabelEditable: React.FunctionComponent = () => {
+  const [labelText, setLabelText] = React.useState('Editable label');
+  const [compactLabelText, setCompactLabelText] = React.useState('Compact editable label');
+
+  const onEditCancel = (prevText: string) => {
+    setLabelText(prevText);
+  };
+
+  const onEditComplete = (text: string) => {
+    setLabelText(text);
+  };
+
+  const onCompactEditCancel = (prevText: string) => {
+    setCompactLabelText(prevText);
+  };
+
+  const onCompactEditComplete = (text: string) => {
+    setCompactLabelText(text);
+  };
+
+  return (
+    <React.Fragment>
+      <Label
+        color="blue"
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        onClose={(event: React.MouseEvent) => {}}
+        closeBtnAriaLabel="Custom close button for editable label"
+        onEditCancel={onEditCancel}
+        onEditComplete={onEditComplete}
+        isEditable
+        editableProps={{
+          'aria-label': 'Editable text',
+          id: 'editable-label'
+        }}
+      >
+        {labelText}
+      </Label>
+      <Label
+        color="grey"
+        isCompact
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        onClose={(event: React.MouseEvent) => {}}
+        closeBtnAriaLabel="Custom close button for compact editable label"
+        onEditCancel={onCompactEditCancel}
+        onEditComplete={onCompactEditComplete}
+        isEditable
+        editableProps={{
+          'aria-label': 'Compact editable text',
+          id: 'compact-editable-label'
+        }}
+      >
+        {compactLabelText}
+      </Label>
+    </React.Fragment>
+  );
+};


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6096

This changes the editable label div to go between being a button and an input, allowing the elements to be more semantic and more accessible in a screen reader. Core updates likely needed to fix the styling. 