### PR TITLE
fix(pagination): updated toggleTemplate description to include ofWord prop

### DIFF
--- a/packages/react-core/src/components/Pagination/Pagination.tsx
+++ b/packages/react-core/src/components/Pagination/Pagination.tsx
@@ -123,7 +123,7 @@ export interface PaginationProps extends React.HTMLProps<HTMLDivElement>, OUIAPr
   dropDirection?: 'up' | 'down';
   /** Object with titles to display in pagination. */
   titles?: PaginationTitles;
-  /** This will be shown in pagination toggle span. You can use firstIndex, lastIndex, itemCount, itemsTitle props. */
+  /** This will be shown in pagination toggle span. You can use firstIndex, lastIndex, itemCount, itemsTitle, ofWord props. */
   toggleTemplate?: ((props: ToggleTemplateProps) => React.ReactElement) | string;
   /** Function called when user sets page. */
   onSetPage?: OnSetPage;


### PR DESCRIPTION
**What**: Closes #6620 

This PR just updates the prop description for `toggleTemplate` to include the new `ofWord` prop added in https://github.com/patternfly/patternfly-react/pull/6500.
