### PR TITLE
feat(HelperText): add react demos

### DIFF
--- a/packages/react-core/src/components/HelperText/HelperText.tsx
+++ b/packages/react-core/src/components/HelperText/HelperText.tsx
@@ -9,17 +9,33 @@ export interface HelperTextProps extends React.HTMLProps<HTMLDivElement | HTMLUL
   className?: string;
   /** Component type of the helper text container */
   component?: 'div' | 'ul';
+  /** ID for the helper text container. The value of this prop can be passed into a form component's
+   * aria-describedby prop when you intend for all helper text items to be announced to
+   * assistive technologies.
+   */
+  id?: string;
+  /** Flag for indicating whether the helper text container is a live region. Use this prop when you
+   * expect or intend for any helper text items within the container to be dynamically updated.
+   */
+  isLiveRegion?: boolean;
 }
 
 export const HelperText: React.FunctionComponent<HelperTextProps> = ({
   children,
   className,
   component = 'div',
+  id,
+  isLiveRegion = false,
   ...props
 }: HelperTextProps) => {
   const Component = component as any;
   return (
-    <Component className={css(styles.helperText, className)} {...props}>
+    <Component
+      id={id}
+      className={css(styles.helperText, className)}
+      aria-live={isLiveRegion ? 'polite' : null}
+      {...props}
+    >
       {children}
     </Component>
   );

--- a/packages/react-core/src/components/HelperText/HelperText.tsx
+++ b/packages/react-core/src/components/HelperText/HelperText.tsx
@@ -33,7 +33,7 @@ export const HelperText: React.FunctionComponent<HelperTextProps> = ({
     <Component
       id={id}
       className={css(styles.helperText, className)}
-      aria-live={isLiveRegion ? 'polite' : null}
+      {...(isLiveRegion && { 'aria-live': 'polite' })}
       {...props}
     >
       {children}

--- a/packages/react-core/src/components/HelperText/HelperTextItem.tsx
+++ b/packages/react-core/src/components/HelperText/HelperTextItem.tsx
@@ -17,7 +17,10 @@ export interface HelperTextItemProps extends React.HTMLProps<HTMLDivElement | HT
   variant?: 'default' | 'indeterminate' | 'warning' | 'success' | 'error';
   /** Custom icon prefixing the helper text. This property will override the default icon paired with each helper text variant. */
   icon?: React.ReactNode;
-  /** Flag indicating the helper text item is dynamic. */
+  /** Flag indicating the helper text item is dynamic. This prop should be used when the
+   * text content of the helper text item will never change, but the icon and styling will
+   * be dynamically updated via the `variant` prop.
+   */
   isDynamic?: boolean;
   /** Flag indicating the helper text should have an icon. Dynamic helper texts include icons by default while static helper texts do not. */
   hasIcon?: boolean;

--- a/packages/react-core/src/components/HelperText/HelperTextItem.tsx
+++ b/packages/react-core/src/components/HelperText/HelperTextItem.tsx
@@ -24,6 +24,11 @@ export interface HelperTextItemProps extends React.HTMLProps<HTMLDivElement | HT
   isDynamic?: boolean;
   /** Flag indicating the helper text should have an icon. Dynamic helper texts include icons by default while static helper texts do not. */
   hasIcon?: boolean;
+  /** ID for the helper text item. The value of this prop can be passed into a form component's
+   * aria-describedby prop when you intend for only specific helper text items to be announced to
+   * assistive technologies.
+   */
+  id?: string;
 }
 
 const variantStyle = {
@@ -42,12 +47,14 @@ export const HelperTextItem: React.FunctionComponent<HelperTextItemProps> = ({
   icon,
   isDynamic = false,
   hasIcon = isDynamic,
+  id,
   ...props
 }: HelperTextItemProps) => {
   const Component = component as any;
   return (
     <Component
       className={css(styles.helperTextItem, variantStyle[variant], isDynamic && styles.modifiers.dynamic, className)}
+      id={id}
       {...props}
     >
       {icon && (

--- a/packages/react-core/src/demos/HelperText.md
+++ b/packages/react-core/src/demos/HelperText.md
@@ -1,0 +1,69 @@
+---
+id: Helper text
+section: components
+---
+
+import MinusIcon from '@patternfly/react-icons/dist/esm/icons/minus-icon';
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
+import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
+
+## Demos
+
+### Static variant with dynamic text
+
+In this demo, the static variant of the Helper Text component (the default) is used with the `hasIcon` prop passed in when there is an error, and the text itself dynamically updates based on the input value. When the input has a value of `johndoe` an error is rendered, while an empty input renders other helper text.
+
+The `aria-describedby` attribute is passed into the Text Input component and is linked to the `id` of the Helper Text component. This notifies assistive technologies of the helper text when the input receives focus, which can be helpful if a user navigates away from and then back to the input so that they are reminded of the helper text.
+
+An `aria-live` region is used to notify assistive technologies when there is an update to the helper text, notifying users immediately when an error or another issue occurs. Without this attribute, a user would have to navigate out of and back into the input field to have the new text announced via the `aria-describedby` attribute.
+
+The `aria-invalid` attribute is also passed into the text input, which allows assistive technologies to notify users that an input is invalid. When this attribute is true, it's important that users are notified of what is causing the input to be invalid; in this case, `aria-describedby` and `aria-live` help accomplish this.
+
+```ts
+import React from 'react';
+import { Form, FormGroup, TextInput, HelperText, HelperTextItem } from '@patternfly/react-core';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
+
+const HelperTextStaticVariantDynamicText: React.FunctionComponent = () => {
+  const [value, setValue] = React.useState('');
+  const [inputValidation, setinputValidation] = React.useState('default');
+
+  const handleInputChange = inputValue => {
+    setValue(inputValue);
+  };
+
+  React.useEffect(() => {
+    if (value === '') {
+      setinputValidation('default');
+    } else if (value === 'johndoe') {
+      setinputValidation('error');
+    } else {
+      setinputValidation('success');
+    }
+  }, [value]);
+
+  return (
+    <Form>
+      <FormGroup label="Username" isRequired fieldId="login-input-helper-text1">
+        <TextInput
+          isRequired
+          type="text"
+          id="login-input-helper-text1"
+          name="login-input-helper-text1"
+          onChange={handleInputChange}
+          aria-describedby="helper-text1"
+          aria-invalid={inputValidation === 'error'}
+        />
+      </FormGroup>
+      <HelperText id="helper-text1" aria-live="polite">
+        {inputValidation !== 'success' && (
+          <HelperTextItem variant={inputValidation as any} hasIcon={inputValidation === 'invalid'}>
+            {inputValidation === 'default' ? 'Please enter a username' : 'Username already exists'}
+          </HelperTextItem>
+        )}
+      </HelperText>
+    </Form>
+  );
+};
+```

--- a/packages/react-core/src/demos/HelperText.md
+++ b/packages/react-core/src/demos/HelperText.md
@@ -20,42 +20,12 @@ The `aria-describedby` attribute is passed into the text input component and is 
 
 Note that this demo does not validate the text input component. When it would need to be validated, there are other steps that would need to be taken to make it accessible, such as passing in `aria-invalid` and `aria-live` attributes to the appropriate components.
 
-```ts
-import React from 'react';
-import { Form, FormGroup, TextInput, HelperText, HelperTextItem } from '@patternfly/react-core';
-import MinusIcon from '@patternfly/react-icons/dist/esm/icons/minus-icon';
-import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
-import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
-
-const HelperTextStaticVariantStaticText: React.FunctionComponent = () => {
-  const [value, setValue] = React.useState('');
-
-  const handleInputChange = inputValue => {
-    setValue(inputValue);
-  };
-
-  return (
-    <Form>
-      <FormGroup label="Middle Name" fieldId="login-input-helper-text1">
-        <TextInput
-          type="text"
-          id="login-input-helper-text1"
-          name="login-input-helper-text1"
-          onChange={handleInputChange}
-          aria-describedby="helper-text1"
-        />
-      </FormGroup>
-      <HelperText id="helper-text1">
-        <HelperTextItem variant={'default'}>Enter your middle name or your middle initial</HelperTextItem>
-      </HelperText>
-    </Form>
-  );
-};
+```ts file='./examples/HelperText/HelperTextStaticVariantStaticText.tsx'
 ```
 
 ### Static variant with dynamic text
 
-In this demo, the static variant of the helper text item component (the default) is used with the `hasIcon` prop passed in when there is an error, and the text itself dynamically updates based on the input value. When the input has a value of `johndoe` an error is rendered to simulate a username already being taken, while an empty input renders other helper text. When the input is valid, no helper text is rendered.
+In this demo, the static variant of the helper text item component (the default) is used with the `hasIcon` prop passed in when there is an error, and the text itself dynamically updates based on the input value. When the input has a value of `johndoe`, an error is rendered to simulate a username already being taken, while an empty input renders other helper text. When the input is valid, no helper text is rendered.
 
 The `aria-describedby` attribute is passed into the text input component and is linked to the `id` of the helper text component. Similar to the static variant with static text demo, this allows assistive technologies to notify users of the helper text content when the navigating to the input.
 
@@ -63,138 +33,16 @@ An `aria-live` region is passed into the helper text component, which allows ass
 
 The `aria-invalid` attribute is also passed into the text input, which allows assistive technologies to notify users that an input is invalid. When this attribute is true, it's important that users are notified of what is causing the input to be invalid; in this case, `aria-describedby` and `aria-live` help accomplish this.
 
-```ts
-import React from 'react';
-import { Form, FormGroup, TextInput, HelperText, HelperTextItem } from '@patternfly/react-core';
-import MinusIcon from '@patternfly/react-icons/dist/esm/icons/minus-icon';
-import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
-import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
-
-const HelperTextStaticVariantDynamicText: React.FunctionComponent = () => {
-  const [value, setValue] = React.useState('');
-  const [inputValidation, setInputValidation] = React.useState('default');
-
-  const handleInputChange = inputValue => {
-    setValue(inputValue);
-  };
-
-  React.useEffect(() => {
-    if (value === '') {
-      setInputValidation('default');
-    } else if (value === 'johndoe') {
-      setInputValidation('error');
-    } else {
-      setInputValidation('success');
-    }
-  }, [value]);
-
-  return (
-    <Form>
-      <FormGroup label="Username" isRequired fieldId="login-input-helper-text2">
-        <TextInput
-          isRequired
-          type="text"
-          id="login-input-helper-text2"
-          name="login-input-helper-text2"
-          onChange={handleInputChange}
-          aria-describedby="helper-text2"
-          aria-invalid={inputValidation === 'error'}
-        />
-      </FormGroup>
-      <HelperText id="helper-text2" aria-live="polite">
-        {inputValidation !== 'success' && (
-          <HelperTextItem variant={inputValidation as any} hasIcon={inputValidation === 'error'}>
-            {inputValidation === 'default' ? 'Please enter a username' : 'Username already exists'}
-          </HelperTextItem>
-        )}
-      </HelperText>
-    </Form>
-  );
-};
+```ts file='./examples/HelperText/HelperTextStaticVariantDynamicText.tsx'
 ```
 
 ### Dynamic variant with static text
 
 In this demo, the helper text item components have the `isDynamic` prop passed in. While the text content of the components is static, the icons and styling will change as the validation of the input changes.
 
-The `aria-describedby` attribute is passed into the text input component, and it is linked to the `id` attribute of a helper text item that results in an invalid input. This will allow assistive technologies to only be notified of any outstanding criteria that has not been met when the input receives focus.
+The `aria-describedby` attribute is passed into the text input component and is linked to the id attribute of a helper text item that results in an invalid input. This will allow assistive technologies to only be notified of any outstanding criteria that has not been met when the input receives focus.
 
-Similar to the static variant with dynamic text example, the `aria-invalid` attribute is passed in, allowing assistive technologies to announce to users when at least one item is causing the input to be invalid.
+Similar to the static variant with dynamic text example, the `aria-invalid` attribute is passed in, allowing assistive technologies to announce to users when at least 1 item is causing the input to be invalid.
 
-```ts
-import React from 'react';
-import { Form, FormGroup, TextInput, HelperText, HelperTextItem } from '@patternfly/react-core';
-import MinusIcon from '@patternfly/react-icons/dist/esm/icons/minus-icon';
-import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
-import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
-
-const HelperTextDynamicVariantDynamicText: React.FunctionComponent = () => {
-  const [value, setValue] = React.useState('');
-  const [inputValidation, setInputValidation] = React.useState({
-    ruleLength: 'indeterminate',
-    ruleCharacterTypes: 'indeterminate'
-  });
-  const { ruleLength, ruleCharacterTypes } = inputValidation;
-
-  React.useEffect(() => {
-    let lengthStatus = ruleLength;
-    let typeStatus = ruleCharacterTypes;
-
-    if (value === '') {
-      setInputValidation({
-        ruleLength: 'indeterminate',
-        ruleCharacterTypes: 'indeterminate'
-      });
-      return;
-    }
-
-    if (!/\d/g.test(value)) {
-      typeStatus = 'error';
-    } else {
-      typeStatus = 'success';
-    }
-
-    if (value.length < 5) {
-      lengthStatus = 'error';
-    } else {
-      lengthStatus = 'success';
-    }
-
-    setInputValidation({ ruleLength: lengthStatus, ruleCharacterTypes: typeStatus });
-  }, [value]);
-
-  const handleInputChange = inputValue => {
-    setValue(inputValue);
-  };
-
-  const filterValidations = () => {
-    return Object.keys(inputValidation).filter(item => {
-      return inputValidation[item] !== 'success';
-    });
-  };
-
-  return (
-    <Form>
-      <FormGroup label="Username" isRequired fieldId="login-input-helper-text3">
-        <TextInput
-          isRequired
-          type="text"
-          id="login-input-helper-text3"
-          name="login-input-helper-text3"
-          onChange={handleInputChange}
-          aria-describedby={filterValidations().join(' ')}
-          aria-invalid={ruleCharacterTypes === 'error' || ruleLength === 'error'}
-        />
-      </FormGroup>
-      <HelperText component="ul">
-        <HelperTextItem component="li" id="ruleLength" isDynamic variant={ruleLength as any}>
-          Must be at least 5 characters in length
-        </HelperTextItem>
-        <HelperTextItem component="li" id="ruleCharacterTypes" isDynamic variant={ruleCharacterTypes as any}>
-          Must include at least 1 number
-        </HelperTextItem>
-      </HelperText>
-    </Form>
-  );
-};
+```ts file='./examples/HelperText/HelperTextDynamicVariantDynamicText.tsx'
 ```

--- a/packages/react-core/src/demos/HelperText.md
+++ b/packages/react-core/src/demos/HelperText.md
@@ -14,11 +14,11 @@ import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
 
 ### Static variant with static text
 
-In this demo, the static variant of the Helper Text Item component (the default) is used, and the text itself will always be visible to users and will never change.
+In this demo, the static variant of the helper text item component (the default) is used, and the text itself will always be visible to users and will never change.
 
-The `aria-describedby` attribute is passed into the Text Input component and is linked to the `id` of the Helper Text component. This allows assistive technologies to notify users of the helper text content when the input receives focus, which can be helpful if a user navigates away from and then back to the input.
+The `aria-describedby` attribute is passed into the text input component and is linked to the `id` of the helper text component. This allows assistive technologies to notify users of the helper text content when the input receives focus, which can be helpful if a user navigates away from and then back to the input.
 
-Note that this demo does not validate the Text Input component. When it would need to be validated, there are other steps that would need to be taken to make it accessible, such as passing in `aria-invalid` and `aria-live` attributes to the appropriate components.
+Note that this demo does not validate the text input component. When it would need to be validated, there are other steps that would need to be taken to make it accessible, such as passing in `aria-invalid` and `aria-live` attributes to the appropriate components.
 
 ```ts
 import React from 'react';
@@ -55,11 +55,11 @@ const HelperTextStaticVariantStaticText: React.FunctionComponent = () => {
 
 ### Static variant with dynamic text
 
-In this demo, the static variant of the Helper Text Item component (the default) is used with the `hasIcon` prop passed in when there is an error, and the text itself dynamically updates based on the input value. When the input has a value of `johndoe` an error is rendered to simulate a username already being taken, while an empty input renders other helper text. When the input is valid, no helper text is rendered.
+In this demo, the static variant of the helper text item component (the default) is used with the `hasIcon` prop passed in when there is an error, and the text itself dynamically updates based on the input value. When the input has a value of `johndoe` an error is rendered to simulate a username already being taken, while an empty input renders other helper text. When the input is valid, no helper text is rendered.
 
-The `aria-describedby` attribute is passed into the Text Input component and is linked to the `id` of the Helper Text component. Similar to the static variant with static text demo, this allows assistive technologies to notify users of the helper text content when the navigating to the input.
+The `aria-describedby` attribute is passed into the text input component and is linked to the `id` of the helper text component. Similar to the static variant with static text demo, this allows assistive technologies to notify users of the helper text content when the navigating to the input.
 
-An `aria-live` region is passed into the Helper Text component, which allows assistive technologies to announce to users when any dynamic content within it updates, such as when the text content changes or gets rendered. Without this attribute, a user would have to navigate out of and back into the input field multiple times to check the status of their input.
+An `aria-live` region is passed into the helper text component, which allows assistive technologies to announce to users when any dynamic content within it updates, such as when the text content changes or gets rendered. Without this attribute, a user would have to navigate out of and back into the input field multiple times to check the status of their input.
 
 The `aria-invalid` attribute is also passed into the text input, which allows assistive technologies to notify users that an input is invalid. When this attribute is true, it's important that users are notified of what is causing the input to be invalid; in this case, `aria-describedby` and `aria-live` help accomplish this.
 
@@ -115,9 +115,9 @@ const HelperTextStaticVariantDynamicText: React.FunctionComponent = () => {
 
 ### Dynamic variant with static text
 
-In this demo, the Helper Text Item components have the `isDynamic` prop passed in. While the text content of the components is static, the icons and styling will change as the validation of the input changes.
+In this demo, the helper text item components have the `isDynamic` prop passed in. While the text content of the components is static, the icons and styling will change as the validation of the input changes.
 
-The `aria-describedby` attribute is passed into the Text Input component, and it is linked to the `id` attribute of a Helper Text Item that results in an invalid input. This will allow assistive technologies to only be notified of any outstanding criteria that has not been met when the input receives focus.
+The `aria-describedby` attribute is passed into the text input component, and it is linked to the `id` attribute of a helper text item that results in an invalid input. This will allow assistive technologies to only be notified of any outstanding criteria that has not been met when the input receives focus.
 
 Similar to the static variant with dynamic text example, the `aria-invalid` attribute is passed in, allowing assistive technologies to announce to users when at least one item is causing the input to be invalid.
 

--- a/packages/react-core/src/demos/HelperText.md
+++ b/packages/react-core/src/demos/HelperText.md
@@ -44,5 +44,5 @@ The `aria-describedby` attribute is passed into the text input component and is 
 
 Similar to the static variant with dynamic text example, the `aria-invalid` attribute is passed in, allowing assistive technologies to announce to users when at least 1 item is causing the input to be invalid.
 
-```ts file='./examples/HelperText/HelperTextDynamicVariantDynamicText.tsx'
+```ts file='./examples/HelperText/HelperTextDynamicVariantStaticText.tsx'
 ```

--- a/packages/react-core/src/demos/HelperText.md
+++ b/packages/react-core/src/demos/HelperText.md
@@ -7,23 +7,27 @@ import MinusIcon from '@patternfly/react-icons/dist/esm/icons/minus-icon';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
 import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
+import CheckIcon from '@patternfly/react-icons/dist/esm/icons/check-icon';
+import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
 
 ## Demos
 
 ### Static variant with static text
 
-In this demo, the static variant of the Helper Text component (the default) is used, and the text itself will always be visible to users and will never change.
+In this demo, the static variant of the Helper Text Item component (the default) is used, and the text itself will always be visible to users and will never change.
 
-The `aria-describedby` attribute is passed into the Text Input component and is linked to the `id` of the Helper Text component. This notifies assistive technologies of the helper text when the input receives focus, which can be helpful if a user navigates away from and then back to the input so that they are reminded of the helper text.
+The `aria-describedby` attribute is passed into the Text Input component and is linked to the `id` of the Helper Text component. This allows assistive technologies to notify users of the helper text content when the input receives focus, which can be helpful if a user navigates away from and then back to the input.
 
-Note that this demo does not validate the Text Input component. When it would need to be validated, there are other steps that would need to be taken to make it accessible, such as passing in `aria-invalid` and `aria-live` attributes.
+Note that this demo does not validate the Text Input component. When it would need to be validated, there are other steps that would need to be taken to make it accessible, such as passing in `aria-invalid` and `aria-live` attributes to the appropriate components.
 
 ```ts
 import React from 'react';
 import { Form, FormGroup, TextInput, HelperText, HelperTextItem } from '@patternfly/react-core';
+import MinusIcon from '@patternfly/react-icons/dist/esm/icons/minus-icon';
+import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 
-const HelperTextStaticVariantDynamicText: React.FunctionComponent = () => {
+const HelperTextStaticVariantStaticText: React.FunctionComponent = () => {
   const [value, setValue] = React.useState('');
 
   const handleInputChange = inputValue => {
@@ -51,22 +55,24 @@ const HelperTextStaticVariantDynamicText: React.FunctionComponent = () => {
 
 ### Static variant with dynamic text
 
-In this demo, the static variant of the Helper Text component (the default) is used with the `hasIcon` prop passed in when there is an error, and the text itself dynamically updates based on the input value. When the input has a value of `johndoe` an error is rendered to simulate a username already being taken, while an empty input renders other helper text. When the input is valid, no helper text is rendered.
+In this demo, the static variant of the Helper Text Item component (the default) is used with the `hasIcon` prop passed in when there is an error, and the text itself dynamically updates based on the input value. When the input has a value of `johndoe` an error is rendered to simulate a username already being taken, while an empty input renders other helper text. When the input is valid, no helper text is rendered.
 
-The `aria-describedby` attribute is passed into the Text Input component and is linked to the `id` of the Helper Text component. This notifies assistive technologies of the helper text when the input receives focus, which can be helpful if a user navigates away from and then back to the input so that they are reminded of the helper text.
+The `aria-describedby` attribute is passed into the Text Input component and is linked to the `id` of the Helper Text component. Similar to the static variant with static text demo, this allows assistive technologies to notify users of the helper text content when the navigating to the input.
 
-An `aria-live` region is used to notify assistive technologies when there is an update to the helper text, notifying users immediately when an error or another issue occurs. Without this attribute, a user would have to navigate out of and back into the input field to have the new text announced via the `aria-describedby` attribute.
+An `aria-live` region is passed into the Helper Text component, which allows assistive technologies to announce to users when any dynamic content within it updates, such as when the text content changes or gets rendered. Without this attribute, a user would have to navigate out of and back into the input field multiple times to check the status of their input.
 
 The `aria-invalid` attribute is also passed into the text input, which allows assistive technologies to notify users that an input is invalid. When this attribute is true, it's important that users are notified of what is causing the input to be invalid; in this case, `aria-describedby` and `aria-live` help accomplish this.
 
 ```ts
 import React from 'react';
 import { Form, FormGroup, TextInput, HelperText, HelperTextItem } from '@patternfly/react-core';
+import MinusIcon from '@patternfly/react-icons/dist/esm/icons/minus-icon';
+import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 
 const HelperTextStaticVariantDynamicText: React.FunctionComponent = () => {
   const [value, setValue] = React.useState('');
-  const [inputValidation, setinputValidation] = React.useState('default');
+  const [inputValidation, setInputValidation] = React.useState('default');
 
   const handleInputChange = inputValue => {
     setValue(inputValue);
@@ -74,11 +80,11 @@ const HelperTextStaticVariantDynamicText: React.FunctionComponent = () => {
 
   React.useEffect(() => {
     if (value === '') {
-      setinputValidation('default');
+      setInputValidation('default');
     } else if (value === 'johndoe') {
-      setinputValidation('error');
+      setInputValidation('error');
     } else {
-      setinputValidation('success');
+      setInputValidation('success');
     }
   }, [value]);
 
@@ -101,6 +107,92 @@ const HelperTextStaticVariantDynamicText: React.FunctionComponent = () => {
             {inputValidation === 'default' ? 'Please enter a username' : 'Username already exists'}
           </HelperTextItem>
         )}
+      </HelperText>
+    </Form>
+  );
+};
+```
+
+### Dynamic variant with static text
+
+In this demo, the Helper Text Item components have the `isDynamic` prop passed in. While the text content of the components is static, the icons and styling will change as the validation of the input changes.
+
+The `aria-describedby` attribute is passed into the Text Input component, and it is linked to the `id` attribute of a Helper Text Item that results in an invalid input. This will allow assistive technologies to only be notified of any outstanding criteria that has not been met when the input receives focus.
+
+Similar to the static variant with dynamic text example, the `aria-invalid` attribute is passed in, allowing assistive technologies to announce to users when at least one item is causing the input to be invalid.
+
+```ts
+import React from 'react';
+import { Form, FormGroup, TextInput, HelperText, HelperTextItem } from '@patternfly/react-core';
+import MinusIcon from '@patternfly/react-icons/dist/esm/icons/minus-icon';
+import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
+
+const HelperTextDynamicVariantDynamicText: React.FunctionComponent = () => {
+  const [value, setValue] = React.useState('');
+  const [inputValidation, setInputValidation] = React.useState({
+    ruleLength: 'indeterminate',
+    ruleCharacterTypes: 'indeterminate'
+  });
+  const { ruleLength, ruleCharacterTypes } = inputValidation;
+
+  React.useEffect(() => {
+    let lengthStatus = ruleLength;
+    let typeStatus = ruleCharacterTypes;
+
+    if (value === '') {
+      setInputValidation({
+        ruleLength: 'indeterminate',
+        ruleCharacterTypes: 'indeterminate'
+      });
+      return;
+    }
+
+    if (!/\d/g.test(value)) {
+      typeStatus = 'error';
+    } else {
+      typeStatus = 'success';
+    }
+
+    if (value.length < 5) {
+      lengthStatus = 'error';
+    } else {
+      lengthStatus = 'success';
+    }
+
+    setInputValidation({ ruleLength: lengthStatus, ruleCharacterTypes: typeStatus });
+  }, [value]);
+
+  const handleInputChange = inputValue => {
+    setValue(inputValue);
+  };
+
+  const filterValidations = () => {
+    return Object.keys(inputValidation).filter(item => {
+      return inputValidation[item] !== 'success';
+    });
+  };
+
+  return (
+    <Form>
+      <FormGroup label="Username" isRequired fieldId="login-input-helper-text3">
+        <TextInput
+          isRequired
+          type="text"
+          id="login-input-helper-text3"
+          name="login-input-helper-text3"
+          onChange={handleInputChange}
+          aria-describedby={filterValidations().join(' ')}
+          aria-invalid={ruleCharacterTypes === 'error' || ruleLength === 'error'}
+        />
+      </FormGroup>
+      <HelperText component="ul">
+        <HelperTextItem component="li" id="ruleLength" isDynamic variant={ruleLength as any}>
+          Must be at least 5 characters in length
+        </HelperTextItem>
+        <HelperTextItem component="li" id="ruleCharacterTypes" isDynamic variant={ruleCharacterTypes as any}>
+          Must include at least 1 number
+        </HelperTextItem>
       </HelperText>
     </Form>
   );

--- a/packages/react-core/src/demos/HelperText.md
+++ b/packages/react-core/src/demos/HelperText.md
@@ -10,9 +10,48 @@ import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclam
 
 ## Demos
 
+### Static variant with static text
+
+In this demo, the static variant of the Helper Text component (the default) is used, and the text itself will always be visible to users and will never change.
+
+The `aria-describedby` attribute is passed into the Text Input component and is linked to the `id` of the Helper Text component. This notifies assistive technologies of the helper text when the input receives focus, which can be helpful if a user navigates away from and then back to the input so that they are reminded of the helper text.
+
+Note that this demo does not validate the Text Input component. When it would need to be validated, there are other steps that would need to be taken to make it accessible, such as passing in `aria-invalid` and `aria-live` attributes.
+
+```ts
+import React from 'react';
+import { Form, FormGroup, TextInput, HelperText, HelperTextItem } from '@patternfly/react-core';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
+
+const HelperTextStaticVariantDynamicText: React.FunctionComponent = () => {
+  const [value, setValue] = React.useState('');
+
+  const handleInputChange = inputValue => {
+    setValue(inputValue);
+  };
+
+  return (
+    <Form>
+      <FormGroup label="Middle Name" fieldId="login-input-helper-text1">
+        <TextInput
+          type="text"
+          id="login-input-helper-text1"
+          name="login-input-helper-text1"
+          onChange={handleInputChange}
+          aria-describedby="helper-text1"
+        />
+      </FormGroup>
+      <HelperText id="helper-text1">
+        <HelperTextItem variant={'default'}>Enter your middle name or your middle initial</HelperTextItem>
+      </HelperText>
+    </Form>
+  );
+};
+```
+
 ### Static variant with dynamic text
 
-In this demo, the static variant of the Helper Text component (the default) is used with the `hasIcon` prop passed in when there is an error, and the text itself dynamically updates based on the input value. When the input has a value of `johndoe` an error is rendered, while an empty input renders other helper text.
+In this demo, the static variant of the Helper Text component (the default) is used with the `hasIcon` prop passed in when there is an error, and the text itself dynamically updates based on the input value. When the input has a value of `johndoe` an error is rendered to simulate a username already being taken, while an empty input renders other helper text. When the input is valid, no helper text is rendered.
 
 The `aria-describedby` attribute is passed into the Text Input component and is linked to the `id` of the Helper Text component. This notifies assistive technologies of the helper text when the input receives focus, which can be helpful if a user navigates away from and then back to the input so that they are reminded of the helper text.
 
@@ -45,20 +84,20 @@ const HelperTextStaticVariantDynamicText: React.FunctionComponent = () => {
 
   return (
     <Form>
-      <FormGroup label="Username" isRequired fieldId="login-input-helper-text1">
+      <FormGroup label="Username" isRequired fieldId="login-input-helper-text2">
         <TextInput
           isRequired
           type="text"
-          id="login-input-helper-text1"
-          name="login-input-helper-text1"
+          id="login-input-helper-text2"
+          name="login-input-helper-text2"
           onChange={handleInputChange}
-          aria-describedby="helper-text1"
+          aria-describedby="helper-text2"
           aria-invalid={inputValidation === 'error'}
         />
       </FormGroup>
-      <HelperText id="helper-text1" aria-live="polite">
+      <HelperText id="helper-text2" aria-live="polite">
         {inputValidation !== 'success' && (
-          <HelperTextItem variant={inputValidation as any} hasIcon={inputValidation === 'invalid'}>
+          <HelperTextItem variant={inputValidation as any} hasIcon={inputValidation === 'error'}>
             {inputValidation === 'default' ? 'Please enter a username' : 'Username already exists'}
           </HelperTextItem>
         )}

--- a/packages/react-core/src/demos/examples/HelperText/HelperTextDynamicVariantDynamicText.tsx
+++ b/packages/react-core/src/demos/examples/HelperText/HelperTextDynamicVariantDynamicText.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Form, FormGroup, TextInput, HelperText, HelperTextItem } from '@patternfly/react-core';
+
+export const HelperTextDynamicVariantDynamicText: React.FunctionComponent = () => {
+  const [value, setValue] = React.useState('');
+  const [inputValidation, setInputValidation] = React.useState({
+    ruleLength: 'indeterminate',
+    ruleCharacterTypes: 'indeterminate'
+  });
+  const { ruleLength, ruleCharacterTypes } = inputValidation;
+
+  React.useEffect(() => {
+    let lengthStatus = ruleLength;
+    let typeStatus = ruleCharacterTypes;
+
+    if (value === '') {
+      setInputValidation({
+        ruleLength: 'indeterminate',
+        ruleCharacterTypes: 'indeterminate'
+      });
+      return;
+    }
+
+    if (!/\d/g.test(value)) {
+      typeStatus = 'error';
+    } else {
+      typeStatus = 'success';
+    }
+
+    if (value.length < 5) {
+      lengthStatus = 'error';
+    } else {
+      lengthStatus = 'success';
+    }
+
+    setInputValidation({ ruleLength: lengthStatus, ruleCharacterTypes: typeStatus });
+  }, [value, ruleLength, ruleCharacterTypes]);
+
+  const handleInputChange = (inputValue: string) => {
+    setValue(inputValue);
+  };
+
+  const filterValidations = () => Object.keys(inputValidation).filter(item => inputValidation[item] !== 'success');
+
+  return (
+    <Form>
+      <FormGroup label="Username" isRequired fieldId="login-input-helper-text3">
+        <TextInput
+          isRequired
+          type="text"
+          id="login-input-helper-text3"
+          name="login-input-helper-text3"
+          onChange={handleInputChange}
+          aria-describedby={filterValidations().join(' ')}
+          aria-invalid={ruleCharacterTypes === 'error' || ruleLength === 'error'}
+          value={value}
+        />
+      </FormGroup>
+      <HelperText component="ul">
+        <HelperTextItem component="li" id="ruleLength" isDynamic variant={ruleLength as any}>
+          Must be at least 5 characters in length
+        </HelperTextItem>
+        <HelperTextItem component="li" id="ruleCharacterTypes" isDynamic variant={ruleCharacterTypes as any}>
+          Must include at least 1 number
+        </HelperTextItem>
+      </HelperText>
+    </Form>
+  );
+};

--- a/packages/react-core/src/demos/examples/HelperText/HelperTextDynamicVariantStaticText.tsx
+++ b/packages/react-core/src/demos/examples/HelperText/HelperTextDynamicVariantStaticText.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Form, FormGroup, TextInput, HelperText, HelperTextItem } from '@patternfly/react-core';
+import { Form, FormGroup, FormHelperText, TextInput, HelperText, HelperTextItem } from '@patternfly/react-core';
 
 export const HelperTextDynamicVariantDynamicText: React.FunctionComponent = () => {
   const [value, setValue] = React.useState('');
@@ -55,15 +55,17 @@ export const HelperTextDynamicVariantDynamicText: React.FunctionComponent = () =
           aria-invalid={ruleCharacterTypes === 'error' || ruleLength === 'error'}
           value={value}
         />
+        <FormHelperText isHidden={false} component="div">
+          <HelperText component="ul">
+            <HelperTextItem component="li" id="ruleLength" isDynamic variant={ruleLength as any}>
+              Must be at least 5 characters in length
+            </HelperTextItem>
+            <HelperTextItem component="li" id="ruleCharacterTypes" isDynamic variant={ruleCharacterTypes as any}>
+              Must include at least 1 number
+            </HelperTextItem>
+          </HelperText>
+        </FormHelperText>
       </FormGroup>
-      <HelperText component="ul">
-        <HelperTextItem component="li" id="ruleLength" isDynamic variant={ruleLength as any}>
-          Must be at least 5 characters in length
-        </HelperTextItem>
-        <HelperTextItem component="li" id="ruleCharacterTypes" isDynamic variant={ruleCharacterTypes as any}>
-          Must include at least 1 number
-        </HelperTextItem>
-      </HelperText>
     </Form>
   );
 };

--- a/packages/react-core/src/demos/examples/HelperText/HelperTextStaticVariantDynamicText.tsx
+++ b/packages/react-core/src/demos/examples/HelperText/HelperTextStaticVariantDynamicText.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Form, FormGroup, TextInput, HelperText, HelperTextItem } from '@patternfly/react-core';
+
+export const HelperTextStaticVariantDynamicText: React.FunctionComponent = () => {
+  const [value, setValue] = React.useState('');
+  const [inputValidation, setInputValidation] = React.useState('default');
+
+  const handleInputChange = (inputValue: string) => {
+    setValue(inputValue);
+  };
+
+  React.useEffect(() => {
+    if (value === '') {
+      setInputValidation('default');
+    } else if (value === 'johndoe') {
+      setInputValidation('error');
+    } else {
+      setInputValidation('success');
+    }
+  }, [value]);
+
+  return (
+    <Form>
+      <FormGroup label="Username" isRequired fieldId="login-input-helper-text2">
+        <TextInput
+          isRequired
+          type="text"
+          id="login-input-helper-text2"
+          name="login-input-helper-text2"
+          onChange={handleInputChange}
+          aria-describedby="helper-text2"
+          aria-invalid={inputValidation === 'error'}
+          value={value}
+        />
+      </FormGroup>
+      <HelperText id="helper-text2" aria-live="polite">
+        {inputValidation !== 'success' && (
+          <HelperTextItem variant={inputValidation as any} hasIcon={inputValidation === 'error'}>
+            {inputValidation === 'default' ? 'Please enter a username' : 'Username already exists'}
+          </HelperTextItem>
+        )}
+      </HelperText>
+    </Form>
+  );
+};

--- a/packages/react-core/src/demos/examples/HelperText/HelperTextStaticVariantDynamicText.tsx
+++ b/packages/react-core/src/demos/examples/HelperText/HelperTextStaticVariantDynamicText.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Form, FormGroup, TextInput, HelperText, HelperTextItem } from '@patternfly/react-core';
+import { Form, FormGroup, FormHelperText, TextInput, HelperText, HelperTextItem } from '@patternfly/react-core';
 
 export const HelperTextStaticVariantDynamicText: React.FunctionComponent = () => {
   const [value, setValue] = React.useState('');
@@ -32,14 +32,16 @@ export const HelperTextStaticVariantDynamicText: React.FunctionComponent = () =>
           aria-invalid={inputValidation === 'error'}
           value={value}
         />
+        <FormHelperText isHidden={false} component="div">
+          <HelperText id="helper-text2" aria-live="polite">
+            {inputValidation !== 'success' && (
+              <HelperTextItem variant={inputValidation as any} hasIcon={inputValidation === 'error'}>
+                {inputValidation === 'default' ? 'Please enter a username' : 'Username already exists'}
+              </HelperTextItem>
+            )}
+          </HelperText>
+        </FormHelperText>
       </FormGroup>
-      <HelperText id="helper-text2" aria-live="polite">
-        {inputValidation !== 'success' && (
-          <HelperTextItem variant={inputValidation as any} hasIcon={inputValidation === 'error'}>
-            {inputValidation === 'default' ? 'Please enter a username' : 'Username already exists'}
-          </HelperTextItem>
-        )}
-      </HelperText>
     </Form>
   );
 };

--- a/packages/react-core/src/demos/examples/HelperText/HelperTextStaticVariantStaticText.tsx
+++ b/packages/react-core/src/demos/examples/HelperText/HelperTextStaticVariantStaticText.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Form, FormGroup, TextInput, HelperText, HelperTextItem } from '@patternfly/react-core';
+import { Form, FormGroup, FormHelperText, TextInput, HelperText, HelperTextItem } from '@patternfly/react-core';
 
 export const HelperTextStaticVariantStaticText: React.FunctionComponent = () => {
   const [value, setValue] = React.useState('');
@@ -19,10 +19,12 @@ export const HelperTextStaticVariantStaticText: React.FunctionComponent = () => 
           aria-describedby="helper-text1"
           value={value}
         />
+        <FormHelperText isHidden={false} component="div">
+          <HelperText id="helper-text1">
+            <HelperTextItem variant={'default'}>Enter your middle name or your middle initial</HelperTextItem>
+          </HelperText>
+        </FormHelperText>
       </FormGroup>
-      <HelperText id="helper-text1">
-        <HelperTextItem variant={'default'}>Enter your middle name or your middle initial</HelperTextItem>
-      </HelperText>
     </Form>
   );
 };

--- a/packages/react-core/src/demos/examples/HelperText/HelperTextStaticVariantStaticText.tsx
+++ b/packages/react-core/src/demos/examples/HelperText/HelperTextStaticVariantStaticText.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Form, FormGroup, TextInput, HelperText, HelperTextItem } from '@patternfly/react-core';
+
+export const HelperTextStaticVariantStaticText: React.FunctionComponent = () => {
+  const [value, setValue] = React.useState('');
+
+  const handleInputChange = (inputValue: string) => {
+    setValue(inputValue);
+  };
+
+  return (
+    <Form>
+      <FormGroup label="Middle Name" fieldId="login-input-helper-text1">
+        <TextInput
+          type="text"
+          id="login-input-helper-text1"
+          name="login-input-helper-text1"
+          onChange={handleInputChange}
+          aria-describedby="helper-text1"
+          value={value}
+        />
+      </FormGroup>
+      <HelperText id="helper-text1">
+        <HelperTextItem variant={'default'}>Enter your middle name or your middle initial</HelperTextItem>
+      </HelperText>
+    </Form>
+  );
+};


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #5941 

[Helper text React demos](https://patternfly-react-pr-7250.surge.sh/components/helper-text/react-demos) for convenience.

These demos are based on conversation from the original issue/PR when Helper Text was created ( #5903 ), including design files, as well as some other component examples/demos on the PF site. The original issue this closes mentioned only the dynamic variant of the Helper Text component, but I think it is worth including additional demos to go over making the component accessible in other common use cases.

I also created an issue in org https://github.com/patternfly/patternfly-org/issues/2917 for a11y docs for the component. Depending on any feedback for this PR, I can transfer some of the repeated verbiage between demos to that a11y doc instead and make the demo text more succinct.

The one demo that could use more feedback is the last one, dynamic variant with static text. I based this off of the [password strength](https://www.patternfly.org/v4/demos/password-strength) demo, which I think is trying to make the helper text accessible but could use tweaking to get it closer where we want it. My implementation here was to have the `aria-describedby` on the input be dynamic, but other possibilities I tinkered with include:

- Adding a static variant Helper Text that dynamically updates ("Username must include the following:" when not valid and "Username is valid!" when valid) and having that live inside an `aria-live` region
- Tweaking the HelperTextItem component so that when it's dynamic, the accessible name is a combination of the variant type ("error", "success", etc) and whatever is passed into the `children` prop, and making that an `aria-live` region. Right now, because the icons are hidden from assistive tech, aria-live won't register an update to the dynamic variants for this demo, which having the accessible name be dynamic should resolve.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
