### PR TITLE
fix(LogViewer): clear ANSI cache when resetting the log window

### DIFF
--- a/packages/react-log-viewer/src/LogViewer/LogViewer.tsx
+++ b/packages/react-log-viewer/src/LogViewer/LogViewer.tsx
@@ -5,6 +5,7 @@ import { LogViewerRow } from './LogViewerRow';
 import { parseConsoleOutput, searchedKeyWordType, stripAnsi } from './utils/utils';
 import { VariableSizeList as List, areEqual } from '../react-window';
 import styles from '@patternfly/react-styles/css/components/LogViewer/log-viewer';
+import AnsiUp from '../ansi_up/ansi_up';
 
 interface LogViewerProps {
   /** String or String Array data being sent by the consumer*/
@@ -97,6 +98,7 @@ const LogViewerBase: React.FunctionComponent<LogViewerProps> = memo(
     const [resizing, setResizing] = useState(false);
     const [loading, setLoading] = useState(true);
     const [listKey, setListKey] = useState(1);
+    const ansiUp = new AnsiUp();
 
     const logViewerRef = innerRef || React.useRef<any>();
     const containerRef = React.useRef<any>();
@@ -107,6 +109,7 @@ const LogViewerBase: React.FunctionComponent<LogViewerProps> = memo(
         window.addEventListener('resize', callbackResize);
         setLoading(false);
         createDummyElements();
+        ansiUp.resetStyles();
       }
       return () => window.removeEventListener('resize', callbackResize);
     }, [containerRef.current]);
@@ -232,6 +235,7 @@ const LogViewerBase: React.FunctionComponent<LogViewerProps> = memo(
         onScroll={onScroll}
         isTextWrapped={isTextWrapped}
         hasLineNumbers={hasLineNumbers}
+        ansiUp={ansiUp}
       >
         {LogViewerRow}
       </List>

--- a/packages/react-log-viewer/src/LogViewer/LogViewerRow.tsx
+++ b/packages/react-log-viewer/src/LogViewer/LogViewerRow.tsx
@@ -15,11 +15,10 @@ interface LogViewerRowProps {
     rowInFocus: searchedKeyWordType;
     searchedWordIndexes: searchedKeyWordType[];
   };
+  ansiUp: AnsiUp;
 }
 
-const ansiUp = new AnsiUp();
-
-export const LogViewerRow: React.FunctionComponent<LogViewerRowProps> = memo(({ index, style, data }) => {
+export const LogViewerRow: React.FunctionComponent<LogViewerRowProps> = memo(({ index, style, data, ansiUp }) => {
   const { parsedData, searchedWordIndexes, rowInFocus } = data;
   const context = useContext(LogViewerContext);
 

--- a/packages/react-log-viewer/src/ansi_up/ansi_up.ts
+++ b/packages/react-log-viewer/src/ansi_up/ansi_up.ts
@@ -78,16 +78,7 @@ export default class AnsiUp {
   constructor() {
     // All construction occurs here
     this.setup_palettes();
-    this._use_classes = false;
-
-    this.bold = false;
-    this.italic = false;
-    this.underline = false;
-    this.fg = this.bg = null;
-
-    this._buffer = '';
-
-    this._url_whitelist = { http: 1, https: 1 };
+    this.resetStyles();
   }
 
   set use_classes(arg: boolean) {
@@ -510,6 +501,19 @@ export default class AnsiUp {
     }
 
     return blocks.join('');
+  }
+
+  resetStyles() {
+    this._use_classes = false;
+
+    this.bold = false;
+    this.italic = false;
+    this.underline = false;
+    this.fg = this.bg = null;
+
+    this._buffer = '';
+
+    this._url_whitelist = { http: 1, https: 1 };
   }
 
   private with_state(pkt: TextPacket): TextWithAttr {

--- a/packages/react-log-viewer/src/react-window/createListComponent.ts
+++ b/packages/react-log-viewer/src/react-window/createListComponent.ts
@@ -11,6 +11,7 @@ export interface RowProps {
   index: number;
   isScrolling?: boolean;
   style: React.CSSProperties;
+  ansiUp: any;
 }
 
 export interface ListProps {
@@ -247,7 +248,8 @@ export default function createListComponent({
         useIsScrolling,
         width,
         isTextWrapped,
-        hasLineNumbers
+        hasLineNumbers,
+        ansiUp
       } = this.props;
       const { isScrolling } = this.state;
 
@@ -264,7 +266,8 @@ export default function createListComponent({
               key: itemKey(index, itemData),
               index,
               isScrolling: useIsScrolling ? isScrolling : undefined,
-              style: this._getItemStyle(index)
+              style: this._getItemStyle(index),
+              ansiUp
             })
           );
         }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7354 
Reset ANSI styles every time when the container changes in case of ANSI style caching.

