### PR TITLE
fix(ProgressStepper): added onTriggerEnter prop to Popover

### DIFF
--- a/packages/react-core/src/components/Popover/Popover.tsx
+++ b/packages/react-core/src/components/Popover/Popover.tsx
@@ -368,6 +368,24 @@ export const Popover: React.FunctionComponent<PopoverProps> = ({
       }
     }
   };
+  const onTriggerEnter = (event: KeyboardEvent) => {
+    if (event.keyCode === KEY_CODES.ENTER || event.keyCode === KEY_CODES.SPACE) {
+      event.preventDefault();
+      if (triggerManually) {
+        if (visible) {
+          shouldClose(null, hide, event);
+        } else {
+          shouldOpen(show, event);
+        }
+      } else {
+        if (visible) {
+          hide();
+        } else {
+          show(true);
+        }
+      }
+    }
+  };
   const onContentMouseDown = () => {
     if (focusTrapActive) {
       setFocusTrapActive(false);
@@ -461,6 +479,7 @@ export const Popover: React.FunctionComponent<PopoverProps> = ({
         distance={distance}
         placement={position}
         onTriggerClick={onTriggerClick}
+        onTriggerEnter={onTriggerEnter}
         onDocumentClick={onDocumentClick}
         onDocumentKeyDown={onDocumentKeyDown}
         enableFlip={enableFlip}

--- a/packages/react-core/src/components/Popover/Popover.tsx
+++ b/packages/react-core/src/components/Popover/Popover.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import * as React from 'react';
-import { KeyTypes, KEY_CODES } from '../../helpers/constants';
+import { KeyTypes } from '../../helpers/constants';
 import styles from '@patternfly/react-styles/css/components/Popover/popover';
 import { css } from '@patternfly/react-styles';
 import { PopoverContext } from './PopoverContext';
@@ -368,24 +368,6 @@ export const Popover: React.FunctionComponent<PopoverProps> = ({
       }
     }
   };
-  const onTriggerEnter = (event: KeyboardEvent) => {
-    if (event.keyCode === KEY_CODES.ENTER || event.keyCode === KEY_CODES.SPACE) {
-      event.preventDefault();
-      if (triggerManually) {
-        if (visible) {
-          shouldClose(null, hide, event);
-        } else {
-          shouldOpen(show, event);
-        }
-      } else {
-        if (visible) {
-          hide();
-        } else {
-          show(true);
-        }
-      }
-    }
-  };
   const onContentMouseDown = () => {
     if (focusTrapActive) {
       setFocusTrapActive(false);
@@ -479,7 +461,6 @@ export const Popover: React.FunctionComponent<PopoverProps> = ({
         distance={distance}
         placement={position}
         onTriggerClick={onTriggerClick}
-        onTriggerEnter={onTriggerEnter}
         onDocumentClick={onDocumentClick}
         onDocumentKeyDown={onDocumentKeyDown}
         enableFlip={enableFlip}

--- a/packages/react-core/src/components/Popover/Popover.tsx
+++ b/packages/react-core/src/components/Popover/Popover.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import * as React from 'react';
-import { KeyTypes } from '../../helpers/constants';
+import { KeyTypes, KEY_CODES } from '../../helpers/constants';
 import styles from '@patternfly/react-styles/css/components/Popover/popover';
 import { css } from '@patternfly/react-styles';
 import { PopoverContext } from './PopoverContext';

--- a/packages/react-core/src/components/ProgressStepper/ProgressStep.tsx
+++ b/packages/react-core/src/components/ProgressStepper/ProgressStep.tsx
@@ -92,7 +92,6 @@ export const ProgressStep: React.FunctionComponent<ProgressStepProps> = ({
           ref={stepRef}
           {...(popoverRender && { tabIndex: 0, role: 'button', type: 'button' })}
           {...(props.id !== undefined && titleId !== undefined && { 'aria-labelledby': `${props.id} ${titleId}` })}
-          style={{ border: 0 }}
         >
           {children}
           {popoverRender && popoverRender(stepRef)}

--- a/packages/react-core/src/components/ProgressStepper/ProgressStep.tsx
+++ b/packages/react-core/src/components/ProgressStepper/ProgressStep.tsx
@@ -60,7 +60,7 @@ export const ProgressStep: React.FunctionComponent<ProgressStepProps> = ({
   ...props
 }: ProgressStepProps) => {
   const _icon = icon !== undefined ? icon : variantIcons[variant];
-  const Component = popoverRender !== undefined ? 'span' : 'div';
+  const Component = popoverRender !== undefined ? 'button' : 'div';
   const stepRef = React.useRef();
 
   if (props.id === undefined || titleId === undefined) {
@@ -92,6 +92,7 @@ export const ProgressStep: React.FunctionComponent<ProgressStepProps> = ({
           ref={stepRef}
           {...(popoverRender && { tabIndex: 0, role: 'button', type: 'button' })}
           {...(props.id !== undefined && titleId !== undefined && { 'aria-labelledby': `${props.id} ${titleId}` })}
+          style={{ border: 0 }}
         >
           {children}
           {popoverRender && popoverRender(stepRef)}

--- a/packages/react-core/src/components/ProgressStepper/ProgressStep.tsx
+++ b/packages/react-core/src/components/ProgressStepper/ProgressStep.tsx
@@ -90,7 +90,7 @@ export const ProgressStep: React.FunctionComponent<ProgressStepProps> = ({
           className={css(styles.progressStepperStepTitle, popoverRender && styles.modifiers.helpText)}
           id={titleId}
           ref={stepRef}
-          {...(popoverRender && { tabIndex: 0, role: 'button', type: 'button' })}
+          {...(popoverRender && { type: 'button' })}
           {...(props.id !== undefined && titleId !== undefined && { 'aria-labelledby': `${props.id} ${titleId}` })}
         >
           {children}

--- a/packages/react-core/src/components/ProgressStepper/__tests__/__snapshots__/ProgressStepper.test.tsx.snap
+++ b/packages/react-core/src/components/ProgressStepper/__tests__/__snapshots__/ProgressStepper.test.tsx.snap
@@ -228,8 +228,6 @@ exports[`ProgressStep renders help text styling 1`] = `
     >
       <button
         class="pf-c-progress-stepper__step-title pf-m-help-text"
-        role="button"
-        tabindex="0"
         type="button"
       >
         Title

--- a/packages/react-core/src/components/ProgressStepper/__tests__/__snapshots__/ProgressStepper.test.tsx.snap
+++ b/packages/react-core/src/components/ProgressStepper/__tests__/__snapshots__/ProgressStepper.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`ProgressStep renders content 1`] = `
     >
       <div
         class="pf-c-progress-stepper__step-title"
+        style="border: 0px;"
       >
         Title
       </div>
@@ -43,6 +44,7 @@ exports[`ProgressStep renders current 1`] = `
     >
       <div
         class="pf-c-progress-stepper__step-title"
+        style="border: 0px;"
       >
         Title
       </div>
@@ -82,6 +84,7 @@ exports[`ProgressStep renders custom icon 1`] = `
     >
       <div
         class="pf-c-progress-stepper__step-title"
+        style="border: 0px;"
       >
         Title
       </div>
@@ -107,6 +110,7 @@ exports[`ProgressStep renders custom null icon - removing default from variant 1
     >
       <div
         class="pf-c-progress-stepper__step-title"
+        style="border: 0px;"
       >
         Title
       </div>
@@ -147,6 +151,7 @@ exports[`ProgressStep renders danger variant 1`] = `
     >
       <div
         class="pf-c-progress-stepper__step-title"
+        style="border: 0px;"
       >
         danger step
       </div>
@@ -173,6 +178,7 @@ exports[`ProgressStep renders default variant 1`] = `
     >
       <div
         class="pf-c-progress-stepper__step-title"
+        style="border: 0px;"
       >
         default step
       </div>
@@ -198,6 +204,7 @@ exports[`ProgressStep renders description 1`] = `
     >
       <div
         class="pf-c-progress-stepper__step-title"
+        style="border: 0px;"
       >
         Title
       </div>
@@ -226,15 +233,16 @@ exports[`ProgressStep renders help text styling 1`] = `
     <div
       class="pf-c-progress-stepper__step-main"
     >
-      <span
+      <button
         class="pf-c-progress-stepper__step-title pf-m-help-text"
         role="button"
+        style="border: 0px;"
         tabindex="0"
         type="button"
       >
         Title
         <div />
-      </span>
+      </button>
     </div>
   </li>
 </DocumentFragment>
@@ -272,6 +280,7 @@ exports[`ProgressStep renders info variant 1`] = `
     >
       <div
         class="pf-c-progress-stepper__step-title"
+        style="border: 0px;"
       >
         info step
       </div>
@@ -298,6 +307,7 @@ exports[`ProgressStep renders pending variant 1`] = `
     >
       <div
         class="pf-c-progress-stepper__step-title"
+        style="border: 0px;"
       >
         pending step
       </div>
@@ -338,6 +348,7 @@ exports[`ProgressStep renders success variant 1`] = `
     >
       <div
         class="pf-c-progress-stepper__step-title"
+        style="border: 0px;"
       >
         success step
       </div>
@@ -378,6 +389,7 @@ exports[`ProgressStep renders warning variant 1`] = `
     >
       <div
         class="pf-c-progress-stepper__step-title"
+        style="border: 0px;"
       >
         warning step
       </div>
@@ -407,6 +419,7 @@ exports[`ProgressStepper gets custom class and id 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
+          style="border: 0px;"
         >
           First
         </div>
@@ -427,6 +440,7 @@ exports[`ProgressStepper gets custom class and id 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
+          style="border: 0px;"
         >
           Second
         </div>
@@ -447,6 +461,7 @@ exports[`ProgressStepper gets custom class and id 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
+          style="border: 0px;"
         >
           Third
         </div>
@@ -476,6 +491,7 @@ exports[`ProgressStepper renders center aligned 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
+          style="border: 0px;"
         >
           First
         </div>
@@ -496,6 +512,7 @@ exports[`ProgressStepper renders center aligned 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
+          style="border: 0px;"
         >
           Second
         </div>
@@ -516,6 +533,7 @@ exports[`ProgressStepper renders center aligned 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
+          style="border: 0px;"
         >
           Third
         </div>
@@ -545,6 +563,7 @@ exports[`ProgressStepper renders compact 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
+          style="border: 0px;"
         >
           First
         </div>
@@ -565,6 +584,7 @@ exports[`ProgressStepper renders compact 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
+          style="border: 0px;"
         >
           Second
         </div>
@@ -585,6 +605,7 @@ exports[`ProgressStepper renders compact 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
+          style="border: 0px;"
         >
           Third
         </div>
@@ -614,6 +635,7 @@ exports[`ProgressStepper renders content 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
+          style="border: 0px;"
         >
           First
         </div>
@@ -634,6 +656,7 @@ exports[`ProgressStepper renders content 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
+          style="border: 0px;"
         >
           Second
         </div>
@@ -654,6 +677,7 @@ exports[`ProgressStepper renders content 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
+          style="border: 0px;"
         >
           Third
         </div>
@@ -683,6 +707,7 @@ exports[`ProgressStepper renders vertically 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
+          style="border: 0px;"
         >
           First
         </div>
@@ -703,6 +728,7 @@ exports[`ProgressStepper renders vertically 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
+          style="border: 0px;"
         >
           Second
         </div>
@@ -723,6 +749,7 @@ exports[`ProgressStepper renders vertically 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
+          style="border: 0px;"
         >
           Third
         </div>

--- a/packages/react-core/src/components/ProgressStepper/__tests__/__snapshots__/ProgressStepper.test.tsx.snap
+++ b/packages/react-core/src/components/ProgressStepper/__tests__/__snapshots__/ProgressStepper.test.tsx.snap
@@ -17,7 +17,6 @@ exports[`ProgressStep renders content 1`] = `
     >
       <div
         class="pf-c-progress-stepper__step-title"
-        style="border: 0px;"
       >
         Title
       </div>
@@ -44,7 +43,6 @@ exports[`ProgressStep renders current 1`] = `
     >
       <div
         class="pf-c-progress-stepper__step-title"
-        style="border: 0px;"
       >
         Title
       </div>
@@ -84,7 +82,6 @@ exports[`ProgressStep renders custom icon 1`] = `
     >
       <div
         class="pf-c-progress-stepper__step-title"
-        style="border: 0px;"
       >
         Title
       </div>
@@ -110,7 +107,6 @@ exports[`ProgressStep renders custom null icon - removing default from variant 1
     >
       <div
         class="pf-c-progress-stepper__step-title"
-        style="border: 0px;"
       >
         Title
       </div>
@@ -151,7 +147,6 @@ exports[`ProgressStep renders danger variant 1`] = `
     >
       <div
         class="pf-c-progress-stepper__step-title"
-        style="border: 0px;"
       >
         danger step
       </div>
@@ -178,7 +173,6 @@ exports[`ProgressStep renders default variant 1`] = `
     >
       <div
         class="pf-c-progress-stepper__step-title"
-        style="border: 0px;"
       >
         default step
       </div>
@@ -204,7 +198,6 @@ exports[`ProgressStep renders description 1`] = `
     >
       <div
         class="pf-c-progress-stepper__step-title"
-        style="border: 0px;"
       >
         Title
       </div>
@@ -236,7 +229,6 @@ exports[`ProgressStep renders help text styling 1`] = `
       <button
         class="pf-c-progress-stepper__step-title pf-m-help-text"
         role="button"
-        style="border: 0px;"
         tabindex="0"
         type="button"
       >
@@ -280,7 +272,6 @@ exports[`ProgressStep renders info variant 1`] = `
     >
       <div
         class="pf-c-progress-stepper__step-title"
-        style="border: 0px;"
       >
         info step
       </div>
@@ -307,7 +298,6 @@ exports[`ProgressStep renders pending variant 1`] = `
     >
       <div
         class="pf-c-progress-stepper__step-title"
-        style="border: 0px;"
       >
         pending step
       </div>
@@ -348,7 +338,6 @@ exports[`ProgressStep renders success variant 1`] = `
     >
       <div
         class="pf-c-progress-stepper__step-title"
-        style="border: 0px;"
       >
         success step
       </div>
@@ -389,7 +378,6 @@ exports[`ProgressStep renders warning variant 1`] = `
     >
       <div
         class="pf-c-progress-stepper__step-title"
-        style="border: 0px;"
       >
         warning step
       </div>
@@ -419,7 +407,6 @@ exports[`ProgressStepper gets custom class and id 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
-          style="border: 0px;"
         >
           First
         </div>
@@ -440,7 +427,6 @@ exports[`ProgressStepper gets custom class and id 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
-          style="border: 0px;"
         >
           Second
         </div>
@@ -461,7 +447,6 @@ exports[`ProgressStepper gets custom class and id 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
-          style="border: 0px;"
         >
           Third
         </div>
@@ -491,7 +476,6 @@ exports[`ProgressStepper renders center aligned 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
-          style="border: 0px;"
         >
           First
         </div>
@@ -512,7 +496,6 @@ exports[`ProgressStepper renders center aligned 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
-          style="border: 0px;"
         >
           Second
         </div>
@@ -533,7 +516,6 @@ exports[`ProgressStepper renders center aligned 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
-          style="border: 0px;"
         >
           Third
         </div>
@@ -563,7 +545,6 @@ exports[`ProgressStepper renders compact 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
-          style="border: 0px;"
         >
           First
         </div>
@@ -584,7 +565,6 @@ exports[`ProgressStepper renders compact 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
-          style="border: 0px;"
         >
           Second
         </div>
@@ -605,7 +585,6 @@ exports[`ProgressStepper renders compact 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
-          style="border: 0px;"
         >
           Third
         </div>
@@ -635,7 +614,6 @@ exports[`ProgressStepper renders content 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
-          style="border: 0px;"
         >
           First
         </div>
@@ -656,7 +634,6 @@ exports[`ProgressStepper renders content 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
-          style="border: 0px;"
         >
           Second
         </div>
@@ -677,7 +654,6 @@ exports[`ProgressStepper renders content 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
-          style="border: 0px;"
         >
           Third
         </div>
@@ -707,7 +683,6 @@ exports[`ProgressStepper renders vertically 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
-          style="border: 0px;"
         >
           First
         </div>
@@ -728,7 +703,6 @@ exports[`ProgressStepper renders vertically 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
-          style="border: 0px;"
         >
           Second
         </div>
@@ -749,7 +723,6 @@ exports[`ProgressStepper renders vertically 1`] = `
       >
         <div
           class="pf-c-progress-stepper__step-title"
-          style="border: 0px;"
         >
           Third
         </div>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7200 . The `Popover` for the `ProgressStepper` component can now be accessed via the keyboard using **Space** and **Enter** keys. The issue was due to the `Popover` component not utilizing the `onTriggerEnter` prop in **Popover.tsx**. It now works like a native button but in a discussion with @thatblindgeye , this issue could be resolved in core by changing the `span` element to a `button` element.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: No issues but read above. There are alternative solutions that may be easier resolutions. Another point to consider is simplifying the code for the `onTriggerEnter` cases.
