### PR TITLE
fix(topology): Revert removal of NodeShape.circle, allow for either circle or ellipse

### DIFF
--- a/packages/react-topology/src/components/groups/DefaultGroupExpanded.tsx
+++ b/packages/react-topology/src/components/groups/DefaultGroupExpanded.tsx
@@ -103,7 +103,7 @@ const DefaultGroupExpanded: React.FC<DefaultGroupExpandedProps> = ({
   const points: (PointWithSize | PointTuple)[] = React.useMemo(() => {
     const newPoints: (PointWithSize | PointTuple)[] = [];
     _.forEach(children, c => {
-      if (c.getNodeShape() === NodeShape.ellipse) {
+      if (c.getNodeShape() === NodeShape.ellipse || c.getNodeShape() === NodeShape.circle) {
         const bounds = c.getBounds();
         const { width, height } = bounds;
         const { x, y } = bounds.getCenter();

--- a/packages/react-topology/src/components/nodes/shapes/shapeUtils.ts
+++ b/packages/react-topology/src/components/nodes/shapes/shapeUtils.ts
@@ -74,6 +74,7 @@ export const getPathForSides = (numSides: number, size: number, padding = 0): st
 
 export const getShapeComponent = (node: Node): React.FC<ShapeProps> => {
   switch (node.getNodeShape()) {
+    case NodeShape.circle:
     case NodeShape.ellipse:
       return Ellipse;
     case NodeShape.stadium:
@@ -106,6 +107,7 @@ export const getDefaultShapeDecoratorCenter = (
   let deltaY = height / 2 + radius / 3;
 
   switch (shape) {
+    case NodeShape.circle:
     case NodeShape.ellipse:
       return {
         x: nodeCenterX + Math.cos(quadrantRadians(quadrant)) * deltaX,

--- a/packages/react-topology/src/types.ts
+++ b/packages/react-topology/src/types.ts
@@ -37,6 +37,7 @@ export enum TopologyQuadrant {
 }
 
 export enum NodeShape {
+  circle = 'circle', // backward compatibility
   ellipse = 'ellipse',
   rect = 'rect',
   rhombus = 'rhombus',


### PR DESCRIPTION
**What**: 
Closes https://github.com/patternfly/patternfly-react/issues/6959

Adds NodeShape.circle back, treat NodeShape.circle as equivalent to NodeShape.ellipse.

