### PR TITLE
fix(popover): forwarded focus to close button with VoiceOver click

### DIFF
--- a/packages/react-core/src/components/Popover/Popover.tsx
+++ b/packages/react-core/src/components/Popover/Popover.tsx
@@ -334,23 +334,6 @@ export const Popover: React.FunctionComponent<PopoverProps> = ({
       }
     }
   };
-  const onTriggerEnter = (event: KeyboardEvent) => {
-    if (event.keyCode === KEY_CODES.ENTER) {
-      if (!visible) {
-        if (triggerManually) {
-          shouldOpen(show, event);
-        } else {
-          show(true);
-        }
-      } else {
-        if (triggerManually) {
-          shouldClose(null, hide, event);
-        } else {
-          hide();
-        }
-      }
-    }
-  };
   const onTriggerClick = (event: MouseEvent) => {
     if (triggerManually) {
       if (visible) {
@@ -362,7 +345,7 @@ export const Popover: React.FunctionComponent<PopoverProps> = ({
       if (visible) {
         hide();
       } else {
-        show();
+        show(true);
       }
     }
   };
@@ -451,7 +434,6 @@ export const Popover: React.FunctionComponent<PopoverProps> = ({
         distance={distance}
         placement={position}
         onTriggerClick={onTriggerClick}
-        onTriggerEnter={onTriggerEnter}
         onDocumentClick={onDocumentClick}
         onDocumentKeyDown={onDocumentKeyDown}
         enableFlip={enableFlip}

--- a/packages/react-core/src/components/Popover/__tests__/Generated/__snapshots__/Popover.test.tsx.snap
+++ b/packages/react-core/src/components/Popover/__tests__/Generated/__snapshots__/Popover.test.tsx.snap
@@ -27,7 +27,6 @@ exports[`Popover should match snapshot (auto-generated) 1`] = `
     onDocumentClick={[Function]}
     onDocumentKeyDown={[Function]}
     onTriggerClick={[Function]}
-    onTriggerEnter={[Function]}
     placement="top"
     popper={
       <FocusTrap

--- a/packages/react-core/src/components/Popover/__tests__/__snapshots__/Popover.test.tsx.snap
+++ b/packages/react-core/src/components/Popover/__tests__/__snapshots__/Popover.test.tsx.snap
@@ -27,7 +27,6 @@ exports[`popover can close from content (uncontrolled) 1`] = `
     onDocumentClick={[Function]}
     onDocumentKeyDown={[Function]}
     onTriggerClick={[Function]}
-    onTriggerEnter={[Function]}
     placement="top"
     popper={
       <FocusTrap
@@ -150,7 +149,6 @@ exports[`popover can have a custom minimum width 1`] = `
     onDocumentClick={[Function]}
     onDocumentKeyDown={[Function]}
     onTriggerClick={[Function]}
-    onTriggerEnter={[Function]}
     placement="top"
     popper={
       <FocusTrap
@@ -256,7 +254,6 @@ exports[`popover can specify position as object value 1`] = `
     onDocumentClick={[Function]}
     onDocumentKeyDown={[Function]}
     onTriggerClick={[Function]}
-    onTriggerEnter={[Function]}
     placement="right"
     popper={
       <FocusTrap
@@ -362,7 +359,6 @@ exports[`popover renders close-button, header and body 1`] = `
     onDocumentClick={[Function]}
     onDocumentKeyDown={[Function]}
     onTriggerClick={[Function]}
-    onTriggerEnter={[Function]}
     placement="top"
     popper={
       <FocusTrap


### PR DESCRIPTION
**What**: Closes #4210 

This PR:
- Forwards focus to close button within popover when triggering with VoiceOver click
  - `cmd+F5` on a Mac to enable VO, then `ctrl+option+space` on button to trigger Popover (see [Activate a link or form control](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts#vo-mac-navigation))
- Removes the optional `onTriggerEnter` function passed as a prop to Popper
  - This function was duplicating the `onTriggerClick` functionality but targeted only at the `Enter` key, but that key press was triggering both functions so this seems to be unnecessary.