### PR TITLE
For Katerina: beginnings of drag/drop accessibility enhancements

### DIFF
--- a/packages/react-core/src/components/DragDrop/DragButton.tsx
+++ b/packages/react-core/src/components/DragDrop/DragButton.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import GripVerticalIcon from '@patternfly/react-icons/dist/esm/icons/grip-vertical-icon';
+import { Button, ButtonVariant } from '../Button';
+import { DraggableContext } from './Draggable';
+
+interface DragButtonProps {
+  /** Accessible label for the button */
+  'aria-label'?: string;
+}
+
+export const DragButton: React.FunctionComponent<DragButtonProps> = ({
+  'aria-label': ariaLabel,
+  ...props
+}: DragButtonProps) => {
+  const { setHasDragButtons, onKeyDown } = React.useContext(DraggableContext);
+
+  React.useEffect(() => {
+    setHasDragButtons(true);
+  }, []);
+
+  return (
+    <Button variant={ButtonVariant.plain} aria-label={ariaLabel} onKeyDown={onKeyDown} {...props}>
+      <GripVerticalIcon />
+    </Button>
+  );
+};
+DragButton.displayName = 'DragButton';

--- a/packages/react-core/src/components/DragDrop/DragDrop.tsx
+++ b/packages/react-core/src/components/DragDrop/DragDrop.tsx
@@ -10,7 +10,9 @@ interface DraggableItemPosition {
 export const DragDropContext = React.createContext({
   onDrag: (_source: DraggableItemPosition) => true as boolean,
   onDragMove: (_source: DraggableItemPosition, _dest?: DraggableItemPosition) => {},
-  onDrop: (_source: DraggableItemPosition, _dest?: DraggableItemPosition) => false as boolean
+  onDrop: (_source: DraggableItemPosition, _dest?: DraggableItemPosition) => false as boolean,
+  isDragging: false,
+  setIsDragging: (isDragging: boolean) => {}
 });
 
 interface DragDropProps {
@@ -28,8 +30,13 @@ export const DragDrop: React.FunctionComponent<DragDropProps> = ({
   children,
   onDrag = () => true,
   onDragMove = () => {},
-  onDrop = () => false
-}: DragDropProps) => (
-  <DragDropContext.Provider value={{ onDrag, onDragMove, onDrop }}>{children}</DragDropContext.Provider>
-);
+  onDrop = () => false,
+
+}: DragDropProps) => {
+  const [isDragging, setIsDragging] = React.useState(false);
+
+  return (
+    <DragDropContext.Provider value={{ onDrag, onDragMove, onDrop, isDragging, setIsDragging }}>{children}</DragDropContext.Provider>
+  );
+};
 DragDrop.displayName = 'DragDrop';

--- a/packages/react-core/src/components/DragDrop/Draggable.tsx
+++ b/packages/react-core/src/components/DragDrop/Draggable.tsx
@@ -4,6 +4,11 @@ import styles from '@patternfly/react-styles/css/components/DragDrop/drag-drop';
 import { DroppableContext } from './DroppableContext';
 import { DragDropContext } from './DragDrop';
 
