### PR TITLE
feat(HelperText): add screenreader text for dynamic variant

### DIFF
--- a/packages/react-core/src/components/HelperText/HelperTextItem.tsx
+++ b/packages/react-core/src/components/HelperText/HelperTextItem.tsx
@@ -70,7 +70,11 @@ export const HelperTextItem: React.FunctionComponent<HelperTextItemProps> = ({
           {variant === 'error' && <ExclamationCircleIcon />}
         </span>
       )}
-      <span className={css(styles.helperTextItemText)}>{children}</span>
+
+      <span className={css(styles.helperTextItemText)}>
+        {children}
+        {isDynamic && <span className="pf-u-screen-reader">: {variant} status;</span>}
+      </span>
     </Component>
   );
 };

--- a/packages/react-core/src/components/HelperText/HelperTextItem.tsx
+++ b/packages/react-core/src/components/HelperText/HelperTextItem.tsx
@@ -29,6 +29,10 @@ export interface HelperTextItemProps extends React.HTMLProps<HTMLDivElement | HT
    * assistive technologies.
    */
   id?: string;
+  /** Text that is only accessible to screen readers in order to announce the status of a helper text item.
+   * This prop can only be used when the isDynamic prop is also passed in.
+   */
+  screenReaderText?: string;
 }
 
 const variantStyle = {
@@ -48,6 +52,7 @@ export const HelperTextItem: React.FunctionComponent<HelperTextItemProps> = ({
   isDynamic = false,
   hasIcon = isDynamic,
   id,
+  screenReaderText = `${variant} status`,
   ...props
 }: HelperTextItemProps) => {
   const Component = component as any;
@@ -73,7 +78,7 @@ export const HelperTextItem: React.FunctionComponent<HelperTextItemProps> = ({
 
       <span className={css(styles.helperTextItemText)}>
         {children}
-        {isDynamic && <span className="pf-u-screen-reader">: {variant} status;</span>}
+        {isDynamic && <span className="pf-u-screen-reader">: {screenReaderText};</span>}
       </span>
     </Component>
   );

--- a/packages/react-core/src/components/HelperText/__tests__/__snapshots__/HelperText.test.tsx.snap
+++ b/packages/react-core/src/components/HelperText/__tests__/__snapshots__/HelperText.test.tsx.snap
@@ -44,6 +44,11 @@ exports[`HelperText dynamic helper text renders successfully 1`] = `
         class="pf-c-helper-text__item-text"
       >
         help test text
+        <span
+          class="pf-u-screen-reader"
+        >
+          : default status;
+        </span>
       </span>
     </div>
   </div>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7263 

[HelperText dynamic demo preview build](https://patternfly-react-pr-7426.surge.sh/components/helper-text/react-demos#dynamic-variant-with-static-text)

Rather than utilizing `aria-live`, I instead added an element to the HelperTextItem with the `pf-u-screen-reader` class. That plus `aria-describedby` does seem to work with VO (would have to test with JAWS and NVDA). I wasn't sure whether we would want to expose the ability to customize this message for screen readers so I opted to not include that right now.

Another option could be using the `output` element which does work nicely with its implicit live region, but the issue then becomes repetitive text being announced from the live region and `aria-describedby` when a user begins typing in the input field. 

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
