### PR TITLE
WIP: Make @patternfly/react-core and other component packages to be peer dependent on @patternfly/react-{styles, icons, tokens}

### DIFF
--- a/packages/react-catalog-view-extension/package.json
+++ b/packages/react-catalog-view-extension/package.json
@@ -35,9 +35,7 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
-    "@patternfly/patternfly": "4.176.0",
-    "@patternfly/react-core": "^4.195.0",
-    "@patternfly/react-styles": "^4.45.0"
+    "@patternfly/patternfly": "4.176.0"
   },
   "devDependencies": {
     "concurrently": "^5.3.0",
@@ -48,6 +46,8 @@
     "typescript": "^4.0.0"
   },
   "peerDependencies": {
+    "@patternfly/react-core": "^4.195.0",
+    "@patternfly/react-styles": "^4.45.0",
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0"
   }

--- a/packages/react-charts/package.json
+++ b/packages/react-charts/package.json
@@ -29,8 +29,6 @@
   },
   "homepage": "https://github.com/patternfly/patternfly-react#readme",
   "dependencies": {
-    "@patternfly/react-styles": "^4.45.0",
-    "@patternfly/react-tokens": "^4.47.0",
     "hoist-non-react-statics": "^3.3.0",
     "lodash": "^4.17.19",
     "tslib": "^2.0.0",
@@ -51,6 +49,8 @@
     "victory-zoom-container": "^35.9.0"
   },
   "peerDependencies": {
+    "@patternfly/react-styles": "^4.45.0",
+    "@patternfly/react-tokens": "^4.47.0",
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0"
   },

--- a/packages/react-code-editor/package.json
+++ b/packages/react-code-editor/package.json
@@ -30,13 +30,13 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
-    "@patternfly/react-core": "^4.195.0",
-    "@patternfly/react-icons": "^4.46.0",
-    "@patternfly/react-styles": "^4.45.0",
     "react-dropzone": "9.0.0",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
+    "@patternfly/react-core": "^4.195.0",
+    "@patternfly/react-icons": "^4.46.0",
+    "@patternfly/react-styles": "^4.45.0",
     "monaco-editor-webpack-plugin": "^2.1.0",
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0",

--- a/packages/react-console/package.json
+++ b/packages/react-console/package.json
@@ -34,7 +34,6 @@
   "dependencies": {
     "@novnc/novnc": "^1.2.0",
     "@patternfly/patternfly": "4.176.0",
-    "@patternfly/react-core": "^4.195.0",
     "@spice-project/spice-html5": "^0.2.1",
     "@types/file-saver": "^2.0.1",
     "file-saver": "^1.3.8",
@@ -47,6 +46,7 @@
     "typescript": "^4.0.0"
   },
   "peerDependencies": {
+    "@patternfly/react-core": "^4.195.0",
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0"
   }

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -34,9 +34,6 @@
     "generate": "node scripts/copyStyles.js"
   },
   "dependencies": {
-    "@patternfly/react-icons": "^4.46.0",
-    "@patternfly/react-styles": "^4.45.0",
-    "@patternfly/react-tokens": "^4.47.0",
     "focus-trap": "6.2.2",
     "react-dropzone": "9.0.0",
     "tippy.js": "5.1.2",
@@ -57,6 +54,9 @@
     "typescript": "^4.0.0"
   },
   "peerDependencies": {
+    "@patternfly/react-icons": "^4.46.0",
+    "@patternfly/react-styles": "^4.45.0",
+    "@patternfly/react-tokens": "^4.47.0",
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0"
   }

--- a/packages/react-table/package.json
+++ b/packages/react-table/package.json
@@ -31,10 +31,6 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
-    "@patternfly/react-core": "^4.195.0",
-    "@patternfly/react-icons": "^4.46.0",
-    "@patternfly/react-styles": "^4.45.0",
-    "@patternfly/react-tokens": "^4.47.0",
     "lodash": "^4.17.19",
     "tslib": "^2.0.0"
   },
@@ -43,6 +39,10 @@
     "typescript": "^4.0.0"
   },
   "peerDependencies": {
+    "@patternfly/react-core": "^4.195.0",
+    "@patternfly/react-icons": "^4.46.0",
+    "@patternfly/react-styles": "^4.45.0",
+    "@patternfly/react-tokens": "^4.47.0",
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0"
   }

