### PR TITLE
chore(docs): added details to upgrade guide:

### DIFF
--- a/packages/react-docs/UPGRADE-GUIDE.md
+++ b/packages/react-docs/UPGRADE-GUIDE.md
@@ -3,7 +3,7 @@ id: Upgrade guide
 section: developer-resources
 ---
 
-Note: this guide details upgrading from PatternFly V3 to V4, and references [major release 2020.07](/v4/developer-resources/release-notes#2020.07-release-notes-2020-06-05) from 2020-06-05.
+**Note:** this guide details upgrading from PatternFly v3 to v4, and references [major release 2020.07](/developer-resources/release-notes#2020.07-release-notes-2020-06-05) from 2020-06-05.
 <hr/>
 
 Hey, Flyers! We’ve been busy for the past 12 weeks keeping up with changes to PatternFly’s HTML and CSS. We’ve replaced `babel` with `tsc` as our compiler of choice and removed prop-types in favor of using our `.d.ts` types, which are supported in most editors.

--- a/packages/react-docs/UPGRADE-GUIDE.md
+++ b/packages/react-docs/UPGRADE-GUIDE.md
@@ -3,6 +3,9 @@ id: Upgrade guide
 section: developer-resources
 ---
 
+Note: this guide details upgrading from PatternFly V3 to V4, and references [major release 2020.07](/v4/developer-resources/release-notes#2020.07-release-notes-2020-06-05) from 2020-06-05.
+<hr/>
+
 Hey, Flyers! We’ve been busy for the past 12 weeks keeping up with changes to PatternFly’s HTML and CSS. We’ve replaced `babel` with `tsc` as our compiler of choice and removed prop-types in favor of using our `.d.ts` types, which are supported in most editors.
 
 This upgrade guide details **what** was broken and **how** to fix it. To learn **why** a change was made, check out the linked pull requests.


### PR DESCRIPTION
Closes #6910 

This PR adds additional context to the upgrade guide, clarifying that it details upgrading from V3 to V4 and linking to the relevant release notes.