### PR TITLE
Fix for no autocomplete for Typeahead Select

### DIFF
--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -934,7 +934,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
                 }
               }}
               ref={this.filterRef}
-              autoComplete="off"
+              autoComplete="never"
             />
           </div>
           <Divider key="inline-filter-divider" />
@@ -1128,7 +1128,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
                   type="text"
                   onClick={this.onClick}
                   onChange={this.onChange}
-                  autoComplete="off"
+                  autoComplete="never"
                   disabled={isDisabled}
                   ref={this.inputRef}
                 />
@@ -1152,7 +1152,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
                   type="text"
                   onChange={this.onChange}
                   onClick={this.onClick}
-                  autoComplete="off"
+                  autoComplete="never"
                   disabled={isDisabled}
                   ref={this.inputRef}
                 />

--- a/packages/react-core/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/packages/react-core/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
@@ -2831,7 +2831,7 @@ exports[`checkbox select renders expanded with filtering successfully 1`] = `
                   class="pf-c-select__menu-search"
                 >
                   <input
-                    autocomplete="off"
+                    autocomplete="never"
                     class="pf-c-form-control pf-m-search"
                     type="search"
                   />
@@ -2956,7 +2956,7 @@ exports[`checkbox select renders expanded with filtering successfully 1`] = `
                     class="pf-c-select__menu-search"
                   >
                     <input
-                      autocomplete="off"
+                      autocomplete="never"
                       class="pf-c-form-control pf-m-search"
                       type="search"
                     />
@@ -3122,7 +3122,7 @@ exports[`checkbox select renders expanded with filtering successfully 1`] = `
                     class="pf-c-select__menu-search"
                   >
                     <input
-                      autocomplete="off"
+                      autocomplete="never"
                       class="pf-c-form-control pf-m-search"
                       type="search"
                     />
@@ -3214,7 +3214,7 @@ exports[`checkbox select renders expanded with filtering successfully 1`] = `
                 key="inline-filter"
               >
                 <input
-                  autoComplete="off"
+                  autoComplete="never"
                   className="pf-c-form-control pf-m-search"
                   key="inline-filter-input"
                   onChange={[Function]}
@@ -3485,7 +3485,7 @@ exports[`checkbox select renders expanded with filtering successfully 2`] = `
                   class="pf-c-select__menu-search"
                 >
                   <input
-                    autocomplete="off"
+                    autocomplete="never"
                     class="pf-c-form-control pf-m-search"
                     type="search"
                   />
@@ -3610,7 +3610,7 @@ exports[`checkbox select renders expanded with filtering successfully 2`] = `
                     class="pf-c-select__menu-search"
                   >
                     <input
-                      autocomplete="off"
+                      autocomplete="never"
                       class="pf-c-form-control pf-m-search"
                       type="search"
                     />
@@ -3776,7 +3776,7 @@ exports[`checkbox select renders expanded with filtering successfully 2`] = `
                     class="pf-c-select__menu-search"
                   >
                     <input
-                      autocomplete="off"
+                      autocomplete="never"
                       class="pf-c-form-control pf-m-search"
                       type="search"
                     />
@@ -3868,7 +3868,7 @@ exports[`checkbox select renders expanded with filtering successfully 2`] = `
                 key="inline-filter"
               >
                 <input
-                  autoComplete="off"
+                  autoComplete="never"
                   className="pf-c-form-control pf-m-search"
                   key="inline-filter-input"
                   onChange={[Function]}
@@ -6002,7 +6002,7 @@ exports[`select custom select filter filters properly 1`] = `
                 >
                   <input
                     aria-label=""
-                    autocomplete="off"
+                    autocomplete="never"
                     class="pf-c-form-control pf-c-select__toggle-typeahead"
                     id="custom-select-filters-select-typeahead"
                     placeholder=""
@@ -6098,7 +6098,7 @@ exports[`select custom select filter filters properly 1`] = `
             <input
               aria-activedescendant={null}
               aria-label=""
-              autoComplete="off"
+              autoComplete="never"
               className="pf-c-form-control pf-c-select__toggle-typeahead"
               disabled={false}
               id="custom-select-filters-select-typeahead"
@@ -9595,7 +9595,7 @@ exports[`typeahead multi select renders closed successfully 1`] = `
                   <input
                     aria-invalid="false"
                     aria-label=""
-                    autocomplete="off"
+                    autocomplete="never"
                     class="pf-c-form-control pf-c-select__toggle-typeahead"
                     id="typeahead-multi-select-closed-select-multi-typeahead-typeahead"
                     placeholder=""
@@ -9647,7 +9647,7 @@ exports[`typeahead multi select renders closed successfully 1`] = `
               aria-activedescendant={null}
               aria-invalid={false}
               aria-label=""
