### PR TITLE
fix(TimePicker): remove automatically validation from onChange event

### DIFF
--- a/packages/react-core/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react-core/src/components/TimePicker/TimePicker.tsx
@@ -357,7 +357,8 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
 
     this.inputRef.current.focus();
     this.setState({
-      isOpen: false
+      isOpen: false,
+      isInvalid: false
     });
   };
 
@@ -366,9 +367,6 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
       this.onToggle(true);
     }
     e.stopPropagation();
-    this.setState({
-      isInvalid: false
-    });
   };
 
   onInputChange = (newTime: string) => {

--- a/packages/react-core/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react-core/src/components/TimePicker/TimePicker.tsx
@@ -366,6 +366,9 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
       this.onToggle(true);
     }
     e.stopPropagation();
+    this.setState({
+      isInvalid: false
+    });
   };
 
   onInputChange = (newTime: string) => {
@@ -383,8 +386,7 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
     }
     this.scrollToSelection(newTime);
     this.setState({
-      timeState: newTime,
-      isInvalid: !this.isValid(newTime)
+      timeState: newTime
     });
   };
 

--- a/packages/react-core/src/components/TimePicker/__tests__/TimePicker.test.tsx
+++ b/packages/react-core/src/components/TimePicker/__tests__/TimePicker.test.tsx
@@ -72,7 +72,7 @@ describe('test isInvalid', () => {
     expect(view.find('.pf-m-error')).toHaveLength(0);
   })
 
-  test('should be invalid after onChange and onBlur', () => {
+  test('should be invalid after onBlur', () => {
     const validateTime = (time: string) => {
       return false;
     }

--- a/packages/react-core/src/components/TimePicker/__tests__/TimePicker.test.tsx
+++ b/packages/react-core/src/components/TimePicker/__tests__/TimePicker.test.tsx
@@ -72,7 +72,7 @@ describe('test isInvalid', () => {
     expect(view.find('.pf-m-error')).toHaveLength(0);
   })
 
-  test('should be invalid after onChange', () => {
+  test('should be invalid after onChange and onBlur', () => {
     const validateTime = (time: string) => {
       return false;
     }
@@ -86,6 +86,10 @@ describe('test isInvalid', () => {
       view.find('input').prop('onChange')(event);
     })
     view.update();
+
+    expect(view.find('.pf-m-error')).toHaveLength(0);
+
+    view.find('input').simulate('blur');
 
     expect(view.find('.pf-m-error')).toHaveLength(1);
   })
@@ -124,6 +128,10 @@ describe('test includeSeconds', () => {
 
     act(() => view.find('input').prop('onChange')(event));
     view.update();
+
+    expect(view.find('.pf-m-error')).toHaveLength(0);
+
+    view.find('input').simulate('blur');
 
     expect(view.find('.pf-m-error')).toHaveLength(1);
   });


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6838 
When the focus is back on the time input, I disable the validation, I am not sure whether it makes more sense not to do any validation when the user is inputting the time. 

