### PR TITLE
refactor(Primary-detail): replace hardcoded class with usePageInsets

### DIFF
--- a/packages/react-core/src/demos/PrimaryDetail.md
+++ b/packages/react-core/src/demos/PrimaryDetail.md
@@ -275,7 +275,7 @@ class PrimaryDetailFullPage extends React.Component {
     );
     const drawerContent = (
       <React.Fragment>
-        <Toolbar id="full-page-data-toolbar" className="pf-m-page-insets">
+        <Toolbar id="full-page-data-toolbar" usePageInsets>
           <ToolbarContent>{ToolbarItems}</ToolbarContent>
         </Toolbar>
         <DataList
@@ -736,7 +736,7 @@ class PrimaryDetailContentPadding extends React.Component {
 
     const drawerContent = (
       <React.Fragment>
-        <Toolbar id="content-padding-data-toolbar" className="pf-m-page-insets">
+        <Toolbar id="content-padding-data-toolbar" usePageInsets>
           <ToolbarContent>{ToolbarItems}</ToolbarContent>
         </Toolbar>
         <DataList
@@ -1633,7 +1633,7 @@ class PrimaryDetailDataListInCard extends React.Component {
 
     const drawerContent = (
       <React.Fragment>
-        <Toolbar id="data-list-data-toolbar" className="pf-m-page-insets">
+        <Toolbar id="data-list-data-toolbar" usePageInsets>
           <ToolbarContent>
             <ToolbarItem>
               <Dropdown
@@ -1998,7 +1998,7 @@ class PrimaryDetailInlineModifier extends React.Component {
     );
     const drawerContent = (
       <React.Fragment>
-        <Toolbar id="inline-modifier-data-toolbar" className="pf-m-page-insets">
+        <Toolbar id="inline-modifier-data-toolbar" usePageInsets>
           <ToolbarContent>{ToolbarItems}</ToolbarContent>
         </Toolbar>
         <DataList


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5130 
Per discussion with @mattnolting , part of this issue had previously been completed. What remained was updating examples/demos using the `pf-m-page-insets` class hardcoded, to instead use the `usePageInsets` prop. In this case only the Primary-detail demo had instances of the hardcoded class.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
N/A
