### PR TITLE
fix(Select): aria-describedby is added properly

### DIFF
--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -103,6 +103,8 @@ export interface SelectProps
   'aria-invalid'?: boolean;
   /** Label for input field of type ahead select variants */
   typeAheadAriaLabel?: string;
+  /** Id of div for input field of type ahead select variants */
+  typeAheadAriaDescribedby?: string;
   /** Label for clear selection button of type ahead select variants */
   clearSelectionsAriaLabel?: string;
   /** Label for toggle of type ahead select variants */
@@ -209,6 +211,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
     'aria-describedby': '',
     'aria-invalid': false,
     typeAheadAriaLabel: '',
+    typeAheadAriaDescribedby: '',
     clearSelectionsAriaLabel: 'Clear all',
     toggleAriaLabel: 'Options menu',
     removeSelectionAriaLabel: 'Remove',
@@ -929,6 +932,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
       validated,
       selections: selectionsProp,
       typeAheadAriaLabel,
+      typeAheadAriaDescribedby,
       clearSelectionsAriaLabel,
       toggleAriaLabel,
       removeSelectionAriaLabel,
@@ -1229,7 +1233,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
           className
         )}
         {...(width && { style: { width } })}
-        {...(validated !== ValidatedOptions.default && { 'aria-describedby': ariaDescribedby })}
+        {...(ariaDescribedby && { 'aria-describedby': ariaDescribedby })}
         {...(validated !== ValidatedOptions.default && { 'aria-invalid': ariaInvalid })}
       >
         {isOpen && menuContainer}
@@ -1250,7 +1254,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
         ref={this.parentRef}
         {...getOUIAProps(Select.displayName, ouiaId !== undefined ? ouiaId : this.state.ouiaStateId, ouiaSafe)}
         {...(width && { style: { width } })}
-        {...(validated !== ValidatedOptions.default && { 'aria-describedby': ariaDescribedby })}
+        {...(ariaDescribedby && { 'aria-describedby': ariaDescribedby })}
         {...(validated !== ValidatedOptions.default && { 'aria-invalid': ariaInvalid })}
       >
         <SelectToggle
@@ -1319,6 +1323,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
                   aria-activedescendant={typeaheadActiveChild && typeaheadActiveChild.id}
                   id={`${selectToggleId}-select-typeahead`}
                   aria-label={typeAheadAriaLabel}
+                  {...(typeAheadAriaDescribedby && { 'aria-describedby': typeAheadAriaDescribedby })}
                   placeholder={placeholderText as string}
                   value={
                     typeaheadInputValue !== null
@@ -1347,6 +1352,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
                   id={`${selectToggleId}-select-multi-typeahead-typeahead`}
                   aria-label={typeAheadAriaLabel}
                   aria-invalid={validated === ValidatedOptions.error}
+                  {...(typeAheadAriaDescribedby && { 'aria-describedby': typeAheadAriaDescribedby })}
                   placeholder={placeholderText as string}
                   value={typeaheadInputValue !== null ? typeaheadInputValue : ''}
                   type="text"


### PR DESCRIPTION
The aria-describedby field is now added regardless of state of validation

Signed-off-by: Tomas Psota <tpsota@redhat.com>

<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7251 

