### PR TITLE
fix: windows issue listening on md changes to refresh

### DIFF
--- a/packages/react-docs/patternfly-docs.source.js
+++ b/packages/react-docs/patternfly-docs.source.js
@@ -1,6 +1,8 @@
 const path = require('path');
 
-module.exports = (sourceMD, sourceProps) => {
+module.exports = (baseSourceMD, sourceProps) => {
+  const sourceMD = (basePath, ...props) => baseSourceMD(basePath.split(path.sep).join(path.posix.sep), ...props);
+
   // Theme pages
   const themePagesPath = require.resolve('theme-patternfly-org/package.json').replace('package.json', 'pages');
   sourceMD(path.join(themePagesPath, '*.md'), 'pages-overview');


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6855 enabling windows to hot refresh with changes on md files
