### PR TITLE
feat(Menu): Added support for checkbox menu

### DIFF
--- a/packages/react-core/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react-core/src/components/Checkbox/Checkbox.tsx
@@ -28,6 +28,8 @@ export interface CheckboxProps
   description?: React.ReactNode;
   /** Body text of the checkbox */
   body?: React.ReactNode;
+  /** Sets the input wrapper component to render. Defaults to <div> */
+  component?: React.ElementType;
 }
 
 // tslint:disable-next-line:no-empty
@@ -45,7 +47,8 @@ export class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
     isDisabled: false,
     isChecked: false,
     onChange: defaultOnChange,
-    ouiaSafe: true
+    ouiaSafe: true,
+    component: 'div'
   };
 
   constructor(props: any) {
@@ -74,6 +77,7 @@ export class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
       body,
       ouiaId,
       ouiaSafe,
+      component: Component,
       ...props
     } = this.props;
     if (!props.id) {
@@ -93,7 +97,7 @@ export class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
 
     checkedProps.checked = checkedProps.checked === null ? false : checkedProps.checked;
     return (
-      <div className={css(styles.check, !label && styles.modifiers.standalone, className)}>
+      <Component className={css(styles.check, !label && styles.modifiers.standalone, className)}>
         <input
           {...props}
           className={css(styles.checkInput)}
@@ -113,7 +117,7 @@ export class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
         )}
         {description && <span className={css(styles.checkDescription)}>{description}</span>}
         {body && <span className={css(styles.checkBody)}>{body}</span>}
-      </div>
+      </Component>
     );
   }
 }

--- a/packages/react-core/src/components/Checkbox/__tests__/Checkbox.test.tsx
+++ b/packages/react-core/src/components/Checkbox/__tests__/Checkbox.test.tsx
@@ -82,4 +82,13 @@ describe('Checkbox', () => {
     render(<Checkbox id={undefined} />);
     expect(myMock).toHaveBeenCalled();
   });
+
+  test('renders component wrapper as span', () => {
+    const { container } = render(
+      <Checkbox component="span" label="label" aria-labelledby="labelId" id="check" isChecked aria-label="check" />
+    );
+    const span = container.querySelector('span');
+    expect(span).toHaveClass('pf-c-check');
+   
+  });
 });

--- a/packages/react-core/src/components/Menu/MenuItem.tsx
+++ b/packages/react-core/src/components/Menu/MenuItem.tsx
@@ -295,7 +295,7 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
       onMouseOver={onMouseOver}
       {...(flyoutMenu && { onKeyDown: handleFlyout })}
       ref={ref}
-      role="none"
+      role={!hasCheck ? 'none' : 'menuitem'}
       {...props}
     >
       <GenerateId>
@@ -305,7 +305,7 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
             className={css(styles.menuItem, getIsSelected() && !hasCheck && styles.modifiers.selected, className)}
             aria-current={getAriaCurrent()}
             {...(!hasCheck && { disabled: isDisabled })}
