### PR TITLE
docs: demo page updates

### DIFF
--- a/packages/react-core/src/demos/Card/Card.md
+++ b/packages/react-core/src/demos/Card/Card.md
@@ -4,7 +4,7 @@ section: demos
 ---
 
 import DashboardWrapper from '../examples/DashboardWrapper';
-
+import { Label, LabelGroup } from '@patternfly/react-core';
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import TrashIcon from '@patternfly/react-icons/dist/esm/icons/trash-icon';
 import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
@@ -21,9 +21,31 @@ import restIcon from './FuseConnector_Icons_REST.png';
 
 ## Demos
 
-This demonstrates how you can assemble a full page view that contains a grid of equal sized cards that includes a toolbar for managing card grid contents.
+This page contains demo(s) that utilize multiple Patternfly components to showcase various use cases not covered under a single component, as well as how components may be used together to achieve a specific purpose in application-style content.
 
 ### Card view
+
+This full page demo view contains a grid of equal sized cards with a toolbar for managing the card grid compnenents. It contains the following components:
+
+<LabelGroup categoryName="Components">
+<Label variant="outline">[Button](/components/button)</Label>
+<Label variant="outline">[Card](/components/card)</Label>
+<Label variant="outline">[Checkbox](/components/checkbox)</Label>
+<Label variant="outline">[Dropdown](/components/dropdown)</Label>
+<Label variant="outline">[EmptyState](/components/empty-state)</Label>
+<Label variant="outline">[OverflowMenu](/components/overflow-menu)</Label>
+<Label variant="outline">[Page](/components/page)</Label>
+<Label variant="outline">[Pagination](/components/pagination)</Label>
+<Label variant="outline">[Select](/components/select)</Label>
+<Label variant="outline">[Text](/components/text)</Label>
+<Label variant="outline">[Title](/components/title)</Label>
+<Label variant="outline">[Toolbar](/components/toolbar)</Label>
+</LabelGroup>
+<br/>
+<LabelGroup categoryName="Layouts">
+<Label variant="outline">[Bullseye](/layouts/bullseye)</Label>
+<Label variant="outline">[Gallery](/layouts/gallery)</Label>
+</LabelGroup>
 
 ```js isFullscreen
 import React from 'react';

--- a/packages/react-core/src/demos/ComposableMenu/ComposableMenu.md
+++ b/packages/react-core/src/demos/ComposableMenu/ComposableMenu.md
@@ -5,6 +5,8 @@ section: demos
 
 import { Link } from '@reach/router';
 
+import { Label, LabelGroup } from '@patternfly/react-core';
+
 import CogIcon from '@patternfly/react-icons/dist/esm/icons/cog-icon';
 import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
 import TableIcon from '@patternfly/react-icons/dist/esm/icons/table-icon';
@@ -23,63 +25,169 @@ import avatarImg from './examples/avatarImg.svg';
 
 ## Demos
 
+This page contains demo(s) that utilize multiple Patternfly components to showcase various use cases not covered under a single component, as well as how components may be used together to achieve a specific purpose in application-style content.
+
 Composable menus currently require consumer keyboard handling and use of our undocumented [popper.js](https://popper.js.org/) wrapper component called Popper. We understand this is inconvientent boilerplate and these examples will be updated to use [Dropdown](/components/dropdown) in a future release.
 
 ### Composable simple dropdown
+
+This demo showcases a simple dropdown, and contains the following components:
+
+<LabelGroup categoryName="Components">
+<Label variant="outline">[Menu](/components/menu)</Label>
+<Label variant="outline">[MenuToggle](/components/menu-toggle)</Label>
+<Label variant="outline">[Popper (not exported yet)](/components/popper)</Label>
+</LabelGroup>
 
 ```ts file="./examples/ComposableSimpleDropdown.tsx"
 ```
 
 ### Composable actions menu
 
+This demo showcases a dropdown action menu, and contains the following components:
+
+<LabelGroup categoryName="Components">
+<Label variant="outline">[Menu](/components/menu)</Label>
+<Label variant="outline">[MenuToggle](/components/menu-toggle)</Label>
+<Label variant="outline">[Popper (not exported yet)](/components/popper)</Label>
+</LabelGroup>
+
 ```ts file="./examples/ComposableActionsMenu.tsx"
 ```
 
 ### Composable simple select
+
+This demo showcases a simple single select, and contains the following components:
+
+<LabelGroup categoryName="Components">
+<Label variant="outline">[Menu](/components/menu)</Label>
+<Label variant="outline">[MenuToggle](/components/menu-toggle)</Label>
+<Label variant="outline">[Popper (not exported yet)](/components/popper)</Label>
+</LabelGroup>
 
 ```ts file="./examples/ComposableSimpleSelect.tsx"
 ```
 
 ### Composable drilldown menu
 
+This demo showcases a drilldown menu, and contains the following components:
+
+<LabelGroup categoryName="Components">
+<Label variant="outline">[Menu](/components/menu)</Label>
+<Label variant="outline">[MenuToggle](/components/menu-toggle)</Label>
+<Label variant="outline">[Divider](/components/divider)</Label>
+<Label variant="outline">[Popper (not exported yet)](/components/popper)</Label>
+</LabelGroup>
+
 ```ts isBeta file="./examples/ComposableDrilldownMenu.tsx"
 ```
 
 ### Composable tree view menu
 
-When rendering a menu-like element that does not contain MenuItem components, [Panel](/components/panel) allows more flexible control and customization.
+This demo showcases a menu containing multiple tree views. When rendering a menu-like element that does not contain MenuItem components, [Panel](/components/panel) allows more flexible control and customization.
+
+It contains the following components:
+
+<LabelGroup categoryName="Components">
+<Label variant="outline">[Panel](/components/panel)</Label>
+<Label variant="outline">[MenuToggle](/components/menu-toggle)</Label>
+<Label variant="outline">[Title](/components/title)</Label>
+<Label variant="outline">[TreeView](/components/tree-view)</Label>
+<Label variant="outline">[Popper (not exported yet)](/components/popper)</Label>
+</LabelGroup>
 
 ```ts file="./examples/ComposableTreeViewMenu.tsx"
 ```
 
 ### Composable flyout
 
+This demo showcases a menu containing multiple flyouts.
+
 The flyout will automatically position to the left or top if it would otherwise go outside the window. The menu must be placed in a container outside the main content like Popper, [Popover](/components/popover) or [Tooltip](/components/tooltip) since it may go over the side nav.
+
+It contains the following components:
+
+<LabelGroup categoryName="Components">
+<Label variant="outline">[Menu](/components/menu)</Label>
+<Label variant="outline">[MenuToggle](/components/menu-toggle)</Label>
+<Label variant="outline">[Popper (not exported yet)](/components/popper)</Label>
+</LabelGroup>
 
 ```ts isBeta file="./examples/ComposableFlyout.tsx"
 ```
 
 ### Composable application launcher
 
+This demo showcases an application launcher, and contains the following components:
+
+<LabelGroup categoryName="Components">
+<Label variant="outline">[Menu](/components/menu)</Label>
+<Label variant="outline">[MenuToggle](/components/menu-toggle)</Label>
+<Label variant="outline">[Tooltip](/components/tooltip)</Label>
+<Label variant="outline">[Divider](/components/divider)</Label>
+<Label variant="outline">[TextInput](/components/text-input)</Label>
+<Label variant="outline">[Popper (not exported yet)](/components/popper)</Label>
+</LabelGroup>
+
 ```ts file="./examples/ComposableApplicationLauncher.tsx"
 ```
 
 ### Composable context selector
+
+This demo showcases a context selector, and contains the following components:
+
+<LabelGroup categoryName="Components">
+<Label variant="outline">[Menu](/components/menu)</Label>
+<Label variant="outline">[MenuToggle](/components/menu-toggle)</Label>
+<Label variant="outline">[Divider](/components/divider)</Label>
+<Label variant="outline">[TextInput](/components/text-input)</Label>
+<Label variant="outline">[InputGroup](/components/input-group)</Label>
+<Label variant="outline">[Button](/components/button)</Label>
+<Label variant="outline">[Popper (not exported yet)](/components/popper)</Label>
+</LabelGroup>
 
 ```ts file="./examples/ComposableContextSelector.tsx"
 ```
 
 ### Composable options menu variants
 
+This demo showcases an options menu, and contains the following components:
+
+<LabelGroup categoryName="Components">
+<Label variant="outline">[Menu](/components/menu)</Label>
+<Label variant="outline">[MenuToggle](/components/menu-toggle)</Label>
+<Label variant="outline">[Divider](/components/divider)</Label>
+<Label variant="outline">[Popper (not exported yet)](/components/popper)</Label>
+</LabelGroup>
+
 ```ts file="./examples/ComposableOptionsMenuVariants.tsx"
 ```
 
 ### Composable dropdown variants
 
+This demo showcases a several dropdown variants, and contains the following components:
+
+<LabelGroup categoryName="Components">
+<Label variant="outline">[Menu](/components/menu)</Label>
+<Label variant="outline">[MenuToggle](/components/menu-toggle)</Label>
+<Label variant="outline">[Divider](/components/divider)</Label>
+<Label variant="outline">[ToggleGroup](/components/toggle-group)</Label>
+<Label variant="outline">[Avatar](/components/avatar)</Label>
+<Label variant="outline">[Popper (not exported yet)](/components/popper)</Label>
+</LabelGroup>
+
 ```ts file="./examples/ComposableDropdwnVariants.tsx"
 ```
 
 ### Composable date select
+
+This demo showcases a date select, and contains the following components:
+
+<LabelGroup categoryName="Components">
+<Label variant="outline">[Menu](/components/menu)</Label>
+<Label variant="outline">[MenuToggle](/components/menu-toggle)</Label>
+<Label variant="outline">[Popper (not exported yet)](/components/popper)</Label>
+</LabelGroup>
 
 ```ts file="./examples/ComposableDateSelect.tsx"
 ```


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Draft for https://github.com/patternfly/patternfly-org/issues/2935

First pass for how an updated demo page with templated content may function. Adds a generic blurb at the top of the demo page, and boilerplate structure for component lists.

"Card view" and "Composable menu" demo pages are updated currently to test and showcase changes.

Open questions:
- Should subcomponents of components be included in the overall component list or should the list only correlate to docs pages?
- How should component lists be shown? Currently it is using LabelGroup/Label to create a visual list, which allows the differentiation between components and layouts.
- Should components and layouts be separate or should they be in the same list? (See "Card view" demo page for layout example)
- Does using LabelGroup to denote components make the sentence blurb indicating a list of components redundant? Should the boilerplate sentence be removed?
- Should PF icons that are imported be called out?

