### PR TITLE
fix(DualListSelector): update mergedCopy for tree variant

### DIFF
--- a/packages/react-core/src/components/DualListSelector/DualListSelector.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelector.tsx
@@ -149,27 +149,30 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
     isTree: false,
     isDisabled: false
   };
-  private originalAvailableCopy = JSON.parse(JSON.stringify(this.props.availableOptions));
-  private originalChosenCopy = JSON.parse(JSON.stringify(this.props.chosenOptions));
 
   // If the DualListSelector uses trees, concat the two initial arrays and merge duplicate folder IDs
-  private mergedCopy = this.props.isTree
-    ? Object.values(
-        (this.originalAvailableCopy as DualListSelectorTreeItemData[])
-          .concat(this.originalChosenCopy as DualListSelectorTreeItemData[])
-          .reduce((mapObj: any, item: DualListSelectorTreeItemData) => {
-            const key = item.id;
-            if (mapObj[key]) {
-              // If map already has an item ID, add the dupe ID's children to the existing map
-              mapObj[key].children.push(...item.children);
-            } else {
-              // Else clone the item data
-              mapObj[key] = { ...item };
-            }
-            return mapObj;
-          }, {})
-      )
-    : null;
+  private createMergedCopy() {
+    const copyOfAvailable = JSON.parse(JSON.stringify(this.props.availableOptions));
+    const copyOfChosen = JSON.parse(JSON.stringify(this.props.chosenOptions));
+
+    return this.props.isTree
+      ? Object.values(
+          (copyOfAvailable as DualListSelectorTreeItemData[])
+            .concat(copyOfChosen as DualListSelectorTreeItemData[])
+            .reduce((mapObj: any, item: DualListSelectorTreeItemData) => {
+              const key = item.id;
+              if (mapObj[key]) {
+                // If map already has an item ID, add the dupe ID's children to the existing map
+                mapObj[key].children.push(...item.children);
+              } else {
+                // Else clone the item data
+                mapObj[key] = { ...item };
+              }
+              return mapObj;
+            }, {})
+        )
+      : null;
+  }
 
   constructor(props: DualListSelectorProps) {
     super(props);
@@ -275,7 +278,7 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
 
       const currChosen = flattenTree(prevState.chosenOptions as DualListSelectorTreeItemData[]);
       const nextChosenOptions = currChosen.concat(movedOptions);
-      const newChosen = this.mergedCopy
+      const newChosen = this.createMergedCopy()
         .map(opt => Object.assign({}, opt))
         .filter(item => filterTreeItemsWithoutFolders(item as DualListSelectorTreeItemData, nextChosenOptions));
 
@@ -330,7 +333,7 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
       // Get next chosen options from current + new nodes and remap from base
       const currChosen = flattenTree(prevState.chosenOptions as DualListSelectorTreeItemData[]);
       const nextChosenOptions = currChosen.concat(prevState.availableTreeOptionsChecked);
-      const newChosen = this.mergedCopy
+      const newChosen = this.createMergedCopy()
         .map(opt => Object.assign({}, opt))
         .filter(item => filterTreeItemsWithoutFolders(item as DualListSelectorTreeItemData, nextChosenOptions));
 
@@ -383,7 +386,7 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
         .filter(item => filterRestTreeItems(item as DualListSelectorTreeItemData, movedOptions));
       const currAvailable = flattenTree(prevState.availableOptions as DualListSelectorTreeItemData[]);
       const nextAvailableOptions = currAvailable.concat(movedOptions);
-      const newAvailable = this.mergedCopy
+      const newAvailable = this.createMergedCopy()
         .map(opt => Object.assign({}, opt))
         .filter(item => filterTreeItemsWithoutFolders(item as DualListSelectorTreeItemData, nextAvailableOptions));
 
@@ -434,7 +437,7 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
       // Get next chosen options from current and remap from base
       const currAvailable = flattenTree(prevState.availableOptions as DualListSelectorTreeItemData[]);
       const nextAvailableOptions = currAvailable.concat(prevState.chosenTreeOptionsChecked);
-      const newAvailable = this.mergedCopy
+      const newAvailable = this.createMergedCopy()
         .map(opt => Object.assign({}, opt))
         .filter(item => filterTreeItemsWithoutFolders(item as DualListSelectorTreeItemData, nextAvailableOptions));
 


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6992 

The issue looked to be that the methods for adding or removing options for the tree variant were always using the value of `mergedCopy`, which was only ever set once using the original available and chosen options arrays. Turning that into a method that gets called instead now uses the current options arrays. To test this out:

1. Go to the [codesandbox for Dual List Selector](https://codesandbox.io/s/immutable-fog-g8kmds) that was posted in the original issue
    a. Move an option from the Available list to the Chosen list
    b. Press the "Order this first" button
    c. Try moving one of the newly rendered options and notice that it doesn't get moved to the Chosen list
2. Go to the [Dual List Selector](https://patternfly-react-pr-7191.surge.sh/components/dual-list-selector) page from the preview build
    a. Copy+paste the code below into one of the code editors
    b. Repeat steps 1a - 1c and notice that the newly rendered options now get moved

<details>
<summary>Click to show code</summary>

```
import React from 'react';
import { DualListSelector } from '@patternfly/react-core';

class TreeDualListSelector extends React.Component {
  constructor(props) {
    super(props);
    this.state = {
      chosenOptions: [],
      availableOptions: [
        {
          id: "1",
          text: "1",
          isChecked: false,
          checkProps: { "aria-label": "1" },
          hasBadge: true,
          badgeProps: { isRead: true },
        },
        {
          id: "2",
          text: "2",
          isChecked: false,
          checkProps: { "aria-label": "2" },
        }]
    };

    this.onListChange = (newAvailableOptions, newChosenOptions) => {
      this.setState({
        availableOptions: newAvailableOptions,
        chosenOptions: newChosenOptions
      });
    };
    this.testSetValue = () => {
      this.setState({
        availableOptions: [
          {
            id: "4",
            text: "4",
            isChecked: false,
            checkProps: { "aria-label": "4" },
            hasBadge: true,
            badgeProps: { isRead: true },
          },
          {
            id: "5",
            text: "5",
            isChecked: false,
            checkProps: { "aria-label": "5" },
          },
          {
            id: "6",
            text: "6",
            isChecked: false,
            checkProps: { "aria-label": "6" },
          },
        ],
      });
    };
  }

  render() {
    return (
      <>
        <button onClick={this.testSetValue}>Order this first</button>
        <DualListSelector
          availableOptions={this.state.availableOptions}
          chosenOptions={this.state.chosenOptions}
          onListChange={this.onListChange}
          id="basicSelector"
          isSearchable
          isTree
        />
      </>

    );
  }
}
```

</details>

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