-            role={!hasCheck ? 'none' : 'menuitem'}
+            {...(!hasCheck && { role: 'menuitem' })}
             ref={innerRef}
             {...(!hasCheck && {
               onClick: (event: any) => {

--- a/packages/react-core/src/components/Menu/MenuItem.tsx
+++ b/packages/react-core/src/components/Menu/MenuItem.tsx
@@ -305,7 +305,7 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
             className={css(styles.menuItem, getIsSelected() && !hasCheck && styles.modifiers.selected, className)}
             aria-current={getAriaCurrent()}
             {...(!hasCheck && { disabled: isDisabled })}
-            role="menuitem"
+            role={hasCheck ? 'none' : 'menuitem'}
             ref={innerRef}
             {...(!hasCheck && {
               onClick: (event: any) => {
@@ -327,6 +327,7 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
                 <span className={css('pf-c-menu__item-check')}>
                   <Checkbox
                     id={randomId}
+                    component="span"
                     isChecked={isSelected || false}
                     onChange={event => onItemSelect(event, onSelect)}
                     isDisabled={isDisabled}

--- a/packages/react-core/src/components/Menu/MenuItem.tsx
+++ b/packages/react-core/src/components/Menu/MenuItem.tsx
@@ -25,7 +25,7 @@ export interface MenuItemProps extends Omit<React.HTMLProps<HTMLLIElement>, 'onC
   /** Target navigation link */
   to?: string;
   /** @beta Flag indicating the item has a checkbox */
-  isCheck?: boolean;
+  hasCheck?: boolean;
   /** Flag indicating whether the item is active */
   isActive?: boolean;
   /** Flag indicating if the item is favorited */
@@ -75,7 +75,7 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
   className,
   itemId = null,
   to,
-  isCheck = false,
+  hasCheck = false,
   isActive = null,
   isFavorited = null,
   isLoadButton = false,
@@ -111,7 +111,7 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
     disableHover
   } = React.useContext(MenuContext);
   let Component = (to ? 'a' : component) as any;
-  if (isCheck && !to) {
+  if (hasCheck && !to) {
     Component = 'label' as any;
   }
   const [flyoutTarget, setFlyoutTarget] = React.useState(null);
@@ -302,18 +302,18 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
         {randomId => (
           <Component
             tabIndex={-1}
-            className={css(styles.menuItem, getIsSelected() && !isCheck && styles.modifiers.selected, className)}
+            className={css(styles.menuItem, getIsSelected() && !hasCheck && styles.modifiers.selected, className)}
             aria-current={getAriaCurrent()}
-            {...(!isCheck && { disabled: isDisabled })}
+            {...(!hasCheck && { disabled: isDisabled })}
             role="menuitem"
             ref={innerRef}
-            {...(!isCheck && {
+            {...(!hasCheck && {
               onClick: (event: any) => {
                 onItemSelect(event, onSelect);
                 _drill && _drill();
               }
             })}
-            {...(isCheck && { htmlFor: randomId })}
+            {...(hasCheck && { htmlFor: randomId })}
             {...additionalProps}
           >
             <span className={css(styles.menuItemMain)}>
@@ -323,7 +323,7 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
                 </span>
               )}
               {icon && <span className={css(styles.menuItemIcon)}>{icon}</span>}
-              {isCheck && (
+              {hasCheck && (
                 <span className={css('pf-c-menu__item-check')}>
                   <Checkbox
                     id={randomId}

--- a/packages/react-core/src/components/Menu/MenuItem.tsx
+++ b/packages/react-core/src/components/Menu/MenuItem.tsx
@@ -8,10 +8,12 @@ import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external
 import AngleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-right-icon';
 import AngleLeftIcon from '@patternfly/react-icons/dist/esm/icons/angle-left-icon';
 import CheckIcon from '@patternfly/react-icons/dist/esm/icons/check-icon';
+import { Checkbox } from '../Checkbox';
 import { MenuContext, MenuItemContext } from './MenuContext';
 import { MenuItemAction } from './MenuItemAction';
 import { canUseDOM } from '../../helpers/util';
 import { useIsomorphicLayoutEffect } from '../../helpers/useIsomorphicLayout';
+import { GenerateId } from '../../helpers/GenerateId/GenerateId';
 
 export interface MenuItemProps extends Omit<React.HTMLProps<HTMLLIElement>, 'onClick'> {
   /** Content rendered inside the menu list item. */
@@ -22,6 +24,8 @@ export interface MenuItemProps extends Omit<React.HTMLProps<HTMLLIElement>, 'onC
   itemId?: any;
   /** Target navigation link */
   to?: string;
+  /** @beta Flag indicating the item has a checkbox */
+  isCheck?: boolean;
   /** Flag indicating whether the item is active */
   isActive?: boolean;
   /** Flag indicating if the item is favorited */
@@ -71,6 +75,7 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
   className,
   itemId = null,
   to,
+  isCheck = false,
   isActive = null,
   isFavorited = null,
   isLoadButton = false,
@@ -105,7 +110,10 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
     setFlyoutRef,
     disableHover
   } = React.useContext(MenuContext);
-  const Component = (to ? 'a' : component) as any;
+  let Component = (to ? 'a' : component) as any;
+  if (isCheck && !to) {
+    Component = 'label' as any;
+  }
   const [flyoutTarget, setFlyoutTarget] = React.useState(null);
   const flyoutContext = React.useContext(FlyoutContext);
   const [flyoutXDirection, setFlyoutXDirection] = React.useState(flyoutContext.direction);
@@ -290,49 +298,65 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
       role="none"
       {...props}
     >
-      <Component
-        tabIndex={-1}
-        className={css(styles.menuItem, getIsSelected() && styles.modifiers.selected, className)}
-        aria-current={getAriaCurrent()}
-        disabled={isDisabled}
-        role="menuitem"
-        ref={innerRef}
-        onClick={(event: any) => {
-          onItemSelect(event, onSelect);
-          _drill && _drill();
-        }}
-        {...additionalProps}
-      >
-        <span className={css(styles.menuItemMain)}>
-          {direction === 'up' && (
-            <span className={css(styles.menuItemToggleIcon)}>
-              <AngleLeftIcon aria-hidden />
+      <GenerateId>
+        {randomId => (
+          <Component
+            tabIndex={-1}
+            className={css(styles.menuItem, getIsSelected() && !isCheck && styles.modifiers.selected, className)}
+            aria-current={getAriaCurrent()}
+            disabled={isDisabled}
+            role="menuitem"
+            ref={innerRef}
+            {...(!isCheck && {
+              onClick: (event: any) => {
+                onItemSelect(event, onSelect);
+                _drill && _drill();
+              }
+            })}
+            {...(isCheck && { htmlFor: randomId })}
+            {...additionalProps}
+          >
+            <span className={css(styles.menuItemMain)}>
+              {direction === 'up' && (
+                <span className={css(styles.menuItemToggleIcon)}>
+                  <AngleLeftIcon aria-hidden />
+                </span>
+              )}
+              {icon && <span className={css(styles.menuItemIcon)}>{icon}</span>}
+              {isCheck && (
+                <span className={css('pf-c-menu__item-check')}>
+                  <Checkbox
+                    id={randomId}
+                    isChecked={isSelected || false}
+                    onChange={event => onItemSelect(event, onSelect)}
+                  />
+                </span>
+              )}
+              <span className={css(styles.menuItemText)}>{children}</span>
+              {isExternalLink && (
+                <span className={css(styles.menuItemExternalIcon)}>
+                  <ExternalLinkAltIcon aria-hidden />
+                </span>
+              )}
+              {(flyoutMenu || direction === 'down') && (
+                <span className={css(styles.menuItemToggleIcon)}>
+                  <AngleRightIcon aria-hidden />
+                </span>
+              )}
+              {getIsSelected() && (
+                <span className={css(styles.menuItemSelectIcon)}>
+                  <CheckIcon aria-hidden />
+                </span>
+              )}
             </span>
-          )}
-          {icon && <span className={css(styles.menuItemIcon)}>{icon}</span>}
-          <span className={css(styles.menuItemText)}>{children}</span>
-          {isExternalLink && (
-            <span className={css(styles.menuItemExternalIcon)}>
-              <ExternalLinkAltIcon aria-hidden />
-            </span>
-          )}
-          {(flyoutMenu || direction === 'down') && (
-            <span className={css(styles.menuItemToggleIcon)}>
-              <AngleRightIcon aria-hidden />
-            </span>
-          )}
-          {getIsSelected() && (
-            <span className={css(styles.menuItemSelectIcon)}>
-              <CheckIcon aria-hidden />
-            </span>
-          )}
-        </span>
-        {description && direction !== 'up' && (
-          <span className={css(styles.menuItemDescription)}>
-            <span>{description}</span>
-          </span>
+            {description && direction !== 'up' && (
+              <span className={css(styles.menuItemDescription)}>
+                <span>{description}</span>
+              </span>
+            )}
+          </Component>
         )}
-      </Component>
+      </GenerateId>
       {flyoutVisible && (
         <MenuContext.Provider value={{ disableHover }}>
           <FlyoutContext.Provider value={{ direction: flyoutXDirection }}>{flyoutMenu}</FlyoutContext.Provider>

--- a/packages/react-core/src/components/Menu/MenuItem.tsx
+++ b/packages/react-core/src/components/Menu/MenuItem.tsx
@@ -304,7 +304,7 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
             tabIndex={-1}
             className={css(styles.menuItem, getIsSelected() && !isCheck && styles.modifiers.selected, className)}
             aria-current={getAriaCurrent()}
-            disabled={isDisabled}
+            {...(!isCheck && { disabled: isDisabled })}
             role="menuitem"
             ref={innerRef}
             {...(!isCheck && {
@@ -329,6 +329,7 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
                     id={randomId}
                     isChecked={isSelected || false}
                     onChange={event => onItemSelect(event, onSelect)}
+                    isDisabled={isDisabled}
                   />
                 </span>
               )}

--- a/packages/react-core/src/components/Menu/MenuItem.tsx
+++ b/packages/react-core/src/components/Menu/MenuItem.tsx
@@ -305,7 +305,7 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
             className={css(styles.menuItem, getIsSelected() && !hasCheck && styles.modifiers.selected, className)}
             aria-current={getAriaCurrent()}
             {...(!hasCheck && { disabled: isDisabled })}
-            role={hasCheck ? 'none' : 'menuitem'}
+            role={!hasCheck ? 'none' : 'menuitem'}
             ref={innerRef}
             {...(!hasCheck && {
               onClick: (event: any) => {

--- a/packages/react-core/src/components/Menu/__tests__/Menu.test.tsx
+++ b/packages/react-core/src/components/Menu/__tests__/Menu.test.tsx
@@ -2,8 +2,12 @@ import React from 'react';
 
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
 
 import { Menu } from '../Menu';
+import { MenuItem } from '../MenuItem';
+import { MenuList } from '../MenuList';
+import { MenuContent } from '../MenuContent';
 
 describe('Menu', () => {
   test('should render Menu successfully', () => {
@@ -45,6 +49,25 @@ describe('Menu', () => {
         </Menu>
       );
       expect(screen.getByText('content')).toHaveClass('pf-m-nav');
+    });
+  });
+
+  describe('with isCheck', () => {
+    test('should render Menu with checkbox items', () => {
+      const { asFragment } = render(
+        <Menu>
+          <MenuContent>
+            <MenuList>
+              <MenuItem isCheck itemId={0}>
+                Checkbox 1
+              </MenuItem>
+            </MenuList>
+          </MenuContent>
+        </Menu>
+      );
+      const checkbox1 = screen.getAllByRole('checkbox')[0];
+      expect(checkbox1).not.toBeChecked();
+      expect(screen.getByText("Checkbox 1")).toBeInTheDocument();
     });
   });
 });

--- a/packages/react-core/src/components/Menu/__tests__/Menu.test.tsx
+++ b/packages/react-core/src/components/Menu/__tests__/Menu.test.tsx
@@ -52,13 +52,13 @@ describe('Menu', () => {
     });
   });
 
-  describe('with isCheck', () => {
+  describe('with hasCheck', () => {
     test('should render Menu with checkbox items', () => {
       const { asFragment } = render(
         <Menu>
           <MenuContent>
             <MenuList>
-              <MenuItem isCheck itemId={0}>
+              <MenuItem hasCheck itemId={0}>
                 Checkbox 1
               </MenuItem>
             </MenuList>

--- a/packages/react-core/src/components/Menu/examples/Menu.md
+++ b/packages/react-core/src/components/Menu/examples/Menu.md
@@ -128,6 +128,11 @@ class MenuIconsList extends React.Component {
 }
 ```
 
+### With checkbox
+
+```ts file="./MenuWithCheckbox.tsx" isBeta
+```
+
 ### Filtering with text input
 
 ```js

--- a/packages/react-core/src/components/Menu/examples/MenuWithCheckbox.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuWithCheckbox.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Menu, MenuContent, MenuList, MenuItem } from '@patternfly/react-core';
+
+export const MenuCheckboxList: React.FunctionComponent = () => {
+  const [activeItem, setActiveItem] = React.useState(0);
+
+  const onSelect = (event, itemId) => {
+    // eslint-disable-next-line no-console
+    console.log(`clicked ${itemId}`);
+    setActiveItem(itemId);
+  };
+
+  return (
+    <Menu activeItemId={activeItem} onSelect={onSelect}>
+      <MenuContent>
+        <MenuList>
+          <MenuItem isCheck itemId={0}>
+            Checkbox 1
+          </MenuItem>
+          <MenuItem isCheck itemId={1}>
+            Checkbox 2
+          </MenuItem>
+          <MenuItem isCheck isDisabled>
+            Checkbox 3
+          </MenuItem>
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+};

--- a/packages/react-core/src/components/Menu/examples/MenuWithCheckbox.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuWithCheckbox.tsx
@@ -18,13 +18,13 @@ export const MenuCheckboxList: React.FunctionComponent = () => {
     <Menu onSelect={onSelect} selected={selectedItems}>
       <MenuContent>
         <MenuList>
-          <MenuItem isCheck itemId={0} isSelected={selectedItems.includes(0)}>
+          <MenuItem hasCheck itemId={0} isSelected={selectedItems.includes(0)}>
             Checkbox 1
           </MenuItem>
-          <MenuItem isCheck itemId={1} isSelected={selectedItems.includes(1)}>
+          <MenuItem hasCheck itemId={1} isSelected={selectedItems.includes(1)}>
             Checkbox 2
           </MenuItem>
-          <MenuItem isCheck itemId={2} isDisabled>
+          <MenuItem hasCheck itemId={2} isDisabled>
             Checkbox 3
           </MenuItem>
         </MenuList>

--- a/packages/react-core/src/components/Menu/examples/MenuWithCheckbox.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuWithCheckbox.tsx
@@ -2,25 +2,29 @@ import React from 'react';
 import { Menu, MenuContent, MenuList, MenuItem } from '@patternfly/react-core';
 
 export const MenuCheckboxList: React.FunctionComponent = () => {
-  const [activeItem, setActiveItem] = React.useState(0);
+  const [selectedItems, setSelectedItems] = React.useState<number[]>([]);
 
-  const onSelect = (event, itemId) => {
-    // eslint-disable-next-line no-console
-    console.log(`clicked ${itemId}`);
-    setActiveItem(itemId);
+  /* eslint no-unused-vars: ["error", {"args": "after-used"}] */
+  const onSelect = (event: React.MouseEvent<Element, MouseEvent>, itemId: number | string) => {
+    const item = itemId as number;
+    if (selectedItems.includes(item)) {
+      setSelectedItems(selectedItems.filter(id => id !== item));
+    } else {
+      setSelectedItems([...selectedItems, item]);
+    }
   };
 
   return (
-    <Menu activeItemId={activeItem} onSelect={onSelect}>
+    <Menu onSelect={onSelect} selected={selectedItems}>
       <MenuContent>
         <MenuList>
-          <MenuItem isCheck itemId={0}>
+          <MenuItem isCheck itemId={0} isSelected={selectedItems.includes(0)}>
             Checkbox 1
           </MenuItem>
-          <MenuItem isCheck itemId={1}>
+          <MenuItem isCheck itemId={1} isSelected={selectedItems.includes(1)}>
             Checkbox 2
           </MenuItem>
-          <MenuItem isCheck isDisabled>
+          <MenuItem isCheck itemId={2} isDisabled>
             Checkbox 3
           </MenuItem>
         </MenuList>

--- a/packages/react-core/src/demos/ComposableMenu/ComposableMenu.md
+++ b/packages/react-core/src/demos/ComposableMenu/ComposableMenu.md
@@ -40,6 +40,11 @@ Composable menus currently require consumer keyboard handling and use of our und
 ```ts file="./examples/ComposableSimpleSelect.tsx"
 ```
 
+### Composable simple checkbox select
+
+```ts isBeta file="./examples/ComposableSimpleCheckboxSelect.tsx"
+```
+
 ### Composable drilldown menu
 
 ```ts isBeta file="./examples/ComposableDrilldownMenu.tsx"

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleCheckboxSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleCheckboxSelect.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { MenuToggle, Menu, MenuContent, MenuList, MenuItem, Popper } from '@patternfly/react-core';
+
+export const ComposableSimpleCheckboxSelect: React.FunctionComponent = () => {
+  const [isOpen, setIsOpen] = React.useState<boolean>(false);
+  const [selectedItems, setSelectedItems] = React.useState<number[]>([]);
+  const toggleRef = React.useRef<HTMLButtonElement>();
+  const menuRef = React.useRef<HTMLDivElement>();
+
+  const handleMenuKeys = React.useCallback(
+    event => {
+      if (menuRef.current) {
+        if (isOpen && menuRef.current.contains(event.target as Node)) {
+          if (event.key === 'Escape' || event.key === 'Tab') {
+            setIsOpen(!isOpen);
+            toggleRef.current.focus();
+          }
+        }
+      }
+    },
+    [isOpen]
+  );
+
+  const handleClickOutside = React.useCallback(
+    event => {
+      if (isOpen && !menuRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    },
+    [isOpen]
+  );
+
+  React.useEffect(() => {
+    window.addEventListener('keydown', handleMenuKeys);
+    window.addEventListener('click', handleClickOutside);
+    return () => {
+      window.removeEventListener('keydown', handleMenuKeys);
+      window.removeEventListener('click', handleClickOutside);
+    };
+  }, [handleClickOutside, handleMenuKeys]);
+
+  const onToggleClick = (ev: React.MouseEvent) => {
+    ev.stopPropagation(); // Stop handleClickOutside from handling
+    setTimeout(() => {
+      if (menuRef.current) {
+        const firstElement = menuRef.current.querySelector('li > button:not(:disabled)');
+        firstElement && (firstElement as HTMLElement).focus();
+      }
+    }, 0);
+    setIsOpen(!isOpen);
+  };
+
+  const onSelect = (ev: React.MouseEvent<Element, MouseEvent>, itemId: number | string) => {
+    const item = itemId as number;
+    if (selectedItems.includes(item)) {
+      setSelectedItems(selectedItems.filter(id => id !== item));
+    } else {
+      setSelectedItems([...selectedItems, item]);
+    }
+  };
+
+  const toggle = (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={onToggleClick}
+      isExpanded={isOpen}
+      style={
+        {
+          width: '200px'
+        } as React.CSSProperties
+      }
+    >
+      Filter by status
+    </MenuToggle>
+  );
+  const menu = (
+    <Menu ref={menuRef} id="select-menu" onSelect={onSelect} selected={selectedItems}>
+      <MenuContent>
+        <MenuList>
+          <MenuItem isCheck itemId={0} isSelected={selectedItems.includes(0)}>
+            Debug
+          </MenuItem>
+          <MenuItem isCheck itemId={1} isSelected={selectedItems.includes(1)}>
+            Info
+          </MenuItem>
+          <MenuItem isCheck itemId={2} isSelected={selectedItems.includes(2)}>
+            Warn
+          </MenuItem>
+          <MenuItem isCheck isDisabled itemId={4} isSelected={selectedItems.includes(4)}>
+            Error
+          </MenuItem>
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+  return <Popper trigger={toggle} popper={menu} isVisible={isOpen} />;
+};

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleCheckboxSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleCheckboxSelect.tsx
@@ -78,16 +78,16 @@ export const ComposableSimpleCheckboxSelect: React.FunctionComponent = () => {
     <Menu ref={menuRef} id="select-menu" onSelect={onSelect} selected={selectedItems}>
       <MenuContent>
         <MenuList>
-          <MenuItem isCheck itemId={0} isSelected={selectedItems.includes(0)}>
+          <MenuItem hasCheck itemId={0} isSelected={selectedItems.includes(0)}>
             Debug
           </MenuItem>
-          <MenuItem isCheck itemId={1} isSelected={selectedItems.includes(1)}>
+          <MenuItem hasCheck itemId={1} isSelected={selectedItems.includes(1)}>
             Info
           </MenuItem>
-          <MenuItem isCheck itemId={2} isSelected={selectedItems.includes(2)}>
+          <MenuItem hasCheck itemId={2} isSelected={selectedItems.includes(2)}>
             Warn
           </MenuItem>
-          <MenuItem isCheck isDisabled itemId={4} isSelected={selectedItems.includes(4)}>
+          <MenuItem hasCheck isDisabled itemId={4} isSelected={selectedItems.includes(4)}>
             Error
           </MenuItem>
         </MenuList>

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleCheckboxSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleCheckboxSelect.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MenuToggle, Menu, MenuContent, MenuList, MenuItem, Popper } from '@patternfly/react-core';
+import { MenuToggle, Menu, MenuContent, MenuList, MenuItem, Popper, Badge } from '@patternfly/react-core';
 
 export const ComposableSimpleCheckboxSelect: React.FunctionComponent = () => {
   const [isOpen, setIsOpen] = React.useState<boolean>(false);
@@ -62,11 +62,12 @@ export const ComposableSimpleCheckboxSelect: React.FunctionComponent = () => {
   const toggle = (
     <MenuToggle
       ref={toggleRef}
+      {...(selectedItems.length > 0 && { badge: <Badge isRead>{selectedItems.length}</Badge> })}
       onClick={onToggleClick}
       isExpanded={isOpen}
       style={
         {
-          width: '200px'
+          width: '220px'
         } as React.CSSProperties
       }
     >


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7166  #7367 #7433

link to checkbox menu example:https://patternfly-react-pr-7368.surge.sh/components/menu#with-checkbox

A new demo was added to composable menus: https://patternfly-react-pr-7368.surge.sh/demos/composable-menu#composable-simple-checkbox-select

Issue to track  keyboard interactions #7382. 
