### PR TITLE
fix(jumplinks): fixed scrollspy breakpoints are incorrect if offset prop changes

### DIFF
--- a/packages/react-core/src/components/JumpLinks/JumpLinks.tsx
+++ b/packages/react-core/src/components/JumpLinks/JumpLinks.tsx
@@ -137,7 +137,7 @@ export const JumpLinks: React.FunctionComponent<JumpLinksProps> = ({
         }
       }
     });
-  }, [scrollItems, hasScrollSpy, scrollableElement]);
+  }, [scrollItems, hasScrollSpy, scrollableElement, offset]);
 
   React.useEffect(() => {
     scrollableElement = document.querySelector(scrollableSelector) as HTMLElement;


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6749 

This PR adds the `offset` prop to the dependencies array of the `scrollSpy` function's `useCallback`, fixing a bug where the scrollspy would never update if the `offset` prop changed.

In our previous demo the `offset` was hard coded so the bug didn't present itself, but the bug can be seen in https://github.com/patternfly/patternfly-react/pull/6731 where the `offset` prop defaults to `10` but then is set dynamically when rendered.