### PR TITLE
fix(OverflowMenu): ignore menu being covered in intg. tests

### DIFF
--- a/packages/react-integration/cypress/integration/overflowmenu.spec.ts
+++ b/packages/react-integration/cypress/integration/overflowmenu.spec.ts
@@ -32,12 +32,12 @@ describe('OverflowMenu Demo Test', () => {
       it('Verify dropdown menu expanded', () => {
         cy.get('#simple-overflow-menu button')
           .last()
-          .click();
+          .click({ force: true });
         cy.get('#simple-overflow-menu .pf-c-dropdown').should('have.class', 'pf-m-expanded');
         // close overflow menu again
         cy.get('#simple-overflow-menu button')
           .last()
-          .click();
+          .click({ force: true });
       });
     });
   });
@@ -72,7 +72,7 @@ describe('OverflowMenu Demo Test', () => {
       it('Verify dropdown menu expanded', () => {
         cy.get('#additional-options-overflow-menu button')
           .last()
-          .click();
+          .click({ force: true });
         cy.get('#additional-options-overflow-menu .pf-c-dropdown').should('have.class', 'pf-m-expanded');
       });
     });
@@ -111,7 +111,7 @@ describe('OverflowMenu Demo Test', () => {
       it('Verify dropdown menu expanded', () => {
         cy.get('#persist-overflow-menu button')
           .last()
-          .click();
+          .click({ force: true });
         cy.get('#persist-overflow-menu .pf-c-dropdown').should('have.class', 'pf-m-expanded');
       });
     });


### PR DESCRIPTION
**What**: Closes #6853


**Additional issues**: For now lets ignore this error. I think it's related to the sidebar being opened and over shadows the items in the page when size is small.