### PR TITLE
feature(Topology): Add Concentric layout to Topology component

### DIFF
--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/TopologyPackage.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/TopologyPackage.tsx
@@ -146,6 +146,9 @@ const TopologyViewComponent: React.FC<TopologyViewComponentProps> = ({ useSideba
             </DropdownItem>,
             <DropdownItem key={5} onClick={() => updateLayout('Grid')}>
               Grid
+            </DropdownItem>,
+            <DropdownItem key={6} onClick={() => updateLayout('Concentric')}>
+              Concentric
             </DropdownItem>
           ]}
         />

--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/layouts/defaultLayoutFactory.ts
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/layouts/defaultLayoutFactory.ts
@@ -4,6 +4,7 @@ import {
   LayoutFactory,
   ForceLayout,
   ColaLayout,
+  ConcentricLayout,
   DagreLayout,
   GridLayout
 } from '@patternfly/react-topology';
@@ -14,6 +15,8 @@ const defaultLayoutFactory: LayoutFactory = (type: string, graph: Graph): Layout
       return new ColaLayout(graph);
     case 'ColaNoForce':
       return new ColaLayout(graph, { layoutOnDrag: false });
+    case 'Concentric':
+      return new ConcentricLayout(graph);
     case 'Dagre':
       return new DagreLayout(graph);
     case 'Force':

--- a/packages/react-topology/src/layouts/ConcentricGroup.ts
+++ b/packages/react-topology/src/layouts/ConcentricGroup.ts
@@ -1,0 +1,2 @@
+import { LayoutGroup } from './LayoutGroup';
+export class ConcentricGroup extends LayoutGroup {}

--- a/packages/react-topology/src/layouts/ConcentricLayout.ts
+++ b/packages/react-topology/src/layouts/ConcentricLayout.ts
@@ -1,0 +1,107 @@
+import { Edge, Graph, Layout, Node } from '../types';
+import { BaseLayout } from './BaseLayout';
+import { LayoutOptions } from './LayoutOptions';
+import { LayoutNode } from './LayoutNode';
+import { LayoutLink } from './LayoutLink';
+import { ConcentricNode } from './ConcentricNode';
+import { ConcentricLink } from './ConcentricLink';
+import { ConcentricGroup } from './ConcentricGroup';
+
+export type ConcentricLayoutOptions = LayoutOptions & {
+  splitLevel?: number;
+};
+
+export class ConcentricLayout extends BaseLayout implements Layout {
+  private concentricOptions: ConcentricLayoutOptions;
+
+  constructor(graph: Graph, options?: Partial<ConcentricLayoutOptions>) {
+    super(graph, options);
+    this.concentricOptions = {
+      ...this.options,
+      ...options
+    };
+  }
+
+  protected createLayoutNode(node: Node, nodeDistance: number, index: number) {
+    return new ConcentricNode(node, nodeDistance, index);
+  }
+
+  protected createLayoutLink(edge: Edge, source: LayoutNode, target: LayoutNode, isFalse: boolean): LayoutLink {
+    return new ConcentricLink(edge, source, target, isFalse);
+  }
+
+  protected createLayoutGroup(node: Node, padding: number, index: number) {
+    return new ConcentricGroup(node, padding, index);
+  }
+
+  protected startLayout(graph: Graph, initialRun: boolean, addingNodes: boolean): void {
+    if (initialRun || addingNodes) {
+      const weights = {};
+      this.nodes.forEach(node => {
+        weights[node.id] = { in: 0, out: 0, total: 0 };
+      });
+      this.edges.forEach(edge => {
+        weights[edge.target.id].in++;
+        weights[edge.target.id].total++;
+        weights[edge.source.id].out++;
+        weights[edge.source.id].total++;
+      });
+
+      const nodesWeight = Object.keys(weights).map(k => ({ id: k, total: weights[k].total }));
+      nodesWeight.sort((a: any, b: any) => b.total - a.total);
+
+      const splitLevel = this.concentricOptions.splitLevel ? this.concentricOptions.splitLevel : 4;
+      const levelWidth = nodesWeight.length > 0 ? nodesWeight[0].total / splitLevel : 0;
+      const levels: any = [[]];
+      let currentLevel = levels[0];
+      nodesWeight.forEach(n => {
+        if (currentLevel.length > 0) {
+          const diff = Math.abs(currentLevel[0].total - n.total);
+          if (diff >= levelWidth) {
+            currentLevel = [];
+            levels.push(currentLevel);
+          }
+        }
+
+        currentLevel.push(n);
+      });
+
+      let innerR = 0;
+      let maxWH = 0;
+      // This padding should be configurable
+      const padding = maxWH;
+      if (levels.length > 0) {
+        let maxWidth = 0;
+        let maxHeight = 0;
+        levels[0].forEach((n: any) => {
+          const node = this.nodesMap[n.id];
+          if (maxWidth < node.width) {
+            maxWidth = node.width;
+          }
+          if (maxHeight < node.height) {
+            maxHeight = node.height;
+          }
+        });
+        maxWH = Math.max(maxWidth, maxHeight);
+        innerR = Math.round((levels[0].length * maxWH) / (2 * Math.PI));
+      }
+      const outerR = levels.length * (maxWH + padding) + innerR;
+      const center = {
+        x: outerR + maxWH,
+        y: outerR + maxWH
+      };
+
+      let r = innerR;
+      for (const level of levels) {
+        const theta = (2 * Math.PI) / level.length;
+        for (let j = 0; j < level.length; j++) {
+          const node = this.nodesMap[level[j].id];
+          node.x = center.x + r * Math.cos(theta * j);
+          node.y = center.y + r * Math.sin(theta * j);
+          node.update();
+        }
+        r += maxWH + padding;
+      }
+    }
+  }
+}

