### PR TITLE
Add correct types to instances of useCallback

### DIFF
--- a/packages/react-core/src/helpers/Popper/Popper.tsx
+++ b/packages/react-core/src/helpers/Popper/Popper.tsx
@@ -149,13 +149,11 @@ export const Popper: React.FunctionComponent<PopperProps> = ({
   const [popperElement, setPopperElement] = React.useState(null);
   const [ready, setReady] = React.useState(false);
   const refOrTrigger = refElement || triggerElement;
-  const onDocumentClickCallback = React.useCallback(event => onDocumentClick(event, refOrTrigger, popperElement), [
-    isVisible,
-    triggerElement,
-    refElement,
-    popperElement,
-    onDocumentClick
-  ]);
+  const onDocumentClickCallback = React.useCallback(
+    (event: MouseEvent) => onDocumentClick(event, refOrTrigger, popperElement),
+    [isVisible, triggerElement, refElement, popperElement, onDocumentClick]
+  );
+
   React.useEffect(() => {
     setReady(true);
   }, []);

--- a/packages/react-topology/src/behavior/useBendpoint.tsx
+++ b/packages/react-topology/src/behavior/useBendpoint.tsx
@@ -56,7 +56,7 @@ export const useBendpoint = <DropResult, CollectedProps, Props = {}>(
   );
 
   // argh react events don't play nice with d3 pan zoom double click event
-  const ref = React.useCallback(
+  const ref = React.useCallback<ConnectDragSource>(
     node => {
       d3.select(node).on(
         'click',

--- a/packages/react-topology/src/components/popper/Popper.tsx
+++ b/packages/react-topology/src/components/popper/Popper.tsx
@@ -192,7 +192,7 @@ const Popper: React.FunctionComponent<PopperProps> = ({
     onClickOutside
   ]);
 
-  const nodeRefCallback = React.useCallback(
+  const nodeRefCallback = React.useCallback<React.RefCallback<HTMLDivElement>>(
     node => {
       nodeRef.current = node;
       initialize();


### PR DESCRIPTION
Adds correct type information to instances of `useCallback` to prevent implicit `any` errrors. This type has [been tightened](https://github.com/eps1lon/types-react-codemod#usecallback-implicit-any) in React 18 so this is needed to land #7142.