-              autoComplete="off"
+              autoComplete="never"
               className="pf-c-form-control pf-c-select__toggle-typeahead"
               disabled={false}
               id="typeahead-multi-select-closed-select-multi-typeahead-typeahead"
@@ -9856,7 +9856,7 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
                   <input
                     aria-invalid="false"
                     aria-label=""
-                    autocomplete="off"
+                    autocomplete="never"
                     class="pf-c-form-control pf-c-select__toggle-typeahead"
                     id="pf-select-toggle-id-13-select-multi-typeahead-typeahead"
                     placeholder=""
@@ -9966,7 +9966,7 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
               aria-activedescendant={null}
               aria-invalid={false}
               aria-label=""
-              autoComplete="off"
+              autoComplete="never"
               className="pf-c-form-control pf-c-select__toggle-typeahead"
               disabled={false}
               id="pf-select-toggle-id-13-select-multi-typeahead-typeahead"
@@ -10585,7 +10585,7 @@ exports[`typeahead multi select renders selected successfully 1`] = `
                   <input
                     aria-invalid="false"
                     aria-label=""
-                    autocomplete="off"
+                    autocomplete="never"
                     class="pf-c-form-control pf-c-select__toggle-typeahead"
                     id="typeahead-multi-select-selected-select-multi-typeahead-typeahead"
                     placeholder=""
@@ -10949,7 +10949,7 @@ exports[`typeahead multi select renders selected successfully 1`] = `
               aria-activedescendant={null}
               aria-invalid={false}
               aria-label=""
-              autoComplete="off"
+              autoComplete="never"
               className="pf-c-form-control pf-c-select__toggle-typeahead"
               disabled={false}
               id="typeahead-multi-select-selected-select-multi-typeahead-typeahead"
@@ -11472,7 +11472,7 @@ exports[`typeahead select renders closed successfully 1`] = `
                 >
                   <input
                     aria-label=""
-                    autocomplete="off"
+                    autocomplete="never"
                     class="pf-c-form-control pf-c-select__toggle-typeahead"
                     id="typeahead-select-closed-select-typeahead"
                     placeholder=""
@@ -11523,7 +11523,7 @@ exports[`typeahead select renders closed successfully 1`] = `
             <input
               aria-activedescendant={null}
               aria-label=""
-              autoComplete="off"
+              autoComplete="never"
               className="pf-c-form-control pf-c-select__toggle-typeahead"
               disabled={false}
               id="typeahead-select-closed-select-typeahead"
@@ -11731,7 +11731,7 @@ exports[`typeahead select renders expanded successfully 1`] = `
                 >
                   <input
                     aria-label=""
-                    autocomplete="off"
+                    autocomplete="never"
                     class="pf-c-form-control pf-c-select__toggle-typeahead"
                     id="pf-select-toggle-id-8-select-typeahead"
                     placeholder=""
@@ -11840,7 +11840,7 @@ exports[`typeahead select renders expanded successfully 1`] = `
             <input
               aria-activedescendant={null}
               aria-label=""
-              autoComplete="off"
+              autoComplete="never"
               className="pf-c-form-control pf-c-select__toggle-typeahead"
               disabled={false}
               id="pf-select-toggle-id-8-select-typeahead"
@@ -12333,7 +12333,7 @@ exports[`typeahead select renders selected successfully 1`] = `
                 >
                   <input
                     aria-label=""
-                    autocomplete="off"
+                    autocomplete="never"
                     class="pf-c-form-control pf-c-select__toggle-typeahead"
                     id="pf-select-toggle-id-9-select-typeahead"
                     placeholder=""
@@ -12460,7 +12460,7 @@ exports[`typeahead select renders selected successfully 1`] = `
             <input
               aria-activedescendant={null}
               aria-label=""
-              autoComplete="off"
+              autoComplete="never"
               className="pf-c-form-control pf-c-select__toggle-typeahead"
               disabled={false}
               id="pf-select-toggle-id-9-select-typeahead"
@@ -12943,7 +12943,7 @@ exports[`typeahead select test select existing option on a non-creatable select 
                 >
                   <input
                     aria-label=""
-                    autocomplete="off"
+                    autocomplete="never"
                     class="pf-c-form-control pf-c-select__toggle-typeahead"
                     id="pf-select-toggle-id-12-select-typeahead"
                     placeholder=""
@@ -13013,7 +13013,7 @@ exports[`typeahead select test select existing option on a non-creatable select 
             <input
               aria-activedescendant={null}
               aria-label=""
-              autoComplete="off"
+              autoComplete="never"
               className="pf-c-form-control pf-c-select__toggle-typeahead"
               disabled={false}
               id="pf-select-toggle-id-12-select-typeahead"


### PR DESCRIPTION
**What**: 
Fixes https://github.com/patternfly/patternfly-react/issues/6625

Fix to not show the auto complete form for the TypeAhead Select component on Chrome

