### PR TITLE
fix(numberinput): import input group component instead

### DIFF
--- a/packages/react-core/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-core/src/components/NumberInput/NumberInput.tsx
@@ -3,6 +3,7 @@ import styles from '@patternfly/react-styles/css/components/NumberInput/number-i
 import { css } from '@patternfly/react-styles';
 import MinusIcon from '@patternfly/react-icons/dist/esm/icons/minus-icon';
 import PlusIcon from '@patternfly/react-icons/dist/esm/icons/plus-icon';
+import { InputGroup } from '../InputGroup';
 import { Button, ButtonProps } from '../Button';
 import { KEY_CODES } from '../../helpers';
 
@@ -94,7 +95,7 @@ export const NumberInput: React.FunctionComponent<NumberInputProps> = ({
       {...props}
     >
       {unit && unitPosition === 'before' && numberInputUnit}
-      <div className={css(styles.inputGroup)}>
+      <InputGroup>
         <Button
           variant="control"
           aria-label={minusBtnAriaLabel}
@@ -129,7 +130,7 @@ export const NumberInput: React.FunctionComponent<NumberInputProps> = ({
             <PlusIcon aria-hidden="true" />
           </span>
         </Button>
-      </div>
+      </InputGroup>
       {unit && unitPosition === 'after' && numberInputUnit}
     </div>
   );


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-react/issues/6251

@KKoukiou can you test this and see if it fixes it? Not sure why we were applying a class instead of importing the `<InputGroup>` component.