### PR TITLE
Fix for edge style on hover of a selected edge

### DIFF
--- a/packages/react-styles/src/css/components/Topology/topology-components.css
+++ b/packages/react-styles/src/css/components/Topology/topology-components.css
@@ -391,20 +391,22 @@
   }
 }
 
-.pf-topology__edge.pf-m-selected .pf-topology__edge__link {
-  fill: var(--edge--active--fill);
-  stroke: var(--edge--active--stroke);
-}
-
-.pf-topology__edge.pf-m-selected .pf-topology-connector-arrow {
-  stroke: var(--edge--active--stroke);
-  fill: var(--edge--active--fill);
-}
-
 .pf-topology__edge.pf-m-hover .pf-topology__edge__link,
-.pf-topology__edge.pf-m-hover .pf-topology-connector-arrow {
+.pf-topology__edge.pf-m-hover .pf-topology__connector-arrow {
   fill: var(--pf-global--Color--100);
   stroke: var(--pf-global--Color--100);
+}
+
+.pf-topology__edge.pf-m-selected .pf-topology__edge__link,
+.pf-topology__edge.pf-m-selected .pf-topology-connector-arrow {
+  fill: var(--edge--active--fill);
+  stroke: var(--edge--active--stroke);
+}
+
+.pf-topology__edge.pf-m-selected.pf-m-hover .pf-topology__edge__link,
+.pf-topology__edge.pf-m-selected.pf-m-hover .pf-topology-connector-arrow {
+  fill: var(--edge--active--fill);
+  stroke: var(--edge--active--stroke);
 }
 
 .pf-topology__edge.pf-m-dragging .pf-topology__edge__link,


### PR DESCRIPTION
**What**: 
Closes https://github.com/patternfly/patternfly-react/issues/7135

Sets the hover state of a selected edge to show the edge line and arrow selected with the background as hover.

**Additional issues**: 
None

**Screen Shot**
![image](https://user-images.githubusercontent.com/11633780/160631162-5145c9e8-7275-432c-9320-da1ad3ca2b16.png)

/cc @mceledonia