### PR TITLE
Feat FocusTrap to be made inactive in ContextSelector.tsx

### DIFF
--- a/packages/react-core/src/components/ContextSelector/ContextSelector.tsx
+++ b/packages/react-core/src/components/ContextSelector/ContextSelector.tsx
@@ -51,6 +51,8 @@ export interface ContextSelectorProps extends ToggleMenuBaseProps, OUIAProps {
   isPlain?: boolean;
   /** Flag to indicate if toggle is textual toggle */
   isText?: boolean;
+  /** Flag to disable focus trap */
+  disableFocusTrap?: boolean;
 }
 
 export class ContextSelector extends React.Component<ContextSelectorProps, { ouiaStateId: string }> {
@@ -70,6 +72,7 @@ export class ContextSelector extends React.Component<ContextSelectorProps, { oui
     onSearchButtonClick: () => undefined as any,
     menuAppendTo: 'inline',
     ouiaSafe: true,
+    disableFocusTrap: false,
     footer: null as React.ReactNode,
     isPlain: false,
     isText: false
@@ -113,12 +116,13 @@ export class ContextSelector extends React.Component<ContextSelectorProps, { oui
       isPlain,
       isText,
       footer,
+      disableFocusTrap,
       ...props
     } = this.props;
     const menuContainer = (
       <div className={css(styles.contextSelectorMenu)}>
         {isOpen && (
-          <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }}>
+          <FocusTrap active={!disableFocusTrap} focusTrapOptions={{ clickOutsideDeactivates: true }}>
             <div className={css(styles.contextSelectorMenuSearch)}>
               <InputGroup>
                 <TextInput


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6494 

I made some simple change followed the `Modal` module where I declare `disableFocusTrap` as a prop and use it 

```tsx
<FocusTrap 
          active={!disableFocusTrap}
          focusTrapOptions={{ clickOutsideDeactivates: true }}>
```
 
<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: 

I could not use `yarn lint` and `pre-commit` hook also keep failing on me, I'm using Window 11. But when I try to use Gitpod, yarn lint ran smoothly 

Error log:

```bash
$ node --max-old-space-size=4096 node_modules/.bin/eslint --ext js,jsx,ts,tsx --cache
C:\Users\Administrator\Desktop\repo\patternfly-react\node_modules\.bin\eslint:2
basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
          ^^^^^^^

SyntaxError: missing ) after argument list
    at wrapSafe (internal/modules/cjs/loader.js:1001:16)
    at Module._compile (internal/modules/cjs/loader.js:1049:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:76:12)
    at internal/main/run_main_module.js:17:47
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```