### PR TITLE
Use correct type for TextArea ref

### DIFF
--- a/packages/react-core/src/components/TextArea/TextArea.tsx
+++ b/packages/react-core/src/components/TextArea/TextArea.tsx
@@ -125,7 +125,7 @@ export class TextAreaBase extends React.Component<TextAreaProps> {
   }
 }
 
-export const TextArea = React.forwardRef((props: TextAreaProps, ref: React.Ref<HTMLInputElement>) => (
+export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>((props, ref) => (
   <TextAreaBase {...props} innerRef={ref as React.MutableRefObject<any>} />
 ));
 TextArea.displayName = 'TextArea';


### PR DESCRIPTION
The reference to the element of `TextArea` was incorrectly set to `HTMLInputElement`, this changes it to the correct type of `HTMLTextAreaElement`.

Closes #7432