### PR TITLE
fix(Card): indicate card selectivity and status if using a screen reader

### DIFF
--- a/packages/react-core/src/components/Card/Card.tsx
+++ b/packages/react-core/src/components/Card/Card.tsx
@@ -36,6 +36,8 @@ export interface CardProps extends React.HTMLProps<HTMLElement>, OUIAProps {
   isPlain?: boolean;
   /** Flag indicating if a card is expanded. Modifies the card to be expandable. */
   isExpanded?: boolean;
+  /** Flag indicating that the card is an option in a listbox */
+  isOption?: boolean;
 }
 
 interface CardContextProps {
@@ -65,6 +67,7 @@ export const Card: React.FunctionComponent<CardProps> = ({
   isLarge = false,
   isFullHeight = false,
   isPlain = false,
+  isOption = false,
   ouiaId,
   ouiaSafe = true,
   ...props
@@ -76,6 +79,8 @@ export const Card: React.FunctionComponent<CardProps> = ({
     console.warn('Card: Cannot use isCompact with isLarge. Defaulting to isCompact');
     isLarge = false;
   }
+
+  const ariaProps = isOption ? { role: 'option', 'aria-selected': isSelected } : {};
 
   const getSelectableModifiers = () => {
     if (isDisabledRaised) {
@@ -112,6 +117,7 @@ export const Card: React.FunctionComponent<CardProps> = ({
           className
         )}
         tabIndex={isSelectable || isSelectableRaised ? '0' : undefined}
+        {...ariaProps}
         {...props}
         {...ouiaProps}
       >

--- a/packages/react-core/src/components/Card/examples/Card.md
+++ b/packages/react-core/src/components/Card/examples/Card.md
@@ -68,6 +68,10 @@ import pfLogoSmall from './pf-logo-small.svg';
 
 ### Selectable
 
+Note: The listbox role on the containing div of this examples is needed because the cards have the option role via their `isOption` prop, and options are required to be inside a listbox. See the [option role documentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/option_role) from MDN for more information.
+
+The cards need to be options in order to effectively communicate that they're selectable (and what their current selection state is) for those using screen readers.
+
 ```ts file='./CardSelectable.tsx'
 ```
 

--- a/packages/react-core/src/components/Card/examples/Card.md
+++ b/packages/react-core/src/components/Card/examples/Card.md
@@ -70,7 +70,7 @@ import pfLogoSmall from './pf-logo-small.svg';
 
 Note: The listbox role on the containing div of this examples is needed because the cards have the option role via their `isOption` prop, and options are required to be inside a listbox. See the [option role documentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/option_role) from MDN for more information.
 
-The cards need to be options in order to effectively communicate that they're selectable (and what their current selection state is) for those using screen readers.
+The cards need to be options in order to effectively communicate that they're selectable (and what their current selection state is) for those using assistive technologies (such as screen readers).
 
 ```ts file='./CardSelectable.tsx'
 ```

--- a/packages/react-core/src/components/Card/examples/CardLegacySelectable.tsx
+++ b/packages/react-core/src/components/Card/examples/CardLegacySelectable.tsx
@@ -60,11 +60,12 @@ export const CardLegacySelectable: React.FunctionComponent = () => {
   ];
 
   return (
-    <>
+    <div role="listbox" aria-label="Selectable cards">
       <Card
         id="legacy-first-card"
         onKeyDown={onKeyDown}
         onClick={onClick}
+        isOption
         isSelectable
         isSelected={selected === 'legacy-first-card'}
       >
@@ -88,12 +89,13 @@ export const CardLegacySelectable: React.FunctionComponent = () => {
         id="legacy-second-card"
         onKeyDown={onKeyDown}
         onClick={onClick}
+        isOption
         isSelectable
         isSelected={selected === 'legacy-second-card'}
       >
         <CardTitle>Second card</CardTitle>
         <CardBody>This is a selectable card. Click me to select me. Click again to deselect me.</CardBody>
       </Card>
-    </>
+    </div>
   );
 };

--- a/packages/react-core/src/components/Card/examples/CardSelectable.tsx
+++ b/packages/react-core/src/components/Card/examples/CardSelectable.tsx
@@ -63,11 +63,12 @@ export const CardSelectable: React.FunctionComponent = () => {
   ];
 
   return (
-    <React.Fragment>
+    <div role="listbox" aria-label="Selectable cards">
       <Card
         id="selectable-first-card"
         onKeyDown={onKeyDown}
         onClick={onClick}
+        isOption
         isSelectableRaised
         isSelected={selected === 'selectable-first-card'}
       >
@@ -91,6 +92,7 @@ export const CardSelectable: React.FunctionComponent = () => {
         id="selectable-second-card"
         onKeyDown={onKeyDown}
         onClick={onClick}
+        isOption
         isSelectableRaised
         isSelected={selected === 'selectable-second-card'}
       >
@@ -98,10 +100,10 @@ export const CardSelectable: React.FunctionComponent = () => {
         <CardBody>This is a selectable card. Click me to select me. Click again to deselect me.</CardBody>
       </Card>
       <br />
-      <Card id="selectable-third-card" isSelectableRaised isDisabledRaised>
+      <Card id="selectable-third-card" isOption isSelectableRaised isDisabledRaised aria-disabled>
         <CardTitle>Third card</CardTitle>
         <CardBody>This is a raised but disabled card.</CardBody>
       </Card>
-    </React.Fragment>
+    </div>
   );
 };

--- a/packages/react-core/src/demos/Card/Card.md
+++ b/packages/react-core/src/demos/Card/Card.md
@@ -103,7 +103,8 @@ class CardViewBasic extends React.Component {
       splitButtonDropdownIsOpen: false,
       page: 1,
       perPage: 10,
-      totalItemCount: 10
+      totalItemCount: 10,
+      focusedItemId: '',
     };
 
     this.onToolbarDropdownToggle = isLowerToolbarDropdownOpen => {
@@ -230,6 +231,10 @@ class CardViewBasic extends React.Component {
         };
       });
     };
+
+    this.onFocus = id => {
+      this.setState({focusedItemId: id})
+    }
   }
 
   selectedItems(e) {
@@ -559,11 +564,14 @@ class CardViewBasic extends React.Component {
             </Toolbar>
           </PageSection>
           <PageSection isFilled>
-            <Gallery hasGutter>
+            <Gallery hasGutter role="listbox" aria-multiselectable="true" aria-activedescendant={this.state.focusedItemId} aria-label="card container">
               <Card 
+                isOption
                 isSelectable 
                 selectableVariant="raised" 
                 isCompact
+                id="add-card"
+                onFocus={() => this.onFocus("add-card")}
               >
                 <Bullseye>
                   <EmptyState variant={EmptyStateVariant.xs}>
@@ -579,10 +587,13 @@ class CardViewBasic extends React.Component {
               </Card>
               {filtered.map((product, key) => (
                 <Card 
+                  isOption
                   isSelectable 
                   selectableVariant="raised" 
                   isCompact 
                   key={product.name}
+                  onFocus={() => this.onFocus(product.name)}
+                  id={product.name}
                   onKeyDown={(e) => this.onKeyDown(e, product.id)}
                   onClick={() => this.onClick(product.id)}
                   isSelected={selectedItems.includes(product.id)}

--- a/packages/react-core/src/demos/Card/Card.md
+++ b/packages/react-core/src/demos/Card/Card.md
@@ -565,18 +565,18 @@ class CardViewBasic extends React.Component {
           </PageSection>
           <PageSection isFilled>
             <Gallery hasGutter role="listbox" aria-multiselectable="true" aria-activedescendant={this.state.focusedItemId} aria-label="card container">
-              <Card 
-                isOption
+              <Card
                 isSelectable 
                 selectableVariant="raised" 
                 isCompact
                 id="add-card"
                 onFocus={() => this.onFocus("add-card")}
+                aria-describedby="#add-card-title"
               >
                 <Bullseye>
                   <EmptyState variant={EmptyStateVariant.xs}>
                     <EmptyStateIcon icon={PlusCircleIcon} />
-                    <Title headingLevel="h2" size="md">
+                    <Title headingLevel="h2" size="md" id="add-card-title">
                       Add a new card to your page
                     </Title>
                     <EmptyStateSecondaryActions>

--- a/packages/react-core/src/demos/Card/Card.md
+++ b/packages/react-core/src/demos/Card/Card.md
@@ -566,6 +566,7 @@ class CardViewBasic extends React.Component {
           <PageSection isFilled>
             <Gallery hasGutter role="listbox" aria-multiselectable="true" aria-activedescendant={this.state.focusedItemId} aria-label="card container">
               <Card
+                isOption
                 isSelectable 
                 selectableVariant="raised" 
                 isCompact

--- a/packages/react-core/src/demos/PrimaryDetail.md
+++ b/packages/react-core/src/demos/PrimaryDetail.md
@@ -1100,6 +1100,7 @@ class PrimaryDetailCardView extends React.Component {
         return;
       }
       if ([13, 32].includes(event.keyCode)) {
+        event.preventDefault();
         const newSelected = event.currentTarget.id;
         this.setState({
           activeCard: newSelected,
@@ -1262,7 +1263,7 @@ class PrimaryDetailCardView extends React.Component {
     };
 
     const drawerContent = (
-      <Gallery hasGutter>
+      <Gallery hasGutter role="listbox" aria-label="Selectable cards">
         {filtered.map((product, key) => (
           <React.Fragment>
             <Card
@@ -1271,6 +1272,7 @@ class PrimaryDetailCardView extends React.Component {
               id={'card-view-' + key}
               onKeyDown={this.onKeyDown}
               onClick={this.onCardClick}
+              isOption
               isSelectable
               isSelected={activeCard === key}
             >

--- a/packages/react-core/src/demos/examples/Tabs/ModalTabs.tsx
+++ b/packages/react-core/src/demos/examples/Tabs/ModalTabs.tsx
@@ -89,9 +89,10 @@ export const ModalTabs: React.FunctionComponent = () => {
           </TextContent>
         </PageSection>
         <PageSection isFilled>
-          <Gallery hasGutter>
+          <Gallery hasGutter role="listbox" aria-label="Selectable cards">
             {products.map(product => (
               <Card
+                isOption
                 isSelectable
                 isSelectableRaised
                 isCompact


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6798

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:

(I believe) I've implemented all of Nicole's suggestions from the issue and applied them to the card view demo. ~~If everything looks like it works well enough I'll update the other places Card is being used to the same pattern used here,  then convert this to a real PR.~~

Direct link to the card view demo for convenience: https://patternfly-react-pr-7091.surge.sh/demos/card-view/react-demos/card-view/