--- a/packages/react-topology/src/layouts/ConcentricLink.ts
+++ b/packages/react-topology/src/layouts/ConcentricLink.ts
@@ -1,0 +1,3 @@
+import { LayoutLink } from './LayoutLink';
+
+export class ConcentricLink extends LayoutLink {}

--- a/packages/react-topology/src/layouts/ConcentricNode.ts
+++ b/packages/react-topology/src/layouts/ConcentricNode.ts
@@ -1,0 +1,8 @@
+import { LayoutNode } from './LayoutNode';
+import { Node } from '../types';
+
+export class ConcentricNode extends LayoutNode {
+  constructor(node: Node, distance: number, index: number = -1) {
+    super(node, distance, index);
+  }
+}

--- a/packages/react-topology/src/layouts/index.ts
+++ b/packages/react-topology/src/layouts/index.ts
@@ -1,5 +1,6 @@
 export * from './BaseLayout';
 export * from './ColaLayout';
+export * from './ConcentricLayout';
 export * from './DagreLayout';
 export * from './ForceLayout';
 export * from './GridLayout';


### PR DESCRIPTION
This PR adds a new Concentric layout to the topology component.

Grid layouts work well to distribute nodes without taking into consideration edges,
![image](https://user-images.githubusercontent.com/1662329/157867516-73d1a722-5439-4afe-9b12-281a4eef0780.png)

but Concentric layouts have better results focused on high connectivity:
![image](https://user-images.githubusercontent.com/1662329/157867281-cb1f4782-f44c-4664-97d7-66aeff15952a.png)
![image](https://user-images.githubusercontent.com/1662329/157867639-ee069c4e-263e-4edf-8f90-69f78119a421.png)

It's still experimental as there may be some corner cases not yet implemented, but it could be ready to have some feedback.

cc @jeff-phillips-18 @andrew-ronaldson

P.S: I have a pending optimized BreadthFirst algorithm that we're implementing in Kiali that will come in a future PR.