### PR TITLE
fix(Table): filterable table demo icon text spacing fix

### DIFF
--- a/packages/react-table/src/demos/Table.md
+++ b/packages/react-table/src/demos/Table.md
@@ -1878,8 +1878,8 @@ class FilterTableDemo extends React.Component {
           onSelect={this.onCategorySelect}
           position={DropdownPosition.left}
           toggle={
-            <DropdownToggle onToggle={this.onCategoryToggle} style={{ width: '100%' }}>
-              <FilterIcon /> {currentCategory}
+            <DropdownToggle onToggle={this.onCategoryToggle} style={{ width: '100%' }} icon={<FilterIcon /> }>
+              {currentCategory}
             </DropdownToggle>
           }
           isOpen={isCategoryDropdownOpen}

--- a/packages/react-table/src/demos/Table.md
+++ b/packages/react-table/src/demos/Table.md
@@ -1872,24 +1872,25 @@ class FilterTableDemo extends React.Component {
   buildCategoryDropdown() {
     const { isCategoryDropdownOpen, currentCategory } = this.state;
 
+    const categoryMenuItems = [
+      <SelectOption key="cat1" value="Location" />,
+      <SelectOption key="cat2" value="Name" />,
+      <SelectOption key="cat3" value="Status" />,
+    ];
+
     return (
       <ToolbarItem>
-        <Dropdown
+        <Select
           onSelect={this.onCategorySelect}
+          selections={currentCategory}
           position={DropdownPosition.left}
-          toggle={
-            <DropdownToggle onToggle={this.onCategoryToggle} style={{ width: '100%' }} icon={<FilterIcon /> }>
-              {currentCategory}
-            </DropdownToggle>
-          }
+          onToggle={this.onCategoryToggle}
           isOpen={isCategoryDropdownOpen}
-          dropdownItems={[
-            <DropdownItem key="cat1">Location</DropdownItem>,
-            <DropdownItem key="cat2">Name</DropdownItem>,
-            <DropdownItem key="cat3">Status</DropdownItem>
-          ]}
+          toggleIcon={<FilterIcon />}
           style={{ width: '100%' }}
-        ></Dropdown>
+        >
+          {categoryMenuItems}
+        </Select>
       </ToolbarItem>
     );
   }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Fixed bug where icon and text for Filterable Table Demos was too close. Passed icon in as `icon` prop as suggested. Closes #6262

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: N/A
