### PR TITLE
fix(Select): retain focus on correct checkbox after view more

### DIFF
--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -294,6 +294,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
       this.props.variant !== 'typeaheadmulti'
     ) {
       this.refCollection[this.state.viewMoreNextIndex][0].focus();
+      this.setState({ viewMoreNextIndex: -1 });
     }
 
     const hasUpdatedChildren =


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7132 

[Select view more example](https://patternfly-react-pr-7505.surge.sh/components/select#view-more-with-checkboxes) (can also copy+paste the code mentioned in the linked issue)

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
