### PR TITLE
fix(ClipboardCopy): dynamic tooltip updates get announced

### DIFF
--- a/packages/react-core/src/components/ClipboardCopy/ClipboardCopyButton.tsx
+++ b/packages/react-core/src/components/ClipboardCopy/ClipboardCopyButton.tsx
@@ -62,6 +62,8 @@ export const ClipboardCopyButton: React.FunctionComponent<ClipboardCopyButtonPro
     entryDelay={entryDelay}
     maxWidth={maxWidth}
     position={position}
+    aria-live="polite"
+    aria="none"
     content={<div>{children}</div>}
   >
     <Button


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #1655 and closes #7096

Convenience links:
[Clipboard copy component](https://patternfly-react-pr-7335.surge.sh/components/clipboard-copy)
[Code block component](https://patternfly-react-pr-7335.surge.sh/components/code-block)

This follows the pattern introduced in PR #7332 

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
