### PR TITLE
fix(react-styles): support esm import and export

### DIFF
--- a/packages/react-styles/scripts/writeClassMaps.js
+++ b/packages/react-styles/scripts/writeClassMaps.js
@@ -15,6 +15,15 @@ exports.default = ${JSON.stringify(classMap, null, 2)};
 `.trim()
   );
 
+const writeESMExport = (file, classMap) =>
+  outputFileSync(
+    join(outDir, file.replace(/.css$/, '.mjs')),
+    `
+import('./${basename(file, '.css.js')}');
+export default ${JSON.stringify(classMap, null, 2)};
+`.trim()
+  );
+
 const writeDTSExport = (file, classMap) =>
   outputFileSync(
     join(outDir, file.replace(/.css$/, '.d.ts')),
@@ -36,6 +45,7 @@ function writeClassMaps(classMaps) {
 
     writeCJSExport(outPath, classMap);
     writeDTSExport(outPath, classMap);
+    writeESMExport(outPath, classMap);
     copyFileSync(file, join(outDir, outPath));
   });
 


### PR DESCRIPTION
The previous version are using `require()`, which is not fully
support esm

Add esm only output to support some pure esm project like vite or
snowpack

<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #

Closes #7054
<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
