### PR TITLE
Pagination: make itemCount optional

### DIFF
--- a/packages/react-core/src/components/Pagination/OptionsToggle.tsx
+++ b/packages/react-core/src/components/Pagination/OptionsToggle.tsx
@@ -37,6 +37,8 @@ export interface OptionsToggleProps extends React.HTMLProps<HTMLDivElement> {
   onEnter?: () => void;
   /** Label for the English word "of" */
   ofWord?: string;
+  /** Label for the English word "many" */
+  manyWord?: string;
 }
 
 let toggleId = 0;
@@ -46,6 +48,7 @@ export const OptionsToggle: React.FunctionComponent<OptionsToggleProps> = ({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   itemsPerPageTitle = 'Items per page',
   ofWord = 'of',
+  manyWord = 'many',
   firstIndex = 0,
   lastIndex = 0,
   itemCount,
@@ -71,12 +74,13 @@ export const OptionsToggle: React.FunctionComponent<OptionsToggleProps> = ({
       <React.Fragment>
         <span className={css(styles.optionsMenuToggleText)}>
           {typeof ToggleTemplate === 'string' ? (
-            fillTemplate(ToggleTemplate, { firstIndex, lastIndex, ofWord, itemCount, itemsTitle })
+            fillTemplate(ToggleTemplate, { firstIndex, lastIndex, ofWord, manyWord, itemCount, itemsTitle })
           ) : (
             <ToggleTemplate
               firstIndex={firstIndex}
               lastIndex={lastIndex}
               ofWord={ofWord}
+              manyWord={manyWord}
               itemCount={itemCount}
               itemsTitle={itemsTitle}
             />

--- a/packages/react-core/src/components/Pagination/Pagination.tsx
+++ b/packages/react-core/src/components/Pagination/Pagination.tsx
@@ -66,6 +66,8 @@ export interface PaginationTitles {
   paginationTitle?: string;
   /** Accessible label for the English word "of" */
   ofWord?: string;
+  /** Accessible label for the English word "many" */
+  manyWord?: string;
 }
 
 export type OnSetPage = (
@@ -177,7 +179,8 @@ export class Pagination extends React.Component<PaginationProps, { ouiaStateId: 
       optionsToggle: 'Items per page',
       currPage: 'Current page',
       paginationTitle: 'Pagination',
-      ofWord: 'of'
+      ofWord: 'of',
+      manyWord: 'many',
     },
     firstPage: 1,
     page: 0,
@@ -279,7 +282,7 @@ export class Pagination extends React.Component<PaginationProps, { ouiaStateId: 
       }
     }
 
-    const toggleTemplateProps = { firstIndex, lastIndex, itemCount, itemsTitle: titles.items, ofWord: titles.ofWord };
+    const toggleTemplateProps = { firstIndex, lastIndex, itemCount, itemsTitle: titles.items, ofWord: titles.ofWord, manyWord: titles.manyWord };
 
     return (
       <div
@@ -309,6 +312,7 @@ export class Pagination extends React.Component<PaginationProps, { ouiaStateId: 
                 itemCount={itemCount}
                 itemsTitle={titles.items}
                 ofWord={titles.ofWord}
+                manyWord={titles.manyWord}
               />
             )}
           </div>
@@ -322,6 +326,7 @@ export class Pagination extends React.Component<PaginationProps, { ouiaStateId: 
           firstIndex={itemsStart !== null ? itemsStart : firstIndex}
           lastIndex={itemsEnd !== null ? itemsEnd : lastIndex}
           ofWord={titles.ofWord}
+          manyWord={titles.manyWord}
           defaultToFullPage={defaultToFullPage}
           itemCount={itemCount}
           page={page}
@@ -342,6 +347,7 @@ export class Pagination extends React.Component<PaginationProps, { ouiaStateId: 
           currPage={titles.currPage}
           paginationTitle={titles.paginationTitle}
           ofWord={titles.ofWord}
+          manyWord={titles.manyWord}
           page={itemCount && itemCount <= 0 ? 0 : page}
           perPage={perPage}
           itemCount={itemCount}

--- a/packages/react-core/src/components/Pagination/PaginationOptionsMenu.tsx
+++ b/packages/react-core/src/components/Pagination/PaginationOptionsMenu.tsx
@@ -46,6 +46,8 @@ export interface PaginationOptionsMenuProps extends React.HTMLProps<HTMLDivEleme
   onPerPageSelect?: OnPerPageSelect;
   /** Label for the English word "of" */
   ofWord?: string;
+  /** Label for the English word "many" */
+  manyWord?: string;
 }
 
 interface PaginationOptionsMenuState {
@@ -65,6 +67,7 @@ export class PaginationOptionsMenu extends React.Component<PaginationOptionsMenu
     perPageSuffix: 'per page',
     optionsToggle: 'Items per page',
     ofWord: 'of',
+    manyWord: 'many',
     perPage: 0,
     firstIndex: 0,
     lastIndex: 0,
@@ -144,7 +147,8 @@ export class PaginationOptionsMenu extends React.Component<PaginationOptionsMenu
       lastIndex,
       itemCount,
       itemsTitle,
-      ofWord
+      ofWord,
+      manyWord,
     } = this.props;
     const { isOpen } = this.state;
 
@@ -181,6 +185,7 @@ export class PaginationOptionsMenu extends React.Component<PaginationOptionsMenu
               itemCount={itemCount}
               itemsTitle={itemsTitle}
               ofWord={ofWord}
+              manyWord={manyWord}
               toggleTemplate={toggleTemplate}
               parentRef={this.parentRef.current}
               isDisabled={isDisabled}

--- a/packages/react-core/src/components/Pagination/ToggleTemplate.tsx
+++ b/packages/react-core/src/components/Pagination/ToggleTemplate.tsx
@@ -18,13 +18,17 @@ export const ToggleTemplate: React.FunctionComponent<ToggleTemplateProps> = ({
   lastIndex = 0,
   itemCount = 0,
   itemsTitle = 'items',
-  ofWord = 'of'
-}: ToggleTemplateProps) => (
-  <React.Fragment>
-    <b>
-      {firstIndex} - {lastIndex}
-    </b>{' '}
-    {ofWord} <b>{itemCount}</b> {itemsTitle}
-  </React.Fragment>
-);
+  ofWord = 'of',
+  manyWord = 'many'
+}: ToggleTemplateProps) => {
+  let total = itemCount === null ? <b>{manyWord}</b> : <><b>{itemCount}</b> {itemsTitle}</>;
+  return (
+    <React.Fragment>
+      <b>
+        {firstIndex} - {lastIndex}
+      </b>{' '}
+      {ofWord} {total}
+    </React.Fragment>
+  )
+};
 ToggleTemplate.displayName = 'ToggleTemplate';


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6602
When itemCount is null, display "items [...] of **many**" in the total count element.