### PR TITLE
Charts: Added support for patterns

### DIFF
--- a/packages/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/react-charts/src/components/Chart/Chart.tsx
@@ -220,6 +220,7 @@ export interface ChartProps extends VictoryChartProps {
   innerRadius?: number;
   /**
    * Generate default pattern defs and populate patternScale
+   * @beta
    */
   isPatternDefs?: boolean;
   /**
@@ -310,6 +311,7 @@ export interface ChartProps extends VictoryChartProps {
    * The optional ID to prefix pattern defs
    *
    * @example patternId="pattern"
+   * @beta
    */
   patternId?: string;
   /**
@@ -322,6 +324,7 @@ export interface ChartProps extends VictoryChartProps {
    * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
    *
    * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
+   * @beta
    */
   patternScale?: string[];
   /**

--- a/packages/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/react-charts/src/components/Chart/Chart.tsx
@@ -219,6 +219,10 @@ export interface ChartProps extends VictoryChartProps {
    */
   innerRadius?: number;
   /**
+   * Generate default pattern defs and populate patternScale
+   */
+  isPatternDefs?: boolean;
+  /**
    * Allows legend items to wrap. A value of true allows the legend to wrap onto the next line
    * if its container is not wide enough.
    *
@@ -437,10 +441,6 @@ export interface ChartProps extends VictoryChartProps {
    */
   themeVariant?: string;
   /**
-   * Generate default pattern defs and populate patternScale
-   */
-  usePatternDefs?: boolean;
-  /**
    * Specifies the width of the svg viewBox of the chart container. This value should be given as a
    * number of pixels.
    *
@@ -468,7 +468,7 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
   themeVariant,
   patternId = getPatternId(),
   patternScale,
-  usePatternDefs = false,
+  isPatternDefs = false,
 
   // destructure last
   theme = getChartTheme(themeColor, showAxis),
@@ -490,7 +490,7 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
     colorScale: defaultColorScale,
     patternScale,
     patternId,
-    usePatternDefs
+    isPatternDefs
   });
 
   // Add pattern props for legend tooltip
@@ -602,7 +602,7 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
     >
       {renderChildren()}
       {getLegend()}
-      {usePatternDefs && getPatternDefs({ patternId, patternScale: defaultColorScale })}
+      {isPatternDefs && getPatternDefs({ patternId, patternScale: defaultColorScale })}
     </VictoryChart>
   );
 };

--- a/packages/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/react-charts/src/components/Chart/Chart.tsx
@@ -23,7 +23,18 @@ import { AxesType, VictoryChart, VictoryChartProps } from 'victory-chart';
 import { ChartContainer } from '../ChartContainer';
 import { ChartLegend, ChartLegendOrientation, ChartLegendPosition } from '../ChartLegend';
 import { ChartCommonStyles, ChartThemeDefinition } from '../ChartTheme';
-import { getChartTheme, getClassName, getComputedLegend, getLabelTextSize, getPaddingForSide } from '../ChartUtils';
+import {
+  getChartTheme,
+  getClassName,
+  getComputedLegend,
+  getLabelTextSize,
+  getPaddingForSide,
+  getPatternId,
+  getPatternDefs,
+  getDefaultColorScale,
+  getDefaultData,
+  getDefaultPatternScale
+} from '../ChartUtils';
 
 /**
  * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
@@ -292,6 +303,24 @@ export interface ChartProps extends VictoryChartProps {
    */
   padding?: PaddingProps;
   /**
+   * The optional ID to prefix pattern defs
+   *
+   * @example patternId="pattern"
+   */
+  patternId?: string;
+  /**
+   * The patternScale prop is an optional prop that defines a pattern to be applied to the children, where applicable.
+   * This prop should be given as an array of CSS colors, or as a string corresponding to a URL. Patterns will be
+   * assigned to children by index, unless they are explicitly specified in styles. Patterns will repeat when there are
+   * more children than patterns in the provided patternScale. Functionality may be overridden via the `style.data.fill`
+   * property.
+   *
+   * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
+   *
+   * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
+   */
+  patternScale?: string[];
+  /**
    * Note: This prop should not be set manually.
    *
    * @hide
@@ -408,6 +437,10 @@ export interface ChartProps extends VictoryChartProps {
    */
   themeVariant?: string;
   /**
+   * Generate default pattern defs and populate patternScale
+   */
+  usePatternDefs?: boolean;
+  /**
    * Specifies the width of the svg viewBox of the chart container. This value should be given as a
    * number of pixels.
    *
@@ -423,6 +456,7 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
   ariaDesc,
   ariaTitle,
   children,
+  colorScale,
   legendAllowWrap = false,
   legendComponent = <ChartLegend />,
   legendData,
@@ -432,6 +466,9 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
   themeColor,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   themeVariant,
+  patternId = getPatternId(),
+  patternScale,
+  usePatternDefs = false,
 
   // destructure last
   theme = getChartTheme(themeColor, showAxis),
@@ -448,13 +485,36 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
     top: getPaddingForSide('top', padding, theme.chart.padding)
   };
 
+  const defaultColorScale = getDefaultColorScale(colorScale as any, theme.chart.colorScale as string[]);
+  const defaultPatternScale = getDefaultPatternScale({
+    colorScale: defaultColorScale,
+    patternScale,
+    patternId,
+    usePatternDefs
+  });
+
+  // Add pattern props for legend tooltip
+  let labelComponent;
+  if (
+    containerComponent.props.labelComponent &&
+    containerComponent.props.labelComponent.type.displayName === 'ChartLegendTooltip'
+  ) {
+    labelComponent = React.cloneElement(containerComponent.props.labelComponent, {
+      patternId,
+      theme,
+      ...(defaultPatternScale && { patternScale: defaultPatternScale }),
+      ...containerComponent.props.labelComponent.props
+    });
+  }
+
   // Clone so users can override container props
   const container = React.cloneElement(containerComponent, {
     desc: ariaDesc,
     title: ariaTitle,
     theme,
     ...containerComponent.props,
-    className: getClassName({ className: containerComponent.props.className }) // Override VictoryContainer class name
+    className: getClassName({ className: containerComponent.props.className }), // Override VictoryContainer class name
+    ...(labelComponent && { labelComponent }) // Override label component props
   });
 
   const legend = React.cloneElement(legendComponent, {
@@ -497,20 +557,42 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
     return getComputedLegend({
       allowWrap: legendAllowWrap,
       chartType: 'chart',
+      colorScale,
       dx,
       dy,
       height,
       legendComponent: legend,
       padding: defaultPadding,
+      ...(defaultPatternScale && { patternScale: defaultPatternScale }),
       position: legendPosition,
       theme,
       width
     });
   };
 
+  // Render children
+  const renderChildren = () =>
+    React.Children.toArray(children).map(child => {
+      if (React.isValidElement(child)) {
+        const { ...childProps } = child.props;
+        return React.cloneElement(child, {
+          colorScale,
+          patternId,
+          theme,
+          ...(defaultPatternScale && { patternScale: defaultPatternScale }),
+          ...childProps,
+          ...((child as any).type.displayName === 'ChartPie' && {
+            data: getDefaultData(childProps.data, defaultPatternScale)
+          }) // Override child props
+        });
+      }
+      return child;
+    });
+
   // Note: containerComponent is required for theme
   return (
     <VictoryChart
+      colorScale={colorScale}
       containerComponent={container}
       height={height}
       padding={defaultPadding}
@@ -518,8 +600,9 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
       width={width}
       {...rest}
     >
-      {children}
+      {renderChildren()}
       {getLegend()}
+      {usePatternDefs && getPatternDefs({ patternId, patternScale: defaultColorScale })}
     </VictoryChart>
   );
 };

--- a/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -257,6 +257,10 @@ export interface ChartDonutProps extends ChartPieProps {
    */
   innerRadius?: NumberOrCallback;
   /**
+   * Generate default pattern defs and populate patternScale
+   */
+  isPatternDefs?: boolean;
+  /**
    * The labelComponent prop takes in an entire label component which will be used
    * to create a label for the area. The new element created from the passed labelComponent
    * will be supplied with the following properties: x, y, index, data, verticalAnchor,
@@ -522,10 +526,6 @@ export interface ChartDonutProps extends ChartPieProps {
    * Note: Default label properties may be applied
    */
   titleComponent?: React.ReactElement<any>;
-  /**
-   * Generate default pattern defs and populate patternScale
-   */
-  usePatternDefs?: boolean;
   /**
    * Specifies the width of the svg viewBox of the chart container. This value should be given as a number of pixels.
    *

--- a/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -357,6 +357,24 @@ export interface ChartDonutProps extends ChartPieProps {
    */
   padAngle?: NumberOrCallback;
   /**
+   * The optional ID to prefix pattern defs
+   *
+   * @example patternId="pattern"
+   */
+  patternId?: string;
+  /**
+   * The patternScale prop is an optional prop that defines a pattern to be applied to the children, where applicable.
+   * This prop should be given as an array of CSS colors, or as a string corresponding to a URL. Patterns will be
+   * assigned to children by index, unless they are explicitly specified in styles. Patterns will repeat when there are
+   * more children than patterns in the provided patternScale. Functionality may be overridden via the `style.data.fill`
+   * property.
+   *
+   * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
+   *
+   * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
+   */
+  patternScale?: string[];
+  /**
    * The padding props specifies the amount of padding in number of pixels between
    * the edge of the chart and any rendered child components. This prop can be given
    * as a number or as an object with padding specified for top, bottom, left
@@ -504,6 +522,10 @@ export interface ChartDonutProps extends ChartPieProps {
    * Note: Default label properties may be applied
    */
   titleComponent?: React.ReactElement<any>;
+  /**
+   * Generate default pattern defs and populate patternScale
+   */
+  usePatternDefs?: boolean;
   /**
    * Specifies the width of the svg viewBox of the chart container. This value should be given as a number of pixels.
    *

--- a/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -258,6 +258,7 @@ export interface ChartDonutProps extends ChartPieProps {
   innerRadius?: NumberOrCallback;
   /**
    * Generate default pattern defs and populate patternScale
+   * @beta
    */
   isPatternDefs?: boolean;
   /**
@@ -364,6 +365,7 @@ export interface ChartDonutProps extends ChartPieProps {
    * The optional ID to prefix pattern defs
    *
    * @example patternId="pattern"
+   * @beta
    */
   patternId?: string;
   /**
@@ -376,6 +378,7 @@ export interface ChartDonutProps extends ChartPieProps {
    * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
    *
    * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
+   * @beta
    */
   patternScale?: string[];
   /**

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
@@ -271,6 +271,10 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    */
   invert?: boolean;
   /**
+   * Generate default pattern defs and populate patternScale
+   */
+  isPatternDefs?: boolean;
+  /**
    * The labelRadius prop defines the radius of the arc that will be used for positioning each slice label.
    * If this prop is not set, the label radius will default to the radius of the pie + label padding.
    *
@@ -425,10 +429,6 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    */
   title?: string;
   /**
-   * Generate default pattern defs and populate patternScale
-   */
-  usePatternDefs?: boolean;
-  /**
    * Specifies the width of the svg viewBox of the chart container. This value should be given as a number of pixels.
    *
    * Because Victory renders responsive containers, the width and height props do not determine the width and
@@ -485,7 +485,7 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
   themeColor,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   themeVariant,
-  usePatternDefs = false,
+  isPatternDefs = false,
   x,
   y,
 
@@ -514,7 +514,7 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
     colorScale: defaultColorScale,
     patternScale,
     patternId,
-    usePatternDefs
+    isPatternDefs
   });
 
   // Returns computed data representing pie chart slices
@@ -562,13 +562,13 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
           invert,
           key: `pf-chart-donut-threshold-child-${index}`,
           padding: defaultPadding,
-          ...(!childProps.usePatternDefs && defaultPatternScale && { patternScale: [null, ...defaultPatternScale] }),
+          ...(!childProps.isPatternDefs && defaultPatternScale && { patternScale: [null, ...defaultPatternScale] }),
           radius: chartRadius - 14, // Donut utilization radius is threshold radius minus 14px spacing
           showStatic: false,
           standalone: false,
           subTitlePosition: childProps.subTitlePosition || subTitlePosition,
           theme: dynamicTheme,
-          _usePatternDefs: usePatternDefs,
+          hasPatternDefs: isPatternDefs,
           width,
           ...childProps
         });
@@ -610,7 +610,7 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
     [
       chart,
       renderChildren(),
-      usePatternDefs && getPatternDefs({ offset: 1, patternId, patternScale: defaultColorScale })
+      isPatternDefs && getPatternDefs({ offset: 1, patternId, patternScale: defaultColorScale })
     ]
   );
 
@@ -620,7 +620,7 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
     <React.Fragment>
       {chart}
       {renderChildren()}
-      {usePatternDefs && getPatternDefs({ offset: 1, patternId, patternScale: defaultColorScale })}
+      {isPatternDefs && getPatternDefs({ offset: 1, patternId, patternScale: defaultColorScale })}
     </React.Fragment>
   );
 };

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
@@ -21,7 +21,15 @@ import hoistNonReactStatics from 'hoist-non-react-statics';
 import { ChartContainer } from '../ChartContainer';
 import { ChartDonut, ChartDonutProps } from '../ChartDonut';
 import { ChartDonutStyles, ChartThemeDefinition } from '../ChartTheme';
-import { getDonutThresholdDynamicTheme, getDonutThresholdStaticTheme, getPaddingForSide } from '../ChartUtils';
+import {
+  getDefaultColorScale,
+  getDefaultPatternScale,
+  getDonutThresholdDynamicTheme,
+  getDonutThresholdStaticTheme,
+  getPaddingForSide,
+  getPatternDefs,
+  getPatternId
+} from '../ChartUtils';
 
 export enum ChartDonutThresholdDonutOrientation {
   left = 'left',
@@ -308,6 +316,24 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    */
   padding?: PaddingProps;
   /**
+   * The optional ID to prefix pattern defs
+   *
+   * @example patternId="pattern"
+   */
+  patternId?: string;
+  /**
+   * The patternScale prop is an optional prop that defines a pattern to be applied to the children, where applicable.
+   * This prop should be given as an array of CSS colors, or as a string corresponding to a URL. Patterns will be
+   * assigned to children by index, unless they are explicitly specified in styles. Patterns will repeat when there are
+   * more children than patterns in the provided patternScale. Functionality may be overridden via the `style.data.fill`
+   * property.
+   *
+   * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
+   *
+   * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
+   */
+  patternScale?: string[];
+  /**
    * Specifies the radius of the chart. If this property is not provided it is computed
    * from width, height, and padding props
    *
@@ -399,6 +425,10 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    */
   title?: string;
   /**
+   * Generate default pattern defs and populate patternScale
+   */
+  usePatternDefs?: boolean;
+  /**
    * Specifies the width of the svg viewBox of the chart container. This value should be given as a number of pixels.
    *
    * Because Victory renders responsive containers, the width and height props do not determine the width and
@@ -440,18 +470,22 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
   ariaDesc,
   ariaTitle,
   children,
+  colorScale,
   constrainToVisibleArea = false,
   containerComponent = <ChartContainer />,
   data = [],
   invert = false,
   labels = [], // Don't show any tooltip labels by default, let consumer override if needed
   padding,
+  patternId = getPatternId(),
+  patternScale,
   radius,
   standalone = true,
   subTitlePosition = ChartDonutStyles.label.subTitlePosition as ChartDonutThresholdSubTitlePosition,
   themeColor,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   themeVariant,
+  usePatternDefs = false,
   x,
   y,
 
@@ -474,6 +508,14 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
       width,
       padding: defaultPadding
     });
+
+  const defaultColorScale = getDefaultColorScale(colorScale, theme.pie.colorScale as string[]);
+  const defaultPatternScale = getDefaultPatternScale({
+    colorScale: defaultColorScale,
+    patternScale,
+    patternId,
+    usePatternDefs
+  });
 
   // Returns computed data representing pie chart slices
   const getComputedData = () => {
@@ -513,17 +555,20 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
 
         return React.cloneElement(child, {
           constrainToVisibleArea,
+          colorScale,
           data: childData,
           endAngle: 360 * (datum[0]._y ? datum[0]._y / 100 : 0),
           height,
           invert,
           key: `pf-chart-donut-threshold-child-${index}`,
           padding: defaultPadding,
+          ...(!childProps.usePatternDefs && defaultPatternScale && { patternScale: [null, ...defaultPatternScale] }),
           radius: chartRadius - 14, // Donut utilization radius is threshold radius minus 14px spacing
           showStatic: false,
           standalone: false,
           subTitlePosition: childProps.subTitlePosition || subTitlePosition,
           theme: dynamicTheme,
+          _usePatternDefs: usePatternDefs,
           width,
           ...childProps
         });
@@ -535,12 +580,15 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
   const chart = (
     <ChartDonut
       allowTooltip={allowTooltip}
+      colorScale={colorScale}
       constrainToVisibleArea={constrainToVisibleArea}
       data={getComputedData()}
       height={height}
       key="pf-chart-donut-threshold"
       labels={labels}
       padding={defaultPadding}
+      patternId={patternId}
+      patternScale={defaultPatternScale ? defaultPatternScale : undefined}
       standalone={false}
       theme={theme}
       width={width}
@@ -559,7 +607,11 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
       theme,
       ...containerComponent.props
     },
-    [chart, renderChildren()]
+    [
+      chart,
+      renderChildren(),
+      usePatternDefs && getPatternDefs({ offset: 1, patternId, patternScale: defaultColorScale })
+    ]
   );
 
   return standalone ? (
@@ -568,6 +620,7 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
     <React.Fragment>
       {chart}
       {renderChildren()}
+      {usePatternDefs && getPatternDefs({ offset: 1, patternId, patternScale: defaultColorScale })}
     </React.Fragment>
   );
 };

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
@@ -272,6 +272,7 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
   invert?: boolean;
   /**
    * Generate default pattern defs and populate patternScale
+   * @beta
    */
   isPatternDefs?: boolean;
   /**
@@ -323,6 +324,7 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    * The optional ID to prefix pattern defs
    *
    * @example patternId="pattern"
+   * @beta
    */
   patternId?: string;
   /**
@@ -335,6 +337,7 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
    *
    * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
+   * @beta
    */
   patternScale?: string[];
   /**

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
@@ -276,6 +276,7 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
   invert?: boolean;
   /**
    * Generate default pattern defs and populate patternScale
+   * @beta
    */
   isPatternDefs?: boolean;
   /**
@@ -392,6 +393,7 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    * The optional ID to prefix pattern defs
    *
    * @example patternId="pattern"
+   * @beta
    */
   patternId?: string;
   /**
@@ -404,6 +406,7 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
    *
    * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
+   * @beta
    */
   patternScale?: string[];
   /**

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
@@ -244,6 +244,13 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    */
   groupComponent?: React.ReactElement<any>;
   /**
+   * Flag indicating parent isPatternDefs prop is in use
+   * Do not use
+   * @hide
+   * @private
+   */
+  hasPatternDefs?: boolean;
+  /**
    * Specifies the height the svg viewBox of the chart container. This value should be given as a
    * number of pixels.
    *
@@ -267,6 +274,10 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    * below 60% and an error below 20%
    */
   invert?: boolean;
+  /**
+   * Generate default pattern defs and populate patternScale
+   */
+  isPatternDefs?: boolean;
   /**
    * Allows legend items to wrap. A value of true allows the legend to wrap onto the next line
    * if its container is not wide enough.
@@ -556,16 +567,6 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    */
   thresholds?: any[];
   /**
-   * Generate default pattern defs and populate patternScale
-   */
-  usePatternDefs?: boolean;
-  /**
-   * Flag indicating parent usePatternDefs prop is in use
-   *
-   * @hide
-   */
-  _usePatternDefs?: boolean;
-  /**
    * Specifies the width of the svg viewBox of the chart container. This value should be given as a number of pixels.
    *
    * Because Victory renders responsive containers, the width and height props do not determine the width and
@@ -609,6 +610,7 @@ export const ChartDonutUtilization: React.FunctionComponent<ChartDonutUtilizatio
   colorScale,
   containerComponent = <ChartContainer />,
   data,
+  hasPatternDefs,
   invert = false,
   legendPosition = ChartCommonStyles.legend.position as ChartDonutUtilizationLegendPosition,
   padding,
@@ -621,8 +623,7 @@ export const ChartDonutUtilization: React.FunctionComponent<ChartDonutUtilizatio
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   themeVariant,
   thresholds,
-  usePatternDefs = false,
-  _usePatternDefs,
+  isPatternDefs = false,
   x,
   y,
 
@@ -637,12 +638,12 @@ export const ChartDonutUtilization: React.FunctionComponent<ChartDonutUtilizatio
     colorScale: defaultColorScale,
     patternScale,
     patternId,
-    usePatternDefs
+    isPatternDefs
   });
 
-  // Hide static pattern and handle edge case where parent does not use usePatternDefs
+  // Hide static pattern and handle edge case where parent does not use isPatternDefs
   const hideStaticPattern = showStatic && !showStaticPattern;
-  const hideThresholdPatterns = !patternScale && _usePatternDefs === false;
+  const hideThresholdPatterns = !patternScale && hasPatternDefs === false;
   if (defaultPatternScale && (hideStaticPattern || hideThresholdPatterns)) {
     for (let i = 0; i < defaultPatternScale.length; i++) {
       if (i !== 0) {
@@ -734,7 +735,7 @@ export const ChartDonutUtilization: React.FunctionComponent<ChartDonutUtilizatio
       patternScale={defaultPatternScale ? defaultPatternScale : undefined}
       standalone={false}
       theme={getThresholdTheme()}
-      usePatternDefs={usePatternDefs}
+      isPatternDefs={isPatternDefs}
       width={width}
       {...rest}
     />

--- a/packages/react-charts/src/components/ChartGroup/ChartGroup.tsx
+++ b/packages/react-charts/src/components/ChartGroup/ChartGroup.tsx
@@ -214,6 +214,10 @@ export interface ChartGroupProps extends VictoryGroupProps {
    */
   horizontal?: boolean;
   /**
+   * Generate default pattern defs and populate patternScale
+   */
+  isPatternDefs?: boolean;
+  /**
    * The labelComponent prop takes in an entire label component which will be used
    * to create a label for the area. The new element created from the passed labelComponent
    * will be supplied with the following properties: x, y, index, data, verticalAnchor,
@@ -430,10 +434,6 @@ export interface ChartGroupProps extends VictoryGroupProps {
    */
   themeVariant?: string;
   /**
-   * Generate default pattern defs and populate patternScale
-   */
-  usePatternDefs?: boolean;
-  /**
    * The width props specifies the width of the svg viewBox of the chart container
    * This value should be given as a number of pixels
    */
@@ -486,7 +486,7 @@ export const ChartGroup: React.FunctionComponent<ChartGroupProps> = ({
   themeColor,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   themeVariant,
-  usePatternDefs = false,
+  isPatternDefs = false,
 
   // destructure last
   theme = getTheme(themeColor),
@@ -506,7 +506,7 @@ export const ChartGroup: React.FunctionComponent<ChartGroupProps> = ({
     colorScale: defaultColorScale,
     patternScale,
     patternId,
-    usePatternDefs
+    isPatternDefs
   });
 
   // Note: containerComponent is required for theme
@@ -517,7 +517,7 @@ export const ChartGroup: React.FunctionComponent<ChartGroupProps> = ({
         patternId,
         patternScale: defaultPatternScale
       })}
-      {usePatternDefs && getPatternDefs({ patternId, patternScale: defaultColorScale })}
+      {isPatternDefs && getPatternDefs({ patternId, patternScale: defaultColorScale })}
     </VictoryGroup>
   );
 };

