### PR TITLE
feat(charts): Added resize observer and examples

### DIFF
--- a/packages/react-charts/src/components/ChartArea/examples/ChartArea.md
+++ b/packages/react-charts/src/components/ChartArea/examples/ChartArea.md
@@ -12,7 +12,7 @@ propComponents: [
 hideDarkMode: true
 ---
 
-import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThreshold, ChartThemeColor, ChartLegendTooltip, ChartThemeVariant, ChartVoronoiContainer, createContainer } from '@patternfly/react-charts';
+import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThreshold, ChartThemeColor, ChartLegendTooltip, ChartThemeVariant, ChartVoronoiContainer, createContainer, getResizeObserver } from '@patternfly/react-charts';
 import '@patternfly/patternfly/patternfly-charts.css';
 
 ## Introduction
@@ -175,30 +175,31 @@ class BottomAlignedLegend extends React.Component {
 ### Multi-color (unordered) bottom-left aligned legend and responsive container
 ```js
 import React from 'react';
-import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor, ChartVoronoiContainer } from '@patternfly/react-charts';
+import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor, ChartVoronoiContainer, getResizeObserver } from '@patternfly/react-charts';
 // import '@patternfly/patternfly/patternfly-charts.css'; // Required for mix-blend-mode CSS property
 
 class MultiColorChart extends React.Component {
   constructor(props) {
     super(props);
     this.containerRef = React.createRef();
+    this.observer = () => {};
     this.state = {
       width: 0
     };
     this.handleResize = () => {
-      if(this.containerRef.current && this.containerRef.current.clientWidth){
+      if (this.containerRef.current && this.containerRef.current.clientWidth) {
         this.setState({ width: this.containerRef.current.clientWidth });
       }
     };
   }
 
   componentDidMount() {
+    this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
     this.handleResize();
-    window.addEventListener('resize', this.handleResize);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this.handleResize);
+    this.observer();
   }
 
   render() {

--- a/packages/react-charts/src/components/ChartBullet/examples/ChartBullet.md
+++ b/packages/react-charts/src/components/ChartBullet/examples/ChartBullet.md
@@ -9,7 +9,7 @@ propComponents: [
 hideDarkMode: true
 ---
 
-import { ChartAxis, ChartBullet, ChartContainer, ChartThemeColor } from '@patternfly/react-charts';
+import { ChartAxis, ChartBullet, ChartContainer, ChartThemeColor, getResizeObserver } from '@patternfly/react-charts';
 
 ## Introduction
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
@@ -80,29 +80,30 @@ This demonstrates a responsive legend which wraps when items are wider than its 
 
 ```js
 import React from 'react';
-import { ChartBullet } from '@patternfly/react-charts';
+import { ChartBullet, getResizeObserver } from '@patternfly/react-charts';
 
 class BulletChart extends React.Component {
   constructor(props) {
     super(props);
     this.containerRef = React.createRef();
+    this.observer = () => {};
     this.state = {
       width: 0
     };
     this.handleResize = () => {
-      if(this.containerRef.current && this.containerRef.current.clientWidth){
+      if (this.containerRef.current && this.containerRef.current.clientWidth) {
         this.setState({ width: this.containerRef.current.clientWidth });
       }
     };
   }
 
   componentDidMount() {
+    this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
     this.handleResize();
-    window.addEventListener('resize', this.handleResize);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this.handleResize);
+    this.observer();
   }
 
   render() {

--- a/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
+++ b/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
@@ -25,7 +25,8 @@ import {
   ChartVoronoiContainer,
   createContainer,
   getInteractiveLegendEvents,
-  getInteractiveLegendItemStyles 
+  getInteractiveLegendItemStyles,
+  getResizeObserver
 } from '@patternfly/react-charts';
 import chart_area_Opacity from '@patternfly/react-tokens/dist/esm/chart_area_Opacity';
 import chart_color_black_500 from '@patternfly/react-tokens/dist/esm/chart_color_black_500';
@@ -105,12 +106,13 @@ This demonstrates a responsive legend which wraps when items are wider than its 
 
 ```js
 import React from 'react';
-import { ChartBullet } from '@patternfly/react-charts';
+import { ChartBullet, getResizeObserver } from '@patternfly/react-charts';
 
 class BulletChart extends React.Component {
   constructor(props) {
     super(props);
     this.containerRef = React.createRef();
+    this.observer = () => {};
     this.state = {
       width: 0
     };
@@ -122,12 +124,12 @@ class BulletChart extends React.Component {
   }
 
   componentDidMount() {
+    this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
     this.handleResize();
-    window.addEventListener('resize', this.handleResize);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this.handleResize);
+    this.observer();
   }
 
   render() {
@@ -261,7 +263,8 @@ import {
   ChartVoronoiContainer,
   createContainer, 
   getInteractiveLegendEvents, 
-  getInteractiveLegendItemStyles 
+  getInteractiveLegendItemStyles,
+  getResizeObserver
 } from '@patternfly/react-charts';
 // import '@patternfly/patternfly/patternfly-charts.css'; // For mixed blend mode
 
@@ -269,6 +272,7 @@ class InteractiveLegendChart extends React.Component {
   constructor(props) {
     super(props);
     this.containerRef = React.createRef();
+    this.observer = () => {};
     this.state = {
       hiddenSeries: new Set(),
       width: 0
@@ -373,12 +377,12 @@ class InteractiveLegendChart extends React.Component {
   };
 
   componentDidMount() {
+    this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
     this.handleResize();
-    window.addEventListener('resize', this.handleResize);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this.handleResize);
+    this.observer();
   }
 
   // Tips:
@@ -470,7 +474,6 @@ import {
 class InteractivePieLegendChart extends React.Component {
   constructor(props) {
     super(props);
-    this.containerRef = React.createRef();
     this.state = {
       hiddenSeries: new Set(),
       width: 0

--- a/packages/react-charts/src/components/ChartLine/examples/ChartLine.md
+++ b/packages/react-charts/src/components/ChartLine/examples/ChartLine.md
@@ -11,7 +11,7 @@ propComponents: [
 hideDarkMode: true
 ---
 
-import { Chart, ChartAxis, ChartGroup, ChartLine, ChartThemeColor, ChartLegendTooltip, ChartThemeVariant, ChartVoronoiContainer, createContainer } from '@patternfly/react-charts';
+import { Chart, ChartAxis, ChartGroup, ChartLine, ChartThemeColor, ChartLegendTooltip, ChartThemeVariant, ChartVoronoiContainer, createContainer, getResizeObserver } from '@patternfly/react-charts';
 import { VictoryZoomContainer } from 'victory-zoom-container';
 
 ## Introduction
@@ -194,30 +194,31 @@ This demonstrates zoom for the x axis only.
 
 ```js
 import React from 'react';
-import { Chart, ChartAxis, ChartGroup, ChartLine, ChartThemeColor } from '@patternfly/react-charts';
+import { Chart, ChartAxis, ChartGroup, ChartLine, ChartThemeColor, getResizeObserver } from '@patternfly/react-charts';
 import { VictoryZoomContainer } from 'victory-zoom-container';
 
 class MultiColorChart extends React.Component {
   constructor(props) {
     super(props);
     this.containerRef = React.createRef();
+    this.observer = () => {};
     this.state = {
       width: 0
     };
     this.handleResize = () => {
-      if(this.containerRef.current && this.containerRef.current.clientWidth){
+      if (this.containerRef.current && this.containerRef.current.clientWidth) {
         this.setState({ width: this.containerRef.current.clientWidth });
       }
     };
   }
 
   componentDidMount() {
+    this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
     this.handleResize();
-    window.addEventListener('resize', this.handleResize);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this.handleResize);
+    this.observer();
   }
 
   render() {

--- a/packages/react-charts/src/components/ChartScatter/examples/ChartScatter.md
+++ b/packages/react-charts/src/components/ChartScatter/examples/ChartScatter.md
@@ -20,7 +20,8 @@ import {
   ChartLine,
   ChartScatter,
   ChartThemeColor,
-  ChartVoronoiContainer
+  ChartVoronoiContainer,
+  getResizeObserver
 } from '@patternfly/react-charts';
 
 ## Introduction
@@ -35,18 +36,19 @@ This demonstrates how to add interactive data points to an area chart.
 
 ```js
 import React from 'react';
-import { Chart, ChartArea, ChartAxis, ChartGroup, ChartScatter, ChartThemeColor, ChartVoronoiContainer } from '@patternfly/react-charts';
+import { Chart, ChartArea, ChartAxis, ChartGroup, ChartScatter, ChartThemeColor, ChartVoronoiContainer, getResizeObserver } from '@patternfly/react-charts';
 // import '@patternfly/patternfly/patternfly-charts.css'; // For mixed blend mode
 
 class ScatterAreaChart extends React.Component {
   constructor(props) {
     super(props);
     this.containerRef = React.createRef();
+    this.observer = () => {};
     this.state = {
       width: 0
     };
     this.handleResize = () => {
-      if(this.containerRef.current && this.containerRef.current.clientWidth){
+      if (this.containerRef.current && this.containerRef.current.clientWidth) {
         this.setState({ width: this.containerRef.current.clientWidth });
       }
     };
@@ -84,12 +86,12 @@ class ScatterAreaChart extends React.Component {
   }
 
   componentDidMount() {
+    this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
     this.handleResize();
-    window.addEventListener('resize', this.handleResize);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this.handleResize);
+    this.observer();
   }
 
   render() {
@@ -153,17 +155,18 @@ This demonstrates how to add interactive data points to a line chart.
 
 ```js
 import React from 'react';
-import { Chart, ChartAxis, ChartGroup, ChartLine, ChartScatter, ChartThemeColor, ChartVoronoiContainer } from '@patternfly/react-charts';
+import { Chart, ChartAxis, ChartGroup, ChartLine, ChartScatter, ChartThemeColor, ChartVoronoiContainer, getResizeObserver } from '@patternfly/react-charts';
 
 class ScatterLineChart extends React.Component {
   constructor(props) {
     super(props);
     this.containerRef = React.createRef();
+    this.observer = () => {};
     this.state = {
       width: 0
     };
     this.handleResize = () => {
-      if(this.containerRef.current && this.containerRef.current.clientWidth){
+      if (this.containerRef.current && this.containerRef.current.clientWidth) {
         this.setState({ width: this.containerRef.current.clientWidth });
       }
     };
@@ -213,12 +216,12 @@ class ScatterLineChart extends React.Component {
   }
 
   componentDidMount() {
+    this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
     this.handleResize();
-    window.addEventListener('resize', this.handleResize);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this.handleResize);
+    this.observer();
   }
 
   render() {

--- a/packages/react-charts/src/components/ChartStack/examples/ChartStack.md
+++ b/packages/react-charts/src/components/ChartStack/examples/ChartStack.md
@@ -21,7 +21,8 @@ import {
   ChartThemeColor,
   ChartTooltip,
   ChartVoronoiContainer,
-  createContainer
+  createContainer,
+  getResizeObserver
 } from '@patternfly/react-charts';
 
 ## Introduction
@@ -176,12 +177,13 @@ import { Chart, ChartBar, ChartAxis, ChartStack, ChartThemeColor, ChartTooltip }
 ### Monthly data with responsive container
 ```js
 import React from 'react';
-import { Chart, ChartAxis, ChartBar, ChartStack, ChartTooltip } from '@patternfly/react-charts';
+import { Chart, ChartAxis, ChartBar, ChartStack, ChartTooltip, getResizeObserver } from '@patternfly/react-charts';
 
 class MonthlyResponsiveStack extends React.Component {
   constructor(props) {
     super(props);
     this.containerRef = React.createRef();
+    this.observer = () => {};
     this.state = {
       width: 0
     };
@@ -246,12 +248,12 @@ class MonthlyResponsiveStack extends React.Component {
   }
 
   componentDidMount() {
+    this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
     this.handleResize();
-    window.addEventListener('resize', this.handleResize);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this.handleResize);
+    this.observer();
   }
 
   render(){
@@ -295,12 +297,13 @@ This demonstrates monthly data with a bottom aligned legend and responsiveness f
 
 ```js
 import React from 'react';
-import { Chart, ChartArea, ChartAxis, ChartStack, ChartLegendTooltip, ChartThemeColor, ChartVoronoiContainer, createContainer } from '@patternfly/react-charts';
+import { Chart, ChartArea, ChartAxis, ChartStack, ChartLegendTooltip, ChartThemeColor, ChartVoronoiContainer, createContainer, getResizeObserver } from '@patternfly/react-charts';
 
 class MultiColorChart extends React.Component {
   constructor(props) {
     super(props);
     this.containerRef = React.createRef();
+    this.observer = () => {};
     this.state = {
       width: 0
     };
@@ -312,12 +315,12 @@ class MultiColorChart extends React.Component {
   }
 
   componentDidMount() {
+    this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
     this.handleResize();
-    window.addEventListener('resize', this.handleResize);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this.handleResize);
+    this.observer();
   }
 
   render() {

--- a/packages/react-charts/src/components/ChartThreshold/examples/ChartThreshold.md
+++ b/packages/react-charts/src/components/ChartThreshold/examples/ChartThreshold.md
@@ -20,7 +20,8 @@ import {
   ChartThreshold,
   ChartThemeColor,
   ChartThemeVariant,
-  ChartVoronoiContainer
+  ChartVoronoiContainer,
+  getResizeObserver
 } from '@patternfly/react-charts';
 import '@patternfly/patternfly/patternfly-charts.css';
 import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
@@ -45,7 +46,8 @@ import {
   ChartGroup,
   ChartThreshold,
   ChartThemeColor,
-  ChartVoronoiContainer
+  ChartVoronoiContainer,
+  getResizeObserver
 } from '@patternfly/react-charts';
 import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
 import chart_color_orange_300 from '@patternfly/react-tokens/dist/esm/chart_color_orange_300';
@@ -54,6 +56,7 @@ class MultiColorChart extends React.Component {
   constructor(props) {
     super(props);
     this.containerRef = React.createRef();
+    this.observer = () => {};
     this.state = {
       width: 0
     };
@@ -65,12 +68,12 @@ class MultiColorChart extends React.Component {
   }
 
   componentDidMount() {
+    this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
     this.handleResize();
-    window.addEventListener('resize', this.handleResize);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this.handleResize);
+    this.observer();
   }
 
   render() {

--- a/packages/react-charts/src/components/ChartUtils/chart-helpers.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-helpers.ts
@@ -4,6 +4,9 @@ interface ChartClassNameInterface {
   className?: string;
 }
 
+// Copied from exenv
+export const canUseDOM = !!(typeof window !== 'undefined' && window.document && window.document.createElement);
+
 // Returns the class name that will be applied to the outer-most div rendered by the chart's container
 export const getClassName = ({ className }: ChartClassNameInterface) => {
   let cleanClassName;

--- a/packages/react-charts/src/components/ChartUtils/chart-resize.tsx
+++ b/packages/react-charts/src/components/ChartUtils/chart-resize.tsx
@@ -1,0 +1,91 @@
+import * as React from 'react';
+import { canUseDOM } from './chart-helpers';
+
+/**
+ * This function creates a ResizeObserver used to handle resize events for the given containerRef. If ResizeObserver
+ * or the given containerRef are not available, a window resize event listener is used by default.
+ *
+ * Example 1:
+ *
+ * private containerRef = React.createRef<HTMLDivElement>();
+ * private observer: any = () => {};
+ *
+ * public componentDidMount() {
+ *   this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
+ * }
+ *
+ * public componentWillUnmount() {
+ *   this.observer();
+ * }
+ *
+ * private handleResize = () => {
+ *   if (this.containerRef.current && this.containerRef.current.clientWidth) {
+ *     this.setState({ width: this.containerRef.current.clientWidth });
+ *   }
+ * };
+ *
+ * public render() {
+ *   return (
+ *     <div ref={this.containerRef} >
+ *       <Chart width={this.state.width} ... />
+ *     </div>
+ *   );
+ * }
+ *
+ * Example 2:
+ *
+ * private inputRef = React.createRef<HTMLInputElement>();
+ * private observer: any = () => {};
+ *
+ * public componentDidMount() {
+ *   this.observer = getResizeObserver(this.inputRef.current, this.handleResize);
+ * }
+ *
+ * public componentWillUnmount() {
+ *   this.observer();
+ * }
+ *
+ * private handleResize = () => {
+ *   if (this.inputRef.current) {
+ *     trimLeft(inputRef.current, String(this.props.value));
+ *   }
+ * };
+ *
+ * public render() {
+ *   return (
+ *     <input ref={this.inputRef} ... />
+ *   );
+ * }
+ *
+ * @param {React.RefObject} containerRef The container reference to observe
+ * @param {Function} handleResize The function to call for resize events
+ * @return {Function} The function used to unobserve resize events
+ */
+export const getResizeObserver = (containerRef: React.RefObject<any>, handleResize: () => void) => {
+  let unobserve: any;
+
+  if (canUseDOM) {
+    const { ResizeObserver } = window as any;
+
+    if (containerRef && ResizeObserver) {
+      const resizeObserver = new ResizeObserver((entries: any) => {
+        // Wrap resize function in requestAnimationFrame to avoid "ResizeObserver loop limit exceeded" errors
+        window.requestAnimationFrame(() => {
+          if (Array.isArray(entries) && entries.length > 0) {
+            handleResize();
+          }
+        });
+      });
+      resizeObserver.observe(containerRef);
+      unobserve = () => resizeObserver.unobserve(containerRef);
+    } else {
+      window.addEventListener('resize', handleResize);
+      unobserve = () => window.removeEventListener('resize', handleResize);
+    }
+  }
+  return () => {
+    if (unobserve) {
+      unobserve();
+    }
+  };
+};

--- a/packages/react-charts/src/components/ChartUtils/index.ts
+++ b/packages/react-charts/src/components/ChartUtils/index.ts
@@ -6,5 +6,6 @@ export * from './chart-label';
 export * from './chart-legend';
 export * from './chart-origin';
 export * from './chart-padding';
+export * from './chart-resize';
 export * from './chart-theme';
 export * from './chart-tooltip';


### PR DESCRIPTION
In order to resize charts, PatternFly examples currently use the window `resize` event. However, this doesn't work with PatternFly's vertical navigation. For example, `onNavToggle` doesn't generate a window resize event when the nav pane is collapsed. This typically results in a chart that does not resize as expected.

To resolve the issue, Cost Management has been using a `ResizeObserver`. This resizes the chart whenever its parent container is resized. Not only for the window resize event, but it's also triggered by PatternFly's vertical navigation `onNavToggle`. 

We would like to contribute this code back to PatternFly and update the existing chart examples. Our `getResizeObserver` code provides a workaround for Chrome and uses the window resize event as a fallback. The developer's existing `handleResize` function remains unchanged.

Fixes https://github.com/patternfly/patternfly-react/issues/5995

**Area chart example**
![chrome-capture](https://user-images.githubusercontent.com/17481322/139470920-d742544d-c5ac-4e9e-adea-39e03ab30dce.gif)
