### PR TITLE
fix(Tabs): enable tabs scroll button for small window

### DIFF
--- a/packages/react-core/src/components/Tabs/Tabs.tsx
+++ b/packages/react-core/src/components/Tabs/Tabs.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as _ from 'lodash';
 import styles from '@patternfly/react-styles/css/components/Tabs/tabs';
 import buttonStyles from '@patternfly/react-styles/css/components/Button/button';
 import { css } from '@patternfly/react-styles';
@@ -178,7 +179,7 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
     }
   }
 
-  handleScrollButtons = () => {
+  handleScrollButtons = _.debounce(() => {
     const container = this.tabList.current;
     let disableLeftScrollButton = true;
     let disableRightScrollButton = true;
@@ -201,7 +202,7 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
       disableLeftScrollButton,
       disableRightScrollButton
     });
-  };
+  }, 100);
 
   scrollLeft = () => {
     // find first Element that is fully in view on the left, then scroll to the element before it

--- a/packages/react-core/src/components/Tabs/Tabs.tsx
+++ b/packages/react-core/src/components/Tabs/Tabs.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as _ from 'lodash';
 import styles from '@patternfly/react-styles/css/components/Tabs/tabs';
 import buttonStyles from '@patternfly/react-styles/css/components/Button/button';
 import { css } from '@patternfly/react-styles';
@@ -127,6 +126,8 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
     }
   }
 
+  scrollTimeout: NodeJS.Timeout = null;
+
   static defaultProps: PickOptional<TabsProps> = {
     activeKey: 0,
     onSelect: () => undefined as any,
@@ -179,30 +180,34 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
     }
   }
 
-  handleScrollButtons = _.debounce(() => {
-    const container = this.tabList.current;
-    let disableLeftScrollButton = true;
-    let disableRightScrollButton = true;
-    let showScrollButtons = false;
+  handleScrollButtons = () => {
+    // add debounce to the scroll event
+    clearTimeout(this.scrollTimeout);
+    this.scrollTimeout = setTimeout(() => {
+      const container = this.tabList.current;
+      let disableLeftScrollButton = true;
+      let disableRightScrollButton = true;
+      let showScrollButtons = false;
 
-    if (container && !this.props.isVertical) {
-      // get first element and check if it is in view
-      const overflowOnLeft = !isElementInView(container, container.firstChild as HTMLElement, false);
+      if (container && !this.props.isVertical) {
+        // get first element and check if it is in view
+        const overflowOnLeft = !isElementInView(container, container.firstChild as HTMLElement, false);
 
-      // get last element and check if it is in view
-      const overflowOnRight = !isElementInView(container, container.lastChild as HTMLElement, false);
+        // get last element and check if it is in view
+        const overflowOnRight = !isElementInView(container, container.lastChild as HTMLElement, false);
 
-      showScrollButtons = overflowOnLeft || overflowOnRight;
+        showScrollButtons = overflowOnLeft || overflowOnRight;
 
-      disableLeftScrollButton = !overflowOnLeft;
-      disableRightScrollButton = !overflowOnRight;
-    }
-    this.setState({
-      showScrollButtons,
-      disableLeftScrollButton,
-      disableRightScrollButton
-    });
-  }, 100);
+        disableLeftScrollButton = !overflowOnLeft;
+        disableRightScrollButton = !overflowOnRight;
+      }
+      this.setState({
+        showScrollButtons,
+        disableLeftScrollButton,
+        disableRightScrollButton
+      });
+    }, 100);
+  };
 
   scrollLeft = () => {
     // find first Element that is fully in view on the left, then scroll to the element before it
@@ -259,6 +264,7 @@ export class Tabs extends React.Component<TabsProps, TabsState> {
         window.removeEventListener('resize', this.handleScrollButtons, false);
       }
     }
