### PR TITLE
fix(ContextSelector): fix listener handling when using popper

### DIFF
--- a/packages/react-core/src/components/ContextSelector/ContextSelector.tsx
+++ b/packages/react-core/src/components/ContextSelector/ContextSelector.tsx
@@ -85,6 +85,7 @@ export class ContextSelector extends React.Component<ContextSelectorProps, { oui
   }
 
   parentRef: React.RefObject<HTMLDivElement> = React.createRef();
+  popperRef: React.RefObject<HTMLDivElement> = React.createRef();
 
   onEnterPressed = (event: any) => {
     if (event.charCode === KEY_CODES.ENTER) {
@@ -154,7 +155,7 @@ export class ContextSelector extends React.Component<ContextSelectorProps, { oui
     const popperContainer = (
       <div
         className={css(styles.contextSelector, isOpen && styles.modifiers.expanded, className)}
-        ref={this.parentRef}
+        ref={this.popperRef}
         {...props}
       >
         {isOpen && menuContainer}
@@ -182,7 +183,7 @@ export class ContextSelector extends React.Component<ContextSelectorProps, { oui
           isOpen={isOpen}
           toggleText={toggleText}
           id={toggleId}
-          parentRef={this.parentRef.current}
+          parentRef={menuAppendTo === 'inline' ? this.parentRef : this.popperRef}
           aria-labelledby={`${screenReaderLabelId} ${toggleId}`}
           isPlain={isPlain}
           isText={isText}

--- a/packages/react-core/src/components/ContextSelector/ContextSelectorToggle.tsx
+++ b/packages/react-core/src/components/ContextSelector/ContextSelectorToggle.tsx
@@ -57,16 +57,16 @@ export class ContextSelectorToggle extends React.Component<ContextSelectorToggle
 
   onDocClick = (event: any) => {
     const { isOpen, parentRef, onToggle } = this.props;
-    if (isOpen && parentRef && !parentRef.contains(event.target)) {
+    if (isOpen && parentRef?.current && !parentRef.current.contains(event.target)) {
       onToggle(null, false);
       this.toggle.current.focus();
     }
   };
 
   onEscPress = (event: any) => {
-    const { isOpen, parentRef, onToggle } = this.props;
+    const { isOpen, onToggle } = this.props;
     const keyCode = event.keyCode || event.which;
-    if (isOpen && keyCode === KEY_CODES.ESCAPE_KEY && parentRef && parentRef.contains(event.target)) {
+    if (isOpen && keyCode === KEY_CODES.ESCAPE_KEY) {
       onToggle(null, false);
       this.toggle.current.focus();
     }


### PR DESCRIPTION
**What**: Closes #7104 

The issue here is that the menu closes because of ContextSelectorToggle's `mousedown` listener, since the menu is detached we need a separate reference for the detached container. 
The other problem is that with Popper `parentRef.current` is null because the menu isn't rendered and re-rendering it doesn't update the reference.