### PR TITLE
fix newline interpolation of text input values

### DIFF
--- a/packages/react-core/src/components/TextInput/TextInput.tsx
+++ b/packages/react-core/src/components/TextInput/TextInput.tsx
@@ -201,7 +201,7 @@ export class TextInputBase extends React.Component<TextInputProps, TextInputStat
         )}
         onChange={this.handleChange}
         type={type}
-        value={value}
+        value={this.sanitizeInputValue(value)}
         aria-invalid={props['aria-invalid'] ? props['aria-invalid'] : validated === ValidatedOptions.error}
         required={isRequired}
         disabled={isDisabled}
@@ -212,6 +212,9 @@ export class TextInputBase extends React.Component<TextInputProps, TextInputStat
       />
     );
   }
+
+  private sanitizeInputValue = (value: string | number) =>
+    typeof value === 'string' ? value.replace(/\n/g, ' ') : value;
 }
 
 export const TextInput = React.forwardRef((props: TextInputProps, ref: React.Ref<HTMLInputElement>) => (


### PR DESCRIPTION
**What**: Closes #5324

when using `ClipboardCopy`, and passing an input text which contains newlines as a template string variable, they are omitted from the input value.

fix this in `TextInputBase` by replacing incoming newlines with whitespace characters, right before setting the input `value` (when the value is of `string` type).

**Additional issues**: N/A
