### PR TITLE
fix(types): SelectOptionProp made optional

### DIFF
--- a/packages/react-core/src/components/Select/SelectOption.tsx
+++ b/packages/react-core/src/components/Select/SelectOption.tsx
@@ -68,7 +68,7 @@ export interface SelectOptionProps extends Omit<React.HTMLProps<HTMLElement>, 't
   /** @hide Internal callback for the setting the index of the next item to focus after view more is clicked */
   setViewMoreNextIndex?: () => void;
   /** @hide Flag indicating this is the last option when there is a footer */
-  isLastOptionBeforeFooter: (index: number) => boolean;
+  isLastOptionBeforeFooter?: (index: number) => boolean;
 }
 
 export class SelectOption extends React.Component<SelectOptionProps> {


### PR DESCRIPTION
Upgrading from 4.135 to >4.150 made some typescript projects broken since the types were not overlapping anymore.

<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6504 

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
