### PR TITLE
Tooltip examples are not accessible on dropdown items

### DIFF
--- a/packages/react-core/src/components/Dropdown/InternalDropdownItem.tsx
+++ b/packages/react-core/src/components/Dropdown/InternalDropdownItem.tsx
@@ -199,7 +199,7 @@ export class InternalDropdownItem extends React.Component<InternalDropdownItemPr
     }
     const renderWithTooltip = (childNode: React.ReactNode) =>
       tooltip ? (
-        <Tooltip content={tooltip} {...tooltipProps}>
+        <Tooltip content={tooltip} {...tooltipProps} aria-live="polite">
           {childNode}
         </Tooltip>
       ) : (

--- a/packages/react-table/src/components/TableComposable/Tr.tsx
+++ b/packages/react-table/src/components/TableComposable/Tr.tsx
@@ -13,7 +13,9 @@ export interface TrProps extends React.HTMLProps<HTMLTableRowElement>, OUIAProps
   innerRef?: React.Ref<any>;
   /** Flag indicating the Tr is hidden */
   isHidden?: boolean;
-  /** Only applicable to Tr within the Tbody: Makes the row expandable and determines if it's expanded or not */
+  /** Only applicable to Tr within the Tbody: Makes the row expandable and determines if it's expanded or not.
+   * To prevent column widths from responding automatically when expandable rows are toggled, the width prop must also be passed into either the th or td component
+   */
   isExpanded?: boolean;
   /** Only applicable to Tr within the Tbody: Whether the row is editable */
   isEditable?: boolean;

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
@@ -194,6 +194,8 @@ type OnCollapse = (
 ) => void;
 ```
 
+Note: Table column widths will respond automatically when toggling expanded rows. To retain column widths between expanded and collapsed states, column header and/or data cell widths must be set.
+
 ```ts file="ComposableTableExpandable.tsx"
 ```
 

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTableCompoundExpandable.tsx
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTableCompoundExpandable.tsx
@@ -67,20 +67,26 @@ export const ComposableTableCompoundExpandable: React.FunctionComponent = () => 
         return (
           <Tbody key={repo.name} isExpanded={isRowExpanded}>
             <Tr>
-              <Td dataLabel={columnNames.name} component="th">
+              <Td width={25} dataLabel={columnNames.name} component="th">
                 <a href="#">{repo.name}</a>
               </Td>
-              <Td dataLabel={columnNames.branches} compoundExpand={compoundExpandParams(repo, 'branches')}>
+              <Td width={10} dataLabel={columnNames.branches} compoundExpand={compoundExpandParams(repo, 'branches')}>
                 <CodeBranchIcon key="icon" /> {repo.branches}
               </Td>
-              <Td dataLabel={columnNames.prs} compoundExpand={compoundExpandParams(repo, 'prs')}>
+              <Td width={10} dataLabel={columnNames.prs} compoundExpand={compoundExpandParams(repo, 'prs')}>
                 <CodeIcon key="icon" /> {repo.prs}
               </Td>
-              <Td dataLabel={columnNames.workspaces} compoundExpand={compoundExpandParams(repo, 'workspaces')}>
+              <Td
+                width={10}
+                dataLabel={columnNames.workspaces}
+                compoundExpand={compoundExpandParams(repo, 'workspaces')}
+              >
                 <CubeIcon key="icon" /> {repo.workspaces}
               </Td>
-              <Td dataLabel={columnNames.lastCommit}>{repo.lastCommit}</Td>
-              <Td>
+              <Td width={15} dataLabel={columnNames.lastCommit}>
+                {repo.lastCommit}
+              </Td>
+              <Td width={30}>
                 <a href="#">Open in GitHub</a>
               </Td>
             </Tr>
@@ -89,7 +95,14 @@ export const ComposableTableCompoundExpandable: React.FunctionComponent = () => 
                 <Td dataLabel={columnNames[expandedCellKey]} noPadding colSpan={6}>
                   <ExpandableRowContent>
                     <div className="pf-u-m-md">
-                      Expanded content for {repo.name}: {expandedCellKey} goes here!
+                      Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem
+                      ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum
+                      sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit
+                      dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor.
+                      Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem
+                      ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum
+                      sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit
+                      dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor.
                     </div>
                   </ExpandableRowContent>
                 </Td>

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTableExpandable.tsx
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTableExpandable.tsx
@@ -36,7 +36,11 @@ export const ComposableTableExpandable: React.FunctionComponent = () => {
       prs: 'b',
       workspaces: 'four',
       lastCommit: 'five',
-      details: { detailFormat: 1, detail1: 'single cell - fullWidth' }
+      details: {
+        detailFormat: 1,
+        detail1:
+          'Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. Lorem ipsum sit dolor. '
+      }
     },
     {
       name: 'parent 3',
@@ -117,11 +121,11 @@ export const ComposableTableExpandable: React.FunctionComponent = () => {
         <Thead>
           <Tr>
             <Th />
-            <Th>{columnNames.name}</Th>
-            <Th>{columnNames.branches}</Th>
-            <Th>{columnNames.prs}</Th>
-            <Th>{columnNames.workspaces}</Th>
-            <Th>{columnNames.lastCommit}</Th>
+            <Th width={25}>{columnNames.name}</Th>
+            <Th width={10}>{columnNames.branches}</Th>
+            <Th width={15}>{columnNames.prs}</Th>
+            <Th width={30}>{columnNames.workspaces}</Th>
+            <Th width={10}>{columnNames.lastCommit}</Th>
           </Tr>
         </Thead>
         {repositories.map((repo, rowIndex) => {

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTableNestedExpandable.tsx
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTableNestedExpandable.tsx
@@ -74,13 +74,15 @@ export const ComposableTableNestedExpandable: React.FunctionComponent = () => {
         <Thead hasNestedHeader>
           <Tr>
             <Th rowSpan={2} />
-            <Th rowSpan={2} hasRightBorder>
+            <Th width={35} rowSpan={2} hasRightBorder>
               {columnNames.team}
             </Th>
             <Th colSpan={3} hasRightBorder>
               {columnNames.members}
             </Th>
-            <Th rowSpan={2}>{columnNames.contact}</Th>
+            <Th width={25} rowSpan={2}>
+              {columnNames.contact}
+            </Th>
           </Tr>
           <Tr resetOffset>
             <Th isSubheader>{columnNames.lead}</Th>

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTableNestedTableExpandable.tsx
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTableNestedTableExpandable.tsx
@@ -142,7 +142,7 @@ export const ComposableTableExpandable: React.FunctionComponent = () => {
       <Thead>
         <Tr>
           <Td />
-          <Th>{columnNames.name}</Th>
+          <Th width={20}>{columnNames.name}</Th>
           <Th>{columnNames.branches}</Th>
           <Th>{columnNames.prs}</Th>
           <Th>{columnNames.link}</Th>

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTableStripedExpandable.tsx
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTableStripedExpandable.tsx
@@ -121,11 +121,11 @@ export const ComposableTableStripedExpandable: React.FunctionComponent = () => {
         <Thead>
           <Tr>
             <Th />
-            <Th>{columnNames.name}</Th>
-            <Th>{columnNames.branches}</Th>
-            <Th>{columnNames.prs}</Th>
-            <Th>{columnNames.workspaces}</Th>
-            <Th>{columnNames.lastCommit}</Th>
+            <Th width={25}>{columnNames.name}</Th>
+            <Th width={10}>{columnNames.branches}</Th>
+            <Th width={15}>{columnNames.prs}</Th>
+            <Th width={30}>{columnNames.workspaces}</Th>
+            <Th width={10}>{columnNames.lastCommit}</Th>
           </Tr>
         </Thead>
         {repositories.map((repo, rowIndex) => {

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTableTree.tsx
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTableTree.tsx
@@ -187,7 +187,7 @@ export const ComposableTableTree: React.FunctionComponent = () => {
     <TableComposable isTreeTable aria-label="Tree table">
       <Thead>
         <Tr>
-          <Th>{columnNames.name}</Th>
+          <Th width={40}>{columnNames.name}</Th>
           <Th>{columnNames.branches}</Th>
           <Th>{columnNames.prs}</Th>
           <Th>{columnNames.workspaces}</Th>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6109

it works partially also using aria-labelledby but the tooltip is announced before the item content
