### PR TITLE
demo: date select dropdown

### DIFF
--- a/packages/react-core/src/demos/ComposableMenu/ComposableMenu.md
+++ b/packages/react-core/src/demos/ComposableMenu/ComposableMenu.md
@@ -28,31 +28,26 @@ Composable menus currently require consumer keyboard handling and use of our und
 ### Composable simple dropdown
 
 ```ts file="./examples/ComposableSimpleDropdown.tsx"
-
 ```
 
 ### Composable actions menu
 
 ```ts file="./examples/ComposableActionsMenu.tsx"
-
 ```
 
 ### Composable simple select
 
 ```ts file="./examples/ComposableSimpleSelect.tsx"
-
 ```
 
 ### Composable drilldown menu
 
 ```ts isBeta file="./examples/ComposableDrilldownMenu.tsx"
-
 ```
 
 ### Composable tree view menu
 
 ```ts file="./examples/ComposableTreeViewMenu.tsx"
-
 ```
 
 ### Composable flyout
@@ -60,29 +55,29 @@ Composable menus currently require consumer keyboard handling and use of our und
 The flyout will automatically position to the left or top if it would otherwise go outside the window. The menu must be placed in a container outside the main content like Popper, [Popover](/components/popover) or [Tooltip](/components/tooltip) since it may go over the side nav.
 
 ```ts isBeta file="./examples/ComposableFlyout.tsx"
-
 ```
 
 ### Composable application launcher
 
 ```ts file="./examples/ComposableApplicationLauncher.tsx"
-
 ```
 
 ### Composable context selector
 
 ```ts file="./examples/ComposableContextSelector.tsx"
-
 ```
 
 ### Composable options menu variants
 
 ```ts file="./examples/ComposableOptionsMenuVariants.tsx"
-
 ```
 
 ### Composable dropdown variants
 
 ```ts file="./examples/ComposableDropdwnVariants.tsx"
+```
 
