### PR TITLE
feature(topology): Add basic Grid layout to Topology component

### DIFF
--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/TopologyPackage.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/TopologyPackage.tsx
@@ -144,8 +144,11 @@ const TopologyViewComponent: React.FC<TopologyViewComponentProps> = ({ useSideba
             <DropdownItem key={3} onClick={() => updateLayout('Cola')}>
               Cola
             </DropdownItem>,
-            <DropdownItem key={3} onClick={() => updateLayout('ColaNoForce')}>
+            <DropdownItem key={4} onClick={() => updateLayout('ColaNoForce')}>
               ColaNoForce
+            </DropdownItem>,
+            <DropdownItem key={5} onClick={() => updateLayout('Grid')}>
+              Grid
             </DropdownItem>
           ]}
         />

--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/layouts/defaultLayoutFactory.ts
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/layouts/defaultLayoutFactory.ts
@@ -1,4 +1,12 @@
-import { Graph, Layout, LayoutFactory, ForceLayout, ColaLayout, DagreLayout } from '@patternfly/react-topology';
+import {
+  Graph,
+  Layout,
+  LayoutFactory,
+  ForceLayout,
+  ColaLayout,
+  DagreLayout,
+  GridLayout
+} from '@patternfly/react-topology';
 
 const defaultLayoutFactory: LayoutFactory = (type: string, graph: Graph): Layout | undefined => {
   switch (type) {
@@ -10,6 +18,8 @@ const defaultLayoutFactory: LayoutFactory = (type: string, graph: Graph): Layout
       return new DagreLayout(graph);
     case 'Force':
       return new ForceLayout(graph);
+    case 'Grid':
+      return new GridLayout(graph);
     default:
       return new ColaLayout(graph, { layoutOnDrag: false });
   }

--- a/packages/react-topology/src/layouts/GridGroup.ts
+++ b/packages/react-topology/src/layouts/GridGroup.ts
@@ -1,0 +1,2 @@
+import { LayoutGroup } from './LayoutGroup';
+export class GridGroup extends LayoutGroup {}

--- a/packages/react-topology/src/layouts/GridLayout.ts
+++ b/packages/react-topology/src/layouts/GridLayout.ts
@@ -1,0 +1,71 @@
+import { Edge, Graph, Layout, Node } from '../types';
+import { BaseLayout } from './BaseLayout';
+import { LayoutOptions } from './LayoutOptions';
+import { LayoutNode } from './LayoutNode';
+import { LayoutLink } from './LayoutLink';
+import { GridNode } from './GridNode';
+import { GridLink } from './GridLink';
+import { GridGroup } from './GridGroup';
+
+export type GridLayoutOptions = LayoutOptions;
+
+export class GridLayout extends BaseLayout implements Layout {
+  private gridOptions: GridLayoutOptions;
+
+  constructor(graph: Graph, options?: Partial<GridLayoutOptions>) {
+    super(graph, options);
+    this.gridOptions = {
+      ...this.options,
+      ...options
+    };
+  }
+
+  protected createLayoutNode(node: Node, nodeDistance: number, index: number) {
+    return new GridNode(node, nodeDistance, index);
+  }
+
+  protected createLayoutLink(edge: Edge, source: LayoutNode, target: LayoutNode, isFalse: boolean): LayoutLink {
+    return new GridLink(edge, source, target, isFalse);
+  }
+
+  protected createLayoutGroup(node: Node, padding: number, index: number) {
+    return new GridGroup(node, padding, index);
+  }
+
+  protected startLayout(graph: Graph, initialRun: boolean, addingNodes: boolean): void {
+    if (initialRun || addingNodes) {
+      this.nodes.sort((a, b) => a.id.localeCompare(b.id));
+      const totalNodes = this.nodes.length;
+      const maxPerRow = Math.round(Math.sqrt(totalNodes));
+      let x = 0;
+      let y = 0;
+      let rowI = 0;
+      let padX = 0;
+      let padY = 0;
+      for (let i = 0; i < totalNodes; i++) {
+        const node = this.nodes[i];
+        if (padX < node.width) {
+          padX = node.width;
+        }
+        if (padY < node.height) {
+          padY = node.height;
+        }
+      }
+      for (let i = 0; i < totalNodes; i++) {
+        const node = this.nodes[i];
+        node.x = x;
+        node.y = y;
+        node.update();
+
+        if (rowI < maxPerRow) {
+          x += padX;
+          rowI++;
+        } else {
+          rowI = 0;
+          x = 0;
+          y += padY;
+        }
+      }
+    }
+  }
+}

--- a/packages/react-topology/src/layouts/GridLink.ts
+++ b/packages/react-topology/src/layouts/GridLink.ts
@@ -1,0 +1,3 @@
+import { LayoutLink } from './LayoutLink';
+
+export class GridLink extends LayoutLink {}

--- a/packages/react-topology/src/layouts/GridNode.ts
+++ b/packages/react-topology/src/layouts/GridNode.ts
@@ -1,0 +1,8 @@
+import { LayoutNode } from './LayoutNode';
+import { Node } from '../types';
+
+export class GridNode extends LayoutNode {
+  constructor(node: Node, distance: number, index: number = -1) {
+    super(node, distance, index);
+  }
+}

--- a/packages/react-topology/src/layouts/index.ts
+++ b/packages/react-topology/src/layouts/index.ts
@@ -2,6 +2,7 @@ export * from './BaseLayout';
 export * from './ColaLayout';
 export * from './DagreLayout';
 export * from './ForceLayout';
+export * from './GridLayout';
 export * from './LayoutNode';
 export * from './LayoutGroup';
 export * from './LayoutLink';


### PR DESCRIPTION
Closes https://github.com/patternfly/patternfly-react/issues/6975

This PR adds a basic grid layout to the topology component:
![image](https://user-images.githubusercontent.com/1662329/155378491-dc2f7c96-4727-40fe-a838-ebb66321f7c7.png)

It's basic, but it offers an "id" ordered grid that may be useful at scale scenarios:
![image](https://user-images.githubusercontent.com/1662329/155379037-1cde6d72-ff78-4586-9433-3b8bca674225.png)

I used it as a learning exercise to get familiar with the topology model, but I think it could be useful in the "demo-app" for layout comparisons.

I'd like to add a couple of more algorithms (in the following/separated PRs) that have good results at scale, like the concentric and breadth-first.

The rationale of this approach is that layout algorithms can introduce performance penalties at scale, so, having "basic" layouts with some tradeoffs could be a good starting point for alternatives.

P.S.: I'm not familiar with the code style of the Patternfly project, please, feel free to suggest how it could be the best way to propose these changes.

Thanks.

cc @jeff-phillips-18 