### PR TITLE
docs(JumpLinks): add jump links with drawer demo

### DIFF
--- a/packages/react-core/src/demos/JumpLinks.md
+++ b/packages/react-core/src/demos/JumpLinks.md
@@ -136,5 +136,7 @@ ScrollspyH2 = () => {
 
 This demo shows how jump links can be used in combination with a drawer.
 
+The scrollable selector passed to the jump links component is an id that was placed on the drawer content component.
+
 ```js isFullscreen file="./examples/JumpLinks/JumpLinksWithDrawer.js"
 ```

--- a/packages/react-core/src/demos/JumpLinks.md
+++ b/packages/react-core/src/demos/JumpLinks.md
@@ -130,3 +130,11 @@ ScrollspyH2 = () => {
   );
 };
 ```
+
+
+### With drawer
+
+This demo shows how jump links can be used in combination with a drawer.
+
+```js isFullscreen file="./examples/JumpLinks/JumpLinksWithDrawer.js"
+```

--- a/packages/react-core/src/demos/JumpLinks.md
+++ b/packages/react-core/src/demos/JumpLinks.md
@@ -136,7 +136,7 @@ ScrollspyH2 = () => {
 
 This demo shows how jump links can be used in combination with a drawer.
 
-The scrollable selector passed to the jump links component is an id that was placed on the drawer content component.
+The `scrollableSelector` prop passed to the jump links component is an `id` that was placed on the `DrawerContent` component.
 
 ```js isFullscreen file="./examples/JumpLinks/JumpLinksWithDrawer.js"
 ```

--- a/packages/react-core/src/demos/examples/JumpLinks/JumpLinksWithDrawer.js
+++ b/packages/react-core/src/demos/examples/JumpLinks/JumpLinksWithDrawer.js
@@ -29,9 +29,10 @@ export const JumpLinksWithDrawer = () => {
 
   React.useEffect(() => {
     const masthead = document.getElementsByClassName('pf-c-masthead')[0];
+    const drawerToggleSection = document.getElementsByClassName('pf-c-page__main-section')[0];
 
     getResizeObserver(masthead, () => {
-      setOffsetHeight(masthead.offsetHeight);
+      setOffsetHeight(masthead.offsetHeight + drawerToggleSection.offsetHeight);
     });
   }, []);
 

--- a/packages/react-core/src/demos/examples/JumpLinks/JumpLinksWithDrawer.js
+++ b/packages/react-core/src/demos/examples/JumpLinks/JumpLinksWithDrawer.js
@@ -11,6 +11,7 @@ import {
   JumpLinks,
   JumpLinksItem,
   JumpLinksList,
+  PageSection,
   Sidebar,
   SidebarContent,
   SidebarPanel,
@@ -79,7 +80,9 @@ export const JumpLinksWithDrawer = () => {
                   </JumpLinks>
                 </SidebarPanel>
                 <SidebarContent>
-                  <Button onClick={onToggleClick}>Toggle drawer</Button>
+                  <PageSection sticky="top" variant="light">
+                    <Button onClick={onToggleClick}>Toggle drawer</Button>
+                  </PageSection>
                   <TextContent>
                     {headings.map(heading => (
                       <div key={heading} style={{ maxWidth: '800px', marginBottom: '32px' }}>

--- a/packages/react-core/src/demos/examples/JumpLinks/JumpLinksWithDrawer.js
+++ b/packages/react-core/src/demos/examples/JumpLinks/JumpLinksWithDrawer.js
@@ -61,7 +61,6 @@ export const JumpLinksWithDrawer = () => {
         <DrawerContent panelContent={panelContent} id="jump-links-drawer-drawer-scrollable-container">
           <DrawerContentBody>
             <DrawerContentBody hasPadding>
-              <Button onClick={onToggleClick}>Toggle drawer</Button>
               <Sidebar>
                 <SidebarPanel variant="sticky">
                   <JumpLinks
@@ -80,6 +79,7 @@ export const JumpLinksWithDrawer = () => {
                   </JumpLinks>
                 </SidebarPanel>
                 <SidebarContent>
+                  <Button onClick={onToggleClick}>Toggle drawer</Button>
                   <TextContent>
                     {headings.map(heading => (
                       <div key={heading}>

--- a/packages/react-core/src/demos/examples/JumpLinks/JumpLinksWithDrawer.js
+++ b/packages/react-core/src/demos/examples/JumpLinks/JumpLinksWithDrawer.js
@@ -61,65 +61,62 @@ export const JumpLinksWithDrawer = () => {
     <DashboardWrapper breadcrumb={null} mainContainerId="scrollable-element">
       <Drawer isExpanded={isExpanded}>
         <DrawerContent panelContent={panelContent} id="jump-links-drawer-drawer-scrollable-container">
-          <DrawerContentBody>
-            <DrawerContentBody hasPadding>
-              <Sidebar>
-                <SidebarPanel variant="sticky">
-                  <JumpLinks
-                    isVertical={true}
-                    label="Jump to section"
-                    scrollableSelector="#jump-links-drawer-drawer-scrollable-container"
-                    offset={offsetHeight}
-                    expandable={{ default: 'expandable', md: 'nonExpandable' }}
-                  >
-                    {headings.map(heading => (
-                      <JumpLinksItem key={heading} href={`#jump-links-drawer-jump-links-${heading.toLowerCase()}`}>
+          <DrawerContentBody hasPadding>
+            <Sidebar>
+              <SidebarPanel variant="sticky">
+                <JumpLinks
+                  isVertical={true}
+                  label="Jump to section"
+                  scrollableSelector="#jump-links-drawer-drawer-scrollable-container"
+                  offset={offsetHeight}
+                  expandable={{ default: 'expandable', md: 'nonExpandable' }}
+                >
+                  {headings.map(heading => (
+                    <JumpLinksItem key={heading} href={`#jump-links-drawer-jump-links-${heading.toLowerCase()}`}>
+                      {`${heading} section`}
+                      <JumpLinksList></JumpLinksList>
+                    </JumpLinksItem>
+                  ))}
+                </JumpLinks>
+              </SidebarPanel>
+              <SidebarContent>
+                <PageSection sticky="top" variant="light">
+                  <Button onClick={onToggleClick}>Toggle drawer</Button>
+                </PageSection>
+                <TextContent>
+                  {headings.map(heading => (
+                    <div key={heading} style={{ maxWidth: '800px', marginBottom: '32px' }}>
+                      <h2 id={`jump-links-drawer-jump-links-${heading.toLowerCase()}`} tabIndex={-1}>
                         {`${heading} section`}
-                        <JumpLinksList></JumpLinksList>
-                      </JumpLinksItem>
-                    ))}
-                  </JumpLinks>
-                </SidebarPanel>
-                <SidebarContent>
-                  <PageSection sticky="top" variant="light">
-                    <Button onClick={onToggleClick}>Toggle drawer</Button>
-                  </PageSection>
-                  <TextContent>
-                    {headings.map(heading => (
-                      <div key={heading} style={{ maxWidth: '800px', marginBottom: '32px' }}>
-                        <h2 id={`jump-links-drawer-jump-links-${heading.toLowerCase()}`} tabIndex={-1}>
-                          {`${heading} section`}
-                        </h2>
-                        <p>
-                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas sed dui ullamcorper,
-                          dignissim purus eu, mattis leo. Curabitur eleifend turpis ipsum, aliquam pretium risus
-                          efficitur vel. Etiam eget enim vitae quam facilisis pharetra at eget diam. Suspendisse ut
-                          vulputate magna. Nunc viverra posuere orci sit amet pulvinar. Quisque dui justo, egestas ac
-                          accumsan suscipit, tristique eu risus. In aliquet libero ante, ac pulvinar lectus pretium in.
-                          Ut enim tellus, vulputate et lorem et, hendrerit rutrum diam. Cras pharetra dapibus elit vitae
-                          ullamcorper. Nulla facilisis euismod diam, at sodales sem laoreet hendrerit. Curabitur
-                          porttitor ex nulla. Proin ligula leo, egestas ac nibh a, pellentesque mollis augue. Donec nec
-                          augue vehicula eros pulvinar vehicula eget rutrum neque. Duis sit amet interdum lorem. Vivamus
-                          porttitor nec quam a accumsan. Nam pretium vitae leo vitae rhoncus.
-                        </p>
-                        <p>
-                          At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium
-                          voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati
-                          cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est
-                          laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero
-                          tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime
-                          placeat facere possimus, omnis voluptas assumenda est, omnis dolor repellendus. Temporibus
-                          autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et
-                          voluptates repudiandae sint et molestiae non recusandae. Itaque earum rerum hic tenetur a
-                          sapiente delectus, ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis
-                          doloribus asperiores repellat.
-                        </p>
-                      </div>
-                    ))}
-                  </TextContent>
-                </SidebarContent>
-              </Sidebar>
-            </DrawerContentBody>
+                      </h2>
+                      <p>
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas sed dui ullamcorper, dignissim
+                        purus eu, mattis leo. Curabitur eleifend turpis ipsum, aliquam pretium risus efficitur vel.
+                        Etiam eget enim vitae quam facilisis pharetra at eget diam. Suspendisse ut vulputate magna. Nunc
+                        viverra posuere orci sit amet pulvinar. Quisque dui justo, egestas ac accumsan suscipit,
+                        tristique eu risus. In aliquet libero ante, ac pulvinar lectus pretium in. Ut enim tellus,
+                        vulputate et lorem et, hendrerit rutrum diam. Cras pharetra dapibus elit vitae ullamcorper.
+                        Nulla facilisis euismod diam, at sodales sem laoreet hendrerit. Curabitur porttitor ex nulla.
+                        Proin ligula leo, egestas ac nibh a, pellentesque mollis augue. Donec nec augue vehicula eros
+                        pulvinar vehicula eget rutrum neque. Duis sit amet interdum lorem. Vivamus porttitor nec quam a
+                        accumsan. Nam pretium vitae leo vitae rhoncus.
+                      </p>
+                      <p>
+                        At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum
+                        deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non
+                        provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et
+                        dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum
+                        soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere
+                        possimus, omnis voluptas assumenda est, omnis dolor repellendus. Temporibus autem quibusdam et
+                        aut officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint et
+                        molestiae non recusandae. Itaque earum rerum hic tenetur a sapiente delectus, ut aut reiciendis
+                        voluptatibus maiores alias consequatur aut perferendis doloribus asperiores repellat.
+                      </p>
+                    </div>
+                  ))}
+                </TextContent>
+              </SidebarContent>
+            </Sidebar>
           </DrawerContentBody>
         </DrawerContent>
       </Drawer>

