### PR TITLE
VerticalTabsTab takes a custom base component now

### DIFF
--- a/packages/react-catalog-view-extension/src/components/VerticalTabs/VerticalTabsTab.tsx
+++ b/packages/react-catalog-view-extension/src/components/VerticalTabs/VerticalTabsTab.tsx
@@ -20,6 +20,8 @@ export interface VerticalTabsTabProps extends Omit<React.HTMLProps<HTMLLIElement
   onActivate?: () => void;
   /** HREF location */
   href?: string;
+  /** Sets the base component to render. defaults to a */
+  component?: React.ElementType<any> | React.ComponentType<any>;
 }
 
 export const VerticalTabsTab: React.FunctionComponent<VerticalTabsTabProps> = ({
@@ -32,6 +34,7 @@ export const VerticalTabsTab: React.FunctionComponent<VerticalTabsTabProps> = ({
   shown = false,
   onActivate = null,
   href,
+  component: Component,
   ...props
 }: VerticalTabsTabProps) => {
   const classes = css('vertical-tabs-pf-tab', { active, 'active-descendant': hasActiveDescendant, shown }, className);
@@ -50,9 +53,14 @@ export const VerticalTabsTab: React.FunctionComponent<VerticalTabsTabProps> = ({
 
   return (
     <li className={classes} {...props}>
-      <a className={linkClasses} onClick={e => handleActivate(e)} href={href}>
-        {title}
-      </a>
+      {Component ? (
+        <Component className={linkClasses} />
+      ) : (
+        <a className={linkClasses} onClick={e => handleActivate(e)} href={href}>
+          {title}
+        </a>
+      )}
+
       {children}
     </li>
   );


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6805

The community developed `react-catalog-view` extension includes a component `VerticalTabsTab` which handles the `onClick` event oddly. This pr implements the fix which was outlined in https://github.com/patternfly/patternfly-react/issues/6805 by me.



<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
