### PR TITLE
fix(Select): popper menu flips correctly

### DIFF
--- a/packages/react-core/src/components/ContextSelector/ContextSelector.tsx
+++ b/packages/react-core/src/components/ContextSelector/ContextSelector.tsx
@@ -65,7 +65,7 @@ export interface ContextSelectorProps extends Omit<ToggleMenuBaseProps, 'menuApp
    * it reaches the boundary. This prop can only be used when the context selector component is not
    * appended inline, e.g. `menuAppendTo="parent"`
    */
-  isFlippable?: boolean;
+  isFlipEnabled?: boolean;
 }
 
 export class ContextSelector extends React.Component<ContextSelectorProps, { ouiaStateId: string }> {
@@ -89,7 +89,7 @@ export class ContextSelector extends React.Component<ContextSelectorProps, { oui
     footer: null as React.ReactNode,
     isPlain: false,
     isText: false,
-    isFlippable: false
+    isFlipEnabled: false
   };
   constructor(props: ContextSelectorProps) {
     super(props);
@@ -132,16 +132,15 @@ export class ContextSelector extends React.Component<ContextSelectorProps, { oui
       isText,
       footer,
       disableFocusTrap,
-      isFlippable,
+      isFlipEnabled,
       ...props
     } = this.props;
     const menuContainer = (
       <div
         className={css(styles.contextSelectorMenu)}
-        // This removes the `position: absolute` styling from the `.pf-c-context-selector__menu` element,
-        // which was causing incorrect positioning of the popper and making it seem like the
-        // menu wasn't flipping.
-        {...(isFlippable && { style: { position: 'revert' } })}
+        // This removes the `position: absolute`styling from the `.pf-c-context-selector__menu`
+        // allowing the menu to flip correctly
+        {...(isFlipEnabled && { style: { position: 'revert' } })}
       >
         {isOpen && (
           <FocusTrap active={!disableFocusTrap} focusTrapOptions={{ clickOutsideDeactivates: true }}>

--- a/packages/react-core/src/components/ContextSelector/ContextSelector.tsx
+++ b/packages/react-core/src/components/ContextSelector/ContextSelector.tsx
@@ -61,6 +61,11 @@ export interface ContextSelectorProps extends Omit<ToggleMenuBaseProps, 'menuApp
   isText?: boolean;
   /** Flag to disable focus trap */
   disableFocusTrap?: boolean;
+  /** Flag for indicating that the context selector menu should automatically flip vertically when
+   * it reaches the boundary. This prop can only be used when the context selector component is not
+   * appended inline, e.g. `menuAppendTo="parent"`
+   */
+  isFlippable?: boolean;
 }
 
 export class ContextSelector extends React.Component<ContextSelectorProps, { ouiaStateId: string }> {
@@ -83,7 +88,8 @@ export class ContextSelector extends React.Component<ContextSelectorProps, { oui
     disableFocusTrap: false,
     footer: null as React.ReactNode,
     isPlain: false,
-    isText: false
+    isText: false,
+    isFlippable: false
   };
   constructor(props: ContextSelectorProps) {
     super(props);
@@ -126,10 +132,17 @@ export class ContextSelector extends React.Component<ContextSelectorProps, { oui
       isText,
       footer,
       disableFocusTrap,
+      isFlippable,
       ...props
     } = this.props;
     const menuContainer = (
-      <div className={css(styles.contextSelectorMenu)}>
+      <div
+        className={css(styles.contextSelectorMenu)}
+        // This removes the `position: absolute` styling from the `.pf-c-context-selector__menu` element,
+        // which was causing incorrect positioning of the popper and making it seem like the
+        // menu wasn't flipping.
+        {...(isFlippable && { style: { position: 'revert' } })}
+      >
         {isOpen && (
           <FocusTrap active={!disableFocusTrap} focusTrapOptions={{ clickOutsideDeactivates: true }}>
             <div className={css(styles.contextSelectorMenuSearch)}>

--- a/packages/react-core/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-core/src/components/Dropdown/Dropdown.tsx
@@ -59,7 +59,7 @@ export interface DropdownProps
    * it reaches the boundary. This prop can only be used when the dropdown component is not
    * appended inline, e.g. `menuAppendTo="parent"`
    */
-  isFlippable?: boolean;
+  isFlipEnabled?: boolean;
 }
 
 export const Dropdown: React.FunctionComponent<DropdownProps> = ({
@@ -71,7 +71,7 @@ export const Dropdown: React.FunctionComponent<DropdownProps> = ({
   alignments,
   contextProps,
   menuAppendTo = 'inline',
-  isFlippable = false,
+  isFlipEnabled = false,
   ...props
 }: DropdownProps) => (
   <DropdownContext.Provider
@@ -97,7 +97,7 @@ export const Dropdown: React.FunctionComponent<DropdownProps> = ({
       ...contextProps
     }}
   >
-    <DropdownWithContext menuAppendTo={menuAppendTo} isFlippable={isFlippable} {...props} />
+    <DropdownWithContext menuAppendTo={menuAppendTo} isFlipEnabled={isFlipEnabled} {...props} />
   </DropdownContext.Provider>
 );
 Dropdown.displayName = 'Dropdown';

--- a/packages/react-core/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-core/src/components/Dropdown/Dropdown.tsx
@@ -55,6 +55,11 @@ export interface DropdownProps
   autoFocus?: boolean;
   /** Props for extreme customization of dropdown */
   contextProps?: typeof DropdownContext;
+  /** Flag for indicating that the dropdown menu should automatically flip vertically when
+   * it reaches the boundary. This prop can only be used when the dropdown component is not
+   * appended inline, e.g. `menuAppendTo="parent"`
+   */
+  isFlippable?: boolean;
 }
 
 export const Dropdown: React.FunctionComponent<DropdownProps> = ({
@@ -66,6 +71,7 @@ export const Dropdown: React.FunctionComponent<DropdownProps> = ({
   alignments,
   contextProps,
   menuAppendTo = 'inline',
+  isFlippable = false,
   ...props
 }: DropdownProps) => (
   <DropdownContext.Provider
@@ -91,7 +97,7 @@ export const Dropdown: React.FunctionComponent<DropdownProps> = ({
       ...contextProps
     }}
   >
-    <DropdownWithContext menuAppendTo={menuAppendTo} {...props} />
+    <DropdownWithContext menuAppendTo={menuAppendTo} isFlippable={isFlippable} {...props} />
   </DropdownContext.Provider>
 );
 Dropdown.displayName = 'Dropdown';

--- a/packages/react-core/src/components/Dropdown/DropdownWithContext.tsx
+++ b/packages/react-core/src/components/Dropdown/DropdownWithContext.tsx
@@ -29,7 +29,8 @@ export class DropdownWithContext extends React.Component<DropdownProps & OUIAPro
     direction: DropdownDirection.down,
     onSelect: (): void => undefined,
     autoFocus: true,
-    menuAppendTo: 'inline'
+    menuAppendTo: 'inline',
+    isFlippable: false
   };
 
   constructor(props: DropdownProps & OUIAProps) {
@@ -75,6 +76,7 @@ export class DropdownWithContext extends React.Component<DropdownProps & OUIAPro
       toggle,
       autoFocus,
       menuAppendTo,
+      isFlippable,
       ...props
     } = this.props;
     const id = toggle.props.id || `pf-dropdown-toggle-id-${DropdownWithContext.currentId++}`;
@@ -96,6 +98,10 @@ export class DropdownWithContext extends React.Component<DropdownProps & OUIAPro
           const BaseComponent = baseComponent as any;
           const menuContainer = (
             <DropdownMenu
+              // This removes the `position: absolute` styling from the `.pf-c-dropdown__menu` element,
+              // which was causing incorrect positioning of the popper and making it seem like the
+              // menu wasn't flipping.
+              {...(isFlippable && { style: { position: 'revert', minWidth: 'min-content' } })}
               setMenuComponentRef={this.setMenuComponentRef}
               component={component}
               isOpen={isOpen}

--- a/packages/react-core/src/components/Dropdown/DropdownWithContext.tsx
+++ b/packages/react-core/src/components/Dropdown/DropdownWithContext.tsx
@@ -30,7 +30,7 @@ export class DropdownWithContext extends React.Component<DropdownProps & OUIAPro
     onSelect: (): void => undefined,
     autoFocus: true,
     menuAppendTo: 'inline',
-    isFlippable: false
+    isFlipEnabled: false
   };
 
   constructor(props: DropdownProps & OUIAProps) {
@@ -76,7 +76,7 @@ export class DropdownWithContext extends React.Component<DropdownProps & OUIAPro
       toggle,
       autoFocus,
       menuAppendTo,
-      isFlippable,
+      isFlipEnabled,
       ...props
     } = this.props;
     const id = toggle.props.id || `pf-dropdown-toggle-id-${DropdownWithContext.currentId++}`;
@@ -98,10 +98,9 @@ export class DropdownWithContext extends React.Component<DropdownProps & OUIAPro
           const BaseComponent = baseComponent as any;
           const menuContainer = (
             <DropdownMenu
-              // This removes the `position: absolute` styling from the `.pf-c-dropdown__menu` element,
-              // which was causing incorrect positioning of the popper and making it seem like the
-              // menu wasn't flipping.
-              {...(isFlippable && { style: { position: 'revert', minWidth: 'min-content' } })}
+              // This removes the `position: absolute` styling from the `.pf-c-dropdown__menu`
+              // allowing the menu to flip correctly
+              {...(isFlipEnabled && { style: { position: 'revert', minWidth: 'min-content' } })}
               setMenuComponentRef={this.setMenuComponentRef}
               component={component}
               isOpen={isOpen}

--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -177,7 +177,7 @@ export interface SelectProps
    * it reaches the boundary. This prop can only be used when the select component is not
    * appended inline, e.g. `menuAppendTo="parent"`
    */
-  isFlippable?: boolean;
+  isFlipEnabled?: boolean;
 }
 
 export interface SelectState {
@@ -251,7 +251,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
     isInputFilterPersisted: false,
     isCreateSelectOptionObject: false,
     shouldResetOnSelect: true,
-    isFlippable: false
+    isFlipEnabled: false
   };
 
   state: SelectState = {
@@ -984,7 +984,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
       loadingVariant,
       isCreateSelectOptionObject,
       shouldResetOnSelect,
-      isFlippable,
+      isFlipEnabled,
       ...props
     } = this.props;
     const {
@@ -1211,10 +1211,9 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
 
     const innerMenu = (
       <SelectMenu
-        // This removes the `position: absolute` styling from the `.pf-c-select__menu` element,
-        // which was causing incorrect positioning of the popper and making it seem like the
-        // menu wasn't flipping.
-        {...(isFlippable && { style: { position: 'revert' } })}
+        // This removes the `position: absolute` styling from the `.pf-c-select__menu`
+        // allowing the menu to flip correctly
+        {...(isFlipEnabled && { style: { position: 'revert' } })}
         {...props}
         isGrouped={isGrouped}
         selected={selections}

--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -173,6 +173,11 @@ export interface SelectProps
    * menuAppendTo={document.getElementById('target')}
    */
   menuAppendTo?: HTMLElement | (() => HTMLElement) | 'inline' | 'parent';
+  /** Flag for indicating that the select menu should automatically flip vertically when
+   * it reaches the boundary. This prop can only be used when the select component is not
+   * appended inline, e.g. `menuAppendTo="parent"`
+   */
+  isFlippable?: boolean;
 }
 
 export interface SelectState {
@@ -245,7 +250,8 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
     isInputValuePersisted: false,
     isInputFilterPersisted: false,
     isCreateSelectOptionObject: false,
-    shouldResetOnSelect: true
+    shouldResetOnSelect: true,
+    isFlippable: false
   };
 
   state: SelectState = {
@@ -978,6 +984,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
       loadingVariant,
       isCreateSelectOptionObject,
       shouldResetOnSelect,
+      isFlippable,
       ...props
     } = this.props;
     const {
@@ -1204,6 +1211,10 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
 
     const innerMenu = (
       <SelectMenu
+        // This removes the `position: absolute` styling from the `.pf-c-select__menu` element,
+        // which was causing incorrect positioning of the popper and making it seem like the
+        // menu wasn't flipping.
+        {...(isFlippable && { style: { position: 'revert' } })}
         {...props}
         isGrouped={isGrouped}
         selected={selections}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7286 

This PR does not resolve issue #7398 as the Overflow Menu component itself doesn't use Popper or `menuAppendTo`

[Context selector](https://patternfly-react-pr-7434.surge.sh/components/context-selector/)
[Dropdown](https://patternfly-react-pr-7434.surge.sh/components/dropdown)
[Select](https://patternfly-react-pr-7434.surge.sh/components/select)

To test, copy+paste the following to the returned component in an example from the above links:

```
menuAppendTo="parent"
isFlippable
```

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