+    clearTimeout(this.scrollTimeout);
   }
 
   componentDidUpdate(prevProps: TabsProps) {

--- a/packages/react-core/src/helpers/util.ts
+++ b/packages/react-core/src/helpers/util.ts
@@ -48,15 +48,15 @@ export function isElementInView(container: HTMLElement, element: HTMLElement, pa
   }
   const containerBounds = container.getBoundingClientRect();
   const elementBounds = element.getBoundingClientRect();
-  const containerBoundsLeft = Math.floor(containerBounds.left);
+  const containerBoundsLeft = Math.ceil(containerBounds.left);
   const containerBoundsRight = Math.floor(containerBounds.right);
-  const elementBoundsLeft = Math.floor(elementBounds.left);
+  const elementBoundsLeft = Math.ceil(elementBounds.left);
   const elementBoundsRight = Math.floor(elementBounds.right);
 
   // Check if in view
   const isTotallyInView = elementBoundsLeft >= containerBoundsLeft && elementBoundsRight <= containerBoundsRight;
   const isPartiallyInView =
-    partial &&
+    (partial || containerBounds.width < elementBounds.width) &&
     ((elementBoundsLeft < containerBoundsLeft && elementBoundsRight > containerBoundsLeft) ||
       (elementBoundsRight > containerBoundsRight && elementBoundsLeft < containerBoundsRight));
 

--- a/packages/react-core/src/helpers/util.ts
+++ b/packages/react-core/src/helpers/util.ts
@@ -43,7 +43,12 @@ export function debounce(this: any, func: (...args: any[]) => any, wait: number)
  *
  * @returns { boolean } True if the component is in View.
  */
-export function isElementInView(container: HTMLElement, element: HTMLElement, partial: boolean, strict?: boolean) {
+export function isElementInView(
+  container: HTMLElement,
+  element: HTMLElement,
+  partial: boolean,
+  strict: boolean = false
+): boolean {
   if (!container || !element) {
     return false;
   }

--- a/packages/react-core/src/helpers/util.ts
+++ b/packages/react-core/src/helpers/util.ts
@@ -39,10 +39,11 @@ export function debounce(this: any, func: (...args: any[]) => any, wait: number)
  * @param {HTMLElement} container  The container to check if the element is in view of.
  * @param {HTMLElement} element    The element to check if it is view
  * @param {boolean} partial   true if partial view is allowed
+ * @param {boolean} strict    true if strict mode is set, never consider the container width and element width
  *
  * @returns { boolean } True if the component is in View.
  */
-export function isElementInView(container: HTMLElement, element: HTMLElement, partial: boolean) {
+export function isElementInView(container: HTMLElement, element: HTMLElement, partial: boolean, strict?: boolean) {
   if (!container || !element) {
     return false;
   }
@@ -56,7 +57,7 @@ export function isElementInView(container: HTMLElement, element: HTMLElement, pa
   // Check if in view
   const isTotallyInView = elementBoundsLeft >= containerBoundsLeft && elementBoundsRight <= containerBoundsRight;
   const isPartiallyInView =
-    (partial || containerBounds.width < elementBounds.width) &&
+    (partial || (!strict && containerBounds.width < elementBounds.width)) &&
     ((elementBoundsLeft < containerBoundsLeft && elementBoundsRight > containerBoundsLeft) ||
       (elementBoundsRight > containerBoundsRight && elementBoundsLeft < containerBoundsRight));
 


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5175 
This issue is because there the button only scrolls left or right when the tab is totally inside the view. However, when the window is small, the tab content could even be longer than the list width, which makes it can never find the element in the view. To solve the problem, I created a new optional prop named `strict` and made a judgment on the element width and the container width, if the container width is smaller than the element width and the `strict` is not set, we treat it as part in view. Only when strict mode is set, we will not take the element width and container width into consideration, which brings more flexibility to the function.
Also, I update the bounding to make it more precise to judge whether an element is in view when the element width is not an integer. And add a debounce to the scroll function.

