### PR TITLE
feat(ComposableTable): add sticky columns and nested headers

### DIFF
--- a/packages/react-table/src/components/TableComposable/InnerScrollContainer.tsx
+++ b/packages/react-table/src/components/TableComposable/InnerScrollContainer.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { css } from '@patternfly/react-styles';
+import styles from '@patternfly/react-styles/css/components/Table/table-scrollable';
+
+export interface InnerScrollContainerProps extends React.HTMLProps<HTMLDivElement> {
+  /** Content rendered inside the inner scroll container */
+  children?: React.ReactNode;
+  /** Additional classes added to the container */
+  className?: string;
+}
+
+export const InnerScrollContainer: React.FunctionComponent<InnerScrollContainerProps> = ({
+  children,
+  className,
+  ...props
+}: InnerScrollContainerProps) => (
+  <div className={css(className, styles.scrollInnerWrapper)} {...props}>
+    {children}
+  </div>
+);
+
+InnerScrollContainer.displayName = 'InnerScrollContainer';

--- a/packages/react-table/src/components/TableComposable/OuterScrollContainer.tsx
+++ b/packages/react-table/src/components/TableComposable/OuterScrollContainer.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { css } from '@patternfly/react-styles';
+import styles from '@patternfly/react-styles/css/components/Table/table-scrollable';
+
+export interface OuterScrollContainerProps extends React.HTMLProps<HTMLDivElement> {
+  /** Content rendered inside the outer scroll container */
+  children?: React.ReactNode;
+  /** Additional classes added to the container */
+  className?: string;
+}
+
+export const OuterScrollContainer: React.FunctionComponent<OuterScrollContainerProps> = ({
+  children,
+  className,
+  ...props
+}: OuterScrollContainerProps) => (
+  <div className={css(className, styles.scrollOuterWrapper)} {...props}>
+    {children}
+  </div>
+);
+
+OuterScrollContainer.displayName = 'OuterScrollContainer';

--- a/packages/react-table/src/components/TableComposable/TableComposable.tsx
+++ b/packages/react-table/src/components/TableComposable/TableComposable.tsx
@@ -53,6 +53,8 @@ export interface TableComposableProps extends React.HTMLProps<HTMLTableElement>,
   isTreeTable?: boolean;
   /** Flag indicating this table is nested within another table */
   isNested?: boolean;
