### PR TITLE
fix(ComposableMenu): update appendTo in demos

### DIFF
--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableActionsMenu.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableActionsMenu.tsx
@@ -10,6 +10,7 @@ export const ComposableActionsMenu: React.FunctionComponent = () => {
   const [selectedItems, setSelectedItems] = React.useState<number[]>([]);
   const toggleRef = React.useRef<HTMLButtonElement>();
   const menuRef = React.useRef<HTMLDivElement>();
+  const containerRef = React.useRef<HTMLDivElement>();
 
   const handleMenuKeys = (event: KeyboardEvent) => {
     if (isOpen && menuRef.current.contains(event.target as Node)) {
@@ -118,5 +119,15 @@ export const ComposableActionsMenu: React.FunctionComponent = () => {
     </Menu>
   );
 
-  return <Popper trigger={toggle} popper={menu} isVisible={isOpen} popperMatchesTriggerWidth={false} />;
+  return (
+    <div ref={containerRef}>
+      <Popper
+        trigger={toggle}
+        popper={menu}
+        isVisible={isOpen}
+        appendTo={containerRef.current}
+        popperMatchesTriggerWidth={false}
+      />
+    </div>
+  );
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableContextSelector.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableContextSelector.tsx
@@ -62,6 +62,7 @@ export const ComposableContextSelector: React.FunctionComponent = () => {
   const menuRef = React.useRef<HTMLDivElement>();
   const toggleRef = React.useRef<HTMLButtonElement>();
   const menuFooterBtnRef = React.useRef<HTMLButtonElement>();
+  const containerRef = React.useRef<HTMLDivElement>();
 
   const handleMenuKeys = (event: KeyboardEvent) => {
     if (!isOpen) {
@@ -198,5 +199,15 @@ export const ComposableContextSelector: React.FunctionComponent = () => {
       </MenuFooter>
     </Menu>
   );
-  return <Popper trigger={toggle} popper={menu} isVisible={isOpen} popperMatchesTriggerWidth={false} />;
+  return (
+    <div ref={containerRef}>
+      <Popper
+        trigger={toggle}
+        popper={menu}
+        appendTo={containerRef.current}
+        isVisible={isOpen}
+        popperMatchesTriggerWidth={false}
+      />
+    </div>
+  );
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableDateSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableDateSelect.tsx
@@ -3,9 +3,10 @@ import { MenuToggle, Menu, MenuContent, MenuList, MenuItem, Popper } from '@patt
 
 export const ComposableSimpleDropdown: React.FunctionComponent = () => {
   const [isOpen, setIsOpen] = React.useState(false);
+  const [selected, setSelected] = React.useState<number>(0);
   const toggleRef = React.useRef<HTMLButtonElement>();
   const menuRef = React.useRef<HTMLDivElement>();
-  const [selected, setSelected] = React.useState<number>(0);
+  const containerRef = React.useRef<HTMLDivElement>();
 
   const handleMenuKeys = (event: KeyboardEvent) => {
     if (!isOpen) {
@@ -109,5 +110,15 @@ export const ComposableSimpleDropdown: React.FunctionComponent = () => {
       </MenuContent>
     </Menu>
   );
-  return <Popper trigger={toggle} popper={menu} isVisible={isOpen} popperMatchesTriggerWidth={false} />;
+  return (
+    <div ref={containerRef}>
+      <Popper
+        trigger={toggle}
+        popper={menu}
+        appendTo={containerRef.current}
+        isVisible={isOpen}
+        popperMatchesTriggerWidth={false}
+      />
+    </div>
+  );
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableDrilldownMenu.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableDrilldownMenu.tsx
@@ -26,6 +26,7 @@ export const ComposableDrilldownMenu: React.FunctionComponent = () => {
   const [menuHeights, setMenuHeights] = React.useState<MenuHeightsType>({});
   const toggleRef = React.useRef<HTMLButtonElement>();
   const menuRef = React.useRef<HTMLDivElement>();
+  const containerRef = React.useRef<HTMLDivElement>();
 
   const handleMenuKeys = (event: KeyboardEvent) => {
     if (isOpen && menuRef.current.contains(event.target as Node)) {
@@ -242,5 +243,15 @@ export const ComposableDrilldownMenu: React.FunctionComponent = () => {
       </MenuContent>
     </Menu>
   );
-  return <Popper trigger={toggle} popper={menu} isVisible={isOpen} popperMatchesTriggerWidth={false} />;
+  return (
+    <div ref={containerRef}>
+      <Popper
+        trigger={toggle}
+        popper={menu}
+        appendTo={containerRef.current}
+        isVisible={isOpen}
+        popperMatchesTriggerWidth={false}
+      />
+    </div>
+  );
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableDropdwnVariants.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableDropdwnVariants.tsx
@@ -23,6 +23,7 @@ export const ComposableDropdwnVariants: React.FunctionComponent = () => {
   const [toggleSelected, setToggleSelected] = React.useState<string>('basic');
   const menuRef = React.useRef<HTMLDivElement>();
   const toggleRef = React.useRef<HTMLButtonElement>();
+  const containerRef = React.useRef<HTMLDivElement>();
 
   const handleToggleSwitch = (selected: boolean, e: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent) => {
     setToggleSelected(e.currentTarget.id);
@@ -224,12 +225,15 @@ export const ComposableDropdwnVariants: React.FunctionComponent = () => {
         />
       </ToggleGroup>
       <br />
-      <Popper
-        trigger={buildToggle()}
-        popper={menu}
-        isVisible={isOpen}
-        popperMatchesTriggerWidth={['image', 'checkbox'].includes(toggleSelected)}
-      />
+      <div ref={containerRef}>
+        <Popper
+          trigger={buildToggle()}
+          popper={menu}
+          appendTo={containerRef.current}
+          isVisible={isOpen}
+          popperMatchesTriggerWidth={['image', 'checkbox'].includes(toggleSelected)}
+        />
+      </div>
     </React.Fragment>
   );
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableFlyout.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableFlyout.tsx
@@ -33,6 +33,7 @@ export const ComposableFlyout: React.FunctionComponent = () => {
   const [isOpen, setIsOpen] = React.useState<boolean>(false);
   const menuRef = React.useRef<HTMLDivElement>();
   const toggleRef = React.useRef<HTMLButtonElement>();
+  const containerRef = React.useRef<HTMLDivElement>();
 
   const handleMenuKeys = (event: KeyboardEvent) => {
     if (!isOpen) {
@@ -99,5 +100,15 @@ export const ComposableFlyout: React.FunctionComponent = () => {
     </Menu>
   );
 
-  return <Popper trigger={toggle} popper={menu} isVisible={isOpen} popperMatchesTriggerWidth={false} />;
+  return (
+    <div ref={containerRef}>
+      <Popper
+        trigger={toggle}
+        popper={menu}
+        appendTo={containerRef.current}
+        isVisible={isOpen}
+        popperMatchesTriggerWidth={false}
+      />
+    </div>
+  );
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableOptionsMenuVariants.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableOptionsMenuVariants.tsx
@@ -6,6 +6,7 @@ export const ComposableOptionsMenuVariants: React.FunctionComponent = () => {
   const [selected, setSelected] = React.useState<string>('');
   const menuRef = React.useRef<HTMLDivElement>();
   const toggleRef = React.useRef<HTMLButtonElement>();
+  const containerRef = React.useRef<HTMLDivElement>();
 
   const handleMenuKeys = (event: KeyboardEvent) => {
     if (isOpen && menuRef.current.contains(event.target as Node)) {
@@ -90,5 +91,9 @@ export const ComposableOptionsMenuVariants: React.FunctionComponent = () => {
       </MenuContent>
     </Menu>
   );
-  return <Popper trigger={toggle} popper={menu} isVisible={isOpen} />;
+  return (
+    <div ref={containerRef}>
+      <Popper trigger={toggle} popper={menu} appendTo={containerRef.current} isVisible={isOpen} />
+    </div>
+  );
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleDropdown.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleDropdown.tsx
@@ -5,6 +5,7 @@ export const ComposableSimpleDropdown: React.FunctionComponent = () => {
   const [isOpen, setIsOpen] = React.useState(false);
   const toggleRef = React.useRef<HTMLButtonElement>();
   const menuRef = React.useRef<HTMLDivElement>();
+  const containerRef = React.useRef<HTMLDivElement>();
 
   const handleMenuKeys = (event: KeyboardEvent) => {
     if (!isOpen) {
@@ -66,5 +67,9 @@ export const ComposableSimpleDropdown: React.FunctionComponent = () => {
       </MenuContent>
     </Menu>
   );
-  return <Popper trigger={toggle} popper={menu} isVisible={isOpen} />;
+  return (
+    <div ref={containerRef}>
+      <Popper trigger={toggle} popper={menu} appendTo={containerRef.current} isVisible={isOpen} />
+    </div>
+  );
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleSelect.tsx
@@ -7,6 +7,7 @@ export const ComposableSimpleSelect: React.FunctionComponent = () => {
   const [selected, setSelected] = React.useState<string>('Select a value');
   const toggleRef = React.useRef<HTMLButtonElement>();
   const menuRef = React.useRef<HTMLDivElement>();
+  const containerRef = React.useRef<HTMLDivElement>();
 
   const handleMenuKeys = (event: KeyboardEvent) => {
     if (isOpen && menuRef.current.contains(event.target as Node)) {
@@ -70,5 +71,9 @@ export const ComposableSimpleSelect: React.FunctionComponent = () => {
       </MenuContent>
     </Menu>
   );
-  return <Popper trigger={toggle} popper={menu} isVisible={isOpen} />;
+  return (
+    <div ref={containerRef}>
+      <Popper trigger={toggle} popper={menu} appendTo={containerRef.current} isVisible={isOpen} />
+    </div>
+  );
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableTreeViewMenu.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableTreeViewMenu.tsx
@@ -217,11 +217,9 @@ export const ComposableTreeViewMenu: React.FunctionComponent = () => {
   };
 
   const toggle = (
-    <div ref={containerRef}>
-      <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
-        {isOpen ? 'Expanded' : 'Collapsed'}
-      </MenuToggle>
-    </div>
+    <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
+      {isOpen ? 'Expanded' : 'Collapsed'}
+    </MenuToggle>
   );
   const statusMapped = statusOptions.map(mapTree);
   const roleMapped = roleOptions.map(mapTree);
@@ -263,12 +261,14 @@ export const ComposableTreeViewMenu: React.FunctionComponent = () => {
     </Panel>
   );
   return (
-    <Popper
-      trigger={toggle}
-      popper={menu}
-      isVisible={isOpen}
-      appendTo={containerRef.current}
-      popperMatchesTriggerWidth={false}
-    />
+    <div ref={containerRef}>
+      <Popper
+        trigger={toggle}
+        popper={menu}
+        isVisible={isOpen}
+        appendTo={containerRef.current}
+        popperMatchesTriggerWidth={false}
+      />
+    </div>
   );
 };


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7291

For the demos I followed how the application launcher demo had it setup by wrapping the returned Popper component in a `div`. It looked to work well for all demos, though the flyout one rendered flyout menus incorrectly (this behavior also appears in the React workspace without this wrapper `div` however).

[Composable menu preview build](https://patternfly-react-pr-7417.surge.sh/demos/composable-menu) 

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
