### PR TITLE
fix(Slider): Input resizing

### DIFF
--- a/packages/react-core/src/components/Slider/Slider.tsx
+++ b/packages/react-core/src/components/Slider/Slider.tsx
@@ -292,7 +292,6 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
     const textInput = (
       <TextInput
         className={css(styles.formControl)}
-        style={inputStyle}
         isDisabled={isDisabled}
         type="number"
         value={localInputValue}
@@ -343,7 +342,11 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
   };
 
   return (
-    <div className={css(styles.slider, className, isDisabled && styles.modifiers.disabled)} style={style} {...props}>
+    <div
+      className={css(styles.slider, className, isDisabled && styles.modifiers.disabled)}
+      style={{ ...style, ...inputStyle }}
+      {...props}
+    >
       {leftActions && <div className={css(styles.sliderActions)}>{leftActions}</div>}
       <div className={css(styles.sliderMain)}>
         <div className={css(styles.sliderRail)} ref={sliderRailRef} onClick={!isDisabled ? onSliderRailClick : null}>

--- a/packages/react-core/src/components/Slider/Slider.tsx
+++ b/packages/react-core/src/components/Slider/Slider.tsx
@@ -104,6 +104,8 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
   // calculate style value percentage
   const stylePercent = ((localValue - min) * 100) / (max - min);
   const style = { '--pf-c-slider--value': `${stylePercent}%` } as React.CSSProperties;
+  const widthChars = React.useMemo(() => localInputValue.toString().length, [localInputValue]);
+  const inputStyle = { '--pf-c-slider__value--c-form-control--width-chars': widthChars } as React.CSSProperties;
 
   const onChangeHandler = (value: string) => {
     setLocalInputValue(Number(value));
@@ -290,6 +292,7 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
     const textInput = (
       <TextInput
         className={css(styles.formControl)}
+        style={inputStyle}
         isDisabled={isDisabled}
         type="number"
         value={localInputValue}

--- a/packages/react-core/src/components/Slider/_tests_/__snapshots__/Slider.test.tsx.snap
+++ b/packages/react-core/src/components/Slider/_tests_/__snapshots__/Slider.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`slider renders continuous slider 1`] = `
     style={
       Object {
         "--pf-c-slider--value": "50%",
+        "--pf-c-slider__value--c-form-control--width-chars": 2,
       }
     }
   >
@@ -172,6 +173,7 @@ exports[`slider renders continuous slider with custom steps 1`] = `
     style={
       Object {
         "--pf-c-slider--value": "50%",
+        "--pf-c-slider__value--c-form-control--width-chars": 1,
       }
     }
   >
@@ -269,6 +271,7 @@ exports[`slider renders disabled slider 1`] = `
     style={
       Object {
         "--pf-c-slider--value": "50%",
+        "--pf-c-slider__value--c-form-control--width-chars": 1,
       }
     }
   >
@@ -368,6 +371,7 @@ exports[`slider renders discrete slider 1`] = `
     style={
       Object {
         "--pf-c-slider--value": "40%",
+        "--pf-c-slider__value--c-form-control--width-chars": 2,
       }
     }
   >
@@ -542,6 +546,7 @@ exports[`slider renders discrete slider with custom steps 1`] = `
     style={
       Object {
         "--pf-c-slider--value": "50%",
+        "--pf-c-slider__value--c-form-control--width-chars": 1,
       }
     }
   >
@@ -706,6 +711,7 @@ exports[`slider renders slider with input 1`] = `
     style={
       Object {
         "--pf-c-slider--value": "50%",
+        "--pf-c-slider__value--c-form-control--width-chars": 2,
       }
     }
   >
@@ -874,6 +880,7 @@ exports[`slider renders slider with input above thumb 1`] = `
     style={
       Object {
         "--pf-c-slider--value": "50%",
+        "--pf-c-slider__value--c-form-control--width-chars": 2,
       }
     }
   >
@@ -1050,6 +1057,7 @@ exports[`slider renders slider with input actions 1`] = `
     style={
       Object {
         "--pf-c-slider--value": "50%",
+        "--pf-c-slider__value--c-form-control--width-chars": 1,
       }
     }
   >

--- a/packages/react-core/src/components/Slider/examples/Slider.md
+++ b/packages/react-core/src/components/Slider/examples/Slider.md
@@ -354,7 +354,7 @@ class ThumbValueInput extends React.Component {
     this.onChange = (value, inputValue, setLocalInputValue) => { 
       let newValue;
       if (inputValue === undefined) { 
-        newValue = Number(value).toFixed(2);
+        newValue = Number(value);
       } else {
         if (inputValue > 100) {
           newValue = 100;

--- a/packages/react-integration/cypress/integration/slider.spec.ts
+++ b/packages/react-integration/cypress/integration/slider.spec.ts
@@ -5,7 +5,11 @@ describe('Slider Demo Test', () => {
 
   it('renders the discrete slider', () => {
     cy.get('#discrete-slider').should('exist');
-    cy.get('#discrete-slider').should('have.attr', 'style', '--pf-c-slider--value:62.5%;');
+    cy.get('#discrete-slider').should(
+      'have.attr',
+      'style',
+      '--pf-c-slider--value:62.5%; --pf-c-slider__value--c-form-control--width-chars:1;'
+    );
   });
 
   it('changes discrete slider value when clicked on', () => {
@@ -23,11 +27,19 @@ describe('Slider Demo Test', () => {
     cy.get('#discrete-slider-input-label > .pf-c-slider__value > .pf-c-input-group > .pf-c-input-group__text').should(
       'exist'
     );
-    cy.get('#discrete-slider-input-label').should('have.attr', 'style', '--pf-c-slider--value:50%;');
+    cy.get('#discrete-slider-input-label').should(
+      'have.attr',
+      'style',
+      '--pf-c-slider--value:50%; --pf-c-slider__value--c-form-control--width-chars:2;'
+    );
   });
 
   it('renders the continuous slider', () => {
     cy.get('#continuous-slider').should('exist');
-    cy.get('#continuous-slider').should('have.attr', 'style', '--pf-c-slider--value:50%;');
+    cy.get('#continuous-slider').should(
+      'have.attr',
+      'style',
+      '--pf-c-slider--value:50%; --pf-c-slider__value--c-form-control--width-chars:2;'
+    );
   });
 });


### PR DESCRIPTION
**What**: Closes #5939

**Additional issues**:
The changes I made makes the input resize every time the input value changes by setting the `--pf-c-slider__value--c-form-control--width-chars`. It was by default set to 3, now it is dynamic. Do we want to keep the width set to 3 and only when it is bigger change it?