### PR TITLE
fix(Select): allow enter to create when there is a single option

### DIFF
--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -679,13 +679,13 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
   };
 
   handleTypeaheadKeys = (position: string, shiftKey: boolean = false) => {
-    const { isOpen, onFavorite } = this.props;
+    const { isOpen, onFavorite, isCreatable } = this.props;
     const { typeaheadCurrIndex, tabbedIntoFavoritesMenu } = this.state;
     const typeaheadActiveChild = this.getTypeaheadActiveChild(typeaheadCurrIndex);
     if (isOpen) {
       if (position === 'enter') {
         if (
-          typeaheadCurrIndex !== -1 && // do not allow selection without moving to an initial option
+          (typeaheadCurrIndex !== -1 || (isCreatable && this.refCollection.length === 1)) && // do not allow selection without moving to an initial option unless it is a single create option
           (typeaheadActiveChild || (this.refCollection[0] && this.refCollection[0][0]))
         ) {
           if (typeaheadActiveChild) {


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7260

This issue was caused by #6966 which prevents enter from selecting an option in typeahead until `ArrowDown` is pressed to navigate into the menu. Creating still works with `ArrowDown` + `Enter`, and I'm not sure if this is a pattern we want to hold for all cases in typeahead. This PR will add an exception for `isCreatable` typeaheads where the create option is the only option in the list (creating a new option where there are still multiple options shown will still require arrow navigation to the create button).
