### PR TITLE
fix(Popper): update Popper modifiers when child DOM changes

### DIFF
--- a/packages/react-core/src/helpers/Popper/Popper.tsx
+++ b/packages/react-core/src/helpers/Popper/Popper.tsx
@@ -165,6 +165,10 @@ export const Popper: React.FunctionComponent<PopperProps> = ({
       element.removeEventListener(event, listener);
     }
   };
+
+  // Obeserver added to address https://github.com/patternfly/patternfly-react/issues/7162
+  // and trigger a Popper update when content changes.
+  // Also accounts for https://github.com/patternfly/patternfly-react/issues/5620
   const observer = new MutationObserver(() => {
     update && update();
   });

--- a/packages/react-core/src/helpers/Popper/Popper.tsx
+++ b/packages/react-core/src/helpers/Popper/Popper.tsx
@@ -165,6 +165,10 @@ export const Popper: React.FunctionComponent<PopperProps> = ({
       element.removeEventListener(event, listener);
     }
   };
+  const observer = new MutationObserver(() => {
+    update && update();
+  });
+
   React.useEffect(() => {
     addEventListener(onMouseEnter, refOrTrigger, 'mouseenter');
     addEventListener(onMouseLeave, refOrTrigger, 'mouseleave');
@@ -175,6 +179,7 @@ export const Popper: React.FunctionComponent<PopperProps> = ({
     addEventListener(onPopperClick, popperElement, 'click');
     onDocumentClick && addEventListener(onDocumentClickCallback, document, 'click');
     addEventListener(onDocumentKeyDown, document, 'keydown');
+    popperElement && observer.observe(popperElement, { attributes: true, childList: true, subtree: true });
     return () => {
       removeEventListener(onMouseEnter, refOrTrigger, 'mouseenter');
       removeEventListener(onMouseLeave, refOrTrigger, 'mouseleave');
@@ -185,6 +190,7 @@ export const Popper: React.FunctionComponent<PopperProps> = ({
       removeEventListener(onPopperClick, popperElement, 'click');
       onDocumentClick && removeEventListener(onDocumentClickCallback, document, 'click');
       removeEventListener(onDocumentKeyDown, document, 'keydown');
+      observer.disconnect();
     };
   }, [
     triggerElement,
@@ -233,7 +239,7 @@ export const Popper: React.FunctionComponent<PopperProps> = ({
     [popperMatchesTriggerWidth]
   );
 
-  const { styles: popperStyles, attributes, forceUpdate } = usePopper(refOrTrigger, popperElement, {
+  const { styles: popperStyles, attributes, update } = usePopper(refOrTrigger, popperElement, {
     placement: getPlacementMemo,
     modifiers: [
       {
@@ -261,12 +267,6 @@ export const Popper: React.FunctionComponent<PopperProps> = ({
       sameWidthMod
     ]
   });
-
-  // force update when content changes
-  // https://github.com/patternfly/patternfly-react/issues/5620
-  React.useEffect(() => {
-    forceUpdate && forceUpdate();
-  }, [popper]);
 
   // Returns the CSS modifier class in order to place the Popper's arrow properly
   // Depends on the position of the Popper relative to the reference element

--- a/packages/react-core/src/helpers/Popper/Popper.tsx
+++ b/packages/react-core/src/helpers/Popper/Popper.tsx
@@ -166,13 +166,6 @@ export const Popper: React.FunctionComponent<PopperProps> = ({
     }
   };
 
-  // Obeserver added to address https://github.com/patternfly/patternfly-react/issues/7162
-  // and trigger a Popper update when content changes.
-  // Also accounts for https://github.com/patternfly/patternfly-react/issues/5620
-  const observer = new MutationObserver(() => {
-    update && update();
-  });
-
   React.useEffect(() => {
     addEventListener(onMouseEnter, refOrTrigger, 'mouseenter');
     addEventListener(onMouseLeave, refOrTrigger, 'mouseleave');
@@ -183,7 +176,15 @@ export const Popper: React.FunctionComponent<PopperProps> = ({
     addEventListener(onPopperClick, popperElement, 'click');
     onDocumentClick && addEventListener(onDocumentClickCallback, document, 'click');
     addEventListener(onDocumentKeyDown, document, 'keydown');
+
+    // Obeserver added to address https://github.com/patternfly/patternfly-react/issues/7162
+    // and trigger a Popper update when content changes.
+    // Also accounts for https://github.com/patternfly/patternfly-react/issues/5620
+    const observer = new MutationObserver(() => {
+      update && update();
+    });
     popperElement && observer.observe(popperElement, { attributes: true, childList: true, subtree: true });
+
     return () => {
       removeEventListener(onMouseEnter, refOrTrigger, 'mouseenter');
       removeEventListener(onMouseLeave, refOrTrigger, 'mouseleave');

--- a/packages/react-core/src/helpers/Popper/Popper.tsx
+++ b/packages/react-core/src/helpers/Popper/Popper.tsx
@@ -177,9 +177,7 @@ export const Popper: React.FunctionComponent<PopperProps> = ({
     onDocumentClick && addEventListener(onDocumentClickCallback, document, 'click');
     addEventListener(onDocumentKeyDown, document, 'keydown');
 
-    // Obeserver added to address https://github.com/patternfly/patternfly-react/issues/7162
-    // and trigger a Popper update when content changes.
-    // Also accounts for https://github.com/patternfly/patternfly-react/issues/5620
+    // Trigger a Popper update when content changes.
     const observer = new MutationObserver(() => {
       update && update();
     });


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7162 

With the help of @mturley, we identified that the contents of openshift's popover were being lazy loaded and stealthily swapping out the 'loading' indicator from their popover without triggering a state change or rerender.

We added a new observer to Popper (on which Popover is built) which will watch the entire contents of the Popper for any DOM tree mutations or updates. Whenever a mutation is detected, we will call Popper's 'update' function which reruns all of Popper's modifiers to make sure it's positioned appropriately. Popper's 'update' function uses debounce and is already being used to check Popper's position everytime the user scrolls or resizes the page, so it shouldn't introduce a performance problem. 

Also, I removed the `useEffect` which watches for changes to the `bodyContent` and calls `forceUpdate` since my change also effectively does that - with the added benefit of using debouce to prevent updates from being performed too many times. 