### PR TITLE
fix(ClipboardCopy): fix rendering comma issue in some situation

### DIFF
--- a/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
+++ b/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
@@ -92,10 +92,9 @@ export class ClipboardCopy extends React.Component<ClipboardCopyProps, Clipboard
   constructor(props: ClipboardCopyProps) {
     super(props);
     this.state = {
-      text:
-        typeof this.props.children === 'string'
-          ? (this.props.children as string | number)
-          : (this.props.children as string[]).join(''),
+      text: Array.isArray(this.props.children)
+        ? this.props.children.join('')
+        : (this.props.children as string | number),
       expanded: this.props.isExpanded,
       copied: false
     };

--- a/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
+++ b/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
@@ -92,7 +92,10 @@ export class ClipboardCopy extends React.Component<ClipboardCopyProps, Clipboard
   constructor(props: ClipboardCopyProps) {
     super(props);
     this.state = {
-      text: this.props.children as string | number,
+      text:
+        typeof this.props.children === 'string'
+          ? (this.props.children as string | number)
+          : (this.props.children as string[]).join(''),
       expanded: this.props.isExpanded,
       copied: false
     };


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6863
Check the type of the `props.children`, if it's an array then concat it and convert to a string.