--- a/packages/react-topology/package.json
+++ b/packages/react-topology/package.json
@@ -28,9 +28,6 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
-    "@patternfly/react-core": "^4.195.0",
-    "@patternfly/react-icons": "^4.46.0",
-    "@patternfly/react-styles": "^4.45.0",
     "@types/d3": "^5.7.2",
     "@types/d3-force": "^1.2.1",
     "@types/dagre": "0.7.42",
@@ -48,6 +45,9 @@
     "webcola": "3.4.0"
   },
   "peerDependencies": {
+    "@patternfly/react-core": "^4.195.0",
+    "@patternfly/react-icons": "^4.46.0",
+    "@patternfly/react-styles": "^4.45.0",
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0"
   },

--- a/packages/react-virtualized-extension/package.json
+++ b/packages/react-virtualized-extension/package.json
@@ -30,14 +30,14 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
-    "@patternfly/react-core": "^4.195.0",
-    "@patternfly/react-icons": "^4.46.0",
-    "@patternfly/react-styles": "^4.45.0",
     "linear-layout-vector": "0.0.1",
     "react-virtualized": "^9.21.1",
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
+    "@patternfly/react-core": "^4.195.0",
+    "@patternfly/react-icons": "^4.46.0",
+    "@patternfly/react-styles": "^4.45.0",
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0"
   },


### PR DESCRIPTION
This will ensure that there is only one version of the
@patternfly/* packages installed on the consumers system, which is the
desired scenario, especially for consumers that want to pin down the
versions of all their patternfly dependencies.

Long story
----------

In cockpit [1] we pin down all @patternfly/react-* package dependencies,
as we want to be able to have reproduceable builds.

To explain it a bit further:
Cockpit's only explicit dependencies could be @patternfly/patternfly
(for importing the base CSS) and @patternfly/react-core (for using the
react components).
@patternfly/react-core imports the per-component stylesheets from @patternfly/react-styles,
to which it has a direct dependency. If we (cockpit) don't manage to lock the version of
@patternfly/react-styles, this package will be updated on demand, when a
new version is released. This could thererically break our CI (as
new stylesheets will generate changes on the UI) and even worse make our
package releases unpredictable, in matters of not controlling the exact
version of the @patternfly/react-styles that we use.

In order to solve the above, in Cockpit we have pinned down all
relevant @patternfly/* packages. This will result in the dependency tree
like this:
```
$ npm ls --depth=1 | grep @patternfly*
├── @patternfly/patternfly@4.159.1             <--- pinned down
├─┬ @patternfly/react-core@4.175.4             <--- pinned down
│ ├── @patternfly/react-icons@4.26.4 deduped
│ ├── @patternfly/react-styles@4.25.4 deduped
│ ├── @patternfly/react-tokens@4.33.1
├── @patternfly/react-icons@4.26.4             <--- pinned down
├── @patternfly/react-styles@4.25.4            <--- pinned down
├─┬ @patternfly/react-table@4.44.4             <--- pinned down
│ ├── @patternfly/react-core@4.175.4 deduped
│ ├── @patternfly/react-icons@4.26.4 deduped
│ ├── @patternfly/react-styles@4.25.4 deduped
│ ├── @patternfly/react-tokens@4.33.1 deduped

```

See how the NPM dep resolves the dependencies exactly how we need, by
keeping just them once, in the root of the tree.
However, this will only work if the the @patternfly/react-{styles,
icons} packages can be deduped, so if the version that we specify is compatible with the versions required by
@patternfly/react-core and so.

Otherwise if will silently do this:
```
$ npm ls --depth=1 | grep @patternfly*
├── @patternfly/patternfly@4.159.1             <--- pinned down
├─┬ @patternfly/react-core@4.175.4             <--- pinned down
│ ├── @patternfly/react-icons@4.26.4 deduped
│ ├── @patternfly/react-styles@4.42.15
│ ├── @patternfly/react-tokens@4.33.1
├── @patternfly/react-icons@4.26.4             <--- pinned down
├── @patternfly/react-styles@4.25.4            <--- pinned down to a version that can't be deduped!!!
├─┬ @patternfly/react-table@4.44.4             <--- pinned down
│ ├── @patternfly/react-core@4.175.4 deduped
│ ├── @patternfly/react-icons@4.26.4 deduped
│ ├── @patternfly/react-styles@4.42.15
│ ├── @patternfly/react-tokens@4.33.1 deduped
```

This is exactly the scenario that we need  to avoid. After some
thinking, I believe making these packages peerDependencies as this
commit implements is the way to go.

Lastly this will make dependabot handle all these as a group.
https://github.com/dependabot/dependabot-core/issues/1296#issuecomment-1035995416

<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
