### PR TITLE
Drawer bug typeerror on resize

### DIFF
--- a/packages/react-core/src/components/Drawer/Drawer.tsx
+++ b/packages/react-core/src/components/Drawer/Drawer.tsx
@@ -30,6 +30,7 @@ export interface DrawerContextProps {
   onExpand?: () => void;
   position?: string;
   drawerRef?: React.RefObject<HTMLDivElement>;
+  drawerContentRef?: React.RefObject<HTMLDivElement>;
   isInline: boolean;
 }
 
@@ -39,6 +40,7 @@ export const DrawerContext = React.createContext<Partial<DrawerContextProps>>({
   onExpand: () => {},
   position: 'right',
   drawerRef: null,
+  drawerContentRef: null,
   isInline: false
 });
 
@@ -53,8 +55,10 @@ export const Drawer: React.FunctionComponent<DrawerProps> = ({
   ...props
 }: DrawerProps) => {
   const drawerRef = React.useRef<HTMLDivElement>();
+  const drawerContentRef = React.useRef<HTMLDivElement>();
+
   return (
-    <DrawerContext.Provider value={{ isExpanded, isStatic, onExpand, position, drawerRef, isInline }}>
+    <DrawerContext.Provider value={{ isExpanded, isStatic, onExpand, position, drawerRef, drawerContentRef, isInline }}>
       <div
         className={css(
           styles.drawer,

--- a/packages/react-core/src/components/Drawer/DrawerContent.tsx
+++ b/packages/react-core/src/components/Drawer/DrawerContent.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/Drawer/drawer';
 import { css } from '@patternfly/react-styles';
 import { DrawerMain } from './DrawerMain';
-import { DrawerColorVariant } from './Drawer';
+import { DrawerColorVariant, DrawerContext } from './Drawer';
 
 export interface DrawerContentProps extends React.HTMLProps<HTMLDivElement> {
   /** Additional classes added to the Drawer. */
@@ -23,7 +23,8 @@ export const DrawerContent: React.FunctionComponent<DrawerContentProps> = ({
   colorVariant = DrawerColorVariant.default,
   ...props
 }: DrawerContentProps) => {
-  const drawerContentRef = React.useRef<HTMLDivElement>();
+  const { drawerContentRef } = React.useContext(DrawerContext);
+
   return (
     <DrawerMain>
       <div
@@ -37,7 +38,7 @@ export const DrawerContent: React.FunctionComponent<DrawerContentProps> = ({
       >
         {children}
       </div>
-      {panelContent && React.cloneElement(panelContent as React.ReactElement, { drawerContentRef })}
+      {panelContent}
     </DrawerMain>
   );
 };

--- a/packages/react-core/src/components/Drawer/DrawerPanelContent.tsx
+++ b/packages/react-core/src/components/Drawer/DrawerPanelContent.tsx
@@ -91,19 +91,22 @@ export const DrawerPanelContent: React.FunctionComponent<DrawerPanelContentProps
       drawerSize = drawerRef.current.getBoundingClientRect().right - drawerRef.current.getBoundingClientRect().left;
     } else if (position === 'right') {
       splitterPos =
-        drawerContentRef.current.getBoundingClientRect().right - splitterRef.current.getBoundingClientRect().left;
+        drawerContentRef?.current.getBoundingClientRect().right - splitterRef.current.getBoundingClientRect().left;
       drawerSize =
-        drawerContentRef.current.getBoundingClientRect().right - drawerContentRef.current.getBoundingClientRect().left;
+        drawerContentRef?.current.getBoundingClientRect().right -
+        drawerContentRef?.current.getBoundingClientRect().left;
     } else if (position === 'left') {
       splitterPos =
-        splitterRef.current.getBoundingClientRect().right - drawerContentRef.current.getBoundingClientRect().left;
+        splitterRef.current.getBoundingClientRect().right - drawerContentRef?.current.getBoundingClientRect().left;
       drawerSize =
-        drawerContentRef.current.getBoundingClientRect().right - drawerContentRef.current.getBoundingClientRect().left;
+        drawerContentRef?.current.getBoundingClientRect().right -
+        drawerContentRef?.current.getBoundingClientRect().left;
     } else if (position === 'bottom') {
       splitterPos =
-        drawerContentRef.current.getBoundingClientRect().bottom - splitterRef.current.getBoundingClientRect().top;
+        drawerContentRef?.current.getBoundingClientRect().bottom - splitterRef.current.getBoundingClientRect().top;
       drawerSize =
-        drawerContentRef.current.getBoundingClientRect().bottom - drawerContentRef.current.getBoundingClientRect().top;
+        drawerContentRef?.current.getBoundingClientRect().bottom -
+        drawerContentRef?.current.getBoundingClientRect().top;
     }
 
     const newSplitterPos = (splitterPos / drawerSize) * 100;

--- a/packages/react-core/src/components/Drawer/DrawerPanelContent.tsx
+++ b/packages/react-core/src/components/Drawer/DrawerPanelContent.tsx
@@ -37,8 +37,6 @@ export interface DrawerPanelContentProps extends React.HTMLProps<HTMLDivElement>
   };
   /** Color variant of the background of the drawer panel */
   colorVariant?: DrawerColorVariant | 'light-200' | 'default';
-  /** @hide Internal ref to drawer content */
-  drawerContentRef?: React.RefObject<HTMLDivElement>;
 }
 let isResizing: boolean = null;
 let newSize: number = 0;
@@ -57,13 +55,14 @@ export const DrawerPanelContent: React.FunctionComponent<DrawerPanelContentProps
   resizeAriaLabel = 'Resize',
   widths,
   colorVariant = DrawerColorVariant.default,
-  drawerContentRef,
   ...props
 }: DrawerPanelContentProps) => {
   const panel = React.useRef<HTMLDivElement>();
   const splitterRef = React.useRef<HTMLDivElement>();
   const [separatorValue, setSeparatorValue] = React.useState(0);
-  const { position, isExpanded, isStatic, onExpand, drawerRef, isInline } = React.useContext(DrawerContext);
+  const { position, isExpanded, isStatic, onExpand, drawerRef, drawerContentRef, isInline } = React.useContext(
+    DrawerContext
+  );
   const hidden = isStatic ? false : !isExpanded;
   const [isExpandedInternal, setIsExpandedInternal] = React.useState(!hidden);
   let currWidth: number = 0;
@@ -91,22 +90,19 @@ export const DrawerPanelContent: React.FunctionComponent<DrawerPanelContentProps
       drawerSize = drawerRef.current.getBoundingClientRect().right - drawerRef.current.getBoundingClientRect().left;
     } else if (position === 'right') {
       splitterPos =
-        drawerContentRef?.current.getBoundingClientRect().right - splitterRef.current.getBoundingClientRect().left;
+        drawerContentRef.current.getBoundingClientRect().right - splitterRef.current.getBoundingClientRect().left;
       drawerSize =
-        drawerContentRef?.current.getBoundingClientRect().right -
-        drawerContentRef?.current.getBoundingClientRect().left;
+        drawerContentRef.current.getBoundingClientRect().right - drawerContentRef.current.getBoundingClientRect().left;
     } else if (position === 'left') {
       splitterPos =
-        splitterRef.current.getBoundingClientRect().right - drawerContentRef?.current.getBoundingClientRect().left;
+        splitterRef.current.getBoundingClientRect().right - drawerContentRef.current.getBoundingClientRect().left;
       drawerSize =
-        drawerContentRef?.current.getBoundingClientRect().right -
-        drawerContentRef?.current.getBoundingClientRect().left;
+        drawerContentRef.current.getBoundingClientRect().right - drawerContentRef.current.getBoundingClientRect().left;
     } else if (position === 'bottom') {
       splitterPos =
-        drawerContentRef?.current.getBoundingClientRect().bottom - splitterRef.current.getBoundingClientRect().top;
+        drawerContentRef.current.getBoundingClientRect().bottom - splitterRef.current.getBoundingClientRect().top;
       drawerSize =
-        drawerContentRef?.current.getBoundingClientRect().bottom -
-        drawerContentRef?.current.getBoundingClientRect().top;
+        drawerContentRef.current.getBoundingClientRect().bottom - drawerContentRef.current.getBoundingClientRect().top;
     }
 
     const newSplitterPos = (splitterPos / drawerSize) * 100;

--- a/packages/react-core/src/components/Drawer/__tests__/Drawer.test.tsx
+++ b/packages/react-core/src/components/Drawer/__tests__/Drawer.test.tsx
@@ -10,7 +10,8 @@ import {
   DrawerPanelContent
 } from '../';
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 Object.values([
   { isExpanded: true, isInline: false, isStatic: false },
@@ -124,3 +125,39 @@ test(`Drawer has resizable callback and id`, () => {
   );
   expect(asFragment()).toMatchSnapshot();
 });
+
+test('Resizeable DrawerPanelContent can be wrapped in a context without causing an error', () => {
+  const TestContext = React.createContext({});
+
+  const consoleError = jest.spyOn(console, 'error').mockImplementation();
+
+  const panelContent = (
+    <TestContext.Provider value={{}}>
+      <DrawerPanelContent
+        isResizable
+      >
+        <DrawerHead>
+          <span>
+            drawer-panel
+          </span>
+          <DrawerActions>
+            <DrawerCloseButton />
+          </DrawerActions>
+        </DrawerHead>
+      </DrawerPanelContent>
+    </TestContext.Provider>
+  );
+
+  render(
+    <Drawer isExpanded={true} position="left">
+      <DrawerContent panelContent={panelContent}>
+        <DrawerContentBody>Drawer content text</DrawerContentBody>
+      </DrawerContent>
+    </Drawer>
+  );
+
+  userEvent.tab();
+  userEvent.keyboard('{arrowleft}');
+
+  expect(consoleError).not.toHaveBeenCalled();
+})

--- a/packages/react-core/src/components/Drawer/__tests__/Generated/__snapshots__/DrawerContent.test.tsx.snap
+++ b/packages/react-core/src/components/Drawer/__tests__/Generated/__snapshots__/DrawerContent.test.tsx.snap
@@ -12,9 +12,7 @@ exports[`DrawerContent should match snapshot (auto-generated) 1`] = `
         ReactNode
       </div>
     </div>
-    <div
-      drawercontentref="[object Object]"
-    >
+    <div>
       test
     </div>
   </div>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7421

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: N/A

The root cause of the bug here is that `DrawerPanelContent` currently expects to be a direct child of `DrawerMain` and receive `drawerContentRef` from `DrawerContent`, but if the panel content is wrapped in a context that prop gets added to the context rather than `DrawerPanelContent`.

This resolution adds `DrawerContentRef` to the context for the drawer so that its value can be accessed by `DrawerPanelContent` regardless of what it may be wrapped in.

<details>
<summary>Easy way to test:</summary>

1. Open the [drawer examples on the live site](https://www.patternfly.org/v4/components/drawer/) and the [drawer examples on the preview for this branch](https://patternfly-react-pr-7531.surge.sh/components/drawer/) in separate tabs
2. Paste the code below into the code editor for one of the examples in each tab (it wraps `DrawerPanelContent` in a context)

```js
import React from 'react';
import {
  Drawer,
  DrawerPanelContent,
  DrawerContent,
  DrawerContentBody,
  DrawerHead,
  DrawerActions,
  DrawerCloseButton,
  Button
} from '@patternfly/react-core';

export const DrawerResizableOnRight: React.FunctionComponent = () => {
  const [isExpanded, setIsExpanded] = React.useState(false);
  const drawerRef = React.useRef<HTMLDivElement>();

  const TestContext = React.createContext({});

  const onExpand = () => {
    drawerRef.current && drawerRef.current.focus();
  };

  const onClick = () => {
    setIsExpanded(!isExpanded);
  };

  const onCloseClick = () => {
    setIsExpanded(false);
  };

  const onResize = (newWidth: number, id: string) => {
    // eslint-disable-next-line no-console
    console.log(`${id} has new width of: ${newWidth}`);
  };

  const panelContent = (
    <TestContext.Provider value={{}}>
      <DrawerPanelContent
        isResizable
        onResize={onResize}
        id="right-resize-panel"
        defaultSize={'500px'}
        minSize={'150px'}
      >
        <DrawerHead>
          <span tabIndex={isExpanded ? 0 : -1} ref={drawerRef}>
            drawer-panel
          </span>
          <DrawerActions>
            <DrawerCloseButton onClick={onCloseClick} />
          </DrawerActions>
        </DrawerHead>
      </DrawerPanelContent>
    </TestContext.Provider>
  );

  const drawerContent = 'Lorem ipsum dolor sit amet';

  return (
    <React.Fragment>
      <Button aria-expanded={isExpanded} onClick={onClick}>
        Toggle drawer
      </Button>
      <Drawer isExpanded={isExpanded} onExpand={onExpand} position="right">
        <DrawerContent panelContent={panelContent}>
          <DrawerContentBody>{drawerContent}</DrawerContentBody>
        </DrawerContent>
      </Drawer>
    </React.Fragment>
  );
};
```
3. Open the console in your dev tools
4. Toggle the edited drawer example in each tab and attempt to resize it
5. View the errors that result in the live drawer example and verify that they don't occur in the preview branch example
</details>