### PR TITLE
chore(charts): Add @public and @private annotations

### DIFF
--- a/packages/react-charts/src/components/ChartUtils/chart-container.tsx
+++ b/packages/react-charts/src/components/ChartUtils/chart-container.tsx
@@ -23,6 +23,7 @@ import { LineSegment } from 'victory-core';
  *
  * @param {string} behaviorA 'brush', 'cursor', 'selection', 'voronoi', or 'zoom'
  * @param {string} behaviorB 'brush', 'cursor', 'selection', 'voronoi', or 'zoom'
+ * @public
  */
 export const createContainer = (behaviorA: ContainerType, behaviorB: ContainerType) => {
   const container: any = victoryCreateContainer(behaviorA, behaviorB);

--- a/packages/react-charts/src/components/ChartUtils/chart-domain.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-domain.ts
@@ -23,7 +23,10 @@ export interface ChartDomain {
   y: [number, number];
 }
 
-// Returns the min and max domain for given data
+/**
+ * Returns the min and max domain for given data
+ * @private
+ */
 export const getDomain = ({ data, maxDomain, minDomain, x, y }: DomainInterface): ChartDomain => {
   // x-domain
   let xLow = 0;
@@ -92,6 +95,10 @@ export const getDomain = ({ data, maxDomain, minDomain, x, y }: DomainInterface)
   return { x: [xLow, xHigh], y: [yLow, yHigh] };
 };
 
+/**
+ * Returns the domain for given min and max properties
+ * @private
+ */
 export const getDomains = ({ maxDomain, minDomain, sources }: SourcesInterface): ChartDomain => {
   const domains: ChartDomain[] = [];
   sources.forEach(source => {

--- a/packages/react-charts/src/components/ChartUtils/chart-helpers.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-helpers.ts
@@ -4,10 +4,16 @@ interface ChartClassNameInterface {
   className?: string;
 }
 
-// Copied from exenv
+/**
+ * Copied from exenv
+ * @private
+ */
 export const canUseDOM = !!(typeof window !== 'undefined' && window.document && window.document.createElement);
 
-// Returns the class name that will be applied to the outer-most div rendered by the chart's container
+/**
+ * Returns the class name that will be applied to the outer-most div rendered by the chart's container
+ * @private
+ */
 export const getClassName = ({ className }: ChartClassNameInterface) => {
   let cleanClassName;
 

--- a/packages/react-charts/src/components/ChartUtils/chart-interactive-legend.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-interactive-legend.ts
@@ -19,7 +19,10 @@ interface ChartInteractiveLegendExtInterface extends ChartInteractiveLegendInter
   target?: 'data' | 'labels'; // Event target
 }
 
-// Returns child names for each series, except given ID index
+/**
+ * Returns child names for each series, except given ID index
+ * @private
+ */
 const getChildNames = ({ chartNames, omitIndex }: ChartInteractiveLegendExtInterface) => {
   const result = [] as any;
   chartNames.map((chartName: any, index: number) => {
@@ -34,7 +37,12 @@ const getChildNames = ({ chartNames, omitIndex }: ChartInteractiveLegendExtInter
   return result;
 };
 
-// Returns events for an interactive legend
+/**
+ * Returns events for an interactive legend
+ *
+ * @param props See ChartInteractiveLegendInterface
+ * @public
+ */
 export const getInteractiveLegendEvents = (props: ChartInteractiveLegendInterface) => [
   ...getInteractiveLegendTargetEvents({ ...props, target: 'data' }),
   ...getInteractiveLegendTargetEvents({ ...props, target: 'labels' })
@@ -51,7 +59,10 @@ const getInteractiveLegendItems = ({ chartNames, omitIndex }: ChartInteractiveLe
   return result;
 };
 
-// Returns styles for interactive legend items
+/**
+ * Returns styles for interactive legend items
+ * @private
+ */
 export const getInteractiveLegendItemStyles = (hidden = false) =>
   !hidden
     ? {}

--- a/packages/react-charts/src/components/ChartUtils/chart-label.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-label.ts
@@ -29,11 +29,17 @@ interface ChartLabelTextSizeInterface {
   theme: ChartThemeDefinition; // The theme that will be applied to the chart
 }
 
-// Returns x coordinate for bullet labels
+/**
+ * Returns x coordinate for bullet labels
+ * @private
+ */
 export const getBulletLabelX = ({ chartWidth, dx = 0, labelPosition }: ChartBulletLabelInterface) =>
   labelPosition === 'top' && chartWidth ? Math.round(chartWidth / 2) : dx;
 
-// Returns y coordinate for bullet labels
+/**
+ * Returns y coordinate for bullet labels
+ * @private
+ */
 export const getBulletLabelY = ({ chartHeight, dy = 0, labelPosition }: ChartBulletLabelInterface) => {
   switch (labelPosition) {
     case 'bottom':
@@ -45,7 +51,10 @@ export const getBulletLabelY = ({ chartHeight, dy = 0, labelPosition }: ChartBul
   }
 };
 
-// Returns x coordinate for pie labels
+/**
+ * Returns x coordinate for pie labels
+ * @private
+ */
 export const getPieLabelX = ({
   dx = 0,
   height,
@@ -75,7 +84,10 @@ export const getPieLabelX = ({
   }
 };
 
-// Returns x coordinate for pie labels
+/**
+ * Returns x coordinate for pie labels
+ * @private
+ */
 export const getPieLabelY = ({ dy = 0, height, labelPosition, padding, width }: ChartPieLabelInterface) => {
   const origin = getPieOrigin({ height, padding, width });
   const radius = Helpers.getRadius({ height, width, padding });
@@ -91,7 +103,10 @@ export const getPieLabelY = ({ dy = 0, height, labelPosition, padding, width }: 
   }
 };
 
-// Returns an approximate size for the give text
+/**
+ * Returns an approximate size for the give text
+ * @private
+ */
 export const getLabelTextSize = ({ text, theme }: ChartLabelTextSizeInterface): { height: number; width: number } => {
   const style: any = theme.legend.style.labels;
 

--- a/packages/react-charts/src/components/ChartUtils/chart-legend.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-legend.ts
@@ -46,7 +46,10 @@ interface ChartLegendTextMaxSizeInterface {
   theme: ChartThemeDefinition; // The theme that will be applied to the chart
 }
 
-// Returns a legend which has been positioned per the given chart properties
+/**
+ * Returns a legend which has been positioned per the given chart properties
+ * @private
+ */
 export const getComputedLegend = ({
   allowWrap = true,
   chartType = 'chart',
@@ -122,7 +125,10 @@ export const getComputedLegend = ({
   return React.cloneElement(legendComponent, legendProps);
 };
 
-// Returns legend dimensions
+/**
+ * Returns legend dimensions
+ * @private
+ */
 export const getLegendDimensions = ({
   legendData,
   legendOrientation,
@@ -140,7 +146,10 @@ export const getLegendDimensions = ({
   return {};
 };
 
-// Returns true if the legend is smaller than its container
+/**
+ * Returns true if the legend is smaller than its container
+ * @private
+ */
 export const doesLegendFit = ({
   dx = 0,
   height,
@@ -179,7 +188,10 @@ export const doesLegendFit = ({
   return width - occupiedWidth > legendDimensions.width;
 };
 
-// Returns the number of legend items per row
+/**
+ * Returns the number of legend items per row
+ * @private
+ */
 export const getLegendItemsPerRow = ({
   dx,
   height,
@@ -215,11 +227,17 @@ export const getLegendItemsPerRow = ({
   return itemsPerRow;
 };
 
-// Returns x coordinate for legend
+/**
+ * Returns x coordinate for legend
+ * @private
+ */
 export const getLegendX = ({ chartType, ...rest }: ChartLegendPositionInterface) =>
   chartType === 'pie' ? getPieLegendX(rest) : getChartLegendX(rest);
 
-// Returns y coordinate for legend
+/**
+ * Returns y coordinate for legend
+ * @private
+ */
 export const getLegendY = ({ chartType, ...rest }: ChartLegendPositionInterface) => {
   switch (chartType) {
     case 'pie':
@@ -231,7 +249,10 @@ export const getLegendY = ({ chartType, ...rest }: ChartLegendPositionInterface)
   }
 };
 
-// Returns y coordinate for bullet legends
+/**
+ * Returns y coordinate for bullet legends
+ * @private
+ */
 export const getBulletLegendY = ({
   dy = 0,
   height,
@@ -269,7 +290,10 @@ export const getBulletLegendY = ({
   }
 };
 
-// Returns x coordinate for chart legends
+/**
+ * Returns x coordinate for chart legends
+ * @private
+ */
 export const getChartLegendX = ({
   dx = 0,
   height,
@@ -305,7 +329,10 @@ export const getChartLegendX = ({
   }
 };
 
-// Returns y coordinate for chart legends
+/**
+ * Returns y coordinate for chart legends
+ * @private
+ */
 export const getChartLegendY = ({
   dy = 0,
   height,
@@ -344,7 +371,10 @@ export const getChartLegendY = ({
   }
 };
 
-// Returns x coordinate for pie legends
+/**
+ * Returns x coordinate for pie legends
+ * @private
+ */
 export const getPieLegendX = ({
   dx = 0,
   height,
@@ -375,7 +405,10 @@ export const getPieLegendX = ({
   }
 };
 
-// Returns y coordinate for pie legends
+/**
+ * Returns y coordinate for pie legends
+ * @private
+ */
 export const getPieLegendY = ({
   dy = 0,
   height,
@@ -409,7 +442,10 @@ export const getPieLegendY = ({
   }
 };
 
-// Returns an approximation of longest text width based on legend styles
+/**
+ * Returns an approximation of longest text width based on legend styles
+ * @private
+ */
 export const getMaxLegendTextSize = ({ legendData, theme }: ChartLegendTextMaxSizeInterface) => {
   const style: any = theme && theme.legend && theme.legend.style ? theme.legend.style.labels : undefined;
   if (!(legendData && legendData.length)) {

--- a/packages/react-charts/src/components/ChartUtils/chart-origin.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-origin.ts
@@ -6,8 +6,11 @@ interface ChartPieOriginInterface {
   width: number; // Chart width
 }
 
-// Returns the origin for pie based charts. For example, something with a radius such as pie, donut, donut utilization,
-// and donut threshold.
+/**
+ * Returns the origin for pie based charts. For example, something with a radius such as pie, donut, donut utilization,
+ * and donut threshold.
+ * @private
+ */
 export const getPieOrigin = ({ height, padding, width }: ChartPieOriginInterface) => {
   const { top, bottom, left, right } = Helpers.getPadding({ padding });
   const radius = Helpers.getRadius({ height, width, padding });

--- a/packages/react-charts/src/components/ChartUtils/chart-padding.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-padding.ts
@@ -1,5 +1,9 @@
 import { PaddingProps } from 'victory-core';
 
+/**
+ * Helper function to return padding style properties
+ * @private
+ */
 export const getPaddingForSide = (
   side: 'bottom' | 'left' | 'right' | 'top',
   padding: PaddingProps,

--- a/packages/react-charts/src/components/ChartUtils/chart-resize.tsx
+++ b/packages/react-charts/src/components/ChartUtils/chart-resize.tsx
@@ -59,6 +59,7 @@ import { canUseDOM } from './chart-helpers';
  * @param {Element} containerRefElement The container reference to observe
  * @param {Function} handleResize The function to call for resize events
  * @return {Function} The function used to unobserve resize events
+ * @private
  */
 export const getResizeObserver = (containerRefElement: Element, handleResize: () => void) => {
   let unobserve: any;

--- a/packages/react-charts/src/components/ChartUtils/chart-theme.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-theme.ts
@@ -36,6 +36,7 @@ import {
  * Apply custom properties to base and color themes
  *
  * @deprecated Use mergeTheme
+ * @public
  */
 export const getCustomTheme = (
   themeColor: string,
@@ -43,49 +44,87 @@ export const getCustomTheme = (
   customTheme: ChartThemeDefinition
 ): ChartThemeDefinition => mergeTheme(themeColor, customTheme);
 
-// Merge custom properties with base and color themes
+/**
+ * Merge custom properties with base and color themes
+ * @param themeColor The theme color to merge with custom theme
+ * @param customTheme The custom theme to merge
+ * @public
+ */
 export const mergeTheme = (themeColor: string, customTheme: ChartThemeDefinition): ChartThemeDefinition =>
   merge(getTheme(themeColor), customTheme);
 
-// Returns axis theme
+/**
+ * Returns axis theme
+ * @private
+ */
 export const getAxisTheme = (themeColor: string): ChartThemeDefinition => mergeTheme(themeColor, ChartAxisTheme);
 
-// Returns bullet chart theme
+/**
+ * Returns bullet chart theme
+ * @private
+ */
 export const getBulletTheme = (themeColor: string): ChartThemeDefinition => mergeTheme(themeColor, ChartBulletTheme);
 
-// Returns comparative error measure theme for bullet chart
+/**
+ * Returns comparative error measure theme for bullet chart
+ * @private
+ */
 export const getBulletComparativeErrorMeasureTheme = (themeColor: string): ChartThemeDefinition =>
   mergeTheme(themeColor, ChartBulletComparativeErrorMeasureTheme);
 
-// Returns comparative measure theme for bullet chart
+/**
+ * Returns comparative measure theme for bullet chart
+ * @private
+ */
 export const getBulletComparativeMeasureTheme = (themeColor: string): ChartThemeDefinition =>
   mergeTheme(themeColor, ChartBulletComparativeMeasureTheme);
 
-// Returns comparative warning measure theme for bullet chart
+/**
+ * Returns comparative warning measure theme for bullet chart
+ * @private
+ */
 export const getBulletComparativeWarningMeasureTheme = (themeColor: string): ChartThemeDefinition =>
   mergeTheme(themeColor, ChartBulletComparativeWarningMeasureTheme);
 
-// Returns group title theme for bullet chart
+/**
+ * Returns group title theme for bullet chart
+ * @private
+ */
 export const getBulletGroupTitleTheme = (themeColor: string): ChartThemeDefinition =>
   mergeTheme(themeColor, ChartBulletGroupTitleTheme);
 
-// Returns primary dot measure theme for bullet chart
+/**
+ * Returns primary dot measure theme for bullet chart
+ * @private
+ */
 export const getBulletPrimaryDotMeasureTheme = (themeColor: string): ChartThemeDefinition =>
   mergeTheme(themeColor, ChartBulletPrimaryDotMeasureTheme);
 
-// Returns primary negative measure theme for bullet chart
+/**
+ * Returns primary negative measure theme for bullet chart
+ * @private
+ */
 export const getBulletPrimaryNegativeMeasureTheme = (themeColor: string): ChartThemeDefinition =>
   mergeTheme(themeColor, ChartBulletPrimaryNegativeMeasureTheme);
 
-// Returns primary segmented measure theme for bullet chart
+/**
+ * Returns primary segmented measure theme for bullet chart
+ * @private
+ */
 export const getBulletPrimarySegmentedMeasureTheme = (themeColor: string): ChartThemeDefinition =>
   mergeTheme(themeColor, ChartBulletPrimarySegmentedMeasureTheme);
 
-// Returns qualitative range theme for bullet chart
+/**
+ * Returns qualitative range theme for bullet chart
+ * @private
+ */
 export const getBulletQualitativeRangeTheme = (themeColor: string): ChartThemeDefinition =>
   mergeTheme(themeColor, ChartBulletQualitativeRangeTheme);
 
-// Returns theme for Chart component
+/**
+ * Returns theme for Chart component
+ * @private
+ */
 export const getChartTheme = (themeColor: string, showAxis: boolean): ChartThemeDefinition => {
   const theme = getTheme(themeColor);
 
@@ -103,9 +142,17 @@ export const getChartTheme = (themeColor: string, showAxis: boolean): ChartTheme
 };
 
 // Returns donut theme
+/**
+ *
+ * @private
+ */
 export const getDonutTheme = (themeColor: string): ChartThemeDefinition => mergeTheme(themeColor, ChartDonutTheme);
 
 // Returns dynamic donut threshold theme
+/**
+ *
+ * @private
+ */
 export const getDonutThresholdDynamicTheme = (themeColor: string): ChartThemeDefinition => {
   const theme = mergeTheme(themeColor, ChartDonutThresholdDynamicTheme);
 
@@ -117,7 +164,10 @@ export const getDonutThresholdDynamicTheme = (themeColor: string): ChartThemeDef
   return theme;
 };
 
-// Returns static donut threshold theme
+/**
+ * Returns static donut threshold theme
+ * @private
+ */
 export const getDonutThresholdStaticTheme = (themeColor: string, invert?: boolean): ChartThemeDefinition => {
   const staticTheme = cloneDeep(ChartDonutThresholdStaticTheme);
   if (invert && staticTheme.pie.colorScale instanceof Array) {
@@ -126,7 +176,10 @@ export const getDonutThresholdStaticTheme = (themeColor: string, invert?: boolea
   return mergeTheme(themeColor, staticTheme);
 };
 
-// Returns donut utilization theme
+/**
+ * Returns donut utilization theme
+ * @private
+ */
 export const getDonutUtilizationTheme = (themeColor: string): ChartThemeDefinition => {
   const theme = mergeTheme(themeColor, ChartDonutUtilizationDynamicTheme);
 
@@ -136,7 +189,10 @@ export const getDonutUtilizationTheme = (themeColor: string): ChartThemeDefiniti
   return theme;
 };
 
-// Returns theme colors
+/**
+ * Returns theme colors
+ * @private
+ */
 export const getThemeColors = (themeColor: string) => {
   switch (themeColor) {
     case ChartThemeColor.blue:
@@ -163,7 +219,10 @@ export const getThemeColors = (themeColor: string) => {
   }
 };
 
-// Applies theme color and variant to base theme
+/**
+ * Applies theme color to base theme
+ * @private
+ */
 export const getTheme = (themeColor: string): ChartThemeDefinition => {
   // Deep clone
   const baseTheme = {
@@ -172,6 +231,9 @@ export const getTheme = (themeColor: string): ChartThemeDefinition => {
   return merge(baseTheme, getThemeColors(themeColor));
 };
 
-// Returns threshold theme
+/**
+ * Returns threshold theme
+ * @private
+ */
 export const getThresholdTheme = (themeColor: string): ChartThemeDefinition =>
   mergeTheme(themeColor, ChartThresholdTheme);

--- a/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
@@ -43,6 +43,7 @@ interface ChartLegendTooltipVisibleTextInterface {
  * When using a cursor container, the tooltip can be offset from the cursor point. If offsetCursorDimensionX is true,
  * the tooltip will appear to the right the vertical cursor. If offsetCursorDimensionY is true, the tooltip will appear
  * above the vertical cursor.
+ * @private
  */
 export const getCursorTooltipCenterOffset = ({
   offsetCursorDimensionX = false,
@@ -68,6 +69,7 @@ export const getCursorTooltipCenterOffset = ({
  * When using a cursor container, the tooltip pointer orientation can be adjusted as the cursor approaches the edge of
  * the chart. If horizontal is true, the tooltip pointer will either be 'left' or 'right'. If horizontal is true, the
  * tooltip pointer will either be 'top' or 'bottom'.
+ * @private
  */
 export const getCursorTooltipPoniterOrientation = ({
   horizontal = true,
@@ -81,7 +83,10 @@ export const getCursorTooltipPoniterOrientation = ({
   return horizontal ? orientationX : orientationY;
 };
 
-// Returns props associated with legend data
+/**
+ * Returns props associated with legend data
+ * @private
+ */
 export const getLegendTooltipDataProps = (defaultProps: ChartLegendProps) => ({
   borderPadding: 0,
   gutter: 0,
@@ -102,7 +107,10 @@ export const getLegendTooltipDataProps = (defaultProps: ChartLegendProps) => ({
   ...defaultProps
 });
 
-// Returns the legend height and width
+/**
+ * Returns the legend height and width
+ * @private
+ */
 export const getLegendTooltipSize = ({
   legendData,
   legendOrientation = 'vertical',
@@ -194,8 +202,11 @@ export const getLegendTooltipSize = ({
   };
 };
 
-// Returns visible legend data, while syncing color scale. If textAsLegendData is true, the text prop is used as
-// legend data so y values can be passed individually to the label component
+/**
+ * Returns visible legend data, while syncing color scale. If textAsLegendData is true, the text prop is used as
+ * legend data so y values can be passed individually to the label component
+ * @private
+ */
 export const getLegendTooltipVisibleData = ({
   activePoints,
   colorScale,
@@ -238,7 +249,10 @@ export const getLegendTooltipVisibleData = ({
   return result;
 };
 
-// Returns visible text for interactive legends
+/**
+ * Returns visible text for interactive legends
+ * @private
+ */
 export const getLegendTooltipVisibleText = ({
   activePoints,
   legendData,


### PR DESCRIPTION
Each chart component has a set of props documented by react-docs, which is considered the public API. However, there are a couple functions we promote in our examples (e.g., `createContainer`, `getCustomTheme`, etc.).

We don't currently generate JavaScript docs, but want to add the standard `@private` and `@public` annotations in the code comments. The intention is to help clarify what functions are considered public, so we don't introduce breaking changes.

Closes https://github.com/patternfly/patternfly-react/issues/7412
