### PR TITLE
Add component displayNames to topology with* HOC/wrappers

### DIFF
--- a/packages/react-topology/src/behavior/useAnchor.tsx
+++ b/packages/react-topology/src/behavior/useAnchor.tsx
@@ -36,5 +36,6 @@ export const withAnchor = <P extends {} = {}>(anchor: Anchor, end?: AnchorEnd, t
     );
     return <WrappedComponent {...props} />;
   };
+  Component.displayName = `withAnchor(${WrappedComponent.displayName || WrappedComponent.name})`;
   return observer(Component);
 };

--- a/packages/react-topology/src/behavior/useBendpoint.tsx
+++ b/packages/react-topology/src/behavior/useBendpoint.tsx
@@ -82,7 +82,7 @@ export interface WithBendpointProps {
   dragNodeRef: WithDndDragProps['dndDragRef'];
 }
 
-export const WithBendpoint = <DropResult, CollectedProps, Props = {}>(
+export const withBendpoint = <DropResult, CollectedProps, Props = {}>(
   spec?: Omit<
     DragSourceSpec<DragObjectWithType, DragSpecOperationType<DragOperationWithType>, DropResult, CollectedProps, Props>,
     'type'
@@ -92,5 +92,11 @@ export const WithBendpoint = <DropResult, CollectedProps, Props = {}>(
     const [dragProps, bendpointRef] = useBendpoint(props.point, spec as any, props);
     return <WrappedComponent {...(props as any)} bendpointRef={bendpointRef} {...dragProps} />;
   };
+  Component.displayName = `withBendpoint(${WrappedComponent.displayName || WrappedComponent.name})`;
   return observer(Component);
 };
+
+/**
+ * @deprecated Use withBendpoint instead
+ */
+export const WithBendpoint = withBendpoint;

--- a/packages/react-topology/src/behavior/useDndDrag.tsx
+++ b/packages/react-topology/src/behavior/useDndDrag.tsx
@@ -319,5 +319,6 @@ export const withDndDrag = <
     const [dndDragProps, dndDragRef] = useDndDrag(spec, props as any);
     return <WrappedComponent {...(props as any)} {...dndDragProps} dndDragRef={dndDragRef} />;
   };
+  Component.displayName = `withDndDrag(${WrappedComponent.displayName || WrappedComponent.name})`;
   return observer(Component);
 };

--- a/packages/react-topology/src/behavior/useDndDrop.tsx
+++ b/packages/react-topology/src/behavior/useDndDrop.tsx
@@ -190,5 +190,6 @@ export const withDndDrop = <
     const [dndDropProps, dndDropRef] = useDndDrop(spec, props as any);
     return <WrappedComponent {...(props as any)} {...dndDropProps} dndDropRef={dndDropRef} />;
   };
+  Component.displayName = `withDndDrop(${WrappedComponent.displayName || WrappedComponent.name})`;
   return observer(Component);
 };

--- a/packages/react-topology/src/behavior/useDragNode.tsx
+++ b/packages/react-topology/src/behavior/useDragNode.tsx
@@ -173,5 +173,6 @@ export const withDragNode = <
     const [dragNodeProps, dragNodeRef] = useDragNode(spec, props as any);
     return <WrappedComponent {...(props as any)} dragNodeRef={dragNodeRef} {...dragNodeProps} />;
   };
+  Component.displayName = `withDragNode(${WrappedComponent.displayName || WrappedComponent.name})`;
   return observer(Component);
 };

--- a/packages/react-topology/src/behavior/usePanZoom.tsx
+++ b/packages/react-topology/src/behavior/usePanZoom.tsx
@@ -114,5 +114,6 @@ export const withPanZoom = () => <P extends WithPanZoomProps>(WrappedComponent: 
     const panZoomRef = usePanZoom();
     return <WrappedComponent {...(props as any)} panZoomRef={panZoomRef} />;
   };
+  Component.displayName = `withPanZoom(${WrappedComponent.displayName || WrappedComponent.name})`;
   return observer(Component);
 };

--- a/packages/react-topology/src/behavior/useReconnect.tsx
+++ b/packages/react-topology/src/behavior/useReconnect.tsx
@@ -26,6 +26,7 @@ export const withSourceDrag = <
     const [dndDragProps, dndDragRef] = useDndDrag(spec, props as any);
     return <WrappedComponent {...(props as any)} sourceDragRef={dndDragRef} {...dndDragProps} />;
   };
