### PR TITLE
fix(react-table): stop using preventDefault for onMouseDown on table rows

### DIFF
--- a/packages/react-table/src/components/Table/Body.tsx
+++ b/packages/react-table/src/components/Table/Body.tsx
@@ -71,9 +71,6 @@ class ContextBody extends React.Component<TableBodyProps, {}> {
             isButton: (event.target as HTMLElement).tagName === 'BUTTON'
           };
           onRowClick(event, row, rowProps, computedData);
-          if (!computedData.isInput) {
-            event.preventDefault();
-          }
         }
       }
     };


### PR DESCRIPTION
Fixes #6525



So it's not clear to me what this preventDefault is meant to guard. This PR is more like a poll of - is this even needed?  @nicolethoen I guess you know :confused: ? 