### PR TITLE
fix(DataListCheck): revert checked prop

### DIFF
--- a/packages/react-core/src/components/DataList/DataListCheck.tsx
+++ b/packages/react-core/src/components/DataList/DataListCheck.tsx
@@ -9,10 +9,15 @@ export interface DataListCheckProps extends Omit<React.HTMLProps<HTMLInputElemen
   isValid?: boolean;
   /** Flag to show if the DataList checkbox is disabled */
   isDisabled?: boolean;
-  /** Flag to show if the DataList checkbox is checked when it is controlled by React state. Both isChecked and checked are valid.
+  /** Flag to show if the DataList checkbox is checked when it is controlled by React state. Both isChecked and checked are valid,
+   * but only use one.
    * To make the DataList checkbox uncontrolled, instead use the defaultChecked prop, but do not use both.
    */
   isChecked?: boolean;
+  /** Flag to show if the DataList checkbox is checked when it is controlled by React state. Both isChecked and checked are valid,
+   * but only use one.
+   * To make the DataList checkbox uncontrolled, instead use the defaultChecked prop, but do not use both.
+   */
   checked?: boolean;
   /** Flag to set default value of DataList checkbox when it is uncontrolled by React state.
    * To make the DataList checkbox controlled, instead use the isChecked prop, but do not use both.

--- a/packages/react-core/src/components/DataList/DataListCheck.tsx
+++ b/packages/react-core/src/components/DataList/DataListCheck.tsx
@@ -9,14 +9,15 @@ export interface DataListCheckProps extends Omit<React.HTMLProps<HTMLInputElemen
   isValid?: boolean;
   /** Flag to show if the DataList checkbox is disabled */
   isDisabled?: boolean;
-  /** Flag to show if the DataList checkbox is checked when it is controlled by React state.
-   * To make the DataList checkbox uncontrolled, instead use the checked prop, but do not use both.
+  /** Flag to show if the DataList checkbox is checked when it is controlled by React state. Both isChecked and checked are valid.
+   * To make the DataList checkbox uncontrolled, instead use the defaultChecked prop, but do not use both.
    */
   isChecked?: boolean;
+  checked?: boolean;
   /** Flag to set default value of DataList checkbox when it is uncontrolled by React state.
    * To make the DataList checkbox controlled, instead use the isChecked prop, but do not use both.
    */
-  checked?: boolean;
+  defaultChecked?: boolean;
   /** A callback for when the DataList checkbox selection changes */
   onChange?: (checked: boolean, event: React.FormEvent<HTMLInputElement>) => void;
   /** Aria-labelledby of the DataList checkbox */
@@ -33,6 +34,7 @@ export const DataListCheck: React.FunctionComponent<DataListCheckProps> = ({
   isDisabled = false,
   isChecked = null,
   checked = null,
+  defaultChecked,
   otherControls = false,
   ...props
 }: DataListCheckProps) => {
@@ -44,8 +46,8 @@ export const DataListCheck: React.FunctionComponent<DataListCheckProps> = ({
         onChange={event => onChange(event.currentTarget.checked, event)}
         aria-invalid={!isValid}
         disabled={isDisabled}
-        {...(checked !== null && { defaultChecked: checked })}
-        {...(isChecked !== null && { checked: isChecked })}
+        {...([true, false].includes(defaultChecked) && { defaultChecked })}
+        {...(![true, false].includes(defaultChecked) && { checked: isChecked || checked })}
       />
     </div>
   );


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7283 

This PR somewhat reverts the component to before PR #7163 while retaining the `defaultChecked` behavior.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
