### PR TITLE
fix(Menu): stop passing disableHover to DrilldownMenu DOM

### DIFF
--- a/packages/react-core/src/components/Menu/DrilldownMenu.tsx
+++ b/packages/react-core/src/components/Menu/DrilldownMenu.tsx
@@ -24,7 +24,7 @@ export const DrilldownMenu: React.FunctionComponent<DrilldownMenuProps> = ({
 }: DrilldownMenuProps) => (
   /* eslint-disable @typescript-eslint/no-unused-vars */
   <MenuContext.Consumer>
-    {({ menuId, parentMenu, flyoutRef, setFlyoutRef, ...context }) => (
+    {({ menuId, parentMenu, flyoutRef, setFlyoutRef, disableHover, ...context }) => (
       <Menu
         id={id}
         parentMenu={menuId}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6534

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
