### PR TITLE
fix(Table): account for added columns with expandable

### DIFF
--- a/packages/react-table/src/components/Table/utils/decorators/collapsible.tsx
+++ b/packages/react-table/src/components/Table/utils/decorators/collapsible.tsx
@@ -67,7 +67,7 @@ export const collapsible: IFormatter = (
 export const expandable: IFormatter = (value: IFormatterValueType, { rowData }: IExtra) =>
   rowData && rowData.hasOwnProperty('parent') ? <ExpandableRowContent>{value}</ExpandableRowContent> : value;
 
-export const expandedRow = (colSpan?: number, additionalColSpan?: number) => {
+export const expandedRow = (colSpan?: number, additionalColSpan: number = 0) => {
   const expandedRowFormatter = (
     value: IFormatterValueType,
     {

--- a/packages/react-table/src/components/Table/utils/decorators/collapsible.tsx
+++ b/packages/react-table/src/components/Table/utils/decorators/collapsible.tsx
@@ -67,7 +67,7 @@ export const collapsible: IFormatter = (
 export const expandable: IFormatter = (value: IFormatterValueType, { rowData }: IExtra) =>
   rowData && rowData.hasOwnProperty('parent') ? <ExpandableRowContent>{value}</ExpandableRowContent> : value;
 
-export const expandedRow = (colSpan?: number) => {
+export const expandedRow = (colSpan?: number, additionalColSpan?: number) => {
   const expandedRowFormatter = (
     value: IFormatterValueType,
     {
@@ -81,8 +81,8 @@ export const expandedRow = (colSpan?: number) => {
   ): decoratorReturnType =>
     value &&
     rowData.hasOwnProperty('parent') && {
-      // todo: rewrite this logic, it is not type safe
-      colSpan: !rowData.cells || rowData.cells.length === 1 ? colSpan + (!!rowData.fullWidth as any) : 1,
+      colSpan:
+        !rowData.cells || rowData.cells.length === 1 ? colSpan + (rowData.fullWidth ? additionalColSpan + 1 : 0) : 1,
       id: contentId + rowIndex + (columnIndex ? '-' + columnIndex : ''),
       className: rowData.noPadding && css(styles.modifiers.noPadding)
     };

--- a/packages/react-table/src/components/Table/utils/headerUtils.tsx
+++ b/packages/react-table/src/components/Table/utils/headerUtils.tsx
@@ -211,6 +211,8 @@ const actionsTransforms = ({
 export interface ICollapseTranform {
   onCollapse: OnCollapse;
   canCollapseAll: boolean;
+  // Account for additional added columns for full width
+  firstUserColumnIndex: number;
 }
 
 /**
@@ -220,13 +222,16 @@ export interface ICollapseTranform {
  * @param {*}  extraObject with onCollapse callback.
  * @returns {*} object with empty title, tranforms - Array, cellTransforms - Array.
  */
-const collapsibleTransforms = (header: (ICell | string)[], { onCollapse, canCollapseAll }: ICollapseTranform) => [
+const collapsibleTransforms = (
+  header: (ICell | string)[],
+  { onCollapse, canCollapseAll, firstUserColumnIndex }: ICollapseTranform
+) => [
   ...(onCollapse
     ? [
         {
           title: '',
           transforms: (canCollapseAll && [collapsible]) || null,
-          cellTransforms: [collapsible, expandedRow(header.length)]
+          cellTransforms: [collapsible, expandedRow(header.length, firstUserColumnIndex)]
         }
       ]
     : [])

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTableExpandable.tsx
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTableExpandable.tsx
@@ -137,14 +137,14 @@ export const ComposableTableExpandable: React.FunctionComponent = () => {
             childIsFullWidth = [1, 3].includes(detailFormat);
             childHasNoPadding = [2, 3].includes(detailFormat);
             if (detail1 && !detail2 && !detail3) {
-              detail1Colspan = childIsFullWidth ? numColumns : numColumns + 1; // Account for toggle column
+              detail1Colspan = !childIsFullWidth ? numColumns : numColumns + 1; // Account for toggle column
             } else if (detail1 && detail2 && !detail3) {
               detail1Colspan = 2;
-              detail2Colspan = childIsFullWidth ? 3 : 4;
+              detail2Colspan = !childIsFullWidth ? 3 : 4;
             } else if (detail1 && detail2 && detail3) {
               detail1Colspan = 2;
               detail2Colspan = 2;
-              detail3Colspan = childIsFullWidth ? 1 : 2;
+              detail3Colspan = !childIsFullWidth ? 1 : 2;
             }
           }
           return (


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #3613

Updates collapsible transform logic to account for additional added columns (actions, selectable, etc). Currently using the internal `firstUserColumnIndex` flag but more fine grained control can be added by checking each feature flag individually instead.