### PR TITLE
fix(Select): prevent double enter, cover additional onclose cases

### DIFF
--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -764,12 +764,14 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
               if (shiftKey) {
                 // close toggle if shift key and tab on input
                 this.onToggle(false);
+                this.onClose();
               } else {
                 // tab to first tabbable item in footer
                 if (tabbableItems[0]) {
                   tabbableItems[0].focus();
                 } else {
                   this.onToggle(false);
+                  this.onClose();
                 }
               }
             } else {
@@ -790,6 +792,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
                   // no next item, close toggle
                   this.onToggle(false);
                   this.inputRef.current.focus();
+                  this.onClose();
                 }
               }
             }

--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -671,10 +671,12 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
     const { isOpen, onFavorite } = this.props;
     const { typeaheadCurrIndex, tabbedIntoFavoritesMenu } = this.state;
     const typeaheadActiveChild = this.getTypeaheadActiveChild(typeaheadCurrIndex);
-
     if (isOpen) {
       if (position === 'enter') {
-        if (typeaheadActiveChild || (this.refCollection[0] && this.refCollection[0][0])) {
+        if (
+          typeaheadCurrIndex !== -1 && // do not allow selection without moving to an initial option
+          (typeaheadActiveChild || (this.refCollection[0] && this.refCollection[0][0]))
+        ) {
           this.setState({
             typeaheadInputValue:
               (typeaheadActiveChild && typeaheadActiveChild.innerText) || this.refCollection[0][0].innerText
@@ -753,6 +755,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
           // Close if there is no footer
           if (!this.props.footer) {
             this.onToggle(false);
+            this.onClose();
           } else {
             // has footer
             const tabbableItems = findTabbableElements(this.footerRef, SelectFooterTabbableItems);

--- a/packages/react-core/src/components/Select/SelectToggle.tsx
+++ b/packages/react-core/src/components/Select/SelectToggle.tsx
@@ -320,6 +320,9 @@ export class SelectToggle extends React.Component<SelectToggleProps> {
             onClick={_event => {
               if (!isDisabled) {
                 onToggle(!isOpen);
+                if (isOpen) {
+                  onClose();
+                }
               }
             }}
             onKeyDown={this.onKeyDown}

--- a/packages/react-integration/cypress/integration/select.spec.ts
+++ b/packages/react-integration/cypress/integration/select.spec.ts
@@ -89,6 +89,7 @@ describe('Select Test', () => {
     find('#typeahead-select-select-typeahead').should('have.value', '');
     find('input:nth-child(1)').type('Flo');
     find('#typeahead-select-select-typeahead').should('have.value', 'Flo');
+    find('#typeahead-select-select-typeahead').trigger('keydown', { keyCode: 40 });
     find('#typeahead-select-select-typeahead').trigger('keydown', { keyCode: 13 });
     find('#typeahead-select-select-typeahead').should('have.value', 'Florida');
     find('button.pf-c-select__toggle-clear:first').click();


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6245 & #6756

#6245 - the `enter` selection behavior is now prevented for typeahead until the arrow keys are used to move to an option.

#6756 - added additional `onClose` behaviors to two cases (when input div is manually clicked closed, and when tab is used to navigate off the input div) where the menu is closed but the internal state isn't reset.