### PR TITLE
Use workspace version of React for documentation

### DIFF
--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -38,10 +38,6 @@
   },
   "devDependencies": {
     "@patternfly/patternfly-a11y": "4.2.1",
-    "@types/react": "^17.0.0",
-    "@types/react-dom": "^17.0.0",
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0",
     "rimraf": "^2.6.3",
     "shx": "^0.3.2",
     "theme-patternfly-org": "0.11.18"


### PR DESCRIPTION
Removes React dependencies from the `react-docs` package, as this dependency is already present in the root of the workspace. Found this [during](https://github.com/patternfly/patternfly-react/pull/7146#discussion_r837760838) the React 18 upgrade so this can be considered part of landing #7142.