### PR TITLE
fix(Select): update typeahead Select children when any option attribute changes

### DIFF
--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import isDeepEqual from 'fast-deep-equal/react';
 import styles from '@patternfly/react-styles/css/components/Select/select';
 import badgeStyles from '@patternfly/react-styles/css/components/Badge/badge';
 import formStyles from '@patternfly/react-styles/css/components/FormControl/form-control';
@@ -262,16 +263,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
     }
 
     // the number or contents of the children has changed, update state.typeaheadFilteredChildren
-    if (
-      prevProps.children.length !== this.props.children.length ||
-      prevProps.children.some((child: React.ReactElement, index: number) => {
-        if (child.props && this.props.children[index].props) {
-          return child.props.value !== this.props.children[index].props.value;
-        } else {
-          return child !== this.props.children[index];
-        }
-      })
-    ) {
+    if (!isDeepEqual(prevProps.children, this.props.children)) {
       this.updateTypeAheadFilteredChildren(prevState.typeaheadInputValue || '', null);
     }
 

--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import isDeepEqual from 'fast-deep-equal/react';
 import styles from '@patternfly/react-styles/css/components/Select/select';
 import badgeStyles from '@patternfly/react-styles/css/components/Badge/badge';
 import formStyles from '@patternfly/react-styles/css/components/FormControl/form-control';
@@ -262,8 +261,26 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
       this.refCollection[this.state.viewMoreNextIndex][0].focus();
     }
 
-    // the number or contents of the children has changed, update state.typeaheadFilteredChildren
-    if (!isDeepEqual(prevProps.children, this.props.children)) {
+    const hasUpdatedChildren =
+      prevProps.children.length !== this.props.children.length ||
+      prevProps.children.some((prevChild: React.ReactElement, index: number) => {
+        const prevChildProps = prevChild.props;
+        const currChild = this.props.children[index];
+        const { props: currChildProps } = currChild;
+
+        if (prevChildProps && currChildProps) {
+          return (
+            prevChildProps.value !== currChildProps.value ||
+            prevChildProps.label !== currChildProps.label ||
+            prevChildProps.isDisabled !== currChildProps.isDisabled ||
+            prevChildProps.isPlaceholder !== currChildProps.isPlaceholder
+          );
+        } else {
+          return prevChild !== currChild;
+        }
+      });
+
+    if (hasUpdatedChildren) {
       this.updateTypeAheadFilteredChildren(prevState.typeaheadInputValue || '', null);
     }
 

--- a/packages/react-core/src/components/Select/examples/Select.md
+++ b/packages/react-core/src/components/Select/examples/Select.md
@@ -348,7 +348,7 @@ class ValidatedSelect extends React.Component {
         console.log('selected:', selection);
       }
       this.setState({
-          validated: validatedState
+        validated: validatedState
       });
     };
 
@@ -1183,13 +1183,13 @@ class TypeaheadSelectInput extends React.Component {
   constructor(props) {
     super(props);
     this.defaultOptions = [
-        { value: 'Alabama' },
-        { value: 'Florida', description: 'This is a description' },
-        { value: 'New Jersey' },
-        { value: 'New Mexico' },
-        { value: 'New York' },
-        { value: 'North Carolina' }
-      ];
+      { value: 'Alabama' },
+      { value: 'Florida', description: 'This is a description' },
+      { value: 'New Jersey' },
+      { value: 'New Mexico' },
+      { value: 'New York' },
+      { value: 'North Carolina' }
+    ];
 
     this.state = {
       options: this.defaultOptions,
@@ -1579,7 +1579,8 @@ class MultiTypeaheadSelectInput extends React.Component {
       isOpen: false,
       selected: [],
       isCreatable: false,
-      hasOnCreateOption: false
+      hasOnCreateOption: false,
+      hasDisabledOption: false
     };
 
     this.onCreateOption = newValue => {
@@ -1627,10 +1628,19 @@ class MultiTypeaheadSelectInput extends React.Component {
         hasOnCreateOption: checked
       });
     };
+
+    this.toggleOptionDisabled = (toggleIndex) => () => {
+      this.setState(prevState => ({
+        hasDisabledOption: !prevState.hasDisabledOption,
+        options: prevState.options.map((option, index) =>
+          index === toggleIndex ? { ...option, disabled: !option.disabled } : option
+        ),
+      }));
+    };
   }
 
   render() {
-    const { isOpen, selected, isCreatable, hasOnCreateOption } = this.state;
+    const { isOpen, selected, isCreatable, hasOnCreateOption, options } = this.state;
     const titleId = 'multi-typeahead-select-id-1';
 
     return (
@@ -1651,7 +1661,7 @@ class MultiTypeaheadSelectInput extends React.Component {
           isCreatable={isCreatable}
           onCreateOption={(hasOnCreateOption && this.onCreateOption) || undefined}
         >
-          {this.state.options.map((option, index) => (
+          {options.map((option, index) => (
             <SelectOption
               isDisabled={option.disabled}
               key={index}
@@ -1675,6 +1685,14 @@ class MultiTypeaheadSelectInput extends React.Component {
           aria-label="toggle new checkbox"
           id="toggle-new-typeahead-multi"
           name="toggle-new-typeahead-multi"
+        />
+        <Checkbox
+          label="isDisabled (1st option only)"
+          isChecked={this.state.hasDisabledOption}
+          onChange={this.toggleOptionDisabled(0)}
+          aria-label="toggle disable first option"
+          id="toggle-disable-first-option"
+          name="toggle-disable-first-option"
         />
       </div>
     );
@@ -2453,7 +2471,7 @@ class SelectWithFooterCheckbox extends React.Component {
           Title
         </span>
         <Select
-        variant={SelectVariant.checkbox}
+          variant={SelectVariant.checkbox}
           aria-label="Select input"
           onToggle={this.onToggle}
           onSelect={this.onSelect}
@@ -2578,7 +2596,7 @@ import {
 } from '@patternfly/react-core';
 
 class SelectViewMoreCheckbox extends React.Component {
-   constructor(props) {
+  constructor(props) {
     super(props);
 
     this.state = {


### PR DESCRIPTION
**What**: Closes #6629

Using a deep equality check to identify when typeahead Select children should be updated as a part of the Select's lifecycle (when the component updates).

The issue only existed for typeahead updates, and an example has been added for verification purposes (Select - Multiple).