### PR TITLE
feat(Menu): allow drilldown menu functions

### DIFF
--- a/packages/react-core/src/components/Menu/MenuItem.tsx
+++ b/packages/react-core/src/components/Menu/MenuItem.tsx
@@ -51,7 +51,7 @@ export interface MenuItemProps extends Omit<React.HTMLProps<HTMLLIElement>, 'onC
   /** @beta Callback function when mouse leaves trigger */
   onShowFlyout?: (event?: any) => void;
   /** @beta Drilldown menu of the item. Should be a Menu or DrilldownMenu type. */
-  drilldownMenu?: React.ReactNode;
+  drilldownMenu?: React.ReactNode | (() => React.ReactNode);
   /** @beta Sub menu direction */
   direction?: 'down' | 'up';
   /** @beta True if item is on current selection path */
@@ -208,7 +208,15 @@ export const MenuItem: React.FunctionComponent<MenuItemProps> = ({
   let _drill: () => void;
   if (direction) {
     if (direction === 'down') {
-      _drill = () => onDrillIn && onDrillIn(menuId, (drilldownMenu as React.ReactElement).props.id, itemId);
+      _drill = () =>
+        onDrillIn &&
+        onDrillIn(
+          menuId,
+          typeof drilldownMenu === 'function'
+            ? drilldownMenu().props.id
+            : (drilldownMenu as React.ReactElement).props.id,
+          itemId
+        );
     } else {
       _drill = () => onDrillOut && onDrillOut(parentMenu, itemId);
     }
@@ -327,7 +335,7 @@ export const MenuItem: React.FunctionComponent<MenuItemProps> = ({
           <FlyoutContext.Provider value={{ direction: flyoutXDirection }}>{flyoutMenu}</FlyoutContext.Provider>
         </MenuContext.Provider>
       )}
-      {drilldownMenu}
+      {typeof drilldownMenu === 'function' ? drilldownMenu() : drilldownMenu}
       <MenuItemContext.Provider value={{ itemId, isDisabled }}>
         {actions}
         {isFavorited !== null && (

--- a/packages/react-core/src/components/Menu/examples/Menu.md
+++ b/packages/react-core/src/components/Menu/examples/Menu.md
@@ -48,11 +48,7 @@ class MenuBasicList extends React.Component {
     const { activeItem, isPlain } = this.state;
     return (
       <React.Fragment>
-        <Menu
-          activeItemId={activeItem}
-          onSelect={this.onSelect}
-          isPlain={isPlain}
-          >
+        <Menu activeItemId={activeItem} onSelect={this.onSelect} isPlain={isPlain}>
           <MenuContent>
             <MenuList>
               <MenuItem itemId={0}>Action</MenuItem>
@@ -71,7 +67,7 @@ class MenuBasicList extends React.Component {
             </MenuList>
           </MenuContent>
         </Menu>
-        <div style={{ marginTop: 20 }}> 
+        <div style={{ marginTop: 20 }}>
           <Checkbox
             label="Plain menu"
             isChecked={isPlain}
@@ -628,7 +624,7 @@ class MenuOptionSingleSelect extends React.Component {
             <MenuItem icon={<TableIcon aria-hidden />} itemId={2}>
               Option 3
             </MenuItem>
-          </MenuList>    
+          </MenuList>
         </MenuContent>
       </Menu>
     );
@@ -880,6 +876,11 @@ class MenuWithDrilldown extends React.Component {
 }
 ```
 
+### With drilldown - submenu functions
+
+```ts file="./MenuDrilldownSubmenuFunctions.tsx" isBeta
+```
+
 ### With drilldown breadcrumbs
 
 ```js isBeta
@@ -934,7 +935,7 @@ class MenuWithDrilldownBreadcrumbs extends React.Component {
           break;
       }
     };
-    
+
     this.onToggleMaxMenuHeight = checked => {
       this.setState({
         withMaxMenuHeight: checked
@@ -1121,10 +1122,7 @@ class MenuWithDrilldownBreadcrumbs extends React.Component {
               <Divider component="li" />
             </>
           )}
-          <MenuContent 
-            menuHeight={`${menuHeights[activeMenu]}px`} 
-            maxMenuHeight={withMaxMenuHeight ? '100px' : 'auto'}
-          >
+          <MenuContent menuHeight={`${menuHeights[activeMenu]}px`} maxMenuHeight={withMaxMenuHeight ? '100px' : 'auto'}>
             <MenuList>
               <MenuItem
                 itemId="group:start_rollout"

--- a/packages/react-core/src/components/Menu/examples/MenuDrilldownSubmenuFunctions.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuDrilldownSubmenuFunctions.tsx
@@ -1,0 +1,179 @@
+import React from 'react';
+import { Menu, MenuContent, MenuList, MenuItem, Divider, DrilldownMenu } from '@patternfly/react-core';
+import StorageDomainIcon from '@patternfly/react-icons/dist/esm/icons/storage-domain-icon';
+import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
+import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
+import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
+
+export const MenuDrilldownSubmenuFunctions: React.FunctionComponent = () => {
+  const [menuDrilledIn, setMenuDrilledIn] = React.useState<string[]>([]);
+  const [drilldownPath, setDrilldownPath] = React.useState<string[]>([]);
+  const [menuHeights, setMenuHeights] = React.useState<any>({});
+  const [activeMenu, setActiveMenu] = React.useState<string>('rootMenu');
+
+  const drillIn = (fromMenuId: string, toMenuId: string, pathId: string) => {
+    setMenuDrilledIn([...menuDrilledIn, fromMenuId]);
+    setDrilldownPath([...drilldownPath, pathId]);
+    setActiveMenu(toMenuId);
+  };
+
+  const drillOut = (toMenuId: string) => {
+    const menuDrilledInSansLast = menuDrilledIn.slice(0, menuDrilledIn.length - 1);
+    const pathSansLast = drilldownPath.slice(0, drilldownPath.length - 1);
+    setMenuDrilledIn(menuDrilledInSansLast);
+    setDrilldownPath(pathSansLast);
+    setActiveMenu(toMenuId);
+  };
+
+  const setHeight = (menuId: string, height: number) => {
+    if (menuHeights[menuId] === undefined) {
+      setMenuHeights({ ...menuHeights, [menuId]: height });
+    }
+  };
+
+  return (
+    <Menu
+      id="rootMenu"
+      containsDrilldown
+      drilldownItemPath={drilldownPath}
+      drilledInMenus={menuDrilledIn}
+      activeMenu={activeMenu}
+      onDrillIn={drillIn}
+      onDrillOut={drillOut}
+      onGetMenuHeight={setHeight}
+    >
+      <MenuContent menuHeight={`${menuHeights[activeMenu]}px`}>
+        <MenuList>
+          <MenuItem
+            itemId="group:start_rollout"
+            direction="down"
+            drilldownMenu={() => (
+              <DrilldownMenu id="drilldownMenuStart">
+                <MenuItem itemId="group:start_rollout_breadcrumb" direction="up">
+                  Start rollout
+                </MenuItem>
+                <Divider component="li" />
+                <MenuItem
+                  itemId="group:app_grouping"
+                  description="Groups A-C"
+                  direction="down"
+                  drilldownMenu={() => (
+                    <DrilldownMenu id="drilldownMenuStartGrouping">
+                      <MenuItem itemId="group:app_grouping_breadcrumb" direction="up">
+                        Application grouping
+                      </MenuItem>
+                      <Divider component="li" />
+                      <MenuItem itemId="group_a">Group A</MenuItem>
+                      <MenuItem itemId="group_b">Group B</MenuItem>
+                      <MenuItem itemId="group_c">Group C</MenuItem>
+                    </DrilldownMenu>
+                  )}
+                >
+                  Application grouping
+                </MenuItem>
+                <MenuItem itemId="count">Count</MenuItem>
+                <MenuItem
+                  itemId="group:labels"
+                  direction="down"
+                  drilldownMenu={() => (
+                    <DrilldownMenu id="drilldownMenuStartLabels">
+                      <MenuItem itemId="group:labels_breadcrumb" direction="up">
+                        Labels
+                      </MenuItem>
+                      <Divider component="li" />
+                      <MenuItem itemId="label_1">Label 1</MenuItem>
+                      <MenuItem itemId="label_2">Label 2</MenuItem>
+                      <MenuItem itemId="label_3">Label 3</MenuItem>
+                    </DrilldownMenu>
+                  )}
+                >
+                  Labels
+                </MenuItem>
+                <MenuItem itemId="annotations">Annotations</MenuItem>
+              </DrilldownMenu>
+            )}
+          >
+            Start rollout
+          </MenuItem>
+          <MenuItem
+            itemId="group:pause_rollout"
+            direction="down"
+            drilldownMenu={() => (
+              <DrilldownMenu id="drilldownMenuPause">
+                <MenuItem itemId="group:pause_rollout_breadcrumb" direction="up">
+                  Pause rollouts
+                </MenuItem>
+                <Divider component="li" />
+                <MenuItem
+                  itemId="group:app_grouping"
+                  description="Groups A-C"
+                  direction="down"
+                  drilldownMenu={() => (
+                    <DrilldownMenu id="drilldownMenuGrouping">
+                      <MenuItem itemId="group:app_grouping_breadcrumb" direction="up">
+                        Application grouping
+                      </MenuItem>
+                      <Divider component="li" />
+                      <MenuItem itemId="group_a">Group A</MenuItem>
+                      <MenuItem itemId="group_b">Group B</MenuItem>
+                      <MenuItem itemId="group_c">Group C</MenuItem>
+                    </DrilldownMenu>
+                  )}
+                >
+                  Application grouping
+                </MenuItem>
+                <MenuItem itemId="count">Count</MenuItem>
+                <MenuItem
+                  itemId="group:labels"
+                  direction="down"
+                  drilldownMenu={() => (
+                    <DrilldownMenu id="drilldownMenuLabels">
+                      <MenuItem itemId="group:labels_breadcrumb" direction="up">
+                        Labels
+                      </MenuItem>
+                      <Divider component="li" />
+                      <MenuItem itemId="label_1">Label 1</MenuItem>
+                      <MenuItem itemId="label_2">Label 2</MenuItem>
+                      <MenuItem itemId="label_3">Label 3</MenuItem>
+                    </DrilldownMenu>
+                  )}
+                >
+                  Labels
+                </MenuItem>
+                <MenuItem itemId="annotations">Annotations</MenuItem>
+              </DrilldownMenu>
+            )}
+          >
+            Pause rollouts
+          </MenuItem>
+          <MenuItem
+            itemId="group:storage"
+            icon={<StorageDomainIcon aria-hidden />}
+            direction="down"
+            drilldownMenu={() => (
+              <DrilldownMenu id="drilldownMenuStorage">
+                <MenuItem itemId="group:storage_breadcrumb" icon={<StorageDomainIcon aria-hidden />} direction="up">
+                  Add storage
+                </MenuItem>
+                <Divider component="li" />
+                <MenuItem icon={<CodeBranchIcon aria-hidden />} itemId="git">
+                  From git
+                </MenuItem>
+                <MenuItem icon={<LayerGroupIcon aria-hidden />} itemId="container">
+                  Container image
+                </MenuItem>
+                <MenuItem icon={<CubeIcon aria-hidden />} itemId="docker">
+                  Docker file
+                </MenuItem>
+              </DrilldownMenu>
+            )}
+          >
+            Add storage
+          </MenuItem>
+          <MenuItem itemId="edit">Edit</MenuItem>
+          <MenuItem itemId="delete_deployment">Delete deployment config</MenuItem>
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+};


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5534

Allows `drilldownMenu` to accept a function returning a ReactNode. 

I've tested by wrapping the current example's drilldownMenus in function statements which works, but I'm not sure how well the component will respond to delays - primarily because the `MenuItem` needs to know the to-be-drilled-in menu's ID before the drilldownMenu would necessarily be returned/rendered. At present, I've invoked the drilldownMenu function in this drill in call to get the ID, but I'm wondering if it would be better to have a separate property for drilldownMenuId? Any thoughts?