### PR TITLE
Add missing 'children' prop in several places

### DIFF
--- a/packages/react-core/src/components/Select/SelectMenu.tsx
+++ b/packages/react-core/src/components/Select/SelectMenu.tsx
@@ -268,7 +268,7 @@ class SelectMenuWithRef extends React.Component<SelectMenuProps> {
   }
 }
 
-export const SelectMenu = React.forwardRef((props, ref) => (
+export const SelectMenu = React.forwardRef<unknown, React.PropsWithChildren<unknown>>((props, ref) => (
   <SelectMenuWithRef innerRef={ref} {...props}>
     {props.children}
   </SelectMenuWithRef>

--- a/packages/react-topology/src/components/ComputeElementDimensions.tsx
+++ b/packages/react-topology/src/components/ComputeElementDimensions.tsx
@@ -5,6 +5,7 @@ import Dimensions from '../geom/Dimensions';
 import { Node } from '../types';
 
 interface ComputeElementDimensionsProps {
+  children?: React.ReactNode;
   element: Node;
 }
 

--- a/packages/react-topology/src/components/contextmenu/ContextMenu.tsx
+++ b/packages/react-topology/src/components/contextmenu/ContextMenu.tsx
@@ -8,7 +8,7 @@ import Popper from '../popper/Popper';
 
 type ContextMenuProps = Pick<
   React.ComponentProps<typeof Popper>,
-  'container' | 'className' | 'open' | 'reference' | 'onRequestClose'
+  'children' | 'container' | 'className' | 'open' | 'reference' | 'onRequestClose'
 >;
 
 const ContextMenu: React.FunctionComponent<ContextMenuProps> = ({

--- a/packages/react-topology/src/components/decorators/Decorator.tsx
+++ b/packages/react-topology/src/components/decorators/Decorator.tsx
@@ -6,6 +6,7 @@ import { createSvgIdUrl, useHover } from '../../utils';
 import { DEFAULT_DECORATOR_PADDING } from '../nodes';
 
 interface DecoratorTypes {
+  children?: React.ReactNode;
   className?: string;
   x: number;
   y: number;

--- a/packages/react-topology/src/components/edges/DefaultEdge.tsx
+++ b/packages/react-topology/src/components/edges/DefaultEdge.tsx
@@ -21,6 +21,7 @@ import { Point } from '../../geom';
 import { getConnectorStartPoint } from './terminals/terminalUtils';
 
 type BaseEdgeProps = {
+  children?: React.ReactNode;
   element: Edge;
   dragging?: boolean;
   className?: string;

--- a/packages/react-topology/src/components/groups/DefaultGroupCollapsed.tsx
+++ b/packages/react-topology/src/components/groups/DefaultGroupCollapsed.tsx
@@ -21,6 +21,7 @@ import LabelBadge from '../nodes/labels/LabelBadge';
 import { CollapsibleGroupProps } from './types';
 
 type DefaultGroupCollapsedProps = {
+  children?: React.ReactNode;
   className?: string;
   element: Node;
   droppable?: boolean;

--- a/packages/react-topology/src/components/nodes/DefaultNode.tsx
+++ b/packages/react-topology/src/components/nodes/DefaultNode.tsx
@@ -37,6 +37,7 @@ const getStatusIcon = (status: NodeStatus) => {
 };
 
 type DefaultNodeProps = {
+  children?: React.ReactNode;
   className?: string;
   element: Node;
   droppable?: boolean;

--- a/packages/react-topology/src/components/popper/Popper.tsx
+++ b/packages/react-topology/src/components/popper/Popper.tsx
@@ -50,6 +50,7 @@ const getReference = (reference: Reference): PopperJSReference =>
   'getBoundingClientRect' in reference ? reference : new VirtualReference(reference);
 
 interface PopperProps {
+  children?: React.ReactNode;
   closeOnEsc?: boolean;
   closeOnOutsideClick?: boolean;
   container?: React.ComponentProps<typeof Portal>['container'];

--- a/packages/react-topology/src/components/popper/Portal.tsx
+++ b/packages/react-topology/src/components/popper/Portal.tsx
@@ -5,6 +5,7 @@ import { useIsomorphicLayoutEffect } from '@patternfly/react-core';
 type GetContainer = Element | null | undefined | (() => Element);
 
 interface PortalProps {
+  children?: React.ReactNode;
   container?: GetContainer;
 }
 


### PR DESCRIPTION
Adds 'children' prop to the types of various components where they were missing.  In React 18 a component type (e.g. `FunctionComponent`) [no longer has](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210) an implicit `children` prop. 

This is needed to land #7142.