+  Component.displayName = `withSourceDrag(${WrappedComponent.displayName || WrappedComponent.name})`;
   return observer(Component);
 };
 
@@ -46,5 +47,6 @@ export const withTargetDrag = <
     const [dndDragProps, dndDragRef] = useDndDrag(spec, props as any);
     return <WrappedComponent {...(props as any)} targetDragRef={dndDragRef} {...dndDragProps} />;
   };
+  Component.displayName = `withTargetDrag(${WrappedComponent.displayName || WrappedComponent.name})`;
   return observer(Component);
 };

--- a/packages/react-topology/src/behavior/useSelection.tsx
+++ b/packages/react-topology/src/behavior/useSelection.tsx
@@ -87,5 +87,6 @@ export const withSelection = (options?: Options) => <P extends WithSelectionProp
     const [selected, onSelect] = useSelection(options);
     return <WrappedComponent {...(props as any)} selected={selected} onSelect={onSelect} />;
   };
+  Component.displayName = `withSelection(${WrappedComponent.displayName || WrappedComponent.name})`;
   return observer(Component);
 };

--- a/packages/react-topology/src/behavior/useSvgAnchor.tsx
+++ b/packages/react-topology/src/behavior/useSvgAnchor.tsx
@@ -40,5 +40,6 @@ export const withSvgAnchor = (end?: AnchorEnd, type?: string) => <P extends With
     const svgAnchorRef = useSvgAnchor(end, type);
     return <WrappedComponent {...(props as any)} svgAnchorRef={svgAnchorRef} />;
   };
+  Component.displayName = `withSvgAnchor(${WrappedComponent.displayName || WrappedComponent.name})`;
   return Component;
 };

--- a/packages/react-topology/src/behavior/withContextMenu.tsx
+++ b/packages/react-topology/src/behavior/withContextMenu.tsx
@@ -50,5 +50,6 @@ export const withContextMenu = <E extends TopologyElement>(
       </>
     );
   };
+  Component.displayName = `withContextMenu(${WrappedComponent.displayName || WrappedComponent.name})`;
   return observer(Component);
 };

--- a/packages/react-topology/src/behavior/withCreateConnector.tsx
+++ b/packages/react-topology/src/behavior/withCreateConnector.tsx
@@ -264,5 +264,6 @@ export const withCreateConnector = <P extends WithCreateConnectorProps & Element
       </>
     );
   };
+  Component.displayName = `withCreateConnector(${WrappedComponent.displayName || WrappedComponent.name})`;
   return observer(Component);
 };

--- a/packages/react-topology/src/behavior/withRemoveConnector.tsx
+++ b/packages/react-topology/src/behavior/withRemoveConnector.tsx
@@ -43,5 +43,6 @@ export const withRemoveConnector = <P extends WithRemoveConnectorProps & Element
       </WrappedComponent>
     );
   };
+  Component.displayName = `withRemoveConnector(${WrappedComponent.displayName || WrappedComponent.name})`;
   return observer(Component);
 };


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6828

When using the `with...` HOC/wrappers, it's really difficult to understand the rendered React component tree in the react dev tools.

<br/>

**Without this PR** all components are just called "Component" and there is no indicator why we have so many nested components.

![topology-with-names-before](https://user-images.githubusercontent.com/139310/150116371-65998cf8-b30c-479b-a1b3-3554966deda5.gif)

<br/>

**With this PR** it shows at least the component name again and the `with....` is rendered as small "badge" when selecting one component.

![topology-with-names](https://user-images.githubusercontent.com/139310/150116174-9eda8521-b8cb-403a-8a02-cc3de10f433a.gif)

<br/>

These nodes are created with code like this, but it's currently not possible for me to create a CodeSandbox with this.

```tsx
      return withCreateConnector(...)(
        withDndDrop<...>(nodeDropTargetSpec)(
          withEditReviewAccess('patch')(
            withDragNode(nodeDragSourceSpec(type))(
              withSelection({ controlled: true })(
                withContextMenu(contextMenuActions)(WorkloadNode),
              ),
            ),
          ),
        ),
      );
```

The original code is part of the OpenShift Developer console [componentFactory.ts](https://github.com/openshift/console/blob/d9379902e515765704bf27b3d281e9e350d47bb1/frontend/packages/topology/src/components/graph-view/components/componentFactory.ts#L47-L66)


<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
It is related to https://bugzilla.redhat.com/show_bug.cgi?id=2041475 and https://github.com/openshift/console/pull/10858 where I fix this in some more components on the ODC side.
