### PR TITLE
fix(CodeEditor): add resizeobserver to code editor

### DIFF
--- a/packages/react-charts/src/components/ChartUtils/chart-resize.tsx
+++ b/packages/react-charts/src/components/ChartUtils/chart-resize.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { canUseDOM } from './chart-helpers';
 
 /**
@@ -11,7 +10,7 @@ import { canUseDOM } from './chart-helpers';
  * private observer: any = () => {};
  *
  * public componentDidMount() {
- *   this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
+ *   this.observer = getResizeObserver(this.containerRef, this.handleResize);
  * }
  *
  * public componentWillUnmount() {
@@ -38,7 +37,7 @@ import { canUseDOM } from './chart-helpers';
  * private observer: any = () => {};
  *
  * public componentDidMount() {
- *   this.observer = getResizeObserver(this.inputRef.current, this.handleResize);
+ *   this.observer = getResizeObserver(this.inputRef, this.handleResize);
  * }
  *
  * public componentWillUnmount() {
@@ -57,17 +56,17 @@ import { canUseDOM } from './chart-helpers';
  *   );
  * }
  *
- * @param {React.RefObject} containerRef The container reference to observe
+ * @param {Element} containerRefElement The container reference to observe
  * @param {Function} handleResize The function to call for resize events
  * @return {Function} The function used to unobserve resize events
  */
