### PR TITLE
feature(topology): Add BreadthFirst layout to the Topology component

### DIFF
--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/TopologyPackage.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/TopologyPackage.tsx
@@ -158,6 +158,9 @@ const TopologyViewComponent: React.FC<TopologyViewComponentProps> = ({ useSideba
             </DropdownItem>,
             <DropdownItem key={6} onClick={() => updateLayout('Concentric')}>
               Concentric
+            </DropdownItem>,
+            <DropdownItem key={7} onClick={() => updateLayout('BreadthFirst')}>
+              BreadthFirst
             </DropdownItem>
           ]}
         />

--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/layouts/defaultLayoutFactory.ts
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/layouts/defaultLayoutFactory.ts
@@ -6,11 +6,14 @@ import {
   ColaLayout,
   ConcentricLayout,
   DagreLayout,
-  GridLayout
+  GridLayout,
+  BreadthFirstLayout
 } from '@patternfly/react-topology';
 
 const defaultLayoutFactory: LayoutFactory = (type: string, graph: Graph): Layout | undefined => {
   switch (type) {
+    case 'BreadthFirst':
+      return new BreadthFirstLayout(graph);
     case 'Cola':
       return new ColaLayout(graph);
     case 'ColaNoForce':

--- a/packages/react-topology/src/layouts/BreadthFirstGroup.ts
+++ b/packages/react-topology/src/layouts/BreadthFirstGroup.ts
@@ -1,0 +1,3 @@
+import { LayoutGroup } from './LayoutGroup';
+
+export class BreadthFirstGroup extends LayoutGroup {}

--- a/packages/react-topology/src/layouts/BreadthFirstLayout.ts
+++ b/packages/react-topology/src/layouts/BreadthFirstLayout.ts
@@ -1,0 +1,123 @@
+import { Edge, Graph, Layout, Node } from '../types';
+import { BaseLayout } from './BaseLayout';
+import { LayoutOptions } from './LayoutOptions';
+import { LayoutNode } from './LayoutNode';
+import { LayoutLink } from './LayoutLink';
+import { BreadthFirstNode } from './BreadthFirstNode';
+import { BreadthFirstLink } from './BreadthFirstLink';
+import { BreadthFirstGroup } from './BreadthFirstGroup';
+
+export type BreadthFirstLayoutOptions = LayoutOptions;
+
+export class BreadthFirstLayout extends BaseLayout implements Layout {
+  private gridOptions: BreadthFirstLayoutOptions;
+
+  constructor(graph: Graph, options?: Partial<BreadthFirstLayoutOptions>) {
+    super(graph, options);
+    this.gridOptions = {
+      ...this.options,
+      ...options
+    };
+  }
+
+  protected createLayoutNode(node: Node, nodeDistance: number, index: number) {
+    return new BreadthFirstNode(node, nodeDistance, index);
+  }
+
+  protected createLayoutLink(edge: Edge, source: LayoutNode, target: LayoutNode, isFalse: boolean): LayoutLink {
+    return new BreadthFirstLink(edge, source, target, isFalse);
+  }
+
+  protected createLayoutGroup(node: Node, padding: number, index: number) {
+    return new BreadthFirstGroup(node, padding, index);
+  }
+
+  protected startLayout(graph: Graph, initialRun: boolean, addingNodes: boolean): void {
+    if (initialRun || addingNodes) {
+      // Breath First algorithm
+
+      // A node is visited in the order of levels
+      const visited = {};
+      // A node is used as a source/target, helper to detect duplicates/cycles.
+      const processed = {};
+      // The list of nodes that are roots in the graph
+      const roots = {};
+      // Helper map with target Ids
+      const targetIds = {};
+      // Helper map with the list of target Ids per source Id.
+      const sourceIds = {};
+
+      let padX = 0;
+      let padY = 0;
+
+      // Initial loop to populated the helpers
+      for (const edge of this.edges) {
+        if (!edge.isFalse) {
+          const sourceId = edge.sourceNode.id;
+          const targetId = edge.targetNode.id;
+          if (!sourceIds[sourceId]) {
+            sourceIds[sourceId] = [];
+          }
+          sourceIds[sourceId].push(targetId);
+          targetIds[targetId] = true;
+        }
+      }
+
+      for (const node of this.nodes) {
+        const id = node.id;
+        if (!targetIds[id]) {
+          roots[id] = true;
+        }
+        if (padX < node.width) {
+          padX = node.width;
+        }
+        if (padY < node.height) {
+          padY = node.height;
+        }
+      }
+
+      // Visiting all nodes to have an array of arrays with ids, organized by breath first levels
+      const levels: any = [];
+      levels.push(Object.keys(roots));
+      let nl = 0;
+      while (Object.keys(visited).length < this.nodes.length) {
+        const nextLevel = {};
+        for (const nodeId of levels[nl]) {
+          if (!visited[nodeId]) {
+            if (sourceIds[nodeId]) {
+              for (const childId of sourceIds[nodeId]) {
+                if (!processed[childId]) {
+                  nextLevel[childId] = true;
+                  processed[childId] = true;
+                }
+              }
+            }
+            visited[nodeId] = true;
+            processed[nodeId] = true;
+          }
+        }
+        const nextLevelKeys = Object.keys(nextLevel);
+        if (nextLevelKeys.length > 0) {
+          levels.push(nextLevelKeys);
+        }
+        nl++;
+      }
+
+      // Updating positions with levels
+      let x = 0;
+      let y = 0;
+      for (const level of levels) {
+        const sortedLevel = level.sort((a: string, b: string) => a.localeCompare(b));
+        for (const nodeId of sortedLevel) {
+          const node = this.nodesMap[nodeId];
+          node.x = x;
+          node.y = y;
+          node.update();
+          x += padX;
+        }
+        y += padY;
+        x = 0;
+      }
+    }
+  }
+}

--- a/packages/react-topology/src/layouts/BreadthFirstLink.ts
+++ b/packages/react-topology/src/layouts/BreadthFirstLink.ts
@@ -1,0 +1,3 @@
+import { LayoutLink } from './LayoutLink';
+
+export class BreadthFirstLink extends LayoutLink {}

--- a/packages/react-topology/src/layouts/BreadthFirstNode.ts
+++ b/packages/react-topology/src/layouts/BreadthFirstNode.ts
@@ -1,0 +1,8 @@
+import { LayoutNode } from './LayoutNode';
+import { Node } from '../types';
+
+export class BreadthFirstNode extends LayoutNode {
+  constructor(node: Node, distance: number, index: number = -1) {
+    super(node, distance, index);
+  }
+}

--- a/packages/react-topology/src/layouts/index.ts
+++ b/packages/react-topology/src/layouts/index.ts
@@ -1,4 +1,5 @@
 export * from './BaseLayout';
+export * from './BreadthFirstLayout';
 export * from './ColaLayout';
 export * from './ConcentricLayout';
 export * from './DagreLayout';


### PR DESCRIPTION
Fixes https://github.com/patternfly/patternfly-react/issues/7152

This is another useful algorithm to provide a BreadthFirst layout to the Patternfly Topology component.

Algorithms like "cola" and "dagre" have typically a cost to calculate the best visualization of a connected graph, but in the domain sometimes with not good results in terms of clarity and hierarchy of the relations:

![image](https://user-images.githubusercontent.com/1662329/160643254-b44af673-5d44-449c-ba30-4f676ae37ef2.png)
![image](https://user-images.githubusercontent.com/1662329/160643372-04f610bc-9c32-4f04-a935-f1f2784d6df6.png)

A BreadthFirst layout may help in these cases, providing a natural "levels" approach that can be combined with other algorithms to help users to identify the dependencies between elements:

![image](https://user-images.githubusercontent.com/1662329/160643578-ac308ef0-864b-464f-8237-71faa7116fff.png)

Note, this first version doesn't manage the overflow of a row. That's an optimization that can be added in follow-up work.

In Kiali, the algorithm may detect when a row is pretty large compared with others and can combine a "grid + breadthfirst" in these cases.

But I think this algorithm can be useful for demos and as a first point to improve the component.

@jeff-phillips-18 @andrew-ronaldson
