### PR TITLE
chore(dep): Upgraded focus trap dependency and added tabble option to…

### DIFF
--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -37,7 +37,7 @@
     "@patternfly/react-icons": "^4.68.2",
     "@patternfly/react-styles": "^4.67.2",
     "@patternfly/react-tokens": "^4.69.2",
-    "focus-trap": "6.2.2",
+    "focus-trap": "6.9.2",
     "react-dropzone": "9.0.0",
     "tippy.js": "5.1.2",
     "tslib": "^2.0.0"

--- a/packages/react-core/src/components/AboutModal/AboutModalContainer.tsx
+++ b/packages/react-core/src/components/AboutModal/AboutModalContainer.tsx
@@ -63,7 +63,7 @@ export const AboutModalContainer: React.FunctionComponent<AboutModalContainerPro
     <Backdrop>
       <FocusTrap
         active={!disableFocusTrap}
-        focusTrapOptions={{ clickOutsideDeactivates: true }}
+        focusTrapOptions={{ clickOutsideDeactivates: true, tabbableOptions: { displayCheck: 'none' } }}
         className={css(styles.bullseye)}
       >
         <AboutModalBox

--- a/packages/react-core/src/components/ContextSelector/ContextSelector.tsx
+++ b/packages/react-core/src/components/ContextSelector/ContextSelector.tsx
@@ -131,7 +131,10 @@ export class ContextSelector extends React.Component<ContextSelectorProps, { oui
     const menuContainer = (
       <div className={css(styles.contextSelectorMenu)}>
         {isOpen && (
-          <FocusTrap active={!disableFocusTrap} focusTrapOptions={{ clickOutsideDeactivates: true }}>
+          <FocusTrap
+            active={!disableFocusTrap}
+            focusTrapOptions={{ clickOutsideDeactivates: true, tabbableOptions: { displayCheck: 'none' } }}
+          >
             <div className={css(styles.contextSelectorMenuSearch)}>
               <InputGroup>
                 <TextInput

--- a/packages/react-core/src/components/Modal/ModalContent.tsx
+++ b/packages/react-core/src/components/Modal/ModalContent.tsx
@@ -185,7 +185,7 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
     <Backdrop>
       <FocusTrap
         active={!disableFocusTrap}
-        focusTrapOptions={{ clickOutsideDeactivates: true }}
+        focusTrapOptions={{ clickOutsideDeactivates: true, tabbableOptions: { displayCheck: 'none' } }}
         className={css(bullsEyeStyles.bullseye)}
       >
         {modalBox}

--- a/packages/react-core/src/components/Popover/Popover.tsx
+++ b/packages/react-core/src/components/Popover/Popover.tsx
@@ -387,6 +387,7 @@ export const Popover: React.FunctionComponent<PopoverProps> = ({
       focusTrapOptions={{
         returnFocusOnDeactivate: true,
         clickOutsideDeactivates: true,
+        tabbableOptions: { displayCheck: 'none' },
         fallbackFocus: () => {
           // If the popover's trigger is focused but scrolled out of view,
           // FocusTrap will throw an error when the Enter button is used on the trigger.

--- a/yarn.lock
+++ b/yarn.lock
@@ -8315,11 +8315,12 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-focus-trap@6.2.2:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.2.2.tgz#0e6f391415b0697c99da932702dedd13084fa131"
+focus-trap@6.9.2:
+  version "6.9.2"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.9.2.tgz#a9ef72847869bd2cbf62cb930aaf8e138fef1ca9"
+  integrity sha512-gBEuXOPNOKPrLdZpMFUSTyIo1eT2NSZRrwZ9r/0Jqw5tmT3Yvxfmu8KBHw8xW2XQkw6E/JoG+OlEq7UDtSUNgw==
   dependencies:
-    tabbable "^5.1.4"
+    tabbable "^5.3.2"
 
 follow-redirects@1.5.10:
   version "1.5.10"
@@ -15374,9 +15375,10 @@ symbol-tree@^3.2.2, symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
-tabbable@^5.1.4:
-  version "5.1.4"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.1.4.tgz#5278929c16d0d909c2cfcdfcfa89dd86bce5dd1a"
+tabbable@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.3.2.tgz#66d6119ee8a533634c3f17deb0caa1c379e36ac7"
+  integrity sha512-6G/8EWRFx8CiSe2++/xHhXkmCRq2rHtDtZbQFHx34cvDfZzIBfvwG9zGUNTWMXWLCYvDj3aQqOzdl3oCxKuBkQ==
 
 table-layout@^0.4.3, table-layout@~0.4.0:
   version "0.4.5"


### PR DESCRIPTION
… fix breaking testing

<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7288 

This was verified because when version was bumped our focus trap test were failing.  adding the `tabbableOptions: { displayCheck: 'none' }` fixed the breaking tests.