### PR TITLE
Fix for drop target highlight, group label position on drag

### DIFF
--- a/packages/react-topology/src/components/groups/DefaultGroupCollapsed.tsx
+++ b/packages/react-topology/src/components/groups/DefaultGroupCollapsed.tsx
@@ -92,6 +92,7 @@ const DefaultGroupCollapsed: React.FunctionComponent<DefaultGroupCollapsedProps>
     styles.topologyGroup,
     className,
     canDrop && 'pf-m-highlight',
+    canDrop && dropTarget && 'pf-m-drop-target',
     dragging && 'pf-m-dragging',
     selected && 'pf-m-selected'
   );

--- a/packages/react-topology/src/components/nodes/DefaultNode.tsx
+++ b/packages/react-topology/src/components/nodes/DefaultNode.tsx
@@ -171,6 +171,7 @@ const DefaultNode: React.FunctionComponent<DefaultNodeProps> = ({
     className,
     isHover && 'pf-m-hover',
     (dragging || edgeDragging) && 'pf-m-dragging',
+    canDrop && 'pf-m-highlight',
     canDrop && dropTarget && 'pf-m-drop-target',
     selected && 'pf-m-selected',
     StatusModifier[status]


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: 
Fixes #7220 
Fixes #7221 

Adds appropriate modifiers on groups and nodes based on the current drag operation.
Don't update group label when a drag operation is in process.

/cc @christianvogt 
