### PR TITLE
fix(TimePicker): apply includeSeconds when making options

### DIFF
--- a/packages/react-core/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react-core/src/components/TimePicker/TimePicker.tsx
@@ -425,7 +425,7 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
     } = this.props;
     const { timeState, isOpen, isInvalid, minTimeState, maxTimeState } = this.state;
     const style = { '--pf-c-date-picker__input--c-form-control--Width': width } as React.CSSProperties;
-    const options = makeTimeOptions(stepMinutes, !is24Hour, delimiter, minTimeState, maxTimeState);
+    const options = makeTimeOptions(stepMinutes, !is24Hour, delimiter, minTimeState, maxTimeState, includeSeconds);
     const isValidFormat = this.isValidFormat(timeState);
     const randomId = id || getUniqueId('time-picker');
 

--- a/packages/react-core/src/components/TimePicker/TimePickerUtils.tsx
+++ b/packages/react-core/src/components/TimePicker/TimePickerUtils.tsx
@@ -6,7 +6,8 @@ export const makeTimeOptions = (
   hour12: boolean,
   delimiter: string,
   minTime: string,
-  maxTime: string
+  maxTime: string,
+  includeSeconds: boolean
 ) => {
   const res = [];
   const iter = new Date(new Date().setHours(0, 0, 0, 0));
@@ -31,7 +32,7 @@ export const makeTimeOptions = (
       .padStart(2, '0');
     const timeOption = `${hour}${delimiter}${minutes}${hour12 ? suffix : ''}`;
     // time option is valid if within min/max constraints
-    if (isWithinMinMax(minTime, maxTime, timeOption, delimiter)) {
+    if (isWithinMinMax(minTime, maxTime, timeOption, delimiter, includeSeconds)) {
       res.push(timeOption);
     }
     iter.setMinutes(iter.getMinutes() + stepMinutes);

--- a/packages/react-core/src/components/TimePicker/examples/TimePicker.md
+++ b/packages/react-core/src/components/TimePicker/examples/TimePicker.md
@@ -64,14 +64,14 @@ import { TimePicker } from '@patternfly/react-core';
 import React from 'react';
 import { TimePicker } from '@patternfly/react-core';
 
-SimpleTimePicker = () => <TimePicker time="3:35:20 PM" includeSeconds />;
+<TimePicker time="3:35:20 PM" includeSeconds />;
 ```
 
-### 24 hours with seconds
+### Basic 24 hours with seconds
 
 ```js
 import React from 'react';
 import { TimePicker } from '@patternfly/react-core';
 
-SimpleTimePicker = () => <TimePicker time="12:35:50" includeSeconds is24Hour />;
+<TimePicker time="12:35:50" includeSeconds is24Hour />;
 ```


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6837
When making time options for the dropdown menu, the `includeSeconds` props in not set. Which makes some errors when comparing option 00:00 with the min time 00:00:00 because they are not the same format.
Also, update the doc to prevent some building warnings.