+export const DraggableContext = React.createContext({
+  setHasDragButtons: (hasDragButtons: boolean) => {},
+  onKeyDown: (e: React.KeyboardEvent) => {}
+});
+
 export interface DraggableProps extends React.HTMLProps<HTMLDivElement> {
   /** Content rendered inside DragDrop */
   children?: React.ReactNode;
@@ -85,17 +90,15 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
   /* eslint-disable prefer-const */
   let [style, setStyle] = React.useState(styleProp);
   /* eslint-enable prefer-const */
-  const [isDragging, setIsDragging] = React.useState(false);
+  const [isDraggingUsingMouse, setIsDraggingUsingMouse] = React.useState(false);
+  const [isDraggingUsingKeyboard, setIsDraggingUsingKeyboard] = React.useState(false);
   const [isValidDrag, setIsValidDrag] = React.useState(true);
+  const [hasDragButtons, setHasDragButtons] = React.useState(false);
   const { zone, droppableId } = React.useContext(DroppableContext);
-  const { onDrag, onDragMove, onDrop } = React.useContext(DragDropContext);
+  const { onDrag, onDragMove, onDrop, isDragging, setIsDragging } = React.useContext(DragDropContext);
   // Some state is better just to leave as vars passed around between various callbacks
   // You can only drag around one item at a time anyways...
-  let startX = 0;
-  let startY = 0;
   let index: number = null; // Index of this draggable
-  let hoveringDroppable: HTMLElement;
-  let hoveringIndex: number = null;
   let mouseMoveListener: EventListener;
   let mouseUpListener: EventListener;
   // Makes it so dragging the _bottom_ of the item over the halfway of another moves it
@@ -103,13 +106,15 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
 
   // After item returning to where it started animation completes
   const onTransitionEnd = (_ev: React.TransitionEvent<HTMLElement>) => {
-    if (isDragging) {
+    if (isDraggingUsingKeyboard || isDraggingUsingMouse) {
+      setIsDraggingUsingKeyboard(false);
+      setIsDraggingUsingMouse(false);
       setIsDragging(false);
       setStyle(styleProp);
     }
   };
 
-  function getSourceAndDest() {
+  function getSourceAndDest(hoveringIndex: number, hoveringDroppable: HTMLElement) {
     const hoveringDroppableId = hoveringDroppable ? hoveringDroppable.getAttribute('data-pf-droppableid') : null;
     const source = {
       droppableId,
@@ -118,21 +123,22 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
     const dest =
       hoveringDroppableId !== null && hoveringIndex !== null
         ? {
-            droppableId: hoveringDroppableId,
-            index: hoveringIndex
-          }
+          droppableId: hoveringDroppableId,
+          index: hoveringIndex
+        }
         : undefined;
     return { source, dest, hoveringDroppableId };
   }
 
-  const onMouseUpWhileDragging = (droppableItems: DroppableItem[]) => {
+  const onMouseUpWhileDragging = (droppableItems: DroppableItem[], hoveringIndex: number, hoveringDroppable: HTMLElement) => {
     droppableItems.forEach(resetDroppableItem);
     document.removeEventListener('mousemove', mouseMoveListener);
     document.removeEventListener('mouseup', mouseUpListener);
     document.removeEventListener('contextmenu', mouseUpListener);
-    const { source, dest, hoveringDroppableId } = getSourceAndDest();
+    const { source, dest, hoveringDroppableId } = getSourceAndDest(hoveringIndex, hoveringDroppable);
     const consumerReordered = onDrop(source, dest);
     if (consumerReordered && droppableId === hoveringDroppableId) {
+      setIsDraggingUsingMouse(false);
       setIsDragging(false);
       setStyle(styleProp);
     } else if (!consumerReordered) {
@@ -148,15 +154,16 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
   };
 
   // This is where the magic happens
-  const onMouseMoveWhileDragging = (ev: MouseEvent, droppableItems: DroppableItem[], blankDivRect: DOMRect) => {
+  const onMouseMoveWhileDragging = (ev: MouseEvent, droppableItems: DroppableItem[], blankDivRect: DOMRect, startingCoordinates?: {startX: number, startY: number}) => {
+    const { startX, startY } = startingCoordinates;
     // Compute each time what droppable node we are hovering over
-    hoveringDroppable = null;
+    let newHoveringDroppable = null as HTMLElement;
     droppableItems.forEach(droppableItem => {
       const { node, rect, isDraggingHost, draggableNodes, draggableNodesRects } = droppableItem;
       if (overlaps(ev, rect)) {
         // Add valid dropzone style
         node.classList.remove(styles.modifiers.dragOutside);
-        hoveringDroppable = node;
+        newHoveringDroppable = node;
         // Check if we need to add a blank div row
         if (node.getAttribute('blankDiv') !== 'true' && !isDraggingHost) {
           const blankDiv = document.createElement('div');
@@ -193,18 +200,15 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
         node.classList.add(styles.modifiers.dragOutside);
       }
     });
-
-    // Move hovering draggable and style it based on cursor position
     setStyle({
       ...style,
-      transform: `translate(${ev.pageX - startX}px, ${ev.pageY - startY}px)`
+      transform: `translate(${ev.clientX - startX}px, ${ev.clientY - startY}px)`
     });
-    setIsValidDrag(Boolean(hoveringDroppable));
+    setIsValidDrag(Boolean(newHoveringDroppable));
 
-    // Iterate through sibling draggable nodes to reposition them and store correct hoveringIndex for onDrop
-    hoveringIndex = null;
-    if (hoveringDroppable) {
-      const { draggableNodes, draggableNodesRects } = droppableItems.find(item => item.node === hoveringDroppable);
+    let newHoveringIndex: number = null;
+    if (newHoveringDroppable) {
+      const { draggableNodes, draggableNodesRects } = droppableItems.find(item => item.node === newHoveringDroppable);
       let lastTranslate = 0;
       draggableNodes.forEach((n, i) => {
         n.style.transition = 'transform 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0s';
@@ -212,34 +216,26 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
         const halfway = rect.y + rect.height / 2;
         let translateY = 0;
         // Use offset for more interactive translations
-        if (startY < halfway && ev.pageY + (blankDivRect.height - startYOffset) > halfway) {
+        if (startY < halfway && ev.clientY + (blankDivRect.height - startYOffset) > halfway) {
           translateY -= blankDivRect.height;
-        } else if (startY >= halfway && ev.pageY - startYOffset <= halfway) {
+        } else if (startY >= halfway && ev.clientY - startYOffset <= halfway) {
           translateY += blankDivRect.height;
         }
         // Clever way to find item currently hovering over
         if ((translateY <= lastTranslate && translateY < 0) || (translateY > lastTranslate && translateY > 0)) {
-          hoveringIndex = i;
+          newHoveringIndex = i;
         }
         n.style.transform = `translate(0, ${translateY}px`;
         lastTranslate = translateY;
       });
     }
-
-    const { source, dest } = getSourceAndDest();
+    const { source, dest } = getSourceAndDest(newHoveringIndex, newHoveringDroppable);
     onDragMove(source, dest);
+    mouseUpListener = () => onMouseUpWhileDragging(droppableItems, newHoveringIndex, newHoveringDroppable);
+    document.addEventListener('mouseup', mouseUpListener);
   };
 
-  const onDragStart = (ev: React.DragEvent<HTMLElement>) => {
-    // Default HTML drag and drop doesn't allow us to change what the thing
-    // being dragged looks like. Because of this we'll use prevent the default
-    // and use `mouseMove` and `mouseUp` instead
-    ev.preventDefault();
-    if (isDragging) {
-      // still in animation
-      return;
-    }
-
+  const calculateBounds = (ev: React.DragEvent<HTMLElement> | React.KeyboardEvent) => {
     // Cache droppable and draggable nodes and their bounding rects
     const dragging = ev.target as HTMLElement;
     const rect = dragging.getBoundingClientRect();
@@ -263,6 +259,24 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
       return acc;
     }, []);
 
+    return {
+      rect,
+      droppableItems
+    };
+  };
+
+  const onDragStart = (ev: React.DragEvent<HTMLElement>) => {
+    // Default HTML drag and drop doesn't allow us to change what the thing
+    // being dragged looks like. Because of this we'll use prevent the default
+    // and use `mouseMove` and `mouseUp` instead
+    ev.preventDefault();
+    if (isDragging) {
+      // still in animation
+      return;
+    }
+
+    const { droppableItems, rect } = calculateBounds(ev);
+
     if (!onDrag({ droppableId, index })) {
       // Consumer disallowed drag
       return;
@@ -275,43 +289,159 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
       left: rect.x,
       width: rect.width,
       height: rect.height,
-      '--pf-c-draggable--m-dragging--BackgroundColor': getInheritedBackgroundColor(dragging),
+      '--pf-c-draggable--m-dragging--BackgroundColor': getInheritedBackgroundColor(ev.target as HTMLElement),
       position: 'fixed',
       zIndex: 5000
     } as any;
     setStyle(style);
     // Store event details
-    startX = ev.pageX;
-    startY = ev.pageY;
-    startYOffset = startY - rect.y;
+    startYOffset = ev.clientY - rect.y;
+    setIsDraggingUsingMouse(true);
     setIsDragging(true);
-    mouseMoveListener = ev => onMouseMoveWhileDragging(ev as MouseEvent, droppableItems, rect);
-    mouseUpListener = () => onMouseUpWhileDragging(droppableItems);
+    mouseMoveListener = e => onMouseMoveWhileDragging(e as MouseEvent, droppableItems, rect, {startX: ev.clientX, startY: ev.clientY});
     document.addEventListener('mousemove', mouseMoveListener);
-    document.addEventListener('mouseup', mouseUpListener);
     // Comment out this line to debug while dragging by right clicking
     // document.addEventListener('contextmenu', mouseUpListener);
   };
 
+  const endDragUsingKeyboard = (cancel: boolean) => {
+    if (isDraggingUsingKeyboard) {
+      setStyle(styleProp);
+      const droppableNodes = Array.from(document.querySelectorAll(`[data-pf-droppable="${zone}"]`)) as HTMLElement[];
+      droppableNodes.forEach(node => {
+        node.classList.remove(styles.modifiers.dragging);
+      });
+
+      setIsDraggingUsingKeyboard(false);
+      setIsDragging(false);
+
+      if (cancel) {
+        onDrop({ droppableId, index }, undefined);
+        // Animate item returning to where it started
+        setStyle({
+          ...style,
+          transition: 'transform 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0s',
+          transform: '',
+          background: styleProp.background,
+          boxShadow: styleProp.boxShadow
+        });
+      }
+    }
+  };
+
+  React.useEffect(() => {
+    document.addEventListener('click', () => endDragUsingKeyboard(true));
+    return () => {
+      document.removeEventListener('click', () => endDragUsingKeyboard(true));
+    }
+  }, [isDraggingUsingKeyboard]);
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (isDraggingUsingKeyboard) {
+      if (e.key === 'Enter' || e.key === ' ' || e.key === 'Escape' || e.key === 'Tab') {
+        setStyle(styleProp);
+        const droppableNodes = Array.from(document.querySelectorAll(`[data-pf-droppable="${zone}"]`)) as HTMLElement[];
+        droppableNodes.forEach(node => {
+          node.classList.remove(styles.modifiers.dragging);
+        });
+
+        setIsDraggingUsingKeyboard(false);
+        setIsDragging(false);
+        if (e.key === ' ' || e.key === 'Tab') {
+          e.preventDefault();
+        }
+        if (e.key === 'Escape') {
+          endDragUsingKeyboard(true);
+        } else {
+          // don't cancel
+          const { droppableItems } = calculateBounds(e);
+          let hoveringIndex = null as number;
+          let hoveringDroppable = null as HTMLElement;
+          droppableItems.forEach(droppableItem => {
+            const { node, rect } = droppableItem;
+            const fakeMouseEvent = new MouseEvent("mousemove", { clientX: rect.x + 1, clientY: rect.y });
+            if (overlaps(fakeMouseEvent, rect)) {
+              hoveringDroppable = node
+            }
+          });
+          const { draggableNodes, draggableNodesRects } = droppableItems.find(item => item.node === hoveringDroppable);
+          let lastTranslate = 0;
+          draggableNodes.forEach((n: HTMLElement, i: number) => {
+            n.style.transition = 'transform 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0s';
+            const rect = draggableNodesRects[i];
+            const halfway = rect.y + rect.height / 2;
+            let translateY = 0;
+            // Use offset for more interactive translations
+            if (rect.y < halfway && rect.y + (rect.height - startYOffset) > halfway) {
+              translateY -= rect.height;
+            } else if (rect.y >= halfway && rect.y - startYOffset <= halfway) {
+              translateY += rect.height;
+            }
+            // Clever way to find item currently hovering over
+            if ((translateY <= lastTranslate && translateY < 0) || (translateY > lastTranslate && translateY > 0)) {
+              hoveringIndex = i;
+            }
+            n.style.transform = `translate(0, ${translateY}px`;
+            lastTranslate = translateY;
+          });
+          onMouseUpWhileDragging(droppableItems, hoveringIndex, hoveringDroppable);
+        }
+      } else if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+        const { droppableItems, rect } = calculateBounds(e);
+        const newClientY = e.key === 'ArrowUp' ? rect.y - rect.height : rect.y + rect.height;
+        const fakeMouseEvent = new MouseEvent("mousemove", { clientX: rect.x + 1, clientY: newClientY });
+        onMouseMoveWhileDragging(fakeMouseEvent, droppableItems, rect, {startX: rect.x, startY: rect.y});
+        e.preventDefault();
+      }
+    } else if (!isDragging) {
+      if (e.key === 'Enter' || e.key === ' ') {
+        if (e.key === ' ') {
+          e.preventDefault();
+        }
+
+        setIsDraggingUsingKeyboard(true);
+        setIsDragging(true);
+        // Cache droppable and draggable nodes and their bounding rects
+        const { rect } = calculateBounds(e);
+
+        if (!onDrag({ droppableId, index })) {
+          // Consumer disallowed drag
+          return;
+        }
+
+        // Set initial style so future style mods take effect
+        style = {
+          ...style,
+          width: rect.width,
+          height: rect.height,
+          '--pf-c-draggable--m-dragging--BackgroundColor': getInheritedBackgroundColor(e.target as HTMLElement),
+          zIndex: 5000
+        } as any;
+        setStyle(style);
+      }
+    }
+  };
+
   const childProps = {
-    'data-pf-draggable-zone': isDragging ? null : zone,
+    'data-pf-draggable-zone': isDraggingUsingMouse || isDraggingUsingKeyboard ? null : zone,
     draggable: true,
     className: css(
       styles.draggable,
-      isDragging && styles.modifiers.dragging,
+      (isDraggingUsingMouse || isDraggingUsingKeyboard) && styles.modifiers.dragging,
       !isValidDrag && styles.modifiers.dragOutside,
       className
     ),
     onDragStart,
     onTransitionEnd,
     style,
+    ...(!hasDragButtons && {onKeyDown, tabIndex: 0}),
     ...props
   };
 
   return (
-    <React.Fragment>
+    <DraggableContext.Provider value={{setHasDragButtons, onKeyDown}}>
       {/* Leave behind blank spot per-design */}
-      {isDragging && (
+      {isDraggingUsingMouse && (
         <div draggable {...props} style={{ ...styleProp, visibility: 'hidden' }}>
           {children}
         </div>
@@ -321,7 +451,7 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
       ) : (
         <div {...childProps}>{children}</div>
       )}
-    </React.Fragment>
+    </DraggableContext.Provider>
   );
 };
 Draggable.displayName = 'Draggable';

--- a/packages/react-core/src/components/Toolbar/ToolbarToggleGroup.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarToggleGroup.tsx
@@ -9,7 +9,7 @@ import globalBreakpointLg from '@patternfly/react-tokens/dist/esm/global_breakpo
 import { formatBreakpointMods, toCamel, capitalize, canUseDOM } from '../../helpers/util';
 
 export interface ToolbarToggleGroupProps extends ToolbarGroupProps {
-  /** An icon to be rendered when the toggle group has collapsed down */
+  /** Content to be rendered when the toggle group has collapsed down */
   toggleIcon: React.ReactNode;
   /** Controls when filters are shown and when the toggle button is hidden. */
   breakpoint: 'md' | 'lg' | 'xl' | '2xl';


### PR DESCRIPTION
My approach/plan:

- If the Draggable item has no interact-able elements within it, then it does not need a drag button because we can put a tab index on the Draggable item to allow the user to put focus on the item. If it does have interact-able elements within it - such as a button or dropdown or link - then the tab index would go on a `DragButton` component, which is basically just a button with the drag icon that will consume a context passed down from the Draggable item. The consumer would need to manually add the `DragButton` to each Draggable item in that case.
- In order to take advantage of all the logic associated with animating everything correctly and applying the correct styles at the right times, I tried to invoke the mouse events from within the keyboard events. I'm only midway through that attempt so it's definitely very messy.
- The current Draggable component (before I started messing with it) used a lot of instance variables rather than state management to pass crucial information between the various even handlers. That is currently one of the most difficult things to incorporate into the keyboard handling. I've tried to refactor it so that event handlers are passing crucial information around via function parameters instead - but now everything feels very tangled and I need to sort it out.
- so far, you can use the keyboard to begin dragging an item (without a drag button), but I have not figured out how to drop that item correctly yet, and I have not yet tried to figure out how to move the dragging item very far. There's a lot let to work on


I have no begun to think about screen reader usage. I think that may need to be a follow up issue. The largest hurdle I see there is that screen readers rely heavily on click events, and our drag/drop component uses mouseup/mousedown events so it may not translate naturally based on our current approach.