--- a/packages/react-charts/src/components/ChartGroup/ChartGroup.tsx
+++ b/packages/react-charts/src/components/ChartGroup/ChartGroup.tsx
@@ -21,7 +21,15 @@ import {
 import { VictoryGroup, VictoryGroupProps, VictoryGroupTTargetType } from 'victory-group';
 import { ChartContainer } from '../ChartContainer';
 import { ChartThemeDefinition } from '../ChartTheme';
-import { getClassName, getTheme } from '../ChartUtils';
+import {
+  getClassName,
+  getDefaultColorScale,
+  getDefaultPatternScale,
+  getPatternId,
+  getPatternDefs,
+  getTheme,
+  renderChildrenWithPatterns
+} from '../ChartUtils';
 
 export enum ChartGroupSortOrder {
   ascending = 'ascending',
@@ -286,6 +294,24 @@ export interface ChartGroupProps extends VictoryGroupProps {
    */
   padding?: PaddingProps;
   /**
+   * The optional ID to prefix pattern defs
+   *
+   * @example patternId="pattern"
+   */
+  patternId?: string;
+  /**
+   * The patternScale prop is an optional prop that defines a pattern to be applied to the children, where applicable.
+   * This prop should be given as an array of CSS colors, or as a string corresponding to a URL. Patterns will be
+   * assigned to children by index, unless they are explicitly specified in styles. Patterns will repeat when there are
+   * more children than patterns in the provided patternScale. Functionality may be overridden via the `style.data.fill`
+   * property.
+   *
+   * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
+   *
+   * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
+   */
+  patternScale?: string[];
+  /**
    * Victory components can pass a boolean polar prop to specify whether a label is part of a polar chart.
    */
   polar?: boolean;
@@ -404,6 +430,10 @@ export interface ChartGroupProps extends VictoryGroupProps {
    */
   themeVariant?: string;
   /**
+   * Generate default pattern defs and populate patternScale
+   */
+  usePatternDefs?: boolean;
+  /**
    * The width props specifies the width of the svg viewBox of the chart container
    * This value should be given as a number of pixels
    */
@@ -449,14 +479,17 @@ export const ChartGroup: React.FunctionComponent<ChartGroupProps> = ({
   ariaDesc,
   ariaTitle,
   children,
+  colorScale,
   containerComponent = <ChartContainer />,
+  patternId = getPatternId(),
+  patternScale,
   themeColor,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   themeVariant,
+  usePatternDefs = false,
 
   // destructure last
   theme = getTheme(themeColor),
-
   ...rest
 }: ChartGroupProps) => {
   // Clone so users can override container props
@@ -468,10 +501,23 @@ export const ChartGroup: React.FunctionComponent<ChartGroupProps> = ({
     className: getClassName({ className: containerComponent.props.className }) // Override VictoryContainer class name
   });
 
+  const defaultColorScale = getDefaultColorScale(colorScale, theme.group.colorScale as string[]);
+  const defaultPatternScale = getDefaultPatternScale({
+    colorScale: defaultColorScale,
+    patternScale,
+    patternId,
+    usePatternDefs
+  });
+
   // Note: containerComponent is required for theme
   return (
-    <VictoryGroup containerComponent={container} theme={theme} {...rest}>
-      {children}
+    <VictoryGroup colorScale={colorScale} containerComponent={container} theme={theme} {...rest}>
+      {renderChildrenWithPatterns({
+        children,
+        patternId,
+        patternScale: defaultPatternScale
+      })}
+      {usePatternDefs && getPatternDefs({ patternId, patternScale: defaultColorScale })}
     </VictoryGroup>
   );
 };

--- a/packages/react-charts/src/components/ChartGroup/ChartGroup.tsx
+++ b/packages/react-charts/src/components/ChartGroup/ChartGroup.tsx
@@ -215,6 +215,7 @@ export interface ChartGroupProps extends VictoryGroupProps {
   horizontal?: boolean;
   /**
    * Generate default pattern defs and populate patternScale
+   * @beta
    */
   isPatternDefs?: boolean;
   /**
@@ -301,6 +302,7 @@ export interface ChartGroupProps extends VictoryGroupProps {
    * The optional ID to prefix pattern defs
    *
    * @example patternId="pattern"
+   * @beta
    */
   patternId?: string;
   /**
@@ -313,6 +315,7 @@ export interface ChartGroupProps extends VictoryGroupProps {
    * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
    *
    * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
+   * @beta
    */
   patternScale?: string[];
   /**

--- a/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
+++ b/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
@@ -171,6 +171,10 @@ export interface ChartLegendProps extends VictoryLegendProps {
    */
   itemsPerRow?: number;
   /**
+   * Generate default pattern defs and populate patternScale
+   */
+  isPatternDefs?: boolean;
+  /**
    * The labelComponent prop takes a component instance which will be used
    * to render each legend label. The new element created from the passed
    * labelComponent will be supplied with the following properties: x, y,
@@ -326,10 +330,6 @@ export interface ChartLegendProps extends VictoryLegendProps {
    * The x and y props define the base position of the legend element.
    */
   y?: number;
-  /**
-   * Generate default pattern defs and populate patternScale
-   */
-  usePatternDefs?: boolean;
 }
 
 export const ChartLegend: React.FunctionComponent<ChartLegendProps> = ({

--- a/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
+++ b/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
@@ -171,10 +171,6 @@ export interface ChartLegendProps extends VictoryLegendProps {
    */
   itemsPerRow?: number;
   /**
-   * Generate default pattern defs and populate patternScale
-   */
-  isPatternDefs?: boolean;
-  /**
    * The labelComponent prop takes a component instance which will be used
    * to render each legend label. The new element created from the passed
    * labelComponent will be supplied with the following properties: x, y,
@@ -215,6 +211,7 @@ export interface ChartLegendProps extends VictoryLegendProps {
    * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
    *
    * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
+   * @beta
    */
   patternScale?: string[];
   /**

--- a/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
+++ b/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
@@ -1,5 +1,5 @@
 ---
-id: Legend chart
+id: Legends
 section: charts
 propComponents: [
   'ChartLegend'

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
@@ -235,6 +235,7 @@ export interface ChartLegendTooltipProps extends ChartCursorTooltipProps {
    * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
    *
    * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
+   * @beta
    */
   patternScale?: string[];
   /**

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
@@ -226,6 +226,18 @@ export interface ChartLegendTooltipProps extends ChartCursorTooltipProps {
    */
   orientation?: OrientationOrCallback;
   /**
+   * The patternScale prop is an optional prop that defines a pattern to be applied to the children, where applicable.
+   * This prop should be given as an array of CSS colors, or as a string corresponding to a URL. Patterns will be
+   * assigned to children by index, unless they are explicitly specified in styles. Patterns will repeat when there are
+   * more children than patterns in the provided patternScale. Functionality may be overridden via the `style.data.fill`
+   * property.
+   *
+   * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
+   *
+   * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
+   */
+  patternScale?: string[];
+  /**
    * The pointerLength prop determines the length of the triangular pointer extending from the flyout. This prop may be
    * given as a positive number or a function of datum.
    *
@@ -329,6 +341,7 @@ export const ChartLegendTooltip: React.FunctionComponent<ChartLegendTooltipProps
   isCursorTooltip = true,
   labelComponent = <ChartLegendTooltipContent />,
   legendData,
+  patternScale,
   text,
   themeColor,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -365,6 +378,7 @@ export const ChartLegendTooltip: React.FunctionComponent<ChartLegendTooltipProps
       flyoutWidth: flyoutWidth || getFlyoutWidth(props),
       height,
       legendData,
+      patternScale,
       title,
       width,
       ...labelComponent.props

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipContent.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipContent.tsx
@@ -126,6 +126,7 @@ export interface ChartLegendTooltipContentProps {
    * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
    *
    * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
+   * @beta
    */
   patternScale?: string[];
   /**

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipContent.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipContent.tsx
@@ -117,6 +117,18 @@ export interface ChartLegendTooltipContentProps {
     };
   }[];
   /**
+   * The patternScale prop is an optional prop that defines a pattern to be applied to the children, where applicable.
+   * This prop should be given as an array of CSS colors, or as a string corresponding to a URL. Patterns will be
+   * assigned to children by index, unless they are explicitly specified in styles. Patterns will repeat when there are
+   * more children than patterns in the provided patternScale. Functionality may be overridden via the `style.data.fill`
+   * property.
+   *
+   * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
+   *
+   * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
+   */
+  patternScale?: string[];
+  /**
    * The text prop defines the text ChartTooltip will render. The text prop may be given as a string, number, or
    * function of datum. When ChartLabel is used as the labelComponent, strings may include newline characters, which
    * ChartLabel will split in to separate <tspan/> elements.
@@ -192,6 +204,7 @@ export const ChartLegendTooltipContent: React.FunctionComponent<ChartLegendToolt
   labelComponent = <ChartLegendTooltipLabel />,
   legendComponent = <ChartLegend />,
   legendData,
+  patternScale,
   text,
   themeColor,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -297,11 +310,13 @@ export const ChartLegendTooltipContent: React.FunctionComponent<ChartLegendToolt
         activePoints,
         colorScale: legendProps.colorScale,
         legendData,
+        patternScale,
         text,
         textAsLegendData: true,
         theme
       }),
       labelComponent: getLabelComponent(),
+      patternScale,
       standalone: false,
       theme,
       x: getX() + legendOffsetX + Helpers.evaluateProp(dx),

--- a/packages/react-charts/src/components/ChartPie/ChartPie.tsx
+++ b/packages/react-charts/src/components/ChartPie/ChartPie.tsx
@@ -27,7 +27,15 @@ import { ChartContainer } from '../ChartContainer';
 import { ChartLegend, ChartLegendOrientation } from '../ChartLegend';
 import { ChartCommonStyles, ChartThemeDefinition } from '../ChartTheme';
 import { ChartTooltip } from '../ChartTooltip';
-import { getComputedLegend, getPaddingForSide, getTheme } from '../ChartUtils';
+import {
+  getComputedLegend,
+  getPaddingForSide,
+  getPatternId,
+  getPatternDefs,
+  getTheme,
+  getDefaultColorScale,
+  getDefaultPatternScale
+} from '../ChartUtils';
 
 export enum ChartPieLabelPosition {
   centroid = 'centroid',
@@ -351,6 +359,24 @@ export interface ChartPieProps extends VictoryPieProps {
    */
   padding?: PaddingProps;
   /**
+   * The optional ID to prefix pattern defs
+   *
+   * @example patternId="pattern"
+   */
+  patternId?: string;
+  /**
+   * The patternScale prop is an optional prop that defines a pattern to be applied to the children, where applicable.
+   * This prop should be given as an array of CSS colors, or as a string corresponding to a URL. Patterns will be
+   * assigned to children by index, unless they are explicitly specified in styles. Patterns will repeat when there are
+   * more children than patterns in the provided patternScale. Functionality may be overridden via the `style.data.fill`
+   * property.
+   *
+   * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
+   *
+   * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
+   */
+  patternScale?: string[];
+  /**
    * Specifies the radius of the chart. If this property is not provided it is computed
    * from width, height, and padding props
    *
@@ -425,6 +451,10 @@ export interface ChartPieProps extends VictoryPieProps {
    */
   themeVariant?: string;
   /**
+   * Generate default pattern defs and populate patternScale
+   */
+  usePatternDefs?: boolean;
+  /**
    * Specifies the width of the svg viewBox of the chart container. This value should be given as a number of pixels.
    *
    * Because Victory renders responsive containers, the width and height props do not determine the width and
@@ -465,19 +495,23 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
   allowTooltip = true,
   ariaDesc,
   ariaTitle,
+  colorScale,
   constrainToVisibleArea = false,
   containerComponent = <ChartContainer />,
-  labels,
   legendAllowWrap = false,
   legendComponent = <ChartLegend />,
   legendData,
   legendPosition = ChartCommonStyles.legend.position as ChartPieLegendPosition,
+  patternId = getPatternId(),
+  patternScale,
   padding,
   radius,
   standalone = true,
+  style,
   themeColor,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   themeVariant,
+  usePatternDefs = false,
 
   // destructure last
   theme = getTheme(themeColor),
@@ -508,15 +542,40 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
   };
   const chartRadius = radius ? radius : getDefaultRadius();
 
+  const defaultColorScale = getDefaultColorScale(colorScale, theme.pie.colorScale as string[]);
+  const defaultPatternScale = getDefaultPatternScale({
+    colorScale: defaultColorScale,
+    patternScale,
+    patternId,
+    usePatternDefs
+  });
+
+  // Merge pattern IDs with `style.data.fill` property
+  const getDefaultStyle = () => {
+    if (!defaultPatternScale) {
+      return style;
+    }
+    const _style = style ? { ...style } : {};
+    _style.data = {
+      fill: ({ slice }: any) => {
+        const pattern = defaultPatternScale[slice.index % defaultPatternScale.length];
+        return pattern && pattern !== null ? pattern : defaultColorScale[slice.index % defaultColorScale.length];
+      },
+      ..._style.data
+    };
+    return _style;
+  };
+
   const chart = (
     <VictoryPie
+      colorScale={colorScale}
       height={height}
       key="pf-chart-pie"
-      labels={labels}
       labelComponent={labelComponent}
       padding={padding}
       radius={chartRadius}
       standalone={false}
+      style={getDefaultStyle()}
       theme={theme}
       width={width}
       {...rest}
@@ -524,6 +583,7 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
   );
 
   const legend = React.cloneElement(legendComponent, {
+    colorScale,
     data: legendData,
     key: 'pf-chart-pie-legend',
     orientation: legendOrientation,
@@ -542,6 +602,7 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
       height,
       legendComponent: legend,
       padding: defaultPadding,
+      ...(defaultPatternScale && { patternScale: defaultPatternScale }),
       position: legendPosition,
       theme,
       width
@@ -549,18 +610,20 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
   };
 
   // Clone so users can override container props
-  const container = React.cloneElement(
-    containerComponent,
-    {
-      desc: ariaDesc,
-      height,
-      title: ariaTitle,
-      width,
-      theme,
-      ...containerComponent.props
-    },
-    [chart, getLegend()]
-  );
+  const container = standalone
+    ? React.cloneElement(
+        containerComponent,
+        {
+          desc: ariaDesc,
+          height,
+          title: ariaTitle,
+          width,
+          theme,
+          ...containerComponent.props
+        },
+        [chart, getLegend(), usePatternDefs && getPatternDefs({ patternId, patternScale: defaultColorScale })]
+      )
+    : null;
 
   return standalone ? (
     <React.Fragment>{container}</React.Fragment>
@@ -568,6 +631,7 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
     <React.Fragment>
       {chart}
       {getLegend()}
+      {usePatternDefs && getPatternDefs({ patternId, patternScale: defaultColorScale })}
     </React.Fragment>
   );
 };

--- a/packages/react-charts/src/components/ChartPie/ChartPie.tsx
+++ b/packages/react-charts/src/components/ChartPie/ChartPie.tsx
@@ -249,6 +249,10 @@ export interface ChartPieProps extends VictoryPieProps {
    */
   innerRadius?: NumberOrCallback;
   /**
+   * Generate default pattern defs and populate patternScale
+   */
+  isPatternDefs?: boolean;
+  /**
    * The labelComponent prop takes in an entire label component which will be used
    * to create a label for the area. The new element created from the passed labelComponent
    * will be supplied with the following properties: x, y, index, data, verticalAnchor,
@@ -451,10 +455,6 @@ export interface ChartPieProps extends VictoryPieProps {
    */
   themeVariant?: string;
   /**
-   * Generate default pattern defs and populate patternScale
-   */
-  usePatternDefs?: boolean;
-  /**
    * Specifies the width of the svg viewBox of the chart container. This value should be given as a number of pixels.
    *
    * Because Victory renders responsive containers, the width and height props do not determine the width and
@@ -511,7 +511,7 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
   themeColor,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   themeVariant,
-  usePatternDefs = false,
+  isPatternDefs = false,
 
   // destructure last
   theme = getTheme(themeColor),
@@ -547,7 +547,7 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
     colorScale: defaultColorScale,
     patternScale,
     patternId,
-    usePatternDefs
+    isPatternDefs
   });
 
   // Merge pattern IDs with `style.data.fill` property
@@ -621,7 +621,7 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
           theme,
           ...containerComponent.props
         },
-        [chart, getLegend(), usePatternDefs && getPatternDefs({ patternId, patternScale: defaultColorScale })]
+        [chart, getLegend(), isPatternDefs && getPatternDefs({ patternId, patternScale: defaultColorScale })]
       )
     : null;
 
@@ -631,7 +631,7 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
     <React.Fragment>
       {chart}
       {getLegend()}
-      {usePatternDefs && getPatternDefs({ patternId, patternScale: defaultColorScale })}
+      {isPatternDefs && getPatternDefs({ patternId, patternScale: defaultColorScale })}
     </React.Fragment>
   );
 };

--- a/packages/react-charts/src/components/ChartPie/ChartPie.tsx
+++ b/packages/react-charts/src/components/ChartPie/ChartPie.tsx
@@ -250,6 +250,7 @@ export interface ChartPieProps extends VictoryPieProps {
   innerRadius?: NumberOrCallback;
   /**
    * Generate default pattern defs and populate patternScale
+   * @beta
    */
   isPatternDefs?: boolean;
   /**
@@ -366,6 +367,7 @@ export interface ChartPieProps extends VictoryPieProps {
    * The optional ID to prefix pattern defs
    *
    * @example patternId="pattern"
+   * @beta
    */
   patternId?: string;
   /**
@@ -378,6 +380,7 @@ export interface ChartPieProps extends VictoryPieProps {
    * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
    *
    * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
+   * @beta
    */
   patternScale?: string[];
   /**

--- a/packages/react-charts/src/components/ChartStack/ChartStack.tsx
+++ b/packages/react-charts/src/components/ChartStack/ChartStack.tsx
@@ -201,6 +201,7 @@ export interface ChartStackProps extends VictoryStackProps {
   horizontal?: boolean;
   /**
    * Generate default pattern defs and populate patternScale
+   * @beta
    */
   isPatternDefs?: boolean;
   /**
@@ -280,6 +281,7 @@ export interface ChartStackProps extends VictoryStackProps {
    * The optional ID to prefix pattern defs
    *
    * @example patternId="pattern"
+   * @beta
    */
   patternId?: string;
   /**
@@ -292,6 +294,7 @@ export interface ChartStackProps extends VictoryStackProps {
    * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
    *
    * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
+   * @beta
    */
   patternScale?: string[];
   /**

--- a/packages/react-charts/src/components/ChartStack/ChartStack.tsx
+++ b/packages/react-charts/src/components/ChartStack/ChartStack.tsx
@@ -200,6 +200,10 @@ export interface ChartStackProps extends VictoryStackProps {
    */
   horizontal?: boolean;
   /**
+   * Generate default pattern defs and populate patternScale
+   */
+  isPatternDefs?: boolean;
+  /**
    * The labelComponent prop takes in an entire label component which will be used
    * to create a label for the area. The new element created from the passed labelComponent
    * will be supplied with the following properties: x, y, index, data, verticalAnchor,
@@ -394,10 +398,6 @@ export interface ChartStackProps extends VictoryStackProps {
    */
   themeVariant?: string;
   /**
-   * Generate default pattern defs and populate patternScale
-   */
-  usePatternDefs?: boolean;
-  /**
    * The width props specifies the width of the svg viewBox of the chart container
    * This value should be given as a number of pixels
    */
@@ -420,7 +420,7 @@ export const ChartStack: React.FunctionComponent<ChartStackProps> = ({
   themeColor,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   themeVariant,
-  usePatternDefs = false,
+  isPatternDefs = false,
 
   // destructure last
   theme = getTheme(themeColor),
@@ -440,7 +440,7 @@ export const ChartStack: React.FunctionComponent<ChartStackProps> = ({
     colorScale: defaultColorScale,
     patternScale,
     patternId,
-    usePatternDefs
+    isPatternDefs
   });
 
   // Note: containerComponent is required for theme

--- a/packages/react-charts/src/components/ChartTheme/examples/ChartTheme.md
+++ b/packages/react-charts/src/components/ChartTheme/examples/ChartTheme.md
@@ -1,5 +1,5 @@
 ---
-id: Themed charts
+id: Themes
 section: charts
 hideDarkMode: true
 ---

--- a/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
+++ b/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
@@ -1,5 +1,5 @@
 ---
-id: Tooltip chart
+id: Tooltips
 section: charts
 propComponents: ['ChartTooltip']
 hideDarkMode: true

--- a/packages/react-charts/src/components/ChartUtils/chart-domain.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-domain.ts
@@ -18,6 +18,10 @@ interface SourcesInterface {
   }[];
 }
 
+/**
+ * Chart domain interface
+ * @private
+ */
 export interface ChartDomain {
   x: [number, number];
   y: [number, number];

--- a/packages/react-charts/src/components/ChartUtils/chart-interactive-legend.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-interactive-legend.ts
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
 import chart_area_Opacity from '@patternfly/react-tokens/dist/esm/chart_area_Opacity';
 import chart_global_label_Fill from '@patternfly/react-tokens/dist/esm/chart_global_label_Fill';
+import { Helpers } from 'victory-core';
 
 interface ChartInteractiveLegendInterface {
   // The names or groups of names associated with each data series
@@ -16,7 +17,7 @@ interface ChartInteractiveLegendInterface {
 
 interface ChartInteractiveLegendExtInterface extends ChartInteractiveLegendInterface {
   omitIndex?: number; // Used to omit child names when attaching events
-  target?: 'data' | 'labels'; // Event target
+  target?: 'data' | 'labels' | 'parent'; // Event target
 }
 
 /**
@@ -25,7 +26,7 @@ interface ChartInteractiveLegendExtInterface extends ChartInteractiveLegendInter
  */
 const getChildNames = ({ chartNames, omitIndex }: ChartInteractiveLegendExtInterface) => {
   const result = [] as any;
-  chartNames.map((chartName: any, index: number) => {
+  chartNames.forEach((chartName: any, index: number) => {
     if (index !== omitIndex) {
       if (Array.isArray(chartName)) {
         chartName.forEach(name => result.push(name));
@@ -44,8 +45,8 @@ const getChildNames = ({ chartNames, omitIndex }: ChartInteractiveLegendExtInter
  * @public
  */
 export const getInteractiveLegendEvents = (props: ChartInteractiveLegendInterface) => [
-  ...getInteractiveLegendTargetEvents({ ...props, target: 'data' }),
-  ...getInteractiveLegendTargetEvents({ ...props, target: 'labels' })
+  ...getInteractiveLegendTargetEvents({ ...props, target: 'data' }), // Legend symbols
+  ...getInteractiveLegendTargetEvents({ ...props, target: 'labels' }) // Legend labels
 ];
 
 // Returns legend items, except given ID index
@@ -128,13 +129,16 @@ const getInteractiveLegendTargetEvents = ({
                       : ({
                           // Skip if hidden
                           style:
-                            props.padAngle !== undefined // Support for pie chart
+                            props.slice !== undefined // Support for pie chart
                               ? {
-                                  ...props.style,
-                                  ...(index !== props.index && { opacity: chart_area_Opacity.value })
+                                  ...Helpers.evaluateStyle(props.style, props),
+                                  ...(index !== props.slice.index && { opacity: chart_area_Opacity.value }),
+                                  ...(props.data[props.slice.index]._fill && {
+                                    fill: props.data[props.slice.index]._fill
+                                  })
                                 }
                               : {
-                                  ...props.style,
+                                  ...Helpers.evaluateStyle(props.style, props),
                                   opacity: chart_area_Opacity.value
                                 }
                         } as any)
@@ -150,7 +154,7 @@ const getInteractiveLegendTargetEvents = ({
                       : {
                           // Skip if hidden
                           style: {
-                            ...props.style,
+                            ...Helpers.evaluateStyle(props.style, props),
                             opacity: chart_area_Opacity.value
                           }
                         }
@@ -167,7 +171,7 @@ const getInteractiveLegendTargetEvents = ({
                       : {
                           // Skip if hidden
                           style: {
-                            ...props.style,
+                            ...Helpers.evaluateStyle(props.style, props),
                             opacity: chart_area_Opacity.value
                           }
                         };

--- a/packages/react-charts/src/components/ChartUtils/chart-legend.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-legend.ts
@@ -9,12 +9,14 @@ import * as React from 'react';
 interface ChartLegendInterface {
   allowWrap?: boolean; // Allow legend items to wrap to the next line
   chartType?: string; // The type of chart (e.g., pie) to lookup for props
+  colorScale?: any; // The color scale that will be applied to the chart
   dx?: number; // Horizontal shift from the x coordinate
   dy?: number; // Vertical shift from the x coordinate
   height: number; // Overall height of SVG
   legendComponent: React.ReactElement<any>; // The base legend component to render
   orientation?: 'horizontal' | 'vertical'; // Orientation of legend
   padding: PaddingProps; // Chart padding
+  patternScale?: string[]; // Legend symbol patterns
   position: 'bottom' | 'bottom-left' | 'right'; // The legend position
   theme: ChartThemeDefinition; // The theme that will be applied to the chart
   width: number; // Overall width of SVG
@@ -53,11 +55,13 @@ interface ChartLegendTextMaxSizeInterface {
 export const getComputedLegend = ({
   allowWrap = true,
   chartType = 'chart',
+  colorScale,
   dx = 0,
   dy = 0,
   height,
   legendComponent,
   padding,
+  patternScale,
   position = ChartCommonStyles.legend.position as ChartLegendPosition,
   theme,
   width,
@@ -115,8 +119,10 @@ export const getComputedLegend = ({
 
   // Clone legend with updated props
   const legendProps = defaults({}, legendComponent.props, {
+    colorScale,
     itemsPerRow: legendItemsPerRow,
     orientation,
+    patternScale,
     standalone: false,
     theme,
     x: legendX > 0 ? legendX : 0,

--- a/packages/react-charts/src/components/ChartUtils/chart-padding.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-padding.ts
@@ -14,6 +14,5 @@ export const getPaddingForSide = (
   } else if (typeof padding == 'object' && Object.keys(padding).length > 0) {
     return padding[side] || 0;
   }
-
   return getPaddingForSide(side, fallback, 0);
 };

--- a/packages/react-charts/src/components/ChartUtils/chart-patterns.tsx
+++ b/packages/react-charts/src/components/ChartUtils/chart-patterns.tsx
@@ -1,6 +1,20 @@
 import * as React from 'react';
 import uniqueId from 'lodash/uniqueId';
 
+interface PatternPropsInterface {
+  children?: any;
+  colorScale?: any;
+  offset?: number;
+  patternId?: string;
+  patternScale?: string[];
+  usePatternDefs?: boolean;
+}
+
+/**
+ * Patterns were pulled from v3.0.3 of the script below, which uses the MIT license.
+ * See https://github.com/highcharts/pattern-fill/blob/master/pattern-fill-v2.js
+ * @private
+ */
 const patterns: any = [
   // Set 1
   {
@@ -196,26 +210,27 @@ const patterns: any = [
   }
 ];
 
-interface PatternPropsInterface {
-  children?: any;
-  colorScale?: any;
-  offset?: number;
-  patternId?: string;
-  patternScale?: string[];
-  usePatternDefs?: boolean;
-}
-
+/**
+ * Helper function to return a pattern ID
+ * @private
+ */
 export const getPatternId = () => uniqueId('pf-pattern');
 
+/**
+ * Helper function to return pattern defs ID
+ * @private
+ */
 export const getPatternDefsId = (prefix: string, index: number) => {
   const id = `${prefix}:${index}`;
   return id;
 };
 
-// Returns pattern defs
-//
-// Note that this is wrapped in an empty tag so Victory does not apply child props to defs
+/**
+ * Helper function to return pattern defs
+ * @private
+ */
 export const getPatternDefs = ({ offset = 0, patternId, patternScale }: PatternPropsInterface) => {
+  // This is wrapped in an empty tag so Victory does not apply child props to defs
   const defs = (
     <React.Fragment key={`defs`}>
       <defs>
@@ -234,15 +249,24 @@ export const getPatternDefs = ({ offset = 0, patternId, patternScale }: PatternP
   return defs;
 };
 
-// Return pattern IDs to use as color scale
+/**
+ * Helper function to return pattern IDs to use as color scale
+ * @private
+ */
 export const getPatternScale = (patternId: string, colorScale: string[]) =>
   colorScale.map((c: any, index: number) => `url(#${getPatternDefsId(patternId, index)})`);
 
-// Return color scale
+/**
+ * Helper function to return default color scale
+ * @private
+ */
 export const getDefaultColorScale = (colorScale: string[], themeColorScale: string[]) =>
   colorScale ? colorScale : themeColorScale;
 
-// Return pattern scale
+/**
+ * Helper function to return default pattern scale
+ * @private
+ */
 export const getDefaultPatternScale = ({
   colorScale,
   patternScale,
@@ -258,7 +282,10 @@ export const getDefaultPatternScale = ({
   return undefined;
 };
 
-// Merge pattern IDs with `data.fill` property, used by interactive pie chart legend
+/**
+ * Merge pattern IDs with `data.fill` property, used by interactive pie chart legend
+ * @private
+ */
 export const getDefaultData = (data: any, patternScale: string[]) => {
   if (!patternScale) {
     return data;
@@ -272,7 +299,10 @@ export const getDefaultData = (data: any, patternScale: string[]) => {
   });
 };
 
-// Render children
+/**
+ * Helper function to render children with patterns
+ * @private
+ */
 export const renderChildrenWithPatterns = ({ children, patternId, patternScale }: PatternPropsInterface) =>
   React.Children.toArray(children).map((child, index) => {
     if (React.isValidElement(child)) {

--- a/packages/react-charts/src/components/ChartUtils/chart-patterns.tsx
+++ b/packages/react-charts/src/components/ChartUtils/chart-patterns.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import uniqueId from 'lodash/uniqueId';
 
+// @beta
 interface PatternPropsInterface {
   children?: any;
   colorScale?: any;

--- a/packages/react-charts/src/components/ChartUtils/chart-patterns.tsx
+++ b/packages/react-charts/src/components/ChartUtils/chart-patterns.tsx
@@ -7,7 +7,7 @@ interface PatternPropsInterface {
   offset?: number;
   patternId?: string;
   patternScale?: string[];
-  usePatternDefs?: boolean;
+  isPatternDefs?: boolean;
 }
 
 /**
@@ -271,12 +271,12 @@ export const getDefaultPatternScale = ({
   colorScale,
   patternScale,
   patternId,
-  usePatternDefs
+  isPatternDefs
 }: PatternPropsInterface) => {
   if (patternScale) {
     return patternScale;
   }
-  if (usePatternDefs) {
+  if (isPatternDefs) {
     return getPatternScale(patternId, colorScale);
   }
   return undefined;

--- a/packages/react-charts/src/components/ChartUtils/chart-patterns.tsx
+++ b/packages/react-charts/src/components/ChartUtils/chart-patterns.tsx
@@ -1,0 +1,299 @@
+import * as React from 'react';
+import uniqueId from 'lodash/uniqueId';
+
+const patterns: any = [
+  // Set 1
+  {
+    // Left diagonal lines
+    d: 'M 0 0 L 5 5 M 4.5 -0.5 L 5.5 0.5 M -0.5 4.5 L 0.5 5.5',
+    height: 5,
+    fill: 'none',
+    patternContentUnits: 'userSpaceOnUse',
+    patternUnits: 'userSpaceOnUse',
+    patternTransform: 'scale(1.4 1.4)',
+    strokeWidth: 2,
+    width: 5,
+    x: 0,
+    y: 0
+  },
+  {
+    // Right diagonal lines
+    d: 'M 0 5 L 5 0 M -0.5 0.5 L 0.5 -0.5 M 4.5 5.5 L 5.5 4.5',
+    height: 5,
+    fill: 'none',
+    patternContentUnits: 'userSpaceOnUse',
+    patternUnits: 'userSpaceOnUse',
+    patternTransform: 'scale(1.4 1.4)',
+    strokeWidth: 2,
+    width: 5,
+    x: 0,
+    y: 0
+  },
+  {
+    // Vertical offset line
+    d: 'M 2 0 L 2 5 M 4 0 L 4 5',
+    height: 5,
+    fill: 'none',
+    patternContentUnits: 'userSpaceOnUse',
+    patternUnits: 'userSpaceOnUse',
+    patternTransform: 'scale(1.4 1.4)',
+    strokeWidth: 2,
+    width: 5,
+    x: 0,
+    y: 0
+  },
+  {
+    // Horizontal lines
+    d: 'M 0 2 L 5 2 M 0 4 L 5 4',
+    height: 5,
+    fill: 'none',
+    patternContentUnits: 'userSpaceOnUse',
+    patternUnits: 'userSpaceOnUse',
+    patternTransform: 'scale(1.4 1.4)',
+    strokeWidth: 2,
+    width: 5,
+    x: 0,
+    y: 0
+  },
+  {
+    // Vertical wave
+    d: 'M 0 1.5 L 2.5 1.5 L 2.5 0 M 2.5 5 L 2.5 3.5 L 5 3.5',
+    height: 5,
+    fill: 'none',
+    patternContentUnits: 'userSpaceOnUse',
+    patternUnits: 'userSpaceOnUse',
+    patternTransform: 'scale(1.4 1.4)',
+    strokeWidth: 2,
+    width: 5,
+    x: 0,
+    y: 0
+  },
+
+  // Set 2
+  {
+    // Horizontal wave
+    d: 'M 0 0 L 5 10 L 10 0',
+    height: 10,
+    fill: 'none',
+    patternContentUnits: 'userSpaceOnUse',
+    patternUnits: 'userSpaceOnUse',
+    strokeWidth: 2,
+    width: 10,
+    x: 0,
+    y: 0
+  },
+  {
+    // Squares
+    d: 'M 3 3 L 8 3 L 8 8 L 3 8 Z',
+    height: 10,
+    fill: 'none',
+    patternContentUnits: 'userSpaceOnUse',
+    patternUnits: 'userSpaceOnUse',
+    strokeWidth: 2,
+    width: 10,
+    x: 0,
+    y: 0
+  },
+  {
+    // Circles
+    d: 'M 5 5 m -4 0 a 4 4 0 1 1 8 0 a 4 4 0 1 1 -8 0',
+    height: 10,
+    fill: 'none',
+    patternContentUnits: 'userSpaceOnUse',
+    patternUnits: 'userSpaceOnUse',
+    strokeWidth: 2,
+    width: 10,
+    x: 0,
+    y: 0
+  },
+  {
+    // Left diagonal lines (thin)
+    d: 'M 0 0 L 10 10 M 9 -1 L 11 1 M -1 9 L 1 11',
+    height: 10,
+    fill: 'none',
+    patternContentUnits: 'userSpaceOnUse',
+    patternUnits: 'userSpaceOnUse',
+    strokeWidth: 2,
+    width: 10,
+    x: 0,
+    y: 0
+  },
+  {
+    // Right diagonal lines (thin)
+    d: 'M 0 10 L 10 0 M -1 1 L 1 -1 M 9 11 L 11 9',
+    height: 10,
+    fill: 'none',
+    patternContentUnits: 'userSpaceOnUse',
+    patternUnits: 'userSpaceOnUse',
+    strokeWidth: 2,
+    width: 10,
+    x: 0,
+    y: 0
+  },
+
+  // Set 3
+  {
+    // Diamonds
+    d: 'M 2 5 L 5 2 L 8 5 L 5 8 Z',
+    height: 10,
+    fill: 'none',
+    patternContentUnits: 'userSpaceOnUse',
+    patternUnits: 'userSpaceOnUse',
+    strokeWidth: 2,
+    width: 10,
+    x: 0,
+    y: 0
+  },
+  {
+    // Thin vertical lines
+    d: 'M 3 0 L 3 10 M 8 0 L 8 10',
+    height: 5,
+    fill: 'none',
+    patternContentUnits: 'userSpaceOnUse',
+    patternUnits: 'userSpaceOnUse',
+    patternTransform: 'scale(1.4 1.4)',
+    strokeWidth: 2,
+    width: 5,
+    x: 0,
+    y: 0
+  },
+  {
+    // Left zig zag
+    d: 'M 10 3 L 5 3 L 5 0 M 5 10 L 5 7 L 0 7',
+    height: 10,
+    fill: 'none',
+    patternContentUnits: 'userSpaceOnUse',
+    patternUnits: 'userSpaceOnUse',
+    strokeWidth: 2,
+    width: 10,
+    x: 0,
+    y: 0
+  },
+  {
+    // Thin horizontal lines
+    d: 'M 0 3 L 10 3 M 0 8 L 10 8',
+    height: 5,
+    fill: 'none',
+    patternContentUnits: 'userSpaceOnUse',
+    patternUnits: 'userSpaceOnUse',
+    patternTransform: 'scale(1.4 1.4)',
+    strokeWidth: 2,
+    width: 5,
+    x: 0,
+    y: 0
+  },
+  {
+    // Right zig zag
+    d: 'M 0 3 L 5 3 L 5 0 M 5 10 L 5 7 L 10 7',
+    height: 10,
+    fill: 'none',
+    patternContentUnits: 'userSpaceOnUse',
+    patternUnits: 'userSpaceOnUse',
+    strokeWidth: 2,
+    width: 10,
+    x: 0,
+    y: 0
+  }
+];
+
+interface PatternPropsInterface {
+  children?: any;
+  colorScale?: any;
+  offset?: number;
+  patternId?: string;
+  patternScale?: string[];
+  usePatternDefs?: boolean;
+}
+
+export const getPatternId = () => uniqueId('pf-pattern');
+
+export const getPatternDefsId = (prefix: string, index: number) => {
+  const id = `${prefix}:${index}`;
+  return id;
+};
+
+// Returns pattern defs
+//
+// Note that this is wrapped in an empty tag so Victory does not apply child props to defs
+export const getPatternDefs = ({ offset = 0, patternId, patternScale }: PatternPropsInterface) => {
+  const defs = (
+    <React.Fragment key={`defs`}>
+      <defs>
+        {patternScale.map((c: string, index: number) => {
+          const { d, fill, stroke = c, strokeWidth, ...rest } = patterns[(index + offset) % patterns.length];
+          const id = getPatternDefsId(patternId, index);
+          return (
+            <pattern id={id} key={id} {...rest}>
+              <path d={d} stroke={stroke} strokeWidth={strokeWidth} fill={fill} />
+            </pattern>
+          );
+        })}
+      </defs>
+    </React.Fragment>
+  );
+  return defs;
+};
+
+// Return pattern IDs to use as color scale
+export const getPatternScale = (patternId: string, colorScale: string[]) =>
+  colorScale.map((c: any, index: number) => `url(#${getPatternDefsId(patternId, index)})`);
+
+// Return color scale
+export const getDefaultColorScale = (colorScale: string[], themeColorScale: string[]) =>
+  colorScale ? colorScale : themeColorScale;
+
+// Return pattern scale
+export const getDefaultPatternScale = ({
+  colorScale,
+  patternScale,
+  patternId,
+  usePatternDefs
+}: PatternPropsInterface) => {
+  if (patternScale) {
+    return patternScale;
+  }
+  if (usePatternDefs) {
+    return getPatternScale(patternId, colorScale);
+  }
+  return undefined;
+};
+
+// Merge pattern IDs with `data.fill` property, used by interactive pie chart legend
+export const getDefaultData = (data: any, patternScale: string[]) => {
+  if (!patternScale) {
+    return data;
+  }
+  return data.map((datum: any, index: number) => {
+    const pattern = patternScale[index % patternScale.length];
+    return {
+      ...(pattern && pattern !== null && { _fill: pattern }),
+      ...datum
+    };
+  });
+};
+
+// Render children
+export const renderChildrenWithPatterns = ({ children, patternId, patternScale }: PatternPropsInterface) =>
+  React.Children.toArray(children).map((child, index) => {
+    if (React.isValidElement(child)) {
+      const { ...childProps } = child.props;
+      const style = childProps.style ? { ...childProps.style } : {};
+
+      // Merge pattern IDs with `style.data.fill` property
+      if (patternScale) {
+        const fill = patternScale[index % patternScale.length];
+        style.data = {
+          ...(fill && fill !== null && { fill }),
+          ...style.data
+        };
+      }
+      const _child = React.cloneElement(child, {
+        patternId,
+        ...(patternScale && { patternScale }),
+        ...childProps,
+        style // Override child props
+      });
+      return _child;
+    }
+    return child;
+  });

--- a/packages/react-charts/src/components/ChartUtils/chart-theme.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-theme.ts
@@ -34,7 +34,6 @@ import {
 
 /**
  * Apply custom properties to base and color themes
- *
  * @deprecated Use mergeTheme
  * @public
  */
@@ -141,16 +140,14 @@ export const getChartTheme = (themeColor: string, showAxis: boolean): ChartTheme
   return theme;
 };
 
-// Returns donut theme
 /**
- *
+ * Returns donut theme
  * @private
  */
 export const getDonutTheme = (themeColor: string): ChartThemeDefinition => mergeTheme(themeColor, ChartDonutTheme);
 
-// Returns dynamic donut threshold theme
 /**
- *
+ * Returns dynamic donut threshold theme
  * @private
  */
 export const getDonutThresholdDynamicTheme = (themeColor: string): ChartThemeDefinition => {

--- a/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
@@ -28,6 +28,7 @@ interface ChartLegendTooltipVisibleDataInterface {
   activePoints?: any[];
   colorScale?: string[];
   legendData: any;
+  patternScale?: string[]; // Legend symbol patterns
   text?: StringOrNumberOrCallback | string[] | number[];
   textAsLegendData?: boolean;
   theme: ChartThemeDefinition;
@@ -211,6 +212,7 @@ export const getLegendTooltipVisibleData = ({
   activePoints,
   colorScale,
   legendData,
+  patternScale,
   text,
   textAsLegendData = false,
   theme
@@ -236,10 +238,12 @@ export const getLegendTooltipVisibleData = ({
           theme && theme.legend && theme.legend.colorScale
             ? theme.legend.colorScale[i % theme.legend.colorScale.length]
             : undefined;
+        const pattern = patternScale ? patternScale[i % patternScale.length] : undefined;
+        const color = colorScale ? colorScale[i % colorScale.length] : themeColor; // Sync color scale
         result.push({
           name: textAsLegendData ? _text[index] : data.name,
           symbol: {
-            fill: colorScale ? colorScale[i % colorScale.length] : themeColor, // Sync color scale
+            fill: pattern && pattern !== null ? pattern : color,
             ...data.symbol
           }
         });

--- a/packages/react-charts/src/components/ChartUtils/index.ts
+++ b/packages/react-charts/src/components/ChartUtils/index.ts
@@ -6,6 +6,7 @@ export * from './chart-label';
 export * from './chart-legend';
 export * from './chart-origin';
 export * from './chart-padding';
+export * from './chart-patterns';
 export * from './chart-resize';
 export * from './chart-theme';
 export * from './chart-tooltip';

--- a/packages/react-charts/src/components/Patterns/examples/patterms.md
+++ b/packages/react-charts/src/components/Patterns/examples/patterms.md
@@ -45,7 +45,7 @@ PatternFly React charts are based on the [Victory](https://formidable.com/open-s
 ### Basic pie chart
 ```js
 import React from 'react';
-import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
+import { ChartPie } from '@patternfly/react-charts';
 
 <div style={{ height: '230px', width: '350px' }}>
   <ChartPie
@@ -64,7 +64,7 @@ import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
       right: 140, // Adjusted to accommodate legend
       top: 20
     }}
-    usePatternDefs
+    isPatternDefs
     width={350}
   />
 </div>
@@ -91,7 +91,7 @@ import { Chart, ChartAxis, ChartBar, ChartGroup, ChartThemeColor, ChartVoronoiCo
       top: 50
     }}
     themeColor={ChartThemeColor.purple}
-    usePatternDefs
+    isPatternDefs
     width={450}
   >
     <ChartAxis />
@@ -128,7 +128,7 @@ import { Chart, ChartAxis, ChartBar, ChartStack, ChartVoronoiContainer } from '@
       top: 50
     }}
     themeColor={ChartThemeColor.green}
-    usePatternDefs
+    isPatternDefs
     width={600}
   >
     <ChartAxis />
@@ -167,7 +167,7 @@ import { ChartDonut } from '@patternfly/react-charts';
     subTitle="Pets"
     title="100"
     themeColor={ChartThemeColor.gold}
-    usePatternDefs
+    isPatternDefs
     width={350}
   />
 </div>
@@ -202,7 +202,7 @@ import { ChartDonutUtilization } from '@patternfly/react-charts';
     title="45%"
     themeColor={ChartThemeColor.green}
     thresholds={[{ value: 60 }, { value: 90 }]}
-    usePatternDefs
+    isPatternDefs
     width={300}
   />
 </div>
@@ -231,7 +231,7 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
       top: 20
     }}
     width={675}
-    usePatternDefs
+    isPatternDefs
   >
     <ChartDonutUtilization
       data={{ x: 'Storage capacity', y: 45 }}
@@ -241,7 +241,7 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
       subTitle="of 100 GBps"
       title="45%"
       themeColor={ChartThemeColor.orange}
-      usePatternDefs
+      isPatternDefs
     />
   </ChartDonutThreshold>
 </div>
@@ -356,7 +356,7 @@ class InteractivePieLegendChart extends React.Component {
           patternId="pattern_a" // Required for interactive legend functionality
           showAxis={false}
           themeColor={ChartThemeColor.multiUnordered}
-          usePatternDefs
+          isPatternDefs
           width={500}
         >
           <ChartPie
@@ -386,7 +386,6 @@ import {
   ChartLegendTooltip,
   ChartScatter, 
   ChartThemeColor,
-  ChartVoronoiContainer,
   createContainer, 
   getInteractiveLegendEvents, 
   getInteractiveLegendItemStyles,
@@ -546,7 +545,7 @@ class InteractiveLegendChart extends React.Component {
             }}
             maxDomain={{y: 9}}
             themeColor={ChartThemeColor.multiUnordered}
-            usePatternDefs
+            isPatternDefs
             width={width}
           >
             <ChartAxis tickValues={['2015', '2016', '2017', '2018']} />
@@ -638,7 +637,7 @@ import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
       top: 20
     }}
     themeColor={ChartThemeColor.multiOrdered}
-    usePatternDefs
+    isPatternDefs
     width={600}
   />
 </div>
@@ -648,7 +647,7 @@ import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
 
 This demonstrates how to omit patterns from pie chart segments.
 
-The approach uses `usePatternDefs` to generate default pattern defs using the given `patternId` prefix. The `patternScale` property is then used to apply indexed pattern IDs to each pie chart segment. If you want to omit a particular pattern from a pie segment, simply provide `null` instead.
+The approach uses `isPatternDefs` to generate default pattern defs using the given `patternId` prefix. The `patternScale` property is then used to apply indexed pattern IDs to each pie chart segment. If you want to omit a particular pattern from a pie segment, simply provide `null` instead.
 
 ```js
 import React from 'react';
@@ -674,7 +673,7 @@ import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
     patternId="pattern_b"
     patternScale={['url("#pattern_b:0")', 'url("#pattern_b:1")', null, null, null]}
     themeColor={ChartThemeColor.multiUnordered}
-    usePatternDefs
+    isPatternDefs
     width={350}
   />
 </div>
@@ -684,7 +683,7 @@ import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
 
 This demonstrates how to apply a custom color scale.
 
-The approach uses `usePatternDefs` to generate default pattern defs using the given `patternId` prefix and custom `colorScale`. The `patternScale` property is then used to apply indexed pattern IDs to each pie chart segment. If you want to omit a particular pattern from a pie segment, simply provide `null` instead.
+The approach uses `isPatternDefs` to generate default pattern defs using the given `patternId` prefix and custom `colorScale`. The `patternScale` property is then used to apply indexed pattern IDs to each pie chart segment. If you want to omit a particular pattern from a pie segment, simply provide `null` instead.
 
 ```js
 import React from 'react';
@@ -713,7 +712,7 @@ import chart_color_green_300 from '@patternfly/react-tokens/dist/esm/chart_color
     }}
     patternId="pattern_c"
     patternScale={['url("#pattern_c:0")', 'url("#pattern_c:1")', null]}
-    usePatternDefs
+    isPatternDefs
     width={350}
   />
 </div>
@@ -725,7 +724,7 @@ This demonstrates how to create custom patterns.
 
 The approach uses custom pattern defs. The `patternScale` property is used to apply pattern IDs to each pie chart segment. If you want to omit a particular pattern from a pie segment, simply provide `null` instead.
 
-Note that `usePatternDefs` and `patternId` are not used here.
+Note that `isPatternDefs` and `patternId` are not used here.
 
 ```js
 import React from 'react';

--- a/packages/react-charts/src/components/Patterns/examples/patterms.md
+++ b/packages/react-charts/src/components/Patterns/examples/patterms.md
@@ -2,9 +2,24 @@
 id: Patterns
 section: charts
 propComponents: [
-  'ChartLegend'
+  'Chart',
+  'ChartArea',
+  'ChartAxis',
+  'ChartBar',
+  'ChartDonut',
+  'ChartDonutThreshold',
+  'ChartDonutUtilization',
+  'ChartGroup',
+  'ChartLegend',
+  'ChartLegendTooltip',
+  'ChartPie',
+  'ChartScatter',
+  'ChartStack',
+  'ChartThemeColor',
+  'ChartVoronoiContainer',
 ]
 hideDarkMode: true
+beta: true
 ---
 
 import { 
@@ -782,8 +797,8 @@ components used in the examples above, Victory pass-thru props are also document
 - For `ChartDonut` props, see [VictoryPie](https://formidable.com/open-source/victory/docs/victory-pie)
 - For `ChartDonutThreshold` props, see [VictoryPie](https://formidable.com/open-source/victory/docs/victory-pie)
 - For `ChartDonutUtilization` props, see [VictoryPie](https://formidable.com/open-source/victory/docs/victory-pie)
-- For `ChartLegend` props, see [VictoryLegend](https://formidable.com/open-source/victory/docs/victory-legend)
 - For `ChartGroup` props, see [VictoryGroup](https://formidable.com/open-source/victory/docs/victory-group)
+- For `ChartLegend` props, see [VictoryLegend](https://formidable.com/open-source/victory/docs/victory-legend)
 - For `ChartPie` props, see [VictoryPie](https://formidable.com/open-source/victory/docs/victory-pie)
 - For `ChartScatter` props, see [VictoryScatter](https://formidable.com/open-source/victory/docs/victory-scatter)
 - For `ChartStack` props, see [VictoryStack](https://formidable.com/open-source/victory/docs/victory-stack)

--- a/packages/react-charts/src/components/Patterns/examples/patterms.md
+++ b/packages/react-charts/src/components/Patterns/examples/patterms.md
@@ -1,0 +1,791 @@
+---
+id: Patterns
+section: charts
+propComponents: [
+  'ChartLegend'
+]
+hideDarkMode: true
+---
+
+import { 
+  Chart,
+  ChartArea,
+  ChartAxis,
+  ChartBar,
+  ChartDonut,
+  ChartDonutThreshold,
+  ChartDonutUtilization,
+  ChartGroup,
+  ChartLegend,
+  ChartLegendTooltip,
+  ChartPie,
+  ChartScatter,
+  ChartStack,
+  ChartThemeColor,
+  ChartVoronoiContainer,
+  createContainer,
+  getInteractiveLegendEvents,
+  getInteractiveLegendItemStyles,
+  getResizeObserver
+} from '@patternfly/react-charts';
+import chart_area_Opacity from '@patternfly/react-tokens/dist/esm/chart_area_Opacity';
+import chart_color_black_500 from '@patternfly/react-tokens/dist/esm/chart_color_black_500';
+import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
+import chart_color_green_300 from '@patternfly/react-tokens/dist/esm/chart_color_green_300';
+import chart_color_cyan_300 from '@patternfly/react-tokens/dist/esm/chart_color_cyan_300';
+import chart_color_gold_300 from '@patternfly/react-tokens/dist/esm/chart_color_gold_300';
+import '@patternfly/patternfly/patternfly-charts.css';
+
+## Introduction
+Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
+
+PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
+
+## Examples
+### Basic pie chart
+```js
+import React from 'react';
+import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
+
+<div style={{ height: '230px', width: '350px' }}>
+  <ChartPie
+    ariaDesc="Average number of pets"
+    ariaTitle="Pie chart example"
+    constrainToVisibleArea={true}
+    data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
+    height={230}
+    labels={({ datum }) => `${datum.x}: ${datum.y}`}
+    legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
+    legendOrientation="vertical"
+    legendPosition="right"
+    padding={{
+      bottom: 20,
+      left: 20,
+      right: 140, // Adjusted to accommodate legend
+      top: 20
+    }}
+    usePatternDefs
+    width={350}
+  />
+</div>
+```
+
+### Bar chart
+```js
+import React from 'react';
+import { Chart, ChartAxis, ChartBar, ChartGroup, ChartThemeColor, ChartVoronoiContainer } from '@patternfly/react-charts';
+
+<div style={{ height: '275px', width: '450px' }}>
+  <Chart
+    ariaDesc="Average number of pets"
+    ariaTitle="Bar chart example"
+    containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
+    domainPadding={{ x: [30, 25] }}
+    legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
+    legendPosition="bottom"
+    height={275}
+    padding={{
+      bottom: 75, // Adjusted to accommodate legend
+      left: 50,
+      right: 50,
+      top: 50
+    }}
+    themeColor={ChartThemeColor.purple}
+    usePatternDefs
+    width={450}
+  >
+    <ChartAxis />
+    <ChartAxis dependentAxis showGrid />
+    <ChartGroup offset={11}>
+      <ChartBar data={[{ name: 'Cats', x: '2015', y: 1 }, { name: 'Cats', x: '2016', y: 2 }, { name: 'Cats', x: '2017', y: 5 }, { name: 'Cats', x: '2018', y: 3 }]} />
+      <ChartBar data={[{ name: 'Dogs', x: '2015', y: 2 }, { name: 'Dogs', x: '2016', y: 1 }, { name: 'Dogs', x: '2017', y: 7 }, { name: 'Dogs', x: '2018', y: 4 }]} />
+      <ChartBar data={[{ name: 'Birds', x: '2015', y: 4 }, { name: 'Birds', x: '2016', y: 4 }, { name: 'Birds', x: '2017', y: 9 }, { name: 'Birds', x: '2018', y: 7 }]} />
+      <ChartBar data={[{ name: 'Mice', x: '2015', y: 3 }, { name: 'Mice', x: '2016', y: 3 }, { name: 'Mice', x: '2017', y: 8 }, { name: 'Mice', x: '2018', y: 5 }]} />
+    </ChartGroup>
+  </Chart>
+</div>
+```
+
+### Stack chart
+```js
+import React from 'react';
+import { Chart, ChartAxis, ChartBar, ChartStack, ChartVoronoiContainer } from '@patternfly/react-charts';
+
+<div style={{ height: '250px', width: '600px' }}>
+  <Chart
+    ariaDesc="Average number of pets"
+    ariaTitle="Stack chart example"
+    containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
+    domainPadding={{ x: [30, 25] }}
+    legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
+    legendOrientation="vertical"
+    legendPosition="right"
+    height={250}
+    padding={{
+      bottom: 50,
+      left: 50,
+      right: 200, // Adjusted to accommodate legend
+      top: 50
+    }}
+    themeColor={ChartThemeColor.green}
+    usePatternDefs
+    width={600}
+  >
+    <ChartAxis />
+    <ChartAxis dependentAxis showGrid />
+    <ChartStack>
+      <ChartBar data={[{ name: 'Cats', x: '2015', y: 1 }, { name: 'Cats', x: '2016', y: 2 }, { name: 'Cats', x: '2017', y: 5 }, { name: 'Cats', x: '2018', y: 3 }]} />
+      <ChartBar data={[{ name: 'Dogs', x: '2015', y: 2 }, { name: 'Dogs', x: '2016', y: 1 }, { name: 'Dogs', x: '2017', y: 7 }, { name: 'Dogs', x: '2018', y: 4 }]} />
+      <ChartBar data={[{ name: 'Birds', x: '2015', y: 4 }, { name: 'Birds', x: '2016', y: 4 }, { name: 'Birds', x: '2017', y: 9 }, { name: 'Birds', x: '2018', y: 7 }]} />
+      <ChartBar data={[{ name: 'Mice', x: '2015', y: 3 }, { name: 'Mice', x: '2016', y: 3 }, { name: 'Mice', x: '2017', y: 8 }, { name: 'Mice', x: '2018', y: 5 }]} />
+    </ChartStack>
+  </Chart>
+</div>
+```
+
+### Donut chart
+```js
+import React from 'react';
+import { ChartDonut } from '@patternfly/react-charts';
+
+<div style={{ height: '230px', width: '350px' }}>
+  <ChartDonut
+    ariaDesc="Average number of pets"
+    ariaTitle="Donut chart example"
+    constrainToVisibleArea={true}
+    data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
+    labels={({ datum }) => `${datum.x}: ${datum.y}%`}
+    legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
+    legendOrientation="vertical"
+    legendPosition="right"
+    padding={{
+      bottom: 20,
+      left: 20,
+      right: 140, // Adjusted to accommodate legend
+      top: 20
+    }}
+    subTitle="Pets"
+    title="100"
+    themeColor={ChartThemeColor.gold}
+    usePatternDefs
+    width={350}
+  />
+</div>
+```
+
+### Donut utilization chart
+
+This demonstrates how to apply a pattern to the static, unused portion of the donut utilization chart.
+
+```js
+import React from 'react';
+import { ChartDonutUtilization } from '@patternfly/react-charts';
+
+<div style={{ height: '275px', width: '300px' }}>
+  <ChartDonutUtilization 
+    ariaDesc="Storage capacity"
+    ariaTitle="Donut utilization chart example"
+    constrainToVisibleArea={true}
+    data={{ x: 'Storage capacity', y: 45 }}
+    height={275}
+    labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
+    legendData={[{ name: `Storage capacity: 45%` }, { name: 'Unused' }]}
+    legendPosition="bottom"
+    padding={{
+      bottom: 65, // Adjusted to accommodate legend
+      left: 20,
+      right: 20,
+      top: 20
+    }}
+    showStaticPattern
+    subTitle="of 100 GBps"
+    title="45%"
+    themeColor={ChartThemeColor.green}
+    thresholds={[{ value: 60 }, { value: 90 }]}
+    usePatternDefs
+    width={300}
+  />
+</div>
+```
+
+### Donut utilization chart with thresholds
+
+This demonstrates how to apply patterns to thresholds.
+
+```js
+import React from 'react';
+import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts';
+
+<div style={{ height: '275px', width: '675px' }}>
+  <ChartDonutThreshold
+    ariaDesc="Storage capacity"
+    ariaTitle="Donut utilization chart with static threshold example"
+    constrainToVisibleArea={true}
+    data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
+    height={275}
+    labels={({ datum }) => datum.x ? datum.x : null}
+    padding={{
+      bottom: 65, // Adjusted to accommodate legend
+      left: 20,
+      right: 20,
+      top: 20
+    }}
+    width={675}
+    usePatternDefs
+  >
+    <ChartDonutUtilization
+      data={{ x: 'Storage capacity', y: 45 }}
+      labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
+      legendData={[{ name: `Storage capacity: 45%` }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at 90%' }]}
+      legendPosition="bottom"
+      subTitle="of 100 GBps"
+      title="45%"
+      themeColor={ChartThemeColor.orange}
+      usePatternDefs
+    />
+  </ChartDonutThreshold>
+</div>
+```
+
+### Interactive legend with pie chart
+
+This demonstrates how to add an interactive legend to a pie chart using events such as `onMouseOver`, `onMouseOut`, and `onClick`.
+
+```js
+import React from 'react';
+import { 
+  Chart,
+  ChartLegend,
+  ChartThemeColor,
+  ChartPie,
+  getInteractiveLegendEvents, 
+  getInteractiveLegendItemStyles 
+} from '@patternfly/react-charts';
+
+class InteractivePieLegendChart extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      hiddenSeries: new Set(),
+      width: 0
+    };
+    this.series = [{
+      datapoints: { x: 'Cats', y: 25 },
+      legendItem: { name: 'Cats: 35' }
+    }, {
+      datapoints: { x: 'Dogs', y: 25 },
+      legendItem: { name: 'Dogs: 25' }
+    }, {
+      datapoints: { x: 'Birds', y: 10 },
+      legendItem: { name: 'Birds: 10' }
+    }];
+
+    // Returns groups of chart names associated with each data series
+    this.getChartNames = () => {
+      const result = [];
+      this.series.map((_, index) => {
+        // Provide names for each series hidden / shown -- use the same name for a pie chart
+        result.push(['pie']);
+      });
+      return result;
+    };
+
+    // Returns onMouseOver, onMouseOut, and onClick events for the interactive legend
+    this.getEvents = () => getInteractiveLegendEvents({
+      chartNames: this.getChartNames(),
+      isHidden: this.isHidden,
+      legendName: 'legend',
+      onLegendClick: this.handleLegendClick
+    });
+
+    // Returns legend data styled per hiddenSeries
+    this.getLegendData = () => {
+      const { hiddenSeries } = this.state;
+      return this.series.map((s, index) => {
+        return {
+          ...s.legendItem, // name property
+          ...getInteractiveLegendItemStyles(hiddenSeries.has(index)) // hidden styles
+        };
+      });
+    };
+
+    // Hide each data series individually
+    this.handleLegendClick = (props) => {
+      if (!this.state.hiddenSeries.delete(props.index)) {
+        this.state.hiddenSeries.add(props.index);
+      }
+      this.setState({ hiddenSeries: new Set(this.state.hiddenSeries) });
+    };
+
+    // Returns true if data series is hidden
+    this.isHidden = (index) => {
+      const { hiddenSeries } = this.state; // Skip if already hidden                
+      return hiddenSeries.has(index);
+    };
+
+    this.isDataAvailable = () => {
+      const { hiddenSeries } = this.state;
+      return hiddenSeries.size !== this.series.length;
+    };
+  };
+
+  render() {
+    const { hiddenSeries, width } = this.state;
+
+    const data = [];
+    this.series.map((s, index) => {
+      data.push(!hiddenSeries.has(index) ? s.datapoints : [{ y: null}]);
+    });
+
+    return (
+      <div style={{ height: '275px', width: '500px' }}>
+        <Chart
+          ariaDesc="Average number of pets"
+          ariaTitle="Pie chart example"
+          events={this.getEvents()}
+          height={275}
+          labels={({ datum }) => `${datum.x}: ${datum.y}`}
+          legendComponent={<ChartLegend name={'legend'} data={this.getLegendData()} />}
+          legendPosition="bottom"
+          padding={{
+            bottom: 65,
+            left: 20,
+            right: 20,
+            top: 20
+          }}
+          patternId="pattern_a" // Required for interactive legend functionality
+          showAxis={false}
+          themeColor={ChartThemeColor.multiUnordered}
+          usePatternDefs
+          width={500}
+        >
+          <ChartPie
+            constrainToVisibleArea={true}
+            data={data}
+            name="pie"
+          />
+        </Chart>
+      </div>
+    );
+  }
+}
+```
+
+### Interactive legend with area chart
+
+This demonstrates how to add an interactive legend using events such as `onMouseOver`, `onMouseOut`, and `onClick`.
+
+```js
+import React from 'react';
+import { 
+  Chart, 
+  ChartArea, 
+  ChartAxis, 
+  ChartGroup, 
+  ChartLegend,
+  ChartLegendTooltip,
+  ChartScatter, 
+  ChartThemeColor,
+  ChartVoronoiContainer,
+  createContainer, 
+  getInteractiveLegendEvents, 
+  getInteractiveLegendItemStyles,
+  getResizeObserver
+} from '@patternfly/react-charts';
+// import '@patternfly/patternfly/patternfly-charts.css'; // For mixed blend mode
+
+class InteractiveLegendChart extends React.Component {
+  constructor(props) {
+    super(props);
+    this.containerRef = React.createRef();
+    this.observer = () => {};
+    this.state = {
+      hiddenSeries: new Set(),
+      width: 0
+    };
+    this.series = [{
+      datapoints: [
+        { x: '2015', y: 3 },
+        { x: '2016', y: 4 },
+        { x: '2017', y: 8 },
+        { x: '2018', y: 6 }
+      ],
+      legendItem: { name: 'Cats' }
+    }, {
+      datapoints: [
+        { x: '2015', y: 2 },
+        { x: '2016', y: 3 },
+        { x: '2017', y: 4 },
+        { x: '2018', y: 5 },
+        { x: '2019', y: 6 }
+      ],
+      legendItem: { name: 'Dogs' }
+    }, {
+      datapoints: [
+        { x: '2015', y: 1 },
+        { x: '2016', y: 2 },
+        { x: '2017', y: 3 },
+        { x: '2018', y: 2 },
+        { x: '2019', y: 4 }
+      ],
+      legendItem: { name: 'Birds' }
+    }];
+
+    // Returns groups of chart names associated with each data series
+    this.getChartNames = () => {
+      const result = [];
+      this.series.map((_, index) => {
+        // Each group of chart names are hidden / shown together
+        result.push([`area-${index}`, `scatter-${index}`]);
+      });
+      return result;
+    };
+
+    // Returns onMouseOver, onMouseOut, and onClick events for the interactive legend
+    this.getEvents = () => getInteractiveLegendEvents({
+      chartNames: this.getChartNames(),
+      isHidden: this.isHidden,
+      legendName: 'legend',
+      onLegendClick: this.handleLegendClick
+    });
+
+    // Returns legend data styled per hiddenSeries
+    this.getLegendData = () => {
+      const { hiddenSeries } = this.state;
+      return this.series.map((s, index) => {
+        return {
+          childName: `area-${index}`, // Sync tooltip legend with the series associated with given chart name
+          ...s.legendItem, // name property
+          ...getInteractiveLegendItemStyles(hiddenSeries.has(index)) // hidden styles
+        };
+      });
+    };
+
+    // Hide each data series individually
+    this.handleLegendClick = (props) => {
+      if (!this.state.hiddenSeries.delete(props.index)) {
+        this.state.hiddenSeries.add(props.index);
+      }
+      this.setState({ hiddenSeries: new Set(this.state.hiddenSeries) });
+    };
+
+    // Set chart width per current window size
+    this.handleResize = () => {
+      if (this.containerRef.current && this.containerRef.current.clientWidth) {
+        this.setState({ width: this.containerRef.current.clientWidth });
+      }
+    };
+
+    // Returns true if data series is hidden
+    this.isHidden = (index) => {
+      const { hiddenSeries } = this.state; // Skip if already hidden                
+      return hiddenSeries.has(index);
+    };
+
+    this.isDataAvailable = () => {
+      const { hiddenSeries } = this.state;
+      return hiddenSeries.size !== this.series.length;
+    };
+
+    // Note: Container order is important
+    const CursorVoronoiContainer = createContainer("voronoi", "cursor");
+
+    this.cursorVoronoiContainer = (
+      <CursorVoronoiContainer
+        cursorDimension="x"
+        labels={({ datum }) => datum.childName.includes('area-') && datum.y !== null ? `${datum.y}` : null}
+        labelComponent={<ChartLegendTooltip legendData={this.getLegendData()} title={(datum) => datum.x}/>}
+        mouseFollowTooltips
+        voronoiDimension="x"
+        voronoiPadding={50}
+      />
+    );
+  };
+
+  componentDidMount() {
+    this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
+    this.handleResize();
+  }
+
+  componentWillUnmount() {
+    this.observer();
+  }
+
+  // Tips:
+  // 1. Omitting hidden components will reassign color scale, use null data instead or custom colors
+  // 2. Set domain or tick axis labels to account for when all data series are hidden
+  // 3. Omit tooltip for ChartScatter component by checking childName prop
+  // 4. Omit tooltip when all data series are hidden
+  // 5. Clone original container to ensure tooltip events are not lost when data series are hidden / shown
+  render() {
+    const { hiddenSeries, width } = this.state;
+
+    const container = React.cloneElement(
+      this.cursorVoronoiContainer, 
+      {
+        disable: !this.isDataAvailable()
+      }
+    );
+
+    return (
+      <div ref={this.containerRef}>
+        <div className="area-chart-legend-bottom-responsive">
+          <Chart
+            ariaDesc="Average number of pets"
+            ariaTitle="Area chart example"
+            containerComponent={container}
+            events={this.getEvents()}
+            height={225}
+            legendComponent={<ChartLegend name={'legend'} data={this.getLegendData()} />}
+            legendPosition="bottom-left"
+            padding={{
+              bottom: 75, // Adjusted to accommodate legend
+              left: 50,
+              right: 50,
+              top: 50,
+            }}
+            maxDomain={{y: 9}}
+            themeColor={ChartThemeColor.multiUnordered}
+            usePatternDefs
+            width={width}
+          >
+            <ChartAxis tickValues={['2015', '2016', '2017', '2018']} />
+            <ChartAxis dependentAxis showGrid />
+            <ChartGroup>
+              {this.series.map((s, index) => {
+                return (
+                  <ChartScatter
+                    data={!hiddenSeries.has(index) ? s.datapoints : [{ y: null}]}
+                    key={'scatter-' + index}
+                    name={'scatter-' + index}
+                    size={({ active }) => (active ? 5 : 3)}
+                  />
+                );
+              })}
+            </ChartGroup>
+            <ChartGroup>
+              {this.series.map((s, index) => {
+                return (
+                  <ChartArea
+                    data={!hiddenSeries.has(index) ? s.datapoints : [{ y: null}]}
+                    interpolation="monotoneX"
+                    key={'area-' + index}
+                    name={'area-' + index}
+                  />
+                );
+              })}
+            </ChartGroup>
+          </Chart>
+        </div>
+      </div>
+    );
+  }
+}
+```
+
+### All patterns
+```js
+import React from 'react';
+import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
+
+<div style={{ height: '325px', width: '600px' }}>
+  <ChartPie
+    ariaDesc="Average number of pets"
+    ariaTitle="Pie chart example"
+    constrainToVisibleArea={true}
+    data={[
+      { x: 'Cats', y: 6 },
+      { x: 'Dogs', y: 6 },
+      { x: 'Birds', y: 6 },
+      { x: 'Fish', y: 6 },
+      { x: 'Rabbits', y: 6 },
+      { x: 'Squirels', y: 6 },
+      { x: 'Chipmunks', y: 6 },
+      { x: 'Bats', y: 6 },
+      { x: 'Ducks', y: 6 },
+      { x: 'Geese', y: 6 },
+      { x: 'Bobcats', y: 6 },
+      { x: 'Foxes', y: 6 },
+      { x: 'Coyotes', y: 6 },
+      { x: 'Deer', y: 6 },
+      { x: 'Bears', y: 10 }
+    ]}
+    height={325}
+    labels={({ datum }) => `${datum.x}: ${datum.y}`}
+    legendData={[
+      { name: 'Cats: 6' },
+      { name: 'Dogs: 6' },
+      { name: 'Birds: 6' },
+      { name: 'Fish: 6' },
+      { name: 'Rabbits: 6' },
+      { name: 'Squirels: 6' },
+      { name: 'Chipmunks: 6' },
+      { name: 'Bats: 6' },
+      { name: 'Ducks: 6' },
+      { name: 'Geese: 6' },
+      { name: 'Bobcat: 6' },
+      { name: 'Foxes: 6' },
+      { name: 'Coyotes: 6' },
+      { name: 'Deer: 6' },
+      { name: 'Bears: 6' },
+    ]}
+    legendAllowWrap
+    legendPosition="bottom"
+    padding={{
+      bottom: 110,
+      left: 20,
+      right: 20,
+      top: 20
+    }}
+    themeColor={ChartThemeColor.multiOrdered}
+    usePatternDefs
+    width={600}
+  />
+</div>
+```
+
+### Custom pattern IDs
+
+This demonstrates how to omit patterns from pie chart segments.
+
+The approach uses `usePatternDefs` to generate default pattern defs using the given `patternId` prefix. The `patternScale` property is then used to apply indexed pattern IDs to each pie chart segment. If you want to omit a particular pattern from a pie segment, simply provide `null` instead.
+
+```js
+import React from 'react';
+import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
+
+<div style={{ height: '230px', width: '350px' }}>
+  <ChartPie
+    ariaDesc="Average number of pets"
+    ariaTitle="Pie chart example"
+    constrainToVisibleArea={true}
+    data={[{ x: 'Cats', y: 15 }, { x: 'Dogs', y: 15 }, { x: 'Birds', y: 15 }, { x: 'Fish', y: 25 }, { x: 'Rabbits', y: 30 }]}
+    height={230}
+    labels={({ datum }) => `${datum.x}: ${datum.y}`}
+    legendData={[{ name: 'Cats: 15' }, { name: 'Dogs: 15' }, { name: 'Birds: 15' }, { name: 'Fish: 25' }, { name: 'Rabbits: 30' }]}
+    legendOrientation="vertical"
+    legendPosition="right"
+    padding={{
+      bottom: 20,
+      left: 20,
+      right: 140, // Adjusted to accommodate legend
+      top: 20
+    }}
+    patternId="pattern_b"
+    patternScale={['url("#pattern_b:0")', 'url("#pattern_b:1")', null, null, null]}
+    themeColor={ChartThemeColor.multiUnordered}
+    usePatternDefs
+    width={350}
+  />
+</div>
+```
+
+### Custom color scale
+
+This demonstrates how to apply a custom color scale.
+
+The approach uses `usePatternDefs` to generate default pattern defs using the given `patternId` prefix and custom `colorScale`. The `patternScale` property is then used to apply indexed pattern IDs to each pie chart segment. If you want to omit a particular pattern from a pie segment, simply provide `null` instead.
+
+```js
+import React from 'react';
+import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
+import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
+import chart_color_gold_300 from '@patternfly/react-tokens/dist/esm/chart_color_gold_300';
+import chart_color_green_300 from '@patternfly/react-tokens/dist/esm/chart_color_green_300';
+
+<div style={{ height: '230px', width: '350px' }}>
+  <ChartPie
+    ariaDesc="Average number of pets"
+    ariaTitle="Pie chart example"
+    colorScale={[chart_color_blue_300.value, chart_color_gold_300.var, chart_color_green_300.value]}
+    constrainToVisibleArea={true}
+    data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
+    height={230}
+    labels={({ datum }) => `${datum.x}: ${datum.y}`}
+    legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
+    legendOrientation="vertical"
+    legendPosition="right"
+    padding={{
+      bottom: 20,
+      left: 20,
+      right: 140, // Adjusted to accommodate legend
+      top: 20
+    }}
+    patternId="pattern_c"
+    patternScale={['url("#pattern_c:0")', 'url("#pattern_c:1")', null]}
+    usePatternDefs
+    width={350}
+  />
+</div>
+```
+
+### Custom pattern defs
+
+This demonstrates how to create custom patterns.
+
+The approach uses custom pattern defs. The `patternScale` property is used to apply pattern IDs to each pie chart segment. If you want to omit a particular pattern from a pie segment, simply provide `null` instead.
+
+Note that `usePatternDefs` and `patternId` are not used here.
+
+```js
+import React from 'react';
+import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
+import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
+import chart_color_green_300 from '@patternfly/react-tokens/dist/esm/chart_color_green_300';
+
+<div style={{ height: '230px', width: '350px' }}>
+  <svg aria-hidden={true} height="0" width="0" style={{display: 'block'}}>
+    <defs>
+      <pattern id="pattern_d:0" patternUnits="userSpaceOnUse" patternContentUnits="userSpaceOnUse" width="10" height="10" x="0" y="0">
+        <path d="M 0 0 L 5 10 L 10 0" stroke={chart_color_blue_300.value} strokeWidth="2" fill="none"></path>
+      </pattern>
+      <pattern id="pattern_d:1" patternUnits="userSpaceOnUse" patternContentUnits="userSpaceOnUse" width="10" height="10" x="0" y="0">
+        <path d="M 0 3 L 5 3 L 5 0 M 5 10 L 5 7 L 10 7" stroke={chart_color_green_300.value} strokeWidth="2" fill="none"></path>
+      </pattern>
+    </defs>
+  </svg>
+  <ChartPie
+    ariaDesc="Average number of pets"
+    ariaTitle="Pie chart example"
+    constrainToVisibleArea={true}
+    data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
+    height={230}
+    labels={({ datum }) => `${datum.x}: ${datum.y}`}
+    legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
+    legendOrientation="vertical"
+    legendPosition="right"
+    padding={{
+      bottom: 20,
+      left: 20,
+      right: 140, // Adjusted to accommodate legend
+      top: 20
+    }}
+    patternScale={['url("#pattern_d:0")', 'url("#pattern_d:1")', null]}
+    themeColor={ChartThemeColor.multiUnordered}
+    width={350}
+  />
+</div>
+```
+
+## Documentation
+### Tips
+- See Victory's [FAQ](https://formidable.com/open-source/victory/docs/faq)
+- `ChartLegend` may be used as a standalone component, instead of using `legendData`
+
+### Note
+Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 
+components used in the examples above, Victory pass-thru props are also documented here:
+
+- For `Chart` props, see [VictoryChart](https://formidable.com/open-source/victory/docs/victory-chart)
+- For `ChartArea` props, see [VictoryArea](https://formidable.com/open-source/victory/docs/victory-area)
+- For `ChartAxis` props, see [VictoryAxis](https://formidable.com/open-source/victory/docs/victory-axis)
+- For `ChartBar` props, see [VictoryBar](https://formidable.com/open-source/victory/docs/victory-bar)
+- For `ChartDonut` props, see [VictoryPie](https://formidable.com/open-source/victory/docs/victory-pie)
+- For `ChartDonutThreshold` props, see [VictoryPie](https://formidable.com/open-source/victory/docs/victory-pie)
+- For `ChartDonutUtilization` props, see [VictoryPie](https://formidable.com/open-source/victory/docs/victory-pie)
+- For `ChartLegend` props, see [VictoryLegend](https://formidable.com/open-source/victory/docs/victory-legend)
+- For `ChartGroup` props, see [VictoryGroup](https://formidable.com/open-source/victory/docs/victory-group)
+- For `ChartPie` props, see [VictoryPie](https://formidable.com/open-source/victory/docs/victory-pie)
+- For `ChartScatter` props, see [VictoryScatter](https://formidable.com/open-source/victory/docs/victory-scatter)
+- For `ChartStack` props, see [VictoryStack](https://formidable.com/open-source/victory/docs/victory-stack)
+- For `ChartVoronoiContainer` props, see [VictoryVoronoiContainer](https://formidable.com/open-source/victory/docs/victory-voronoi-container)


### PR DESCRIPTION
Added support for patterns. For examples, please see https://patternfly-react-pr-7390.surge.sh/charts/patterns.

Reviewed with @mceledonia, @heyethankim, & @mcarrano.

<img width="398" alt="Screen Shot 2022-05-15 at 10 32 10 PM" src="https://user-images.githubusercontent.com/17481322/168510121-e65fb378-d203-4d80-b27c-64a9b368667f.png">

Design issue: https://github.com/patternfly/patternfly-design/issues/1136
Closes: https://github.com/patternfly/patternfly-react/issues/7537