### PR TITLE
feat(Table): set default sort direction

### DIFF
--- a/packages/react-table/src/components/Table/TableTypes.ts
+++ b/packages/react-table/src/components/Table/TableTypes.ts
@@ -139,6 +139,7 @@ export type IFormatterValueType = formatterValueType & {
 export interface ISortBy {
   index?: number;
   direction?: 'asc' | 'desc';
+  defaultDirection?: 'asc' | 'desc';
 }
 
 export interface IAction extends Omit<DropdownItemProps, 'title' | 'onClick'> {

--- a/packages/react-table/src/components/Table/TableTypes.tsx
+++ b/packages/react-table/src/components/Table/TableTypes.tsx
@@ -137,8 +137,11 @@ export type IFormatterValueType = formatterValueType & {
 };
 
 export interface ISortBy {
+  /** Index of the current sorted column */
   index?: number;
+  /** Current sort direction */
   direction?: 'asc' | 'desc';
+  /** Defaulting sorting direction. Defaults to "asc". */
   defaultDirection?: 'asc' | 'desc';
 }
 

--- a/packages/react-table/src/components/Table/examples/Table.md
+++ b/packages/react-table/src/components/Table/examples/Table.md
@@ -330,7 +330,9 @@ class SortableTable extends React.Component {
         ['a', 'two', 'k', 'four', 'five'],
         ['p', 'two', 'b', 'four', 'five']
       ],
-      sortBy: {}
+      sortBy: {
+        defaultDirection: 'asc' // starting sort direction when first sorting a column. Defaults to 'asc'
+      }
     };
     this.onSort = this.onSort.bind(this);
   }

--- a/packages/react-table/src/components/Table/examples/Table.md
+++ b/packages/react-table/src/components/Table/examples/Table.md
@@ -2,7 +2,7 @@
 id: Table
 cssPrefix: pf-c-table
 section: components
-propComponents: ['Table', 'TableHeader', 'TableBody']
+propComponents: ['Table', 'TableHeader', 'TableBody', 'ISortBy']
 ouia: true
 ---
 

--- a/packages/react-table/src/components/Table/utils/decorators/sortable.tsx
+++ b/packages/react-table/src/components/Table/utils/decorators/sortable.tsx
@@ -39,8 +39,7 @@ export const sortable: ITransform = (
   function sortClicked(event: React.MouseEvent) {
     let reversedDirection: SortByDirection;
     if (!isSortedBy) {
-      reversedDirection =
-        sortBy.direction && sortBy.direction === SortByDirection.desc ? SortByDirection.desc : SortByDirection.asc;
+      reversedDirection = sortBy.defaultDirection ? (sortBy.defaultDirection as SortByDirection) : SortByDirection.asc;
     } else {
       reversedDirection = sortBy.direction === SortByDirection.asc ? SortByDirection.desc : SortByDirection.asc;
     }

--- a/packages/react-table/src/components/Table/utils/decorators/sortable.tsx
+++ b/packages/react-table/src/components/Table/utils/decorators/sortable.tsx
@@ -39,7 +39,8 @@ export const sortable: ITransform = (
   function sortClicked(event: React.MouseEvent) {
     let reversedDirection: SortByDirection;
     if (!isSortedBy) {
-      reversedDirection = SortByDirection.asc;
+      reversedDirection =
+        sortBy.direction && sortBy.direction === SortByDirection.desc ? SortByDirection.desc : SortByDirection.asc;
     } else {
       reversedDirection = sortBy.direction === SortByDirection.asc ? SortByDirection.desc : SortByDirection.asc;
     }

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
@@ -27,6 +27,7 @@ propComponents:
     'EditableSelectInputProps',
     'EditableTextCellProps',
     'ThSortType',
+    'ISortBy',
   ]
 ouia: true
 ---
@@ -313,7 +314,8 @@ ComposableTableSortable = () => {
                     sort: {
                       sortBy: {
                         index: activeSortIndex,
-                        direction: activeSortDirection
+                        direction: activeSortDirection,
+                        defaultDirection: 'asc' // starting sort direction when first sorting a column. Defaults to 'asc'
                       },
                       onSort,
                       columnIndex


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5329

For both `Table` and `TableComposable` - the default sort direction can now be changed by setting `sortBy.defaultDirection` and will continue to default to ascending order.

Edit: updated to use a separate prop because using `sortBy.direction` meant that the starting sort order would change when toggling sort between different columns.