### PR TITLE
fix(Tooltip): make ref variant announced by assistive tech

### DIFF
--- a/packages/react-core/src/components/Tabs/examples/Tabs.md
+++ b/packages/react-core/src/components/Tabs/examples/Tabs.md
@@ -106,6 +106,8 @@ class SimpleTabs extends React.Component {
 
 When using a React ref to link a Tooltip to a Tab component via the `reference` prop, you should avoid manually passing in a value of "off" to the `aria-live` prop. Doing so may lead to the tooltip becoming less accessible to assistive technologies.
 
+The tooltip should also have the `id` prop passed in. The value given to this prop should then be passed into the tab's `aria-describedby` prop. This ensures a tooltip used with a React ref will be announced by the JAWS and NVDA screen readers.
+
 ```js
 import React from 'react';
 import { Tabs, Tab, TabTitleText, Checkbox, Tooltip } from '@patternfly/react-core';
@@ -163,11 +165,13 @@ class SimpleTabs extends React.Component {
             title={<TabTitleText>ARIA Disabled (Tooltip)</TabTitleText>}
             isAriaDisabled
             ref={tooltipRef}
+            aria-describedby="tooltip-ref1"
           >
             ARIA Disabled (Tooltip)
           </Tab>
         </Tabs>
         <Tooltip
+          id="tooltip-ref1"
           content="Aria-disabled tabs are like disabled tabs, but focusable. Allows for tooltip support."
           reference={tooltipRef}
         />

--- a/packages/react-core/src/components/Tabs/examples/Tabs.md
+++ b/packages/react-core/src/components/Tabs/examples/Tabs.md
@@ -56,7 +56,12 @@ class SimpleTabs extends React.Component {
 
     return (
       <div>
-        <Tabs activeKey={activeTabKey} onSelect={this.handleTabClick} isBox={isBox} aria-label="Tabs in the default example">
+        <Tabs
+          activeKey={activeTabKey}
+          onSelect={this.handleTabClick}
+          isBox={isBox}
+          aria-label="Tabs in the default example"
+        >
           <Tab eventKey={0} title={<TabTitleText>Users</TabTitleText>}>
             Users
           </Tab>
@@ -99,7 +104,7 @@ class SimpleTabs extends React.Component {
 
 ### With tooltip react ref
 
-When using a React ref to link a Tooltip to a Tab component via the `reference` prop, you should avoid manually passing in a value of off to the `aria-live` prop. Doing so may lead to the tooltip becoming less accessible to assistive technologies.
+When using a React ref to link a Tooltip to a Tab component via the `reference` prop, you should avoid manually passing in a value of "off" to the `aria-live` prop. Doing so may lead to the tooltip becoming less accessible to assistive technologies.
 
 ```js
 import React from 'react';
@@ -132,7 +137,12 @@ class SimpleTabs extends React.Component {
 
     return (
       <div>
-        <Tabs activeKey={activeTabKey} onSelect={this.handleTabClick} isBox={isBox} aria-label="Tabs in the example with a tooltip ref">
+        <Tabs
+          activeKey={activeTabKey}
+          onSelect={this.handleTabClick}
+          isBox={isBox}
+          aria-label="Tabs in the example with a tooltip ref"
+        >
           <Tab eventKey={0} title={<TabTitleText>Users</TabTitleText>}>
             Users
           </Tab>
@@ -336,7 +346,12 @@ class ScrollButtonsPrimaryTabs extends React.Component {
     const { activeTabKey, isBox } = this.state;
     return (
       <div>
-        <Tabs activeKey={activeTabKey} onSelect={this.handleTabClick} isBox={isBox} aria-label="Tabs in the default overflow example">
+        <Tabs
+          activeKey={activeTabKey}
+          onSelect={this.handleTabClick}
+          isBox={isBox}
+          aria-label="Tabs in the default overflow example"
+        >
           <Tab eventKey={0} title={<TabTitleText>Users</TabTitleText>}>
             Users
           </Tab>
@@ -422,7 +437,13 @@ class VerticalTabs extends React.Component {
 
     return (
       <div>
-        <Tabs activeKey={activeTabKey} onSelect={this.handleTabClick} isVertical isBox={isBox} aria-label="Tabs in the vertical example">
+        <Tabs
+          activeKey={activeTabKey}
+          onSelect={this.handleTabClick}
+          isVertical
+          isBox={isBox}
+          aria-label="Tabs in the vertical example"
+        >
           <Tab eventKey={0} title={<TabTitleText>Users</TabTitleText>}>
             Users
           </Tab>
@@ -687,7 +708,13 @@ class PageInsetsTabs extends React.Component {
     const { activeTabKey, isBox } = this.state;
     return (
       <div>
-        <Tabs activeKey={activeTabKey} onSelect={this.handleTabClick} usePageInsets isBox={isBox} aria-label="Tabs in the page insets example">
+        <Tabs
+          activeKey={activeTabKey}
+          onSelect={this.handleTabClick}
+          usePageInsets
+          isBox={isBox}
+          aria-label="Tabs in the page insets example"
+        >
           <Tab eventKey={0} title={<TabTitleText>Users</TabTitleText>}>
             Users
           </Tab>
@@ -751,7 +778,11 @@ class IconAndTextTabs extends React.Component {
 
   render() {
     return (
-      <Tabs activeKey={this.state.activeTabKey} onSelect={this.handleTabClick} aria-label="Tabs in the icons and text example">
+      <Tabs
+        activeKey={this.state.activeTabKey}
+        onSelect={this.handleTabClick}
+        aria-label="Tabs in the icons and text example"
+      >
         <Tab
           eventKey={0}
           title={
@@ -874,9 +905,19 @@ class SecondaryTabs extends React.Component {
     const { activeTabKey1, activeTabKey2, isBox } = this.state;
     return (
       <div>
-        <Tabs activeKey={activeTabKey1} onSelect={this.handleTabClickFirst} isBox={isBox} aria-label="Tabs in the tabs with subtabs example">
+        <Tabs
+          activeKey={activeTabKey1}
+          onSelect={this.handleTabClickFirst}
+          isBox={isBox}
+          aria-label="Tabs in the tabs with subtabs example"
+        >
           <Tab eventKey={0} title={<TabTitleText>Users</TabTitleText>}>
-            <Tabs aria-label="secondary tabs for users" activeKey={activeTabKey2} isSecondary onSelect={this.handleTabClickSecond}>
+            <Tabs
+              aria-label="secondary tabs for users"
+              activeKey={activeTabKey2}
+              isSecondary
+              onSelect={this.handleTabClickSecond}
+            >
               <Tab eventKey={20} title={<TabTitleText>Secondary tab item 1</TabTitleText>}>
                 Secondary tab item 1 item section
               </Tab>
@@ -981,7 +1022,13 @@ class FilledTabs extends React.Component {
     const { activeTabKey, isBox } = this.state;
     return (
       <div>
-        <Tabs isFilled activeKey={activeTabKey} onSelect={this.handleTabClick} isBox={isBox} aria-label="Tabs in the filled example">
+        <Tabs
+          isFilled
+          activeKey={activeTabKey}
+          onSelect={this.handleTabClick}
+          isBox={isBox}
+          aria-label="Tabs in the filled example"
+        >
           <Tab eventKey={0} title={<TabTitleText>Users</TabTitleText>}>
             Users
           </Tab>
@@ -1042,7 +1089,13 @@ class FilledTabsWithIcons extends React.Component {
     const { activeTabKey, isBox } = this.state;
     return (
       <div>
-        <Tabs isFilled activeKey={activeTabKey} onSelect={this.handleTabClick} isBox={isBox} aria-label="Tabs in the filled with icons example">
+        <Tabs
+          isFilled
+          activeKey={activeTabKey}
+          onSelect={this.handleTabClick}
+          isBox={isBox}
+          aria-label="Tabs in the filled with icons example"
+        >
           <Tab
             eventKey={0}
             title={
@@ -1268,7 +1321,11 @@ class SeparateTabContent extends React.Component {
   render() {
     return (
       <React.Fragment>
-        <Tabs activeKey={this.state.activeTabKey} onSelect={this.handleTabClick} aria-label="Tabs in the seperate content example">
+        <Tabs
+          activeKey={this.state.activeTabKey}
+          onSelect={this.handleTabClick}
+          aria-label="Tabs in the seperate content example"
+        >
           <Tab
             eventKey={0}
             title={<TabTitleText>Tab item 1</TabTitleText>}
@@ -1289,13 +1346,30 @@ class SeparateTabContent extends React.Component {
           />
         </Tabs>
         <div>
-          <TabContent eventKey={0} id="refTab1Section" ref={this.contentRef1} aria-label="This is content for the first tab">
+          <TabContent
+            eventKey={0}
+            id="refTab1Section"
+            ref={this.contentRef1}
+            aria-label="This is content for the first tab"
+          >
             Tab 1 section
           </TabContent>
-          <TabContent eventKey={1} id="refTab2Section" ref={this.contentRef2} aria-label="This is content for the second tab" hidden>
+          <TabContent
+            eventKey={1}
+            id="refTab2Section"
+            ref={this.contentRef2}
+            aria-label="This is content for the second tab"
+            hidden
+          >
             Tab 2 section
           </TabContent>
-          <TabContent eventKey={2} id="refTab3Section" ref={this.contentRef3} aria-label="This is content for the third tab" hidden>
+          <TabContent
+            eventKey={2}
+            id="refTab3Section"
+            ref={this.contentRef3}
+            aria-label="This is content for the third tab"
+            hidden
+          >
             Tab 3 section
           </TabContent>
         </div>
@@ -1349,10 +1423,22 @@ const TabContentWithBody = () => {
         <TabContent eventKey={0} id="refTab1Section" ref={contentRef1} aria-label="This is content for the first tab">
           <TabContentBody hasPadding> Tab 1 section </TabContentBody>
         </TabContent>
-        <TabContent eventKey={1} id="refTab2Section" ref={contentRef2} aria-label="This is content for the second tab" hidden>
+        <TabContent
+          eventKey={1}
+          id="refTab2Section"
+          ref={contentRef2}
+          aria-label="This is content for the second tab"
+          hidden
+        >
           <TabContentBody hasPadding> Tab 2 section </TabContentBody>
         </TabContent>
-        <TabContent eventKey={2} id="refTab3Section" ref={contentRef3} aria-label="This is content for the third tab" hidden>
+        <TabContent
+          eventKey={2}
+          id="refTab3Section"
+          ref={contentRef3}
+          aria-label="This is content for the third tab"
+          hidden
+        >
           <TabContentBody hasPadding> Tab 3 section </TabContentBody>
         </TabContent>
       </div>
@@ -1383,7 +1469,12 @@ class MountingSimpleTabs extends React.Component {
 
   render() {
     return (
-      <Tabs mountOnEnter activeKey={this.state.activeTabKey} onSelect={this.handleTabClick} aria-label="Tabs in the children mounting on click example">
+      <Tabs
+        mountOnEnter
+        activeKey={this.state.activeTabKey}
+        onSelect={this.handleTabClick}
+        aria-label="Tabs in the children mounting on click example"
+      >
         <Tab eventKey={0} title={<TabTitleText>Tab item 1</TabTitleText>}>
           Tab 1 section
         </Tab>
@@ -1421,7 +1512,12 @@ class UnmountingSimpleTabs extends React.Component {
 
   render() {
     return (
-      <Tabs unmountOnExit activeKey={this.state.activeTabKey} onSelect={this.handleTabClick} aria-label="Tabs in the unmounting invisible children example">
+      <Tabs
+        unmountOnExit
+        activeKey={this.state.activeTabKey}
+        onSelect={this.handleTabClick}
+        aria-label="Tabs in the unmounting invisible children example"
+      >
         <Tab eventKey={0} title={<TabTitleText>Tab item 1</TabTitleText>}>
           Tab 1 section
         </Tab>
@@ -1471,7 +1567,11 @@ class ToggledSeparateContent extends React.Component {
           {isTab2Hidden ? 'Show' : 'Hide'} tab 2
         </Button>
         <Divider style={{ paddingTop: '1rem', paddingBottom: '1rem' }} />
-        <Tabs activeKey={this.state.activeTabKey} onSelect={this.handleTabClick} aria-label="Tabs in the toggled separate content example">
+        <Tabs
+          activeKey={this.state.activeTabKey}
+          onSelect={this.handleTabClick}
+          aria-label="Tabs in the toggled separate content example"
+        >
           <Tab eventKey={0} title="Tab item 1" tabContentId="refTab1Section" tabContentRef={this.contentRef1} />
           {!isTab2Hidden && (
             <Tab eventKey={1} title="Tab item 2" tabContentId="refTab2Section" tabContentRef={this.contentRef2} />
@@ -1479,15 +1579,32 @@ class ToggledSeparateContent extends React.Component {
           <Tab eventKey={2} title="Tab item 3" tabContentId="refTab3Section" tabContentRef={this.contentRef3} />
         </Tabs>
         <div>
-          <TabContent eventKey={0} id="refTab1Section" ref={this.contentRef1} aria-label="This is content for the first tab">
+          <TabContent
+            eventKey={0}
+            id="refTab1Section"
+            ref={this.contentRef1}
+            aria-label="This is content for the first tab"
+          >
             Tab 1 section
           </TabContent>
           {!isTab2Hidden && (
-            <TabContent eventKey={1} id="refTab2Section" ref={this.contentRef2} aria-label="This is content for the second tab" hidden>
+            <TabContent
+              eventKey={1}
+              id="refTab2Section"
+              ref={this.contentRef2}
+              aria-label="This is content for the second tab"
+              hidden
+            >
               Tab 2 section
             </TabContent>
           )}
-          <TabContent eventKey={2} id="refTab3Section" ref={this.contentRef3} aria-label="This is content for the third tab" hidden>
+          <TabContent
+            eventKey={2}
+            id="refTab3Section"
+            ref={this.contentRef3}
+            aria-label="This is content for the third tab"
+            hidden
+          >
             Tab 3 section
           </TabContent>
         </div>

--- a/packages/react-core/src/components/Tabs/examples/Tabs.md
+++ b/packages/react-core/src/components/Tabs/examples/Tabs.md
@@ -99,7 +99,7 @@ class SimpleTabs extends React.Component {
 
 ### With tooltip react ref
 
-When using a React ref to link a Tooltip to a Tab component, an `id` must be manually set on the Tooltip component, and the Tab component must have a matching `aria-describedby` attribute so that screen readers are able to announce the Tooltip contents.
+When using a React ref to link a Tooltip to a Tab component via the `reference` prop, you should avoid manually passing in a value of off to the `aria-live` prop. Doing so may lead to the tooltip becoming less accessible to assistive technologies.
 
 ```js
 import React from 'react';
@@ -153,7 +153,6 @@ class SimpleTabs extends React.Component {
             title={<TabTitleText>ARIA Disabled (Tooltip)</TabTitleText>}
             isAriaDisabled
             ref={tooltipRef}
-            aria-describedby="tooltip-tab-5"
           >
             ARIA Disabled (Tooltip)
           </Tab>
@@ -161,7 +160,6 @@ class SimpleTabs extends React.Component {
         <Tooltip
           content="Aria-disabled tabs are like disabled tabs, but focusable. Allows for tooltip support."
           reference={tooltipRef}
-          id="tooltip-tab-5"
         />
         <div style={{ marginTop: '20px' }}>
           <Checkbox

--- a/packages/react-core/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-core/src/components/Tooltip/Tooltip.tsx
@@ -36,6 +36,12 @@ export interface TooltipProps extends Omit<React.HTMLProps<HTMLDivElement>, 'con
    */
   aria?: 'describedby' | 'labelledby' | 'none';
   /**
+   * Determines whether the tooltip is an aria-live region. If the reference prop is passed in the
+   * default behavior is 'polite' in order to ensure the tooltip contents is announced to
+   * assistive technologies. Otherwise the default behavior is 'off'.
+   */
+  'aria-live'?: 'off' | 'polite';
+  /**
    * The reference element to which the Tooltip is relatively placed to.
    * If you cannot wrap the reference with the Tooltip, you can use the reference prop instead.
    * Usage: <Tooltip><Button>Reference</Button></Tooltip>
@@ -155,6 +161,7 @@ export const Tooltip: React.FunctionComponent<TooltipProps> = ({
   children,
   animationDuration = 300,
   reference,
+  'aria-live': ariaLive = reference ? 'polite' : 'off',
   boundary,
   isAppLauncher,
   tippyProps,
@@ -251,6 +258,7 @@ export const Tooltip: React.FunctionComponent<TooltipProps> = ({
   const hasCustomMaxWidth = maxWidth !== tooltipMaxWidth.value;
   const content = (
     <div
+      aria-live={ariaLive}
       className={css(styles.tooltip, className)}
       role="tooltip"
       id={id}

--- a/packages/react-core/src/components/Tooltip/examples/Tooltip.md
+++ b/packages/react-core/src/components/Tooltip/examples/Tooltip.md
@@ -40,8 +40,11 @@ TooltipReactRef = () => {
   const tooltipRef = React.useRef();
   return (
     <div style={{ margin: '100px' }}>
-      <button ref={tooltipRef}>Tooltip attached via react ref</button>
+      <button aria-describedby="tooltip-ref1" ref={tooltipRef}>
+        Tooltip attached via react ref
+      </button>
       <Tooltip
+        id="tooltip-ref1"
         content={
           <div>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
@@ -61,8 +64,11 @@ import React from 'react';
 import { Tooltip } from '@patternfly/react-core';
 
 <div style={{ margin: '100px' }}>
-  <button id="tooltip-selector">Tooltip attached via selector ref</button>
+  <button aria-describedby="tooltip-ref2" id="tooltip-selector">
+    Tooltip attached via selector ref
+  </button>
   <Tooltip
+    id="tooltip-ref2"
     content={
       <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.</div>
     }
@@ -73,7 +79,7 @@ import { Tooltip } from '@patternfly/react-core';
 
 ### On icon with dynamic content
 
-When the tooltip is used as a wrapper and its content will dynamically update, the `aria` prop should have a value of "off" passed in. This prevents assistive technologies from announcing the tooltip contents more than once. Additionally, the `aria-live` prop should have a value of "polite" passed in, in order for assistive technologies to announce when the tooltip contents gets updated.
+When the tooltip is used as a wrapper and its content will dynamically update, the `aria` prop should have a value of "none" passed in. This prevents assistive technologies from announcing the tooltip contents more than once. Additionally, the `aria-live` prop should have a value of "polite" passed in, in order for assistive technologies to announce when the tooltip contents gets updated.
 
 When using a React or selector ref with a tooltip that has dynamic content, the `aria` and `aria-live` props do not need to be manually passed in.
 

--- a/packages/react-core/src/components/Tooltip/examples/Tooltip.md
+++ b/packages/react-core/src/components/Tooltip/examples/Tooltip.md
@@ -12,6 +12,7 @@ import './TooltipExamples.css';
 ## Examples
 
 ### Basic
+
 ```js
 import React from 'react';
 import { Tooltip } from '@patternfly/react-core';
@@ -22,12 +23,15 @@ import { Tooltip } from '@patternfly/react-core';
       <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.</div>
     }
   >
-    <span tabIndex="0" style={{ border: '1px dashed' }}>I have a tooltip!</span>
+    <span tabIndex="0" style={{ border: '1px dashed' }}>
+      I have a tooltip!
+    </span>
   </Tooltip>
-</div>
+</div>;
 ```
 
 ### Tooltip react ref
+
 ```js
 import React from 'react';
 import { Tooltip } from '@patternfly/react-core';
@@ -39,16 +43,19 @@ TooltipReactRef = () => {
       <button ref={tooltipRef}>Tooltip attached via react ref</button>
       <Tooltip
         content={
-          <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.</div>
+          <div>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
+          </div>
         }
         reference={tooltipRef}
       />
     </div>
   );
-}
+};
 ```
 
 ### Tooltip selector ref
+
 ```js
 import React from 'react';
 import { Tooltip } from '@patternfly/react-core';
@@ -61,10 +68,15 @@ import { Tooltip } from '@patternfly/react-core';
     }
     reference={() => document.getElementById('tooltip-selector')}
   />
-</div>
+</div>;
 ```
 
-### On icon
+### On icon with dynamic content
+
+When the tooltip is used as a wrapper and its content will dynamically update, the `aria` prop should have a value of "off" passed in. This prevents assistive technologies from announcing the tooltip contents more than once. Additionally, the `aria-live` prop should have a value of "polite" passed in, in order for assistive technologies to announce when the tooltip contents gets updated.
+
+When using a React or selector ref with a tooltip that has dynamic content, the `aria` and `aria-live` props do not need to be manually passed in.
+
 ```js
 import React from 'react';
 import { Tooltip, Button } from '@patternfly/react-core';
@@ -77,8 +89,13 @@ IconExample = () => {
   const [content, setContent] = React.useState(copyText);
   return (
     <div style={{ margin: '100px' }}>
-      <Tooltip content={showSuccessContent ? doneCopyText : copyText}>
-        <Button variant="plain" aria-label="Icon with tooltip attached" id="tt-ref" onClick={() => setShowSuccessContent(!showSuccessContent)}>
+      <Tooltip aria="none" aria-live="polite" content={showSuccessContent ? doneCopyText : copyText}>
+        <Button
+          aria-label="Clipboard"
+          variant="plain"
+          id="tt-ref"
+          onClick={() => setShowSuccessContent(!showSuccessContent)}
+        >
           <CopyIcon />
         </Button>
       </Tooltip>
@@ -88,6 +105,7 @@ IconExample = () => {
 ```
 
 ### Options
+
 ```js
 import React from 'react';
 import { Button, Tooltip, Checkbox, Select, SelectOption, TextInput } from '@patternfly/react-core';
@@ -105,26 +123,26 @@ OptionsTooltip = () => {
   const [exitDelayInput, setExitDelayInput] = React.useState(0);
   const [animationDuration, setAnimationDuration] = React.useState(300);
   const tipBoxRef = React.useRef(null);
-  
+
   const scrollToRef = ref => {
     if (ref && ref.current) {
       ref.current.scrollTop = 400;
       ref.current.scrollLeft = 300;
     }
-  }
-  
+  };
+
   React.useEffect(() => {
     scrollToRef(tipBoxRef);
   }, []);
-  
+
   return (
     <>
       <div>
-        <div style={{ border: '1px solid'}}>
+        <div style={{ border: '1px solid' }}>
           <Checkbox
             label="trigger: mouseenter"
             isChecked={trigger.includes('mouseenter')}
-            onChange={(checked) => {
+            onChange={checked => {
               let updatedTrigger;
               checked && (updatedTrigger = trigger.concat('mouseenter'));
               !checked && (updatedTrigger = trigger.filter(t => t !== 'mouseenter'));
@@ -137,7 +155,7 @@ OptionsTooltip = () => {
           <Checkbox
             label="trigger: focus"
             isChecked={trigger.includes('focus')}
-            onChange={(checked) => {
+            onChange={checked => {
               let updatedTrigger;
               checked && (updatedTrigger = trigger.concat('focus'));
               !checked && (updatedTrigger = trigger.filter(t => t !== 'focus'));
@@ -150,7 +168,7 @@ OptionsTooltip = () => {
           <Checkbox
             label="trigger: click"
             isChecked={trigger.includes('click')}
-            onChange={(checked) => {
+            onChange={checked => {
               let updatedTrigger;
               checked && (updatedTrigger = trigger.concat('click'));
               !checked && (updatedTrigger = trigger.filter(t => t !== 'click'));
@@ -163,36 +181,36 @@ OptionsTooltip = () => {
           <Checkbox
             label="trigger: manual"
             isChecked={trigger.includes('manual')}
-            onChange={(checked) => {
+            onChange={checked => {
               let updatedTrigger;
               checked && (updatedTrigger = trigger.concat('manual'));
               !checked && (updatedTrigger = trigger.filter(t => t !== 'manual'));
               setIsVisible(false);
               setTrigger(updatedTrigger);
             }}
-            aria-label="trigger: manual"   
-            id="trigger_manual"         
+            aria-label="trigger: manual"
+            id="trigger_manual"
           />
         </div>
-        <div style={{ border: '1px solid'}}>
+        <div style={{ border: '1px solid' }}>
           <Checkbox
             label="content left-aligned"
             isChecked={contentLeftAligned}
-            onChange={(checked) => setContentLeftAligned(checked)}
+            onChange={checked => setContentLeftAligned(checked)}
             aria-label="content left-aligned"
-            id="content_left_aligned"          
+            id="content_left_aligned"
           />
         </div>
-        <div style={{ border: '1px solid'}}>
+        <div style={{ border: '1px solid' }}>
           <Checkbox
             label="enableFlip"
             isChecked={enableFlip}
-            onChange={(checked) => setEnableFlip(checked)}
-            aria-label="enableFlip"    
-            id="enable_flip"    
+            onChange={checked => setEnableFlip(checked)}
+            aria-label="enableFlip"
+            id="enable_flip"
           />
         </div>
-        <div style={{ border: '1px solid'}}>
+        <div style={{ border: '1px solid' }}>
           position (will flip if enableFlip is true). The 'auto' position requires enableFlip to be set to true.
           <Select
             onToggle={() => setPositionSelectOpen(!positionSelectOpen)}
@@ -219,22 +237,41 @@ OptionsTooltip = () => {
             <SelectOption value="right-end" />
           </Select>
         </div>
-        <div style={{ border: '1px solid'}}>
+        <div style={{ border: '1px solid' }}>
           <Checkbox
             label="isVisible (also set trigger to only manual to programmatically control it)"
             isChecked={isVisible}
-            onChange={(checked) => setIsVisible(checked)}
-            aria-label="isVisible" 
-            id="is_visible"       
+            onChange={checked => setIsVisible(checked)}
+            aria-label="isVisible"
+            id="is_visible"
           />
         </div>
-        <div style={{ border: '1px solid'}}>
-          Entry delay (ms) <TextInput value={entryDelayInput} type="number" onChange={val => setEntryDelayInput(val)} aria-label="entry delay" />
-          Exit delay (ms) <TextInput value={exitDelayInput} type="number" onChange={val => setExitDelayInput(val)} aria-label="exit delay" />
-          Animation duration (ms) <TextInput value={animationDuration} type="number" onChange={val => setAnimationDuration(val)} aria-label="animation duration" />
+        <div style={{ border: '1px solid' }}>
+          Entry delay (ms){' '}
+          <TextInput
+            value={entryDelayInput}
+            type="number"
+            onChange={val => setEntryDelayInput(val)}
+            aria-label="entry delay"
+          />
+          Exit delay (ms) <TextInput
+            value={exitDelayInput}
+            type="number"
+            onChange={val => setExitDelayInput(val)}
+            aria-label="exit delay"
+          />
+          Animation duration (ms){' '}
+          <TextInput
+            value={animationDuration}
+            type="number"
+            onChange={val => setAnimationDuration(val)}
+            aria-label="animation duration"
+          />
         </div>
-        <div style={{ border: '1px solid'}}>
-          flip behavior examples (enableFlip has to be true). "flip" will try to flip the tooltip to the opposite of the starting position. The second option ensures that there are 3 escape positions for every possible starting position (default). This setting is ignored if position prop is set to 'auto'.
+        <div style={{ border: '1px solid' }}>
+          flip behavior examples (enableFlip has to be true). "flip" will try to flip the tooltip to the opposite of the
+          starting position. The second option ensures that there are 3 escape positions for every possible starting
+          position (default). This setting is ignored if position prop is set to 'auto'.
           <Select
             onToggle={() => setFlipSelectOpen(!flipSelectOpen)}
             onSelect={(event, selection) => {
@@ -254,7 +291,9 @@ OptionsTooltip = () => {
       <div id="tooltip-boundary" className="tooltip-box" ref={tipBoxRef}>
         <Tooltip
           content={
-            <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.</div>
+            <div>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
+            </div>
           }
           trigger={trigger.join(' ')}
           enableFlip={enableFlip}
@@ -272,5 +311,5 @@ OptionsTooltip = () => {
       </div>
     </>
   );
-}
+};
 ```


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7331

Convenience links:

[Tooltip component](https://patternfly-react-pr-7332.surge.sh/components/tooltip)
[Tabs component](https://patternfly-react-pr-7332.surge.sh/components/tabs)

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
This PR also updates the Tab component that was previously updated in PR #6940.

Additionally, this PR could also resolve issues #7021 and #4446, but only when using the React or selector ref variants (or by using `aria="none"` and `aria-live="polite"` props). So this could potentially require altering how the Tooltip prop is setup or just a larger discussion, depending on if another solution can be found when not using a ref. This I believe was alluded to in another issue in this epic #1655: "One possible alternative is to render the tooltip as an aria-live region."

This PR getting merged would also go towards fixing #7096, as that would be updated to follow the "Icon with dynamic content" Tooltip example in this PR.