### PR TITLE
fix(NotificationDrawer): Drawer receives focus after opening

### DIFF
--- a/packages/react-core/src/components/NotificationDrawer/NotificationDrawer.tsx
+++ b/packages/react-core/src/components/NotificationDrawer/NotificationDrawer.tsx
@@ -8,7 +8,7 @@ export interface NotificationDrawerProps extends React.HTMLProps<HTMLDivElement>
   children?: React.ReactNode;
   /**  Additional classes added to the notification drawer */
   className?: string;
-  /** Forwarded ref */
+  /** @hide Forwarded ref */
   innerRef?: React.Ref<any>;
 }
 

--- a/packages/react-core/src/components/NotificationDrawer/NotificationDrawer.tsx
+++ b/packages/react-core/src/components/NotificationDrawer/NotificationDrawer.tsx
@@ -18,7 +18,7 @@ const NotificationDrawerBase: React.FunctionComponent<NotificationDrawerProps> =
   innerRef,
   ...props
 }: NotificationDrawerProps) => (
-  <div ref={innerRef} tabIndex={0} {...props} className={css(styles.notificationDrawer, className)}>
+  <div ref={innerRef} {...props} className={css(styles.notificationDrawer, className)}>
     {children}
   </div>
 );

--- a/packages/react-core/src/components/NotificationDrawer/NotificationDrawer.tsx
+++ b/packages/react-core/src/components/NotificationDrawer/NotificationDrawer.tsx
@@ -8,15 +8,21 @@ export interface NotificationDrawerProps extends React.HTMLProps<HTMLDivElement>
   children?: React.ReactNode;
   /**  Additional classes added to the notification drawer */
   className?: string;
+  /** Forwarded ref */
+  innerRef?: React.Ref<any>;
 }
 
-export const NotificationDrawer: React.FunctionComponent<NotificationDrawerProps> = ({
+const NotificationDrawerBase: React.FunctionComponent<NotificationDrawerProps> = ({
   children,
   className = '',
+  innerRef,
   ...props
 }: NotificationDrawerProps) => (
-  <div {...props} className={css(styles.notificationDrawer, className)}>
+  <div ref={innerRef} tabIndex={0} {...props} className={css(styles.notificationDrawer, className)}>
     {children}
   </div>
 );
+export const NotificationDrawer = React.forwardRef((props: NotificationDrawerProps, ref: React.Ref<any>) => (
+  <NotificationDrawerBase innerRef={ref} {...props} />
+));
 NotificationDrawer.displayName = 'NotificationDrawer';

--- a/packages/react-core/src/components/NotificationDrawer/__tests__/Generated/__snapshots__/NotificationDrawer.test.tsx.snap
+++ b/packages/react-core/src/components/NotificationDrawer/__tests__/Generated/__snapshots__/NotificationDrawer.test.tsx.snap
@@ -1,13 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NotificationDrawer should match snapshot (auto-generated) 1`] = `
-<div>
-  <div
-    class="pf-c-notification-drawer ''"
-  >
-    <div>
-      ReactNode
-    </div>
+<NotificationDrawerBase
+  className="''"
+  innerRef={null}
+>
+  <div>
+    ReactNode
   </div>
-</div>
+</NotificationDrawerBase>
 `;

--- a/packages/react-core/src/components/NotificationDrawer/__tests__/Generated/__snapshots__/NotificationDrawer.test.tsx.snap
+++ b/packages/react-core/src/components/NotificationDrawer/__tests__/Generated/__snapshots__/NotificationDrawer.test.tsx.snap
@@ -1,12 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NotificationDrawer should match snapshot (auto-generated) 1`] = `
-<NotificationDrawerBase
-  className="''"
-  innerRef={null}
->
-  <div>
-    ReactNode
+<div>
+  <div
+    class="pf-c-notification-drawer ''"
+  >
+    <div>
+      ReactNode
+    </div>
   </div>
-</NotificationDrawerBase>
+</div>
 `;

--- a/packages/react-core/src/components/NotificationDrawer/__tests__/__snapshots__/NotificationDrawer.test.tsx.snap
+++ b/packages/react-core/src/components/NotificationDrawer/__tests__/__snapshots__/NotificationDrawer.test.tsx.snap
@@ -1,11 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`className is added to the root element 1`] = `"pf-c-notification-drawer extra-class"`;
+exports[`className is added to the root element 1`] = `"extra-class"`;
 
 exports[`renders with PatternFly Core styles 1`] = `
-<div>
-  <div
-    class="pf-c-notification-drawer"
-  />
-</div>
+<NotificationDrawerBase
+  innerRef={null}
+/>
 `;

