### PR TITLE
fix(charts): Add style for tooltip cursor

### DIFF
--- a/packages/react-charts/src/components/ChartCursorContainer/ChartCursorContainer.tsx
+++ b/packages/react-charts/src/components/ChartCursorContainer/ChartCursorContainer.tsx
@@ -1,6 +1,9 @@
+/* eslint-disable camelcase */
+import chart_global_label_Fill from '@patternfly/react-tokens/dist/esm/chart_global_label_Fill';
+
 import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import { CallbackArgs, CoordinatesPropType, OriginType } from 'victory-core';
+import { CallbackArgs, CoordinatesPropType, LineSegment, OriginType } from 'victory-core';
 import {
   CursorCoordinatesPropType,
   VictoryCursorContainer,
@@ -201,6 +204,7 @@ export interface ChartCursorContainerProps extends VictoryCursorContainerProps {
 
 export const ChartCursorContainer: React.FunctionComponent<ChartCursorContainerProps> = ({
   className,
+  cursorComponent = <LineSegment />,
   themeColor,
   themeVariant,
 
@@ -215,11 +219,20 @@ export const ChartCursorContainer: React.FunctionComponent<ChartCursorContainerP
     ...cursorLabelComponent.props
   });
 
+  // Clone so users can override cursor container props
+  const cursor = React.cloneElement(cursorComponent, {
+    style: {
+      strokeColor: chart_global_label_Fill.value
+    },
+    ...cursorComponent.props
+  });
+
   // Note: theme is required by voronoiContainerMixin
   return (
     // Note: className is valid, but Victory is missing a type
     <VictoryCursorContainer
       className={chartClassName}
+      cursorComponent={cursor}
       cursorLabelComponent={chartCursorLabelComponent}
       theme={theme}
       {...rest}

--- a/packages/react-charts/src/components/ChartUtils/chart-container.tsx
+++ b/packages/react-charts/src/components/ChartUtils/chart-container.tsx
@@ -1,7 +1,11 @@
+/* eslint-disable camelcase */
+import chart_global_label_Fill from '@patternfly/react-tokens/dist/esm/chart_global_label_Fill';
+
 import * as React from 'react';
 import { ContainerType, createContainer as victoryCreateContainer } from 'victory-create-container';
 import { ChartCursorTooltip } from '../ChartCursorTooltip';
 import { ChartLabel } from '../ChartLabel';
+import { LineSegment } from 'victory-core';
 
 /**
  * Makes a container component with multiple behaviors. It allows you to effectively combine any two
@@ -27,6 +31,13 @@ export const createContainer = (behaviorA: ContainerType, behaviorB: ContainerTy
 
   if (isCursor) {
     container.defaultProps.cursorLabelComponent = <ChartLabel textAnchor="start" />;
+    container.defaultProps.cursorComponent = (
+      <LineSegment
+        style={{
+          stroke: chart_global_label_Fill.value
+        }}
+      />
+    );
   }
   if (isVoronoi) {
     container.defaultProps.labelComponent = <ChartCursorTooltip />;


### PR DESCRIPTION
To support the dark theme, we need to style the vertical cursor used with tooltips. In order to do that, we must override Victory's cursor component.

https://github.com/patternfly/patternfly-react/issues/7360

Testing: Changed stroke style to red
<img width="779" alt="Screen Shot 2022-05-04 at 7 23 59 PM" src="https://user-images.githubusercontent.com/17481322/166841060-52ff1623-2d01-4180-be15-ab7abaa99e34.png">

