### PR TITLE
docs(toolbar): fixed toolbar link under props in jump links

### DIFF
--- a/packages/react-core/src/components/Toolbar/examples/Toolbar.md
+++ b/packages/react-core/src/components/Toolbar/examples/Toolbar.md
@@ -50,7 +50,7 @@ class ToolbarItems extends React.Component {
     );
 
     return (
-      <Toolbar id="toolbar">
+      <Toolbar id="toolbar-items">
         <ToolbarContent>{items}</ToolbarContent>
       </Toolbar>
     );


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-react/issues/6656