### PR TITLE
Add option to hide topology connector menu on drag end

### DIFF
--- a/packages/react-topology/src/behavior/withCreateConnector.tsx
+++ b/packages/react-topology/src/behavior/withCreateConnector.tsx
@@ -28,6 +28,7 @@ export interface CreateConnectorOptions {
   handleLength?: number;
   dragItem?: DragObjectWithType;
   dragOperation?: DragOperationWithType;
+  hideConnectorMenu?: boolean;
 }
 
 interface ConnectorComponentProps {
@@ -84,7 +85,8 @@ const CreateConnectorWidget: React.FC<CreateConnectorWidgetProps> = observer(pro
     handleLength = DEFAULT_HANDLE_LENGTH,
     contextMenuClass,
     dragItem,
-    dragOperation
+    dragOperation,
+    hideConnectorMenu
   } = props;
   const [prompt, setPrompt] = React.useState<PromptData | null>(null);
   const [active, setActive] = React.useState(false);
@@ -111,7 +113,7 @@ const CreateConnectorWidget: React.FC<CreateConnectorWidgetProps> = observer(pro
         const event = monitor.getDragEvent();
         if ((isNode(dropResult) || isGraph(dropResult)) && event) {
           const choices = await dragProps.onCreate(dragProps.element, dropResult, event, monitor.getDropHints());
-          if (choices && choices.length) {
+          if (choices && choices.length && !hideConnectorMenu) {
             setPrompt({ element: dragProps.element, target: dropResult, event, choices });
             return;
           }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**:
Currently the only way to manually hide connector context menu on drag end in topology is by returning null/empty array from the `onCreate` callback. But it is not possible to do so when rendering custom react elements (i.e. not using `ContextMenuItem`) for the choices.

The PR adds an additional option to the connector options which hides the connector menu on drag end when the option is set.
<!-- Are there any upstream issues or separate issues you need to reference? -->