--- a/packages/react-core/src/components/NotificationDrawer/__tests__/__snapshots__/NotificationDrawer.test.tsx.snap
+++ b/packages/react-core/src/components/NotificationDrawer/__tests__/__snapshots__/NotificationDrawer.test.tsx.snap
@@ -3,7 +3,9 @@
 exports[`className is added to the root element 1`] = `"extra-class"`;
 
 exports[`renders with PatternFly Core styles 1`] = `
-<NotificationDrawerBase
-  innerRef={null}
-/>
+<div>
+  <div
+    class="pf-c-notification-drawer"
+  />
+</div>
 `;

--- a/packages/react-core/src/demos/NotificationDrawer/NotificationDrawer.md
+++ b/packages/react-core/src/demos/NotificationDrawer/NotificationDrawer.md
@@ -87,6 +87,7 @@ import { Table, TableHeader, TableBody } from '@patternfly/react-table';
 class BasicNotificationDrawer extends React.Component {
   constructor(props) {
     super(props);
+    this.drawerRef = React.createRef();
     this.state = {
       isDropdownOpen: false,
       isKebabDropdownOpen: false,
@@ -178,6 +179,10 @@ class BasicNotificationDrawer extends React.Component {
         isUnreadMap: null,
         showNotifications: showNotifications
       });
+    };
+
+    this.focusDrawer = () => {
+      this.drawerRef.current.focus();
     };
   }
 
