### PR TITLE
fix(Card): indicate card selectivity and status if using a screen reader

### DIFF
--- a/packages/react-catalog-view-extension/src/components/CatalogTile/__snapshots__/CatalogTile.test.tsx.snap
+++ b/packages/react-catalog-view-extension/src/components/CatalogTile/__snapshots__/CatalogTile.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`CatalogTile href renders properly 1`] = `
   >
     <div
       class="pf-c-card__title catalog-tile-pf-header"
+      id="test-href-title"
     >
       <div
         class="catalog-tile-pf-title"
@@ -111,6 +112,7 @@ exports[`CatalogTile renders properly 1`] = `
       </div>
       <div
         class="pf-c-card__title catalog-tile-pf-header"
+        id="single-badge-test-title"
       >
         <div
           class="catalog-tile-pf-title"
@@ -215,6 +217,7 @@ exports[`CatalogTile renders properly 1`] = `
       </div>
       <div
         class="pf-c-card__title catalog-tile-pf-header"
+        id="multi-badge-test-title"
       >
         <div
           class="catalog-tile-pf-title"
@@ -291,6 +294,7 @@ exports[`CatalogTile renders properly 1`] = `
       </div>
       <div
         class="pf-c-card__title catalog-tile-pf-header"
+        id="test-iconClass-title"
       >
         <div
           class="catalog-tile-pf-title"
@@ -364,6 +368,7 @@ exports[`CatalogTile renders properly 1`] = `
       </div>
       <div
         class="pf-c-card__title catalog-tile-pf-header"
+        id="tile-footer-test-title"
       >
         <div
           class="catalog-tile-pf-title"
@@ -442,6 +447,7 @@ exports[`CatalogTile renders properly 1`] = `
       </div>
       <div
         class="pf-c-card__title catalog-tile-pf-header"
+        id="custom-icon-svg-test-title"
       >
         <div
           class="catalog-tile-pf-title"