+  /** Collection of column spans for nested headers */
+  nestedHeaderColumnSpans?: number[];
 }
 
 const TableComposableBase: React.FunctionComponent<TableComposableProps> = ({
@@ -69,6 +71,7 @@ const TableComposableBase: React.FunctionComponent<TableComposableProps> = ({
   ouiaSafe = true,
   isTreeTable = false,
   isNested = false,
+  nestedHeaderColumnSpans,
   ...props
 }: TableComposableProps) => {
   const tableRef = innerRef || React.useRef(null);
@@ -156,6 +159,14 @@ const TableComposableBase: React.FunctionComponent<TableComposableProps> = ({
       {...ouiaProps}
       {...props}
     >
+      {nestedHeaderColumnSpans &&
+        nestedHeaderColumnSpans.map((span: number, index) => {
+          if (span === 1) {
+            return <col key={index} />;
+          } else {
+            return <colgroup key={index} span={span} />;
+          }
+        })}
       {children}
     </table>
   );

--- a/packages/react-table/src/components/TableComposable/Th.tsx
+++ b/packages/react-table/src/components/TableComposable/Th.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
+import scrollStyles from '@patternfly/react-styles/css/components/Table/table-scrollable';
 import { info } from '../Table/utils/decorators/info';
 import { sortable, sortableFavorites } from '../Table/utils/decorators/sortable';
 import { selectable } from '../Table/utils/decorators/selectable';
@@ -38,6 +39,14 @@ export interface ThProps
   info?: ThInfoType;
   /** Adds scope to the column to associate header cells with data cells*/
   scope?: string;
+  /** Indicates the header column should be sticky */
+  isStickyColumn?: boolean;
+  /** Adds a border to the right side of the cell */
+  hasRightBorder?: boolean;
+  /** Minimum width for a sticky column */
+  stickyMinWidth?: string;
+  /** Left offset of a sticky column */
+  stickyLeftOffset?: string;
 }
 
 const ThBase: React.FunctionComponent<ThProps> = ({
@@ -56,6 +65,10 @@ const ThBase: React.FunctionComponent<ThProps> = ({
   visibility,
   innerRef,
   info: infoProps,
+  isStickyColumn = false,
+  hasRightBorder = false,
+  stickyMinWidth = '100px',
+  stickyLeftOffset,
   ...props
 }: ThProps) => {
   const [showTooltip, setShowTooltip] = React.useState(false);
@@ -132,11 +145,20 @@ const ThBase: React.FunctionComponent<ThProps> = ({
       className={css(
         className,
         textCenter && styles.modifiers.center,
+        isStickyColumn && scrollStyles.tableStickyColumn,
+        hasRightBorder && scrollStyles.modifiers.borderRight,
         modifier && styles.modifiers[modifier as 'breakWord' | 'fitContent' | 'nowrap' | 'truncate' | 'wrap'],
         mergedClassName
       )}
       {...mergedProps}
       {...props}
+      {...(isStickyColumn && {
+        style: {
+          '--pf-c-table__sticky-column--MinWidth': stickyMinWidth ? stickyMinWidth : undefined,
+          '--pf-c-table__sticky-column--Left': stickyLeftOffset ? stickyLeftOffset : undefined,
+          ...props.style
+        } as React.CSSProperties
+      })}
     >
       {transformedChildren}
     </MergedComponent>

--- a/packages/react-table/src/components/TableComposable/Th.tsx
+++ b/packages/react-table/src/components/TableComposable/Th.tsx
@@ -45,7 +45,7 @@ export interface ThProps
   hasRightBorder?: boolean;
   /** Minimum width for a sticky column */
   stickyMinWidth?: string;
-  /** Left offset of a sticky column */
+  /** Left offset of a sticky column. This will typically be equal to the combined value set by stickyMinWidth of any sticky columns that precede the current sticky column. */
   stickyLeftOffset?: string;
 }
 

--- a/packages/react-table/src/components/TableComposable/Th.tsx
+++ b/packages/react-table/src/components/TableComposable/Th.tsx
@@ -69,7 +69,7 @@ const ThBase: React.FunctionComponent<ThProps> = ({
   info: infoProps,
   isStickyColumn = false,
   hasRightBorder = false,
-  stickyMinWidth = '100px',
+  stickyMinWidth = '120px',
   stickyLeftOffset,
   isSubheader = false,
   ...props

--- a/packages/react-table/src/components/TableComposable/Th.tsx
+++ b/packages/react-table/src/components/TableComposable/Th.tsx
@@ -47,6 +47,8 @@ export interface ThProps
   stickyMinWidth?: string;
   /** Left offset of a sticky column. This will typically be equal to the combined value set by stickyMinWidth of any sticky columns that precede the current sticky column. */
   stickyLeftOffset?: string;
+  /** Indicates the <th> is part of a subheader of a nested header */
+  isSubheader?: boolean;
 }
 
 const ThBase: React.FunctionComponent<ThProps> = ({
@@ -69,6 +71,7 @@ const ThBase: React.FunctionComponent<ThProps> = ({
   hasRightBorder = false,
   stickyMinWidth = '100px',
   stickyLeftOffset,
+  isSubheader = false,
   ...props
 }: ThProps) => {
   const [showTooltip, setShowTooltip] = React.useState(false);
@@ -145,6 +148,7 @@ const ThBase: React.FunctionComponent<ThProps> = ({
       className={css(
         className,
         textCenter && styles.modifiers.center,
+        isSubheader && styles.tableSubhead,
         isStickyColumn && scrollStyles.tableStickyColumn,
         hasRightBorder && scrollStyles.modifiers.borderRight,
         modifier && styles.modifiers[modifier as 'breakWord' | 'fitContent' | 'nowrap' | 'truncate' | 'wrap'],

--- a/packages/react-table/src/components/TableComposable/Thead.tsx
+++ b/packages/react-table/src/components/TableComposable/Thead.tsx
@@ -11,6 +11,8 @@ export interface TheadProps extends React.HTMLProps<HTMLTableSectionElement> {
   noWrap?: boolean;
   /** Forwarded ref */
   innerRef?: React.Ref<any>;
+  /** Indicates the <thead> contains a nested header */
+  hasNestedHeader?: boolean;
 }
 
 const TheadBase: React.FunctionComponent<TheadProps> = ({
@@ -18,9 +20,18 @@ const TheadBase: React.FunctionComponent<TheadProps> = ({
   className,
   noWrap = false,
   innerRef,
+  hasNestedHeader,
   ...props
 }: TheadProps) => (
-  <thead className={css(className, noWrap && styles.modifiers.nowrap)} ref={innerRef} {...props}>
+  <thead
+    className={css(
+      className,
+      noWrap && styles.modifiers.nowrap,
+      hasNestedHeader && styles.modifiers.nestedColumnHeader
+    )}
+    ref={innerRef}
+    {...props}
+  >
     {children}
   </thead>
 );

--- a/packages/react-table/src/components/TableComposable/Tr.tsx
+++ b/packages/react-table/src/components/TableComposable/Tr.tsx
@@ -23,6 +23,8 @@ export interface TrProps extends React.HTMLProps<HTMLTableRowElement>, OUIAProps
   isRowSelected?: boolean;
   /** An event handler for the row */
   onRowClick?: (event?: React.KeyboardEvent | React.MouseEvent) => void;
+  /** Flag indicating the spacing offset of the first cell should be reset */
+  resetOffset?: boolean;
 }
 
 const TrBase: React.FunctionComponent<TrProps> = ({
@@ -36,6 +38,7 @@ const TrBase: React.FunctionComponent<TrProps> = ({
   innerRef,
   ouiaId,
   ouiaSafe = true,
+  resetOffset = false,
   onRowClick,
   ...props
 }: TrProps) => {
@@ -59,7 +62,8 @@ const TrBase: React.FunctionComponent<TrProps> = ({
         isExpanded && styles.modifiers.expanded,
         isEditable && inlineStyles.modifiers.inlineEditable,
         isHoverable && styles.modifiers.hoverable,
-        isRowSelected && styles.modifiers.selected
+        isRowSelected && styles.modifiers.selected,
+        resetOffset && styles.modifiers.firstCellOffsetReset
       )}
       hidden={isHidden || (isExpanded !== undefined && !isExpanded)}
       {...(isHoverable && { tabIndex: 0 })}

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
@@ -52,6 +52,7 @@ import LeafIcon from '@patternfly/react-icons/dist/esm/icons/leaf-icon';
 import FolderIcon from '@patternfly/react-icons/dist/esm/icons/folder-icon';
 import FolderOpenIcon from '@patternfly/react-icons/dist/esm/icons/folder-open-icon';
 import SortAmountDownIcon from '@patternfly/react-icons/dist/esm/icons/sort-amount-down-icon';
+import BlueprintIcon from '@patternfly/react-icons/dist/esm/icons/blueprint-icon';
 
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
@@ -2011,4 +2012,763 @@ class DraggableTable extends React.Component {
     );
   }
 }
+```
+
+### Composable: Sticky column
+
+To make a column sticky, wrap `TableComposable` with `InnerScrollContainer` and add the following properties to the `Th` that should be sticky: `isStickyColumn` and `hasRightBorder`. To prevent the default text wrapping behavior and allow horizontal scrolling, all `Th` should also have the `modifier="nowrap"` property. To set the minimum width of the sticky column, use the `stickyMinWidth` property.
+
+```js
+import React from 'react';
+import {
+  TableComposable,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Caption,
+  TableText,
+  InnerScrollContainer
+} from '@patternfly/react-table';
+import { Flex, FlexItem } from '@patternfly/react-core';
+import BlueprintIcon from '@patternfly/react-icons/dist/esm/icons/blueprint-icon';
+
+ComposableTableStickyColumn = () => {
+  const columns = ['Fact', 'State', 'Header 3', 'Header 4', 'Header 5', 'Header 6', 'Header 7', 'Header 8', 'Header 9'];
+  const [rows, setRows] = React.useState([
+    [
+      'Fact 1',
+      'State 1',
+      'Test cell 1-3',
+      'Test cell 1-4',
+      'Test cell 1-5',
+      'Test cell 1-6',
+      'Test cell 1-7',
+      'Test cell 1-8',
+      'Test cell 1-9'
+    ],
+    [
+      'Fact 2',
+      'State 2',
+      'Test cell 2-3',
+      'Test cell 2-4',
+      'Test cell 2-5',
+      'Test cell 2-6',
+      'Test cell 2-7',
+      'Test cell 2-8',
+      'Test cell 2-9'
+    ],
+    [
+      'Fact 3',
+      'State 3',
+      'Test cell 3-3',
+      'Test cell 3-4',
+      'Test cell 3-5',
+      'Test cell 3-6',
+      'Test cell 3-7',
+      'Test cell 3-8',
+      'Test cell 3-9'
+    ],
+    [
+      'Fact 4',
+      'State 4',
+      'Test cell 4-3',
+      'Test cell 4-4',
+      'Test cell 4-5',
+      'Test cell 4-6',
+      'Test cell 4-7',
+      'Test cell 4-8',
+      'Test cell 4-9'
+    ],
+    [
+      'Fact 5',
+      'State 5',
+      'Test cell 5-3',
+      'Test cell 5-4',
+      'Test cell 5-5',
+      'Test cell 5-6',
+      'Test cell 5-7',
+      'Test cell 5-8',
+      'Test cell 5-9'
+    ],
+    [
+      'Fact 6',
+      'State 6',
+      'Test cell 6-3',
+      'Test cell 6-4',
+      'Test cell 6-5',
+      'Test cell 6-6',
+      'Test cell 6-7',
+      'Test cell 6-8',
+      'Test cell 6-9'
+    ],
+    [
+      'Fact 7',
+      'State 7',
+      'Test cell 7-3',
+      'Test cell 7-4',
+      'Test cell 7-5',
+      'Test cell 7-6',
+      'Test cell 7-7',
+      'Test cell 7-8',
+      'Test cell 7-9'
+    ],
+    [
+      'Fact 8',
+      'State 8',
+      'Test cell 8-3',
+      'Test cell 8-4',
+      'Test cell 8-5',
+      'Test cell 8-6',
+      'Test cell 8-7',
+      'Test cell 8-8',
+      'Test cell 8-9'
+    ],
+    [
+      'Fact 9',
+      'State 9',
+      'Test cell 9-3',
+      'Test cell 9-4',
+      'Test cell 9-5',
+      'Test cell 9-6',
+      'Test cell 9-7',
+      'Test cell 9-8',
+      'Test cell 9-9'
+    ]
+  ]);
+  // index of the currently active column
+  const [activeSortIndex, setActiveSortIndex] = React.useState(-1);
+  // sort direction of the currently active column
+  const [activeSortDirection, setActiveSortDirection] = React.useState('none');
+  const onSort = (event, index, direction) => {
+    setActiveSortIndex(index);
+    setActiveSortDirection(direction);
+    // sorts the rows
+    const updatedRows = rows.sort((a, b) => {
+      if (typeof a[index] === 'number') {
+        // numeric sort
+        if (direction === 'asc') {
+          return a[index] - b[index];
+        }
+        return b[index] - a[index];
+      } else {
+        // string sort
+        if (direction === 'asc') {
+          return a[index].localeCompare(b[index]);
+        }
+        return b[index].localeCompare(a[index]);
+      }
+    });
+    setRows(updatedRows);
+  };
+  return (
+    <React.Fragment>
+      <InnerScrollContainer>
+        <TableComposable aria-label="Sticky column table" gridBreakPoint="">
+          <Thead>
+            <Tr>
+              {columns.map((column, columnIndex) => {
+                const sortParams =
+                  columnIndex === 0 || columnIndex === 1
+                    ? {
+                        sort: {
+                          sortBy: {
+                            index: activeSortIndex,
+                            direction: activeSortDirection
+                          },
+                          onSort,
+                          columnIndex
+                        }
+                      }
+                    : {};
+
+                if (columnIndex === 0) {
+                  return (
+                    <Th key={columnIndex} isStickyColumn hasRightBorder modifier="nowrap" {...sortParams}>
+                      <Flex flexWrap={{ default: 'nowrap' }}>
+                        <FlexItem>{column}</FlexItem>
+                      </Flex>
+                    </Th>
+                  );
+                } else if (columnIndex === 1) {
+                  return (
+                    <Th key={columnIndex} modifier="nowrap" {...sortParams}>
+                      <Flex flexWrap={{ default: 'nowrap' }}>
+                        <FlexItem>{column}</FlexItem>
+                      </Flex>
+                    </Th>
+                  );
+                } else {
+                  return (
+                    <Th key={columnIndex} modifier="nowrap">
+                      <TableText>
+                        <Flex flexWrap={{ default: 'nowrap' }}>
+                          <FlexItem>
+                            <BlueprintIcon />
+                          </FlexItem>
+                          <FlexItem>{column}</FlexItem>
+                        </Flex>
+                      </TableText>
+                    </Th>
+                  );
+                }
+              })}
+            </Tr>
+          </Thead>
+          <Tbody>
+            {rows.map((row, rowIndex) => (
+              <Tr key={rowIndex}>
+                {row.map((cell, cellIndex) => {
+                  if (cellIndex === 0) {
+                    return (
+                      <Th key={cellIndex} isStickyColumn hasRightBorder>
+                        {cell}
+                      </Th>
+                    );
+                  } else {
+                    return (
+                      <Td key={`${rowIndex}_${cellIndex}`} dataLabel={columns[cellIndex]}>
+                        {cell}
+                      </Td>
+                    );
+                  }
+                })}
+              </Tr>
+            ))}
+          </Tbody>
+        </TableComposable>
+      </InnerScrollContainer>
+    </React.Fragment>
+  );
+};
+```
+
+### Composable: Multiple sticky columns
+
+To make multiple columns sticky, wrap `TableComposable` with `InnerScrollContainer` and add `isStickyColumn` to all columns that should be sticky. The rightmost column should also have the `hasRightBorder` property, and each sticky column after the first must define a `stickyLeftOffset` property that equals the combined width of the previous sticky columns - set by `stickyMinWidth`. To prevent the default text wrapping behavior and allow horizontal scrolling, all `Th` should also have the `modifier="nowrap"` property.
+
+```js
+import React from 'react';
+import {
+  TableComposable,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Caption,
+  TableText,
+  InnerScrollContainer
+} from '@patternfly/react-table';
+import { Flex, FlexItem } from '@patternfly/react-core';
+import BlueprintIcon from '@patternfly/react-icons/dist/esm/icons/blueprint-icon';
+
+ComposableTableMultipleStickyColumn = () => {
+  const columns = ['Fact', 'State', 'Header 3', 'Header 4', 'Header 5', 'Header 6', 'Header 7', 'Header 8', 'Header 9'];
+  const [rows, setRows] = React.useState([
+    [
+      'Fact 1',
+      'State 1',
+      'Test cell 1-3',
+      'Test cell 1-4',
+      'Test cell 1-5',
+      'Test cell 1-6',
+      'Test cell 1-7',
+      'Test cell 1-8',
+      'Test cell 1-9'
+    ],
+    [
+      'Fact 2',
+      'State 2',
+      'Test cell 2-3',
+      'Test cell 2-4',
+      'Test cell 2-5',
+      'Test cell 2-6',
+      'Test cell 2-7',
+      'Test cell 2-8',
+      'Test cell 2-9'
+    ],
+    [
+      'Fact 3',
+      'State 3',
+      'Test cell 3-3',
+      'Test cell 3-4',
+      'Test cell 3-5',
+      'Test cell 3-6',
+      'Test cell 3-7',
+      'Test cell 3-8',
+      'Test cell 3-9'
+    ],
+    [
+      'Fact 4',
+      'State 4',
+      'Test cell 4-3',
+      'Test cell 4-4',
+      'Test cell 4-5',
+      'Test cell 4-6',
+      'Test cell 4-7',
+      'Test cell 4-8',
+      'Test cell 4-9'
+    ],
+    [
+      'Fact 5',
+      'State 5',
+      'Test cell 5-3',
+      'Test cell 5-4',
+      'Test cell 5-5',
+      'Test cell 5-6',
+      'Test cell 5-7',
+      'Test cell 5-8',
+      'Test cell 5-9'
+    ],
+    [
+      'Fact 6',
+      'State 6',
+      'Test cell 6-3',
+      'Test cell 6-4',
+      'Test cell 6-5',
+      'Test cell 6-6',
+      'Test cell 6-7',
+      'Test cell 6-8',
+      'Test cell 6-9'
+    ],
+    [
+      'Fact 7',
+      'State 7',
+      'Test cell 7-3',
+      'Test cell 7-4',
+      'Test cell 7-5',
+      'Test cell 7-6',
+      'Test cell 7-7',
+      'Test cell 7-8',
+      'Test cell 7-9'
+    ],
+    [
+      'Fact 8',
+      'State 8',
+      'Test cell 8-3',
+      'Test cell 8-4',
+      'Test cell 8-5',
+      'Test cell 8-6',
+      'Test cell 8-7',
+      'Test cell 8-8',
+      'Test cell 8-9'
+    ],
+    [
+      'Fact 9',
+      'State 9',
+      'Test cell 9-3',
+      'Test cell 9-4',
+      'Test cell 9-5',
+      'Test cell 9-6',
+      'Test cell 9-7',
+      'Test cell 9-8',
+      'Test cell 9-9'
+    ]
+  ]);
+  // index of the currently active column
+  const [activeSortIndex, setActiveSortIndex] = React.useState(-1);
+  // sort direction of the currently active column
+  const [activeSortDirection, setActiveSortDirection] = React.useState('none');
+  const onSort = (event, index, direction) => {
+    setActiveSortIndex(index);
+    setActiveSortDirection(direction);
+    // sorts the rows
+    const updatedRows = rows.sort((a, b) => {
+      if (typeof a[index] === 'number') {
+        // numeric sort
+        if (direction === 'asc') {
+          return a[index] - b[index];
+        }
+        return b[index] - a[index];
+      } else {
+        // string sort
+        if (direction === 'asc') {
+          return a[index].localeCompare(b[index]);
+        }
+        return b[index].localeCompare(a[index]);
+      }
+    });
+    setRows(updatedRows);
+  };
+  return (
+    <React.Fragment>
+      <InnerScrollContainer>
+        <TableComposable aria-label="Sticky column table" gridBreakPoint="">
+          <Thead>
+            <Tr>
+              {columns.map((column, columnIndex) => {
+                const sortParams =
+                  columnIndex === 0 || columnIndex === 1
+                    ? {
+                        sort: {
+                          sortBy: {
+                            index: activeSortIndex,
+                            direction: activeSortDirection
+                          },
+                          onSort,
+                          columnIndex
+                        }
+                      }
+                    : {};
+
+                if (columnIndex === 0) {
+                  return (
+                    <Th key={columnIndex} isStickyColumn modifier="nowrap" {...sortParams}>
+                      <Flex flexWrap={{ default: 'nowrap' }}>
+                        <FlexItem>{column}</FlexItem>
+                      </Flex>
+                    </Th>
+                  );
+                } else if (columnIndex === 1) {
+                  return (
+                    <Th
+                      key={columnIndex}
+                      isStickyColumn
+                      stickyMinWidth="80px"
+                      stickyLeftOffset="107px"
+                      hasRightBorder
+                      modifier="nowrap"
+                      {...sortParams}
+                    >
+                      <Flex flexWrap={{ default: 'nowrap' }}>
+                        <FlexItem>{column}</FlexItem>
+                      </Flex>
+                    </Th>
+                  );
+                } else {
+                  return (
+                    <Th key={columnIndex} modifier="nowrap">
+                      <TableText>
+                        <Flex flexWrap={{ default: 'nowrap' }}>
+                          <FlexItem>
+                            <BlueprintIcon />
+                          </FlexItem>
+                          <FlexItem>{column}</FlexItem>
+                        </Flex>
+                      </TableText>
+                    </Th>
+                  );
+                }
+              })}
+            </Tr>
+          </Thead>
+          <Tbody>
+            {rows.map((row, rowIndex) => (
+              <Tr key={rowIndex}>
+                {row.map((cell, cellIndex) => {
+                  if (cellIndex === 0) {
+                    return (
+                      <Th key={cellIndex} isStickyColumn modifier="nowrap">
+                        <TableText>
+                          <Flex flexWrap={{ default: 'nowrap' }}>
+                            <FlexItem>{cell}</FlexItem>
+                          </Flex>
+                        </TableText>
+                      </Th>
+                    );
+                  } else if (cellIndex === 1) {
+                    return (
+                      <Th
+                        key={cellIndex}
+                        isStickyColumn
+                        stickyMinWidth="80px"
+                        stickyLeftOffset="107px"
+                        modifier="nowrap"
+                        hasRightBorder
+                      >
+                        <TableText>
+                          <Flex flexWrap={{ default: 'nowrap' }}>
+                            <FlexItem>
+                              <BlueprintIcon />
+                            </FlexItem>
+                            <FlexItem>{cell}</FlexItem>
+                          </Flex>
+                        </TableText>
+                      </Th>
+                    );
+                  } else {
+                    return (
+                      <Td key={`${rowIndex}_${cellIndex}`} dataLabel={columns[cellIndex]}>
+                        {cell}
+                      </Td>
+                    );
+                  }
+                })}
+              </Tr>
+            ))}
+          </Tbody>
+        </TableComposable>
+      </InnerScrollContainer>
+    </React.Fragment>
+  );
+};
+```
+
+### Composable: Sticky columns and header
+
+To maintain proper sticky behavior across sticky columns and header, `TableComposable` must be wrapped with `OuterScrollContainer` and `InnerScrollContainer` as shown in the example below.
+
+```js
+import React from 'react';
+import {
+  TableComposable,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Caption,
+  TableText,
+  InnerScrollContainer,
+  OuterScrollContainer
+} from '@patternfly/react-table';
+import { Flex, FlexItem } from '@patternfly/react-core';
+import BlueprintIcon from '@patternfly/react-icons/dist/esm/icons/blueprint-icon';
+
+ComposableTableStickyColumnAndHeader = () => {
+  const columns = ['Fact', 'State', 'Header 3', 'Header 4', 'Header 5', 'Header 6', 'Header 7', 'Header 8', 'Header 9'];
+  const [rows, setRows] = React.useState([
+    [
+      'Fact 1',
+      'State 1',
+      'Test cell 1-3',
+      'Test cell 1-4',
+      'Test cell 1-5',
+      'Test cell 1-6',
+      'Test cell 1-7',
+      'Test cell 1-8',
+      'Test cell 1-9'
+    ],
+    [
+      'Fact 2',
+      'State 2',
+      'Test cell 2-3',
+      'Test cell 2-4',
+      'Test cell 2-5',
+      'Test cell 2-6',
+      'Test cell 2-7',
+      'Test cell 2-8',
+      'Test cell 2-9'
+    ],
+    [
+      'Fact 3',
+      'State 3',
+      'Test cell 3-3',
+      'Test cell 3-4',
+      'Test cell 3-5',
+      'Test cell 3-6',
+      'Test cell 3-7',
+      'Test cell 3-8',
+      'Test cell 3-9'
+    ],
+    [
+      'Fact 4',
+      'State 4',
+      'Test cell 4-3',
+      'Test cell 4-4',
+      'Test cell 4-5',
+      'Test cell 4-6',
+      'Test cell 4-7',
+      'Test cell 4-8',
+      'Test cell 4-9'
+    ],
+    [
+      'Fact 5',
+      'State 5',
+      'Test cell 5-3',
+      'Test cell 5-4',
+      'Test cell 5-5',
+      'Test cell 5-6',
+      'Test cell 5-7',
+      'Test cell 5-8',
+      'Test cell 5-9'
+    ],
+    [
+      'Fact 6',
+      'State 6',
+      'Test cell 6-3',
+      'Test cell 6-4',
+      'Test cell 6-5',
+      'Test cell 6-6',
+      'Test cell 6-7',
+      'Test cell 6-8',
+      'Test cell 6-9'
+    ],
+    [
+      'Fact 7',
+      'State 7',
+      'Test cell 7-3',
+      'Test cell 7-4',
+      'Test cell 7-5',
+      'Test cell 7-6',
+      'Test cell 7-7',
+      'Test cell 7-8',
+      'Test cell 7-9'
+    ],
+    [
+      'Fact 8',
+      'State 8',
+      'Test cell 8-3',
+      'Test cell 8-4',
+      'Test cell 8-5',
+      'Test cell 8-6',
+      'Test cell 8-7',
+      'Test cell 8-8',
+      'Test cell 8-9'
+    ],
+    [
+      'Fact 9',
+      'State 9',
+      'Test cell 9-3',
+      'Test cell 9-4',
+      'Test cell 9-5',
+      'Test cell 9-6',
+      'Test cell 9-7',
+      'Test cell 9-8',
+      'Test cell 9-9'
+    ]
+  ]);
+  // index of the currently active column
+  const [activeSortIndex, setActiveSortIndex] = React.useState(-1);
+  // sort direction of the currently active column
+  const [activeSortDirection, setActiveSortDirection] = React.useState('none');
+  const onSort = (event, index, direction) => {
+    setActiveSortIndex(index);
+    setActiveSortDirection(direction);
+    // sorts the rows
+    const updatedRows = rows.sort((a, b) => {
+      if (typeof a[index] === 'number') {
+        // numeric sort
+        if (direction === 'asc') {
+          return a[index] - b[index];
+        }
+        return b[index] - a[index];
+      } else {
+        // string sort
+        if (direction === 'asc') {
+          return a[index].localeCompare(b[index]);
+        }
+        return b[index].localeCompare(a[index]);
+      }
+    });
+    setRows(updatedRows);
+  };
+  return (
+    <React.Fragment>
+      <div style={{ height: '600px' }}>
+        <OuterScrollContainer>
+          <InnerScrollContainer>
+            <TableComposable aria-label="Sticky column table" gridBreakPoint="" isStickyHeader>
+              <Thead>
+                <Tr>
+                  {columns.map((column, columnIndex) => {
+                    const sortParams =
+                      columnIndex === 0 || columnIndex === 1
+                        ? {
+                            sort: {
+                              sortBy: {
+                                index: activeSortIndex,
+                                direction: activeSortDirection
+                              },
+                              onSort,
+                              columnIndex
+                            }
+                          }
+                        : {};
+
+                    if (columnIndex === 0) {
+                      return (
+                        <Th key={columnIndex} isStickyColumn modifier="nowrap" {...sortParams}>
+                          <Flex flexWrap={{ default: 'nowrap' }}>
+                            <FlexItem>{column}</FlexItem>
+                          </Flex>
+                        </Th>
+                      );
+                    } else if (columnIndex === 1) {
+                      return (
+                        <Th
+                          key={columnIndex}
+                          isStickyColumn
+                          stickyMinWidth="80px"
+                          stickyLeftOffset="107px"
+                          hasRightBorder
+                          modifier="nowrap"
+                          {...sortParams}
+                        >
+                          <Flex flexWrap={{ default: 'nowrap' }}>
+                            <FlexItem>{column}</FlexItem>
+                          </Flex>
+                        </Th>
+                      );
+                    } else {
+                      return (
+                        <Th key={columnIndex} modifier="nowrap">
+                          <TableText>
+                            <Flex flexWrap={{ default: 'nowrap' }}>
+                              <FlexItem>
+                                <BlueprintIcon />
+                              </FlexItem>
+                              <FlexItem>{column}</FlexItem>
+                            </Flex>
+                          </TableText>
+                        </Th>
+                      );
+                    }
+                  })}
+                </Tr>
+              </Thead>
+              <Tbody>
+                {rows.map((row, rowIndex) => (
+                  <Tr key={rowIndex}>
+                    {row.map((cell, cellIndex) => {
+                      if (cellIndex === 0) {
+                        return (
+                          <Th key={cellIndex} isStickyColumn modifier="nowrap">
+                            <TableText>
+                              <Flex flexWrap={{ default: 'nowrap' }}>
+                                <FlexItem>{cell}</FlexItem>
+                              </Flex>
+                            </TableText>
+                          </Th>
+                        );
+                      } else if (cellIndex === 1) {
+                        return (
+                          <Th
+                            key={cellIndex}
+                            isStickyColumn
+                            stickyMinWidth="80px"
+                            stickyLeftOffset="107px"
+                            modifier="nowrap"
+                            hasRightBorder
+                          >
+                            <TableText>
+                              <Flex flexWrap={{ default: 'nowrap' }}>
+                                <FlexItem>
+                                  <BlueprintIcon />
+                                </FlexItem>
+                                <FlexItem>{cell}</FlexItem>
+                              </Flex>
+                            </TableText>
+                          </Th>
+                        );
+                      } else {
+                        return (
+                          <Td key={`${rowIndex}_${cellIndex}`} dataLabel={columns[cellIndex]}>
+                            {cell}
+                          </Td>
+                        );
+                      }
+                    })}
+                  </Tr>
+                ))}
+              </Tbody>
+            </TableComposable>
+          </InnerScrollContainer>
+        </OuterScrollContainer>
+      </div>
+    </React.Fragment>
+  );
+};
 ```

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
@@ -2185,31 +2185,20 @@ ComposableTableStickyColumn = () => {
 
                 if (columnIndex === 0) {
                   return (
-                    <Th key={columnIndex} isStickyColumn hasRightBorder modifier="nowrap" {...sortParams}>
-                      <Flex flexWrap={{ default: 'nowrap' }}>
-                        <FlexItem>{column}</FlexItem>
-                      </Flex>
+                    <Th key={columnIndex} isStickyColumn hasRightBorder modifier="truncate" {...sortParams}>
+                      {column}
                     </Th>
                   );
                 } else if (columnIndex === 1) {
                   return (
-                    <Th key={columnIndex} modifier="nowrap" {...sortParams}>
-                      <Flex flexWrap={{ default: 'nowrap' }}>
-                        <FlexItem>{column}</FlexItem>
-                      </Flex>
+                    <Th key={columnIndex} modifier="truncate" {...sortParams}>
+                      {column}
                     </Th>
                   );
                 } else {
                   return (
-                    <Th key={columnIndex} modifier="nowrap">
-                      <TableText>
-                        <Flex flexWrap={{ default: 'nowrap' }}>
-                          <FlexItem>
-                            <BlueprintIcon />
-                          </FlexItem>
-                          <FlexItem>{column}</FlexItem>
-                        </Flex>
-                      </TableText>
+                    <Th key={columnIndex} modifier="truncate">
+                      {column}
                     </Th>
                   );
                 }
@@ -2222,13 +2211,13 @@ ComposableTableStickyColumn = () => {
                 {row.map((cell, cellIndex) => {
                   if (cellIndex === 0) {
                     return (
-                      <Th key={cellIndex} isStickyColumn hasRightBorder>
+                      <Th key={cellIndex} isStickyColumn hasRightBorder modifier="truncate">
                         {cell}
                       </Th>
                     );
                   } else {
                     return (
-                      <Td key={`${rowIndex}_${cellIndex}`} dataLabel={columns[cellIndex]}>
+                      <Td key={`${rowIndex}_${cellIndex}`} modifier="nowrap" dataLabel={columns[cellIndex]}>
                         {cell}
                       </Td>
                     );
@@ -2415,10 +2404,8 @@ ComposableTableMultipleStickyColumn = () => {
 
                 if (columnIndex === 0) {
                   return (
-                    <Th key={columnIndex} isStickyColumn modifier="nowrap" {...sortParams}>
-                      <Flex flexWrap={{ default: 'nowrap' }}>
-                        <FlexItem>{column}</FlexItem>
-                      </Flex>
+                    <Th key={columnIndex} isStickyColumn modifier="truncate" {...sortParams}>
+                      {column}
                     </Th>
                   );
                 } else if (columnIndex === 1) {
@@ -2426,28 +2413,19 @@ ComposableTableMultipleStickyColumn = () => {
                     <Th
                       key={columnIndex}
                       isStickyColumn
-                      stickyMinWidth="80px"
-                      stickyLeftOffset="107px"
+                      stickyMinWidth="120px"
+                      stickyLeftOffset="100px"
                       hasRightBorder
-                      modifier="nowrap"
+                      modifier="truncate"
                       {...sortParams}
                     >
-                      <Flex flexWrap={{ default: 'nowrap' }}>
-                        <FlexItem>{column}</FlexItem>
-                      </Flex>
+                      {column}
                     </Th>
                   );
                 } else {
                   return (
-                    <Th key={columnIndex} modifier="nowrap">
-                      <TableText>
-                        <Flex flexWrap={{ default: 'nowrap' }}>
-                          <FlexItem>
-                            <BlueprintIcon />
-                          </FlexItem>
-                          <FlexItem>{column}</FlexItem>
-                        </Flex>
-                      </TableText>
+                    <Th key={columnIndex} modifier="truncate">
+                      {column}
                     </Th>
                   );
                 }
@@ -2460,12 +2438,8 @@ ComposableTableMultipleStickyColumn = () => {
                 {row.map((cell, cellIndex) => {
                   if (cellIndex === 0) {
                     return (
-                      <Th key={cellIndex} isStickyColumn modifier="nowrap">
-                        <TableText>
-                          <Flex flexWrap={{ default: 'nowrap' }}>
-                            <FlexItem>{cell}</FlexItem>
-                          </Flex>
-                        </TableText>
+                      <Th key={cellIndex} isStickyColumn modifier="truncate">
+                        {cell}
                       </Th>
                     );
                   } else if (cellIndex === 1) {
@@ -2474,23 +2448,17 @@ ComposableTableMultipleStickyColumn = () => {
                         key={cellIndex}
                         isStickyColumn
                         stickyMinWidth="80px"
-                        stickyLeftOffset="107px"
-                        modifier="nowrap"
+                        stickyLeftOffset="100px"
+                        modifier="truncate"
                         hasRightBorder
                       >
-                        <TableText>
-                          <Flex flexWrap={{ default: 'nowrap' }}>
-                            <FlexItem>
-                              <BlueprintIcon />
-                            </FlexItem>
-                            <FlexItem>{cell}</FlexItem>
-                          </Flex>
-                        </TableText>
+                        <BlueprintIcon />
+                        {` ${cell}`}
                       </Th>
                     );
                   } else {
                     return (
-                      <Td key={`${rowIndex}_${cellIndex}`} dataLabel={columns[cellIndex]}>
+                      <Td key={`${rowIndex}_${cellIndex}`} modifier="nowrap" dataLabel={columns[cellIndex]}>
                         {cell}
                       </Td>
                     );
@@ -2680,10 +2648,8 @@ ComposableTableStickyColumnAndHeader = () => {
 
                     if (columnIndex === 0) {
                       return (
-                        <Th key={columnIndex} isStickyColumn modifier="nowrap" {...sortParams}>
-                          <Flex flexWrap={{ default: 'nowrap' }}>
-                            <FlexItem>{column}</FlexItem>
-                          </Flex>
+                        <Th key={columnIndex} isStickyColumn modifier="truncate" {...sortParams}>
+                          {column}
                         </Th>
                       );
                     } else if (columnIndex === 1) {
@@ -2694,25 +2660,16 @@ ComposableTableStickyColumnAndHeader = () => {
                           stickyMinWidth="80px"
                           stickyLeftOffset="107px"
                           hasRightBorder
-                          modifier="nowrap"
+                          modifier="truncate"
                           {...sortParams}
                         >
-                          <Flex flexWrap={{ default: 'nowrap' }}>
-                            <FlexItem>{column}</FlexItem>
-                          </Flex>
+                          {column}
                         </Th>
                       );
                     } else {
                       return (
-                        <Th key={columnIndex} modifier="nowrap">
-                          <TableText>
-                            <Flex flexWrap={{ default: 'nowrap' }}>
-                              <FlexItem>
-                                <BlueprintIcon />
-                              </FlexItem>
-                              <FlexItem>{column}</FlexItem>
-                            </Flex>
-                          </TableText>
+                        <Th key={columnIndex} modifier="truncate">
+                          {column}
                         </Th>
                       );
                     }
@@ -2725,12 +2682,8 @@ ComposableTableStickyColumnAndHeader = () => {
                     {row.map((cell, cellIndex) => {
                       if (cellIndex === 0) {
                         return (
-                          <Th key={cellIndex} isStickyColumn modifier="nowrap">
-                            <TableText>
-                              <Flex flexWrap={{ default: 'nowrap' }}>
-                                <FlexItem>{cell}</FlexItem>
-                              </Flex>
-                            </TableText>
+                          <Th key={cellIndex} isStickyColumn modifier="truncate">
+                            {cell}
                           </Th>
                         );
                       } else if (cellIndex === 1) {
@@ -2740,22 +2693,16 @@ ComposableTableStickyColumnAndHeader = () => {
                             isStickyColumn
                             stickyMinWidth="80px"
                             stickyLeftOffset="107px"
-                            modifier="nowrap"
+                            modifier="truncate"
                             hasRightBorder
                           >
-                            <TableText>
-                              <Flex flexWrap={{ default: 'nowrap' }}>
-                                <FlexItem>
-                                  <BlueprintIcon />
-                                </FlexItem>
-                                <FlexItem>{cell}</FlexItem>
-                              </Flex>
-                            </TableText>
+                            <BlueprintIcon />
+                            {` ${cell}`}
                           </Th>
                         );
                       } else {
                         return (
-                          <Td key={`${rowIndex}_${cellIndex}`} dataLabel={columns[cellIndex]}>
+                          <Td key={`${rowIndex}_${cellIndex}`} modifier="nowrap" dataLabel={columns[cellIndex]}>
                             {cell}
                           </Td>
                         );

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
@@ -2447,7 +2447,7 @@ ComposableTableMultipleStickyColumn = () => {
                       <Th
                         key={cellIndex}
                         isStickyColumn
-                        stickyMinWidth="80px"
+                        stickyMinWidth="120px"
                         stickyLeftOffset="100px"
                         modifier="truncate"
                         hasRightBorder
@@ -2657,8 +2657,8 @@ ComposableTableStickyColumnAndHeader = () => {
                         <Th
                           key={columnIndex}
                           isStickyColumn
-                          stickyMinWidth="80px"
-                          stickyLeftOffset="107px"
+                          stickyMinWidth="120px"
+                          stickyLeftOffset="100px"
                           hasRightBorder
                           modifier="truncate"
                           {...sortParams}
@@ -2691,8 +2691,8 @@ ComposableTableStickyColumnAndHeader = () => {
                           <Th
                             key={cellIndex}
                             isStickyColumn
-                            stickyMinWidth="80px"
-                            stickyLeftOffset="107px"
+                            stickyMinWidth="120px"
+                            stickyLeftOffset="100px"
                             modifier="truncate"
                             hasRightBorder
                           >

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
@@ -28,6 +28,8 @@ propComponents:
     'EditableTextCellProps',
     'ThSortType',
     'ISortBy',
+    'InnerScrollContainer',
+    'OuterScrollContainer',
   ]
 ouia: true
 ---
@@ -2830,7 +2832,7 @@ ComposableTableStickyColumnAndHeader = () => {
     });
     setRows(updatedRows);
   };
-  console.log(colSpans);
+
   return (
     <React.Fragment>
       <InnerScrollContainer>

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
@@ -2414,7 +2414,7 @@ ComposableTableMultipleStickyColumn = () => {
                       key={columnIndex}
                       isStickyColumn
                       stickyMinWidth="120px"
-                      stickyLeftOffset="100px"
+                      stickyLeftOffset="120px"
                       hasRightBorder
                       modifier="truncate"
                       {...sortParams}
@@ -2448,7 +2448,7 @@ ComposableTableMultipleStickyColumn = () => {
                         key={cellIndex}
                         isStickyColumn
                         stickyMinWidth="120px"
-                        stickyLeftOffset="100px"
+                        stickyLeftOffset="120px"
                         modifier="truncate"
                         hasRightBorder
                       >
@@ -2658,7 +2658,7 @@ ComposableTableStickyColumnAndHeader = () => {
                           key={columnIndex}
                           isStickyColumn
                           stickyMinWidth="120px"
-                          stickyLeftOffset="100px"
+                          stickyLeftOffset="120px"
                           hasRightBorder
                           modifier="truncate"
                           {...sortParams}
@@ -2692,7 +2692,7 @@ ComposableTableStickyColumnAndHeader = () => {
                             key={cellIndex}
                             isStickyColumn
                             stickyMinWidth="120px"
-                            stickyLeftOffset="100px"
+                            stickyLeftOffset="120px"
                             modifier="truncate"
                             hasRightBorder
                           >

--- a/packages/react-table/src/components/TableComposable/index.ts
+++ b/packages/react-table/src/components/TableComposable/index.ts
@@ -5,3 +5,5 @@ export * from './Tr';
 export * from './Th';
 export * from './Td';
 export * from './Caption';
+export * from './OuterScrollContainer';
+export * from './InnerScrollContainer';


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6163 and #6463

Sticky columns:
- Adds `isStickyColumn`, `hasRightBorder`, `stickyMinWidth`, `stickyLeftOffset` (all Th) properties
- Adds `OuterScrollContainer` and `InnerScrollContainer` wrapper components to use for scrollable tables
- Adds new examples showing a single sticky column, multiple sticky columns, and sticky columns with a sticky header + descriptions in each example for prop usage

Nested headers:
- Adds `nestedHeaderColumnSpans` (TableComposable), `isSubheader` (Th), `hasNestedHeader` (Thead), `resetOffset` (Tr) properties
- Adds new examples showing a basic nested header and a nested header with expandable rows + descriptions for prop usage

Update - added nested header support as it builds on top of properties added by sticky columns