### PR TITLE
Automatically detect React version in ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,7 +24,7 @@
     },
     "settings": {
         "react": {
-            "version": "16.4.0"
+            "version": "detect"
         }
     },
     "globals": {


### PR DESCRIPTION
This changes the ESLint configuration so it automatically detects the React version, needed to land #7142.