### PR TITLE
fix(LogViewer): fix the issue that scrollbar could compress the content of the logs

### DIFF
--- a/packages/react-log-viewer/src/LogViewer/LogViewer.tsx
+++ b/packages/react-log-viewer/src/LogViewer/LogViewer.tsx
@@ -223,12 +223,15 @@ const LogViewerBase: React.FunctionComponent<LogViewerProps> = memo(
         outerClassName={css(styles.logViewerScrollContainer)}
         innerClassName={css(styles.logViewerList)}
         height={containerRef.current.clientHeight}
+        width={containerRef.current.clientWidth}
         itemSize={guessRowHeight}
         itemCount={typeof itemCount === 'undefined' ? parsedData.length : itemCount}
         itemData={dataToRender}
         ref={logViewerRef}
         overscanCount={overScanCount}
         onScroll={onScroll}
+        isTextWrapped={isTextWrapped}
+        hasLineNumbers={hasLineNumbers}
       >
         {LogViewerRow}
       </List>

--- a/packages/react-log-viewer/src/LogViewer/LogViewerRow.tsx
+++ b/packages/react-log-viewer/src/LogViewer/LogViewerRow.tsx
@@ -78,6 +78,7 @@ export const LogViewerRow: React.FunctionComponent<LogViewerRowProps> = memo(({ 
       <span className={css(styles.logViewerIndex)}>{getRowIndex(index)}</span>
       <span
         className={css(styles.logViewerText)}
+        style={{ width: 'fit-content' }}
         dangerouslySetInnerHTML={{ __html: ansiUp.ansi_to_html(getFormattedData()) }}
       />
     </div>

--- a/packages/react-log-viewer/src/react-window/createListComponent.ts
+++ b/packages/react-log-viewer/src/react-window/createListComponent.ts
@@ -143,7 +143,7 @@ export default function createListComponent({
     }
 
     scrollTo(scrollOffset: number): void {
-      scrollOffset = Math.max(0, scrollOffset + 15);
+      scrollOffset = Math.max(0, scrollOffset);
 
       this.setState(prevState => {
         if (prevState.scrollOffset === scrollOffset) {
@@ -268,7 +268,7 @@ export default function createListComponent({
             className: innerClassName,
             ref: innerRef,
             style: {
-              height: estimatedTotalSize > height ? estimatedTotalSize + 15 : height, // get rid of the effects of always on scrollbar
+              height: estimatedTotalSize > height ? estimatedTotalSize : height, // get rid of the effects of always on scrollbar
               /* eslint-disable-next-line no-nested-ternary */
               width: isTextWrapped ? (hasLineNumbers ? width - 65 : width) : 'auto',
               pointerEvents: isScrolling ? 'none' : undefined

--- a/packages/react-log-viewer/src/react-window/createListComponent.ts
+++ b/packages/react-log-viewer/src/react-window/createListComponent.ts
@@ -143,7 +143,7 @@ export default function createListComponent({
     }
 
     scrollTo(scrollOffset: number): void {
-      scrollOffset = Math.max(0, scrollOffset);
+      scrollOffset = Math.max(0, scrollOffset + 15);
 
       this.setState(prevState => {
         if (prevState.scrollOffset === scrollOffset) {
@@ -216,7 +216,10 @@ export default function createListComponent({
         outerElementType,
         outerTagName,
         style,
-        useIsScrolling
+        useIsScrolling,
+        width,
+        isTextWrapped,
+        hasLineNumbers
       } = this.props;
       const { isScrolling } = this.state;
 
@@ -255,6 +258,7 @@ export default function createListComponent({
             paddingTop: 0,
             paddingBottom: 0,
             WebkitOverflowScrolling: 'touch',
+            overflowX: isTextWrapped ? 'hidden' : 'auto',
             ...style
           }
         },
@@ -264,7 +268,9 @@ export default function createListComponent({
             className: innerClassName,
             ref: innerRef,
             style: {
-              height: estimatedTotalSize > height ? estimatedTotalSize : height,
+              height: estimatedTotalSize > height ? estimatedTotalSize + 15 : height, // get rid of the effects of always on scrollbar
+              /* eslint-disable-next-line no-nested-ternary */
+              width: isTextWrapped ? (hasLineNumbers ? width - 65 : width) : 'auto',
               pointerEvents: isScrolling ? 'none' : undefined
             }
           },

--- a/packages/react-log-viewer/src/react-window/createListComponent.ts
+++ b/packages/react-log-viewer/src/react-window/createListComponent.ts
@@ -268,7 +268,7 @@ export default function createListComponent({
             className: innerClassName,
             ref: innerRef,
             style: {
-              height: estimatedTotalSize > height ? estimatedTotalSize : height, // get rid of the effects of always on scrollbar
+              height: estimatedTotalSize > height ? estimatedTotalSize : height,
               /* eslint-disable-next-line no-nested-ternary */
               width: isTextWrapped ? (hasLineNumbers ? width - 65 : width) : 'auto',
               pointerEvents: isScrolling ? 'none' : undefined


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6701 
Use a small trick to prevent list width from changing when user changes setting of showing scrollbar from 'Always' to 'Automatically'.
