### PR TITLE
fix(jumplinks): fixed to always set clicked item as active

### DIFF
--- a/packages/react-core/src/components/JumpLinks/JumpLinks.tsx
+++ b/packages/react-core/src/components/JumpLinks/JumpLinks.tsx
@@ -100,6 +100,8 @@ export const JumpLinks: React.FunctionComponent<JumpLinksProps> = ({
   const [scrollItems, setScrollItems] = React.useState(hasScrollSpy ? getScrollItems(children, []) : []);
   const [activeIndex, setActiveIndex] = React.useState(activeIndexProp);
   const [isExpanded, setIsExpanded] = React.useState(isExpandedProp);
+  // Boolean to disable scroll listener from overriding active state of clicked jumplink
+  const isLinkClicked = React.useRef(false);
   // Allow expanding to be controlled for a niche use case
   React.useEffect(() => setIsExpanded(isExpandedProp), [isExpandedProp]);
   const navRef = React.useRef<HTMLElement>();
@@ -108,6 +110,10 @@ export const JumpLinks: React.FunctionComponent<JumpLinksProps> = ({
 
   const scrollSpy = React.useCallback(() => {
     if (!canUseDOM || !hasScrollSpy || !(scrollableElement instanceof HTMLElement)) {
+      return;
+    }
+    if (isLinkClicked.current) {
+      isLinkClicked.current = false;
       return;
     }
     const scrollPosition = Math.ceil(scrollableElement.scrollTop + offset);
@@ -158,6 +164,7 @@ export const JumpLinks: React.FunctionComponent<JumpLinksProps> = ({
             const scrollItem = scrollItems[itemIndex];
             return React.cloneElement(child as React.ReactElement<JumpLinksItemProps>, {
               onClick(ev: React.MouseEvent<HTMLAnchorElement>) {
+                isLinkClicked.current = true;
                 // Items might have rendered after this component. Do a quick refresh.
                 let newScrollItems;
                 if (!scrollItem) {
@@ -188,6 +195,7 @@ export const JumpLinks: React.FunctionComponent<JumpLinksProps> = ({
                   }
                   newScrollItem.focus();
                   ev.preventDefault();
+                  setActiveIndex(itemIndex);
                 }
                 if (onClickProp) {
                   onClickProp(ev);


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6156 

This PR updates the JumpLinks to always set the clicked JumpLink as active when clicked.
- calls `setActiveIndex` in each JumpLink's `onClick` to set that link as active.
- adds `isLinkClicked` boolean variable which disables the scroll listener from also calling `setActiveIndex` and overriding the clicked link's active state when the linked section scrolls into place.
- this fixes the issue of the last JumpLink never showing as active when the linked section doesn't reach the top of the page.