--- a/packages/react-core/src/demos/examples/JumpLinks/JumpLinksWithDrawer.js
+++ b/packages/react-core/src/demos/examples/JumpLinks/JumpLinksWithDrawer.js
@@ -98,6 +98,18 @@ export const JumpLinksWithDrawer = () => {
                           augue vehicula eros pulvinar vehicula eget rutrum neque. Duis sit amet interdum lorem. Vivamus
                           porttitor nec quam a accumsan. Nam pretium vitae leo vitae rhoncus.
                         </p>
+                        <p>
+                          At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium
+                          voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati
+                          cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est
+                          laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero
+                          tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime
+                          placeat facere possimus, omnis voluptas assumenda est, omnis dolor repellendus. Temporibus
+                          autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et
+                          voluptates repudiandae sint et molestiae non recusandae. Itaque earum rerum hic tenetur a
+                          sapiente delectus, ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis
+                          doloribus asperiores repellat.
+                        </p>
                       </div>
                     ))}
                   </TextContent>

--- a/packages/react-core/src/demos/examples/JumpLinks/JumpLinksWithDrawer.js
+++ b/packages/react-core/src/demos/examples/JumpLinks/JumpLinksWithDrawer.js
@@ -82,7 +82,7 @@ export const JumpLinksWithDrawer = () => {
                   <Button onClick={onToggleClick}>Toggle drawer</Button>
                   <TextContent>
                     {headings.map(heading => (
-                      <div key={heading}>
+                      <div key={heading} style={{ maxWidth: '800px', marginBottom: '32px' }}>
                         <h2 id={`jump-links-drawer-jump-links-${heading.toLowerCase()}`} tabIndex={-1}>
                           {`${heading} section`}
                         </h2>

--- a/packages/react-core/src/demos/examples/JumpLinks/JumpLinksWithDrawer.js
+++ b/packages/react-core/src/demos/examples/JumpLinks/JumpLinksWithDrawer.js
@@ -1,0 +1,112 @@
+import React from 'react';
+import {
+  Button,
+  Drawer,
+  DrawerPanelContent,
+  DrawerContent,
+  DrawerContentBody,
+  DrawerHead,
+  DrawerActions,
+  DrawerCloseButton,
+  JumpLinks,
+  JumpLinksItem,
+  JumpLinksList,
+  Sidebar,
+  SidebarContent,
+  SidebarPanel,
+  TextContent,
+  getResizeObserver
+} from '@patternfly/react-core';
+import DashboardWrapper from '../DashboardWrapper';
+
+export const JumpLinksWithDrawer = () => {
+  const headings = ['First', 'Second', 'Third', 'Fourth', 'Fifth'];
+
+  const [offsetHeight, setOffsetHeight] = React.useState(0);
+  const [isExpanded, setIsExpanded] = React.useState(false);
+  const drawerRef = React.useRef();
+
+  React.useEffect(() => {
+    const masthead = document.getElementsByClassName('pf-c-masthead')[0];
+
+    getResizeObserver(masthead, () => {
+      setOffsetHeight(masthead.offsetHeight);
+    });
+  }, []);
+
+  const onCloseClick = () => {
+    setIsExpanded(false);
+  };
+
+  const onToggleClick = () => {
+    setIsExpanded(!isExpanded);
+  };
+
+  const panelContent = (
+    <DrawerPanelContent>
+      <DrawerHead>
+        <span tabIndex={isExpanded ? 0 : -1} ref={drawerRef}>
+          drawer-panel
+        </span>
+        <DrawerActions>
+          <DrawerCloseButton onClick={onCloseClick} />
+        </DrawerActions>
+      </DrawerHead>
+    </DrawerPanelContent>
+  );
+
+  return (
+    <DashboardWrapper breadcrumb={null} mainContainerId="scrollable-element">
+      <Drawer isExpanded={isExpanded}>
+        <DrawerContent panelContent={panelContent} id="jump-links-drawer-drawer-scrollable-container">
+          <DrawerContentBody>
+            <DrawerContentBody hasPadding>
+              <Button onClick={onToggleClick}>Toggle drawer</Button>
+              <Sidebar>
+                <SidebarPanel variant="sticky">
+                  <JumpLinks
+                    isVertical={true}
+                    label="Jump to section"
+                    scrollableSelector="#jump-links-drawer-drawer-scrollable-container"
+                    offset={offsetHeight}
+                    expandable={{ default: 'expandable', md: 'nonExpandable' }}
+                  >
+                    {headings.map(heading => (
+                      <JumpLinksItem key={heading} href={`#jump-links-drawer-jump-links-${heading.toLowerCase()}`}>
+                        {`${heading} section`}
+                        <JumpLinksList></JumpLinksList>
+                      </JumpLinksItem>
+                    ))}
+                  </JumpLinks>
+                </SidebarPanel>
+                <SidebarContent>
+                  <TextContent>
+                    {headings.map(heading => (
+                      <div key={heading}>
+                        <h2 id={`jump-links-drawer-jump-links-${heading.toLowerCase()}`} tabIndex={-1}>
+                          {`${heading} section`}
+                        </h2>
+                        <p>
+                          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas sed dui ullamcorper,
+                          dignissim purus eu, mattis leo. Curabitur eleifend turpis ipsum, aliquam pretium risus
+                          efficitur vel. Etiam eget enim vitae quam facilisis pharetra at eget diam. Suspendisse ut
+                          vulputate magna. Nunc viverra posuere orci sit amet pulvinar. Quisque dui justo, egestas ac
+                          accumsan suscipit, tristique eu risus. In aliquet libero ante, ac pulvinar lectus pretium in.
+                          Ut enim tellus, vulputate et lorem et, hendrerit rutrum diam. Cras pharetra dapibus elit vitae
+                          ullamcorper. Nulla facilisis euismod diam, at sodales sem laoreet hendrerit. Curabitur
+                          porttitor ex nulla. Proin ligula leo, egestas ac nibh a, pellentesque mollis augue. Donec nec
+                          augue vehicula eros pulvinar vehicula eget rutrum neque. Duis sit amet interdum lorem. Vivamus
+                          porttitor nec quam a accumsan. Nam pretium vitae leo vitae rhoncus.
+                        </p>
+                      </div>
+                    ))}
+                  </TextContent>
+                </SidebarContent>
+              </Sidebar>
+            </DrawerContentBody>
+          </DrawerContentBody>
+        </DrawerContent>
+      </Drawer>
+    </DashboardWrapper>
+  );
+};


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6582 

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:

One item on this that I'm not sure about: I didn't see how the drawer was to be toggled in the core demo. I took a similar approach to the switch used to demonstrate vertical vs horizontal capabilities in the other JumpLinks demo, but am more than happy to change it.

Convenience link to the jump links demos page: https://patternfly-react-pr-7520.surge.sh/components/jump-links/react-demos

And the new demo itself: https://patternfly-react-pr-7520.surge.sh/components/jump-links/react-demos/with-drawer/