### PR TITLE
Feat(AlertGroup): 6890 alert group overflow

### DIFF
--- a/packages/react-core/src/components/AlertGroup/AlertGroup.tsx
+++ b/packages/react-core/src/components/AlertGroup/AlertGroup.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { canUseDOM } from '../../helpers';
+import { Alert } from '../Alert';
 import { AlertGroupInline } from './AlertGroupInline';
 
 export interface AlertGroupProps extends Omit<React.HTMLProps<HTMLUListElement>, 'className'> {
@@ -14,6 +15,10 @@ export interface AlertGroupProps extends Omit<React.HTMLProps<HTMLUListElement>,
   isLiveRegion?: boolean;
   /** Determine where the alert is appended to */
   appendTo?: HTMLElement | (() => HTMLElement);
+  /** Max number to display before showing overflow, default is 3 */
+  maxDisplayed?: number;
+  /** Amount overflowed by */
+  overflowedBy?: number;
 }
 
 interface AlertGroupState {
@@ -49,10 +54,16 @@ export class AlertGroup extends React.Component<AlertGroupProps, AlertGroupState
   }
 
   render() {
-    const { className, children, isToast, isLiveRegion, ...props } = this.props;
+    const { className, children, isToast, isLiveRegion, maxDisplayed = 3, ...props } = this.props;
+    let shownChildren = children;
+    let overflow = 0;
+    if (Array.isArray(children) && children.length > maxDisplayed) {
+      shownChildren = children.slice(0,maxDisplayed);
+      overflow = children.length - maxDisplayed;
+    }
     const alertGroup = (
-      <AlertGroupInline className={className} isToast={isToast} isLiveRegion={isLiveRegion} {...props}>
-        {children}
+      <AlertGroupInline className={className} isToast={isToast} isLiveRegion={isLiveRegion} overflowedBy={overflow} {...props}>
+        {shownChildren}
       </AlertGroupInline>
     );
     if (!this.props.isToast) {

--- a/packages/react-core/src/components/AlertGroup/AlertGroup.tsx
+++ b/packages/react-core/src/components/AlertGroup/AlertGroup.tsx
@@ -14,8 +14,6 @@ export interface AlertGroupProps extends Omit<React.HTMLProps<HTMLUListElement>,
   isLiveRegion?: boolean;
   /** Determine where the alert is appended to */
   appendTo?: HTMLElement | (() => HTMLElement);
-  /** Amount overflowed by */
-  overflowedBy?: number;
   /** Function to call if user clicks on overflow message */
   onOverflowClick?: () => void;
   /** Custom text to show for the overflow message */

--- a/packages/react-core/src/components/AlertGroup/AlertGroup.tsx
+++ b/packages/react-core/src/components/AlertGroup/AlertGroup.tsx
@@ -15,10 +15,14 @@ export interface AlertGroupProps extends Omit<React.HTMLProps<HTMLUListElement>,
   isLiveRegion?: boolean;
   /** Determine where the alert is appended to */
   appendTo?: HTMLElement | (() => HTMLElement);
-  /** Max number to display before showing overflow, default is 3 */
+  /** Max number to display before showing overflow, negative numbers will show all, default is 3 */
   maxDisplayed?: number;
   /** Amount overflowed by */
   overflowedBy?: number;
+  /** Function to call if user clicks on overflow message */
+  onOverflowClick?: () => void;
+  /** Custom text to show for the overflow message */
+  overflowMessage?: string;
 }
 
 interface AlertGroupState {
@@ -54,15 +58,16 @@ export class AlertGroup extends React.Component<AlertGroupProps, AlertGroupState
   }
 
   render() {
-    const { className, children, isToast, isLiveRegion, maxDisplayed = 3, ...props } = this.props;
+    const { className, children, isToast, isLiveRegion, maxDisplayed = 3, onOverflowClick, overflowMessage, ...props } = this.props;
     let shownChildren = children;
-    let overflow = 0;
-    if (Array.isArray(children) && children.length > maxDisplayed) {
-      shownChildren = children.slice(0,maxDisplayed);
-      overflow = children.length - maxDisplayed;
-    }
+    // let overflow = 0;
+    // if (onOverflowClick && maxDisplayed > -1 && Array.isArray(children) && children.length > maxDisplayed) {
+    //   shownChildren = children.slice(0,maxDisplayed-1);
+    //   overflow = children.length - maxDisplayed + 1;
+    // }
     const alertGroup = (
-      <AlertGroupInline className={className} isToast={isToast} isLiveRegion={isLiveRegion} overflowedBy={overflow} {...props}>
+      <AlertGroupInline onOverflowClick={onOverflowClick} className={className} isToast={isToast} isLiveRegion={isLiveRegion} overflowMessage={overflowMessage} {...props}>
+      {/* <AlertGroupInline onOverflowClick={onOverflowClick} className={className} isToast={isToast} isLiveRegion={isLiveRegion} overflowedBy={overflow} {...props}> */}
         {shownChildren}
       </AlertGroupInline>
     );

--- a/packages/react-core/src/components/AlertGroup/AlertGroup.tsx
+++ b/packages/react-core/src/components/AlertGroup/AlertGroup.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { canUseDOM } from '../../helpers';
-import { Alert } from '../Alert';
 import { AlertGroupInline } from './AlertGroupInline';
 
 export interface AlertGroupProps extends Omit<React.HTMLProps<HTMLUListElement>, 'className'> {
@@ -15,8 +14,6 @@ export interface AlertGroupProps extends Omit<React.HTMLProps<HTMLUListElement>,
   isLiveRegion?: boolean;
   /** Determine where the alert is appended to */
   appendTo?: HTMLElement | (() => HTMLElement);
-  /** Max number to display before showing overflow, negative numbers will show all, default is 3 */
-  maxDisplayed?: number;
   /** Amount overflowed by */
   overflowedBy?: number;
   /** Function to call if user clicks on overflow message */
@@ -58,17 +55,17 @@ export class AlertGroup extends React.Component<AlertGroupProps, AlertGroupState
   }
 
   render() {
-    const { className, children, isToast, isLiveRegion, maxDisplayed = 3, onOverflowClick, overflowMessage, ...props } = this.props;
-    let shownChildren = children;
-    // let overflow = 0;
-    // if (onOverflowClick && maxDisplayed > -1 && Array.isArray(children) && children.length > maxDisplayed) {
-    //   shownChildren = children.slice(0,maxDisplayed-1);
-    //   overflow = children.length - maxDisplayed + 1;
-    // }
+    const { className, children, isToast, isLiveRegion, onOverflowClick, overflowMessage, ...props } = this.props;
     const alertGroup = (
-      <AlertGroupInline onOverflowClick={onOverflowClick} className={className} isToast={isToast} isLiveRegion={isLiveRegion} overflowMessage={overflowMessage} {...props}>
-      {/* <AlertGroupInline onOverflowClick={onOverflowClick} className={className} isToast={isToast} isLiveRegion={isLiveRegion} overflowedBy={overflow} {...props}> */}
-        {shownChildren}
+      <AlertGroupInline
+        onOverflowClick={onOverflowClick}
+        className={className}
+        isToast={isToast}
+        isLiveRegion={isLiveRegion}
+        overflowMessage={overflowMessage}
+        {...props}
+      >
+        {children}
       </AlertGroupInline>
     );
     if (!this.props.isToast) {

--- a/packages/react-core/src/components/AlertGroup/AlertGroupInline.tsx
+++ b/packages/react-core/src/components/AlertGroup/AlertGroupInline.tsx
@@ -2,12 +2,14 @@ import * as React from 'react';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/AlertGroup/alert-group';
 import { AlertGroupProps } from './AlertGroup';
+import { Alert } from '..';
 
 export const AlertGroupInline: React.FunctionComponent<AlertGroupProps> = ({
   className,
   children,
   isToast,
   isLiveRegion,
+  overflowedBy,
   ...rest
 }: AlertGroupProps) => (
   <ul
@@ -19,6 +21,9 @@ export const AlertGroupInline: React.FunctionComponent<AlertGroupProps> = ({
     {React.Children.toArray(children).map((Alert: React.ReactNode, index: number) => (
       <li key={index}>{Alert}</li>
     ))}
+    {overflowedBy > 0 &&
+      <li><Alert title={overflowedBy + " more alerts"}/></li>
+    }
   </ul>
 );
 AlertGroupInline.displayName = 'AlertGroupInline';

--- a/packages/react-core/src/components/AlertGroup/AlertGroupInline.tsx
+++ b/packages/react-core/src/components/AlertGroup/AlertGroupInline.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/AlertGroup/alert-group';
 import { AlertGroupProps } from './AlertGroup';
-import { Alert } from '..';
 
 export const AlertGroupInline: React.FunctionComponent<AlertGroupProps> = ({
   className,
@@ -10,6 +9,8 @@ export const AlertGroupInline: React.FunctionComponent<AlertGroupProps> = ({
   isToast,
   isLiveRegion,
   overflowedBy,
+  onOverflowClick,
+  overflowMessage,
   ...rest
 }: AlertGroupProps) => (
   <ul
@@ -21,8 +22,12 @@ export const AlertGroupInline: React.FunctionComponent<AlertGroupProps> = ({
     {React.Children.toArray(children).map((Alert: React.ReactNode, index: number) => (
       <li key={index}>{Alert}</li>
     ))}
-    {overflowedBy > 0 &&
-      <li><Alert title={overflowedBy + " more alerts"}/></li>
+    {overflowMessage &&
+    // {overflowedBy > 0 &&
+      <li>
+        <button onClick={onOverflowClick} className={css(styles.alertGroupOverflowButton)}>{overflowMessage}</button>
+        {/* <button onClick={onOverflowClick} className={css(styles.alertGroupOverflowButton)}>{overflowMessage || "View " + overflowedBy + " more alerts"}</button> */}
+      </li>
     }
   </ul>
 );

--- a/packages/react-core/src/components/AlertGroup/AlertGroupInline.tsx
+++ b/packages/react-core/src/components/AlertGroup/AlertGroupInline.tsx
@@ -8,7 +8,6 @@ export const AlertGroupInline: React.FunctionComponent<AlertGroupProps> = ({
   children,
   isToast,
   isLiveRegion,
-  overflowedBy,
   onOverflowClick,
   overflowMessage,
   ...rest
@@ -22,13 +21,13 @@ export const AlertGroupInline: React.FunctionComponent<AlertGroupProps> = ({
     {React.Children.toArray(children).map((Alert: React.ReactNode, index: number) => (
       <li key={index}>{Alert}</li>
     ))}
-    {overflowMessage &&
-    // {overflowedBy > 0 &&
+    {overflowMessage && (
       <li>
-        <button onClick={onOverflowClick} className={css(styles.alertGroupOverflowButton)}>{overflowMessage}</button>
-        {/* <button onClick={onOverflowClick} className={css(styles.alertGroupOverflowButton)}>{overflowMessage || "View " + overflowedBy + " more alerts"}</button> */}
+        <button onClick={onOverflowClick} className={css(styles.alertGroupOverflowButton)}>
+          {overflowMessage}
+        </button>
       </li>
-    }
+    )}
   </ul>
 );
 AlertGroupInline.displayName = 'AlertGroupInline';

--- a/packages/react-core/src/components/AlertGroup/__tests__/AlertGroup.test.tsx
+++ b/packages/react-core/src/components/AlertGroup/__tests__/AlertGroup.test.tsx
@@ -28,6 +28,21 @@ test('Alert Group works with n children', () => {
   expect(view).toBeTruthy();
 });
 
+test('Alert group overflow shows up', () => {
+  const overflowMessage = "View 2 more alerts";
+  const onOverflowClick = jest.fn();
+  const wrapper = mount(
+    <AlertGroup overflowMessage={overflowMessage} onOverflowClick={onOverflowClick}>
+      <Alert variant="danger" title="alert title" />
+    </AlertGroup>
+  )
+  expect(wrapper.find('.pf-c-alert-group > li')).toHaveLength(2);
+  expect(wrapper.find('.pf-c-alert-group__overflow-button').text()).toContain(overflowMessage);
+  expect(wrapper).toMatchSnapshot();
+  wrapper.find('.pf-c-alert-group__overflow-button').simulate('click');
+  expect(onOverflowClick).toBeCalled();
+});
+
 test('Standard Alert Group is not a toast alert group', () => {
   const wrapper = mount(
     <AlertGroup>

--- a/packages/react-core/src/components/AlertGroup/__tests__/__snapshots__/AlertGroup.test.tsx.snap
+++ b/packages/react-core/src/components/AlertGroup/__tests__/__snapshots__/AlertGroup.test.tsx.snap
@@ -8,6 +8,95 @@ exports[`Alert Group should match snapshot 1`] = `
 </div>
 `;
 
+exports[`Alert group overflow shows up 1`] = `
+<AlertGroup
+  onOverflowClick={[MockFunction]}
+  overflowMessage="View 2 more alerts"
+>
+  <AlertGroupInline
+    onOverflowClick={[MockFunction]}
+    overflowMessage="View 2 more alerts"
+  >
+    <ul
+      aria-atomic={null}
+      aria-live={null}
+      className="pf-c-alert-group"
+    >
+      <li
+        key="0"
+      >
+        <Alert
+          key=".0"
+          title="alert title"
+          variant="danger"
+        >
+          <div
+            aria-label="Danger Alert"
+            className="pf-c-alert pf-m-danger"
+            data-ouia-component-id="OUIA-Generated-Alert-danger-1"
+            data-ouia-component-type="PF4/Alert"
+            data-ouia-safe={true}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+          >
+            <AlertIcon
+              variant="danger"
+            >
+              <div
+                className="pf-c-alert__icon"
+              >
+                <ExclamationCircleIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
+                >
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 512 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                    />
+                  </svg>
+                </ExclamationCircleIcon>
+              </div>
+            </AlertIcon>
+            <h4
+              className="pf-c-alert__title"
+            >
+              <span
+                className="pf-u-screen-reader"
+              >
+                Danger alert:
+              </span>
+              alert title
+            </h4>
+          </div>
+        </Alert>
+      </li>
+      <li>
+        <button
+          className="pf-c-alert-group__overflow-button"
+          onClick={[MockFunction]}
+        >
+          View 2 more alerts
+        </button>
+      </li>
+    </ul>
+  </AlertGroupInline>
+</AlertGroup>
+`;
+
 exports[`Standard Alert Group is not a toast alert group 1`] = `
 <AlertGroup>
   <AlertGroupInline>
@@ -27,7 +116,7 @@ exports[`Standard Alert Group is not a toast alert group 1`] = `
           <div
             aria-label="Danger Alert"
             className="pf-c-alert pf-m-danger"
-            data-ouia-component-id="OUIA-Generated-Alert-danger-1"
+            data-ouia-component-id="OUIA-Generated-Alert-danger-2"
             data-ouia-component-type="PF4/Alert"
             data-ouia-safe={true}
             onMouseEnter={[Function]}
@@ -215,6 +304,7 @@ exports[`alertgroup closes when alerts are closed 1`] = `
 <AlertGroup
   appendTo={
     <body>
+      <div />
       <div />
       <div>
         <ul
@@ -421,6 +511,7 @@ exports[`alertgroup closes when alerts are closed 1`] = `
       appendTo={
         <body>
           <div />
+          <div />
           <div>
             <ul
               class="pf-c-alert-group pf-m-toast"
@@ -547,6 +638,7 @@ exports[`alertgroup closes when alerts are closed 1`] = `
       <ul
         appendTo={
           <body>
+            <div />
             <div />
             <div>
               <ul

--- a/packages/react-core/src/components/AlertGroup/examples/AlertGroup.md
+++ b/packages/react-core/src/components/AlertGroup/examples/AlertGroup.md
@@ -79,7 +79,7 @@ class ToastAlertGroup extends React.Component {
 ```
 
 ### Toast alert group with overflow capture
-After a specified number of alerts displayed is reached, we will see an overflow message instead of new alerts.
+After a specified number of alerts displayed is reached, we will see an overflow message instead of new alerts. Alerts asynchronously appended into dynamic AlertGroups with `isLiveRegion` will be announced to assistive technology at the moment the change happens. When the overflow message appears or is updated in AlertGroups with `isLiveRegion`, the `View 1 more alert` text will be read, but the alert message will not be read. screen reader user or keyboard user will need a way to navigate to and reveal the hidden alerts before they disappear. Alternatively, there should be a place that notifications or alerts are collected to be viewed or read later.
 ```js
 import React from 'react';
 import { Alert, AlertGroup, AlertActionCloseButton, AlertVariant, InputGroup } from '@patternfly/react-core';
@@ -93,11 +93,12 @@ class ToastAlertGroup extends React.Component {
       showAll: false
     };
     this.getOverflowMessage = (alertsNumber, showAll = this.state.showAll) => {
-      if (alertsNumber > this.state.maxDisplayed) {
+      const overflow = alertsNumber - this.state.maxDisplayed;
+      if (overflow > 0) {
         if (showAll) {
-          return "Hide " + (alertsNumber - this.state.maxDisplayed) + " alerts";
+          return "Hide " + (overflow) + " alerts";
         }
-        return "View " + (alertsNumber - this.state.maxDisplayed) + " more alerts";
+        return "View " + (overflow) + " more alerts";
       }
       return '';
     };
@@ -224,11 +225,12 @@ class SingularAdditiveAlertGroup extends React.Component {
       showAll: false
     };
     this.getOverflowMessage = (alertsNumber, showAll = this.state.showAll) => {
-      if (alertsNumber > this.state.maxDisplayed) {
+      const overflow = alertsNumber - this.state.maxDisplayed;
+      if (overflow > 0) {
         if (showAll) {
-          return "Hide " + (alertsNumber - this.state.maxDisplayed) + " alerts";
+          return "Hide " + (overflow) + " alerts";
         }
-        return "View " + (alertsNumber - this.state.maxDisplayed) + " more alerts";
+        return "View " + (overflow) + " more alerts";
       }
       return '';
     };

--- a/packages/react-core/src/components/AlertGroup/examples/AlertGroup.md
+++ b/packages/react-core/src/components/AlertGroup/examples/AlertGroup.md
@@ -100,7 +100,7 @@ class ToastAlertGroup extends React.Component {
         return "View " + (alertsNumber - this.state.maxDisplayed) + " more alerts";
       }
       return '';
-    }
+    };
     this.addAlert = (title, variant, key) => {
       this.setState({
         ...this.state,
@@ -123,7 +123,7 @@ class ToastAlertGroup extends React.Component {
     const addSuccessAlert = () => { this.addAlert('Toast success alert', 'success', getUniqueId()) };
     const addDangerAlert = () => { this.addAlert('Toast danger alert', 'danger', getUniqueId()) };
     const addInfoAlert = () => { this.addAlert('Toast info alert', 'info', getUniqueId()) };
-    const onOverflowClick = () => { console.log(this.state.alerts); this.setState({
+    const onOverflowClick = () => { this.setState({
       ...this.state,
       overflowMessage: this.getOverflowMessage(this.state.alerts.length, !this.state.showAll),
       showAll: !this.state.showAll
@@ -189,6 +189,86 @@ class SingularAdditiveAlertGroup extends React.Component {
         </InputGroup>
         <AlertGroup isLiveRegion>
           {this.state.alerts.map(({ title, variant, key }) => (
+            <Alert
+              isInline
+              variant={AlertVariant[variant]}
+              title={title}
+              key={key}
+              actionClose={
+                <AlertActionCloseButton
+                  title={title}
+                  variantLabel={`${variant} alert`}
+                  onClose={() => this.removeAlert(key)}
+                />
+              }/>
+          ))}
+        </AlertGroup>
+      </React.Fragment>
+    );
+  }
+}
+```
+
+### Singular dynamic alert group with overflow message
+This alert will appear in the page, most likely in response to a user action. Use overflow message to show/hide alerts
+```js
+import React from 'react';
+import { Alert, AlertGroup, AlertVariant, AlertActionCloseButton, InputGroup } from '@patternfly/react-core';
+class SingularAdditiveAlertGroup extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      alerts: [],
+      maxDisplayed: "4",
+      overflowMessage: '',
+      showAll: false
+    };
+    this.getOverflowMessage = (alertsNumber, showAll = this.state.showAll) => {
+      if (alertsNumber > this.state.maxDisplayed) {
+        if (showAll) {
+          return "Hide " + (alertsNumber - this.state.maxDisplayed) + " alerts";
+        }
+        return "View " + (alertsNumber - this.state.maxDisplayed) + " more alerts";
+      }
+      return '';
+    };
+    this.addAlert = (title, variant, key) => {
+      this.setState({
+        ...this.state,
+        alerts: [ ...this.state.alerts, { title: title, variant: variant, key }],
+        overflowMessage: this.getOverflowMessage(this.state.alerts.length + 1)
+      });
+    };
+    this.removeAlert = key => {
+      const newAlerts = [...this.state.alerts.filter(el => el.key !== key)];
+      this.setState({
+        ...this.state,
+        alerts: newAlerts,
+        overflowMessage: this.getOverflowMessage(newAlerts.length)
+      });
+    };
+  }
+  render() {
+    const btnClasses = ['pf-c-button', 'pf-m-secondary'].join(' ');
+    const getUniqueId = () => (new Date().getTime());
+    const addSuccessAlert = () => { this.addAlert('Single success alert', 'success', getUniqueId()) };
+    const addDangerAlert = () => { this.addAlert('Single danger alert', 'danger', getUniqueId()) };
+    const addInfoAlert = () => { this.addAlert('Single info alert', 'info', getUniqueId()) };
+    const onOverflowClick = () => { this.setState({
+      ...this.state,
+      overflowMessage: this.getOverflowMessage(this.state.alerts.length, !this.state.showAll),
+      showAll: !this.state.showAll
+    })};
+    return (
+      <React.Fragment>
+        <InputGroup style={{ marginBottom: '16px' }}>
+          <button onClick={addSuccessAlert} type="button" className={btnClasses}>Add single success alert</button>
+          <button onClick={addDangerAlert} type="button" className={btnClasses}>Add single danger alert</button>
+          <button onClick={addInfoAlert} type="button" className={btnClasses}>Add single info alert</button>
+        </InputGroup>
+        <AlertGroup isLiveRegion maxDisplayed={this.state.maxDisplayed}
+          overflowMessage={this.state.overflowMessage} onOverflowClick={onOverflowClick}>
+          {this.state.alerts.slice(0, this.state.showAll ? this.state.alerts.length : this.state.maxDisplayed).map(({ title, variant, key }) => (
             <Alert
               isInline
               variant={AlertVariant[variant]}

--- a/packages/react-core/src/components/AlertGroup/examples/AlertGroup.md
+++ b/packages/react-core/src/components/AlertGroup/examples/AlertGroup.md
@@ -80,7 +80,7 @@ class ToastAlertGroup extends React.Component {
 
 ### Toast alert group with overflow capture
 After a specified number of alerts displayed is reached, we will see an overflow message instead of new alerts. Alerts asynchronously appended into dynamic AlertGroups with `isLiveRegion` will be announced to assistive technology at the moment the change happens. When the overflow message appears or is updated in AlertGroups with `isLiveRegion`, the `View 1 more alert` text will be read, but the alert message will not be read. screen reader user or keyboard user will need a way to navigate to and reveal the hidden alerts before they disappear. Alternatively, there should be a place that notifications or alerts are collected to be viewed or read later.
-```js
+```js isBeta
 import React from 'react';
 import { Alert, AlertGroup, AlertActionCloseButton, AlertVariant, InputGroup } from '@patternfly/react-core';
 class ToastAlertGroup extends React.Component {
@@ -89,15 +89,11 @@ class ToastAlertGroup extends React.Component {
     this.state = {
       alerts: [],
       maxDisplayed: "4",
-      overflowMessage: '',
-      showAll: false
+      overflowMessage: ''
     };
-    this.getOverflowMessage = (alertsNumber, showAll = this.state.showAll) => {
+    this.getOverflowMessage = (alertsNumber) => {
       const overflow = alertsNumber - this.state.maxDisplayed;
       if (overflow > 0) {
-        if (showAll) {
-          return "Hide " + (overflow) + " alerts";
-        }
         return "View " + (overflow) + " more alerts";
       }
       return '';
@@ -124,11 +120,9 @@ class ToastAlertGroup extends React.Component {
     const addSuccessAlert = () => { this.addAlert('Toast success alert', 'success', getUniqueId()) };
     const addDangerAlert = () => { this.addAlert('Toast danger alert', 'danger', getUniqueId()) };
     const addInfoAlert = () => { this.addAlert('Toast info alert', 'info', getUniqueId()) };
-    const onOverflowClick = () => { this.setState({
-      ...this.state,
-      overflowMessage: this.getOverflowMessage(this.state.alerts.length, !this.state.showAll),
-      showAll: !this.state.showAll
-    })};
+    const onOverflowClick = () => {
+      console.log('Overflow message clicked');
+    };
     return (
       <React.Fragment>
         <InputGroup style={{ marginBottom: '16px' }}>
@@ -137,105 +131,7 @@ class ToastAlertGroup extends React.Component {
           <button onClick={addInfoAlert} type="button" className={btnClasses}>Add toast info alert</button>
         </InputGroup>
         <AlertGroup isToast isLiveRegion onOverflowClick={onOverflowClick} maxDisplayed={this.state.maxDisplayed} overflowMessage={this.state.overflowMessage}>
-          {this.state.alerts.slice(0, this.state.showAll ? this.state.alerts.length : this.state.maxDisplayed).map(({key, variant, title}) => (
-            <Alert
-              variant={AlertVariant[variant]}
-              title={title}
-              actionClose={
-                <AlertActionCloseButton
-                  title={title}
-                  variantLabel={`${variant} alert`}
-                  onClose={() => this.removeAlert(key)}
-                />
-              }
-              key={key} />
-          ))}
-        </AlertGroup>
-      </React.Fragment>
-    );
-  }
-}
-```
-
-### Toast alert group with overflow capture, opening into a notification drawer
-After a specified number of alerts displayed is reached, we will see an overflow message instead of new alerts. Alerts asynchronously appended into dynamic AlertGroups with `isLiveRegion` will be announced to assistive technology at the moment the change happens. When the overflow message appears or is updated in AlertGroups with `isLiveRegion`, the `View 1 more alert` text will be read, but the alert message will not be read. screen reader user or keyboard user will need a way to navigate to and reveal the hidden alerts before they disappear. Alternatively, there should be a place that notifications or alerts are collected to be viewed or read later.
-```js
-import React from 'react';
-import { Alert, AlertGroup, AlertActionCloseButton, AlertVariant, InputGroup,
-NotificationDrawer, NotificationDrawerHeader, NotificationDrawerBody, NotificationDrawerList, 
-NotificationDrawerListItem, NotificationDrawerListItemHeader, NotificationDrawerListItemBody } from '@patternfly/react-core';
-class ToastAlertGroup extends React.Component {
-  constructor() {
-    super();
-    this.state = {
-      alerts: [],
-      maxDisplayed: "4",
-      overflowMessage: '',
-      showAll: false
-    };
-    this.getOverflowMessage = (alertsNumber, showAll = this.state.showAll) => {
-      const overflow = alertsNumber - this.state.maxDisplayed;
-      if (overflow > 0) {
-        if (showAll) {
-          return "Show alerts here";
-        }
-        return "View " + (overflow) + " more alerts in the notification drawer";
-      }
-      return '';
-    };
-    this.addAlert = (title, variant, key) => {
-      this.setState({
-        ...this.state,
-        alerts: [ ...this.state.alerts, { title: title, variant: variant, key }],
-        overflowMessage: this.getOverflowMessage(this.state.alerts.length + 1)
-      });
-    };
-    this.removeAlert = key => {
-      const newAlerts = [...this.state.alerts.filter(el => el.key !== key)];
-      this.setState({
-        ...this.state,
-        alerts: newAlerts,
-        overflowMessage: this.getOverflowMessage(newAlerts.length)
-      });
-    };
-  }
-  render() {
-    const btnClasses = ['pf-c-button', 'pf-m-secondary'].join(' ');
-    const getUniqueId = () => (new Date().getTime());
-    const addSuccessAlert = () => { this.addAlert('Toast success alert', 'success', getUniqueId()) };
-    const addDangerAlert = () => { this.addAlert('Toast danger alert', 'danger', getUniqueId()) };
-    const addInfoAlert = () => { this.addAlert('Toast info alert', 'info', getUniqueId()) };
-    const onOverflowClick = () => { this.setState({
-      ...this.state,
-      overflowMessage: this.getOverflowMessage(this.state.alerts.length, !this.state.showAll),
-      showAll: !this.state.showAll
-    })};
-    return (
-      <React.Fragment>
-        <InputGroup style={{ marginBottom: '16px' }}>
-          <button onClick={addSuccessAlert} type="button" className={btnClasses}>Add toast success alert</button>
-          <button onClick={addDangerAlert} type="button" className={btnClasses}>Add toast danger alert</button>
-          <button onClick={addInfoAlert} type="button" className={btnClasses}>Add toast info alert</button>
-        </InputGroup>
-        {this.state.showAll && this.state.alerts.length && <NotificationDrawer>
-          <NotificationDrawerHeader onClose={onOverflowClick}></NotificationDrawerHeader>
-          <NotificationDrawerBody>
-            <NotificationDrawerList>
-              {this.state.showAll && this.state.alerts.length && this.state.alerts.map(({key, variant, title}) => (
-              <NotificationDrawerListItem variant={AlertVariant[variant]}>
-                <NotificationDrawerListItemHeader
-                  variant={AlertVariant[variant]}
-                  title={title}
-                >
-                </NotificationDrawerListItemHeader>
-              </NotificationDrawerListItem>
-              ))}
-            </NotificationDrawerList>
-          </NotificationDrawerBody>
-        </NotificationDrawer>
-        }
-        <AlertGroup isToast isLiveRegion onOverflowClick={onOverflowClick} maxDisplayed={this.state.maxDisplayed} overflowMessage={this.state.overflowMessage}>
-          {this.state.alerts.slice(0, this.state.showAll ? 0 : this.state.maxDisplayed).map(({key, variant, title}) => (
+          {this.state.alerts.slice(0, this.state.maxDisplayed).map(({key, variant, title}) => (
             <Alert
               variant={AlertVariant[variant]}
               title={title}
@@ -309,8 +205,8 @@ class SingularAdditiveAlertGroup extends React.Component {
 ```
 
 ### Singular dynamic alert group with overflow message
-This alert will appear in the page, most likely in response to a user action. Use overflow message to show/hide alerts
-```js
+This alert will appear in the page, most likely in response to a user action.
+```js isBeta
 import React from 'react';
 import { Alert, AlertGroup, AlertVariant, AlertActionCloseButton, InputGroup } from '@patternfly/react-core';
 class SingularAdditiveAlertGroup extends React.Component {
@@ -319,15 +215,11 @@ class SingularAdditiveAlertGroup extends React.Component {
     this.state = {
       alerts: [],
       maxDisplayed: "4",
-      overflowMessage: '',
-      showAll: false
+      overflowMessage: ''
     };
-    this.getOverflowMessage = (alertsNumber, showAll = this.state.showAll) => {
+    this.getOverflowMessage = (alertsNumber) => {
       const overflow = alertsNumber - this.state.maxDisplayed;
       if (overflow > 0) {
-        if (showAll) {
-          return "Hide " + (overflow) + " alerts";
-        }
         return "View " + (overflow) + " more alerts";
       }
       return '';
@@ -354,11 +246,9 @@ class SingularAdditiveAlertGroup extends React.Component {
     const addSuccessAlert = () => { this.addAlert('Single success alert', 'success', getUniqueId()) };
     const addDangerAlert = () => { this.addAlert('Single danger alert', 'danger', getUniqueId()) };
     const addInfoAlert = () => { this.addAlert('Single info alert', 'info', getUniqueId()) };
-    const onOverflowClick = () => { this.setState({
-      ...this.state,
-      overflowMessage: this.getOverflowMessage(this.state.alerts.length, !this.state.showAll),
-      showAll: !this.state.showAll
-    })};
+    const onOverflowClick = () => {
+      console.log('Overflow message clicked');
+    };
     return (
       <React.Fragment>
         <InputGroup style={{ marginBottom: '16px' }}>
@@ -368,7 +258,7 @@ class SingularAdditiveAlertGroup extends React.Component {
         </InputGroup>
         <AlertGroup isLiveRegion maxDisplayed={this.state.maxDisplayed}
           overflowMessage={this.state.overflowMessage} onOverflowClick={onOverflowClick}>
-          {this.state.alerts.slice(0, this.state.showAll ? this.state.alerts.length : this.state.maxDisplayed).map(({ title, variant, key }) => (
+          {this.state.alerts.slice(0, this.state.maxDisplayed).map(({ title, variant, key }) => (
             <Alert
               isInline
               variant={AlertVariant[variant]}

--- a/packages/react-core/src/components/AlertGroup/examples/AlertGroup.md
+++ b/packages/react-core/src/components/AlertGroup/examples/AlertGroup.md
@@ -79,7 +79,7 @@ class ToastAlertGroup extends React.Component {
 ```
 
 ### Toast alert group with overflow capture
-After a specified number of alerts displayed is reached, we will see an overflow message instead of new alerts. Alerts asynchronously appended into dynamic AlertGroups with `isLiveRegion` will be announced to assistive technology at the moment the change happens. When the overflow message appears or is updated in AlertGroups with `isLiveRegion`, the `View 1 more alert` text will be read, but the alert message will not be read. screen reader user or keyboard user will need a way to navigate to and reveal the hidden alerts before they disappear. Alternatively, there should be a place that notifications or alerts are collected to be viewed or read later.
+After a specified number of alerts displayed is reached, we will see an overflow message instead of new alerts. Alerts asynchronously appended into dynamic AlertGroups with `isLiveRegion` will be announced to assistive technology at the moment the change happens. When the overflow message appears or is updated in AlertGroups with `isLiveRegion`, the `View 1 more alert` text will be read, but the alert message will not be read. screen reader user or keyboard user will need a way to navigate to and reveal the hidden alerts before they disappear. Alternatively, there should be a place that notifications or alerts are collected to be viewed or read later. In this example we are showing a max of 4 alerts.
 ```js isBeta
 import React from 'react';
 import { Alert, AlertGroup, AlertActionCloseButton, AlertVariant, InputGroup } from '@patternfly/react-core';
@@ -130,7 +130,7 @@ class ToastAlertGroup extends React.Component {
           <button onClick={addDangerAlert} type="button" className={btnClasses}>Add toast danger alert</button>
           <button onClick={addInfoAlert} type="button" className={btnClasses}>Add toast info alert</button>
         </InputGroup>
-        <AlertGroup isToast isLiveRegion onOverflowClick={onOverflowClick} maxDisplayed={this.state.maxDisplayed} overflowMessage={this.state.overflowMessage}>
+        <AlertGroup isToast isLiveRegion onOverflowClick={onOverflowClick} overflowMessage={this.state.overflowMessage}>
           {this.state.alerts.slice(0, this.state.maxDisplayed).map(({key, variant, title}) => (
             <Alert
               variant={AlertVariant[variant]}
@@ -205,7 +205,7 @@ class SingularAdditiveAlertGroup extends React.Component {
 ```
 
 ### Singular dynamic alert group with overflow message
-This alert will appear in the page, most likely in response to a user action.
+This alert will appear in the page, most likely in response to a user action. In this example we are showing a max of 4 alerts.
 ```js isBeta
 import React from 'react';
 import { Alert, AlertGroup, AlertVariant, AlertActionCloseButton, InputGroup } from '@patternfly/react-core';
@@ -256,8 +256,7 @@ class SingularAdditiveAlertGroup extends React.Component {
           <button onClick={addDangerAlert} type="button" className={btnClasses}>Add single danger alert</button>
           <button onClick={addInfoAlert} type="button" className={btnClasses}>Add single info alert</button>
         </InputGroup>
-        <AlertGroup isLiveRegion maxDisplayed={this.state.maxDisplayed}
-          overflowMessage={this.state.overflowMessage} onOverflowClick={onOverflowClick}>
+        <AlertGroup isLiveRegion overflowMessage={this.state.overflowMessage} onOverflowClick={onOverflowClick}>
           {this.state.alerts.slice(0, this.state.maxDisplayed).map(({ title, variant, key }) => (
             <Alert
               isInline

--- a/packages/react-core/src/components/AlertGroup/examples/AlertGroup.md
+++ b/packages/react-core/src/components/AlertGroup/examples/AlertGroup.md
@@ -78,6 +78,84 @@ class ToastAlertGroup extends React.Component {
 }
 ```
 
+### Toast alert group with overflow capture
+After a specified number of alerts displayed is reached, we will see an overflow message instead of new alerts.
+```js
+import React from 'react';
+import { Alert, AlertGroup, AlertActionCloseButton, AlertVariant, InputGroup } from '@patternfly/react-core';
+class ToastAlertGroup extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      alerts: [],
+      maxDisplayed: "4",
+      overflowMessage: '',
+      showAll: false
+    };
+    this.getOverflowMessage = (alertsNumber, showAll = this.state.showAll) => {
+      if (alertsNumber > this.state.maxDisplayed) {
+        if (showAll) {
+          return "Hide " + (alertsNumber - this.state.maxDisplayed) + " alerts";
+        }
+        return "View " + (alertsNumber - this.state.maxDisplayed) + " more alerts";
+      }
+      return '';
+    }
+    this.addAlert = (title, variant, key) => {
+      this.setState({
+        ...this.state,
+        alerts: [ ...this.state.alerts, { title: title, variant: variant, key }],
+        overflowMessage: this.getOverflowMessage(this.state.alerts.length + 1)
+      });
+    };
+    this.removeAlert = key => {
+      const newAlerts = [...this.state.alerts.filter(el => el.key !== key)];
+      this.setState({
+        ...this.state,
+        alerts: newAlerts,
+        overflowMessage: this.getOverflowMessage(newAlerts.length)
+      });
+    };
+  }
+  render() {
+    const btnClasses = ['pf-c-button', 'pf-m-secondary'].join(' ');
+    const getUniqueId = () => (new Date().getTime());
+    const addSuccessAlert = () => { this.addAlert('Toast success alert', 'success', getUniqueId()) };
+    const addDangerAlert = () => { this.addAlert('Toast danger alert', 'danger', getUniqueId()) };
+    const addInfoAlert = () => { this.addAlert('Toast info alert', 'info', getUniqueId()) };
+    const onOverflowClick = () => { console.log(this.state.alerts); this.setState({
+      ...this.state,
+      overflowMessage: this.getOverflowMessage(this.state.alerts.length, !this.state.showAll),
+      showAll: !this.state.showAll
+    })};
+    return (
+      <React.Fragment>
+        <InputGroup style={{ marginBottom: '16px' }}>
+          <button onClick={addSuccessAlert} type="button" className={btnClasses}>Add toast success alert</button>
+          <button onClick={addDangerAlert} type="button" className={btnClasses}>Add toast danger alert</button>
+          <button onClick={addInfoAlert} type="button" className={btnClasses}>Add toast info alert</button>
+        </InputGroup>
+        <AlertGroup isToast isLiveRegion onOverflowClick={onOverflowClick} maxDisplayed={this.state.maxDisplayed} overflowMessage={this.state.overflowMessage}>
+          {this.state.alerts.slice(0, this.state.showAll ? this.state.alerts.length : this.state.maxDisplayed).map(({key, variant, title}) => (
+            <Alert
+              variant={AlertVariant[variant]}
+              title={title}
+              actionClose={
+                <AlertActionCloseButton
+                  title={title}
+                  variantLabel={`${variant} alert`}
+                  onClose={() => this.removeAlert(key)}
+                />
+              }
+              key={key} />
+          ))}
+        </AlertGroup>
+      </React.Fragment>
+    );
+  }
+}
+```
+
 ### Singular dynamic alert group
 This alert will appear in the page, most likely in response to a user action.
 ```js


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6890 - ability to add an overflow alert which can be clicked, examples using this to limit number of displayed alerts and the ability to click to see those that are hidden

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