-export const getResizeObserver = (containerRef: React.RefObject<any>, handleResize: () => void) => {
+export const getResizeObserver = (containerRefElement: Element, handleResize: () => void) => {
   let unobserve: any;
 
   if (canUseDOM) {
     const { ResizeObserver } = window as any;
 
-    if (containerRef && ResizeObserver) {
+    if (containerRefElement && ResizeObserver) {
       const resizeObserver = new ResizeObserver((entries: any) => {
         // Wrap resize function in requestAnimationFrame to avoid "ResizeObserver loop limit exceeded" errors
         window.requestAnimationFrame(() => {
@@ -76,8 +75,8 @@ export const getResizeObserver = (containerRef: React.RefObject<any>, handleResi
           }
         });
       });
-      resizeObserver.observe(containerRef);
-      unobserve = () => resizeObserver.unobserve(containerRef);
+      resizeObserver.observe(containerRefElement);
+      unobserve = () => resizeObserver.unobserve(containerRefElement);
     } else {
       window.addEventListener('resize', handleResize);
       unobserve = () => window.removeEventListener('resize', handleResize);

--- a/packages/react-charts/src/components/ChartUtils/chart-resize.tsx
+++ b/packages/react-charts/src/components/ChartUtils/chart-resize.tsx
@@ -10,7 +10,7 @@ import { canUseDOM } from './chart-helpers';
  * private observer: any = () => {};
  *
  * public componentDidMount() {
- *   this.observer = getResizeObserver(this.containerRef, this.handleResize);
+ *   this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
  * }
  *
  * public componentWillUnmount() {
@@ -37,7 +37,7 @@ import { canUseDOM } from './chart-helpers';
  * private observer: any = () => {};
  *
  * public componentDidMount() {
- *   this.observer = getResizeObserver(this.inputRef, this.handleResize);
+ *   this.observer = getResizeObserver(this.inputRef.current, this.handleResize);
  * }
  *
  * public componentWillUnmount() {

--- a/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
@@ -8,6 +8,7 @@ import {
   EmptyStateIcon,
   EmptyStateSecondaryActions,
   EmptyStateVariant,
+  getResizeObserver,
   Title,
   Tooltip
 } from '@patternfly/react-core';
@@ -192,7 +193,9 @@ export class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState
   static displayName = 'CodeEditor';
   private editor: any = null;
   private wrapperRef = React.createRef<HTMLDivElement>();
+  private ref = React.createRef<HTMLDivElement>();
   timer = null as number;
+  observer: any = () => {};
 
   static defaultProps: CodeEditorProps = {
     className: '',
@@ -276,6 +279,12 @@ export class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState
     this.setState({ value });
   };
 
+  handleResize = () => {
+    if (this.editor) {
+      this.editor.layout();
+    }
+  };
+
   componentDidUpdate(prevProps: CodeEditorProps) {
     const { code } = this.props;
     if (prevProps.code !== code) {
@@ -285,10 +294,13 @@ export class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState
 
   componentDidMount() {
     document.addEventListener('keydown', this.handleGlobalKeys);
+    this.observer = getResizeObserver(this.ref.current, this.handleResize);
+    this.handleResize();
   }
 
   componentWillUnmount() {
     document.removeEventListener('keydown', this.handleGlobalKeys);
+    this.observer();
   }
 
   handleGlobalKeys = (event: KeyboardEvent) => {
@@ -541,7 +553,7 @@ export class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState
           );
 
           return (
-            <div className={css(styles.codeEditor, isReadOnly && styles.modifiers.readOnly, className)}>
+            <div className={css(styles.codeEditor, isReadOnly && styles.modifiers.readOnly, className)} ref={this.ref}>
               {isUploadEnabled || providedEmptyState ? (
                 <div
                   {...getRootProps({

--- a/packages/react-core/src/helpers/index.ts
+++ b/packages/react-core/src/helpers/index.ts
@@ -8,3 +8,4 @@ export * from './util';
 export * from './Popper/Popper';
 export * from './useIsomorphicLayout';
 export * from './KeyboardHandler';
+export * from './resizeObserver';

--- a/packages/react-core/src/helpers/resizeObserver.tsx
+++ b/packages/react-core/src/helpers/resizeObserver.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { canUseDOM } from './util';
 
 /**
@@ -11,7 +10,7 @@ import { canUseDOM } from './util';
  * private observer: any = () => {};
  *
  * public componentDidMount() {
- *   this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
+ *   this.observer = getResizeObserver(this.containerRef, this.handleResize);
  * }
  *
  * public componentWillUnmount() {
@@ -38,7 +37,7 @@ import { canUseDOM } from './util';
  * private observer: any = () => {};
  *
  * public componentDidMount() {
- *   this.observer = getResizeObserver(this.inputRef.current, this.handleResize);
+ *   this.observer = getResizeObserver(this.inputRef, this.handleResize);
  * }
  *
  * public componentWillUnmount() {
@@ -57,17 +56,17 @@ import { canUseDOM } from './util';
  *   );
  * }
  *
- * @param {React.RefObject} containerRef The container reference to observe
+ * @param {Element} containerRefElement The container reference to observe
  * @param {Function} handleResize The function to call for resize events
  * @return {Function} The function used to unobserve resize events
  */
-export const getResizeObserver = (containerRef: React.RefObject<any>, handleResize: () => void) => {
+export const getResizeObserver = (containerRefElement: Element, handleResize: () => void) => {
   let unobserve: any;
 
   if (canUseDOM) {
     const { ResizeObserver } = window as any;
 
-    if (containerRef && ResizeObserver) {
+    if (containerRefElement && ResizeObserver) {
       const resizeObserver = new ResizeObserver((entries: any) => {
         // Wrap resize function in requestAnimationFrame to avoid "ResizeObserver loop limit exceeded" errors
         window.requestAnimationFrame(() => {
@@ -76,8 +75,8 @@ export const getResizeObserver = (containerRef: React.RefObject<any>, handleResi
           }
         });
       });
-      resizeObserver.observe(containerRef);
-      unobserve = () => resizeObserver.unobserve(containerRef);
+      resizeObserver.observe(containerRefElement);
+      unobserve = () => resizeObserver.unobserve(containerRefElement);
     } else {
       window.addEventListener('resize', handleResize);
       unobserve = () => window.removeEventListener('resize', handleResize);

--- a/packages/react-core/src/helpers/resizeObserver.tsx
+++ b/packages/react-core/src/helpers/resizeObserver.tsx
@@ -10,7 +10,7 @@ import { canUseDOM } from './util';
  * private observer: any = () => {};
  *
  * public componentDidMount() {
- *   this.observer = getResizeObserver(this.containerRef, this.handleResize);
+ *   this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
  * }
  *
  * public componentWillUnmount() {
@@ -37,7 +37,7 @@ import { canUseDOM } from './util';
  * private observer: any = () => {};
  *
  * public componentDidMount() {
- *   this.observer = getResizeObserver(this.inputRef, this.handleResize);
+ *   this.observer = getResizeObserver(this.inputRef.current, this.handleResize);
  * }
  *
  * public componentWillUnmount() {


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6227

This also fixes a type discrepancy in the resizeObserver and chart-resize functions
@dlabrecq, I'd love if you'd make sure I didn't create more problems by fixing the issue I found.