### PR TITLE
fix(Slider): fixed examples with custom steps and input

### DIFF
--- a/packages/react-core/src/components/Slider/Slider.tsx
+++ b/packages/react-core/src/components/Slider/Slider.tsx
@@ -219,15 +219,18 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
 
     /* If custom steps are discrete, snap to closest step value */
     if (!areCustomStepsContinuous && customSteps) {
-      const numSteps = customSteps.length - 1;
-      const percentagePerStep = 100 / numSteps;
-      const customStepPercentage = newPercentage / percentagePerStep;
-      const stepIndex = customSteps.findIndex(stepObj => stepObj.value >= customStepPercentage);
-      if (customSteps[stepIndex].value === customStepPercentage) {
+      let percentage = newPercentage;
+      if (customSteps[customSteps.length - 1].value !== 100) {
+        const numSteps = customSteps.length - 1;
+        const percentagePerStep = 100 / numSteps;
+        percentage = newPercentage / percentagePerStep;
+      }
+      const stepIndex = customSteps.findIndex(stepObj => stepObj.value >= percentage);
+      if (customSteps[stepIndex].value === percentage) {
         snapValue = customSteps[stepIndex].value;
       } else {
         const midpoint = (customSteps[stepIndex].value + customSteps[stepIndex - 1].value) / 2;
-        if (midpoint > customStepPercentage) {
+        if (midpoint > percentage) {
           snapValue = customSteps[stepIndex - 1].value;
         } else {
           snapValue = customSteps[stepIndex].value;

--- a/packages/react-core/src/components/Slider/examples/Slider.md
+++ b/packages/react-core/src/components/Slider/examples/Slider.md
@@ -29,6 +29,7 @@ class DiscreteInput extends React.Component {
       value3: 25,
       value4: 50,
       value5: 50,
+      value6: 3
     };
 
     this.steps = [
@@ -41,6 +42,15 @@ class DiscreteInput extends React.Component {
       { value: 75, label: '6' },
       { value: 87.5, label: '7', isLabelHidden: true },
       { value: 100, label: '8' }
+    ];
+
+    this.stepsDiscreteWithMax = [
+      { value: 0, label: "A" },
+      { value: 1, label: "B" },
+      { value: 2, label: "C" },
+      { value: 3, label: "D" },
+      { value: 4, label: "E" },
+      { value: 5, label: "F" }
     ];
 
     this.onChange = value => {
@@ -72,6 +82,12 @@ class DiscreteInput extends React.Component {
           value5: value
         });
     };
+
+    this.onChange6 = value => {
+        this.setState({
+          value6: value
+        });
+    };
   }
 
   render() {
@@ -97,6 +113,17 @@ class DiscreteInput extends React.Component {
         <Text component={TextVariants.h3}>Slider value is: {Math.floor(this.state.value5)}</Text>
         <Text component={TextVariants.small}>(min = -25, max = 75, step = 10, boundaries shown, ticks not shown) </Text>
         <Slider value={this.state.value5} onChange={this.onChange5} min={-25} max={75} step={10} />
+        <br />
+        <Text component={TextVariants.h3}>Slider value is: {Math.floor(this.state.value6)}</Text>
+        <Text component={TextVariants.small}>(max = 5, custom steps) </Text>
+        <Slider
+            value={this.state.value6}
+            showTicks
+            max={5}
+            customSteps={this.stepsDiscreteWithMax}
+            onChange={this.onChange6}
+          />
+          <br />
       </>
     );
   }


### PR DESCRIPTION
**What**: Closes #6644
I can't think of a quicker fix...
I also added one more example, I don't know if it is necessary, it is the example from the original issue https://github.com/patternfly/patternfly-react/issues/5833 
