### PR TITLE
Add correct types for class components using context API

### DIFF
--- a/packages/react-core/src/components/Dropdown/DropdownMenu.tsx
+++ b/packages/react-core/src/components/Dropdown/DropdownMenu.tsx
@@ -45,6 +45,7 @@ export interface DropdownMenuItem extends React.HTMLAttributes<any> {
 
 export class DropdownMenu extends React.Component<DropdownMenuProps> {
   static displayName = 'DropdownMenu';
+  context!: React.ContextType<typeof DropdownContext>;
   refsCollection = [] as HTMLElement[][];
 
   static defaultProps: DropdownMenuProps = {

--- a/packages/react-core/src/components/Menu/Menu.tsx
+++ b/packages/react-core/src/components/Menu/Menu.tsx
@@ -72,6 +72,7 @@ export interface MenuState {
 class MenuBase extends React.Component<MenuProps, MenuState> {
   static displayName = 'Menu';
   static contextType = MenuContext;
+  context!: React.ContextType<typeof MenuContext>;
   private menuRef = React.createRef<HTMLDivElement>();
   private activeMenu = null as Element;
   static defaultProps: MenuProps = {

--- a/packages/react-core/src/components/Nav/NavList.tsx
+++ b/packages/react-core/src/components/Nav/NavList.tsx
@@ -23,7 +23,7 @@ export interface NavListProps
 export class NavList extends React.Component<NavListProps> {
   static displayName = 'NavList';
   static contextType = NavContext;
-
+  context!: React.ContextType<typeof NavContext>;
   static defaultProps: NavListProps = {
     ariaLeftScroll: 'Scroll left',
     ariaRightScroll: 'Scroll right'

--- a/packages/react-core/src/components/Toolbar/ToolbarExpandableContent.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarExpandableContent.tsx
@@ -28,7 +28,8 @@ export interface ToolbarExpandableContentProps extends React.HTMLProps<HTMLDivEl
 
 export class ToolbarExpandableContent extends React.Component<ToolbarExpandableContentProps> {
   static displayName = 'ToolbarExpandableContent';
-  static contextType: any = ToolbarContext;
+  static contextType = ToolbarContext;
+  context!: React.ContextType<typeof ToolbarContext>;
   static defaultProps: PickOptional<ToolbarExpandableContentProps> = {
     isExpanded: false,
     clearFiltersButtonText: 'Clear all filters'

--- a/packages/react-core/src/components/Toolbar/ToolbarFilter.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarFilter.tsx
@@ -45,7 +45,8 @@ interface ToolbarFilterState {
 
 export class ToolbarFilter extends React.Component<ToolbarFilterProps, ToolbarFilterState> {
   static displayName = 'ToolbarFilter';
-  static contextType: any = ToolbarContext;
+  static contextType = ToolbarContext;
+  context!: React.ContextType<typeof ToolbarContext>;
   static defaultProps: PickOptional<ToolbarFilterProps> = {
     chips: [] as (string | ToolbarChip)[],
     showToolbarItem: true

--- a/packages/react-core/src/components/Toolbar/ToolbarUtils.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarUtils.tsx
@@ -5,7 +5,7 @@ import globalBreakpointLg from '@patternfly/react-tokens/dist/esm/global_breakpo
 import globalBreakpointXl from '@patternfly/react-tokens/dist/esm/global_breakpoint_xl';
 import globalBreakpoint2xl from '@patternfly/react-tokens/dist/esm/global_breakpoint_2xl';
 
-interface ToolbarContextProps {
+export interface ToolbarContextProps {
   isExpanded: boolean;
   toggleIsExpanded: () => void;
   chipGroupContentRef: RefObject<HTMLDivElement>;

--- a/packages/react-topology/src/components/defs/SVGDefsSetter.tsx
+++ b/packages/react-topology/src/components/defs/SVGDefsSetter.tsx
@@ -4,6 +4,7 @@ import { SVGDefsSetterProps } from './SVGDefs';
 export class SVGDefsSetter extends React.Component<SVGDefsSetterProps> {
   static displayName = 'SVGDefsSetter';
   static contextType = SVGDefsContext;
+  context!: React.ContextType<typeof SVGDefsContext>;
   componentDidMount() {
     const { addDef, id, children } = this.props;
     addDef(id, children);


### PR DESCRIPTION
In React 18 the default type for `context` is `unknown`, meaning that unless proper types are added the build will fail. This adds the correct types to these contexts when used in class component.

Needed to land #7142.