+### Composable date select
+
+```ts file="./examples/ComposableDateSelect.tsx"
 ```

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableDateSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableDateSelect.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MenuToggle, Menu, MenuContent, MenuList, MenuItem, Popper, Flex } from '@patternfly/react-core';
+import { MenuToggle, Menu, MenuContent, MenuList, MenuItem, Popper, Flex, FlexItem } from '@patternfly/react-core';
 
 export const ComposableSimpleDropdown: React.FunctionComponent = () => {
   const [isOpen, setIsOpen] = React.useState(false);
@@ -91,18 +91,9 @@ export const ComposableSimpleDropdown: React.FunctionComponent = () => {
   };
 
   const toggle = (
-    <MenuToggle
-      ref={toggleRef}
-      onClick={onToggleClick}
-      isExpanded={isOpen}
-      style={
-        {
-          '--pf-c-menu--Width': '250px'
-        } as React.CSSProperties
-      }
-    >
+    <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen} style={{ minWidth: '250px' }}>
       <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
-        {toggleText[selected]}
+        <FlexItem>{toggleText[selected]}</FlexItem>
         {dateText[selected]}
       </Flex>
     </MenuToggle>

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableDateSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableDateSelect.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { MenuToggle, Menu, MenuContent, MenuList, MenuItem, Popper } from '@patternfly/react-core';
+
+export const ComposableSimpleDropdown: React.FunctionComponent = () => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const toggleRef = React.useRef<HTMLButtonElement>();
+  const menuRef = React.useRef<HTMLDivElement>();
+  const [selected, setSelected] = React.useState<number>(0);
+
+  const handleMenuKeys = (event: KeyboardEvent) => {
+    if (!isOpen) {
+      return;
+    }
+    if (menuRef.current.contains(event.target as Node) || toggleRef.current.contains(event.target as Node)) {
+      if (event.key === 'Escape' || event.key === 'Tab') {
+        setIsOpen(!isOpen);
+        toggleRef.current.focus();
+      }
+    }
+  };
+
+  const handleClickOutside = (event: MouseEvent) => {
+    if (isOpen && !menuRef.current.contains(event.target as Node)) {
+      setIsOpen(false);
+    }
+  };
+
+  React.useEffect(() => {
+    window.addEventListener('keydown', handleMenuKeys);
+    window.addEventListener('click', handleClickOutside);
+    return () => {
+      window.removeEventListener('keydown', handleMenuKeys);
+      window.removeEventListener('click', handleClickOutside);
+    };
+  }, [isOpen, menuRef]);
+
+  const onToggleClick = (ev: React.MouseEvent) => {
+    ev.stopPropagation(); // Stop handleClickOutside from handling
+    setTimeout(() => {
+      if (menuRef.current) {
+        const firstElement = menuRef.current.querySelector('li > button:not(:disabled)');
+        firstElement && (firstElement as HTMLElement).focus();
+      }
+    }, 0);
+    setIsOpen(!isOpen);
+  };
+
+  const monthStrings = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December'
+  ];
+
+  const dateString = (date: Date) => `${monthStrings[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()}`;
+
+  const date = new Date();
+
+  const toggleText = {
+    0: 'Today ',
+    1: 'Yesterday ',
+    2: 'Last 7 days ',
+    3: 'Last 14 days ',
+    4: 'Custom'
+  };
+
+  const dateText = {
+    0: <small className="pf-u-color-200">({dateString(date)})</small>,
+    1: (
+      <small className="pf-u-color-200">
+        ({dateString(new Date(new Date().setDate(date.getDate() - 1)))} - {dateString(date)})
+      </small>
+    ),
+    2: (
+      <small className="pf-u-color-200">
+        ({dateString(new Date(new Date().setDate(date.getDate() - 7)))} - {dateString(date)})
+      </small>
+    ),
+    3: (
+      <small className="pf-u-color-200">
+        ({dateString(new Date(new Date().setDate(date.getDate() - 14)))} - {dateString(date)})
+      </small>
+    ),
+    4: ''
+  };
+
+  const toggle = (
+    <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
+      {toggleText[selected]} {dateText[selected]}
+    </MenuToggle>
+  );
+  const menu = (
+    // eslint-disable-next-line no-console
+    <Menu ref={menuRef} onSelect={(_ev, itemId) => setSelected(itemId as number)} selected={selected}>
+      <MenuContent>
+        <MenuList>
+          <MenuItem itemId={0}>Today</MenuItem>
+          <MenuItem itemId={1}>Yesterday</MenuItem>
+          <MenuItem itemId={2}>Last 7 days</MenuItem>
+          <MenuItem itemId={3}>Last 14 days</MenuItem>
+          <MenuItem itemId={4}>Custom</MenuItem>
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+  return <Popper trigger={toggle} popper={menu} isVisible={isOpen} popperMatchesTriggerWidth={false} />;
+};

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableDateSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableDateSelect.tsx
@@ -91,7 +91,16 @@ export const ComposableSimpleDropdown: React.FunctionComponent = () => {
   };
 
   const toggle = (
-    <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
+    <MenuToggle
+      ref={toggleRef}
+      onClick={onToggleClick}
+      isExpanded={isOpen}
+      style={
+        {
+          '--pf-c-menu--Width': '250px'
+        } as React.CSSProperties
+      }
+    >
       <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
         {toggleText[selected]}
         {dateText[selected]}

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableDateSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableDateSelect.tsx
@@ -68,8 +68,7 @@ export const ComposableSimpleDropdown: React.FunctionComponent = () => {
     0: 'Today ',
     1: 'Yesterday ',
     2: 'Last 7 days ',
-    3: 'Last 14 days ',
-    4: 'Custom'
+    3: 'Last 14 days '
   };
 
   const dateText = {
@@ -88,8 +87,7 @@ export const ComposableSimpleDropdown: React.FunctionComponent = () => {
       <small className="pf-u-color-200">
         ({dateString(new Date(new Date().setDate(date.getDate() - 14)))} - {dateString(date)})
       </small>
-    ),
-    4: ''
+    )
   };
 
   const toggle = (
@@ -106,7 +104,6 @@ export const ComposableSimpleDropdown: React.FunctionComponent = () => {
           <MenuItem itemId={1}>Yesterday</MenuItem>
           <MenuItem itemId={2}>Last 7 days</MenuItem>
           <MenuItem itemId={3}>Last 14 days</MenuItem>
-          <MenuItem itemId={4}>Custom</MenuItem>
         </MenuList>
       </MenuContent>
     </Menu>

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableDateSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableDateSelect.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MenuToggle, Menu, MenuContent, MenuList, MenuItem, Popper } from '@patternfly/react-core';
+import { MenuToggle, Menu, MenuContent, MenuList, MenuItem, Popper, Flex } from '@patternfly/react-core';
 
 export const ComposableSimpleDropdown: React.FunctionComponent = () => {
   const [isOpen, setIsOpen] = React.useState(false);
@@ -92,7 +92,10 @@ export const ComposableSimpleDropdown: React.FunctionComponent = () => {
 
   const toggle = (
     <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
-      {toggleText[selected]} {dateText[selected]}
+      <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+        {toggleText[selected]}
+        {dateText[selected]}
+      </Flex>
     </MenuToggle>
   );
   const menu = (

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableDateSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableDateSelect.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MenuToggle, Menu, MenuContent, MenuList, MenuItem, Popper, Flex, FlexItem } from '@patternfly/react-core';
+import { MenuToggle, Menu, MenuContent, MenuList, MenuItem, Popper } from '@patternfly/react-core';
 
 export const ComposableSimpleDropdown: React.FunctionComponent = () => {
   const [isOpen, setIsOpen] = React.useState(false);
@@ -92,10 +92,8 @@ export const ComposableSimpleDropdown: React.FunctionComponent = () => {
 
   const toggle = (
     <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen} style={{ minWidth: '250px' }}>
-      <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
-        <FlexItem>{toggleText[selected]}</FlexItem>
-        {dateText[selected]}
-      </Flex>
+      <span style={{ verticalAlign: 'middle', marginRight: '8px' }}>{toggleText[selected]}</span>
+      {dateText[selected]}
     </MenuToggle>
   );
   const menu = (


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6460

Adds a new date select demo to the composable menu demos page (can be moved if it's better in another place).

@mcarrano @mmenestr Does this match the design well enough re: the lighter/smaller grey text for the date? Also is the "custom" option supposed to function differently for this specific demo or will that be a follow up?
