### PR TITLE
fix(Modal): tooltip visibility on modal open

### DIFF
--- a/packages/react-core/src/components/Modal/ModalBoxTitle.tsx
+++ b/packages/react-core/src/components/Modal/ModalBoxTitle.tsx
@@ -37,7 +37,7 @@ export const ModalBoxTitle: React.FunctionComponent<ModalBoxTitleProps> = ({
   titleLabel = '',
   ...props
 }: ModalBoxTitleProps) => {
-  const [isTooltipVisible, setIsTooltipVisible] = React.useState(false);
+  const [hasTooltip, setHasTooltip] = React.useState(false);
   const h1 = React.useRef<HTMLHeadingElement>();
   const label = titleLabel || (isVariantIcon(titleIconVariant) ? `${capitalize(titleIconVariant)} alert:` : titleLabel);
   const variantIcons = {
@@ -50,7 +50,7 @@ export const ModalBoxTitle: React.FunctionComponent<ModalBoxTitleProps> = ({
   const CustomIcon = !isVariantIcon(titleIconVariant) && titleIconVariant;
 
   useIsomorphicLayoutEffect(() => {
-    setIsTooltipVisible(h1.current && h1.current.offsetWidth < h1.current.scrollWidth);
+    setHasTooltip(h1.current && h1.current.offsetWidth < h1.current.scrollWidth);
   }, []);
 
   const content = (
@@ -70,12 +70,6 @@ export const ModalBoxTitle: React.FunctionComponent<ModalBoxTitleProps> = ({
     </h1>
   );
 
-  return isTooltipVisible ? (
-    <Tooltip content={title} isVisible>
-      {content}
-    </Tooltip>
-  ) : (
-    content
-  );
+  return hasTooltip ? <Tooltip content={title}>{content}</Tooltip> : content;
 };
 ModalBoxTitle.displayName = 'ModalBoxTitle';


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7112 

While this PR resolves the issue linked, this does potentially produce a problem for keyboard users as they will be unable to display the tooltip since the title can't be focused. If this would be considered an issue (which if tooltips are being utilized, there's argument that the modal title *is* important), one solution to this would be to add `{...(hasTooltip && { tabIndex: 0 })}` on the ModalBoxTitle component so that keyboard users can tab to the title. This, however, a) goes against recommendations of not using tooltip on static elements (*this* could be resolved with a quick "don't use tooltips on static elements, except in cases of truncation"), and b) could also affect tests, as whether the title is focusable would have to be determined (though this might be easier to handle as it's more a case of taking into account an extra Tab press or not rather than a tooltip that blocks an unknown part of the page).

Another option would be to re-visit whether Modal titles should be truncated, or possibly adding a button that can be clicked to reveal the tooltip with the entire title contents (more of a popover/toggletip, though).

To test this fix:

1. Go to the [Modal preview build]() (link will be edited in upon build)
2. Copy the code below and replace the code in the first example code editor with it
3. Open the modal and notice that the tooltip does not automatically display

<details>
<summary>Click to display code block</summary>

```
import React from "react";
import { Modal, ModalVariant, Button, Bullseye } from "@patternfly/react-core";

class LargeModal extends React.Component {
  constructor(props) {
    super(props);
    this.state = {
      isModalOpen: false
    };
    this.handleModalToggle = () => {
      this.setState(({ isModalOpen }) => ({
        isModalOpen: !isModalOpen
      }));
    };
  }

  render() {
    const { isModalOpen } = this.state;

    return (
      <React.Fragment>
        <Bullseye>
          <Button variant="primary" onClick={this.handleModalToggle}>
            Show medium modal
          </Button>
        </Bullseye>
        <Modal
          variant={ModalVariant.medium}
          title="Very long title such that it overflows and causes the text to be shortened using an elipsis."
          isOpen={isModalOpen}
          onClose={this.handleModalToggle}
          actions={[
            <Button
              key="confirm"
              variant="primary"
              onClick={this.handleModalToggle}
            >
              Confirm
            </Button>,
            <Button
              key="cancel"
              variant="link"
              onClick={this.handleModalToggle}
            >
              Cancel
            </Button>
          ]}
        >
          Notice how clicking the button to open the modal shows a tooltip on
          the title and does not hide it until you hover over the title again.
        </Modal>
      </React.Fragment>
    );
  }
}
```

</details>

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
