### PR TITLE
docs(Menu/MenuToggle): Composable Menu - Typeahead Select Demo

### DIFF
--- a/packages/react-core/src/components/Menu/MenuItem.tsx
+++ b/packages/react-core/src/components/Menu/MenuItem.tsx
@@ -50,6 +50,8 @@ export interface MenuItemProps extends Omit<React.HTMLProps<HTMLLIElement>, 'onC
   isExternalLink?: boolean;
   /** Flag indicating if the option is selected */
   isSelected?: boolean;
+  /** Flag indicating the item is focused */
+  isFocused?: boolean;
   /** @beta Flyout menu */
   flyoutMenu?: React.ReactElement;
   /** @beta Callback function when mouse leaves trigger */
@@ -88,6 +90,7 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
   isDisabled = false,
   isExternalLink = false,
   isSelected = null,
+  isFocused,
   icon,
   actions,
   onShowFlyout,
@@ -290,6 +293,7 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
         _isOnPath && styles.modifiers.currentPath,
         isLoadButton && styles.modifiers.load,
         isLoading && styles.modifiers.loading,
+        isFocused && styles.modifiers.focus,
         className
       )}
       onMouseOver={onMouseOver}

--- a/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
+++ b/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
@@ -60,18 +60,25 @@ export class MenuToggleBase extends React.Component<MenuToggleProps> {
     const isPlain = variant === 'plain';
     const isPlainText = variant === 'plainText';
     const isTypeahead = variant === 'typeahead';
+    const toggleControls = (
+      <span className={css(styles.menuToggleControls)}>
+        <span className={css(styles.menuToggleToggleIcon)}>
+          <CaretDownIcon aria-hidden />
+        </span>
+      </span>
+    );
 
     const content = (
       <>
         {icon && <span className={css(styles.menuToggleIcon)}>{icon}</span>}
         {isTypeahead ? children : <span className="pf-c-menu-toggle__text">{children}</span>}
         {badge && <span className={css(styles.menuToggleCount)}>{badge}</span>}
-        {!isTypeahead && (
-          <span className={css(styles.menuToggleControls)}>
-            <span className={css(styles.menuToggleToggleIcon)}>
-              <CaretDownIcon aria-hidden />
-            </span>
-          </span>
+        {isTypeahead ? (
+          <button type="button" className="pf-c-menu-toggle__button" onClick={onClick} aria-label="Menu toggle">
+            {toggleControls}
+          </button>
+        ) : (
+          toggleControls
         )}
       </>
     );

--- a/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
+++ b/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
@@ -74,7 +74,7 @@ export class MenuToggleBase extends React.Component<MenuToggleProps> {
         {isTypeahead ? children : <span className="pf-c-menu-toggle__text">{children}</span>}
         {badge && <span className={css(styles.menuToggleCount)}>{badge}</span>}
         {isTypeahead ? (
-          <button type="button" className="pf-c-menu-toggle__button" onClick={onClick} aria-label="Menu toggle">
+          <button type="button" className={css(styles.menuToggleButton)} aria-expanded={isExpanded} onClick={onClick} aria-label="Menu toggle">
             {toggleControls}
           </button>
         ) : (

--- a/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
+++ b/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
@@ -4,8 +4,10 @@ import { css } from '@patternfly/react-styles';
 import CaretDownIcon from '@patternfly/react-icons/dist/esm/icons/caret-down-icon';
 import { BadgeProps } from '../Badge';
 
+export type MenuToggleElement = HTMLDivElement | HTMLButtonElement;
+
 export interface MenuToggleProps
-  extends Omit<React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>, 'ref'> {
+  extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<MenuToggleElement>, MenuToggleElement>, 'ref'> {
   /** Content rendered inside the toggle */
   children?: React.ReactNode;
   /** Additional classes added to the toggle */
@@ -19,18 +21,18 @@ export interface MenuToggleProps
   /** Flag indicating the toggle takes up the full width of its parent */
   isFullWidth?: boolean;
   /** Variant styles of the menu toggle */
-  variant?: 'default' | 'plain' | 'primary' | 'plainText' | 'secondary';
+  variant?: 'default' | 'plain' | 'primary' | 'plainText' | 'secondary' | 'typeahead';
   /** Optional icon rendered inside the toggle, before the children content */
   icon?: React.ReactNode;
   /** Optional badge rendered inside the toggle, after the children content */
   badge?: BadgeProps | React.ReactNode;
   /** Forwarded ref */
-  innerRef?: React.Ref<HTMLButtonElement>;
+  innerRef?: React.Ref<MenuToggleElement>;
 }
 
 export class MenuToggleBase extends React.Component<MenuToggleProps> {
   displayName = 'MenuToggleBase';
-  static defaultProps = {
+  static defaultProps: MenuToggleProps = {
     className: '',
     isExpanded: false,
     isDisabled: false,
@@ -51,24 +53,50 @@ export class MenuToggleBase extends React.Component<MenuToggleProps> {
       isFullWidth,
       variant,
       innerRef,
-      ...props
+      onClick,
+      'aria-label': ariaLabel,
+      ...otherProps
     } = this.props;
-
     const isPlain = variant === 'plain';
     const isPlainText = variant === 'plainText';
+    const isTypeahead = variant === 'typeahead';
 
     const content = (
-      <React.Fragment>
+      <>
         {icon && <span className={css(styles.menuToggleIcon)}>{icon}</span>}
-        <span className="pf-c-menu-toggle__text">{children}</span>
-        {badge && <span className={css(styles.menuToggleCount)}>{badge as React.ReactNode}</span>}
-        <span className={css(styles.menuToggleControls)}>
-          <span className={css(styles.menuToggleToggleIcon)}>
-            <CaretDownIcon aria-hidden />
+        {isTypeahead ? children : <span className="pf-c-menu-toggle__text">{children}</span>}
+        {badge && <span className={css(styles.menuToggleCount)}>{badge}</span>}
+        {!isTypeahead && (
+          <span className={css(styles.menuToggleControls)}>
+            <span className={css(styles.menuToggleToggleIcon)}>
+              <CaretDownIcon aria-hidden />
+            </span>
           </span>
-        </span>
-      </React.Fragment>
+        )}
+      </>
     );
+
+    const componentProps = {
+      className: css(
+        styles.menuToggle,
+        isExpanded && styles.modifiers.expanded,
+        variant === 'primary' && styles.modifiers.primary,
+        (isPlain || isPlainText) && styles.modifiers.plain,
+        isPlainText && styles.modifiers.text,
+        isFullHeight && styles.modifiers.fullHeight,
+        isTypeahead && styles.modifiers.typeahead,
+        isFullWidth && styles.modifiers.fullWidth,
+        className
+      ),
+      children: isPlain ? children : content,
+      ...(isDisabled && { disabled: true }),
+      ...otherProps
+    };
+
+    if (isTypeahead) {
+      return <div ref={innerRef as React.Ref<HTMLDivElement>} {...componentProps} />;
+    }
+
     return (
       <button
         className={css(
@@ -82,21 +110,18 @@ export class MenuToggleBase extends React.Component<MenuToggleProps> {
           isFullWidth && styles.modifiers.fullWidth,
           className
         )}
+        ref={innerRef as React.Ref<HTMLButtonElement>}
         type="button"
-        aria-expanded={false}
-        ref={innerRef}
-        {...(isExpanded && { 'aria-expanded': true })}
-        {...(isDisabled && { disabled: true })}
-        {...props}
-      >
-        {isPlain && children}
-        {!isPlain && content}
-      </button>
+        aria-label={ariaLabel}
+        aria-expanded={isExpanded}
+        onClick={onClick}
+        {...componentProps}
+      />
     );
   }
 }
 
-export const MenuToggle = React.forwardRef((props: MenuToggleProps, ref: React.Ref<HTMLButtonElement>) => (
+export const MenuToggle = React.forwardRef((props: MenuToggleProps, ref: React.Ref<MenuToggleElement>) => (
   <MenuToggleBase innerRef={ref} {...props} />
 ));
 

--- a/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
+++ b/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
@@ -74,7 +74,13 @@ export class MenuToggleBase extends React.Component<MenuToggleProps> {
         {isTypeahead ? children : <span className="pf-c-menu-toggle__text">{children}</span>}
         {badge && <span className={css(styles.menuToggleCount)}>{badge}</span>}
         {isTypeahead ? (
-          <button type="button" className={css(styles.menuToggleButton)} aria-expanded={isExpanded} onClick={onClick} aria-label="Menu toggle">
+          <button
+            type="button"
+            className={css(styles.menuToggleButton)}
+            aria-expanded={isExpanded}
+            onClick={onClick}
+            aria-label="Menu toggle"
+          >
             {toggleControls}
           </button>
         ) : (

--- a/packages/react-core/src/components/TextInputGroup/TextInputGroup.tsx
+++ b/packages/react-core/src/components/TextInputGroup/TextInputGroup.tsx
@@ -9,6 +9,8 @@ export interface TextInputGroupProps extends React.HTMLProps<HTMLDivElement> {
   className?: string;
   /** Adds disabled styling and a disabled context value which text input group main hooks into for the input itself */
   isDisabled?: boolean;
+  /** Flag to indicate the toggle has no border or background */
+  isPlain?: boolean;
   /** @hide A reference object to attach to the input box */
   innerRef?: React.RefObject<any>;
 }
@@ -21,6 +23,7 @@ export const TextInputGroup: React.FunctionComponent<TextInputGroupProps> = ({
   children,
   className,
   isDisabled,
+  isPlain,
   innerRef,
   ...props
 }: TextInputGroupProps) => {
@@ -30,7 +33,12 @@ export const TextInputGroup: React.FunctionComponent<TextInputGroupProps> = ({
     <TextInputGroupContext.Provider value={{ isDisabled }}>
       <div
         ref={textInputGroupRef}
-        className={css(styles.textInputGroup, isDisabled && styles.modifiers.disabled, className)}
+        className={css(
+          styles.textInputGroup,
+          isDisabled && styles.modifiers.disabled,
+          isPlain && styles.modifiers.plain,
+          className
+        )}
         {...props}
       >
         {children}

--- a/packages/react-core/src/components/TextInputGroup/TextInputGroupMain.tsx
+++ b/packages/react-core/src/components/TextInputGroup/TextInputGroupMain.tsx
@@ -37,7 +37,7 @@ export interface TextInputGroupMainProps extends Omit<React.HTMLProps<HTMLDivEle
   value?: string | number;
   /** Placeholder value for the input */
   placeholder?: string;
-  /** @hide A reference object to attach to the input box */
+  /** A reference object to attach to the input box */
   innerRef?: React.RefObject<any>;
 }
 

--- a/packages/react-core/src/demos/ComposableMenu/ComposableMenu.md
+++ b/packages/react-core/src/demos/ComposableMenu/ComposableMenu.md
@@ -20,6 +20,9 @@ import pfIcon from './examples/pf-logo-small.svg';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import CaretDownIcon from '@patternfly/react-icons/dist/esm/icons/caret-down-icon';
 import avatarImg from './examples/avatarImg.svg';
+import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+import { css } from '@patternfly/react-styles';
+import styles from '@patternfly/react-styles/css/components/Menu/menu';
 
 ## Demos
 
@@ -43,6 +46,11 @@ Composable menus currently require consumer keyboard handling and use of our und
 ### Composable simple checkbox select
 
 ```ts isBeta file="./examples/ComposableSimpleCheckboxSelect.tsx"
+```
+
+### Composable typeahead select
+
+```ts file="./examples/ComposableTypeaheadSelect.tsx"
 ```
 
 ### Composable drilldown menu

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableTypeaheadSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableTypeaheadSelect.tsx
@@ -31,6 +31,7 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
   const [inputValue, setInputValue] = React.useState<string>('');
   const [menuItems, setMenuItems] = React.useState<MenuItemProps[]>(intitalMenuItems);
   const [focusedItemIndex, setFocusedItemIndex] = React.useState<number | null>(null);
+  const [isSelected, setIsSelected] = React.useState(false);
 
   const menuToggleRef = React.useRef<MenuToggleElement>({} as MenuToggleElement);
   const textInputRef = React.useRef<HTMLInputElement>();
@@ -58,7 +59,11 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
   const focusOnInput = () => menuToggleRef.current?.querySelector('input')?.focus();
 
   const onMenuSelect = (_event: React.MouseEvent<Element, MouseEvent>, itemId: string | number) => {
-    itemId && setInputValue(itemId.toString());
+    if (itemId) {
+      setInputValue(itemId.toString());
+      setIsSelected(true);
+    }
+
     setIsMenuOpen(false);
     setFocusedItemIndex(null);
     focusOnInput();
@@ -98,7 +103,11 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
     switch (event.key) {
       // Select the first available option
       case 'Enter':
-        isMenuOpen && setInputValue(String(focusedItem.children));
+        if (isMenuOpen) {
+          setInputValue(String(focusedItem.children));
+          setIsSelected(true);
+        }
+
         setIsMenuOpen(prevIsOpen => !prevIsOpen);
         setFocusedItemIndex(null);
         focusOnInput();
@@ -129,6 +138,11 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
     textInputRef.current?.focus();
   };
 
+  const onTextInputChange = (value: string) => {
+    setInputValue(value);
+    setIsSelected(false);
+  };
+
   return (
     <Popper
       trigger={
@@ -137,7 +151,7 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
             <TextInputGroupMain
               value={inputValue}
               onClick={toggleMenuOpen}
-              onChange={value => setInputValue(value)}
+              onChange={onTextInputChange}
               onKeyDown={onInputKeyDown}
               id="typeahead-select-input"
               autoComplete="off"
@@ -158,13 +172,14 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
         </MenuToggle>
       }
       popper={
-        <Menu id="select-menu" onSelect={onMenuSelect} selected={inputValue}>
+        <Menu id="select-menu" onSelect={onMenuSelect} selected={isSelected && inputValue}>
           <MenuContent>
             <MenuList>
               {menuItems.map((itemProps, index) => (
                 <MenuItem
                   key={itemProps.itemId || itemProps.children}
                   className={css(focusedItemIndex === index && styles.modifiers.focus, itemProps.className)}
+                  onClick={() => setIsSelected(true)}
                   {...itemProps}
                   ref={null}
                 />

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableTypeaheadSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableTypeaheadSelect.tsx
@@ -14,11 +14,8 @@ import {
   TextInputGroupMain,
   MenuToggleElement
 } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
-import styles from '@patternfly/react-styles/css/components/Menu/menu';
-import TableIcon from '@patternfly/react-icons/dist/esm/icons/table-icon';
 import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
-import CaretDownIcon from '@patternfly/react-icons/dist/esm/icons/caret-down-icon';
+import TableIcon from '@patternfly/react-icons/dist/esm/icons/table-icon';
 
 const intitalMenuItems: MenuItemProps[] = [
   { itemId: 'Option 1', children: 'Option 1' },
@@ -161,12 +158,9 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
             <TextInputGroupUtilities>
               {!!inputValue && (
                 <Button variant="plain" onClick={() => setInputValue('')} aria-label="Clear input value">
-                  <TimesIcon />
+                  <TimesIcon aria-hidden />
                 </Button>
               )}
-              <Button variant="plain" onClick={toggleMenuOpen} aria-label="Toggle menu">
-                <CaretDownIcon />
-              </Button>
             </TextInputGroupUtilities>
           </TextInputGroup>
         </MenuToggle>
@@ -178,7 +172,8 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
               {menuItems.map((itemProps, index) => (
                 <MenuItem
                   key={itemProps.itemId || itemProps.children}
-                  className={css(focusedItemIndex === index && styles.modifiers.focus, itemProps.className)}
+                  isFocused={focusedItemIndex === index}
+                  className={itemProps.className}
                   onClick={() => setIsSelected(true)}
                   {...itemProps}
                   ref={null}

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableTypeaheadSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableTypeaheadSelect.tsx
@@ -1,0 +1,180 @@
+import React from 'react';
+
+import {
+  Menu,
+  MenuContent,
+  MenuList,
+  MenuItem,
+  Popper,
+  MenuToggle,
+  TextInputGroup,
+  MenuItemProps,
+  Button,
+  TextInputGroupUtilities,
+  TextInputGroupMain,
+  MenuToggleElement
+} from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+import styles from '@patternfly/react-styles/css/components/Menu/menu';
+import TableIcon from '@patternfly/react-icons/dist/esm/icons/table-icon';
+import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+import CaretDownIcon from '@patternfly/react-icons/dist/esm/icons/caret-down-icon';
+
+const intitalMenuItems: MenuItemProps[] = [
+  { itemId: 'Option 1', children: 'Option 1' },
+  { itemId: 'Option 2', children: 'Option 2' },
+  { itemId: 'Option 3', children: 'Option 3', icon: <TableIcon aria-hidden /> }
+];
+
+export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
+  const [isMenuOpen, setIsMenuOpen] = React.useState(false);
+  const [inputValue, setInputValue] = React.useState<string>('');
+  const [menuItems, setMenuItems] = React.useState<MenuItemProps[]>(intitalMenuItems);
+  const [focusedItemIndex, setFocusedItemIndex] = React.useState<number | null>(null);
+
+  const menuToggleRef = React.useRef<MenuToggleElement>({} as MenuToggleElement);
+  const textInputRef = React.useRef<HTMLInputElement>();
+
+  React.useEffect(() => {
+    let newMenuItems: MenuItemProps[] = intitalMenuItems;
+
+    // Filter menu items based on the text input value when one exists
+    if (inputValue) {
+      newMenuItems = intitalMenuItems.filter(menuItem =>
+        String(menuItem.children)
+          .toLowerCase()
+          .includes(inputValue.toLowerCase())
+      );
+
+      // When no options are found after filtering, display 'No results found'
+      if (!newMenuItems.length) {
+        newMenuItems = [{ isDisabled: true, children: 'No results found' }];
+      }
+    }
+
+    setMenuItems(newMenuItems);
+  }, [inputValue]);
+
+  const focusOnInput = () => menuToggleRef.current?.querySelector('input')?.focus();
+
+  const onMenuSelect = (_event: React.MouseEvent<Element, MouseEvent>, itemId: string | number) => {
+    itemId && setInputValue(itemId.toString());
+    setIsMenuOpen(false);
+    setFocusedItemIndex(null);
+    focusOnInput();
+  };
+
+  const handleMenuArrowKeys = (key: string) => {
+    let indexToFocus;
+
+    if (isMenuOpen) {
+      if (key === 'ArrowUp') {
+        // When no index is set or at the first index, focus to the last, otherwise decrement focus index
+        if (focusedItemIndex === null || focusedItemIndex === 0) {
+          indexToFocus = menuItems.length - 1;
+        } else {
+          indexToFocus = focusedItemIndex - 1;
+        }
+      }
+
+      if (key === 'ArrowDown') {
+        // When no index is set or at the last index, focus to the first, otherwise increment focus index
+        if (focusedItemIndex === null || focusedItemIndex === menuItems.length - 1) {
+          indexToFocus = 0;
+        } else {
+          indexToFocus = focusedItemIndex + 1;
+        }
+      }
+
+      setFocusedItemIndex(indexToFocus);
+    }
+  };
+
+  const onInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    const enabledMenuItems = menuItems.filter(menuItem => !menuItem.isDisabled);
+    const [firstMenuItem] = enabledMenuItems;
+    const focusedItem = focusedItemIndex ? enabledMenuItems[focusedItemIndex] : firstMenuItem;
+
+    switch (event.key) {
+      // Select the first available option
+      case 'Enter':
+        isMenuOpen && setInputValue(String(focusedItem.children));
+        setIsMenuOpen(prevIsOpen => !prevIsOpen);
+        setFocusedItemIndex(null);
+        focusOnInput();
+
+        break;
+      case 'Tab':
+      case 'Escape':
+        setIsMenuOpen(false);
+        break;
+      case 'ArrowUp':
+      case 'ArrowDown':
+        handleMenuArrowKeys(event.key);
+        break;
+      default:
+        !isMenuOpen && setIsMenuOpen(true);
+    }
+  };
+
+  // Close the menu when a click occurs outside of the menu toggle content
+  const onDocumentClick = (event: MouseEvent) => {
+    if (!menuToggleRef.current?.contains(event?.target as HTMLElement)) {
+      setIsMenuOpen(false);
+    }
+  };
+
+  const toggleMenuOpen = () => {
+    setIsMenuOpen(prevIsOpen => !prevIsOpen);
+    textInputRef.current?.focus();
+  };
+
+  return (
+    <Popper
+      trigger={
+        <MenuToggle variant="typeahead" onClick={toggleMenuOpen} innerRef={menuToggleRef} isFullWidth>
+          <TextInputGroup isPlain>
+            <TextInputGroupMain
+              value={inputValue}
+              onClick={toggleMenuOpen}
+              onChange={value => setInputValue(value)}
+              onKeyDown={onInputKeyDown}
+              id="typeahead-select-input"
+              autoComplete="off"
+              innerRef={textInputRef}
+            />
+
+            <TextInputGroupUtilities>
+              {!!inputValue && (
+                <Button variant="plain" onClick={() => setInputValue('')} aria-label="Clear input value">
+                  <TimesIcon />
+                </Button>
+              )}
+              <Button variant="plain" onClick={toggleMenuOpen} aria-label="Toggle menu">
+                <CaretDownIcon />
+              </Button>
+            </TextInputGroupUtilities>
+          </TextInputGroup>
+        </MenuToggle>
+      }
+      popper={
+        <Menu id="select-menu" onSelect={onMenuSelect} selected={inputValue}>
+          <MenuContent>
+            <MenuList>
+              {menuItems.map((itemProps, index) => (
+                <MenuItem
+                  key={itemProps.itemId || itemProps.children}
+                  className={css(focusedItemIndex === index && styles.modifiers.focus, itemProps.className)}
+                  {...itemProps}
+                  ref={null}
+                />
+              ))}
+            </MenuList>
+          </MenuContent>
+        </Menu>
+      }
+      isVisible={isMenuOpen}
+      onDocumentClick={onDocumentClick}
+    />
+  );
+};

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableTypeaheadSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableTypeaheadSelect.tsx
@@ -143,7 +143,13 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
   return (
     <Popper
       trigger={
-        <MenuToggle variant="typeahead" onClick={toggleMenuOpen} innerRef={menuToggleRef} isFullWidth>
+        <MenuToggle
+          variant="typeahead"
+          onClick={toggleMenuOpen}
+          innerRef={menuToggleRef}
+          isExpanded={isMenuOpen}
+          isFullWidth
+        >
           <TextInputGroup isPlain>
             <TextInputGroupMain
               value={inputValue}


### PR DESCRIPTION
**What**: Closes #6888

As a part of this, the MenuToggle was switched from a `button` to a `div` since we cannot have a button within a button, and we want the Icon to clear typeahead input values to be inside of a button.

The build will fail and styling of this should not be tested until this core PR is merged: https://github.com/patternfly/patternfly/pull/4673