### PR TITLE
fix row index in tree table examples

### DIFF
--- a/packages/react-table/src/components/Table/examples/LegacyTableTree.tsx
+++ b/packages/react-table/src/components/Table/examples/LegacyTableTree.tsx
@@ -137,6 +137,12 @@ export const LegacyTableTree: React.FunctionComponent = () => {
       icon = isExpanded ? <FolderOpenIcon aria-hidden /> : <FolderIcon aria-hidden />;
     }
     flattenedNodes.push(node);
+
+    const childRows =
+      node.children && node.children.length
+        ? buildRows(node.children, level + 1, 1, rowIndex + 1, !isExpanded || isHidden)
+        : [];
+
     return [
       {
         cells: [node.name, node.branches, node.pullRequests, node.workspaces],
@@ -151,16 +157,8 @@ export const LegacyTableTree: React.FunctionComponent = () => {
           icon
         }
       },
-      ...(node.children && node.children.length
-        ? buildRows(node.children, level + 1, 1, rowIndex + 1, !isExpanded || isHidden)
-        : []),
-      ...buildRows(
-        remainingNodes,
-        level,
-        posinset + 1,
-        rowIndex + 1 + ((node.children && node.children.length) || 0),
-        isHidden
-      )
+      ...childRows,
+      ...buildRows(remainingNodes, level, posinset + 1, rowIndex + 1 + childRows.length, isHidden)
     ];
   };
 

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTableTree.tsx
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTableTree.tsx
@@ -163,6 +163,11 @@ export const ComposableTableTree: React.FunctionComponent = () => {
       }
     };
 
+    const childRows =
+      node.children && node.children.length
+        ? renderRows(node.children, level + 1, 1, rowIndex + 1, !isExpanded || isHidden)
+        : [];
+
     return [
       <TreeRowWrapper key={node.name} row={{ props: treeRow.props }}>
         <Td dataLabel={columnNames.name} treeRow={treeRow}>
@@ -172,16 +177,8 @@ export const ComposableTableTree: React.FunctionComponent = () => {
         <Td dataLabel={columnNames.prs}>{node.pullRequests}</Td>
         <Td dataLabel={columnNames.workspaces}>{node.workspaces}</Td>
       </TreeRowWrapper>,
-      ...(node.children && node.children.length
-        ? renderRows(node.children, level + 1, 1, rowIndex + 1, !isExpanded || isHidden)
-        : []),
-      ...renderRows(
-        remainingNodes,
-        level,
-        posinset + 1,
-        rowIndex + 1 + ((node.children && node.children.length) || 0),
-        isHidden
-      )
+      ...childRows,
+      ...renderRows(remainingNodes, level, posinset + 1, rowIndex + 1 + childRows.length, isHidden)
     ];
   };
 


### PR DESCRIPTION
correct the row index calculation by appending the child row offset for each level, for both `ComposableTableTree` and `LegacyTableTree`.

see [this POC][1] for an illustration (with visible row indices).


fixes: #6719


[1]: https://codesandbox.io/s/eager-golick-0jzpc