### PR TITLE
fix(Tooltip): horizontal scroll bar causing misaligned tooltip

### DIFF
--- a/packages/react-core/src/components/Tooltip/examples/Tooltip.md
+++ b/packages/react-core/src/components/Tooltip/examples/Tooltip.md
@@ -105,10 +105,18 @@ OptionsTooltip = () => {
   const [exitDelayInput, setExitDelayInput] = React.useState(0);
   const [animationDuration, setAnimationDuration] = React.useState(300);
   const tipBoxRef = React.useRef(null);
-  const scrollToRef = ref => ref && ref.current && (ref.current.scrollTop = 400);
+  
+  const scrollToRef = ref => {
+    if (ref && ref.current) {
+      ref.current.scrollTop = 400;
+      ref.current.scrollLeft = 300;
+    }
+  }
+  
   React.useEffect(() => {
     scrollToRef(tipBoxRef);
   }, []);
+  
   return (
     <>
       <div>

--- a/packages/react-core/src/components/Tooltip/examples/TooltipExamples.css
+++ b/packages/react-core/src/components/Tooltip/examples/TooltipExamples.css
@@ -2,7 +2,7 @@
   height: 450px;
   position: relative;
   width: 100%;
-  overflow-y: scroll;
+  overflow: scroll;
   overscroll-behavior: contain;
   margin: 0 auto;
   border: 2px dashed #ff6b81;
@@ -12,10 +12,10 @@
 .tooltip-box::after {
   content: '';
   display: block;
-  width: 1px;
+  width: 1500px;
   height: 600px;
 }
 .tooltip-button {
   position: absolute;
-  left: 300px;
+  left: 600px;
 }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6972

The update was made to fix the last example on the tooltip docs.
sometimes the horizontal scrollbar was visible, and sometimes it wasn't... when it was visible, it cause the tooltip to misalign.
I made it so that in this example, the horizontal scrollbar is always visible.