### PR TITLE
Topology dark theme

### DIFF
--- a/packages/react-integration/demo-app-ts/src/App.tsx
+++ b/packages/react-integration/demo-app-ts/src/App.tsx
@@ -13,9 +13,8 @@ import {
   PageHeader,
   PageHeaderTools,
   PageHeaderToolsItem,
-  SelectOption,
-  Select,
-  SelectVariant
+  PageHeaderToolsGroup,
+  Radio
 } from '@patternfly/react-core';
 import imgBrand from './assets/images/imgBrand.svg';
 import imgAvatar from './assets/images/imgAvatar.svg';
@@ -25,42 +24,31 @@ import './App.css';
 interface AppState {
   activeItem: number | string;
   isNavOpen: boolean;
-  isThemesOpen: boolean;
-  theme: string;
+  isDarkTheme: boolean;
 }
 
 class App extends React.Component<{}, AppState> {
   state: AppState = {
     activeItem: '',
     isNavOpen: true,
-    isThemesOpen: false,
-    theme: 'Light theme'
+    isDarkTheme: false
   };
 
   private onNavSelect = (selectedItem: { itemId: number | string }) => {
     this.setState({ activeItem: selectedItem.itemId });
   };
 
-  private onThemeSelect = (event: React.MouseEvent<Element, MouseEvent>, selectedItem: string) => {
-    this.setState({ theme: selectedItem, isThemesOpen: false });
+  private onThemeSelect = (isDarkTheme: boolean) => {
+    this.setState({ isDarkTheme });
     const htmlElement = document.getElementsByTagName('html')[0];
     if (htmlElement) {
-      if (selectedItem === 'Dark theme') {
+      if (isDarkTheme) {
         htmlElement.classList.add('pf-theme-dark');
       } else {
         htmlElement.classList.remove('pf-theme-dark');
       }
     }
   };
-
-  private onThemeToggle = () => {
-    this.setState({ isThemesOpen: !this.state.isThemesOpen });
-  };
-
-  private themeSelectItems = [
-    <SelectOption key="light" value="Light theme" />,
-    <SelectOption key="dark" value="Dark theme" />
-  ];
 
   private getPages = () => (
     <React.Fragment>
@@ -82,23 +70,32 @@ class App extends React.Component<{}, AppState> {
   private getSkipToContentLink = () => <SkipToContent href={`#${this.pageId}`}>Skip to Content</SkipToContent>;
 
   render() {
-    const { isNavOpen, activeItem, isThemesOpen, theme } = this.state;
+    const { isNavOpen, activeItem, isDarkTheme } = this.state;
 
     const AppToolbar = (
       <PageHeaderTools>
-        <PageHeaderToolsItem>
-          <Select
-            toggleId="select-theme-toggle"
-            variant={SelectVariant.single}
-            position="right"
-            onToggle={this.onThemeToggle}
-            onSelect={this.onThemeSelect}
-            selections={theme}
-            isOpen={isThemesOpen}
-          >
-            {this.themeSelectItems}
-          </Select>
-        </PageHeaderToolsItem>
+        <PageHeaderToolsGroup>
+          <PageHeaderToolsItem style={{ marginRight: '10px' }}>
+            <Radio
+              id="light-theme"
+              aria-label="Light theme"
+              label={`Light theme`}
+              name="light-theme"
+              isChecked={!isDarkTheme}
+              onChange={checked => checked && this.onThemeSelect(false)}
+            />
+          </PageHeaderToolsItem>
+          <PageHeaderToolsItem>
+            <Radio
+              id="dark-theme"
+              label="Dark theme"
+              aria-label="Dark theme"
+              name="dark-theme"
+              isChecked={isDarkTheme}
+              onChange={checked => checked && this.onThemeSelect(true)}
+            />
+          </PageHeaderToolsItem>
+        </PageHeaderToolsGroup>
         <Avatar src={imgAvatar} alt="Avatar image" />
       </PageHeaderTools>
     );

--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/TopologyPackage.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/TopologyPackage.tsx
@@ -589,7 +589,7 @@ const TopologyViewComponent: React.FunctionComponent<TopologyViewComponentProps>
   );
 };
 
-export const Topology = () => {
+export const Topology = React.memo(() => {
   const controller = new Visualization();
   controller.registerLayoutFactory(defaultLayoutFactory);
   controller.registerComponentFactory(defaultComponentFactory);
@@ -600,9 +600,9 @@ export const Topology = () => {
       <TopologyViewComponent useSidebar={false} />
     </VisualizationProvider>
   );
-};
+});
 
-export const WithSideBar = () => {
+export const WithSideBar = React.memo(() => {
   const controller = new Visualization();
   controller.registerLayoutFactory(defaultLayoutFactory);
   controller.registerComponentFactory(defaultComponentFactory);
@@ -613,9 +613,9 @@ export const WithSideBar = () => {
       <TopologyViewComponent useSidebar />
     </VisualizationProvider>
   );
-};
+});
 
-export const WithResizableSideBar = () => {
+export const WithResizableSideBar = React.memo(() => {
   const controller = new Visualization();
   controller.registerLayoutFactory(defaultLayoutFactory);
   controller.registerComponentFactory(defaultComponentFactory);
@@ -625,4 +625,4 @@ export const WithResizableSideBar = () => {
       <TopologyViewComponent useSidebar sideBarResizable />
     </VisualizationProvider>
   );
-};
+});

--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/components/StyleNode.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/components/StyleNode.tsx
@@ -22,6 +22,7 @@ import BlueprintIcon from '@patternfly/react-icons/dist/esm/icons/blueprint-icon
 import PauseCircle from '@patternfly/react-icons/dist/esm/icons/pause-circle-icon';
 import Thumbtack from '@patternfly/react-icons/dist/esm/icons/thumbtack-icon';
 import useDetailsLevel from '@patternfly/react-topology/dist/esm/hooks/useDetailsLevel';
+import { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
 
 export enum DataTypes {
   Default,
@@ -34,6 +35,7 @@ type StyleNodeProps = {
   getCustomShape?: (node: Node) => React.FunctionComponent<ShapeProps>;
   getShapeDecoratorCenter?: (quadrant: TopologyQuadrant, node: Node) => { x: number; y: number };
   showLabel?: boolean; // Defaults to true
+  labelIcon?: React.ComponentClass<SVGIconProps>;
   showStatusDecorator?: boolean; // Defaults to false
   regrouping?: boolean;
   dragging?: boolean;
@@ -134,6 +136,7 @@ const StyleNode: React.FunctionComponent<StyleNodeProps> = ({
     return newData;
   }, [data]);
 
+  const LabelIcon = passedData.labelIcon;
   return (
     <DefaultNode
       element={element}
@@ -146,6 +149,7 @@ const StyleNode: React.FunctionComponent<StyleNodeProps> = ({
       showStatusDecorator={detailsLevel === ScaleDetailsLevel.high && passedData.showStatusDecorator}
       onContextMenu={data.showContextMenu ? onContextMenu : undefined}
       contextMenuOpen={contextMenuOpen}
+      labelIcon={LabelIcon && <LabelIcon noVerticalAlign />}
       attachments={
         detailsLevel === ScaleDetailsLevel.high && renderDecorators(element, passedData, rest.getShapeDecoratorCenter)
       }

--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/data/generator.ts
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/data/generator.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import {
   EdgeAnimationSpeed,
   EdgeModel,
@@ -8,8 +9,10 @@ import {
   NodeShape,
   NodeStatus
 } from '@patternfly/react-topology';
+import SignOutAltIcon from '@patternfly/react-icons/dist/esm/icons/skull-icon';
 import { createEdge, createNode } from '../utils/styleUtils';
 import { logos } from '../utils/logos';
+import { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
 
 const getRandomNode = (numNodes: number, notNode = -1): number => {
   let node = Math.floor(Math.random() * numNodes);
@@ -74,8 +77,11 @@ export const getNodeOptions = (
   showDecorators?: boolean;
   showContextMenu?: boolean;
   labelIconClass?: string;
+  labelIcon?: React.ComponentClass<SVGIconProps>;
 } => {
   const shapeEnumIndex = Math.round(Math.random() * (nodeCreationOptions.shapes.length - 1));
+  const labelIconClass = index % 2 === 0 && nodeCreationOptions.nodeIcons ? logos.get('icon-java') : undefined;
+  const labelIcon = index % 2 === 1 && nodeCreationOptions.nodeIcons ? SignOutAltIcon : undefined;
   return {
     status: nodeCreationOptions.statuses[index % nodeCreationOptions.statuses.length],
     shape: nodeCreationOptions.shapes[shapeEnumIndex],
@@ -85,7 +91,8 @@ export const getNodeOptions = (
     showStatusDecorator: nodeCreationOptions.statusDecorators,
     showDecorators: nodeCreationOptions.showDecorators,
     showContextMenu: nodeCreationOptions.contextMenus,
-    labelIconClass: nodeCreationOptions.nodeIcons ? logos.get('icon-java') : undefined
+    labelIconClass,
+    labelIcon
   };
 };
 

--- a/packages/react-styles/src/css/components/Topology/topology-components.css
+++ b/packages/react-styles/src/css/components/Topology/topology-components.css
@@ -39,6 +39,10 @@
   --pf-topology__node__label__text--m-secondary--Fill: var(--pf-global--secondary-color--100);
 
   --pf-topology__node--m-selected--node__label__text--Fill: var(--pf-global--Color--light-100);
+  --pf-topology__node--m-selected--m-info--node__label__text--Fill: var(--pf-global--Color--light-100);
+  --pf-topology__node--m-selected--m-danger--node__label__text--Fill: var(--pf-global--Color--light-100);
+  --pf-topology__node--m-selected--m-warning--node__label__text--Fill: var(--pf-global--Color--light-100);
+  --pf-topology__node--m-selected--m-success--node__label__text--Fill: var(--pf-global--Color--light-100);
 
   --pf-topology__node__label__background--Fill: var(--pf-global--BackgroundColor--100);
 
@@ -109,13 +113,21 @@
   --pf-topology__node--m-hover--background--Stroke: var(--pf-global--palette--black-100);
   --pf-topology__node--m-hover--label__background--Stroke: var(--pf-global--palette--black-100);
 
-  /* TODO Selected default and selected info look the same in dark */
-
   --pf-topology__node__label__background--Stroke: var(--pf-global--BorderColor--300);
   --pf-topology__node__label__text--Fill: var(--pf-global--Color--100);
+  --pf-topology__node__label__text--m-secondary--Fill: var(--pf-global--Color--100);
+
+  /* selected nodes */
+  --pf-topology__node--m-selected--node__background--Stroke: var(--pf-global--palette--blue-300);
+  --pf-topology__node--m-selected--node__label__background--Stroke: var(--pf-global--primary-color--300);
+  --pf-topology__node--m-selected--node__label__background--Fill: var(--pf-global--primary-color--300);
 
   /* make text dark when selected but TODO not on the default, only the statuses */
-  --pf-topology__node--m-selected--node__label__text--Fill: var(--pf-global--palette--black-900);
+  --pf-topology__node--m-selected--node__label__text--Fill: var(--pf-global--Color--100);
+  --pf-topology__node--m-selected--m-info--node__label__text--Fill: var(--pf-global--palette--black-900);
+  --pf-topology__node--m-selected--m-danger--node__label__text--Fill: var(--pf-global--palette--black-900);
+  --pf-topology__node--m-selected--m-warning--node__label__text--Fill: var(--pf-global--palette--black-900);
+  --pf-topology__node--m-selected--m-success--node__label__text--Fill: var(--pf-global--palette--black-900);
   
   /* TODO not done yet */
   --pf-topology__group__background--Fill: var(--pf-global--BackgroundColor--100);
@@ -210,23 +222,23 @@
 
 .pf-topology__node.pf-m-selected .pf-topology__node__background {
   stroke-width: 2px;
-  stroke: var(--pf-topology__node--m-selected--node__background--Stroke);
+  --pf-topology__node__background--Stroke: var(--pf-topology__node--m-selected--node__background--Stroke);
 }
 
 .pf-topology__node.pf-m-info .pf-topology__node__background {
-  stroke: var(--pf-topology__node--m-info--node__background--Stroke);
+  --pf-topology__node__background--Stroke: var(--pf-topology__node--m-info--node__background--Stroke);
 }
 
 .pf-topology__node.pf-m-success .pf-topology__node__background {
-  stroke: var(--pf-topology__node--m-success--node__background--Stroke);
+  --pf-topology__node__background--Stroke: var(--pf-topology__node--m-success--node__background--Stroke);
 }
 
 .pf-topology__node.pf-m-warning .pf-topology__node__background {
-  stroke: var(--pf-topology__node--m-warning--node__background--Stroke);
+  --pf-topology__node__background--Stroke: var(--pf-topology__node--m-warning--node__background--Stroke);
 }
 
 .pf-topology__node.pf-m-danger .pf-topology__node__background {
-  stroke: var(--pf-topology__node--m-danger--node__background--Stroke);
+  --pf-topology__node__background--Stroke: var(--pf-topology__node--m-danger--node__background--Stroke);
 }
 
 .pf-topology__node.pf-m-drop-target .pf-topology__node__background {
@@ -284,7 +296,7 @@
 }
 
 .pf-topology__node.pf-m-selected .pf-topology__node__label > text {
-  fill: var(--pf-topology__node--m-selected--node__label__text--Fill);
+  --pf-topology__node__label__text--Fill: var(--pf-topology__node--m-selected--node__label__text--Fill);
 }
 
 .pf-topology__node__label__background {
@@ -293,51 +305,46 @@
   stroke: var(--pf-topology__node__label__background--Stroke);
 }
 
-.pf-topology__node.pf-m-selected .pf-topology__node__label__background {
+.pf-topology__node.pf-m-selected  {
   stroke-width: 2px;
-  stroke: var(--pf-topology__node--m-selected--node__label__background--Stroke);
+  --pf-topology__node__label__background--Stroke: var(--pf-topology__node--m-selected--node__label__background--Stroke);
+  --pf-topology__node__label__background--Fill: var(--pf-topology__node--m-selected--node__label__background--Fill);
 }
 
-.pf-topology__node.pf-m-selected .pf-topology__node__label__background {
-  fill: var(--pf-topology__node--m-selected--node__label__background--Fill);
+.pf-topology__node.pf-m-info {
+  --pf-topology__node__label__background--Stroke: var(--pf-topology__node--m-info--node__label__background--Stroke);
 }
 
-.pf-topology__node.pf-m-info .pf-topology__node__label__background {
-  stroke: var(--pf-topology__node--m-info--node__label__background--Stroke);
+.pf-topology__node.pf-m-success {
+  --pf-topology__node__label__background--Stroke: var(--pf-topology__node--m-success--node__label__background--Stroke);
 }
 
-.pf-topology__node.pf-m-success .pf-topology__node__label__background {
-  stroke: var(--pf-topology__node--m-success--node__label__background--Stroke);
+.pf-topology__node.pf-m-warning {
+  --pf-topology__node__label__background--Stroke: var(--pf-topology__node--m-warning--node__label__background--Stroke);
 }
 
-.pf-topology__node.pf-m-warning .pf-topology__node__label__background {
-  stroke: var(--pf-topology__node--m-warning--node__label__background--Stroke);
+.pf-topology__node.pf-m-danger {
+  --pf-topology__node__label__background--Stroke: var(--pf-topology__node--m-danger--node__label__background--Stroke);
 }
 
-.pf-topology__node.pf-m-danger .pf-topology__node__label__background {
-  stroke: var(--pf-topology__node--m-danger--node__label__background--Stroke);
-  fill: var(--pf-topology__node--m-selected--m-danger--node__label__background--Fill);
-}
-
-.pf-topology__node.pf-m-selected.pf-m-info .pf-topology__node__label__background {
-  fill: var(--pf-topology__node--m-selected--m-info--node__label__background--Fill);
-  --pf-topology__node--m-selected--node__label__text--Fill: yellow;
-
+.pf-topology__node.pf-m-selected.pf-m-info {
+  --pf-topology__node__label__background--Fill: var(--pf-topology__node--m-selected--m-info--node__label__background--Fill);
+  --pf-topology__node--m-selected--node__label__text--Fill: var(--pf-topology__node--m-selected--m-info--node__label__text--Fill);
 }
 
 .pf-topology__node.pf-m-selected.pf-m-danger  {
-  fill: var(--pf-topology__node--m-selected--m-danger--node__label__background--Fill);
-  --pf-topology__node--m-selected--node__label__text--Fill: yellow;
+  --pf-topology__node__label__background--Fill: var(--pf-topology__node--m-selected--m-danger--node__label__background--Fill);
+  --pf-topology__node--m-selected--node__label__text--Fill: var(--pf-topology__node--m-selected--m-danger--node__label__text--Fill);
 }
 
-.pf-topology__node.pf-m-selected.pf-m-warning .pf-topology__node__label__background {
-  fill: var(--pf-topology__node--m-selected--m-warning--node__label__background--Fill);
-  --pf-topology__node--m-selected--node__label__text--Fill: yellow;
+.pf-topology__node.pf-m-selected.pf-m-warning {
+  --pf-topology__node__label__background--Fill: var(--pf-topology__node--m-selected--m-warning--node__label__background--Fill);
+  --pf-topology__node--m-selected--node__label__text--Fill: var(--pf-topology__node--m-selected--m-warning--node__label__text--Fill);
 }
 
-.pf-topology__node.pf-m-selected.pf-m-success .pf-topology__node__label__background {
-  fill: var(--pf-topology__node--m-selected--m-success--node__label__background--Fill);
-  --pf-topology__node--m-selected--node__label__text--Fill: yellow;
+.pf-topology__node.pf-m-selected.pf-m-success {
+  --pf-topology__node__label__background--Fill: var(--pf-topology__node--m-selected--m-success--node__label__background--Fill);
+  --pf-topology__node--m-selected--node__label__text--Fill: var(--pf-topology__node--m-selected--m-success--node__label__text--Fill);
 }
 
 /* *********** NODE LABEL BADGE ********* */

--- a/packages/react-styles/src/css/components/Topology/topology-components.css
+++ b/packages/react-styles/src/css/components/Topology/topology-components.css
@@ -80,26 +80,22 @@
 
   --pf-topology__group--m-alt-group--topology__group__background--Fill: var(--pf-global--palette--white);
 
-  --pf-topology__group--m-selected--topology__group__background--Fill: var(--pf-global--palette--blue-50);
   --pf-topology__group--m-selected--topology__group__background--Stroke: var(--pf-global--active-color--100);
-
   --pf-topology__group--m-hover--topology__group__background--Stroke: var(--pf-global--BackgroundColor--dark-400);
-
   --pf-topology__group--m-drop-target--topology__group__background--Fill: var(--pf-global--palette--blue-50);
   --pf-topology__group--m-drop-target--topology__group__background--Stroke: var(--pf-global--active-color--100);
-
   --pf-topology__group__collapsed-badge__node__label__badge__rect--Fill: var(--pf-global--palette--white);
   --pf-topology__group__collapsed-badge__node__label__badge__rect--Stroke: var(--pf-global--palette--black-300);
-
   --pf-topology__group__collapsed-badge__node__label__badge__text--Fill: var(--pf-global--palette--black-800);
 
   --pf-topology__group__label__node__label__background--Fill: var(--pf-global--BackgroundColor--dark-300);
-
   --pf-topology__group__label__text--Fill: var(--pf-global--palette--white); 
-
   --pf-topology__group__label__node__action-icon__icon--Color: var(--pf-global--palette--white);
-
   --pf-topology__group--m-selected--group__label__node__label__background--Fill: var(--pf-global--active-color--100);
+
+  --pf-topology__edge--Stroke: var(--pf-global--secondary-color--100);
+  --pf-topology__edge--ActiveStroke: var(--pf-global--active-color--100);
+  --pf-topology__edge--InteractiveStroke: var(--pf-global--active-color--100);
 }
 
 /* DARK THEME OVERRIDES */
@@ -129,10 +125,17 @@
   --pf-topology__node--m-selected--m-warning--node__label__text--Fill: var(--pf-global--palette--black-900);
   --pf-topology__node--m-selected--m-success--node__label__text--Fill: var(--pf-global--palette--black-900);
   
-  /* TODO not done yet */
-  --pf-topology__group__background--Fill: var(--pf-global--BackgroundColor--100);
-  --pf-topology__group__background--Stroke: var(--pf-global--BorderColor--300);
+  /* Group */
+  --pf-topology__group__background--Fill: var(--pf-global--BackgroundColor--300);
+  --pf-topology__group__background--Stroke: var(--pf-global--palette--black-300);
+  --pf-topology__group--m-alt-group--topology__group__background--Fill: var(--pf-global--palette--black-500);
+  --pf-topology__group--m-alt-group--topology__group__background--Stroke: var(--pf-global--BorderColor--100);
+  --pf-topology__group--m-selected--topology__group__background--Stroke: var(--pf-global--active-color--300);
+  --pf-topology__group--m-hover--topology__group__background--Stroke: var(--pf-global--palette--black-800);
+  --pf-topology__group--m-hover--topology__group__background--Stroke: var(--pf-global--palette--black-100);
+  --pf-topology__group--m-drop-target--topology__group__background--Stroke: var(--pf-global--palette--blue-300);
 
+  --pf-topology__group--m-selected--group__label__node__label__background--Fill: var(--pf-global--primary-color--300);
 }
 
 .pf-topology-visualization-surface {
@@ -416,6 +419,7 @@
   outline: none;
 }
 
+/* TOPOLOGY GROUP BACKGROUND */
 .pf-topology__group__background {
   fill: var(--pf-topology__group__background--Fill);
   stroke: var(--pf-topology__group__background--Stroke);
@@ -423,24 +427,24 @@
 }
 
 .pf-topology__group.pf-m-alt-group .pf-topology__group__background {
-  fill: var(--pf-topology__group--m-alt-group--topology__group__background--Fill);
+  --pf-topology__group__background--Fill: var(--pf-topology__group--m-alt-group--topology__group__background--Fill);
+  --pf-topology__group__background--Stroke: var(--pf-topology__group--m-alt-group--topology__group__background--Stroke);
 }
 
 .pf-topology__group.pf-m-selected .pf-topology__group__background {
-  fill: var(--pf-topology__group--m-selected--topology__group__background--Fill);
-  stroke: var(--pf-topology__group--m-selected--topology__group__background--Stroke);
+  --pf-topology__group__background--Stroke: var(--pf-topology__group--m-selected--topology__group__background--Stroke);
 }
 
 .pf-topology__group.pf-m-hover .pf-topology__group__background {
-  stroke: var(--pf-topology__group--m-hover--topology__group__background--Stroke);
+  --pf-topology__group__background--Stroke: var(--pf-topology__group--m-hover--topology__group__background--Stroke);
 }
 
 .pf-topology__group.pf-m-drop-target .pf-topology__group__background {
-  fill: var(--pf-topology__group--m-drop-target--topology__group__background--Fill);
-  stroke: var(--pf-topology__group--m-drop-target--topology__group__background--Stroke);
+  --pf-topology__group__background--Stroke: var(--pf-topology__group--m-drop-target--topology__group__background--Stroke);
   stroke-dasharray: 12;
 }
 
+/* GROUP COLLAPSED BADGE */
 .pf-topology__group__collapsed-badge.pf-topology__node__label__badge > rect {
   fill: var(--pf-topology__group__collapsed-badge__node__label__badge__rect--Fill);
   stroke: var(--pf-topology__group__collapsed-badge__node__label__badge__rect--Stroke);
@@ -452,6 +456,7 @@
   fill: var(--pf-topology__group__collapsed-badge__node__label__badge__text--Fill);
 }
 
+/*  GROUP LABEL */
 .pf-topology__group__label .pf-topology__node__label__background {
   fill: var(--pf-topology__group__label__node__label__background--Fill);
 }
@@ -470,18 +475,19 @@
   fill: var(--pf-topology__group--m-selected--group__label__node__label__background--Fill);
 }
 
+/* EDGE */
 .pf-topology__edge {
   --edge--stroke-width: 2px;
   --edge--stroke-dasharray: 0;
-  --edge--stroke: var(--pf-global--secondary-color--100);
+  --edge--stroke: var(--pf-topology__edge--Stroke);
   --edge--fill: var(--edge--stroke);
   --edge--opacity: 1;
   --edge--cursor: pointer;
-  --edge--active--stroke: var(--pf-global--active-color--100);
+  --edge--active--stroke: var(--pf-topology__edge--ActiveStroke);
   --edge--active--fill: var(--edge--active--stroke);
   --edge--drag-active--opacity: 0.4;
   --edge__arrow--cursor: default;
-  --edge--interactive--stroke: var(--pf-global--active-color--100);
+  --edge--interactive--stroke: var(--pf-topology__edge--InteractiveStroke);
   --edge--interactive--fill: var(--edge--interactive--stroke);
 
   cursor: var(--edge--cursor);

--- a/packages/react-styles/src/css/components/Topology/topology-components.css
+++ b/packages/react-styles/src/css/components/Topology/topology-components.css
@@ -282,7 +282,6 @@
 
 .pf-topology__node__background {
   fill: var(--pf-topology__node__background--Fill);
-  stroke-width: 1px;
   stroke-width: var(--pf-topology__node__background--StrokeWidth);
   stroke: var(--pf-topology__node__background--Stroke);
 }

--- a/packages/react-styles/src/css/components/Topology/topology-components.css
+++ b/packages/react-styles/src/css/components/Topology/topology-components.css
@@ -45,8 +45,9 @@
   /* node labels */
   --pf-topology__node__label__text--Fill: var(--pf-global--palette--black-1000);
   --pf-topology__node__label__text--m-secondary--Fill: var(--pf-global--Color--200);
-
+  
   --pf-topology__node--m-selected--node__label__text--Fill: var(--pf-global--Color--light-100);
+  --pf-topology__node--m-selected--node__label__text--m-secondary--Fill: var(--pf-global--Color--light-100);
   --pf-topology__node--m-selected--m-info--node__label__text--Fill: var(--pf-global--Color--light-100);
   --pf-topology__node--m-selected--m-danger--node__label__text--Fill: var(--pf-global--Color--light-100);
   --pf-topology__node--m-selected--m-warning--node__label__text--Fill: var(--pf-global--Color--light-100);
@@ -83,8 +84,10 @@
 
 
   --pf-topology__node__separator--Stroke: var(--pf-global--palette--black-300);
+  --pf-topology__node--m-selected--separator--Stroke: var(--pf-global--palette--black-300);
 
   --pf-topology__node__action-icon__icon--Color: var(--pf-global--palette--black-1000);
+  --pf-topology__node--m-selected--action-icon__icon--Color: var(--pf-global--Color--light-100);
 
   /* group */
   --pf-topology__group--m-selected--topology__node__action-icon__icon--Color: var(--pf-global--palette--white);
@@ -184,8 +187,9 @@
 
   /* dark selected nodes */
   --pf-topology__node--m-selected--node__background--Stroke: var(--pf-global--palette--blue-300);
-  --pf-topology__node--m-selected--node__label__background--Stroke: var(--pf-global--primary-color--300);
-  --pf-topology__node--m-selected--node__label__background--Fill: var(--pf-global--primary-color--300);
+  --pf-topology__node--m-selected--node__label__background--Stroke: var(--pf-global--palette--blue-400);
+  --pf-topology__node--m-selected--node__label__background--Fill: var(--pf-global--palette--blue-400);
+  --pf-topology__node--m-selected--separator--Stroke: var(--pf-global--palette--blue-300);
 
   --pf-topology__node--m-selected--node__label__text--Fill: var(--pf-global--Color--100);
   --pf-topology__node--m-selected--m-info--node__label__text--Fill: var(--pf-global--palette--black-900);
@@ -194,6 +198,8 @@
   --pf-topology__node--m-selected--m-success--node__label__text--Fill: var(--pf-global--palette--black-900);
   
   --pf-topology__node__label__icon--Color: var(--pf-global--palette--black-600);
+
+  --pf-topology__node__action-icon__icon--Color: var(--pf-global--Color--100);
 
   /* dark group */
   --pf-topology__group__background--Fill: var(--pf-global--BackgroundColor--300);
@@ -398,6 +404,7 @@
 
 .pf-topology__node.pf-m-selected .pf-topology__node__label > text {
   --pf-topology__node__label__text--Fill: var(--pf-topology__node--m-selected--node__label__text--Fill);
+  --pf-topology__node__label__text--m-secondary--Fill: var(--pf-topology__node--m-selected--node__label__text--m-secondary--Fill);
 }
 
 .pf-topology__node__label__background {
@@ -410,6 +417,8 @@
   stroke-width: 2px;
   --pf-topology__node__label__background--Stroke: var(--pf-topology__node--m-selected--node__label__background--Stroke);
   --pf-topology__node__label__background--Fill: var(--pf-topology__node--m-selected--node__label__background--Fill);
+  --pf-topology__node__separator--Stroke: var(--pf-topology__node--m-selected--separator--Stroke);
+  --pf-topology__node__action-icon__icon--Color: var(--pf-topology__node--m-selected--action-icon__icon--Color);
 }
 
 .pf-topology__node.pf-m-info {
@@ -512,6 +521,10 @@
 
 .pf-topology__node__action-icon__icon {
   color: var(--pf-topology__node__action-icon__icon--Color);
+}
+
+.pf-topology__node__action-icon__icon svg {
+  fill: currentColor;
 }
 
 .pf-topology__group.pf-m-selected .pf-topology__node__action-icon__icon {

--- a/packages/react-styles/src/css/components/Topology/topology-components.css
+++ b/packages/react-styles/src/css/components/Topology/topology-components.css
@@ -70,6 +70,8 @@
   --pf-topology__node--m-selected--m-success--node__label__background--Fill: var(--pf-global--success-color--100);
 
   /* node label icon */
+  --pf-topology__node__label__icon--Color: var(--pf-global--Color--200);
+
   --pf-topology__node__label__icon__background--Fill: var(--pf-global--palette--white);
   --pf-topology__node__label__icon__background--Stroke: var(--pf-global--palette--black-300);
 
@@ -191,6 +193,8 @@
   --pf-topology__node--m-selected--m-warning--node__label__text--Fill: var(--pf-global--palette--black-900);
   --pf-topology__node--m-selected--m-success--node__label__text--Fill: var(--pf-global--palette--black-900);
   
+  --pf-topology__node__label__icon--Color: var(--pf-global--palette--black-600);
+
   /* dark group */
   --pf-topology__group__background--Fill: var(--pf-global--BackgroundColor--300);
   --pf-topology__group__background--Stroke: var(--pf-global--palette--black-300);
@@ -453,6 +457,10 @@
 .pf-topology__node__label__badge > text {
   font-size: var(--pf-global--FontSize--xs);
   pointer-events: none;
+}
+
+.pf-topology__node__label__icon {
+  color: var(--pf-topology__node__label__icon--Color);
 }
 
 .pf-topology__node__label__icon > svg {

--- a/packages/react-styles/src/css/components/Topology/topology-components.css
+++ b/packages/react-styles/src/css/components/Topology/topology-components.css
@@ -94,8 +94,42 @@
   --pf-topology__group--m-selected--group__label__node__label__background--Fill: var(--pf-global--active-color--100);
 
   --pf-topology__edge--Stroke: var(--pf-global--secondary-color--100);
+  --pf-topology__edge--HoverStroke: var(--pf-global--Color--100);
   --pf-topology__edge--ActiveStroke: var(--pf-global--active-color--100);
   --pf-topology__edge--InteractiveStroke: var(--pf-global--active-color--100);
+
+  --pf-topology__edge--m-info--EdgeStroke: var(--pf-global--primary-color--light-100);
+  --pf-topology__edge--m-success--EdgeStroke: var(--pf-global--success-color--100);
+  --pf-topology__edge--m-warning--EdgeStroke: var(--pf-global--warning-color--100);
+  --pf-topology__edge--m-danger--EdgeStroke: var(--pf-global--danger-color--100);
+
+  --pf-topology__edge--m-selected--background--Stroke: var(--pf-global--active-color--200);
+  --pf-topology__edge--m-hover--background--Stroke: var(--pf-global--BorderColor--100);
+
+  --pf-topology__edge__tag__text--Fill: var(--pf-global--palette--white);
+  --pf-topology__edge__tag__text--Stroke: var(--pf-global--palette--white);
+
+  --pf-topology__edge__tag--m-info--background--Fill: var(--pf-global--primary-color--light-100);
+  --pf-topology__edge__tag--m-success--background--Fill: var(--pf-global--success-color--100);
+  --pf-topology__edge__tag--m-warning--background--Fill: var(--pf-global--warning-color--100);
+
+  --pf-topology__edge__tag--m-warning--text--Fill: var(--pf-global--palette--black-1000);
+  --pf-topology__edge__tag--m-warning--text--Stroke: var(--pf-global--palette--black-1000);
+
+  --pf-topology__edge__tag--m-danger--background--Fill: var(--pf-global--danger-color--100);
+
+  --pf-topology-connector-arrow--m-alt-connector-arrow--Fill: var(--pf-global--palette--white);
+
+  --pf-topology__connector-square--m-source--Fill: var(--pf-global--palette--white);
+
+  --pf-topology-default-create-connector__arrow--Fill: var(--pf-global--Color--light-200);
+
+  --pf-topology-default-create-connector--m-hover--line--Stroke: var(--pf-global--Color--100);
+
+  --pf-topology-default-create-connector--m-hover--arrow--Fill: var(--pf-global--Color--100);
+  --pf-topology-default-create-connector--m-hover--arrow--Stroke: var(--pf-global--Color--100);
+  
+
 }
 
 /* DARK THEME OVERRIDES */
@@ -483,6 +517,8 @@
   --edge--fill: var(--edge--stroke);
   --edge--opacity: 1;
   --edge--cursor: pointer;
+  --edge--hover--stroke: var(--pf-topology__edge--HoverStroke);
+  --edge--hover--fill: var(--edge--hover--stroke);
   --edge--active--stroke: var(--pf-topology__edge--ActiveStroke);
   --edge--active--fill: var(--edge--active--stroke);
   --edge--drag-active--opacity: 0.4;
@@ -497,19 +533,18 @@
 }
 
 .pf-topology__edge.pf-m-info {
-  --edge--stroke: var(--pf-global--primary-color--light-100);
+  --edge--stroke: var(--pf-topology__edge--m-info--EdgeStroke);
 }
 
 .pf-topology__edge.pf-m-success {
-  --edge--stroke: var(--pf-global--success-color--100);
+  --edge--stroke: var(--pf-topology__edge--m-success--EdgeStroke);
 }
-
 .pf-topology__edge.pf-m-warning {
-  --edge--stroke: var(--pf-global--warning-color--100);
+  --edge--stroke: var(--pf-topology__edge--m-warning--EdgeStroke);
 }
 
 .pf-topology__edge.pf-m-danger {
-  --edge--stroke: var(--pf-global--danger-color--100);
+  --edge--stroke: var(--pf-topology__edge--m-danger--EdgeStroke);
 }
 
 .pf-topology__edge__background {
@@ -518,18 +553,19 @@
   fill: none;
 }
 .pf-topology__edge.pf-m-selected .pf-topology__edge__background {
-  stroke: var(--pf-global--active-color--200);
+  stroke: var(--pf-topology__edge--m-selected--background--Stroke);
 }
 .pf-topology__edge.pf-m-hover .pf-topology__edge__background {
-  stroke: var(--pf-global--BorderColor--100);
+  stroke: var(--pf-topology__edge--m-hover--background--Stroke);
 }
 
 .pf-topology__edge__link {
-   stroke-width: var(--edge--stroke-width);
-   stroke-dasharray: var(--edge--stroke-dasharray);
+  stroke-width: var(--edge--stroke-width);
+  stroke-dasharray: var(--edge--stroke-dasharray);
   fill-opacity: 0;
-   animation: pf-topology__edge__dash 0s linear infinite forwards;
+  animation: pf-topology__edge__dash 0s linear infinite forwards;
  }
+
 .pf-topology__edge__link.pf-m-dotted {
   stroke-dasharray: 2;
   stroke-dashoffset: 2;
@@ -557,12 +593,6 @@
   }
 }
 
-.pf-topology__edge.pf-m-hover .pf-topology__edge__link,
-.pf-topology__edge.pf-m-hover .pf-topology__connector-arrow {
-  fill: var(--pf-global--Color--100);
-  stroke: var(--pf-global--Color--100);
-}
-
 .pf-topology__edge.pf-m-selected .pf-topology__edge__link,
 .pf-topology__edge.pf-m-selected .pf-topology-connector-arrow {
   fill: var(--edge--active--fill);
@@ -578,10 +608,16 @@
 .pf-topology__edge.pf-m-dragging {
   pointer-events: none;
 }
+.pf-topology__edge.pf-m-hover .pf-topology__edge__link,
+.pf-topology__edge.pf-m-hover .pf-topology-connector-arrow {
+  fill: var(--edge--hover--fill);
+  stroke: var(--edge--hover--stroke);
+}
+
 .pf-topology__edge.pf-m-dragging .pf-topology__edge__link,
 .pf-topology__edge.pf-m-dragging .pf-topology-connector-arrow {
-  stroke: var(--edge--interactive--stroke);
   fill: var(--edge--interactive--fill);
+  stroke: var(--edge--interactive--stroke);
 }
 
 .pf-topology__edge .pf-topology-connector-arrow {
@@ -599,31 +635,32 @@
 }
 
 .pf-topology__edge__tag > text {
-  stroke: var(--pf-global--palette--white);
+  fill: var(--pf-topology__edge__tag__text--Fill);
+  stroke: var(--pf-topology__edge__tag__text--Stroke);
   stroke-width: 0.5;
   font-size: 10px;
   pointer-events: none;
-  fill: var(--pf-global--palette--white);
 }
 
 .pf-topology__edge__tag.pf-m-info .pf-topology__edge__tag__background {
-  fill: var(--pf-global--primary-color--light-100);
+  fill: var(--pf-topology__edge__tag--m-info--background--Fill);
 }
 
 .pf-topology__edge__tag.pf-m-success .pf-topology__edge__tag__background {
-  fill: var(--pf-global--success-color--100);
+  fill: var(--pf-topology__edge__tag--m-success--background--Fill);
 }
 
 .pf-topology__edge__tag.pf-m-warning .pf-topology__edge__tag__background {
-  fill: var(--pf-global--warning-color--100);
+  fill: var(--pf-topology__edge__tag--m-warning--background--Fill);
 }
+
 .pf-topology__edge__tag.pf-m-warning > text {
-  stroke: var(--pf-global--palette--black-1000);
-  fill: var(--pf-global--palette--black-1000);
+  fill: var(--pf-topology__edge__tag--m-warning--text--Fill);
+  stroke: var(--pf-topology__edge__tag--m-warning--text--Stroke);
 }
 
 .pf-topology__edge__tag.pf-m-danger .pf-topology__edge__tag__background {
-  fill: var(--pf-global--danger-color--100);
+  fill: var(--pf-topology__edge__tag--m-danger--background--Fill);
 }
 
 .pf-topology-connector-arrow {
@@ -632,7 +669,7 @@
 }
 
 .pf-topology-connector-arrow.pf-m-alt-connector-arrow {
-  fill: var(--pf-global--palette--white);
+  fill: var(--pf-topology-connector-arrow--m-alt-connector-arrow--Fill);
 }
 
 .pf-topology__connector-cross {
@@ -650,7 +687,7 @@
 }
 
 .pf-topology__connector-square.pf-m-source, .pf-topology__connector-circle.pf-m-source {
-  fill: var(--pf-global--palette--white);
+  fill: var(--pf-topology__connector-square--m-source--Fill);
 }
 
 .pf-topology__connector-x {
@@ -669,17 +706,17 @@
 }
 
 .pf-topology-default-create-connector__arrow {
-  fill: var(--pf-global--Color--light-200);
+  fill: var(--pf-topology-default-create-connector__arrow--Fill);
   stroke: var(--pf-topology-create-connector-color);
 }
 
 .pf-topology-default-create-connector.pf-m-hover .pf-topology-default-create-connector__line {
-  stroke: var(--pf-global--Color--100);
+  stroke: var(--pf-topology-default-create-connector--m-hover--line--Stroke);
 }
 
 .pf-topology-default-create-connector.pf-m-hover .pf-topology-default-create-connector__arrow {
-  fill: var(--pf-global--Color--100);
-  stroke: var(--pf-global--Color--100);
+  fill: var(--pf-topology-default-create-connector--m-hover--arrow--Fill);
+  stroke: var(--pf-topology-default-create-connector--m-hover--arrow--Stroke);
 }
 
 .pf-topology-default-create-connector__create {
@@ -695,30 +732,9 @@
   fill: var(--pf-topology-create-connector-color);
 }
 
-
-
 .pf-theme-dark .pfext-catalog-item-icon__img--large {
-    /* Not perfect, but gives a better result for colors than just inverting
-    by inverts to switch b/w, then rotates to get colors approximately back */
-    filter: brightness(1.5) invert(1) hue-rotate(180deg) saturate(4);
-  }
+  /* Not perfect, but gives a better result for colors than just inverting
+  by inverts to switch b/w, then rotates to get colors approximately back */
+  filter: brightness(1.5) invert(1) hue-rotate(180deg) saturate(4);
+}
 
-
-/* .pf-theme-dark .pf-topology__node__background {
-  fill: var(--pf-global--BackgroundColor--300);
-  stroke: var(--pf-global--palette--black-400);
-} */
-
-/* .pf-theme-dark .pf-topology__node__background.pf-m-disabled {
-  fill: var(--pf-global--BackgroundColor--50);
-} */
-
-/* TODO check state colors */
-/* TODO decorators */
-
-
-/* .pf-theme-dark {
-  --pf-topology__node__background--Fill: var(--pf-global--BackgroundColor--300);
-  --pf-topology__node__background--Stroke: var(--pf-global--BorderColor--300);
-} */
-  /* TODO hover gets border 400 */

--- a/packages/react-styles/src/css/components/Topology/topology-components.css
+++ b/packages/react-styles/src/css/components/Topology/topology-components.css
@@ -1,24 +1,30 @@
 :root {
-  /* TODO fix connector color variable */
-
   --pf-topology-visualization-surface--BackgroundColor: transparent;
 
   --pf-topology__node--Color: #393f44;
 
+  /* Create connector */
+  /* Remove --pf-topology-create-connector-color at a breaking change */
   --pf-topology-create-connector-color: var(--pf-global--secondary-color--100);
-  --pf-topology__create-connector-color: var(--pf-global--secondary-color--100);
+  --pf-topology__create-connector-color--Stroke: var(--pf-topology-create-connector-color, --pf-global--secondary-color--100);
+  --pf-topology__create-connector-color--Fill: var(--pf-topology-create-connector-color, --pf-global--secondary-color--100);
+
+  /* node */
   --pf-topology__node__background--Fill: var(--pf-global--BackgroundColor--100);
   --pf-topology__node__background--Stroke: var(--pf-global--BorderColor--100);
-
+  --pf-topology__node__background--StrokeWidth: 1px;
+  --pf-topology__node--m-dragging--background--StrokeWidth: 1px;
+  
   --pf-topology__node--m-hover--background--Stroke: unset;
   --pf-topology__node--m-hover--label__background--Stroke: unset;
 
-  --pf-topology__node--m-disabled--Background: var(--pf-global--BackgroundColor--200);
-  --pf-topology__node--m-info--Background: var(--pf-global--primary-color--light-100);
-  --pf-topology__node--m-success--Background: var(--pf-global--success-color--100);
-  --pf-topology__node--m-warning--Background: var(--pf-global--warning-color--100);
-  --pf-topology__node--m-danger--Background: var(--pf-global--danger-color--100);
-  --pf-topology__node--m-selected--Background: var(--pf-global--active-color--100);
+  --pf-topology__node--m-disabled--Background--Fill: var(--pf-global--BackgroundColor--200);
+  --pf-topology__node--m-disabled--Background--Stroke: var(--pf-global--BorderColor--100);
+  --pf-topology__node--m-info--Background--Fill: var(--pf-global--primary-color--light-100);
+  --pf-topology__node--m-success--Background--Fill: var(--pf-global--success-color--100);
+  --pf-topology__node--m-warning--Background--Fill: var(--pf-global--warning-color--100);
+  --pf-topology__node--m-danger--Background--Fill: var(--pf-global--danger-color--100);
+  --pf-topology__node--m-selected--Background--Fill: var(--pf-global--active-color--100);
 
   --pf-topology__node--m-selected--node__background--Stroke: var(--pf-global--active-color--100);
   --pf-topology__node--m-info--node__background--Stroke: var(--pf-global--primary-color--light-100);
@@ -26,6 +32,7 @@
   --pf-topology__node--m-warning--node__background--Stroke: var(--pf-global--warning-color--100);
   --pf-topology__node--m-danger--node__background--Stroke: var(--pf-global--danger-color--100);
 
+  /* node decorators */
   --pf-topology__node_decorator--Color: var(--pf-global--Color--200);
   --pf-topology__node__decorator__bg--Fill: var(--pf-global--BackgroundColor--light-100);
   --pf-topology__node__decorator__bg--Stroke: var(--pf-global--BorderColor--100);
@@ -35,8 +42,9 @@
   --pf-topology__node__decorator__status--m-warning--Color: var(--pf-global--warning-color--100);
   --pf-topology__node__decorator__status--m-success--Color: var(--pf-global--success-color--100);
 
+  /* node labels */
   --pf-topology__node__label__text--Fill: var(--pf-global--palette--black-1000);
-  --pf-topology__node__label__text--m-secondary--Fill: var(--pf-global--secondary-color--100);
+  --pf-topology__node__label__text--m-secondary--Fill: var(--pf-global--Color--200);
 
   --pf-topology__node--m-selected--node__label__text--Fill: var(--pf-global--Color--light-100);
   --pf-topology__node--m-selected--m-info--node__label__text--Fill: var(--pf-global--Color--light-100);
@@ -45,13 +53,15 @@
   --pf-topology__node--m-selected--m-success--node__label__text--Fill: var(--pf-global--Color--light-100);
 
   --pf-topology__node__label__background--Fill: var(--pf-global--BackgroundColor--100);
-
   --pf-topology__node__label__background--Stroke: var(--pf-global--BorderColor--100);
+
   --pf-topology__node--m-selected--node__label__background--Stroke: var(--pf-global--active-color--100);
   --pf-topology__node--m-info--node__label__background--Stroke: var(--pf-global--primary-color--light-100);
   --pf-topology__node--m-success--node__label__background--Stroke: var(--pf-global--success-color--100);
   --pf-topology__node--m-warning--node__label__background--Stroke: var(--pf-global--warning-color--100);
   --pf-topology__node--m-danger--node__label__background--Stroke: var(--pf-global--danger-color--100);
+  --pf-topology__node__label__background--StrokeWidth: 1px;
+  --pf-topology__node__label--m-dragging--background--StrokeWidth: 1px;
 
   --pf-topology__node--m-selected--node__label__background--Fill: var(--pf-global--active-color--100);
   --pf-topology__node--m-selected--m-info--node__label__background--Fill: var(--pf-global--primary-color--light-100);
@@ -59,6 +69,7 @@
   --pf-topology__node--m-selected--m-warning--node__label__background--Fill: var(--pf-global--warning-color--100);
   --pf-topology__node--m-selected--m-success--node__label__background--Fill: var(--pf-global--success-color--100);
 
+  /* node label icon */
   --pf-topology__node__label__icon__background--Fill: var(--pf-global--palette--white);
   --pf-topology__node__label__icon__background--Stroke: var(--pf-global--palette--black-300);
 
@@ -73,12 +84,14 @@
 
   --pf-topology__node__action-icon__icon--Color: var(--pf-global--palette--black-1000);
 
+  /* group */
   --pf-topology__group--m-selected--topology__node__action-icon__icon--Color: var(--pf-global--palette--white);
 
   --pf-topology__group__background--Fill: var(--pf-global--BackgroundColor--light-300);
   --pf-topology__group__background--Stroke: var(--pf-global--palette--white);
 
   --pf-topology__group--m-alt-group--topology__group__background--Fill: var(--pf-global--palette--white);
+  --pf-topology__group--m-selected--topology__group__background--Fill: var(--pf-global--palette--blue-50);
 
   --pf-topology__group--m-selected--topology__group__background--Stroke: var(--pf-global--active-color--100);
   --pf-topology__group--m-hover--topology__group__background--Stroke: var(--pf-global--BackgroundColor--dark-400);
@@ -89,13 +102,17 @@
   --pf-topology__group__collapsed-badge__node__label__badge__text--Fill: var(--pf-global--palette--black-800);
 
   --pf-topology__group__label__node__label__background--Fill: var(--pf-global--BackgroundColor--dark-300);
+  --pf-topology__group__label__node__label__background--StrokeWidth: 1px;
   --pf-topology__group__label__text--Fill: var(--pf-global--palette--white); 
   --pf-topology__group__label__node__action-icon__icon--Color: var(--pf-global--palette--white);
   --pf-topology__group--m-selected--group__label__node__label__background--Fill: var(--pf-global--active-color--100);
 
+  /* edge */
   --pf-topology__edge--Stroke: var(--pf-global--secondary-color--100);
+  --pf-topology__edge--StrokeWidth: 1px;
   --pf-topology__edge--HoverStroke: var(--pf-global--Color--100);
   --pf-topology__edge--ActiveStroke: var(--pf-global--active-color--100);
+  --pf-topology__edge--ActiveStrokeWidth: 2px;
   --pf-topology__edge--InteractiveStroke: var(--pf-global--active-color--100);
 
   --pf-topology__edge--m-info--EdgeStroke: var(--pf-global--primary-color--light-100);
@@ -109,6 +126,7 @@
   --pf-topology__edge__tag__text--Fill: var(--pf-global--palette--white);
   --pf-topology__edge__tag__text--Stroke: var(--pf-global--palette--white);
 
+  --pf-topology__edge__tag__background--Fill: var(--pf-global--secondary-color--100);
   --pf-topology__edge__tag--m-info--background--Fill: var(--pf-global--primary-color--light-100);
   --pf-topology__edge__tag--m-success--background--Fill: var(--pf-global--success-color--100);
   --pf-topology__edge__tag--m-warning--background--Fill: var(--pf-global--warning-color--100);
@@ -118,18 +136,16 @@
 
   --pf-topology__edge__tag--m-danger--background--Fill: var(--pf-global--danger-color--100);
 
+  /* connectors */
   --pf-topology-connector-arrow--m-alt-connector-arrow--Fill: var(--pf-global--palette--white);
 
-  --pf-topology__connector-square--m-source--Fill: var(--pf-global--palette--white);
+  --pf-topology__connector-square--m-source--Fill: var(--pf-global--BackgroundColor--100);
 
   --pf-topology-default-create-connector__arrow--Fill: var(--pf-global--Color--light-200);
 
   --pf-topology-default-create-connector--m-hover--line--Stroke: var(--pf-global--Color--100);
-
   --pf-topology-default-create-connector--m-hover--arrow--Fill: var(--pf-global--Color--100);
   --pf-topology-default-create-connector--m-hover--arrow--Stroke: var(--pf-global--Color--100);
-  
-
 }
 
 /* DARK THEME OVERRIDES */
@@ -137,39 +153,79 @@
   --pf-topology-visualization-surface--BackgroundColor: var(--pf-global--BackgroundColor--200);
 
   --pf-topology__node--Color: var(--pf-global--Color--100); 
+
+  /* dark create connector */
+  --pf-topology__create-connector-color--Stroke: var(--pf-global--palette--black-300);
+  --pf-topology__create-connector-color--Fill: var(--pf-global--palette--black-100);
+  --pf-topology-default-create-connector__arrow--Fill: var(--pf-global--BackgroundColor--100);
+  --pf-topology-default-create-connector--m-hover--line--Stroke: var(--pf-global--palette--black-100);
+  --pf-topology-default-create-connector--m-hover--arrow--Fill: var(--pf-global--palette--black-100);
+  --pf-topology-default-create-connector--m-hover--arrow--Stroke: var(--pf-global--palette--black-100);
+
+  /* dark node */
   --pf-topology__node__background--Fill: var(--pf-global--BackgroundColor--300);
   --pf-topology__node__background--Stroke:  var(--pf-global--palette--black-300);
-  /* TODO Hover state - uses filter for shadow but needs different stroke */
+
+  --pf-topology__node--m-disabled--Background--Fill: var(--pf-topology__node__background--Fill);
+  --pf-topology__node--m-disabled--Background--Stroke: var(--pf-global--palette--black-500);
+  
+  --pf-topology__node--m-dragging--background--StrokeWidth: 2px;
+  
   --pf-topology__node--m-hover--background--Stroke: var(--pf-global--palette--black-100);
   --pf-topology__node--m-hover--label__background--Stroke: var(--pf-global--palette--black-100);
 
+  /* dark node labels */
+  --pf-topology__node__label__background--Fill: var(--pf-global--BackgroundColor--300);
   --pf-topology__node__label__background--Stroke: var(--pf-global--BorderColor--300);
+  --pf-topology__node__label--m-dragging--background--StrokeWidth: 2px;
   --pf-topology__node__label__text--Fill: var(--pf-global--Color--100);
-  --pf-topology__node__label__text--m-secondary--Fill: var(--pf-global--Color--100);
 
-  /* selected nodes */
+  /* dark selected nodes */
   --pf-topology__node--m-selected--node__background--Stroke: var(--pf-global--palette--blue-300);
   --pf-topology__node--m-selected--node__label__background--Stroke: var(--pf-global--primary-color--300);
   --pf-topology__node--m-selected--node__label__background--Fill: var(--pf-global--primary-color--300);
 
-  /* make text dark when selected but TODO not on the default, only the statuses */
   --pf-topology__node--m-selected--node__label__text--Fill: var(--pf-global--Color--100);
   --pf-topology__node--m-selected--m-info--node__label__text--Fill: var(--pf-global--palette--black-900);
   --pf-topology__node--m-selected--m-danger--node__label__text--Fill: var(--pf-global--palette--black-900);
   --pf-topology__node--m-selected--m-warning--node__label__text--Fill: var(--pf-global--palette--black-900);
   --pf-topology__node--m-selected--m-success--node__label__text--Fill: var(--pf-global--palette--black-900);
   
-  /* Group */
+  /* dark group */
   --pf-topology__group__background--Fill: var(--pf-global--BackgroundColor--300);
   --pf-topology__group__background--Stroke: var(--pf-global--palette--black-300);
   --pf-topology__group--m-alt-group--topology__group__background--Fill: var(--pf-global--palette--black-500);
   --pf-topology__group--m-alt-group--topology__group__background--Stroke: var(--pf-global--BorderColor--100);
+  --pf-topology__group--m-selected--topology__group__background--Fill: var(--pf-global--palette--black-700);
   --pf-topology__group--m-selected--topology__group__background--Stroke: var(--pf-global--active-color--300);
   --pf-topology__group--m-hover--topology__group__background--Stroke: var(--pf-global--palette--black-800);
   --pf-topology__group--m-hover--topology__group__background--Stroke: var(--pf-global--palette--black-100);
   --pf-topology__group--m-drop-target--topology__group__background--Stroke: var(--pf-global--palette--blue-300);
 
+  --pf-topology__group__label__node__label__background--StrokeWidth: 2px;
+  --pf-topology__group__label__node__label__background--Stroke: var(--pf-global--palette--black-300);
+  --pf-topology__group--m-hover--label__node__label__background--Stroke: var(--pf-global--palette--black-100);
+  --pf-topology__group--m-selected--label__node__label__background--Stroke: var(--pf-global--primary-color--300);
+
   --pf-topology__group--m-selected--group__label__node__label__background--Fill: var(--pf-global--primary-color--300);
+
+  /* dark edge */
+  --pf-topology__edge--HoverStroke: var(--pf-global--palette--black-300);
+  --pf-topology__edge--m-hover--background--Stroke: var(--pf-global--palette--black-600);
+
+  --pf-topology__edge--ActiveStroke: var(--pf-global--palette--blue-300);
+  --pf-topology__edge--m-selected--background--Stroke: var(--pf-global--palette--black-600);
+
+  --pf-topology__edge__tag__background--Fill: var(--pf-global--palette--black-300);
+  --pf-topology__edge__tag__text--Fill: var(--pf-global--palette--black-900);
+  --pf-topology__edge__tag__text--Stroke: var(--pf-global--palette--black-900);
+
+}
+
+:root:where(.pf-theme-dark) .pfext-catalog-item-icon__img--large {
+  /* Not perfect, but gives a better result for colors than just inverting
+  by inverts to switch b/w, then rotates to get colors approximately back */
+  filter: brightness(1.5) invert(1) hue-rotate(180deg) saturate(4);
 }
 
 .pf-topology-visualization-surface {
@@ -207,14 +263,15 @@
   transform: translateY(-50%);
 }
 
-/* ******* NODE ********* */
+/* Node */
 .pf-topology__node {
   outline: none;
   color: var(--pf-topology__node--Color);
 }
 
 /* Color is defined in the svg but fill will override it */
-.pf-topology__node svg {
+.pf-topology__node svg,
+.pf-topology__group svg {
   fill: var(--pf-topology__node--Color);
 }
 
@@ -226,31 +283,38 @@
 .pf-topology__node__background {
   fill: var(--pf-topology__node__background--Fill);
   stroke-width: 1px;
+  stroke-width: var(--pf-topology__node__background--StrokeWidth);
   stroke: var(--pf-topology__node__background--Stroke);
 }
 
 .pf-topology__node__background.pf-m-disabled {
-  --pf-topology__node__background--Fill: var(--pf-topology__node--m-disabled--Background);
+  --pf-topology__node__background--Fill: var(--pf-topology__node--m-disabled--Background--Fill);
+  --pf-topology__node__background--Stroke: var(--pf-topology__node--m-disabled--Background--Stroke);
 }
 
 .pf-topology__node__background.pf-m-info {
-  --pf-topology__node__background--Fill: var(--pf-topology__node--m-info--Background);
+  --pf-topology__node__background--Fill: var(--pf-topology__node--m-info--Background--Fill);
 }
 
 .pf-topology__node__background.pf-m-success {
-  --pf-topology__node__background--Fill: var(--pf-topology__node--m-success--Background);
+  --pf-topology__node__background--Fill: var(--pf-topology__node--m-success--Background--Fill);
 }
 
 .pf-topology__node__background.pf-m-warning {
-  --pf-topology__node__background--Fill: var(--pf-topology__node--m-warning--Background);
+  --pf-topology__node__background--Fill: var(--pf-topology__node--m-warning--Background--Fill);
 }
 
 .pf-topology__node__background.pf-m-danger {
-  --pf-topology__node__background--Fill: var(--pf-topology__node--m-danger--Background);
+  --pf-topology__node__background--Fill: var(--pf-topology__node--m-danger--Background--Fill);
 }
 
 .pf-topology__node__background.pf-m-selected {
-  --pf-topology__node__background--Fill: var(--pf-topology__node--m-selected--Background);
+  --pf-topology__node__background--Fill: var(--pf-topology__node--m-selected--Background--Fill);
+}
+
+.pf-topology__node.pf-m-dragging {
+  --pf-topology__node__background--StrokeWidth: var(--pf-topology__node--m-dragging--background--StrokeWidth);
+  --pf-topology__node__label__background--StrokeWidth: var(--pf-topology__node__label--m-dragging--background--StrokeWidth);
 }
 
 .pf-topology__node.pf-m-dragging .pf-topology__node__background {
@@ -278,10 +342,7 @@
   --pf-topology__node__background--Stroke: var(--pf-topology__node--m-danger--node__background--Stroke);
 }
 
-.pf-topology__node.pf-m-drop-target .pf-topology__node__background {
-}
-
-/* ******** DECORATOR ******** */
+/* Node decorator */
 .pf-topology__node__decorator {
   --pf-topology__node--Color: var(--pf-topology__node_decorator--Color);
   transition: color 0.2s ease;
@@ -320,7 +381,7 @@
   --pf-topology__node_decorator--Color: var(--pf-topology__node__decorator__status--m-success--Color);
 }
 
-/* ************* NODE LABEL ************** */
+/* Node label */
 .pf-topology__node__label > text {
   fill: var(--pf-topology__node__label__text--Fill);
   font-size: var(--pf-global--FontSize--sm);
@@ -338,7 +399,7 @@
 
 .pf-topology__node__label__background {
   fill: var(--pf-topology__node__label__background--Fill);
-  stroke-width: 1px;
+  stroke-width: var(--pf-topology__node__label__background--StrokeWidth);
   stroke: var(--pf-topology__node__label__background--Stroke);
 }
 
@@ -384,8 +445,9 @@
   --pf-topology__node--m-selected--node__label__text--Fill: var(--pf-topology__node--m-selected--m-success--node__label__text--Fill);
 }
 
-/* *********** NODE LABEL BADGE ********* */
+/* Node label badge */
 .pf-topology__node__label__badge > rect {
+  /* TODO Color is hard coded in the badge. */
   stroke-width: 1px;
 }
 
@@ -453,7 +515,7 @@
   outline: none;
 }
 
-/* TOPOLOGY GROUP BACKGROUND */
+/* Group background */
 .pf-topology__group__background {
   fill: var(--pf-topology__group__background--Fill);
   stroke: var(--pf-topology__group__background--Stroke);
@@ -466,11 +528,13 @@
 }
 
 .pf-topology__group.pf-m-selected .pf-topology__group__background {
+  --pf-topology__group__background--Fill: var(--pf-topology__group--m-selected--topology__group__background--Fill);
   --pf-topology__group__background--Stroke: var(--pf-topology__group--m-selected--topology__group__background--Stroke);
 }
 
 .pf-topology__group.pf-m-hover .pf-topology__group__background {
   --pf-topology__group__background--Stroke: var(--pf-topology__group--m-hover--topology__group__background--Stroke);
+  --pf-topology__group__label__node__label__background--Stroke: var(--pf-topology__group--m-hover--label__node__label__background--Stroke);
 }
 
 .pf-topology__group.pf-m-drop-target .pf-topology__group__background {
@@ -478,7 +542,7 @@
   stroke-dasharray: 12;
 }
 
-/* GROUP COLLAPSED BADGE */
+/* Collapsed group badge */
 .pf-topology__group__collapsed-badge.pf-topology__node__label__badge > rect {
   fill: var(--pf-topology__group__collapsed-badge__node__label__badge__rect--Fill);
   stroke: var(--pf-topology__group__collapsed-badge__node__label__badge__rect--Stroke);
@@ -490,9 +554,11 @@
   fill: var(--pf-topology__group__collapsed-badge__node__label__badge__text--Fill);
 }
 
-/*  GROUP LABEL */
+/*  Group label */
 .pf-topology__group__label .pf-topology__node__label__background {
   fill: var(--pf-topology__group__label__node__label__background--Fill);
+  --pf-topology__node__label__background--Stroke: var(--pf-topology__group__label__node__label__background--Stroke);
+  --pf-topology__node__label__background--StrokeWidth: var(--pf-topology__group__label__node__label__background--StrokeWidth);
 }
 
 .pf-topology__group__label > text {
@@ -507,11 +573,12 @@
 
 .pf-topology__group.pf-m-selected .pf-topology__group__label .pf-topology__node__label__background {
   fill: var(--pf-topology__group--m-selected--group__label__node__label__background--Fill);
+  --pf-topology__group__label__node__label__background--Stroke: var(--pf-topology__group--m-selected--label__node__label__background--Stroke);
 }
 
-/* EDGE */
+/* Edge */
 .pf-topology__edge {
-  --edge--stroke-width: 2px;
+  --edge--stroke-width: var(--pf-topology__edge--StrokeWidth);
   --edge--stroke-dasharray: 0;
   --edge--stroke: var(--pf-topology__edge--Stroke);
   --edge--fill: var(--edge--stroke);
@@ -520,6 +587,7 @@
   --edge--hover--stroke: var(--pf-topology__edge--HoverStroke);
   --edge--hover--fill: var(--edge--hover--stroke);
   --edge--active--stroke: var(--pf-topology__edge--ActiveStroke);
+  --edge--active--stroke-width: var(--pf-topology__edge--ActiveStrokeWidth);
   --edge--active--fill: var(--edge--active--stroke);
   --edge--drag-active--opacity: 0.4;
   --edge__arrow--cursor: default;
@@ -597,6 +665,7 @@
 .pf-topology__edge.pf-m-selected .pf-topology-connector-arrow {
   fill: var(--edge--active--fill);
   stroke: var(--edge--active--stroke);
+  stroke-width: var(--edge--active--stroke-width);
 }
 
 .pf-topology__edge.pf-m-selected.pf-m-hover .pf-topology__edge__link,
@@ -630,7 +699,7 @@
 }
 
 .pf-topology__edge__tag__background {
-  fill: var(--edge--stroke);
+  fill: var(--pf-topology__edge__tag__background--Fill);
   stroke-width: 0;
 }
 
@@ -663,6 +732,7 @@
   fill: var(--pf-topology__edge__tag--m-danger--background--Fill);
 }
 
+/* Connectors */
 .pf-topology-connector-arrow {
   stroke-width: 1;
   stroke: var(--edge--stroke);
@@ -700,14 +770,14 @@
 }
 
 .pf-topology-default-create-connector__line {
-  stroke: var(--pf-topology-create-connector-color);
+  stroke: var(--pf-topology__create-connector-color--Stroke);
   stroke-width: 2px;
   stroke-dasharray: 3px, 3px;
 }
 
 .pf-topology-default-create-connector__arrow {
   fill: var(--pf-topology-default-create-connector__arrow--Fill);
-  stroke: var(--pf-topology-create-connector-color);
+  stroke: var(--pf-topology__create-connector-color--Stroke);
 }
 
 .pf-topology-default-create-connector.pf-m-hover .pf-topology-default-create-connector__line {
@@ -719,9 +789,6 @@
   stroke: var(--pf-topology-default-create-connector--m-hover--arrow--Stroke);
 }
 
-.pf-topology-default-create-connector__create {
-}
-
 .pf-topology-default-create-connector__create__bg {
   stroke-width: 10px;
   stroke: transparent;
@@ -729,12 +796,6 @@
 }
 
 .pf-topology-default-create-connector__create__cursor {
-  fill: var(--pf-topology-create-connector-color);
-}
-
-.pf-theme-dark .pfext-catalog-item-icon__img--large {
-  /* Not perfect, but gives a better result for colors than just inverting
-  by inverts to switch b/w, then rotates to get colors approximately back */
-  filter: brightness(1.5) invert(1) hue-rotate(180deg) saturate(4);
+  fill: var(--pf-topology__create-connector-color--Fill);
 }
 

--- a/packages/react-styles/src/css/components/Topology/topology-components.css
+++ b/packages/react-styles/src/css/components/Topology/topology-components.css
@@ -789,6 +789,9 @@
   stroke: var(--pf-topology-default-create-connector--m-hover--arrow--Stroke);
 }
 
+.pf-topology-default-create-connector__create {
+}
+
 .pf-topology-default-create-connector__create__bg {
   stroke-width: 10px;
   stroke: transparent;

--- a/packages/react-styles/src/css/components/Topology/topology-components.css
+++ b/packages/react-styles/src/css/components/Topology/topology-components.css
@@ -1,13 +1,135 @@
 :root {
+  /* TODO fix connector color variable */
+
+  --pf-topology-visualization-surface--BackgroundColor: transparent;
+
+  --pf-topology__node--Color: #393f44;
+
   --pf-topology-create-connector-color: var(--pf-global--secondary-color--100);
+  --pf-topology__create-connector-color: var(--pf-global--secondary-color--100);
+  --pf-topology__node__background--Fill: var(--pf-global--BackgroundColor--100);
+  --pf-topology__node__background--Stroke: var(--pf-global--BorderColor--100);
+
+  --pf-topology__node--m-hover--background--Stroke: unset;
+  --pf-topology__node--m-hover--label__background--Stroke: unset;
+
+  --pf-topology__node--m-disabled--Background: var(--pf-global--BackgroundColor--200);
+  --pf-topology__node--m-info--Background: var(--pf-global--primary-color--light-100);
+  --pf-topology__node--m-success--Background: var(--pf-global--success-color--100);
+  --pf-topology__node--m-warning--Background: var(--pf-global--warning-color--100);
+  --pf-topology__node--m-danger--Background: var(--pf-global--danger-color--100);
+  --pf-topology__node--m-selected--Background: var(--pf-global--active-color--100);
+
+  --pf-topology__node--m-selected--node__background--Stroke: var(--pf-global--active-color--100);
+  --pf-topology__node--m-info--node__background--Stroke: var(--pf-global--primary-color--light-100);
+  --pf-topology__node--m-success--node__background--Stroke: var(--pf-global--success-color--100);
+  --pf-topology__node--m-warning--node__background--Stroke: var(--pf-global--warning-color--100);
+  --pf-topology__node--m-danger--node__background--Stroke: var(--pf-global--danger-color--100);
+
+  --pf-topology__node_decorator--Color: var(--pf-global--Color--200);
+  --pf-topology__node__decorator__bg--Fill: var(--pf-global--BackgroundColor--light-100);
+  --pf-topology__node__decorator__bg--Stroke: var(--pf-global--BorderColor--100);
+
+  --pf-topology__node__decorator__status--m-info--Color: var(--pf-global--primary-color--light-100);
+  --pf-topology__node__decorator__status--m-danger--Color: var(--pf-global--danger-color--100);
+  --pf-topology__node__decorator__status--m-warning--Color: var(--pf-global--warning-color--100);
+  --pf-topology__node__decorator__status--m-success--Color: var(--pf-global--success-color--100);
+
+  --pf-topology__node__label__text--Fill: var(--pf-global--palette--black-1000);
+  --pf-topology__node__label__text--m-secondary--Fill: var(--pf-global--secondary-color--100);
+
+  --pf-topology__node--m-selected--node__label__text--Fill: var(--pf-global--Color--light-100);
+
+  --pf-topology__node__label__background--Fill: var(--pf-global--BackgroundColor--100);
+
+  --pf-topology__node__label__background--Stroke: var(--pf-global--BorderColor--100);
+  --pf-topology__node--m-selected--node__label__background--Stroke: var(--pf-global--active-color--100);
+  --pf-topology__node--m-info--node__label__background--Stroke: var(--pf-global--primary-color--light-100);
+  --pf-topology__node--m-success--node__label__background--Stroke: var(--pf-global--success-color--100);
+  --pf-topology__node--m-warning--node__label__background--Stroke: var(--pf-global--warning-color--100);
+  --pf-topology__node--m-danger--node__label__background--Stroke: var(--pf-global--danger-color--100);
+
+  --pf-topology__node--m-selected--node__label__background--Fill: var(--pf-global--active-color--100);
+  --pf-topology__node--m-selected--m-info--node__label__background--Fill: var(--pf-global--primary-color--light-100);
+  --pf-topology__node--m-selected--m-danger--node__label__background--Fill: var(--pf-global--danger-color--100);
+  --pf-topology__node--m-selected--m-warning--node__label__background--Fill: var(--pf-global--warning-color--100);
+  --pf-topology__node--m-selected--m-success--node__label__background--Fill: var(--pf-global--success-color--100);
+
+  --pf-topology__node__label__icon__background--Fill: var(--pf-global--palette--white);
+  --pf-topology__node__label__icon__background--Stroke: var(--pf-global--palette--black-300);
+
+  --pf-topology__node--m-selected--label__icon__background--Stroke: var(--pf-global--active-color--100);
+  --pf-topology__node--m-info--label__icon__background--Stroke: var(--pf-global--primary-color--light-100);
+  --pf-topology__node--m-success--label__icon__background--Stroke: var(--pf-global--success-color--100);
+  --pf-topology__node--m-warning--label__icon__background--Stroke: var(--pf-global--warning-color--100);
+  --pf-topology__node--m-danger--label__icon__background--Stroke: var(--pf-global--danger-color--100);
+
+
+  --pf-topology__node__separator--Stroke: var(--pf-global--palette--black-300);
+
+  --pf-topology__node__action-icon__icon--Color: var(--pf-global--palette--black-1000);
+
+  --pf-topology__group--m-selected--topology__node__action-icon__icon--Color: var(--pf-global--palette--white);
+
+  --pf-topology__group__background--Fill: var(--pf-global--BackgroundColor--light-300);
+  --pf-topology__group__background--Stroke: var(--pf-global--palette--white);
+
+  --pf-topology__group--m-alt-group--topology__group__background--Fill: var(--pf-global--palette--white);
+
+  --pf-topology__group--m-selected--topology__group__background--Fill: var(--pf-global--palette--blue-50);
+  --pf-topology__group--m-selected--topology__group__background--Stroke: var(--pf-global--active-color--100);
+
+  --pf-topology__group--m-hover--topology__group__background--Stroke: var(--pf-global--BackgroundColor--dark-400);
+
+  --pf-topology__group--m-drop-target--topology__group__background--Fill: var(--pf-global--palette--blue-50);
+  --pf-topology__group--m-drop-target--topology__group__background--Stroke: var(--pf-global--active-color--100);
+
+  --pf-topology__group__collapsed-badge__node__label__badge__rect--Fill: var(--pf-global--palette--white);
+  --pf-topology__group__collapsed-badge__node__label__badge__rect--Stroke: var(--pf-global--palette--black-300);
+
+  --pf-topology__group__collapsed-badge__node__label__badge__text--Fill: var(--pf-global--palette--black-800);
+
+  --pf-topology__group__label__node__label__background--Fill: var(--pf-global--BackgroundColor--dark-300);
+
+  --pf-topology__group__label__text--Fill: var(--pf-global--palette--white); 
+
+  --pf-topology__group__label__node__action-icon__icon--Color: var(--pf-global--palette--white);
+
+  --pf-topology__group--m-selected--group__label__node__label__background--Fill: var(--pf-global--active-color--100);
+}
+
+/* DARK THEME OVERRIDES */
+:root:where(.pf-theme-dark) {
+  --pf-topology-visualization-surface--BackgroundColor: var(--pf-global--BackgroundColor--200);
+
+  --pf-topology__node--Color: var(--pf-global--Color--100); 
+  --pf-topology__node__background--Fill: var(--pf-global--BackgroundColor--300);
+  --pf-topology__node__background--Stroke:  var(--pf-global--palette--black-300);
+  /* TODO Hover state - uses filter for shadow but needs different stroke */
+  --pf-topology__node--m-hover--background--Stroke: var(--pf-global--palette--black-100);
+  --pf-topology__node--m-hover--label__background--Stroke: var(--pf-global--palette--black-100);
+
+  /* TODO Selected default and selected info look the same in dark */
+
+  --pf-topology__node__label__background--Stroke: var(--pf-global--BorderColor--300);
+  --pf-topology__node__label__text--Fill: var(--pf-global--Color--100);
+
+  /* make text dark when selected but TODO not on the default, only the statuses */
+  --pf-topology__node--m-selected--node__label__text--Fill: var(--pf-global--palette--black-900);
+  
+  /* TODO not done yet */
+  --pf-topology__group__background--Fill: var(--pf-global--BackgroundColor--100);
+  --pf-topology__group__background--Stroke: var(--pf-global--BorderColor--300);
+
 }
 
 .pf-topology-visualization-surface {
+  background-color: var(--pf-topology-visualization-surface--BackgroundColor);
   height: 100%;
   flex-grow: 1;
   flex-shrink: 1;
   overflow: hidden;
-  position: relative;
+  position: relative; 
 }
 
 .pf-topology-visualization-surface__svg {
@@ -36,38 +158,50 @@
   transform: translateY(-50%);
 }
 
+/* ******* NODE ********* */
 .pf-topology__node {
   outline: none;
+  color: var(--pf-topology__node--Color);
+}
+
+/* Color is defined in the svg but fill will override it */
+.pf-topology__node svg {
+  fill: var(--pf-topology__node--Color);
+}
+
+.pf-topology__node.pf-m-hover {
+  --pf-topology__node__background--Stroke: var(--pf-topology__node--m-hover--background--Stroke);
+  --pf-topology__node__label__background--Stroke: var(--pf-topology__node--m-hover--label__background--Stroke);
 }
 
 .pf-topology__node__background {
-  fill: var(--pf-global--palette--white);
+  fill: var(--pf-topology__node__background--Fill);
   stroke-width: 1px;
-  stroke: var(--pf-global--palette--black-300);
+  stroke: var(--pf-topology__node__background--Stroke);
 }
 
 .pf-topology__node__background.pf-m-disabled {
-  fill: var(--pf-global--BackgroundColor--200);
+  --pf-topology__node__background--Fill: var(--pf-topology__node--m-disabled--Background);
 }
 
 .pf-topology__node__background.pf-m-info {
-  fill: var(--pf-global--primary-color--light-100);
+  --pf-topology__node__background--Fill: var(--pf-topology__node--m-info--Background);
 }
 
 .pf-topology__node__background.pf-m-success {
-  fill: var(--pf-global--success-color--100);
+  --pf-topology__node__background--Fill: var(--pf-topology__node--m-success--Background);
 }
 
 .pf-topology__node__background.pf-m-warning {
-  fill: var(--pf-global--warning-color--100);
+  --pf-topology__node__background--Fill: var(--pf-topology__node--m-warning--Background);
 }
 
 .pf-topology__node__background.pf-m-danger {
-  fill: var(--pf-global--danger-color--100);
+  --pf-topology__node__background--Fill: var(--pf-topology__node--m-danger--Background);
 }
 
 .pf-topology__node__background.pf-m-selected {
-  fill: var(--pf-global--active-color--100);
+  --pf-topology__node__background--Fill: var(--pf-topology__node--m-selected--Background);
 }
 
 .pf-topology__node.pf-m-dragging .pf-topology__node__background {
@@ -76,119 +210,137 @@
 
 .pf-topology__node.pf-m-selected .pf-topology__node__background {
   stroke-width: 2px;
-  stroke: var(--pf-global--active-color--100);
+  stroke: var(--pf-topology__node--m-selected--node__background--Stroke);
 }
 
 .pf-topology__node.pf-m-info .pf-topology__node__background {
-  stroke: var(--pf-global--primary-color--light-100);
+  stroke: var(--pf-topology__node--m-info--node__background--Stroke);
 }
 
 .pf-topology__node.pf-m-success .pf-topology__node__background {
-  stroke: var(--pf-global--success-color--100);
+  stroke: var(--pf-topology__node--m-success--node__background--Stroke);
 }
 
 .pf-topology__node.pf-m-warning .pf-topology__node__background {
-  stroke: var(--pf-global--warning-color--100);
+  stroke: var(--pf-topology__node--m-warning--node__background--Stroke);
 }
 
 .pf-topology__node.pf-m-danger .pf-topology__node__background {
-  stroke: var(--pf-global--danger-color--100);
+  stroke: var(--pf-topology__node--m-danger--node__background--Stroke);
 }
 
 .pf-topology__node.pf-m-drop-target .pf-topology__node__background {
 }
 
+/* ******** DECORATOR ******** */
 .pf-topology__node__decorator {
-  color: var(--pf-global--Color--200);
+  --pf-topology__node--Color: var(--pf-topology__node_decorator--Color);
   transition: color 0.2s ease;
   outline: none;
 }
 
+.pf-topology__node__decorator svg {
+ fill: var(--pf-topology__node_decorator--Color);
+}
+
 .pf-topology__node__decorator__bg {
-  fill: var(--pf-global--BackgroundColor--light-100);
-  stroke: var(--pf-global--palette--black-300);
+  fill: var(--pf-topology__node__decorator__bg--Fill);
+  stroke: var(--pf-topology__node__decorator__bg--Stroke);
   stroke-width: 1px;
 }
 
 .pf-topology__node__decorator__icon {
   font-size: var(--pf-global--icon--FontSize--sm);
+  color: var(--pf-topology__node_decorator--Color);
+}
+
+.pf-topology__node__decorator__status {
+  color: var(--pf-topology__node_decorator--Color);
 }
 
 .pf-topology__node__decorator__status .pf-m-info {
-  color: var(--pf-global--primary-color--light-100);
+  --pf-topology__node_decorator--Color: var(--pf-topology__node__decorator__status--m-info--Color);
 }
 .pf-topology__node__decorator__status .pf-m-danger {
-  color: var(--pf-global--danger-color--100);
+  --pf-topology__node_decorator--Color: var(--pf-topology__node__decorator__status--m-danger--Color);
 }
 .pf-topology__node__decorator__status .pf-m-warning {
-  color: var(--pf-global--warning-color--100);
+  --pf-topology__node_decorator--Color: var(--pf-topology__node__decorator__status--m-warning--Color);
 }
 .pf-topology__node__decorator__status .pf-m-success {
-  color: var(--pf-global--success-color--100);
+  --pf-topology__node_decorator--Color: var(--pf-topology__node__decorator__status--m-success--Color);
 }
 
+/* ************* NODE LABEL ************** */
 .pf-topology__node__label > text {
-  fill: var(--pf-global--palette--black-1000);
+  fill: var(--pf-topology__node__label__text--Fill);
   font-size: var(--pf-global--FontSize--sm);
   pointer-events: none;
 }
 
 .pf-topology__node__label > text.pf-m-secondary {
-  fill: var(--pf-global--secondary-color--100);
+  fill: var(--pf-topology__node__label__text--m-secondary--Fill);
   font-size: var(--pf-global--FontSize--xs);
 }
 
 .pf-topology__node.pf-m-selected .pf-topology__node__label > text {
-  fill: var(--pf-global--palette--white);
+  fill: var(--pf-topology__node--m-selected--node__label__text--Fill);
 }
 
 .pf-topology__node__label__background {
-  fill: var(--pf-global--palette--white);
+  fill: var(--pf-topology__node__label__background--Fill);
   stroke-width: 1px;
-  stroke: var(--pf-global--palette--black-300);
+  stroke: var(--pf-topology__node__label__background--Stroke);
 }
 
 .pf-topology__node.pf-m-selected .pf-topology__node__label__background {
   stroke-width: 2px;
-  stroke: var(--pf-global--active-color--100);
-}
-
-.pf-topology__node.pf-m-info .pf-topology__node__label__background {
-  stroke: var(--pf-global--primary-color--light-100);
-}
-
-.pf-topology__node.pf-m-success .pf-topology__node__label__background {
-  stroke: var(--pf-global--success-color--100);
-}
-
-.pf-topology__node.pf-m-warning .pf-topology__node__label__background {
-  stroke: var(--pf-global--warning-color--100);
-}
-
-.pf-topology__node.pf-m-danger .pf-topology__node__label__background {
-  stroke: var(--pf-global--danger-color--100);
+  stroke: var(--pf-topology__node--m-selected--node__label__background--Stroke);
 }
 
 .pf-topology__node.pf-m-selected .pf-topology__node__label__background {
-  fill: var(--pf-global--active-color--100);
+  fill: var(--pf-topology__node--m-selected--node__label__background--Fill);
+}
+
+.pf-topology__node.pf-m-info .pf-topology__node__label__background {
+  stroke: var(--pf-topology__node--m-info--node__label__background--Stroke);
+}
+
+.pf-topology__node.pf-m-success .pf-topology__node__label__background {
+  stroke: var(--pf-topology__node--m-success--node__label__background--Stroke);
+}
+
+.pf-topology__node.pf-m-warning .pf-topology__node__label__background {
+  stroke: var(--pf-topology__node--m-warning--node__label__background--Stroke);
+}
+
+.pf-topology__node.pf-m-danger .pf-topology__node__label__background {
+  stroke: var(--pf-topology__node--m-danger--node__label__background--Stroke);
+  fill: var(--pf-topology__node--m-selected--m-danger--node__label__background--Fill);
 }
 
 .pf-topology__node.pf-m-selected.pf-m-info .pf-topology__node__label__background {
-  fill: var(--pf-global--primary-color--light-100);
+  fill: var(--pf-topology__node--m-selected--m-info--node__label__background--Fill);
+  --pf-topology__node--m-selected--node__label__text--Fill: yellow;
+
 }
 
-.pf-topology__node.pf-m-selected.pf-m-danger .pf-topology__node__label__background {
-  fill: var(--pf-global--danger-color--100);
+.pf-topology__node.pf-m-selected.pf-m-danger  {
+  fill: var(--pf-topology__node--m-selected--m-danger--node__label__background--Fill);
+  --pf-topology__node--m-selected--node__label__text--Fill: yellow;
 }
 
 .pf-topology__node.pf-m-selected.pf-m-warning .pf-topology__node__label__background {
-  fill: var(--pf-global--warning-color--100);
+  fill: var(--pf-topology__node--m-selected--m-warning--node__label__background--Fill);
+  --pf-topology__node--m-selected--node__label__text--Fill: yellow;
 }
 
 .pf-topology__node.pf-m-selected.pf-m-success .pf-topology__node__label__background {
-  fill: var(--pf-global--success-color--100);
+  fill: var(--pf-topology__node--m-selected--m-success--node__label__background--Fill);
+  --pf-topology__node--m-selected--node__label__text--Fill: yellow;
 }
 
+/* *********** NODE LABEL BADGE ********* */
 .pf-topology__node__label__badge > rect {
   stroke-width: 1px;
 }
@@ -201,37 +353,38 @@
 .pf-topology__node__label__icon > svg {
   height: 100%;
   width: 100%;
+  fill: currentColor;
 }
 
 .pf-topology__node__label__icon__background {
-  fill: var(--pf-global--palette--white);
+  fill: var(--pf-topology__node__label__icon__background--Fill);
   stroke-width: 1px;
-  stroke: var(--pf-global--palette--black-300);
+  stroke: var(--pf-topology__node__label__icon__background--Stroke);
 }
 
 .pf-topology__node.pf-m-selected .pf-topology__node__label__icon__background {
   stroke-width: 2px;
-  stroke: var(--pf-global--active-color--100);
+  stroke: var(--pf-topology__node--m-selected--label__icon__background--Stroke);
 }
 
 .pf-topology__node.pf-m-info .pf-topology__node__label__icon__background {
-  stroke: var(--pf-global--primary-color--light-100);
+  stroke: var(--pf-topology__node--m-info--label__icon__background--Stroke);
 }
 
 .pf-topology__node.pf-m-success .pf-topology__node__label__icon__background {
-  stroke: var(--pf-global--success-color--100);
+  stroke: var(--pf-topology__node--m-success--label__icon__background--Stroke);
 }
 
 .pf-topology__node.pf-m-warning .pf-topology__node__label__icon__background {
-  stroke: var(--pf-global--warning-color--100);
+  stroke: var(--pf-topology__node--m-warning--label__icon__background--Stroke);
 }
 
 .pf-topology__node.pf-m-danger .pf-topology__node__label__icon__background {
-  stroke: var(--pf-global--danger-color--100);
+  stroke: var(--pf-topology__node--m-danger--label__icon__background--Stroke);
 }
 
 .pf-topology__node__separator {
-  stroke: var(--pf-global--palette--black-300);
+  stroke: var(--pf-topology__node__separator--Stroke);
   stroke-width: 1;
 }
 
@@ -245,11 +398,11 @@
 }
 
 .pf-topology__node__action-icon__icon {
-  color: var(--pf-global--palette--black-1000);
+  color: var(--pf-topology__node__action-icon__icon--Color);
 }
 
 .pf-topology__group.pf-m-selected .pf-topology__node__action-icon__icon {
-  color: var(--pf-global--palette--white);
+  color: var(--pf-topology__group--m-selected--topology__node__action-icon__icon--Color);
 }
 
 .pf-topology__group {
@@ -257,57 +410,57 @@
 }
 
 .pf-topology__group__background {
-  fill: var(--pf-global--BackgroundColor--light-300);
-  stroke: var(--pf-global--palette--white);
+  fill: var(--pf-topology__group__background--Fill);
+  stroke: var(--pf-topology__group__background--Stroke);
   stroke-width: 5px;
 }
 
 .pf-topology__group.pf-m-alt-group .pf-topology__group__background {
-  fill: var(--pf-global--palette--white);
+  fill: var(--pf-topology__group--m-alt-group--topology__group__background--Fill);
 }
 
 .pf-topology__group.pf-m-selected .pf-topology__group__background {
-  fill: var(--pf-global--palette--blue-50);
-  stroke: var(--pf-global--active-color--100);
+  fill: var(--pf-topology__group--m-selected--topology__group__background--Fill);
+  stroke: var(--pf-topology__group--m-selected--topology__group__background--Stroke);
 }
 
 .pf-topology__group.pf-m-hover .pf-topology__group__background {
-  stroke: var(--pf-global--BackgroundColor--dark-400);
+  stroke: var(--pf-topology__group--m-hover--topology__group__background--Stroke);
 }
 
 .pf-topology__group.pf-m-drop-target .pf-topology__group__background {
-  fill: var(--pf-global--palette--blue-50);
-  stroke: var(--pf-global--active-color--100);
+  fill: var(--pf-topology__group--m-drop-target--topology__group__background--Fill);
+  stroke: var(--pf-topology__group--m-drop-target--topology__group__background--Stroke);
   stroke-dasharray: 12;
 }
 
 .pf-topology__group__collapsed-badge.pf-topology__node__label__badge > rect {
-  fill: var(--pf-global--palette--white);
-  stroke: var(--pf-global--palette--black-300);
+  fill: var(--pf-topology__group__collapsed-badge__node__label__badge__rect--Fill);
+  stroke: var(--pf-topology__group__collapsed-badge__node__label__badge__rect--Stroke);
 }
 
 .pf-topology__group__collapsed-badge.pf-topology__node__label__badge > text {
   font-size: var(--pf-global--FontSize--xs);
   pointer-events: none;
-  fill: var(--pf-global--palette--black-800);
+  fill: var(--pf-topology__group__collapsed-badge__node__label__badge__text--Fill);
 }
 
 .pf-topology__group__label .pf-topology__node__label__background {
-  fill: var(--pf-global--BackgroundColor--dark-300);
+  fill: var(--pf-topology__group__label__node__label__background--Fill);
 }
 
 .pf-topology__group__label > text {
-  fill: var(--pf-global--palette--white);
+  fill: var(--pf-topology__group__label__text--Fill);
   font-size: var(--pf-global--FontSize--sm);
   pointer-events: none;
 }
 
 .pf-topology__group__label .pf-topology__node__action-icon__icon {
-  color: var(--pf-global--palette--white);
+  color: var(--pf-topology__group__label__node__action-icon__icon--Color);
 }
 
 .pf-topology__group.pf-m-selected .pf-topology__group__label .pf-topology__node__label__background {
-  fill: var(--pf-global--active-color--100);
+  fill: var(--pf-topology__group--m-selected--group__label__node__label__background--Fill);
 }
 
 .pf-topology__edge {
@@ -529,3 +682,30 @@
   fill: var(--pf-topology-create-connector-color);
 }
 
+
+
+.pf-theme-dark .pfext-catalog-item-icon__img--large {
+    /* Not perfect, but gives a better result for colors than just inverting
+    by inverts to switch b/w, then rotates to get colors approximately back */
+    filter: brightness(1.5) invert(1) hue-rotate(180deg) saturate(4);
+  }
+
+
+/* .pf-theme-dark .pf-topology__node__background {
+  fill: var(--pf-global--BackgroundColor--300);
+  stroke: var(--pf-global--palette--black-400);
+} */
+
+/* .pf-theme-dark .pf-topology__node__background.pf-m-disabled {
+  fill: var(--pf-global--BackgroundColor--50);
+} */
+
+/* TODO check state colors */
+/* TODO decorators */
+
+
+/* .pf-theme-dark {
+  --pf-topology__node__background--Fill: var(--pf-global--BackgroundColor--300);
+  --pf-topology__node__background--Stroke: var(--pf-global--BorderColor--300);
+} */
+  /* TODO hover gets border 400 */


### PR DESCRIPTION
Adds dark styling adjustments.
Closes #7181 

Note:
As part of this PR, I added Patternfly-style variables for all color variables, since a large number of them needed to be overridden in dark theme. However, it does not exactly match Patternfly conventions because the associated classnames are slightly different that the Patternfly convention, and it seemed better to match the class names for clarity.
Also, the edges already had a variable system in place, so I did not bring this into the same convention either, but instead left it as is and initialized its values with values matching the convention above.

Exceptions to dark styling as spec'd in https://marvelapp.com/prototype/i195ic1/screen/85808125:
- Node badge colors are currently set directly on the rect, not in CSS, so this will need to be addressed in a future issue.
- Compatible/incompatible connectors are not currently supported, so this has not been implemented.
- Shadows on the critical default nodes are hard coded in the react code, so these were not addressed here.
