### PR TITLE
fix(Select): Fixed so that view more btn click does not close the men…

### DIFF
--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -1006,6 +1006,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
         onClick={e => {
           this.clearSelection(e);
           onClear(e);
+          e.stopPropagation();
         }}
         aria-label={clearSelectionsAriaLabel}
         type="button"

--- a/packages/react-core/src/components/Select/SelectToggle.tsx
+++ b/packages/react-core/src/components/Select/SelectToggle.tsx
@@ -87,7 +87,7 @@ export class SelectToggle extends React.Component<SelectToggleProps> {
   }
 
   componentDidMount() {
-    document.addEventListener('click', this.onDocClick);
+    document.addEventListener('click', this.onDocClick, { capture: true });
     document.addEventListener('touchstart', this.onDocClick);
     document.addEventListener('keydown', this.handleGlobalKeys);
   }

--- a/packages/react-integration/cypress/integration/selectfavorites.spec.ts
+++ b/packages/react-integration/cypress/integration/selectfavorites.spec.ts
@@ -14,6 +14,8 @@ describe('Select Test', () => {
       .first()
       .click();
     cy.get('#Favorites').should('not.exist');
+    // toggle closed
+    cy.get('#favorites-select').click();
   });
 
   it('Verify Single Grouped Select with Favorites', () => {
@@ -52,6 +54,8 @@ describe('Select Test', () => {
       .first()
       .click();
     cy.get('#Favorites').should('not.exist');
+    // toggle closed
+    cy.get('#typeahead-select').click();
   });
 
   it('Verify Multi Typeahead  Select with Favorites', () => {


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5894 

Tested the fix by downgrading the react version of the demo-app to 16.   You would have to build this branch locally and do the sam if you want to test it in react 16 (remember to downgrade the root package.json since it is a mono repo. 
The fix caused a regression in the `clear button` behavior for `typeahead` select so I fixed that too. 

@mcarrano this fix also changed the behaviour of when you unfavorite a menu item.  Previously when you clicked an item to unfavorite it from the top Favorites portion of the menu, the menu would close.  If you unfavorited something by clicking the actual menu item, it would stay open.  Now it will stay open regardless of where you unfavorited it from.
