### PR TITLE
insets example that make more sense

### DIFF
--- a/packages/react-core/src/components/Tabs/examples/Tabs.md
+++ b/packages/react-core/src/components/Tabs/examples/Tabs.md
@@ -640,8 +640,8 @@ class InsetTabs extends React.Component {
           inset={{
             default: 'insetNone',
             md: 'insetSm',
-            xl: 'inset2xl',
-            '2xl': 'insetLg'
+            xl: 'insetLg',
+            '2xl': 'inset2xl'
           }}
           isBox={isBox}
           aria-label="Tabs in the inset example"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**:
Insets in the documentation page don't make sense with xl being smaller then lg

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
