### PR TITLE
feat(contextselector): added support for context selector items as links

### DIFF
--- a/packages/react-core/src/components/ContextSelector/ContextSelectorItem.tsx
+++ b/packages/react-core/src/components/ContextSelector/ContextSelectorItem.tsx
@@ -16,6 +16,8 @@ export interface ContextSelectorItemProps {
   index: number;
   /** Internal callback for ref tracking */
   sendRef: (index: number, current: any) => void;
+  /** Link href, indicates item should render as anchor tag */
+  href?: string;
 }
 
 export class ContextSelectorItem extends React.Component<ContextSelectorItemProps> {
@@ -26,10 +28,11 @@ export class ContextSelectorItem extends React.Component<ContextSelectorItemProp
     isDisabled: false,
     onClick: (): any => undefined,
     index: undefined as number,
-    sendRef: () => {}
+    sendRef: () => {},
+    href: null as string
   };
 
-  ref: React.RefObject<HTMLButtonElement> = React.createRef();
+  ref: React.RefObject<HTMLButtonElement & HTMLAnchorElement> = React.createRef();
 
   componentDidMount() {
     /* eslint-disable-next-line */
@@ -38,13 +41,19 @@ export class ContextSelectorItem extends React.Component<ContextSelectorItemProp
 
   render() {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { className, children, onClick, isDisabled, index, sendRef, ...props } = this.props;
+    const { className, children, onClick, isDisabled, index, sendRef, href, ...props } = this.props;
+    const Component = href ? 'a' : 'button';
+    const isDisabledLink = href && isDisabled;
     return (
       <ContextSelectorContext.Consumer>
         {({ onSelect }) => (
           <li role="none">
-            <button
-              className={css(styles.contextSelectorMenuListItem, className)}
+            <Component
+              className={css(
+                styles.contextSelectorMenuListItem,
+                isDisabledLink && styles.modifiers.disabled,
+                className
+              )}
               ref={this.ref}
               onClick={event => {
                 if (!isDisabled) {
@@ -52,11 +61,13 @@ export class ContextSelectorItem extends React.Component<ContextSelectorItemProp
                   onSelect(event, children);
                 }
               }}
-              disabled={isDisabled}
+              disabled={isDisabled && !href}
+              href={href}
+              {...(isDisabledLink && { 'aria-disabled': true, tabIndex: -1 })}
               {...props}
             >
               {children}
-            </button>
+            </Component>
           </li>
         )}
       </ContextSelectorContext.Consumer>

--- a/packages/react-core/src/components/ContextSelector/__tests__/__snapshots__/ContextSelector.test.tsx.snap
+++ b/packages/react-core/src/components/ContextSelector/__tests__/__snapshots__/ContextSelector.test.tsx.snap
@@ -97,6 +97,7 @@ exports[`Renders ContextSelector open 1`] = `
            
           <ContextSelectorItem
             className=""
+            href={null}
             isDisabled={false}
             key="0"
             onClick={[Function]}
@@ -106,6 +107,7 @@ exports[`Renders ContextSelector open 1`] = `
           </ContextSelectorItem>
           <ContextSelectorItem
             className=""
+            href={null}
             isDisabled={false}
             key="1"
             onClick={[Function]}
@@ -115,6 +117,7 @@ exports[`Renders ContextSelector open 1`] = `
           </ContextSelectorItem>
           <ContextSelectorItem
             className=""
+            href={null}
             isDisabled={false}
             key="2"
             onClick={[Function]}
@@ -124,6 +127,7 @@ exports[`Renders ContextSelector open 1`] = `
           </ContextSelectorItem>
           <ContextSelectorItem
             className=""
+            href={null}
             isDisabled={false}
             key="3"
             onClick={[Function]}
@@ -133,6 +137,7 @@ exports[`Renders ContextSelector open 1`] = `
           </ContextSelectorItem>
           <ContextSelectorItem
             className=""
+            href={null}
             isDisabled={false}
             key="4"
             onClick={[Function]}

--- a/packages/react-core/src/components/ContextSelector/__tests__/__snapshots__/ContextSelectorMenuList.test.tsx.snap
+++ b/packages/react-core/src/components/ContextSelector/__tests__/__snapshots__/ContextSelectorMenuList.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`Renders ContextSelectorMenuList closed 1`] = `
 >
   <ContextSelectorItem
     className=""
+    href={null}
     index={0}
     isDisabled={false}
     key=".$0"
@@ -18,6 +19,7 @@ exports[`Renders ContextSelectorMenuList closed 1`] = `
   </ContextSelectorItem>
   <ContextSelectorItem
     className=""
+    href={null}
     index={1}
     isDisabled={false}
     key=".$1"
@@ -28,6 +30,7 @@ exports[`Renders ContextSelectorMenuList closed 1`] = `
   </ContextSelectorItem>
   <ContextSelectorItem
     className=""
+    href={null}
     index={2}
     isDisabled={false}
     key=".$2"
@@ -38,6 +41,7 @@ exports[`Renders ContextSelectorMenuList closed 1`] = `
   </ContextSelectorItem>
   <ContextSelectorItem
     className=""
+    href={null}
     index={3}
     isDisabled={false}
     key=".$3"
@@ -48,6 +52,7 @@ exports[`Renders ContextSelectorMenuList closed 1`] = `
   </ContextSelectorItem>
   <ContextSelectorItem
     className=""
+    href={null}
     index={4}
     isDisabled={false}
     key=".$4"
@@ -67,6 +72,7 @@ exports[`Renders ContextSelectorMenuList open 1`] = `
 >
   <ContextSelectorItem
     className=""
+    href={null}
     index={0}
     isDisabled={false}
     key=".$0"
@@ -77,6 +83,7 @@ exports[`Renders ContextSelectorMenuList open 1`] = `
   </ContextSelectorItem>
   <ContextSelectorItem
     className=""
+    href={null}
     index={1}
     isDisabled={false}
     key=".$1"
@@ -87,6 +94,7 @@ exports[`Renders ContextSelectorMenuList open 1`] = `
   </ContextSelectorItem>
   <ContextSelectorItem
     className=""
+    href={null}
     index={2}
     isDisabled={false}
     key=".$2"
@@ -97,6 +105,7 @@ exports[`Renders ContextSelectorMenuList open 1`] = `
   </ContextSelectorItem>
   <ContextSelectorItem
     className=""
+    href={null}
     index={3}
     isDisabled={false}
     key=".$3"
@@ -107,6 +116,7 @@ exports[`Renders ContextSelectorMenuList open 1`] = `
   </ContextSelectorItem>
   <ContextSelectorItem
     className=""
+    href={null}
     index={4}
     isDisabled={false}
     key=".$4"

--- a/packages/react-core/src/components/ContextSelector/examples/ContextSelector.md
+++ b/packages/react-core/src/components/ContextSelector/examples/ContextSelector.md
@@ -18,6 +18,20 @@ class SimpleContextSelector extends React.Component {
   constructor(props) {
     super(props);
     this.items = [
+      {
+        text: 'Link',
+        href: '#'
+      },
+      'Action',
+      {
+        text: 'Disabled link',
+        href: '#',
+        isDisabled: true
+      },
+      {
+        text: 'Disabled action',
+        isDisabled: true
+      },
       'My project',
       'OpenShift cluster',
       'Production Ansible',
@@ -32,7 +46,7 @@ class SimpleContextSelector extends React.Component {
 
     this.state = {
       isOpen: false,
-      selected: this.items[0],
+      selected: this.items[0].text || this.items[0],
       searchValue: '',
       filteredItems: this.items
     };
@@ -58,7 +72,10 @@ class SimpleContextSelector extends React.Component {
       const filtered =
         this.state.searchValue === ''
           ? this.items
-          : this.items.filter(str => str.toLowerCase().indexOf(this.state.searchValue.toLowerCase()) !== -1);
+          : this.items.filter(item => {
+            const str = item.text ? item.text : item;
+            return str.toLowerCase().indexOf(this.state.searchValue.toLowerCase()) !== -1;
+          });
 
       this.setState({ filteredItems: filtered || [] });
     };
@@ -77,9 +94,11 @@ class SimpleContextSelector extends React.Component {
         onSearchButtonClick={this.onSearchButtonClick}
         screenReaderLabel="Selected Project:"
       >
-        {filteredItems.map((item, index) => (
-          <ContextSelectorItem key={index}>{item}</ContextSelectorItem>
-        ))}
+        {
+          filteredItems.map((item, index) => {
+            const { text = null, href = null, isDisabled } = item;
+            return (<ContextSelectorItem key={index} href={href} isDisabled={isDisabled}>{text || item}</ContextSelectorItem>);
+        })}
       </ContextSelector>
     );
   }

--- a/packages/react-core/src/components/ContextSelector/examples/ContextSelector.md
+++ b/packages/react-core/src/components/ContextSelector/examples/ContextSelector.md
@@ -94,10 +94,9 @@ class SimpleContextSelector extends React.Component {
         onSearchButtonClick={this.onSearchButtonClick}
         screenReaderLabel="Selected Project:"
       >
-        {
-          filteredItems.map((item, index) => {
-            const { text = null, href = null, isDisabled } = item;
-            return (<ContextSelectorItem key={index} href={href} isDisabled={isDisabled}>{text || item}</ContextSelectorItem>);
+        {filteredItems.map((item, index) => {
+          const { text = null, href = null, isDisabled } = item;
+          return (<ContextSelectorItem key={index} href={href} isDisabled={isDisabled}>{text || item}</ContextSelectorItem>);
         })}
       </ContextSelector>
     );
@@ -111,7 +110,27 @@ class SimpleContextSelector extends React.Component {
 import React from 'react';
 import { ContextSelector, ContextSelectorItem } from '@patternfly/react-core';
 
+interface Item {
+  text: string;
+  href?: string;
+  isDisabled?: boolean;
+}
+
 const items = [
+  {
+    text: 'Link',
+    href: '#'
+  },
+  'Action',
+  {
+    text: 'Disabled link',
+    href: '#',
+    isDisabled: true
+  },
+  {
+    text: 'Disabled action',
+    isDisabled: true
+  },
   'My Project',
   'OpenShift Cluster',
   'Production Ansible',
@@ -125,8 +144,9 @@ const items = [
 ];
 
 const PlainTextContextSelector: React.FunctionComponent = () => {
+  const firstItemText = typeof items[0] === 'string' ? items[0] : items[0].text;
   const [isOpen, setOpen] = React.useState(false);
-  const [selected, setSelected] = React.useState(items[0]);
+  const [selected, setSelected] = React.useState(firstItemText);
   const [searchValue, setSearchValue] = React.useState('');
   const [filteredItems, setFilteredItems] = React.useState(items);
 
@@ -145,7 +165,12 @@ const PlainTextContextSelector: React.FunctionComponent = () => {
 
   function onSearchButtonClick(event: React.SyntheticEvent<HTMLButtonElement>) {
     const filtered =
-      searchValue === '' ? items : items.filter(str => str.toLowerCase().indexOf(searchValue.toLowerCase()) !== -1);
+      searchValue === ''
+        ? items
+        : items.filter(item => {
+          const str = (typeof item === 'string') ? item : item.text;
+          return str.toLowerCase().indexOf(searchValue.toLowerCase()) !== -1;
+        });
 
     setFilteredItems(filtered || []);
   };
@@ -162,9 +187,12 @@ const PlainTextContextSelector: React.FunctionComponent = () => {
       isPlain
       isText
     >
-      {filteredItems.map((item, index) => (
-        <ContextSelectorItem key={index}>{item}</ContextSelectorItem>
-      ))}
+      {filteredItems.map((item, index) => {
+        const [text, href = null, isDisabled = false] = (typeof item === 'string')
+          ? [item, null, false]
+          : [item.text, item.href, item.isDisabled];
+        return <ContextSelectorItem key={index} href={href} isDisabled={isDisabled}>{text}</ContextSelectorItem>;
+      })}
     </ContextSelector>
   );
 };
@@ -180,6 +208,20 @@ class FooterContextSelector extends React.Component {
   constructor(props) {
     super(props);
     this.items = [
+      {
+        text: 'Link',
+        href: '#'
+      },
+      'Action',
+      {
+        text: 'Disabled link',
+        href: '#',
+        isDisabled: true
+      },
+      {
+        text: 'Disabled action',
+        isDisabled: true
+      },
       'My project',
       'OpenShift cluster',
       'Production Ansible',
@@ -194,7 +236,7 @@ class FooterContextSelector extends React.Component {
 
     this.state = {
       isOpen: false,
-      selected: this.items[0],
+      selected: this.items[0].text || this.items[0],
       searchValue: '',
       filteredItems: this.items
     };
@@ -220,7 +262,10 @@ class FooterContextSelector extends React.Component {
       const filtered =
         this.state.searchValue === ''
           ? this.items
-          : this.items.filter(str => str.toLowerCase().indexOf(this.state.searchValue.toLowerCase()) !== -1);
+          : this.items.filter(item => {
+            const str = item.text ? item.text : item;
+            return str.toLowerCase().indexOf(this.state.searchValue.toLowerCase()) !== -1;
+          });
 
       this.setState({ filteredItems: filtered || [] });
     };
@@ -244,9 +289,10 @@ class FooterContextSelector extends React.Component {
           </ContextSelectorFooter>
         }
       >
-        {filteredItems.map((item, index) => (
-          <ContextSelectorItem key={index}>{item}</ContextSelectorItem>
-        ))}
+        {filteredItems.map((item, index) => {
+          const { text = null, href = null, isDisabled } = item;
+          return (<ContextSelectorItem key={index} href={href} isDisabled={isDisabled}>{text || item}</ContextSelectorItem>);
+        })}
       </ContextSelector>
     );
   }

--- a/packages/react-core/src/components/Menu/MenuItem.tsx
+++ b/packages/react-core/src/components/Menu/MenuItem.tsx
@@ -217,7 +217,9 @@ export const MenuItem: React.FunctionComponent<MenuItemProps> = ({
   if (Component === 'a') {
     additionalProps = {
       href: to,
-      'aria-disabled': isDisabled ? true : null
+      'aria-disabled': isDisabled ? true : null,
+      // prevent invalid 'disabled' attribute on <a> tags
+      disabled: null
     };
   } else if (Component === 'button') {
     additionalProps = {
@@ -287,7 +289,7 @@ export const MenuItem: React.FunctionComponent<MenuItemProps> = ({
         }}
         className={css(styles.menuItem, getIsSelected() && styles.modifiers.selected, className)}
         aria-current={getAriaCurrent()}
-        disabled={Component !== 'a' && isDisabled}
+        disabled={isDisabled}
         {...additionalProps}
       >
         <span className={css(styles.menuItemMain)}>

--- a/packages/react-core/src/components/Menu/MenuItem.tsx
+++ b/packages/react-core/src/components/Menu/MenuItem.tsx
@@ -287,7 +287,7 @@ export const MenuItem: React.FunctionComponent<MenuItemProps> = ({
         }}
         className={css(styles.menuItem, getIsSelected() && styles.modifiers.selected, className)}
         aria-current={getAriaCurrent()}
-        disabled={isDisabled}
+        disabled={Component !== 'a' && isDisabled}
         {...additionalProps}
       >
         <span className={css(styles.menuItemMain)}>

--- a/packages/react-core/src/demos/ComposableMenu.md
+++ b/packages/react-core/src/demos/ComposableMenu.md
@@ -1188,6 +1188,22 @@ import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 
 MenuContextSelector = () => {
   const items = [
+    {
+      text: 'Action'
+    },
+    {
+      text: 'Link',
+      href: '#'
+    },
+    {
+      text: 'Disabled action',
+      isDisabled: true
+    },
+    {
+      text: 'Disabled link',
+      href: '#',
+      isDisabled: true
+    },
     'My project',
     'OpenShift cluster',
     'Production Ansible',
@@ -1200,7 +1216,7 @@ MenuContextSelector = () => {
     'Azure 2'
   ];
   const [isOpen, setIsOpen] = React.useState(false);
-  const [selected, setSelected] = React.useState(items[0]);
+  const [selected, setSelected] = React.useState(items[0].text || items[0]);
   const [filteredItems, setFilteredItems] = React.useState(items);
   const [searchInputValue, setSearchInputValue] = React.useState('');
   const toggleRef = React.useRef();
@@ -1311,11 +1327,16 @@ MenuContextSelector = () => {
       <Divider />
       <MenuContent maxMenuHeight="200px">
         <MenuList>
-          {filteredItems.map((item, index) => (
-            <MenuItem itemId={item} key={index}>
-              {item}
-            </MenuItem>
-          ))}
+          {filteredItems.map((item, index) => {
+            const [ itemText, isDisabled, href ] = typeof item === 'string'
+              ? [ item, null, null ]
+              : [ item.text, item.isDisabled || null, item.href || null ];
+            return (
+              <MenuItem itemId={itemText} key={index} isDisabled={isDisabled} to={href}>
+                {itemText}
+              </MenuItem>
+            );
+          })}
         </MenuList>
       </MenuContent>
       <MenuFooter>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: 
Closes #5635 
Closes #6573 

This PR:
Adds support for context selector items as links:
- Adds new `href` string prop, which when provided renders `<a>` tag instead of `<button>`
- Updates existing `disabled` functionality by checking for `href` prop:
  - If `href` prop is not provided, no change to `disabled` attribute on rendered `<button>`
  - If `href` prop is passed, do not add `disabled` attribute (invalid on `<a>` tag that will be rendered), instead set `aria-disabled=true` and `tabindex=-1`

Fixes `disabled` attribute being added to `MenuItem` anchor tags, which is invalid.

Updated composable menu context selector demo to include MenuItem as links.
