### PR TITLE
fix(Select): prevent footer clicks from toggling

### DIFF
--- a/packages/react-core/src/components/Select/SelectToggle.tsx
+++ b/packages/react-core/src/components/Select/SelectToggle.tsx
@@ -100,11 +100,14 @@ export class SelectToggle extends React.Component<SelectToggleProps> {
   }
 
   onDocClick = (event: Event) => {
-    const { parentRef, menuRef, isOpen, onToggle, onClose } = this.props;
+    const { parentRef, menuRef, footerRef, isOpen, onToggle, onClose } = this.props;
     const clickedOnToggle = parentRef && parentRef.current && parentRef.current.contains(event.target as Node);
     const clickedWithinMenu =
       menuRef && menuRef.current && menuRef.current.contains && menuRef.current.contains(event.target as Node);
-    if (isOpen && !(clickedOnToggle || clickedWithinMenu)) {
+    const clickedWithinFooter =
+      footerRef && footerRef.current && footerRef.current.contains && footerRef.current.contains(event.target as Node);
+
+    if (isOpen && !(clickedOnToggle || clickedWithinMenu || clickedWithinFooter)) {
       onToggle(false, event);
       onClose();
     }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6983

Adds an extra check which prevents a click on the footer or footer item from toggling an open menu closed, for Selects that use `menuAppendTo` (the default inline select will already prevent this toggle). If a footer item should close the menu that should be handled in its event handler. 
