### PR TITLE
fix/docs(Switch): fix uncontrolled examples

### DIFF
--- a/packages/react-core/src/components/Switch/Switch.tsx
+++ b/packages/react-core/src/components/Switch/Switch.tsx
@@ -12,12 +12,18 @@ export interface SwitchProps
   id?: string;
   /** Additional classes added to the switch */
   className?: string;
-  /** Text value for the label when on */
+  /** Text value for the visible label when on */
   label?: React.ReactNode;
-  /** Text value for the label when off */
+  /** Text value for the visible label when off */
   labelOff?: React.ReactNode;
-  /** Flag to show if the switch is checked. */
+  /** Flag to show if the switch is checked when it is controlled by React state.
+   * To make the switch uncontrolled instead use the defaultChecked prop, but do not use both.
+   */
   isChecked?: boolean;
+  /** Flag to set the default checked value of the switch when it is uncontrolled by React state.
+   * To make the switch controlled instead use the isChecked prop, but do not use both.
+   */
+  defaultChecked?: boolean;
   /** Flag to show if the switch has a check icon. */
   hasCheckIcon?: boolean;
   /** Flag to show if the switch is disabled. */
@@ -63,6 +69,7 @@ export class Switch extends React.Component<SwitchProps & OUIAProps, { ouiaState
       label,
       labelOff,
       isChecked,
+      defaultChecked,
       hasCheckIcon,
       isDisabled,
       onChange,
@@ -84,7 +91,8 @@ export class Switch extends React.Component<SwitchProps & OUIAProps, { ouiaState
           className={css(styles.switchInput)}
           type="checkbox"
           onChange={event => onChange(event.target.checked, event)}
-          checked={isChecked}
+          {...([true, false].includes(defaultChecked) && { defaultChecked })}
+          {...(![true, false].includes(defaultChecked) && { checked: isChecked })}
           disabled={isDisabled}
           aria-labelledby={isAriaLabelledBy ? `${this.id}-on` : null}
           {...props}

--- a/packages/react-core/src/components/Switch/examples/Switch.md
+++ b/packages/react-core/src/components/Switch/examples/Switch.md
@@ -176,19 +176,9 @@ import { Switch } from '@patternfly/react-core';
     aria-label="Message when on"
     label="Message when on"
     labelOff="Message when off"
-    isChecked
+    isChecked={null}
   />
   <br />
-  <Switch
-    id="uncontrolled-switch-off"
-    aria-label="Message when on"
-    label="Message when on"
-    labelOff="Message when off"
-    isChecked={false}
-  />
-  <br />
-  <Switch id="uncontrolled-no-label-switch-on" aria-label="Message when on" isChecked />
-  <br />
-  <Switch id="uncontrolled-no-label-switch-off" aria-label="Message when on" isChecked={false} />
+  <Switch id="uncontrolled-no-label-switch-on" aria-label="Message when on" isChecked={null} />
 </React.Fragment>;
 ```

--- a/packages/react-core/src/components/Switch/examples/Switch.md
+++ b/packages/react-core/src/components/Switch/examples/Switch.md
@@ -171,14 +171,8 @@ import React from 'react';
 import { Switch } from '@patternfly/react-core';
 
 <React.Fragment>
-  <Switch
-    id="uncontrolled-switch-on"
-    aria-label="Message when on"
-    label="Message when on"
-    labelOff="Message when off"
-    isChecked={null}
-  />
+  <Switch id="uncontrolled-switch-on" label="Message when on" labelOff="Message when off" defaultChecked={false} />
   <br />
-  <Switch id="uncontrolled-no-label-switch-on" aria-label="Message when on" isChecked={null} />
+  <Switch id="uncontrolled-no-label-switch-on" aria-label="Message when on" defaultChecked={true} />
 </React.Fragment>;
 ```


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7255

@tlabaj Did these work before? Uncontrolled inputs shouldn't be setting `isChecked`, and half of the example switches are redundant now that it works. I'm curious if this was meant as a static demo initially.
