### PR TITLE
Use JSDoc comments for all deprecations

### DIFF
--- a/packages/react-core/src/components/FileUpload/FileUpload.tsx
+++ b/packages/react-core/src/components/FileUpload/FileUpload.tsx
@@ -23,7 +23,7 @@ export interface FileUploadProps
   value?: string | File;
   /** Value to be shown in the read-only filename field. */
   filename?: string;
-  /** *(deprecated)* A callback for when the file contents change. Please instead use onFileInputChange, onTextChange, onDataChange, onClearClick individually.  */
+  /** @deprecated A callback for when the file contents change. Please instead use onFileInputChange, onTextChange, onDataChange, onClearClick individually.  */
   onChange?: (
     value: string | File,
     filename: string,

--- a/packages/react-core/src/components/Toolbar/ToolbarContent.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarContent.tsx
@@ -16,7 +16,7 @@ export interface ToolbarContentProps extends React.HTMLProps<HTMLDivElement> {
     xl?: 'hidden' | 'visible';
     '2xl'?: 'hidden' | 'visible';
   };
-  /** Deprecated: prop misspelled */
+  /** @deprecated prop misspelled */
   visiblity?: {
     default?: 'hidden' | 'visible';
     md?: 'hidden' | 'visible';

--- a/packages/react-core/src/components/Toolbar/ToolbarGroup.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarGroup.tsx
@@ -22,7 +22,7 @@ export interface ToolbarGroupProps extends Omit<React.HTMLProps<HTMLDivElement>,
     xl?: 'hidden' | 'visible';
     '2xl'?: 'hidden' | 'visible';
   };
-  /** Deprecated: prop misspelled */
+  /** @deprecated prop misspelled */
   visiblity?: {
     default?: 'hidden' | 'visible';
     md?: 'hidden' | 'visible';

--- a/packages/react-core/src/components/Toolbar/ToolbarItem.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarItem.tsx
@@ -38,7 +38,7 @@ export interface ToolbarItemProps extends React.HTMLProps<HTMLDivElement> {
     xl?: 'hidden' | 'visible';
     '2xl'?: 'hidden' | 'visible';
   };
-  /** Deprecated: prop misspelled */
+  /** @deprecated prop misspelled */
   visiblity?: {
     default?: 'hidden' | 'visible';
     md?: 'hidden' | 'visible';

--- a/packages/react-core/src/components/Toolbar/ToolbarToggleGroup.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarToggleGroup.tsx
@@ -21,7 +21,7 @@ export interface ToolbarToggleGroupProps extends ToolbarGroupProps {
     xl?: 'hidden' | 'visible';
     '2xl'?: 'hidden' | 'visible';
   };
-  /** Deprecated: prop misspelled */
+  /** @deprecated prop misspelled */
   visiblity?: {
     default?: 'hidden' | 'visible';
     md?: 'hidden' | 'visible';

--- a/packages/react-table/src/components/Table/TableTypes.tsx
+++ b/packages/react-table/src/components/Table/TableTypes.tsx
@@ -254,7 +254,7 @@ export interface IRow extends RowType {
   isLastVisible?: boolean;
   /** Whether the row checkbox/radio button is selected */
   selected?: boolean;
-  /** deprecated - Use disableSelection instead - Whether the row checkbox is disabled */
+  /** @deprecated Use disableSelection instead - Whether the row checkbox is disabled */
   disableCheckbox?: boolean;
   /** Whether the row checkbox/radio button is disabled */
   disableSelection?: boolean;


### PR DESCRIPTION
Replaces comments for deprecations with proper JSDoc syntax which allows IDEs like VSCode to [highlight this](https://code.visualstudio.com/updates/v1_49#_deprecated-tag-support-for-javascript-and-typescript) this to the developer.
closes #6617 