### PR TITLE
Fixes #6814: Don't trigger mobx update when node dimension or position doesn't change

### DIFF
--- a/packages/react-topology/src/elements/BaseNode.ts
+++ b/packages/react-topology/src/elements/BaseNode.ts
@@ -253,16 +253,17 @@ export default class BaseNode<E extends NodeModel = NodeModel, D = any> extends 
 
   setModel(model: E): void {
     super.setModel(model);
+
     let d: Dimensions | undefined;
     let p: Point | undefined;
 
-    if ('width' in model && model.width != null) {
+    if ('width' in model && model.width != null && model.width !== this.dimensions.width) {
       if (!d) {
         d = this.dimensions.clone();
       }
       d.width = model.width;
     }
-    if ('height' in model && model.height != null) {
+    if ('height' in model && model.height != null && model.height !== this.dimensions.height) {
       if (!d) {
         d = this.dimensions.clone();
       }
@@ -272,13 +273,13 @@ export default class BaseNode<E extends NodeModel = NodeModel, D = any> extends 
       this.setDimensions(d);
     }
 
-    if ('x' in model && model.x != null) {
+    if ('x' in model && model.x != null && model.x !== this.position.x) {
       if (!p) {
         p = this.position.clone();
       }
       p.x = model.x;
     }
-    if ('y' in model && model.y != null) {
+    if ('y' in model && model.y != null && model.y !== this.position.y) {
       if (!p) {
         p = this.position.clone();
       }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Fixes #6814. Don't update the internal `this.dimensions` and `this.position` updates if the `width`, `height`, `x` and `y` attributes of the model doesn't change.

This might improve the performance of the topology a little bit. In the mobx dev tools on Firefox I found this "rerender reason" and found via logging that this case (mode.width === this.dimensions.width) was true for some rerenders. But for sure, this doesn't solve the biggest performance reason.

See also https://github.com/patternfly/patternfly-react/blob/main/packages/react-topology/src/elements/BaseNode.ts#L33-L42

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
None
