### PR TITLE
Revert BaseLayout startLayout method back to protected.

### DIFF
--- a/packages/react-topology/src/layouts/BaseLayout.ts
+++ b/packages/react-topology/src/layouts/BaseLayout.ts
@@ -400,7 +400,12 @@ export class BaseLayout implements Layout {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public startLayout(graph: Graph, initialRun: boolean, addingNodes: boolean, onEnd?: () => void): void {}
+  protected startLayout(graph: Graph, initialRun: boolean, addingNodes: boolean, onEnd?: () => void): void {}
+
+  // Interim, remove and update startLayout to public in next breaking change build
+  public doStartLayout(graph: Graph, initialRun: boolean, addingNodes: boolean, onEnd?: () => void): void {
+    return this.startLayout(graph, initialRun, addingNodes, onEnd);
+  }
 
   protected updateLayout(): void {
     this.forceSimulation.useForceSimulation(this.nodes, this.edges, this.getFixedNodeDistance);

--- a/packages/react-topology/src/layouts/BreadthFirstLayout.ts
+++ b/packages/react-topology/src/layouts/BreadthFirstLayout.ts
@@ -32,7 +32,7 @@ export class BreadthFirstLayout extends BaseLayout implements Layout {
     return new BreadthFirstGroup(node, padding, index);
   }
 
-  public startLayout(graph: Graph, initialRun: boolean, addingNodes: boolean): void {
+  protected startLayout(graph: Graph, initialRun: boolean, addingNodes: boolean): void {
     if (initialRun || addingNodes) {
       // Breath First algorithm
 

--- a/packages/react-topology/src/layouts/ColaGroupsLayout.ts
+++ b/packages/react-topology/src/layouts/ColaGroupsLayout.ts
@@ -179,7 +179,7 @@ class ColaGroupsLayout extends ColaLayout implements Layout {
     addingNodes: boolean
   ): Promise<void> {
     return new Promise<void>(resolve => {
-      childLayout.startLayout(graph, initialRun, addingNodes, () => {
+      childLayout.doStartLayout(graph, initialRun, addingNodes, () => {
         resolve();
       });
     });

--- a/packages/react-topology/src/layouts/ColaLayout.ts
+++ b/packages/react-topology/src/layouts/ColaLayout.ts
@@ -186,7 +186,7 @@ class ColaLayout extends BaseLayout implements Layout {
     );
   }
 
-  public startLayout(graph: Graph, initialRun: boolean, addingNodes: boolean, onEnd?: () => void): void {
+  protected startLayout(graph: Graph, initialRun: boolean, addingNodes: boolean, onEnd?: () => void): void {
     this.onEnd = onEnd;
     if (!this.simulationStopped) {
       this.startColaLayout(initialRun, addingNodes);

--- a/packages/react-topology/src/layouts/ConcentricLayout.ts
+++ b/packages/react-topology/src/layouts/ConcentricLayout.ts
@@ -34,7 +34,7 @@ export class ConcentricLayout extends BaseLayout implements Layout {
     return new ConcentricGroup(node, padding, index);
   }
 
-  public startLayout(graph: Graph, initialRun: boolean, addingNodes: boolean): void {
+  protected startLayout(graph: Graph, initialRun: boolean, addingNodes: boolean): void {
     if (initialRun || addingNodes) {
       const weights = {};
       this.nodes.forEach(node => {

--- a/packages/react-topology/src/layouts/DagreLayout.ts
+++ b/packages/react-topology/src/layouts/DagreLayout.ts
@@ -52,7 +52,7 @@ export class DagreLayout extends BaseLayout implements Layout {
     return [];
   }
 
-  public startLayout(graph: Graph, initialRun: boolean, addingNodes: boolean): void {
+  protected startLayout(graph: Graph, initialRun: boolean, addingNodes: boolean): void {
     if (initialRun || addingNodes) {
       const dagreGraph = new dagre.graphlib.Graph({ compound: true });
       dagreGraph.setGraph(_.omit(this.dagreOptions, Object.keys(LAYOUT_DEFAULTS)));

--- a/packages/react-topology/src/layouts/ForceLayout.ts
+++ b/packages/react-topology/src/layouts/ForceLayout.ts
@@ -28,7 +28,7 @@ export class ForceLayout extends BaseLayout implements Layout {
     return distance;
   };
 
-  public startLayout(graph: Graph): void {
+  protected startLayout(graph: Graph): void {
     const { width, height } = graph.getBounds();
     const cx = width / 2;
     const cy = height / 2;

--- a/packages/react-topology/src/layouts/GridLayout.ts
+++ b/packages/react-topology/src/layouts/GridLayout.ts
@@ -32,7 +32,7 @@ export class GridLayout extends BaseLayout implements Layout {
     return new GridGroup(node, padding, index);
   }
 
-  public startLayout(graph: Graph, initialRun: boolean, addingNodes: boolean): void {
+  protected startLayout(graph: Graph, initialRun: boolean, addingNodes: boolean): void {
     if (initialRun || addingNodes) {
       this.nodes.sort((a, b) => a.id.localeCompare(b.id));
       const totalNodes = this.nodes.length;


### PR DESCRIPTION
**What**: 
Closes https://github.com/patternfly/patternfly-react/issues/7406

Changes the BaseLayout.startLayout method back to protected. Added an interim public method that can be used to access the startLayout method.