### PR TITLE
fix(DropdownGroup): Forward custom props to the DOM

### DIFF
--- a/packages/react-core/src/components/Dropdown/DropdownGroup.tsx
+++ b/packages/react-core/src/components/Dropdown/DropdownGroup.tsx
@@ -14,13 +14,14 @@ export interface DropdownGroupProps extends Omit<React.HTMLProps<HTMLDivElement>
 export const DropdownGroup: React.FunctionComponent<DropdownGroupProps> = ({
   children = null,
   className = '',
-  label = ''
+  label = '',
+  ...props
 }: DropdownGroupProps) => (
   <DropdownContext.Consumer>
     {({ sectionClass, sectionTitleClass, sectionComponent }) => {
       const SectionComponent = sectionComponent as any;
       return (
-        <SectionComponent className={css(sectionClass, className)}>
+        <SectionComponent className={css(sectionClass, className)} {...props}>
           {label && (
             <h1 className={css(sectionTitleClass)} aria-hidden>
               {label}


### PR DESCRIPTION
**What**: From issue #6454, I `forward DropdownGroup` custom props to the DOM. Now custom props can also be given to `ApplicationLauncherGroup`.

**Additional issues**: This is a simple change, should not create any issues
