### PR TITLE
Catalog extension: Add a little bit spacing between title and items

### DIFF
--- a/packages/react-catalog-view-extension/buildSass.js
+++ b/packages/react-catalog-view-extension/buildSass.js
@@ -26,7 +26,7 @@ const res = sass.renderSync({
   importer
 });
 if (!fs.existsSync(outDir)) {
-  fs.mkdirSync(outDir);
+  fs.mkdirSync(outDir, { recursive: true });
 }
 
 fs.writeFileSync(path.join(outDir, 'react-catalog-view-extension.css'), res.css);

--- a/packages/react-catalog-view-extension/package.json
+++ b/packages/react-catalog-view-extension/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/patternfly/patternfly-react/blob/main/packages/react-catalog-view-extension/README.md",
   "scripts": {
-    "generate": "concurrently \"yarn build:sass\" \"yarn copy:sass\"",
+    "generate": "yarn build:sass && yarn copy:sass",
     "build:sass": "node buildSass.js",
     "copy:sass": "shx mkdir -p dist/sass && shx cp -r sass/react-catalog-view-extension/* dist/sass",
     "clean": "rimraf dist"
@@ -40,7 +40,6 @@
     "@patternfly/react-styles": "^4.48.21"
   },
   "devDependencies": {
-    "concurrently": "^5.3.0",
     "rimraf": "^2.6.2",
     "sass": "^1.42.1",
     "shx": "^0.3.2",

--- a/packages/react-catalog-view-extension/sass/react-catalog-view-extension/_filter-side-panel.scss
+++ b/packages/react-catalog-view-extension/sass/react-catalog-view-extension/_filter-side-panel.scss
@@ -14,7 +14,7 @@
 .filter-panel-pf-category-title {
   border: 0;
   font-size: inherit;
-  margin: 0;
+  margin: 0 0 8px 0;
   font-weight: 700;
 }
 

--- a/packages/react-catalog-view-extension/src/components/FilterSidePanel/examples/filterSidePanel.css
+++ b/packages/react-catalog-view-extension/src/components/FilterSidePanel/examples/filterSidePanel.css
@@ -14,7 +14,7 @@
 .filter-panel-pf-category-title {
   border: 0;
   font-size: inherit;
-  margin: 0;
+  margin: 0 0 8px 0;
   font-weight: 700;
 }
 


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7059

Add a small spacing between the catalog sidebar filter title and items.

WHY no variable for this? Because the catalog uses hardcoded px everywhere.

In OpenShift console before:

![helm-charts-before](https://user-images.githubusercontent.com/139310/158140637-c7e925ac-ba19-4d04-96d6-56eaa81ba68a.png)

With this PR:

![after](https://user-images.githubusercontent.com/139310/158140702-6fa74aeb-c19f-4066-b953-78552d74c274.png)

In the documentation example before:

![image](https://user-images.githubusercontent.com/139310/158139952-1e2913c8-e876-494a-8657-987e033b54cb.png)

With this PR:

![image](https://user-images.githubusercontent.com/139310/158140937-b345b366-0c06-40e1-b71e-d4fa55decb4f.png)

You can try this out in this PR codesandbox: https://codesandbox.io/s/react-catalog-sample-ik0m1v?file=/index.js

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