--- a/packages/react-core/src/components/Card/Card.tsx
+++ b/packages/react-core/src/components/Card/Card.tsx
@@ -37,11 +37,11 @@ export interface CardProps extends React.HTMLProps<HTMLElement>, OUIAProps {
   /** Flag indicating if a card is expanded. Modifies the card to be expandable. */
   isExpanded?: boolean;
   /** Flag indicating that the card should render a hidden input to make it selectable */
-  hasHiddenInput?: boolean;
-  /** Aria label to apply to the hidden input if one is rendered */
-  hiddenInputAriaLabel?: string;
-  /** Callback that executes when the hidden input is changed */
-  onHiddenInputChange?: (labelledBy: string, event: React.FormEvent<HTMLInputElement>) => void;
+  hasSelectableInput?: boolean;
+  /** Aria label to apply to the selectable input if one is rendered */
+  selectableInputAriaLabel?: string;
+  /** Callback that executes when the selectable input is changed */
+  onSelectableInputChange?: (labelledBy: string, event: React.FormEvent<HTMLInputElement>) => void;
 }
 
 interface CardContextProps {
@@ -80,9 +80,9 @@ export const Card: React.FunctionComponent<CardProps> = ({
   isPlain = false,
   ouiaId,
   ouiaSafe = true,
-  hasHiddenInput = false,
-  hiddenInputAriaLabel,
-  onHiddenInputChange = () => {},
+  hasSelectableInput = false,
+  selectableInputAriaLabel,
+  onSelectableInputChange = () => {},
   ...props
 }: CardProps) => {
   const Component = component as any;
@@ -117,18 +117,18 @@ export const Card: React.FunctionComponent<CardProps> = ({
   };
 
   React.useEffect(() => {
-    if (hiddenInputAriaLabel) {
-      setAriaProps({ 'aria-label': hiddenInputAriaLabel });
+    if (selectableInputAriaLabel) {
+      setAriaProps({ 'aria-label': selectableInputAriaLabel });
     } else if (titleId) {
       setAriaProps({ 'aria-labelledby': titleId });
-    } else if (hasHiddenInput && !containsCardTitleChildRef.current) {
+    } else if (hasSelectableInput && !containsCardTitleChildRef.current) {
       setAriaProps({});
       // eslint-disable-next-line no-console
       console.warn(
-        'If no CardTitle component is passed as a child of Card the hiddenInputAriaLabel prop must be passed'
+        'If no CardTitle component is passed as a child of Card the selectableInputAriaLabel prop must be passed'
       );
     }
-  }, [hasHiddenInput, hiddenInputAriaLabel, titleId]);
+  }, [hasSelectableInput, selectableInputAriaLabel, titleId]);
 
   return (
     <CardContext.Provider
@@ -138,14 +138,14 @@ export const Card: React.FunctionComponent<CardProps> = ({
         isExpanded
       }}
     >
-      {hasHiddenInput && (
+      {hasSelectableInput && (
         <input
           className="pf-screen-reader"
           id={`${id}-input`}
           {...ariaProps}
           type="checkbox"
           checked={isSelected}
-          onChange={event => onHiddenInputChange(id, event)}
+          onChange={event => onSelectableInputChange(id, event)}
           disabled={isDisabledRaised}
           tabIndex={-1}
         />

--- a/packages/react-core/src/components/Card/Card.tsx
+++ b/packages/react-core/src/components/Card/Card.tsx
@@ -36,7 +36,7 @@ export interface CardProps extends React.HTMLProps<HTMLElement>, OUIAProps {
   isPlain?: boolean;
   /** Flag indicating if a card is expanded. Modifies the card to be expandable. */
   isExpanded?: boolean;
-  /** Flag indicating that the card should render a hidden input for a11y reasons */
+  /** Flag indicating that the card should render a hidden input to make it selectable */
   hasHiddenInput?: boolean;
   /** Aria label to apply to the hidden input if one is rendered */
   hiddenInputAriaLabel?: string;

--- a/packages/react-core/src/components/Card/Card.tsx
+++ b/packages/react-core/src/components/Card/Card.tsx
@@ -109,8 +109,11 @@ export const Card: React.FunctionComponent<CardProps> = ({
     return '';
   };
 
+  const containsCardTitleChildRef = React.useRef(false);
+
   const registerTitleId = (id: string) => {
     setTitleId(id);
+    containsCardTitleChildRef.current = !!id;
   };
 
   React.useEffect(() => {
@@ -118,7 +121,8 @@ export const Card: React.FunctionComponent<CardProps> = ({
       setAriaProps({ 'aria-label': hiddenInputAriaLabel });
     } else if (titleId) {
       setAriaProps({ 'aria-labelledby': titleId });
-    } else if (hasHiddenInput) {
+    } else if (hasHiddenInput && !containsCardTitleChildRef.current) {
+      setAriaProps({});
       // eslint-disable-next-line no-console
       console.warn(
         'If no CardTitle component is passed as a child of Card the hiddenInputAriaLabel prop must be passed'

--- a/packages/react-core/src/components/Card/Card.tsx
+++ b/packages/react-core/src/components/Card/Card.tsx
@@ -96,46 +96,6 @@ export const Card: React.FunctionComponent<CardProps> = ({
     return '';
   };
 
-  const CardComponent = (
-    <Component
-      id={id}
-      className={css(
-        styles.card,
-        isCompact && styles.modifiers.compact,
-        isExpanded && styles.modifiers.expanded,
-        isFlat && styles.modifiers.flat,
-        isRounded && styles.modifiers.rounded,
-        isLarge && styles.modifiers.displayLg,
-        isFullHeight && styles.modifiers.fullHeight,
-        isPlain && styles.modifiers.plain,
-        getSelectableModifiers(),
-        className
-      )}
-      tabIndex={isSelectable || isSelectableRaised ? '0' : undefined}
-      {...props}
-      {...ouiaProps}
-    >
-      {children}
-    </Component>
-  );
-
-  const inputId = `${id}-input`;
-
-  const CardWithHiddenInput = (
-    <label htmlFor={inputId}>
-      <input
-        className="pf-screen-reader"
-        id={inputId}
-        type="checkbox"
-        checked={isSelected}
-        onChange={event => onHiddenInputChange(id, event)}
-        aria-labelledby={id}
-        disabled={isDisabledRaised}
-      />
-      {CardComponent}
-    </label>
-  );
-
   return (
     <CardContext.Provider
       value={{
@@ -143,7 +103,38 @@ export const Card: React.FunctionComponent<CardProps> = ({
         isExpanded
       }}
     >
-      {hasHiddenInput ? CardWithHiddenInput : CardComponent}
+      {hasHiddenInput && (
+        <input
+          className="pf-screen-reader"
+          id={`${id}-input`}
+          type="checkbox"
+          checked={isSelected}
+          onChange={event => onHiddenInputChange(id, event)}
+          aria-labelledby={id}
+          disabled={isDisabledRaised}
+          tabIndex={-1}
+        />
+      )}
+      <Component
+        id={id}
+        className={css(
+          styles.card,
+          isCompact && styles.modifiers.compact,
+          isExpanded && styles.modifiers.expanded,
+          isFlat && styles.modifiers.flat,
+          isRounded && styles.modifiers.rounded,
+          isLarge && styles.modifiers.displayLg,
+          isFullHeight && styles.modifiers.fullHeight,
+          isPlain && styles.modifiers.plain,
+          getSelectableModifiers(),
+          className
+        )}
+        tabIndex={isSelectable || isSelectableRaised ? '0' : undefined}
+        {...props}
+        {...ouiaProps}
+      >
+        {children}
+      </Component>
     </CardContext.Provider>
   );
 };

--- a/packages/react-core/src/components/Card/Card.tsx
+++ b/packages/react-core/src/components/Card/Card.tsx
@@ -50,6 +50,11 @@ interface CardContextProps {
   isExpanded: boolean;
 }
 
+interface AriaProps {
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+}
+
 export const CardContext = React.createContext<Partial<CardContextProps>>({
   cardId: '',
   registerTitleId: () => {},
@@ -83,6 +88,7 @@ export const Card: React.FunctionComponent<CardProps> = ({
   const Component = component as any;
   const ouiaProps = useOUIAProps(Card.displayName, ouiaId, ouiaSafe);
   const [titleId, setTitleId] = React.useState('');
+  const [ariaProps, setAriaProps] = React.useState<AriaProps>();
 
   if (isCompact && isLarge) {
     // eslint-disable-next-line no-console
@@ -107,22 +113,18 @@ export const Card: React.FunctionComponent<CardProps> = ({
     setTitleId(id);
   };
 
-  const getAriaProps = () => {
-    if (!hasHiddenInput) {
-      return;
-    }
-
+  React.useEffect(() => {
     if (hiddenInputAriaLabel) {
-      return { 'aria-label': hiddenInputAriaLabel };
+      setAriaProps({ 'aria-label': hiddenInputAriaLabel });
+    } else if (titleId) {
+      setAriaProps({ 'aria-labelledby': titleId });
+    } else if (hasHiddenInput) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'If no CardTitle component is passed as a child of Card the hiddenInputAriaLabel prop must be passed'
+      );
     }
-
-    if (titleId) {
-      return { 'aria-labelledby': titleId };
-    }
-
-    // eslint-disable-next-line no-console
-    console.warn('If no CardTitle component is passed as a child of Card the hiddenInputAriaLabel prop must be passed');
-  };
+  }, [hasHiddenInput, hiddenInputAriaLabel, titleId]);
 
   return (
     <CardContext.Provider
@@ -136,7 +138,7 @@ export const Card: React.FunctionComponent<CardProps> = ({
         <input
           className="pf-screen-reader"
           id={`${id}-input`}
-          {...getAriaProps()}
+          {...ariaProps}
           type="checkbox"
           checked={isSelected}
           onChange={event => onHiddenInputChange(id, event)}

--- a/packages/react-core/src/components/Card/CardTitle.tsx
+++ b/packages/react-core/src/components/Card/CardTitle.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Card/card';
+import { CardContext } from './Card';
 
 export interface CardTitleProps extends React.HTMLProps<HTMLDivElement> {
   /** Content rendered inside the CardTitle */
@@ -17,9 +18,18 @@ export const CardTitle: React.FunctionComponent<CardTitleProps> = ({
   component = 'div',
   ...props
 }: CardTitleProps) => {
+  const { cardId, registerTitleId } = React.useContext(CardContext);
   const Component = component as any;
+  const titleId = cardId ? `${cardId}-title` : '';
+
+  React.useEffect(() => {
+    registerTitleId(titleId);
+
+    return () => registerTitleId('');
+  }, [registerTitleId, titleId]);
+
   return (
-    <Component className={css(styles.cardTitle, className)} {...props}>
+    <Component className={css(styles.cardTitle, className)} id={titleId} {...props}>
       {children}
     </Component>
   );

--- a/packages/react-core/src/components/Card/CardTitle.tsx
+++ b/packages/react-core/src/components/Card/CardTitle.tsx
@@ -29,7 +29,7 @@ export const CardTitle: React.FunctionComponent<CardTitleProps> = ({
   }, [registerTitleId, titleId]);
 
   return (
-    <Component className={css(styles.cardTitle, className)} id={titleId} {...props}>
+    <Component className={css(styles.cardTitle, className)} id={titleId || undefined} {...props}>
       {children}
     </Component>
   );

--- a/packages/react-core/src/components/Card/__tests__/Card.test.tsx
+++ b/packages/react-core/src/components/Card/__tests__/Card.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { Card } from '../Card';
+import { CardTitle } from '../CardTitle';
 
 describe('Card', () => {
   test('renders with PatternFly Core styles', () => {
@@ -117,5 +118,65 @@ describe('Card', () => {
 
     render(<Card isLarge isCompact />);
     expect(consoleWarnMock).toHaveBeenCalled();
+  });
+
+  test('card renders with a hidden input to improve a11y when hasSelectableInput is passed', () => {
+    render(<Card isSelectable hasSelectableInput />);
+
+    const selectableInput = screen.getByRole('checkbox', { hidden: true });
+
+    expect(selectableInput).toBeInTheDocument();
+  });
+
+  test('card does not render the hidden input when hasSelectableInput is not passed', () => {
+    render(<Card isSelectable />);
+
+    const selectableInput = screen.queryByRole('checkbox', { hidden: true });
+
+    expect(selectableInput).not.toBeInTheDocument();
+  });
+
+  test('card warns when hasSelectableInput is passed without selectableInputAriaLabel or a card title', () => {
+    const consoleWarnMock = jest.fn();
+    global.console = { warn: consoleWarnMock } as any;
+
+    render(<Card isSelectable hasSelectableInput />);
+
+    const selectableInput = screen.getByRole('checkbox', { hidden: true });
+
+    expect(consoleWarnMock).toBeCalled();
+    expect(selectableInput).toHaveAccessibleName('');
+  });
+
+  test('card applies selectableInputAriaLabel to the hidden input', () => {
+    render(<Card isSelectable hasSelectableInput selectableInputAriaLabel="Input label test" />);
+
+    const selectableInput = screen.getByRole('checkbox', { hidden: true });
+
+    expect(selectableInput).toHaveAccessibleName('Input label test');
+  });
+
+  test('card applies the supplied card title as the aria label of the hidden input', () => {
+    render(
+      <Card id="card" isSelectable hasSelectableInput>
+        <CardTitle>Card title from title component</CardTitle>
+      </Card>
+    );
+
+    const selectableInput = screen.getByRole('checkbox', { hidden: true });
+
+    expect(selectableInput).toHaveAccessibleName('Card title from title component');
+  });
+
+  test('card prioritizes selectableInputAriaLabel over card title labelling via card title', () => {
+    render(
+      <Card id="card" isSelectable hasSelectableInput selectableInputAriaLabel="Input label test">
+        <CardTitle>Card title from title component</CardTitle>
+      </Card>
+    );
+
+    const selectableInput = screen.getByRole('checkbox', { hidden: true });
+
+    expect(selectableInput).toHaveAccessibleName('Input label test');
   });
 });

--- a/packages/react-core/src/components/Card/__tests__/Card.test.tsx
+++ b/packages/react-core/src/components/Card/__tests__/Card.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
+
 import { render, screen } from '@testing-library/react';
-import { Card } from '../Card';
-import { CardTitle } from '../CardTitle';
+import '@testing-library/jest-dom';
+
+import { Card, CardContext } from '../Card';
 
 describe('Card', () => {
   test('renders with PatternFly Core styles', () => {
@@ -157,9 +159,22 @@ describe('Card', () => {
   });
 
   test('card applies the supplied card title as the aria label of the hidden input', () => {
+
+    // this component is used to mock the CardTitle's title registry behavior to keep this a pure unit test
+    const MockCardTitle = ({ children }) => {
+      const { registerTitleId } = React.useContext(CardContext);
+      const id = 'card-title-id';
+
+      React.useEffect(() => {
+        registerTitleId(id);
+      });
+
+      return <div id={id}>{children}</div>;
+    };
+
     render(
       <Card id="card" isSelectable hasSelectableInput>
-        <CardTitle>Card title from title component</CardTitle>
+        <MockCardTitle>Card title from title component</MockCardTitle>
       </Card>
     );
 
@@ -169,9 +184,22 @@ describe('Card', () => {
   });
 
   test('card prioritizes selectableInputAriaLabel over card title labelling via card title', () => {
+
+    // this component is used to mock the CardTitle's title registry behavior to keep this a pure unit test
+    const MockCardTitle = ({ children }) => {
+      const { registerTitleId } = React.useContext(CardContext);
+      const id = 'card-title-id';
+
+      React.useEffect(() => {
+        registerTitleId(id);
+      });
+
+      return <div id={id}>{children}</div>;
+    };
+
     render(
       <Card id="card" isSelectable hasSelectableInput selectableInputAriaLabel="Input label test">
-        <CardTitle>Card title from title component</CardTitle>
+        <MockCardTitle>Card title from title component</MockCardTitle>
       </Card>
     );
 

--- a/packages/react-core/src/components/Card/__tests__/CardTitle.test.tsx
+++ b/packages/react-core/src/components/Card/__tests__/CardTitle.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { CardTitle } from '../CardTitle';
+import { CardContext } from '../Card';
 
 describe('CardTitle', () => {
   test('renders with PatternFly Core styles', () => {
@@ -18,5 +19,17 @@ describe('CardTitle', () => {
 
     render(<CardTitle data-testid={testId} />);
     expect(screen.getByTestId(testId)).toBeInTheDocument();
+  });
+
+  test('calls the registerTitleId function provided by the CardContext with the generated title id', () => {
+    const mockRegisterTitleId = jest.fn();
+
+    render(
+      <CardContext.Provider value={{ cardId: 'card', registerTitleId: mockRegisterTitleId }}>
+        <CardTitle>text</CardTitle>
+      </CardContext.Provider>
+    );
+
+    expect(mockRegisterTitleId).toHaveBeenCalledWith('card-title');
   });
 });

--- a/packages/react-core/src/components/Card/examples/Card.css
+++ b/packages/react-core/src/components/Card/examples/Card.css
@@ -1,0 +1,1 @@
+input:focus + .pf-c-card { border: 5px solid red; }

--- a/packages/react-core/src/components/Card/examples/Card.css
+++ b/packages/react-core/src/components/Card/examples/Card.css
@@ -1,1 +1,0 @@
-input:focus + .pf-c-card { border: 5px solid red; }

--- a/packages/react-core/src/components/Card/examples/Card.md
+++ b/packages/react-core/src/components/Card/examples/Card.md
@@ -6,7 +6,6 @@ propComponents: ['Card', 'CardActions', 'CardHeader', 'CardHeaderMain', 'CardTit
 ouia: true
 ---
 
-import './Card.css';
 import pfLogo from './pfLogo.svg';
 import pfLogoSmall from './pf-logo-small.svg';
 

--- a/packages/react-core/src/components/Card/examples/Card.md
+++ b/packages/react-core/src/components/Card/examples/Card.md
@@ -6,6 +6,7 @@ propComponents: ['Card', 'CardActions', 'CardHeader', 'CardHeaderMain', 'CardTit
 ouia: true
 ---
 
+import './Card.css';
 import pfLogo from './pfLogo.svg';
 import pfLogoSmall from './pf-logo-small.svg';
 

--- a/packages/react-core/src/components/Card/examples/Card.md
+++ b/packages/react-core/src/components/Card/examples/Card.md
@@ -73,11 +73,11 @@ import pfLogoSmall from './pf-logo-small.svg';
 
 ### Selectable accessibility highlight
 
-This example demonstrates how the `hasSelectableInput` and `onSelectableInputChange` props enable improved accessibility for selectable cards.
+This example demonstrates how the `hasSelectableInput` and `onSelectableInputChange` props improve accessibility for selectable cards.
 
-The first card sets `hasSelectableInput` to true, which renders a checkbox input that is only visible to, and navigable by, screen readers. This input communicates to assistive technology users that a card is selectable , and the current selection state if so.
+The first card sets `hasSelectableInput` to true, which renders a checkbox input that is only visible to, and navigable by, screen readers. This input communicates to assistive technology users that a card is selectable, and if so, it communicates the current selection state as well.
 
-By default this input will have an aria-label that corresponds to the title given to the card if using the card title component. If you don't use the card title component in your selectable card you must pass a custom aria-label for this input using the `selectableInputAriaLabel` prop.
+By default this input will have an aria-label that corresponds to the title given to the card if using the card title component. If you don't use the card title component in your selectable card, you must pass a custom aria-label for this input using the `selectableInputAriaLabel` prop.
 
 The first card also (by passing an onchange callback to `onSelectableInputChange`) enables the selection/deselection of the associated card by checking/unchecking the checkbox input.
 

--- a/packages/react-core/src/components/Card/examples/Card.md
+++ b/packages/react-core/src/components/Card/examples/Card.md
@@ -71,6 +71,23 @@ import pfLogoSmall from './pf-logo-small.svg';
 ```ts file='./CardSelectable.tsx'
 ```
 
+### Selectable accessibility highlight
+
+This example demonstrates how the `hasSelectableInput` and `onSelectableInputChange` props enable improved accessibility for selectable cards.
+
+The first card sets `hasSelectableInput` to true, which renders a checkbox input that is only visible to, and navigable by, screen readers. This input communicates to assistive technology users that a card is selectable , and the current selection state if so.
+
+By default this input will have an aria-label that corresponds to the title given to the card if using the card title component. If you don't use the card title component in your selectable card you must pass a custom aria-label for this input using the `selectableInputAriaLabel` prop.
+
+The first card also (by passing an onchange callback to `onSelectableInputChange`) enables the selection/deselection of the associated card by checking/unchecking the checkbox input.
+
+The second card does not set `hasSelectableInput` to true, so the input is not rendered. It does not communicate to screen reader users that it is selectable or if it is currently selected.
+
+To best understand this example it is encouraged that you navigate both of these cards using a screen reader.
+
+```ts file='./CardSelectableA11yHighlight.tsx'
+```
+
 ### With heading element
 
 ```ts file='./CardWithHeadingElement.tsx'

--- a/packages/react-core/src/components/Card/examples/CardLegacySelectable.tsx
+++ b/packages/react-core/src/components/Card/examples/CardLegacySelectable.tsx
@@ -70,10 +70,10 @@ export const CardLegacySelectable: React.FunctionComponent = () => {
         id="legacy-first-card"
         onKeyDown={onKeyDown}
         onClick={onClick}
-        onHiddenInputChange={onChange}
+        onSelectableInputChange={onChange}
         isSelectable
         isSelected={selected === 'legacy-first-card'}
-        hasHiddenInput
+        hasSelectableInput
       >
         <CardHeader>
           <CardActions>
@@ -95,10 +95,10 @@ export const CardLegacySelectable: React.FunctionComponent = () => {
         id="legacy-second-card"
         onKeyDown={onKeyDown}
         onClick={onClick}
-        onHiddenInputChange={onChange}
+        onSelectableInputChange={onChange}
         isSelectable
         isSelected={selected === 'legacy-second-card'}
-        hasHiddenInput
+        hasSelectableInput
       >
         <CardTitle>Second legacy selectable card</CardTitle>
         <CardBody>This is a selectable card. Click me to select me. Click again to deselect me.</CardBody>

--- a/packages/react-core/src/components/Card/examples/CardLegacySelectable.tsx
+++ b/packages/react-core/src/components/Card/examples/CardLegacySelectable.tsx
@@ -87,7 +87,7 @@ export const CardLegacySelectable: React.FunctionComponent = () => {
             />
           </CardActions>
         </CardHeader>
-        <CardTitle>First card</CardTitle>
+        <CardTitle>First legacy selectable card</CardTitle>
         <CardBody>This is a selectable card. Click me to select me. Click again to deselect me.</CardBody>
       </Card>
       <br />
@@ -100,7 +100,7 @@ export const CardLegacySelectable: React.FunctionComponent = () => {
         isSelected={selected === 'legacy-second-card'}
         hasHiddenInput
       >
-        <CardTitle>Second card</CardTitle>
+        <CardTitle>Second legacy selectable card</CardTitle>
         <CardBody>This is a selectable card. Click me to select me. Click again to deselect me.</CardBody>
       </Card>
     </>

--- a/packages/react-core/src/components/Card/examples/CardLegacySelectable.tsx
+++ b/packages/react-core/src/components/Card/examples/CardLegacySelectable.tsx
@@ -31,6 +31,11 @@ export const CardLegacySelectable: React.FunctionComponent = () => {
     setSelected(newSelected);
   };
 
+  const onChange = (labelledById: string, _event: React.FormEvent<HTMLInputElement>) => {
+    const newSelected = labelledById === selected ? null : labelledById;
+    setSelected(newSelected);
+  };
+
   const onToggle = (isOpen: boolean, event: any) => {
     event.stopPropagation();
     setIsKebabOpen(isOpen);
@@ -65,8 +70,10 @@ export const CardLegacySelectable: React.FunctionComponent = () => {
         id="legacy-first-card"
         onKeyDown={onKeyDown}
         onClick={onClick}
+        onHiddenInputChange={onChange}
         isSelectable
         isSelected={selected === 'legacy-first-card'}
+        hasHiddenInput
       >
         <CardHeader>
           <CardActions>
@@ -88,8 +95,10 @@ export const CardLegacySelectable: React.FunctionComponent = () => {
         id="legacy-second-card"
         onKeyDown={onKeyDown}
         onClick={onClick}
+        onHiddenInputChange={onChange}
         isSelectable
         isSelected={selected === 'legacy-second-card'}
+        hasHiddenInput
       >
         <CardTitle>Second card</CardTitle>
         <CardBody>This is a selectable card. Click me to select me. Click again to deselect me.</CardBody>

--- a/packages/react-core/src/components/Card/examples/CardSelectable.tsx
+++ b/packages/react-core/src/components/Card/examples/CardSelectable.tsx
@@ -73,8 +73,8 @@ export const CardSelectable: React.FunctionComponent = () => {
         id="selectable-first-card"
         onKeyDown={onKeyDown}
         onClick={onClick}
-        hasHiddenInput
-        onHiddenInputChange={onChange}
+        hasSelectableInput
+        onSelectableInputChange={onChange}
         isSelectableRaised
         isSelected={selected === 'selectable-first-card'}
       >
@@ -98,8 +98,8 @@ export const CardSelectable: React.FunctionComponent = () => {
         id="selectable-second-card"
         onKeyDown={onKeyDown}
         onClick={onClick}
-        hasHiddenInput
-        onHiddenInputChange={onChange}
+        hasSelectableInput
+        onSelectableInputChange={onChange}
         isSelectableRaised
         isSelected={selected === 'selectable-second-card'}
       >
@@ -107,7 +107,7 @@ export const CardSelectable: React.FunctionComponent = () => {
         <CardBody>This is a selectable card. Click me to select me. Click again to deselect me.</CardBody>
       </Card>
       <br />
-      <Card id="selectable-third-card" isSelectableRaised isDisabledRaised hasHiddenInput>
+      <Card id="selectable-third-card" isSelectableRaised isDisabledRaised hasSelectableInput>
         <CardTitle>Third card</CardTitle>
         <CardBody>This is a raised but disabled card.</CardBody>
       </Card>

--- a/packages/react-core/src/components/Card/examples/CardSelectable.tsx
+++ b/packages/react-core/src/components/Card/examples/CardSelectable.tsx
@@ -31,6 +31,11 @@ export const CardSelectable: React.FunctionComponent = () => {
     setSelected(newSelected);
   };
 
+  const onChange = (labelledById: string, _event: React.FormEvent<HTMLInputElement>) => {
+    const newSelected = labelledById === selected ? null : labelledById;
+    setSelected(newSelected);
+  };
+
   const onToggle = (
     isOpen: boolean,
     event: MouseEvent | TouchEvent | KeyboardEvent | React.KeyboardEvent<any> | React.MouseEvent<HTMLButtonElement>
@@ -68,6 +73,8 @@ export const CardSelectable: React.FunctionComponent = () => {
         id="selectable-first-card"
         onKeyDown={onKeyDown}
         onClick={onClick}
+        hasHiddenInput
+        onHiddenInputChange={onChange}
         isSelectableRaised
         isSelected={selected === 'selectable-first-card'}
       >
@@ -91,6 +98,8 @@ export const CardSelectable: React.FunctionComponent = () => {
         id="selectable-second-card"
         onKeyDown={onKeyDown}
         onClick={onClick}
+        hasHiddenInput
+        onHiddenInputChange={onChange}
         isSelectableRaised
         isSelected={selected === 'selectable-second-card'}
       >
@@ -98,7 +107,7 @@ export const CardSelectable: React.FunctionComponent = () => {
         <CardBody>This is a selectable card. Click me to select me. Click again to deselect me.</CardBody>
       </Card>
       <br />
-      <Card id="selectable-third-card" isSelectableRaised isDisabledRaised>
+      <Card id="selectable-third-card" isSelectableRaised isDisabledRaised hasHiddenInput>
         <CardTitle>Third card</CardTitle>
         <CardBody>This is a raised but disabled card.</CardBody>
       </Card>

--- a/packages/react-core/src/components/Card/examples/CardSelectableA11yHighlight.tsx
+++ b/packages/react-core/src/components/Card/examples/CardSelectableA11yHighlight.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { Card, CardTitle, CardBody } from '@patternfly/react-core';
+
+export const CardSelectableA11yHighlight: React.FunctionComponent = () => {
+  const [selected, setSelected] = React.useState<string>('');
+
+  const onKeyDown = (event: React.KeyboardEvent) => {
+    if (event.target !== event.currentTarget) {
+      return;
+    }
+    if ([' ', 'Enter'].includes(event.key)) {
+      event.preventDefault();
+      const newSelected = event.currentTarget.id === selected ? null : event.currentTarget.id;
+      setSelected(newSelected);
+    }
+  };
+
+  const onClick = (event: React.MouseEvent) => {
+    const newSelected = event.currentTarget.id === selected ? null : event.currentTarget.id;
+    setSelected(newSelected);
+  };
+
+  const onChange = (labelledById: string, _event: React.FormEvent<HTMLInputElement>) => {
+    const newSelected = labelledById === selected ? null : labelledById;
+    setSelected(newSelected);
+  };
+
+  return (
+    <React.Fragment>
+      <Card
+        id="selectable-first-card"
+        onKeyDown={onKeyDown}
+        onClick={onClick}
+        hasSelectableInput
+        onSelectableInputChange={onChange}
+        isSelectableRaised
+        isSelected={selected === 'selectable-first-card'}
+      >
+        <CardTitle>Selectable card with proper accessibility considerations</CardTitle>
+        <CardBody>
+          When using a screen reader a checkbox will become navigable that indicates this card is selectable and
+          communicate if it is currently selected.
+        </CardBody>
+      </Card>
+      <br />
+      <Card
+        id="selectable-second-card"
+        onKeyDown={onKeyDown}
+        onClick={onClick}
+        isSelectableRaised
+        isSelected={selected === 'selectable-second-card'}
+      >
+        <CardTitle>Selectable card without proper accessibility considerations</CardTitle>
+        <CardBody>
+          When using a screen reader there are no indications that this card is selectable or if it is currently
+          selected.
+        </CardBody>
+      </Card>
+    </React.Fragment>
+  );
+};

--- a/packages/react-core/src/demos/Card/Card.md
+++ b/packages/react-core/src/demos/Card/Card.md
@@ -3,7 +3,6 @@ id: Card view
 section: demos
 ---
 
-import '../../components/Card/examples/Card.css';
 import DashboardWrapper from '../examples/DashboardWrapper';
 
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';

--- a/packages/react-core/src/demos/Card/Card.md
+++ b/packages/react-core/src/demos/Card/Card.md
@@ -561,8 +561,7 @@ class CardViewBasic extends React.Component {
           <PageSection isFilled>
             <Gallery hasGutter>
               <Card 
-                isSelectable 
-                selectableVariant="raised" 
+                isSelectableRaised
                 isCompact
               >
                 <Bullseye>
@@ -579,12 +578,11 @@ class CardViewBasic extends React.Component {
               </Card>
               {filtered.map((product, key) => (
                 <Card 
-                  isSelectable 
-                  selectableVariant="raised" 
+                  isSelectableRaised 
                   hasHiddenInput
                   isCompact 
                   key={product.name}
-                  id={product.name}
+                  id={product.name.replace(/ /g, '-')}
                   onKeyDown={(e) => this.onKeyDown(e, product.id)}
                   onClick={() => this.onClick(product.id)}
                   onHiddenInputChange={() => this.onClick(product.id)}

--- a/packages/react-core/src/demos/Card/Card.md
+++ b/packages/react-core/src/demos/Card/Card.md
@@ -2,7 +2,7 @@
 id: Card view
 section: demos
 ---
-
+import '../../components/Card/examples/Card.css';
 import DashboardWrapper from '../examples/DashboardWrapper';
 
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';

--- a/packages/react-core/src/demos/Card/Card.md
+++ b/packages/react-core/src/demos/Card/Card.md
@@ -578,13 +578,13 @@ class CardViewBasic extends React.Component {
               {filtered.map((product, key) => (
                 <Card
                   isSelectableRaised
-                  hasHiddenInput
+                  hasSelectableInput
                   isCompact
                   key={product.name}
                   id={product.name.replace(/ /g, '-')}
                   onKeyDown={e => this.onKeyDown(e, product.id)}
                   onClick={() => this.onClick(product.id)}
-                  onHiddenInputChange={() => this.onClick(product.id)}
+                  onSelectableInputChange={() => this.onClick(product.id)}
                   isSelected={selectedItems.includes(product.id)}
                 >
                   <CardHeader>

--- a/packages/react-core/src/demos/Card/Card.md
+++ b/packages/react-core/src/demos/Card/Card.md
@@ -2,6 +2,7 @@
 id: Card view
 section: demos
 ---
+
 import '../../components/Card/examples/Card.css';
 import DashboardWrapper from '../examples/DashboardWrapper';
 
@@ -197,7 +198,7 @@ class CardViewBasic extends React.Component {
         });
       }
     };
-    
+
     this.onKeyDown = (event, productId) => {
       console.log(productId);
       if (event.target !== event.currentTarget) {
@@ -206,28 +207,30 @@ class CardViewBasic extends React.Component {
       if ([' ', 'Enter'].includes(event.key)) {
         event.preventDefault();
         this.setState(prevState => {
-          return prevState.selectedItems.includes(productId*1) ? 
-          {
-            selectedItems: [...prevState.selectedItems.filter(id => productId * 1 != id)],
-            areAllSelected: false
-          } : {
-            selectedItems: [...prevState.selectedItems, productId * 1],
-            areAllSelected: prevState.totalItemCount === prevState.selectedItems.length + 1
-          };
+          return prevState.selectedItems.includes(productId * 1)
+            ? {
+                selectedItems: [...prevState.selectedItems.filter(id => productId * 1 != id)],
+                areAllSelected: false
+              }
+            : {
+                selectedItems: [...prevState.selectedItems, productId * 1],
+                areAllSelected: prevState.totalItemCount === prevState.selectedItems.length + 1
+              };
         });
       }
     };
-    
+
     this.onClick = productId => {
       this.setState(prevState => {
-        return prevState.selectedItems.includes(productId*1) ? 
-        {
-          selectedItems: [...prevState.selectedItems.filter(id => productId * 1 != id)],
-          areAllSelected: false
-        } : {
-          selectedItems: [...prevState.selectedItems, productId * 1],
-          areAllSelected: prevState.totalItemCount === prevState.selectedItems.length + 1
-        };
+        return prevState.selectedItems.includes(productId * 1)
+          ? {
+              selectedItems: [...prevState.selectedItems.filter(id => productId * 1 != id)],
+              areAllSelected: false
+            }
+          : {
+              selectedItems: [...prevState.selectedItems, productId * 1],
+              areAllSelected: prevState.totalItemCount === prevState.selectedItems.length + 1
+            };
       });
     };
   }
@@ -559,11 +562,8 @@ class CardViewBasic extends React.Component {
             </Toolbar>
           </PageSection>
           <PageSection isFilled>
-            <Gallery hasGutter>
-              <Card 
-                isSelectableRaised
-                isCompact
-              >
+            <Gallery hasGutter aria-label="Selectable card container">
+              <Card isSelectableRaised isCompact>
                 <Bullseye>
                   <EmptyState variant={EmptyStateVariant.xs}>
                     <EmptyStateIcon icon={PlusCircleIcon} />
@@ -577,13 +577,13 @@ class CardViewBasic extends React.Component {
                 </Bullseye>
               </Card>
               {filtered.map((product, key) => (
-                <Card 
-                  isSelectableRaised 
+                <Card
+                  isSelectableRaised
                   hasHiddenInput
-                  isCompact 
+                  isCompact
                   key={product.name}
                   id={product.name.replace(/ /g, '-')}
-                  onKeyDown={(e) => this.onKeyDown(e, product.id)}
+                  onKeyDown={e => this.onKeyDown(e, product.id)}
                   onClick={() => this.onClick(product.id)}
                   onHiddenInputChange={() => this.onClick(product.id)}
                   isSelected={selectedItems.includes(product.id)}

--- a/packages/react-core/src/demos/Card/Card.md
+++ b/packages/react-core/src/demos/Card/Card.md
@@ -581,10 +581,13 @@ class CardViewBasic extends React.Component {
                 <Card 
                   isSelectable 
                   selectableVariant="raised" 
+                  hasHiddenInput
                   isCompact 
                   key={product.name}
+                  id={product.name}
                   onKeyDown={(e) => this.onKeyDown(e, product.id)}
                   onClick={() => this.onClick(product.id)}
+                  onHiddenInputChange={() => this.onClick(product.id)}
                   isSelected={selectedItems.includes(product.id)}
                 >
                   <CardHeader>

--- a/packages/react-core/src/demos/PrimaryDetail.md
+++ b/packages/react-core/src/demos/PrimaryDetail.md
@@ -1100,6 +1100,7 @@ class PrimaryDetailCardView extends React.Component {
         return;
       }
       if ([13, 32].includes(event.keyCode)) {
+        event.preventDefault();
         const newSelected = event.currentTarget.id;
         this.setState({
           activeCard: newSelected,
@@ -1117,6 +1118,17 @@ class PrimaryDetailCardView extends React.Component {
 
       this.setState({
         activeCard: newSelected,
+        isDrawerExpanded: true
+      });
+    };
+
+    this.onChange = (labelledById, _event) => {
+      if (labelledById === this.state.activeCard) {
+        return;
+      }
+
+      this.setState({
+        activeCard: labelledById,
         isDrawerExpanded: true
       });
     };
@@ -1271,8 +1283,10 @@ class PrimaryDetailCardView extends React.Component {
               id={'card-view-' + key}
               onKeyDown={this.onKeyDown}
               onClick={this.onCardClick}
+              onHiddenInputChange={this.onChange}
               isSelectable
-              isSelected={activeCard === key}
+              isSelected={activeCard === 'card-view-' + key}
+              hasHiddenInput
             >
               <CardHeader>
                 <img src={icons[product.icon]} alt={`${product.name} icon`} style={{ height: '50px' }} />

--- a/packages/react-core/src/demos/PrimaryDetail.md
+++ b/packages/react-core/src/demos/PrimaryDetail.md
@@ -1283,10 +1283,10 @@ class PrimaryDetailCardView extends React.Component {
               id={'card-view-' + key}
               onKeyDown={this.onKeyDown}
               onClick={this.onCardClick}
-              onHiddenInputChange={this.onChange}
+              onSelectableInputChange={this.onChange}
               isSelectable
               isSelected={activeCard === 'card-view-' + key}
-              hasHiddenInput
+              hasSelectableInput
             >
               <CardHeader>
                 <img src={icons[product.icon]} alt={`${product.name} icon`} style={{ height: '50px' }} />

--- a/packages/react-core/src/demos/PrimaryDetail.md
+++ b/packages/react-core/src/demos/PrimaryDetail.md
@@ -1274,7 +1274,7 @@ class PrimaryDetailCardView extends React.Component {
     };
 
     const drawerContent = (
-      <Gallery hasGutter>
+      <Gallery hasGutter aria-label="Selectable card container">
         {filtered.map((product, key) => (
           <React.Fragment>
             <Card

--- a/packages/react-core/src/demos/examples/Tabs/ModalTabs.tsx
+++ b/packages/react-core/src/demos/examples/Tabs/ModalTabs.tsx
@@ -94,12 +94,12 @@ export const ModalTabs: React.FunctionComponent = () => {
               <Card
                 isSelectable
                 isSelectableRaised
-                hasHiddenInput
+                hasSelectableInput
                 isCompact
                 key={product.id}
                 id={product.name.replace(/ /g, '-')}
                 onClick={onCardClick(product)}
-                onHiddenInputChange={() => onCardClick(product)()}
+                onSelectableInputChange={() => onCardClick(product)()}
                 onKeyPress={onCardKeyPress(product)}
               >
                 <CardTitle>{product.name}</CardTitle>

--- a/packages/react-core/src/demos/examples/Tabs/ModalTabs.tsx
+++ b/packages/react-core/src/demos/examples/Tabs/ModalTabs.tsx
@@ -94,9 +94,12 @@ export const ModalTabs: React.FunctionComponent = () => {
               <Card
                 isSelectable
                 isSelectableRaised
+                hasHiddenInput
                 isCompact
                 key={product.id}
+                id={product.name}
                 onClick={onCardClick(product)}
+                onHiddenInputChange={() => onCardClick(product)()}
                 onKeyPress={onCardKeyPress(product)}
               >
                 <CardTitle>{product.name}</CardTitle>

--- a/packages/react-core/src/demos/examples/Tabs/ModalTabs.tsx
+++ b/packages/react-core/src/demos/examples/Tabs/ModalTabs.tsx
@@ -97,7 +97,7 @@ export const ModalTabs: React.FunctionComponent = () => {
                 hasHiddenInput
                 isCompact
                 key={product.id}
-                id={product.name}
+                id={product.name.replace(/ /g, '-')}
                 onClick={onCardClick(product)}
                 onHiddenInputChange={() => onCardClick(product)()}
                 onKeyPress={onCardKeyPress(product)}

--- a/packages/react-core/src/demos/examples/Tabs/ModalTabs.tsx
+++ b/packages/react-core/src/demos/examples/Tabs/ModalTabs.tsx
@@ -89,7 +89,7 @@ export const ModalTabs: React.FunctionComponent = () => {
           </TextContent>
         </PageSection>
         <PageSection isFilled>
-          <Gallery hasGutter>
+          <Gallery hasGutter aria-label="Selectable card container">
             {products.map(product => (
               <Card
                 isSelectable


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6798 

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
See PR #7091 for the previous attempt to resolve this issue and the issues identified with that approach.

This draft PR demonstrates a potential approach to improving Card accessibility by including hidden inputs for the purpose of screen reader navigation, this approach is similar to the one used for our [switch component](https://www.patternfly.org/v4/components/switch/html).

I believe this approach has been done in such a way that it is opt-in only and doesn't require a breaking change. The new structure is only rendered when a 'hasHiddenInput' prop is passed.

Currently, the checkboxes are all positioned at the top left corner of the page and there is no visual indication that the actual card is focused when its associated checkbox is focused. If this is identified as the best path forward for this issue I will create a core issue for those changes.

Convenience links:
[Card/selectable](https://patternfly-react-pr-7144.surge.sh/components/card#selectable)
[Card/legacy selectable](https://patternfly-react-pr-7144.surge.sh/components/card#legacy-selectable)
[Card view demo](https://patternfly-react-pr-7144.surge.sh/demos/card-view/react-demos/card-view)
[Tabs/modal tabs demo](https://patternfly-react-pr-7144.surge.sh/components/tabs/react-demos/modal-tabs/)
[Primary-detail card view demo](https://patternfly-react-pr-7144.surge.sh/demos/primary-detail/react-demos/primary-detail-card-view)