@@ -359,7 +364,7 @@ class BasicNotificationDrawer extends React.Component {
     ];
 
     const notificationDrawer = (
-      <NotificationDrawer>
+      <NotificationDrawer ref={this.drawerRef}>
         <NotificationDrawerHeader count={this.getNumberUnread()} onClose={this.onCloseNotificationDrawer}>
           <Dropdown
             onSelect={this.onSelect}
@@ -499,6 +504,7 @@ class BasicNotificationDrawer extends React.Component {
           sidebar={Sidebar}
           isManagedSidebar
           notificationDrawer={notificationDrawer}
+          onNotificationDrawerExpand={this.focusDrawer}
           isNotificationDrawerExpanded={isDrawerExpanded}
           skipToContent={PageSkipToContent}
           breadcrumb={PageBreadcrumb}

--- a/packages/react-core/src/demos/NotificationDrawer/NotificationDrawer.md
+++ b/packages/react-core/src/demos/NotificationDrawer/NotificationDrawer.md
@@ -603,6 +603,7 @@ import { Table, TableHeader, TableBody } from '@patternfly/react-table';
 class GroupedNotificationDrawer extends React.Component {
   constructor(props) {
     super(props);
+    this.drawerRef = React.createRef();
     this.state = {
       isDropdownOpen: false,
       isKebabDropdownOpen: false,
@@ -741,6 +742,12 @@ class GroupedNotificationDrawer extends React.Component {
       this.setState({
         thirdDrawerGroupExpanded: value
       });
+    };
+
+    this.focusDrawer = () => {
+      if (!document.activeElement.closest(`.${this.drawerRef.current.className}`)) {
+        this.drawerRef.current.focus();
+      }
     };
   }
 
@@ -925,7 +932,7 @@ class GroupedNotificationDrawer extends React.Component {
     ];
 
     const notificationDrawer = (
-      <NotificationDrawer>
+      <NotificationDrawer ref={this.drawerRef}>
         <NotificationDrawerHeader count={this.getNumberUnread()} onClose={this.onCloseNotificationDrawer}>
           <Dropdown
             onSelect={this.onSelect}
@@ -1220,6 +1227,7 @@ class GroupedNotificationDrawer extends React.Component {
           isManagedSidebar
           notificationDrawer={notificationDrawer}
           isNotificationDrawerExpanded={isDrawerExpanded}
+          onNotificationDrawerExpand={this.focusDrawer}
           skipToContent={PageSkipToContent}
           breadcrumb={PageBreadcrumb}
           mainContainerId={pageId}

--- a/packages/react-core/src/demos/NotificationDrawer/NotificationDrawer.md
+++ b/packages/react-core/src/demos/NotificationDrawer/NotificationDrawer.md
@@ -19,7 +19,7 @@ import AttentionBellIcon from '@patternfly/react-icons/dist/esm/icons/attention-
 - Focus must be manually managed when the NotificationDrawer component is opened:
 
   1. Create a React `ref` and pass it into the NotificationDrawer component's `ref` attribute
-  2. Pass in a function to the `onNotificationDrawerExpand` prop of the Page component that will place focus on the NotificationDrawer component via the previously created `ref`
+  2. Pass in a function to the `onNotificationDrawerExpand` prop of the Page component that will place focus on the first interact-able element inside the NotificationDrawer component via the previously created `ref`
 
 ### Basic
 
@@ -187,7 +187,8 @@ class BasicNotificationDrawer extends React.Component {
     };
 
     this.focusDrawer = () => {
-      this.drawerRef.current.focus();
+      const firstTabbableItem = this.drawerRef.current.querySelector('a, button');
+      firstTabbableItem.focus();
     };
   }
 
@@ -754,7 +755,8 @@ class GroupedNotificationDrawer extends React.Component {
     this.focusDrawer = () => {
       // Prevent the NotificationDrawer from receiving focus if a drawer group item is opened
       if (!document.activeElement.closest(`.${this.drawerRef.current.className}`)) {
-        this.drawerRef.current.focus();
+        const firstTabbableItem = this.drawerRef.current.querySelector('a, button');
+        firstTabbableItem.focus();
       }
     };
   }

--- a/packages/react-core/src/demos/NotificationDrawer/NotificationDrawer.md
+++ b/packages/react-core/src/demos/NotificationDrawer/NotificationDrawer.md
@@ -16,6 +16,11 @@ import AttentionBellIcon from '@patternfly/react-icons/dist/esm/icons/attention-
 
 ## Demos
 
+- Focus must be manually managed when the NotificationDrawer component is opened:
+
+  1. Create a React `ref` and pass it into the NotificationDrawer component's `ref` attribute
+  2. Pass in a function to the `onNotificationDrawerExpand` prop of the Page component that will place focus on the NotificationDrawer component via the previously created `ref`
+
 ### Basic
 
 ```js isFullscreen
@@ -31,6 +36,7 @@ import {
   CardBody,
   Drawer,
   DrawerContent,
+  DrawerContext,
   DrawerContentBody,
   Dropdown,
   DropdownGroup,
@@ -183,6 +189,7 @@ class BasicNotificationDrawer extends React.Component {
 
     this.focusDrawer = () => {
       this.drawerRef.current.focus();
+      console.log(DrawerContext);
     };
   }
 
@@ -531,6 +538,8 @@ class BasicNotificationDrawer extends React.Component {
 
 ### Grouped
 
+When using the NotificationDrawerGroupList and related components, the function that is passed in to the `onNotificationDrawerExpand` prop on the Page component must also ensure the NotificationDrawer component only receives focus when it is initially opened. Otherwise any time a drawer group item is opened the NotificationDrawer component will receive focus, which would be unexpected behavior for users.
+
 ```js isFullscreen
 import React from 'react';
 import {
@@ -745,6 +754,7 @@ class GroupedNotificationDrawer extends React.Component {
     };
 
     this.focusDrawer = () => {
+      // Prevent the NotificationDrawer from receiving focus if a drawer group item is opened
       if (!document.activeElement.closest(`.${this.drawerRef.current.className}`)) {
         this.drawerRef.current.focus();
       }

--- a/packages/react-core/src/demos/NotificationDrawer/NotificationDrawer.md
+++ b/packages/react-core/src/demos/NotificationDrawer/NotificationDrawer.md
@@ -36,7 +36,6 @@ import {
   CardBody,
   Drawer,
   DrawerContent,
-  DrawerContext,
   DrawerContentBody,
   Dropdown,
   DropdownGroup,
@@ -189,7 +188,6 @@ class BasicNotificationDrawer extends React.Component {
 
     this.focusDrawer = () => {
       this.drawerRef.current.focus();
-      console.log(DrawerContext);
     };
   }
 


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5888 

- Updated the NotificationDrawer component to be similar to the Tab component by using forwardRef to handle placing focus on the NotificationDrawer
- Added instructions on the React Demos page for how to manage focus

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
