### PR TITLE
feat(form): added maxWidth prop

### DIFF
--- a/packages/react-core/src/components/Form/Form.tsx
+++ b/packages/react-core/src/components/Form/Form.tsx
@@ -9,8 +9,10 @@ export interface FormProps extends React.HTMLProps<HTMLFormElement> {
   className?: string;
   /** Sets the Form to horizontal. */
   isHorizontal?: boolean;
-  /** Flag to limit the max-width to 500px. */
+  /** Limits the max-width of the form. */
   isWidthLimited?: boolean;
+  /** Sets a custom max-width when using isWidthLimited. */
+  maxWidth?: string;
 }
 
 export const Form: React.FunctionComponent<FormProps> = ({
@@ -18,15 +20,23 @@ export const Form: React.FunctionComponent<FormProps> = ({
   className = '',
   isHorizontal = false,
   isWidthLimited = false,
+  maxWidth = '',
   ...props
 }: FormProps) => (
   <form
     noValidate
+    {...(maxWidth && {
+      style: {
+        '--pf-c-form--m-limit-width--MaxWidth': maxWidth,
+        ...props.style
+      } as React.CSSProperties
+    })}
     {...props}
     className={css(
       styles.form,
       isHorizontal && styles.modifiers.horizontal,
       isWidthLimited && styles.modifiers.limitWidth,
+      maxWidth && styles.modifiers.limitWidth,
       className
     )}
   >

--- a/packages/react-core/src/components/Form/Form.tsx
+++ b/packages/react-core/src/components/Form/Form.tsx
@@ -11,7 +11,7 @@ export interface FormProps extends React.HTMLProps<HTMLFormElement> {
   isHorizontal?: boolean;
   /** Limits the max-width of the form. */
   isWidthLimited?: boolean;
-  /** Sets a custom max-width when using isWidthLimited. */
+  /** Sets a custom max-width for the form. */
   maxWidth?: string;
 }
 
@@ -35,8 +35,7 @@ export const Form: React.FunctionComponent<FormProps> = ({
     className={css(
       styles.form,
       isHorizontal && styles.modifiers.horizontal,
-      isWidthLimited && styles.modifiers.limitWidth,
-      maxWidth && styles.modifiers.limitWidth,
+      (isWidthLimited || maxWidth) && styles.modifiers.limitWidth,
       className
     )}
   >


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-react/issues/7226

@tlabaj just to confirm from our convo the other day, if we end up adding breakpoint support for this var/prop later on, we can use this existing prop to either accept a string (a static max-width), or an object with default, sm, md, lg, etc values for max-widths at different breakpoints without introducing a breaking change? Or there may be another way to do it without a breaking change?