### PR TITLE
feat(Table): update clickable area for checks/radios

### DIFF
--- a/packages/react-integration/cypress/integration/tableselectable.spec.ts
+++ b/packages/react-integration/cypress/integration/tableselectable.spec.ts
@@ -26,11 +26,11 @@ describe('Table Selectable Test', () => {
 
   it('Test selectable checkbox', () => {
     for (let i = 1; i <= 3; i++) {
-      cy.get(`tbody tr:nth-child(${i}) .pf-c-table__check > input`).check();
+      cy.get(`tbody tr:nth-child(${i}) .pf-c-table__check > label > input`).check();
     }
 
     for (let i = 1; i <= 3; i++) {
-      cy.get(`tbody tr:nth-child(${i}) .pf-c-table__check > input`).should('be.checked');
+      cy.get(`tbody tr:nth-child(${i}) .pf-c-table__check > label > input`).should('be.checked');
     }
   });
 
@@ -39,14 +39,14 @@ describe('Table Selectable Test', () => {
     cy.get('input[name=selectVariant][value=radio]').click();
 
     for (let i = 1; i <= 3; i++) {
-      cy.get(`tbody tr:nth-child(${i}) .pf-c-table__check > input`).check();
+      cy.get(`tbody tr:nth-child(${i}) .pf-c-table__check > label > input`).check();
     }
     // Only last radio input should be checked in the end of the iteration
     for (let i = 1; i <= 3; i++) {
       if (i < 3) {
-        cy.get(`tbody tr:nth-child(${i}) .pf-c-table__check > input`).should('not.be.checked');
+        cy.get(`tbody tr:nth-child(${i}) .pf-c-table__check > label > input`).should('not.be.checked');
       } else {
-        cy.get(`tbody tr:nth-child(${i}) .pf-c-table__check > input`).should('be.checked');
+        cy.get(`tbody tr:nth-child(${i}) .pf-c-table__check > label > input`).should('be.checked');
       }
     }
   });

--- a/packages/react-table/src/components/Table/SelectColumn.tsx
+++ b/packages/react-table/src/components/Table/SelectColumn.tsx
@@ -22,7 +22,9 @@ export const SelectColumn: React.FunctionComponent<SelectColumnProps> = ({
   ...props
 }: SelectColumnProps) => (
   <React.Fragment>
-    <input {...props} type={selectVariant} onChange={onSelect} />
+    <label>
+      <input {...props} type={selectVariant} onChange={onSelect} />
+    </label>
     {children}
   </React.Fragment>
 );

--- a/packages/react-virtualized-extension/src/components/Virtualized/__snapshots__/VirtualizedTable.test.tsx.snap
+++ b/packages/react-virtualized-extension/src/components/Virtualized/__snapshots__/VirtualizedTable.test.tsx.snap
@@ -2635,13 +2635,15 @@ exports[`Selectable virtualized table 1`] = `
                                           onSelect={[Function]}
                                           selectVariant="checkbox"
                                         >
-                                          <input
-                                            aria-label="Select all rows"
-                                            checked={false}
-                                            name="check-all"
-                                            onChange={[Function]}
-                                            type="checkbox"
-                                          />
+                                          <label>
+                                            <input
+                                              aria-label="Select all rows"
+                                              checked={false}
+                                              name="check-all"
+                                              onChange={[Function]}
+                                              type="checkbox"
+                                            />
+                                          </label>
                                         </SelectColumn>
                                       </td>
                                     </ThBase>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6695

This change does not currently apply to the tree view variant of Table. Adding in the `<label>` tag does not provide the correct padding (instead pushing out the checkbox such that the expand toggle is on top of it) and prevents the checkbox from being clicked. @mattnolting Am I missing a change here beyond adding label?