### PR TITLE
feat(CodeBlock): add class to code component

### DIFF
--- a/packages/react-core/src/components/CodeBlock/CodeBlockCode.tsx
+++ b/packages/react-core/src/components/CodeBlock/CodeBlockCode.tsx
@@ -5,14 +5,20 @@ import { css } from '@patternfly/react-styles';
 export interface CodeBlockCodeProps extends React.HTMLProps<HTMLPreElement> {
   /** Code rendered inside the code block */
   children?: React.ReactNode;
+  /** Additional classes passed to the code block pre wrapper */
+  className?: string;
+  /** Additional classes passed to the code block code */
+  codeClassName?: string;
 }
 
 export const CodeBlockCode: React.FunctionComponent<CodeBlockCodeProps> = ({
   children = null,
+  className,
+  codeClassName,
   ...props
 }: CodeBlockCodeProps) => (
-  <pre className={css(styles.codeBlockPre)} {...props}>
-    <code className={css(styles.codeBlockCode)}>{children}</code>
+  <pre className={css(styles.codeBlockPre, className)} {...props}>
+    <code className={css(styles.codeBlockCode, codeClassName)}>{children}</code>
   </pre>
 );
 


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7156

Added a class to both the wrapper and the actual code component, though I'm unsure if just the wrapper className prop would suffice. LMK if it would be clearer to remove the code classname.
