### PR TITLE
fix(CodeEditor): compare props and state to prevent re-renders

### DIFF
--- a/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
@@ -279,6 +279,15 @@ export class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState
     this.setState({ value });
   };
 
+  static getDerivedStateFromProps(props: CodeEditorProps, state: CodeEditorState) {
+    if (props.code !== state.value) {
+      return {
+        value: props.code
+      };
+    }
+    return null;
+  }
+
   handleResize = () => {
     if (this.editor) {
       this.editor.layout();


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6501 

The reason that causes this issue is that when the user defines their own `onChange` function, they will call `setState` to set the `value`, and the `value` will be passed as a prop to the CodeEditor. At the same time, in the CodeEditor component, it will first call `componentDidUpdate` to set the code to the new value, then it will also call the `onChange` function inside the CodeEditor component, where it will use `this.setState` (https://github.com/patternfly/patternfly-react/blob/main/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx#L279) to set the changed value to the state even the value is already changed, which causes the unnecessary re-renders (Unlike functional component, every time `this.setState` is called, the component will be re-rendered no matter whether the state changed or not).

The way to fix it is to override the `getDerivedStateFromProps` function and check the `prop.code` and `state.value` and don't re-render the component if they are the same. In this way, it will not re-render many times when the `onChange` function is being defined by the users.

