### PR TITLE
fix(Menu): remove rogue scrollbar from drilldown menus

### DIFF
--- a/packages/react-core/src/components/Menu/MenuContent.tsx
+++ b/packages/react-core/src/components/Menu/MenuContent.tsx
@@ -21,8 +21,31 @@ export const MenuContent = React.forwardRef((props: MenuContentProps, ref: React
   const menuContentRef = React.createRef<HTMLDivElement>();
   const refCallback = (el: HTMLElement, menuId: string, onGetMenuHeight: (menuId: string, height: number) => void) => {
     if (el) {
-      // if this menu has a parent MenuList, then we need to account for that parent list's padding.
-      const clientHeight = el.closest(`.${styles.menuList}`) ? el.clientHeight + 16 : el.clientHeight;
+      let clientHeight = el.clientHeight;
+
+      // if this menu is a submenu, we need to account for the root menu list's padding and root menu content's border.
+      let rootMenuList = null;
+      let parentEl = el.closest(`.${styles.menuList}`);
+      while (parentEl !== null && parentEl.nodeType === 1) {
+        if (parentEl.classList.contains(styles.menuList)) {
+          rootMenuList = parentEl;
+        }
+        parentEl = parentEl.parentElement;
+      }
+
+      if (rootMenuList) {
+        const rootMenuListStyles = getComputedStyle(rootMenuList);
+        const rootMenuListPaddingOffset =
+          parseFloat(rootMenuListStyles.getPropertyValue('padding-top').replace(/px/g, '')) +
+          parseFloat(rootMenuListStyles.getPropertyValue('padding-bottom').replace(/px/g, '')) +
+          parseFloat(
+            getComputedStyle(rootMenuList.parentElement)
+              .getPropertyValue('border-bottom-width')
+              .replace(/px/g, '')
+          );
+        clientHeight = clientHeight + rootMenuListPaddingOffset;
+      }
+
       onGetMenuHeight && onGetMenuHeight(menuId, clientHeight);
       getHeight && getHeight(clientHeight.toString());
     }

--- a/packages/react-core/src/components/Menu/MenuContent.tsx
+++ b/packages/react-core/src/components/Menu/MenuContent.tsx
@@ -21,8 +21,10 @@ export const MenuContent = React.forwardRef((props: MenuContentProps, ref: React
   const menuContentRef = React.createRef<HTMLDivElement>();
   const refCallback = (el: HTMLElement, menuId: string, onGetMenuHeight: (menuId: string, height: number) => void) => {
     if (el) {
-      onGetMenuHeight && onGetMenuHeight(menuId, el.clientHeight);
-      getHeight && getHeight(el.clientHeight.toString());
+      // if this menu has a parent MenuList, then we need to account for that parent list's padding.
+      const clientHeight = el.closest(`.${styles.menuList}`) ? el.clientHeight + 16 : el.clientHeight;
+      onGetMenuHeight && onGetMenuHeight(menuId, clientHeight);
+      getHeight && getHeight(clientHeight.toString());
     }
     return ref || menuContentRef;
   };


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6842

unfortunately, the top/bottom padding for the MenuContent is = 0.5rem, so it makes the calculation complicated and dependent on font size. And when I try to load the value of the variable into react for possible calcluations, even that 0.5rem value is overridden by a subsequent rule so I cannot import the variable value directly into the component using react-tokens.
(i.e. `import c_menu__list_PaddingTop from '@patternfly/react-tokens/dist/esm/c_menu__list_PaddingTop';` returns the wrong value).

so for now, I use the default value of 16px, which is what the padding top and bottom defaults to with no custom overrides. Not sure if there is an alternate option right now...