### PR TITLE
feat(FileUploadField): forward more props to the TextArea

### DIFF
--- a/packages/react-core/src/components/FileUpload/FileUploadField.tsx
+++ b/packages/react-core/src/components/FileUpload/FileUploadField.tsx
@@ -78,6 +78,10 @@ export interface FileUploadFieldProps extends Omit<React.HTMLProps<HTMLDivElemen
   containerRef?: React.Ref<HTMLDivElement>;
   /** Text area text changed */
   onTextChange?: (text: string) => void;
+  /** Callback for when focus is lost on the text area field */
+  onTextAreaBlur?: (event?: any) => void;
+  /** Placeholder string to display in the empty text area field */
+  textAreaPlaceholder?: string;
 }
 
 export const FileUploadField: React.FunctionComponent<FileUploadFieldProps> = ({
@@ -90,6 +94,8 @@ export const FileUploadField: React.FunctionComponent<FileUploadFieldProps> = ({
   onClearButtonClick = () => {},
   onTextAreaClick,
   onTextChange,
+  onTextAreaBlur,
+  textAreaPlaceholder = '',
   className = '',
   isDisabled = false,
   isReadOnly = false,
@@ -169,6 +175,8 @@ export const FileUploadField: React.FunctionComponent<FileUploadFieldProps> = ({
             value={value as string}
             onChange={onTextAreaChange}
             onClick={onTextAreaClick}
+            onBlur={onTextAreaBlur}
+            placeholder={textAreaPlaceholder}
           />
         )}
         {isLoading && (

--- a/packages/react-core/src/components/FileUpload/__tests__/__snapshots__/FileUpload.test.tsx.snap
+++ b/packages/react-core/src/components/FileUpload/__tests__/__snapshots__/FileUpload.test.tsx.snap
@@ -59,6 +59,7 @@ exports[`simple fileupload 1`] = `
         class="pf-c-form-control pf-m-resize-vertical"
         id="simple-text-file"
         name="simple-text-file"
+        placeholder=""
       />
     </div>
     <input

--- a/packages/react-core/src/components/FileUpload/__tests__/__snapshots__/FileUploadField.test.tsx.snap
+++ b/packages/react-core/src/components/FileUpload/__tests__/__snapshots__/FileUploadField.test.tsx.snap
@@ -58,6 +58,7 @@ exports[`simple fileuploadfield 1`] = `
         class="pf-c-form-control pf-m-resize-vertical"
         id="custom-file-upload"
         name="custom-file-upload"
+        placeholder=""
       />
     </div>
     <p>

--- a/packages/react-core/src/components/FileUpload/examples/FileUpload.md
+++ b/packages/react-core/src/components/FileUpload/examples/FileUpload.md
@@ -268,7 +268,8 @@ class CustomFileUpload extends React.Component {
       isLoading: false,
       isDragActive: false,
       hideDefaultPreview: false,
-      children: false
+      children: false,
+      hasPlaceholderText: false
     };
     this.handleTextAreaChange = value => {
       this.setState({ value });
@@ -283,11 +284,12 @@ class CustomFileUpload extends React.Component {
       isLoading,
       isDragActive,
       hideDefaultPreview,
-      children
+      children,
+      hasPlaceholderText
     } = this.state;
     return (
       <div>
-        {['filename', 'isClearButtonDisabled', 'isDragActive', 'isLoading', 'hideDefaultPreview', 'children'].map(
+        {['filename', 'isClearButtonDisabled', 'isDragActive', 'isLoading', 'hideDefaultPreview', 'children', 'hasPlaceholderText'].map(
           stateKey => (
             <Checkbox
               key={stateKey}
@@ -321,6 +323,7 @@ class CustomFileUpload extends React.Component {
           isDragActive={isDragActive}
           hideDefaultPreview={hideDefaultPreview}
           browseButtonText="Upload"
+          textAreaPlaceholder={hasPlaceholderText ? "File preview" : ''}
         >
           {children && (
             <div className="pf-u-m-md">(A custom preview of the uploaded file can be passed as children)</div>


### PR DESCRIPTION
Adds placeholder and onBlur event to the TextArea within the FileUploadField component

Signed-off-by: Tomas Psota <tpsota@redhat.com>

<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7004 

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
