### PR TITLE
fix(DataListCheck): assign checked prop to correct attribute

### DIFF
--- a/packages/react-core/src/components/DataList/DataListCheck.tsx
+++ b/packages/react-core/src/components/DataList/DataListCheck.tsx
@@ -9,9 +9,13 @@ export interface DataListCheckProps extends Omit<React.HTMLProps<HTMLInputElemen
   isValid?: boolean;
   /** Flag to show if the DataList checkbox is disabled */
   isDisabled?: boolean;
-  /** Flag to show if the DataList checkbox is checked */
+  /** Flag to show if the DataList checkbox is checked when it is controlled by React state.
+   * To make the DataList checkbox uncontrolled, instead use the checked prop, but do not use both.
+   */
   isChecked?: boolean;
-  /** Flag to set default value of DataList checkbox when it is uncontrolled by React state */
+  /** Flag to set default value of DataList checkbox when it is uncontrolled by React state.
+   * To make the DataList checkbox controlled, instead use the isChecked prop, but do not use both.
+   */
   checked?: boolean;
   /** A callback for when the DataList checkbox selection changes */
   onChange?: (checked: boolean, event: React.FormEvent<HTMLInputElement>) => void;
@@ -40,7 +44,8 @@ export const DataListCheck: React.FunctionComponent<DataListCheckProps> = ({
         onChange={event => onChange(event.currentTarget.checked, event)}
         aria-invalid={!isValid}
         disabled={isDisabled}
-        checked={isChecked || checked}
+        {...(checked !== null && { defaultChecked: checked })}
+        {...(isChecked !== null && { checked: isChecked })}
       />
     </div>
   );


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6762 

Based on the latest update to the DataListCheck component, I changed the attribute to which the `checked` prop was assigned. Having the `checked` attribute on the input element be _either_ of the `isChecked` or `checked` props was causing the behavior seen in the linked issue (a console warning of changing from uncontrolled to controlled, or vice versa). 

With this update, a console warning should only occur if *both* `checked` and `isChecked` props are passed in (which I've noted not to do in the prop descriptions). EDIT: this warning may only appear when testing in a local workspace and may not appear in the preview build.

 If `checked` is passed in, then it's assigned to the correct `defaultChecked` attribute (previously being assigned to the checked attribute was the reason why the checkbox wasn't updating visually, as it wasn't updating at all I believe). If neither prop is passed in, then the component should act as a normal uncontrolled checkbox.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
