### PR TITLE
refactor(Nav): make nav group titles optional

### DIFF
--- a/packages/react-core/src/components/Nav/NavGroup.tsx
+++ b/packages/react-core/src/components/Nav/NavGroup.tsx
@@ -5,7 +5,7 @@ import { getUniqueId } from '../../helpers/util';
 
 export interface NavGroupProps extends React.HTMLProps<HTMLDivElement> {
   /** Title shown for the group */
-  title: string;
+  title?: string;
   /** Anything that can be rendered inside of the group */
   children?: React.ReactNode;
   /** Additional classes added to the container */
@@ -20,12 +20,21 @@ export const NavGroup: React.FunctionComponent<NavGroupProps> = ({
   className = '',
   id = getUniqueId(),
   ...props
-}: NavGroupProps) => (
-  <section className={css(styles.navSection, className)} aria-labelledby={id} {...props}>
-    <h2 className={css(styles.navSectionTitle)} id={id}>
-      {title}
-    </h2>
-    <ul className={css(styles.navList, className)}>{children}</ul>
-  </section>
-);
+}: NavGroupProps) => {
+  if (!title && !props['aria-label']) {
+    // eslint-disable-next-line no-console
+    console.warn("For accessibility reasons an aria-label should be specified on nav groups if a title isn't");
+  }
+
+  return (
+    <section className={css(styles.navSection, className)} aria-labelledby={id} {...props}>
+      {title && (
+        <h2 className={css(styles.navSectionTitle)} id={id}>
+          {title}
+        </h2>
+      )}
+      <ul className={css(styles.navList, className)}>{children}</ul>
+    </section>
+  );
+};
 NavGroup.displayName = 'NavGroup';

--- a/packages/react-core/src/components/Nav/NavGroup.tsx
+++ b/packages/react-core/src/components/Nav/NavGroup.tsx
@@ -26,8 +26,10 @@ export const NavGroup: React.FunctionComponent<NavGroupProps> = ({
     console.warn("For accessibility reasons an aria-label should be specified on nav groups if a title isn't");
   }
 
+  const labelledBy = title ? id : undefined;
+
   return (
-    <section className={css(styles.navSection, className)} aria-labelledby={id} {...props}>
+    <section className={css(styles.navSection, className)} aria-labelledby={labelledBy} {...props}>
       {title && (
         <h2 className={css(styles.navSectionTitle)} id={id}>
           {title}

--- a/packages/react-core/src/components/Nav/examples/Nav.md
+++ b/packages/react-core/src/components/Nav/examples/Nav.md
@@ -55,7 +55,7 @@ class NavDefaultList extends React.Component {
 
 ### Grouped
 
-Note: to keep nav groups accessible an aria label should be supplied if a title prop is not passed.
+Note: to keep nav groups accessible an `aria-label` should be supplied if the `title` prop is not passed.
 
 ```js
 import React from 'react';

--- a/packages/react-core/src/components/Nav/examples/Nav.md
+++ b/packages/react-core/src/components/Nav/examples/Nav.md
@@ -55,6 +55,8 @@ class NavDefaultList extends React.Component {
 
 ### Grouped
 
+Note: to keep nav groups accessible an aria label should be supplied if a title prop is not passed.
+
 ```js
 import React from 'react';
 import { Nav, NavExpandable, NavItem, NavItemSeparator, NavList, NavGroup } from '@patternfly/react-core';


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6770

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: N/A

I chose to proceed with the second option I suggested, and implemented the suggestions of @thatblindgeye and @mcoker in that solution.
