### PR TITLE
fix(demo-app): reorder css imports to load in dark theme correctly

### DIFF
--- a/packages/react-integration/demo-app-ts/src/index.tsx
+++ b/packages/react-integration/demo-app-ts/src/index.tsx
@@ -1,8 +1,8 @@
 import '@patternfly/react-core/dist/styles/base.css';
-import '@patternfly/patternfly/patternfly-theme-dark.css';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
+import '@patternfly/patternfly/patternfly-theme-dark.css';
 
 ReactDOM.render(<App />, document.getElementById('root'));


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7223
