### PR TITLE
Charts: Simplify pattern visibility

### DIFF
--- a/packages/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/react-charts/src/components/Chart/Chart.tsx
@@ -33,7 +33,6 @@ import {
   getDefaultData,
   getDefaultPatternProps
 } from '../ChartUtils';
-import { PatternScaleInterface } from '../ChartUtils/chart-patterns';
 
 /**
  * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
@@ -199,6 +198,20 @@ export interface ChartProps extends VictoryChartProps {
    */
   groupComponent?: React.ReactElement<any>;
   /**
+   * The hasPatterns prop is an optional prop that indicates whether a pattern is shown for a chart.
+   * SVG patterns are dynamically generated (unique to each chart) in order to apply colors from the selected
+   * color theme or custom color scale. Those generated patterns are applied in a specific order (via a URL), similar
+   * to the color theme ordering defined by PatternFly. If the multi-color theme was in use; for example, colorized
+   * patterns would be displayed in that same order. Create custom patterns via the patternScale prop.
+   *
+   * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
+   *
+   * @example hasPatterns={ true }
+   * @example hasPatterns={[ true, true, false ]}
+   * @beta
+   */
+  hasPatterns?: boolean | boolean[];
+  /**
    * Specifies the height the svg viewBox of the chart container. This value should be given as a
    * number of pixels.
    *
@@ -219,11 +232,6 @@ export interface ChartProps extends VictoryChartProps {
    * @propType number | Function
    */
   innerRadius?: number;
-  /**
-   * Generate default pattern defs and populate patternScale
-   * @beta
-   */
-  isPatternDefs?: boolean;
   /**
    * Allows legend items to wrap. A value of true allows the legend to wrap onto the next line
    * if its container is not wide enough.
@@ -274,7 +282,7 @@ export interface ChartProps extends VictoryChartProps {
    * domain of a chart is static, while the minimum value depends on data or other variable information. If the domain
    * prop is set in addition to maximumDomain, domain will be used.
    *
-   * note: The x value supplied to the maxDomain prop refers to the independent variable, and the y value refers to the
+   * Note: The x value supplied to the maxDomain prop refers to the independent variable, and the y value refers to the
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
@@ -289,7 +297,7 @@ export interface ChartProps extends VictoryChartProps {
    * domain of a chart is static, while the maximum value depends on data or other variable information. If the domain
    * prop is set in addition to minimumDomain, domain will be used.
    *
-   * note: The x value supplied to the minDomain prop refers to the independent variable, and the y value refers to the
+   * Note: The x value supplied to the minDomain prop refers to the independent variable, and the y value refers to the
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
@@ -309,18 +317,16 @@ export interface ChartProps extends VictoryChartProps {
    */
   padding?: PaddingProps;
   /**
-   * The patternScale prop is an optional prop that defines a pattern to be applied to the children, where applicable.
-   * This prop should be given as an array of CSS colors, or as a string corresponding to a URL. Patterns will be
-   * assigned to children by index, unless they are explicitly specified in styles. Patterns will repeat when there are
-   * more children than patterns in the provided patternScale. Functionality may be overridden via the `style.data.fill`
-   * property.
+   * The patternScale prop is an optional prop that defines patterns to apply, where applicable. This prop should be
+   * given as a string array of pattern URLs. Patterns will be assigned to children by index and will repeat when there
+   * are more children than patterns in the provided patternScale. Use null to omit the pattern for a given index.
    *
    * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
    *
-   * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
+   * @example patternScale={[ 'url("#pattern1")', 'url("#pattern2")', null ]}
    * @beta
    */
-  patternScale?: PatternScaleInterface[];
+  patternScale?: string[];
   /**
    * Note: This prop should not be set manually.
    *
@@ -384,7 +390,7 @@ export interface ChartProps extends VictoryChartProps {
    * specified for "x" and/or "y". When this prop is false (or false for a given dimension), padding will be applied
    * without regard to quadrant. If this prop is not specified, domainPadding will be coerced to existing quadrants.
    *
-   * note: The x value supplied to the singleQuadrantDomainPadding prop refers to the independent variable, and the y
+   * Note: The x value supplied to the singleQuadrantDomainPadding prop refers to the independent variable, and the y
    * value refers to the dependent variable. This may cause confusion in horizontal charts, as the independent variable
    * will corresponds to the y axis.
    *
@@ -456,7 +462,7 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
   ariaTitle,
   children,
   colorScale,
-  isPatternDefs = false,
+  hasPatterns,
   legendAllowWrap = false,
   legendComponent = <ChartLegend />,
   legendData,
@@ -483,10 +489,10 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
     top: getPaddingForSide('top', padding, theme.chart.padding)
   };
 
-  const { defaultColorScale, defaultPatternScale, patternId } = getDefaultPatternProps({
+  const { defaultColorScale, defaultPatternScale, isPatternDefs, patternId } = getDefaultPatternProps({
     colorScale,
-    isPatternDefs,
     patternScale,
+    hasPatterns,
     themeColorScale: theme.chart.colorScale as string[]
   });
 
@@ -559,10 +565,10 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
       height,
       legendComponent: legend,
       padding: defaultPadding,
-      ...(defaultPatternScale && { patternScale: defaultPatternScale }),
       position: legendPosition,
       theme,
-      width
+      width,
+      ...(defaultPatternScale && { patternScale: defaultPatternScale })
     });
   };
 

--- a/packages/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/react-charts/src/components/Chart/Chart.tsx
@@ -29,12 +29,11 @@ import {
   getComputedLegend,
   getLabelTextSize,
   getPaddingForSide,
-  getPatternId,
   getPatternDefs,
-  getDefaultColorScale,
   getDefaultData,
-  getDefaultPatternScale
+  getDefaultPatternProps
 } from '../ChartUtils';
+import { PatternScaleInterface } from '../ChartUtils/chart-patterns';
 
 /**
  * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
@@ -94,12 +93,14 @@ export interface ChartProps extends VictoryChartProps {
   /**
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   defaultAxes?: AxesType;
   /**
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   defaultPolarAxes?: AxesType;
@@ -308,13 +309,6 @@ export interface ChartProps extends VictoryChartProps {
    */
   padding?: PaddingProps;
   /**
-   * The optional ID to prefix pattern defs
-   *
-   * @example patternId="pattern"
-   * @beta
-   */
-  patternId?: string;
-  /**
    * The patternScale prop is an optional prop that defines a pattern to be applied to the children, where applicable.
    * This prop should be given as an array of CSS colors, or as a string corresponding to a URL. Patterns will be
    * assigned to children by index, unless they are explicitly specified in styles. Patterns will repeat when there are
@@ -326,10 +320,11 @@ export interface ChartProps extends VictoryChartProps {
    * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
    * @beta
    */
-  patternScale?: string[];
+  patternScale?: PatternScaleInterface[];
   /**
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   prependDefaultAxes?: boolean;
@@ -372,6 +367,7 @@ export interface ChartProps extends VictoryChartProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   sharedEvents?: { events: any[]; getEventState: Function };
@@ -460,18 +456,17 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
   ariaTitle,
   children,
   colorScale,
+  isPatternDefs = false,
   legendAllowWrap = false,
   legendComponent = <ChartLegend />,
   legendData,
   legendPosition = ChartCommonStyles.legend.position as ChartLegendPosition,
   padding,
+  patternScale,
   showAxis = true,
   themeColor,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   themeVariant,
-  patternId = getPatternId(),
-  patternScale,
-  isPatternDefs = false,
 
   // destructure last
   theme = getChartTheme(themeColor, showAxis),
@@ -488,12 +483,11 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
     top: getPaddingForSide('top', padding, theme.chart.padding)
   };
 
-  const defaultColorScale = getDefaultColorScale(colorScale as any, theme.chart.colorScale as string[]);
-  const defaultPatternScale = getDefaultPatternScale({
-    colorScale: defaultColorScale,
+  const { defaultColorScale, defaultPatternScale, patternId } = getDefaultPatternProps({
+    colorScale,
+    isPatternDefs,
     patternScale,
-    patternId,
-    isPatternDefs
+    themeColorScale: theme.chart.colorScale as string[]
   });
 
   // Add pattern props for legend tooltip
@@ -503,7 +497,6 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
     containerComponent.props.labelComponent.type.displayName === 'ChartLegendTooltip'
   ) {
     labelComponent = React.cloneElement(containerComponent.props.labelComponent, {
-      patternId,
       theme,
       ...(defaultPatternScale && { patternScale: defaultPatternScale }),
       ...containerComponent.props.labelComponent.props
@@ -580,7 +573,6 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
         const { ...childProps } = child.props;
         return React.cloneElement(child, {
           colorScale,
-          patternId,
           theme,
           ...(defaultPatternScale && { patternScale: defaultPatternScale }),
           ...childProps,
@@ -605,7 +597,7 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
     >
       {renderChildren()}
       {getLegend()}
-      {isPatternDefs && getPatternDefs({ patternId, patternScale: defaultColorScale })}
+      {isPatternDefs && getPatternDefs({ patternId, colorScale: defaultColorScale })}
     </VictoryChart>
   );
 };

--- a/packages/react-charts/src/components/ChartArea/ChartArea.tsx
+++ b/packages/react-charts/src/components/ChartArea/ChartArea.tsx
@@ -312,6 +312,7 @@ export interface ChartAreaProps extends VictoryAreaProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   sharedEvents?: { events: any[]; getEventState: Function };

--- a/packages/react-charts/src/components/ChartArea/ChartArea.tsx
+++ b/packages/react-charts/src/components/ChartArea/ChartArea.tsx
@@ -222,7 +222,7 @@ export interface ChartAreaProps extends VictoryAreaProps {
    * domain of a chart is static, while the minimum value depends on data or other variable information. If the domain
    * prop is set in addition to maximumDomain, domain will be used.
    *
-   * note: The x value supplied to the maxDomain prop refers to the independent variable, and the y value refers to the
+   * Note: The x value supplied to the maxDomain prop refers to the independent variable, and the y value refers to the
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
@@ -237,7 +237,7 @@ export interface ChartAreaProps extends VictoryAreaProps {
    * domain of a chart is static, while the maximum value depends on data or other variable information. If the domain
    * prop is set in addition to minimumDomain, domain will be used.
    *
-   * note: The x value supplied to the minDomain prop refers to the independent variable, and the y value refers to the
+   * Note: The x value supplied to the minDomain prop refers to the independent variable, and the y value refers to the
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
@@ -324,7 +324,7 @@ export interface ChartAreaProps extends VictoryAreaProps {
    * specified for "x" and/or "y". When this prop is false (or false for a given dimension), padding will be applied
    * without regard to quadrant. If this prop is not specified, domainPadding will be coerced to existing quadrants.
    *
-   * note: The x value supplied to the singleQuadrantDomainPadding prop refers to the independent variable, and the y
+   * Note: The x value supplied to the singleQuadrantDomainPadding prop refers to the independent variable, and the y
    * value refers to the dependent variable. This may cause confusion in horizontal charts, as the independent variable
    * will corresponds to the y axis.
    *

--- a/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
+++ b/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
@@ -204,7 +204,7 @@ export interface ChartAxisProps extends VictoryAxisProps {
    * domain of a chart is static, while the minimum value depends on data or other variable information. If the domain
    * prop is set in addition to maximumDomain, domain will be used.
    *
-   * note: The x value supplied to the maxDomain prop refers to the independent variable, and the y value refers to the
+   * Note: The x value supplied to the maxDomain prop refers to the independent variable, and the y value refers to the
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
@@ -219,7 +219,7 @@ export interface ChartAxisProps extends VictoryAxisProps {
    * domain of a chart is static, while the maximum value depends on data or other variable information. If the domain
    * prop is set in addition to minimumDomain, domain will be used.
    *
-   * note: The x value supplied to the minDomain prop refers to the independent variable, and the y value refers to the
+   * Note: The x value supplied to the minDomain prop refers to the independent variable, and the y value refers to the
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
@@ -312,7 +312,7 @@ export interface ChartAxisProps extends VictoryAxisProps {
    * specified for "x" and/or "y". When this prop is false (or false for a given dimension), padding will be applied
    * without regard to quadrant. If this prop is not specified, domainPadding will be coerced to existing quadrants.
    *
-   * note: The x value supplied to the singleQuadrantDomainPadding prop refers to the independent variable, and the y
+   * Note: The x value supplied to the singleQuadrantDomainPadding prop refers to the independent variable, and the y
    * value refers to the dependent variable. This may cause confusion in horizontal charts, as the independent variable
    * will corresponds to the y axis.
    *
@@ -335,7 +335,7 @@ export interface ChartAxisProps extends VictoryAxisProps {
    * determine relative layout for components in Chart. Functional styles may be defined for
    * grid, tick, and tickLabel style properties, and they will be evaluated with each tick.
    *
-   * note: When a component is rendered as a child of another Victory component, or within a custom
+   * Note: When a component is rendered as a child of another Victory component, or within a custom
    * <svg> element with standalone={false} parent styles will be applied to the enclosing <g> tag.
    * Many styles that can be applied to a parent <svg> will not be expressed when applied to a <g>.
    *

--- a/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
+++ b/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
@@ -296,6 +296,7 @@ export interface ChartAxisProps extends VictoryAxisProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   sharedEvents?: { events: any[]; getEventState: Function };

--- a/packages/react-charts/src/components/ChartBar/ChartBar.tsx
+++ b/packages/react-charts/src/components/ChartBar/ChartBar.tsx
@@ -305,6 +305,7 @@ export interface ChartBarProps extends VictoryBarProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   polar?: boolean;
@@ -348,6 +349,7 @@ export interface ChartBarProps extends VictoryBarProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   sharedEvents?: { events: any[]; getEventState: Function };

--- a/packages/react-charts/src/components/ChartBar/ChartBar.tsx
+++ b/packages/react-charts/src/components/ChartBar/ChartBar.tsx
@@ -254,7 +254,7 @@ export interface ChartBarProps extends VictoryBarProps {
    * domain of a chart is static, while the minimum value depends on data or other variable information. If the domain
    * prop is set in addition to maximumDomain, domain will be used.
    *
-   * note: The x value supplied to the maxDomain prop refers to the independent variable, and the y value refers to the
+   * Note: The x value supplied to the maxDomain prop refers to the independent variable, and the y value refers to the
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
@@ -269,7 +269,7 @@ export interface ChartBarProps extends VictoryBarProps {
    * domain of a chart is static, while the maximum value depends on data or other variable information. If the domain
    * prop is set in addition to minimumDomain, domain will be used.
    *
-   * note: The x value supplied to the minDomain prop refers to the independent variable, and the y value refers to the
+   * Note: The x value supplied to the minDomain prop refers to the independent variable, and the y value refers to the
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
@@ -361,7 +361,7 @@ export interface ChartBarProps extends VictoryBarProps {
    * specified for "x" and/or "y". When this prop is false (or false for a given dimension), padding will be applied
    * without regard to quadrant. If this prop is not specified, domainPadding will be coerced to existing quadrants.
    *
-   * note: The x value supplied to the singleQuadrantDomainPadding prop refers to the independent variable, and the y
+   * Note: The x value supplied to the singleQuadrantDomainPadding prop refers to the independent variable, and the y
    * value refers to the dependent variable. This may cause confusion in horizontal charts, as the independent variable
    * will corresponds to the y axis.
    *

--- a/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
@@ -245,7 +245,7 @@ export interface ChartBulletProps {
    * domain of a chart is static, while the minimum value depends on data or other variable information. If the domain
    * prop is set in addition to maximumDomain, domain will be used.
    *
-   * note: The x value supplied to the maxDomain prop refers to the independent variable, and the y value refers to the
+   * Note: The x value supplied to the maxDomain prop refers to the independent variable, and the y value refers to the
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
@@ -262,7 +262,7 @@ export interface ChartBulletProps {
    * domain of a chart is static, while the maximum value depends on data or other variable information. If the domain
    * prop is set in addition to minimumDomain, domain will be used.
    *
-   * note: The x value supplied to the minDomain prop refers to the independent variable, and the y value refers to the
+   * Note: The x value supplied to the minDomain prop refers to the independent variable, and the y value refers to the
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *

--- a/packages/react-charts/src/components/ChartBullet/examples/ChartBullet.md
+++ b/packages/react-charts/src/components/ChartBullet/examples/ChartBullet.md
@@ -118,7 +118,7 @@ class BulletChart extends React.Component {
           constrainToVisibleArea
           height={250}
           labels={({ datum }) => `${datum.name}: ${datum.y}`}
-          legendAllowWrap={true}
+          legendAllowWrap
           legendPosition="bottom-left"
           maxDomain={{y: 100}}
           padding={{

--- a/packages/react-charts/src/components/ChartContainer/ChartContainer.tsx
+++ b/packages/react-charts/src/components/ChartContainer/ChartContainer.tsx
@@ -73,6 +73,7 @@ export interface ChartContainerProps extends VictoryContainerProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   polar?: boolean;

--- a/packages/react-charts/src/components/ChartCursorContainer/ChartCursorContainer.tsx
+++ b/packages/react-charts/src/components/ChartCursorContainer/ChartCursorContainer.tsx
@@ -24,6 +24,7 @@ export interface ChartCursorContainerProps extends VictoryCursorContainerProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   children?: React.ReactElement | React.ReactElement[];
@@ -134,6 +135,7 @@ export interface ChartCursorContainerProps extends VictoryCursorContainerProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   polar?: boolean;

--- a/packages/react-charts/src/components/ChartCursorTooltip/ChartCursorTooltip.tsx
+++ b/packages/react-charts/src/components/ChartCursorTooltip/ChartCursorTooltip.tsx
@@ -144,6 +144,7 @@ export interface ChartCursorTooltipProps extends ChartTooltipProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   height?: number;
@@ -257,6 +258,7 @@ export interface ChartCursorTooltipProps extends ChartTooltipProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   width?: number;

--- a/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -22,7 +22,7 @@ import { ChartContainer } from '../ChartContainer';
 import { ChartLabel } from '../ChartLabel';
 import { ChartPie, ChartPieLegendPosition, ChartPieProps } from '../ChartPie';
 import { ChartCommonStyles, ChartDonutStyles, ChartThemeDefinition } from '../ChartTheme';
-import { getPieLabelX, getPieLabelY, getPaddingForSide } from '../ChartUtils';
+import { getPieLabelX, getPieLabelY, getPaddingForSide, PatternScaleInterface } from '../ChartUtils';
 
 interface ChartDonutSubTitleInterface {
   dy?: number;
@@ -362,13 +362,6 @@ export interface ChartDonutProps extends ChartPieProps {
    */
   padAngle?: NumberOrCallback;
   /**
-   * The optional ID to prefix pattern defs
-   *
-   * @example patternId="pattern"
-   * @beta
-   */
-  patternId?: string;
-  /**
    * The patternScale prop is an optional prop that defines a pattern to be applied to the children, where applicable.
    * This prop should be given as an array of CSS colors, or as a string corresponding to a URL. Patterns will be
    * assigned to children by index, unless they are explicitly specified in styles. Patterns will repeat when there are
@@ -380,7 +373,7 @@ export interface ChartDonutProps extends ChartPieProps {
    * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
    * @beta
    */
-  patternScale?: string[];
+  patternScale?: PatternScaleInterface[];
   /**
    * The padding props specifies the amount of padding in number of pixels between
    * the edge of the chart and any rendered child components. This prop can be given
@@ -402,6 +395,7 @@ export interface ChartDonutProps extends ChartPieProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   sharedEvents?: { events: any[]; getEventState: Function };

--- a/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -22,7 +22,7 @@ import { ChartContainer } from '../ChartContainer';
 import { ChartLabel } from '../ChartLabel';
 import { ChartPie, ChartPieLegendPosition, ChartPieProps } from '../ChartPie';
 import { ChartCommonStyles, ChartDonutStyles, ChartThemeDefinition } from '../ChartTheme';
-import { getPieLabelX, getPieLabelY, getPaddingForSide, PatternScaleInterface } from '../ChartUtils';
+import { getPieLabelX, getPieLabelY, getPaddingForSide } from '../ChartUtils';
 
 interface ChartDonutSubTitleInterface {
   dy?: number;
@@ -233,6 +233,20 @@ export interface ChartDonutProps extends ChartPieProps {
    */
   groupComponent?: React.ReactElement<any>;
   /**
+   * The hasPatterns prop is an optional prop that indicates whether a pattern is shown for a chart.
+   * SVG patterns are dynamically generated (unique to each chart) in order to apply colors from the selected
+   * color theme or custom color scale. Those generated patterns are applied in a specific order (via a URL), similar
+   * to the color theme ordering defined by PatternFly. If the multi-color theme was in use; for example, colorized
+   * patterns would be displayed in that same order. Create custom patterns via the patternScale prop.
+   *
+   * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
+   *
+   * @example hasPatterns={ true }
+   * @example hasPatterns={[ true, true, false ]}
+   * @beta
+   */
+  hasPatterns?: boolean | boolean[];
+  /**
    * Specifies the height the svg viewBox of the chart container. This value should be given as a
    * number of pixels.
    *
@@ -256,11 +270,6 @@ export interface ChartDonutProps extends ChartPieProps {
    * @propType number | Function
    */
   innerRadius?: NumberOrCallback;
-  /**
-   * Generate default pattern defs and populate patternScale
-   * @beta
-   */
-  isPatternDefs?: boolean;
   /**
    * The labelComponent prop takes in an entire label component which will be used
    * to create a label for the area. The new element created from the passed labelComponent
@@ -362,18 +371,16 @@ export interface ChartDonutProps extends ChartPieProps {
    */
   padAngle?: NumberOrCallback;
   /**
-   * The patternScale prop is an optional prop that defines a pattern to be applied to the children, where applicable.
-   * This prop should be given as an array of CSS colors, or as a string corresponding to a URL. Patterns will be
-   * assigned to children by index, unless they are explicitly specified in styles. Patterns will repeat when there are
-   * more children than patterns in the provided patternScale. Functionality may be overridden via the `style.data.fill`
-   * property.
+   * The patternScale prop is an optional prop that defines patterns to apply, where applicable. This prop should be
+   * given as a string array of pattern URLs. Patterns will be assigned to children by index and will repeat when there
+   * are more children than patterns in the provided patternScale. Use null to omit the pattern for a given index.
    *
    * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
    *
-   * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
+   * @example patternScale={[ 'url("#pattern1")', 'url("#pattern2")', null ]}
    * @beta
    */
-  patternScale?: PatternScaleInterface[];
+  patternScale?: string[];
   /**
    * The padding props specifies the amount of padding in number of pixels between
    * the edge of the chart and any rendered child components. This prop can be given

--- a/packages/react-charts/src/components/ChartDonut/examples/ChartDonut.md
+++ b/packages/react-charts/src/components/ChartDonut/examples/ChartDonut.md
@@ -28,7 +28,7 @@ import { ChartDonut } from '@patternfly/react-charts';
   <ChartDonut
     ariaDesc="Average number of pets"
     ariaTitle="Donut chart example"
-    constrainToVisibleArea={true}
+    constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     subTitle="Pets"
@@ -46,7 +46,7 @@ import { ChartDonut } from '@patternfly/react-charts';
   <ChartDonut
     ariaDesc="Average number of pets"
     ariaTitle="Donut chart example"
-    constrainToVisibleArea={true}
+    constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
@@ -74,7 +74,7 @@ import { ChartDonut, ChartThemeColor } from '@patternfly/react-charts';
   <ChartDonut
     ariaDesc="Average number of pets"
     ariaTitle="Donut chart example"
-    constrainToVisibleArea={true}
+    constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
@@ -103,7 +103,7 @@ import { ChartDonut } from '@patternfly/react-charts';
   <ChartDonut
     ariaDesc="Average number of pets"
     ariaTitle="Donut chart example"
-    constrainToVisibleArea={true}
+    constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     donutOrientation="top"
     height={275}
@@ -133,7 +133,7 @@ import { ChartDonut } from '@patternfly/react-charts';
   <ChartDonut
     ariaDesc="Average number of pets"
     ariaTitle="Donut chart example"
-    constrainToVisibleArea={true}
+    constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={150}
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
@@ -153,7 +153,7 @@ import { ChartDonut } from '@patternfly/react-charts';
   <ChartDonut
     ariaDesc="Average number of pets"
     ariaTitle="Donut chart example"
-    constrainToVisibleArea={true}
+    constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={150}
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
@@ -182,7 +182,7 @@ import { ChartDonut } from '@patternfly/react-charts';
   <ChartDonut
     ariaDesc="Average number of pets"
     ariaTitle="Donut chart example"
-    constrainToVisibleArea={true}
+    constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={165}
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
@@ -212,7 +212,7 @@ import { ChartDonut } from '@patternfly/react-charts';
   <ChartDonut
     ariaDesc="Average number of pets"
     ariaTitle="Donut chart example"
-    constrainToVisibleArea={true}
+    constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={200}
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
@@ -21,7 +21,7 @@ import { SliceProps, VictoryPie, VictorySliceLabelPositionType } from 'victory-p
 import { ChartContainer } from '../ChartContainer';
 import { ChartDonut, ChartDonutProps } from '../ChartDonut';
 import { ChartCommonStyles, ChartThemeDefinition, ChartDonutUtilizationStyles } from '../ChartTheme';
-import { getDonutUtilizationTheme, PatternScaleInterface } from '../ChartUtils';
+import { getDonutUtilizationTheme } from '../ChartUtils';
 
 export enum ChartDonutUtilizationLabelPosition {
   centroid = 'centroid',
@@ -244,6 +244,20 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    */
   groupComponent?: React.ReactElement<any>;
   /**
+   * The hasPatterns prop is an optional prop that indicates whether a pattern is shown for a chart.
+   * SVG patterns are dynamically generated (unique to each chart) in order to apply colors from the selected
+   * color theme or custom color scale. Those generated patterns are applied in a specific order (via a URL), similar
+   * to the color theme ordering defined by PatternFly. If the multi-color theme was in use; for example, colorized
+   * patterns would be displayed in that same order. Create custom patterns via the patternScale prop.
+   *
+   * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
+   *
+   * @example hasPatterns={ true }
+   * @example hasPatterns={[ true, true, false ]}
+   * @beta
+   */
+  hasPatterns?: boolean | boolean[];
+  /**
    * Specifies the height the svg viewBox of the chart container. This value should be given as a
    * number of pixels.
    *
@@ -267,11 +281,6 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    * below 60% and an error below 20%
    */
   invert?: boolean;
-  /**
-   * Generate default pattern defs and populate patternScale
-   * @beta
-   */
-  isPatternDefs?: boolean;
   /**
    * This will show the static, unused portion of the donut utilization chart.
    *
@@ -392,18 +401,16 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    */
   padding?: PaddingProps;
   /**
-   * The patternScale prop is an optional prop that defines a pattern to be applied to the children, where applicable.
-   * This prop should be given as an array of CSS colors, or as a string corresponding to a URL. Patterns will be
-   * assigned to children by index, unless they are explicitly specified in styles. Patterns will repeat when there are
-   * more children than patterns in the provided patternScale. Functionality may be overridden via the `style.data.fill`
-   * property.
+   * The patternScale prop is an optional prop that defines patterns to apply, where applicable. This prop should be
+   * given as a string array of pattern URLs. Patterns will be assigned to children by index and will repeat when there
+   * are more children than patterns in the provided patternScale. Use null to omit the pattern for a given index.
    *
    * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
    *
-   * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
+   * @example patternScale={[ 'url("#pattern1")', 'url("#pattern2")', null ]}
    * @beta
    */
-  patternScale?: PatternScaleInterface[];
+  patternScale?: string[];
   /**
    * Moves the given pattern index to top of scale, used to sync patterns with ChartDonutThreshold
    *
@@ -608,14 +615,11 @@ export const ChartDonutUtilization: React.FunctionComponent<ChartDonutUtilizatio
   isStatic = true,
   legendPosition = ChartCommonStyles.legend.position as ChartDonutUtilizationLegendPosition,
   padding,
-  patternScale,
-  patternUnshiftIndex,
   standalone = true,
   themeColor,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   themeVariant,
   thresholds,
-  isPatternDefs = false,
   x,
   y,
 
@@ -700,12 +704,9 @@ export const ChartDonutUtilization: React.FunctionComponent<ChartDonutUtilizatio
       colorScale={colorScale}
       data={getComputedData()}
       height={height}
-      isPatternDefs={isPatternDefs}
       key="pf-chart-donut-utilization"
       legendPosition={legendPosition}
       padding={padding}
-      patternScale={patternScale}
-      patternUnshiftIndex={patternUnshiftIndex}
       standalone={false}
       theme={getThresholdTheme()}
       width={width}

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
@@ -21,7 +21,7 @@ import { SliceProps, VictoryPie, VictorySliceLabelPositionType } from 'victory-p
 import { ChartContainer } from '../ChartContainer';
 import { ChartDonut, ChartDonutProps } from '../ChartDonut';
 import { ChartCommonStyles, ChartThemeDefinition, ChartDonutUtilizationStyles } from '../ChartTheme';
-import { getDefaultColorScale, getDefaultPatternScale, getDonutUtilizationTheme, getPatternId } from '../ChartUtils';
+import { getDonutUtilizationTheme, PatternScaleInterface } from '../ChartUtils';
 
 export enum ChartDonutUtilizationLabelPosition {
   centroid = 'centroid',
@@ -244,13 +244,6 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    */
   groupComponent?: React.ReactElement<any>;
   /**
-   * Flag indicating parent isPatternDefs prop is in use
-   * Do not use
-   * @hide
-   * @private
-   */
-  hasPatternDefs?: boolean;
-  /**
    * Specifies the height the svg viewBox of the chart container. This value should be given as a
    * number of pixels.
    *
@@ -279,6 +272,15 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    * @beta
    */
   isPatternDefs?: boolean;
+  /**
+   * This will show the static, unused portion of the donut utilization chart.
+   *
+   * Note: This prop should not be set manually.
+   *
+   * @private
+   * @hide
+   */
+  isStatic?: boolean;
   /**
    * Allows legend items to wrap. A value of true allows the legend to wrap onto the next line
    * if its container is not wide enough.
@@ -390,13 +392,6 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    */
   padding?: PaddingProps;
   /**
-   * The optional ID to prefix pattern defs
-   *
-   * @example patternId="pattern"
-   * @beta
-   */
-  patternId?: string;
-  /**
    * The patternScale prop is an optional prop that defines a pattern to be applied to the children, where applicable.
    * This prop should be given as an array of CSS colors, or as a string corresponding to a URL. Patterns will be
    * assigned to children by index, unless they are explicitly specified in styles. Patterns will repeat when there are
@@ -408,7 +403,16 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
    * @beta
    */
-  patternScale?: string[];
+  patternScale?: PatternScaleInterface[];
+  /**
+   * Moves the given pattern index to top of scale, used to sync patterns with ChartDonutThreshold
+   *
+   * Note: This prop should not be set manually.
+   *
+   * @private
+   * @hide
+   */
+  patternUnshiftIndex?: number;
   /**
    * Specifies the radius of the chart. If this property is not provided it is computed
    * from width, height, and padding props
@@ -421,23 +425,10 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   sharedEvents?: { events: any[]; getEventState: Function };
-  /**
-   * This will show the static, unused portion of the donut utilization chart.
-   *
-   * Note: This prop should not be set manually.
-   *
-   * @hide
-   */
-  showStatic?: boolean;
-  /**
-   * This will apply patterns for the static, unused portion of the donut utilization chart.
-   *
-   * @hide
-   */
-  showStaticPattern?: boolean;
   /**
    * Use the sortKey prop to indicate how data should be sorted. This prop
    * is given directly to the lodash sortBy function to be executed on the
@@ -613,14 +604,12 @@ export const ChartDonutUtilization: React.FunctionComponent<ChartDonutUtilizatio
   colorScale,
   containerComponent = <ChartContainer />,
   data,
-  hasPatternDefs,
   invert = false,
+  isStatic = true,
   legendPosition = ChartCommonStyles.legend.position as ChartDonutUtilizationLegendPosition,
   padding,
-  patternId = getPatternId(),
   patternScale,
-  showStatic = true,
-  showStaticPattern = false,
+  patternUnshiftIndex,
   standalone = true,
   themeColor,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -636,30 +625,11 @@ export const ChartDonutUtilization: React.FunctionComponent<ChartDonutUtilizatio
   width = theme.pie.width,
   ...rest
 }: ChartDonutUtilizationProps) => {
-  const defaultColorScale = getDefaultColorScale(colorScale, theme.pie.colorScale as string[]);
-  const defaultPatternScale = getDefaultPatternScale({
-    colorScale: defaultColorScale,
-    patternScale,
-    patternId,
-    isPatternDefs
-  });
-
-  // Hide static pattern and handle edge case where parent does not use isPatternDefs
-  const hideStaticPattern = showStatic && !showStaticPattern;
-  const hideThresholdPatterns = !patternScale && hasPatternDefs === false;
-  if (defaultPatternScale && (hideStaticPattern || hideThresholdPatterns)) {
-    for (let i = 0; i < defaultPatternScale.length; i++) {
-      if (i !== 0) {
-        defaultPatternScale[i] = null;
-      }
-    }
-  }
-
   // Returns computed data representing pie chart slices
   const getComputedData = () => {
     const datum = getData();
     const computedData: [{ x?: any; y: any }] = [{ x: datum[0]._x, y: datum[0]._y || 0 }];
-    if (showStatic) {
+    if (isStatic) {
       computedData.push({ y: datum[0]._x ? Math.abs(100 - datum[0]._y) : 100 });
     }
     return computedData;
@@ -692,9 +662,8 @@ export const ChartDonutUtilization: React.FunctionComponent<ChartDonutUtilizatio
   // Returns theme based on threshold and current value
   const getThresholdTheme = () => {
     const newTheme = { ...theme };
-
-    if (data) {
-      const datum = getData();
+    const datum = getData();
+    if (datum) {
       const donutThresholds = getDonutThresholds();
       const mergeThemeProps = (i: number) => {
         // Merge just the first color of dynamic (blue, green, etc.) with static (gray) for expected colorScale
@@ -731,14 +700,14 @@ export const ChartDonutUtilization: React.FunctionComponent<ChartDonutUtilizatio
       colorScale={colorScale}
       data={getComputedData()}
       height={height}
+      isPatternDefs={isPatternDefs}
       key="pf-chart-donut-utilization"
       legendPosition={legendPosition}
       padding={padding}
-      patternId={patternId}
-      patternScale={defaultPatternScale ? defaultPatternScale : undefined}
+      patternScale={patternScale}
+      patternUnshiftIndex={patternUnshiftIndex}
       standalone={false}
       theme={getThresholdTheme()}
-      isPatternDefs={isPatternDefs}
       width={width}
       {...rest}
     />

--- a/packages/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
+++ b/packages/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
@@ -29,7 +29,7 @@ import { ChartDonutUtilization } from '@patternfly/react-charts';
   <ChartDonutUtilization
     ariaDesc="Storage capacity"
     ariaTitle="Donut utilization chart example"
-    constrainToVisibleArea={true}
+    constrainToVisibleArea
     data={{ x: 'GBps capacity', y: 75 }}
     labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
     subTitle="of 100 GBps"
@@ -74,7 +74,7 @@ class DonutUtilizationChart extends React.Component {
         <ChartDonutUtilization
           ariaDesc="Storage capacity"
           ariaTitle="Donut utilization chart example"
-          constrainToVisibleArea={true}
+          constrainToVisibleArea
           data={{ x: 'GBps capacity', y: used }}
           labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
           legendData={[{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }]}
@@ -132,7 +132,7 @@ class InvertedDonutUtilizationChart extends React.Component {
         <ChartDonutUtilization
           ariaDesc="Storage capacity"
           ariaTitle="Donut utilization chart example"
-          constrainToVisibleArea={true}
+          constrainToVisibleArea
           data={{ x: 'GBps capacity', y: used }}
           invert
           labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
@@ -191,7 +191,7 @@ class VerticalLegendUtilizationChart extends React.Component {
         <ChartDonutUtilization
           ariaDesc="Storage capacity"
           ariaTitle="Donut utilization chart example"
-          constrainToVisibleArea={true}
+          constrainToVisibleArea
           data={{ x: 'Storage capacity', y: used }}
           height={300}
           labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
@@ -225,7 +225,7 @@ import { ChartDonutUtilization } from '@patternfly/react-charts';
   <ChartDonutUtilization
     ariaDesc="Storage capacity"
     ariaTitle="Donut utilization chart example"
-    constrainToVisibleArea={true}
+    constrainToVisibleArea
     data={{ x: 'Storage capacity', y: 45 }}
     height={275}
     labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
@@ -254,7 +254,7 @@ import { ChartDonutUtilization } from '@patternfly/react-charts';
   <ChartDonutUtilization
     ariaDesc="Storage capacity"
     ariaTitle="Donut utilization chart example"
-    constrainToVisibleArea={true}
+    constrainToVisibleArea
     data={{ x: 'Storage capacity', y: 75 }}
     height={175}
     labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
@@ -301,7 +301,7 @@ class UtilizationChart extends React.Component {
         <ChartDonutUtilization
           ariaDesc="Storage capacity"
           ariaTitle="Donut utilization chart example"
-          constrainToVisibleArea={true}
+          constrainToVisibleArea
           data={{ x: 'Storage capacity', y: used }}
           height={175}
           labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
@@ -336,7 +336,7 @@ import { ChartDonutUtilization } from '@patternfly/react-charts';
   <ChartDonutUtilization
     ariaDesc="Storage capacity"
     ariaTitle="Donut utilization chart example"
-    constrainToVisibleArea={true}
+    constrainToVisibleArea
     data={{ x: 'Storage capacity', y: 45 }}
     height={185}
     labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
@@ -366,7 +366,7 @@ import { ChartDonutUtilization } from '@patternfly/react-charts';
   <ChartDonutUtilization
     ariaDesc="Storage capacity"
     ariaTitle="Donut utilization chart example"
-    constrainToVisibleArea={true}
+    constrainToVisibleArea
     data={{ x: 'Storage capacity', y: 45 }}
     height={200}
     labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
@@ -397,7 +397,7 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
   <ChartDonutThreshold
     ariaDesc="Storage capacity"
     ariaTitle="Donut utilization chart with static threshold example"
-    constrainToVisibleArea={true}
+    constrainToVisibleArea
     data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
     labels={({ datum }) => datum.x ? datum.x : null}
   >
@@ -442,7 +442,7 @@ class ThresholdChart extends React.Component {
         <ChartDonutThreshold
           ariaDesc="Storage capacity"
           ariaTitle="Donut utilization chart with static threshold example"
-          constrainToVisibleArea={true}
+          constrainToVisibleArea
           data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
           labels={({ datum }) => datum.x ? datum.x : null}
           padding={{
@@ -505,7 +505,7 @@ class InvertedThresholdChart extends React.Component {
         <ChartDonutThreshold
           ariaDesc="Storage capacity"
           ariaTitle="Donut utilization chart with static threshold example"
-          constrainToVisibleArea={true}
+          constrainToVisibleArea
           data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 20%', y: 20 }]}
           invert
           labels={({ datum }) => datum.x ? datum.x : null}
@@ -564,7 +564,7 @@ class CustomLegendThresholdChart extends React.Component {
         <ChartDonutThreshold
           ariaDesc="Storage capacity"
           ariaTitle="Donut utilization chart with static threshold example"
-          constrainToVisibleArea={true}
+          constrainToVisibleArea
           data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
           height={350}
           labels={({ datum }) => datum.x ? datum.x : null}
@@ -603,7 +603,7 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
   <ChartDonutThreshold
     ariaDesc="Storage capacity"
     ariaTitle="Donut utilization chart with static threshold example"
-    constrainToVisibleArea={true}
+    constrainToVisibleArea
     data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
     height={275}
     labels={({ datum }) => datum.x ? datum.x : null}
@@ -636,7 +636,7 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
   <ChartDonutThreshold
     ariaDesc="Storage capacity"
     ariaTitle="Donut utilization chart with static threshold example"
-    constrainToVisibleArea={true}
+    constrainToVisibleArea
     data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
     height={185}
     labels={({ datum }) => datum.x ? datum.x : null}
@@ -683,7 +683,7 @@ class ThresholdChart extends React.Component {
         <ChartDonutThreshold
           ariaDesc="Storage capacity"
           ariaTitle="Donut utilization chart with static threshold example"
-          constrainToVisibleArea={true}
+          constrainToVisibleArea
           data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
           height={185}
           labels={({ datum }) => datum.x ? datum.x : null}
@@ -723,7 +723,7 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
   <ChartDonutThreshold
     ariaDesc="Storage capacity"
     ariaTitle="Donut utilization chart with static threshold example"
-    constrainToVisibleArea={true}
+    constrainToVisibleArea
     data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
     height={200}
     labels={({ datum }) => datum.x ? datum.x : null}
@@ -758,7 +758,7 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
   <ChartDonutThreshold
     ariaDesc="Storage capacity"
     ariaTitle="Donut utilization chart with static threshold example"
-    constrainToVisibleArea={true}
+    constrainToVisibleArea
     data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
     height={225}
     labels={({ datum }) => datum.x ? datum.x : null}

--- a/packages/react-charts/src/components/ChartGroup/ChartGroup.tsx
+++ b/packages/react-charts/src/components/ChartGroup/ChartGroup.tsx
@@ -23,12 +23,11 @@ import { ChartContainer } from '../ChartContainer';
 import { ChartThemeDefinition } from '../ChartTheme';
 import {
   getClassName,
-  getDefaultColorScale,
-  getDefaultPatternScale,
-  getPatternId,
+  getDefaultPatternProps,
   getPatternDefs,
   getTheme,
-  renderChildrenWithPatterns
+  renderChildrenWithPatterns,
+  PatternScaleInterface
 } from '../ChartUtils';
 
 export enum ChartGroupSortOrder {
@@ -299,13 +298,6 @@ export interface ChartGroupProps extends VictoryGroupProps {
    */
   padding?: PaddingProps;
   /**
-   * The optional ID to prefix pattern defs
-   *
-   * @example patternId="pattern"
-   * @beta
-   */
-  patternId?: string;
-  /**
    * The patternScale prop is an optional prop that defines a pattern to be applied to the children, where applicable.
    * This prop should be given as an array of CSS colors, or as a string corresponding to a URL. Patterns will be
    * assigned to children by index, unless they are explicitly specified in styles. Patterns will repeat when there are
@@ -317,7 +309,7 @@ export interface ChartGroupProps extends VictoryGroupProps {
    * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
    * @beta
    */
-  patternScale?: string[];
+  patternScale?: PatternScaleInterface[];
   /**
    * Victory components can pass a boolean polar prop to specify whether a label is part of a polar chart.
    */
@@ -362,6 +354,7 @@ export interface ChartGroupProps extends VictoryGroupProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   sharedEvents?: { events: any[]; getEventState: Function };
@@ -484,12 +477,11 @@ export const ChartGroup: React.FunctionComponent<ChartGroupProps> = ({
   children,
   colorScale,
   containerComponent = <ChartContainer />,
-  patternId = getPatternId(),
+  isPatternDefs = false,
   patternScale,
   themeColor,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   themeVariant,
-  isPatternDefs = false,
 
   // destructure last
   theme = getTheme(themeColor),
@@ -504,12 +496,11 @@ export const ChartGroup: React.FunctionComponent<ChartGroupProps> = ({
     className: getClassName({ className: containerComponent.props.className }) // Override VictoryContainer class name
   });
 
-  const defaultColorScale = getDefaultColorScale(colorScale, theme.group.colorScale as string[]);
-  const defaultPatternScale = getDefaultPatternScale({
-    colorScale: defaultColorScale,
+  const { defaultColorScale, defaultPatternScale, patternId } = getDefaultPatternProps({
+    colorScale,
+    isPatternDefs,
     patternScale,
-    patternId,
-    isPatternDefs
+    themeColorScale: theme.group.colorScale as string[]
   });
 
   // Note: containerComponent is required for theme
@@ -517,10 +508,9 @@ export const ChartGroup: React.FunctionComponent<ChartGroupProps> = ({
     <VictoryGroup colorScale={colorScale} containerComponent={container} theme={theme} {...rest}>
       {renderChildrenWithPatterns({
         children,
-        patternId,
         patternScale: defaultPatternScale
       })}
-      {isPatternDefs && getPatternDefs({ patternId, patternScale: defaultColorScale })}
+      {isPatternDefs && getPatternDefs({ patternId, colorScale: defaultColorScale })}
     </VictoryGroup>
   );
 };

--- a/packages/react-charts/src/components/ChartGroup/ChartGroup.tsx
+++ b/packages/react-charts/src/components/ChartGroup/ChartGroup.tsx
@@ -26,8 +26,7 @@ import {
   getDefaultPatternProps,
   getPatternDefs,
   getTheme,
-  renderChildrenWithPatterns,
-  PatternScaleInterface
+  renderChildrenWithPatterns
 } from '../ChartUtils';
 
 export enum ChartGroupSortOrder {
@@ -202,6 +201,20 @@ export interface ChartGroupProps extends VictoryGroupProps {
    */
   groupComponent?: React.ReactElement<any>;
   /**
+   * The hasPatterns prop is an optional prop that indicates whether a pattern is shown for a chart.
+   * SVG patterns are dynamically generated (unique to each chart) in order to apply colors from the selected
+   * color theme or custom color scale. Those generated patterns are applied in a specific order (via a URL), similar
+   * to the color theme ordering defined by PatternFly. If the multi-color theme was in use; for example, colorized
+   * patterns would be displayed in that same order. Create custom patterns via the patternScale prop.
+   *
+   * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
+   *
+   * @example hasPatterns={ true }
+   * @example hasPatterns={[ true, true, false ]}
+   * @beta
+   */
+  hasPatterns?: boolean | boolean[];
+  /**
    * The height props specifies the height the svg viewBox of the chart container.
    * This value should be given as a number of pixels
    */
@@ -212,11 +225,6 @@ export interface ChartGroupProps extends VictoryGroupProps {
    * and the dependent variable will be plotted on the x axis.
    */
   horizontal?: boolean;
-  /**
-   * Generate default pattern defs and populate patternScale
-   * @beta
-   */
-  isPatternDefs?: boolean;
   /**
    * The labelComponent prop takes in an entire label component which will be used
    * to create a label for the area. The new element created from the passed labelComponent
@@ -244,7 +252,7 @@ export interface ChartGroupProps extends VictoryGroupProps {
    * domain of a chart is static, while the minimum value depends on data or other variable information. If the domain
    * prop is set in addition to maximumDomain, domain will be used.
    *
-   * note: The x value supplied to the maxDomain prop refers to the independent variable, and the y value refers to the
+   * Note: The x value supplied to the maxDomain prop refers to the independent variable, and the y value refers to the
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
@@ -259,7 +267,7 @@ export interface ChartGroupProps extends VictoryGroupProps {
    * domain of a chart is static, while the maximum value depends on data or other variable information. If the domain
    * prop is set in addition to minimumDomain, domain will be used.
    *
-   * note: The x value supplied to the minDomain prop refers to the independent variable, and the y value refers to the
+   * Note: The x value supplied to the minDomain prop refers to the independent variable, and the y value refers to the
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
@@ -298,18 +306,16 @@ export interface ChartGroupProps extends VictoryGroupProps {
    */
   padding?: PaddingProps;
   /**
-   * The patternScale prop is an optional prop that defines a pattern to be applied to the children, where applicable.
-   * This prop should be given as an array of CSS colors, or as a string corresponding to a URL. Patterns will be
-   * assigned to children by index, unless they are explicitly specified in styles. Patterns will repeat when there are
-   * more children than patterns in the provided patternScale. Functionality may be overridden via the `style.data.fill`
-   * property.
+   * The patternScale prop is an optional prop that defines patterns to apply, where applicable. This prop should be
+   * given as a string array of pattern URLs. Patterns will be assigned to children by index and will repeat when there
+   * are more children than patterns in the provided patternScale. Use null to omit the pattern for a given index.
    *
    * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
    *
-   * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
+   * @example patternScale={[ 'url("#pattern1")', 'url("#pattern2")', null ]}
    * @beta
    */
-  patternScale?: PatternScaleInterface[];
+  patternScale?: string[];
   /**
    * Victory components can pass a boolean polar prop to specify whether a label is part of a polar chart.
    */
@@ -366,7 +372,7 @@ export interface ChartGroupProps extends VictoryGroupProps {
    * specified for "x" and/or "y". When this prop is false (or false for a given dimension), padding will be applied
    * without regard to quadrant. If this prop is not specified, domainPadding will be coerced to existing quadrants.
    *
-   * note: The x value supplied to the singleQuadrantDomainPadding prop refers to the independent variable, and the y
+   * Note: The x value supplied to the singleQuadrantDomainPadding prop refers to the independent variable, and the y
    * value refers to the dependent variable. This may cause confusion in horizontal charts, as the independent variable
    * will corresponds to the y axis.
    *
@@ -477,7 +483,7 @@ export const ChartGroup: React.FunctionComponent<ChartGroupProps> = ({
   children,
   colorScale,
   containerComponent = <ChartContainer />,
-  isPatternDefs = false,
+  hasPatterns,
   patternScale,
   themeColor,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -496,9 +502,9 @@ export const ChartGroup: React.FunctionComponent<ChartGroupProps> = ({
     className: getClassName({ className: containerComponent.props.className }) // Override VictoryContainer class name
   });
 
-  const { defaultColorScale, defaultPatternScale, patternId } = getDefaultPatternProps({
+  const { defaultColorScale, defaultPatternScale, isPatternDefs, patternId } = getDefaultPatternProps({
     colorScale,
-    isPatternDefs,
+    hasPatterns,
     patternScale,
     themeColorScale: theme.group.colorScale as string[]
   });

--- a/packages/react-charts/src/components/ChartLabel/ChartLabel.tsx
+++ b/packages/react-charts/src/components/ChartLabel/ChartLabel.tsx
@@ -54,6 +54,8 @@ export interface ChartLabelProps extends VictoryLabelProps {
    * Note: This prop should not be set manually.
    *
    * @propType number | string | Function
+   *
+   * @private
    * @hide
    */
   children?: StringOrNumberOrCallback;
@@ -103,6 +105,7 @@ export interface ChartLabelProps extends VictoryLabelProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   index?: string | number;
@@ -144,6 +147,7 @@ export interface ChartLabelProps extends VictoryLabelProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   polar?: boolean;
@@ -158,6 +162,7 @@ export interface ChartLabelProps extends VictoryLabelProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   scale?: { x?: any; y?: any };
@@ -199,6 +204,7 @@ export interface ChartLabelProps extends VictoryLabelProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   width?: number;

--- a/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
+++ b/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
@@ -21,7 +21,7 @@ import { ChartContainer } from '../ChartContainer';
 import { ChartLabel } from '../ChartLabel';
 import { ChartPoint } from '../ChartPoint';
 import { ChartThemeDefinition } from '../ChartTheme';
-import { getTheme } from '../ChartUtils';
+import { getTheme, PatternScaleInterface } from '../ChartUtils';
 
 export enum ChartLegendOrientation {
   horizontal = 'horizontal',
@@ -213,7 +213,7 @@ export interface ChartLegendProps extends VictoryLegendProps {
    * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
    * @beta
    */
-  patternScale?: string[];
+  patternScale?: PatternScaleInterface[];
   /**
    * The responsive prop specifies whether the rendered container should be a responsive container with a viewBox
    * attribute, or a static container with absolute width and height.
@@ -238,6 +238,7 @@ export interface ChartLegendProps extends VictoryLegendProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   sharedEvents?: { events: any[]; getEventState: Function };
@@ -362,7 +363,7 @@ export const ChartLegend: React.FunctionComponent<ChartLegendProps> = ({
             : undefined;
         const pattern = patternScale[index % patternScale.length];
         const color = colorScale ? colorScale[index % colorScale.length] : themeColor; // Sync color scale
-        return pattern && pattern !== null ? pattern : color;
+        return pattern && pattern.isVisible !== false ? pattern.value : color;
       },
       ..._style.data
     };

--- a/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
+++ b/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
@@ -21,7 +21,7 @@ import { ChartContainer } from '../ChartContainer';
 import { ChartLabel } from '../ChartLabel';
 import { ChartPoint } from '../ChartPoint';
 import { ChartThemeDefinition } from '../ChartTheme';
-import { getTheme, PatternScaleInterface } from '../ChartUtils';
+import { getTheme } from '../ChartUtils';
 
 export enum ChartLegendOrientation {
   horizontal = 'horizontal',
@@ -155,15 +155,6 @@ export interface ChartLegendProps extends VictoryLegendProps {
    */
   gutter?: number | { left: number; right: number };
   /**
-   * Specifies the height the svg viewBox of the chart container. This value should be given as a
-   * number of pixels.
-   *
-   * Because Victory renders responsive containers, the width and height props do not determine the width and
-   * height of the chart in number of pixels, but instead define an aspect ratio for the chart. The exact number of
-   * pixels will depend on the size of the container the chart is rendered into.
-   */
-  height?: number;
-  /**
    * The itemsPerRow prop determines how many items to render in each row
    * of a horizontal legend, or in each column of a vertical legend. This
    * prop should be given as an integer. When this prop is not given,
@@ -202,18 +193,16 @@ export interface ChartLegendProps extends VictoryLegendProps {
    */
   padding?: PaddingProps;
   /**
-   * The patternScale prop is an optional prop that defines a pattern to be applied to the children, where applicable.
-   * This prop should be given as an array of CSS colors, or as a string corresponding to a URL. Patterns will be
-   * assigned to children by index, unless they are explicitly specified in styles. Patterns will repeat when there are
-   * more children than patterns in the provided patternScale. Functionality may be overridden via the `data.symbol.fill`
-   * property.
+   * The patternScale prop is an optional prop that defines patterns to apply, where applicable. This prop should be
+   * given as a string array of pattern URLs. Patterns will be assigned to children by index and will repeat when there
+   * are more children than patterns in the provided patternScale. Use null to omit the pattern for a given index.
    *
    * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
    *
-   * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
+   * @example patternScale={[ 'url("#pattern1")', 'url("#pattern2")', null ]}
    * @beta
    */
-  patternScale?: PatternScaleInterface[];
+  patternScale?: string[];
   /**
    * The responsive prop specifies whether the rendered container should be a responsive container with a viewBox
    * attribute, or a static container with absolute width and height.
@@ -361,9 +350,9 @@ export const ChartLegend: React.FunctionComponent<ChartLegendProps> = ({
           theme && theme.legend && theme.legend.colorScale
             ? theme.legend.colorScale[index % theme.legend.colorScale.length]
             : undefined;
-        const pattern = patternScale[index % patternScale.length];
         const color = colorScale ? colorScale[index % colorScale.length] : themeColor; // Sync color scale
-        return pattern && pattern.isVisible !== false ? pattern.value : color;
+        const pattern = patternScale[index % patternScale.length];
+        return pattern ? pattern : color;
       },
       ..._style.data
     };

--- a/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
+++ b/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
@@ -532,11 +532,6 @@ class InteractivePieLegendChart extends React.Component {
       const { hiddenSeries } = this.state; // Skip if already hidden                
       return hiddenSeries.has(index);
     };
-
-    this.isDataAvailable = () => {
-      const { hiddenSeries } = this.state;
-      return hiddenSeries.size !== this.series.length;
-    };
   };
 
   render() {
@@ -544,7 +539,7 @@ class InteractivePieLegendChart extends React.Component {
 
     const data = [];
     this.series.map((s, index) => {
-      data.push(!hiddenSeries.has(index) ? s.datapoints : [{ y: null}]);
+      data.push(!hiddenSeries.has(index) ? s.datapoints : { y: null });
     });
 
     return (
@@ -554,7 +549,6 @@ class InteractivePieLegendChart extends React.Component {
           ariaTitle="Pie chart example"
           events={this.getEvents()}
           height={275}
-          labels={({ datum }) => `${datum.x}: ${datum.y}`}
           legendComponent={<ChartLegend name={'legend'} data={this.getLegendData()} />}
           legendPosition="bottom"
           padding={{
@@ -570,6 +564,7 @@ class InteractivePieLegendChart extends React.Component {
           <ChartPie
             constrainToVisibleArea={true}
             data={data}
+            labels={({ datum }) => `${datum.x}: ${datum.y}`}
             name="pie"
           />
         </Chart>

--- a/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
+++ b/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
@@ -47,7 +47,7 @@ import { ChartDonut } from '@patternfly/react-charts';
   <ChartDonut
     ariaDesc="Average number of pets"
     ariaTitle="Donut chart example"
-    constrainToVisibleArea={true}
+    constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
@@ -146,7 +146,7 @@ class BulletChart extends React.Component {
             constrainToVisibleArea
             height={250}
             labels={({ datum }) => `${datum.name}: ${datum.y}`}
-            legendAllowWrap={true}
+            legendAllowWrap
             legendPosition="bottom-left"
             maxDomain={{y: 100}}
             padding={{
@@ -562,7 +562,7 @@ class InteractivePieLegendChart extends React.Component {
           width={300}
         >
           <ChartPie
-            constrainToVisibleArea={true}
+            constrainToVisibleArea
             data={data}
             labels={({ datum }) => `${datum.x}: ${datum.y}`}
             name="pie"
@@ -609,7 +609,7 @@ class TooltipPieChart extends React.Component {
         <ChartPie
           ariaDesc="Average number of pets"
           ariaTitle="Pie chart example"
-          constrainToVisibleArea={true}
+          constrainToVisibleArea
           data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
           height={275}
           labels={({ datum }) => `${datum.x}: ${datum.y}`}
@@ -777,7 +777,7 @@ class LegendLayoutPieChart extends React.Component {
         <ChartDonut
           ariaDesc="Average number of pets"
           ariaTitle="Pie chart example"
-          constrainToVisibleArea={true}
+          constrainToVisibleArea
           data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
           height={230}
           labels={({ datum }) => `${datum.x}: ${datum.y}`}

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
@@ -18,7 +18,8 @@ import {
   getLegendTooltipSize,
   getLegendTooltipVisibleData,
   getLegendTooltipVisibleText,
-  getTheme
+  getTheme,
+  PatternScaleInterface
 } from '../ChartUtils';
 
 /**
@@ -42,6 +43,7 @@ export interface ChartLegendTooltipProps extends ChartCursorTooltipProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   activePoints?: any[];
@@ -159,6 +161,7 @@ export interface ChartLegendTooltipProps extends ChartCursorTooltipProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   height?: number;
@@ -237,7 +240,7 @@ export interface ChartLegendTooltipProps extends ChartCursorTooltipProps {
    * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
    * @beta
    */
-  patternScale?: string[];
+  patternScale?: PatternScaleInterface[];
   /**
    * The pointerLength prop determines the length of the triangular pointer extending from the flyout. This prop may be
    * given as a positive number or a function of datum.
@@ -314,6 +317,7 @@ export interface ChartLegendTooltipProps extends ChartCursorTooltipProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   width?: number;

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
@@ -18,8 +18,7 @@ import {
   getLegendTooltipSize,
   getLegendTooltipVisibleData,
   getLegendTooltipVisibleText,
-  getTheme,
-  PatternScaleInterface
+  getTheme
 } from '../ChartUtils';
 
 /**
@@ -229,18 +228,16 @@ export interface ChartLegendTooltipProps extends ChartCursorTooltipProps {
    */
   orientation?: OrientationOrCallback;
   /**
-   * The patternScale prop is an optional prop that defines a pattern to be applied to the children, where applicable.
-   * This prop should be given as an array of CSS colors, or as a string corresponding to a URL. Patterns will be
-   * assigned to children by index, unless they are explicitly specified in styles. Patterns will repeat when there are
-   * more children than patterns in the provided patternScale. Functionality may be overridden via the `style.data.fill`
-   * property.
+   * The patternScale prop is an optional prop that defines patterns to apply, where applicable. This prop should be
+   * given as a string array of pattern URLs. Patterns will be assigned to children by index and will repeat when there
+   * are more children than patterns in the provided patternScale. Use null to omit the pattern for a given index.
    *
    * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
    *
-   * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
+   * @example patternScale={[ 'url("#pattern1")', 'url("#pattern2")', null ]}
    * @beta
    */
-  patternScale?: PatternScaleInterface[];
+  patternScale?: string[];
   /**
    * The pointerLength prop determines the length of the triangular pointer extending from the flyout. This prop may be
    * given as a positive number or a function of datum.

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipContent.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipContent.tsx
@@ -11,8 +11,7 @@ import {
   getLegendTooltipSize,
   getLegendTooltipVisibleData,
   getLegendTooltipVisibleText,
-  getTheme,
-  PatternScaleInterface
+  getTheme
 } from '../ChartUtils';
 
 /**
@@ -119,18 +118,16 @@ export interface ChartLegendTooltipContentProps {
     };
   }[];
   /**
-   * The patternScale prop is an optional prop that defines a pattern to be applied to the children, where applicable.
-   * This prop should be given as an array of CSS colors, or as a string corresponding to a URL. Patterns will be
-   * assigned to children by index, unless they are explicitly specified in styles. Patterns will repeat when there are
-   * more children than patterns in the provided patternScale. Functionality may be overridden via the `style.data.fill`
-   * property.
+   * The patternScale prop is an optional prop that defines patterns to apply, where applicable. This prop should be
+   * given as a string array of pattern URLs. Patterns will be assigned to children by index and will repeat when there
+   * are more children than patterns in the provided patternScale. Use null to omit the pattern for a given index.
    *
    * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
    *
-   * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
+   * @example patternScale={[ 'url("#pattern1")', 'url("#pattern2")', null ]}
    * @beta
    */
-  patternScale?: PatternScaleInterface[];
+  patternScale?: string[];
   /**
    * The text prop defines the text ChartTooltip will render. The text prop may be given as a string, number, or
    * function of datum. When ChartLabel is used as the labelComponent, strings may include newline characters, which

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipContent.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipContent.tsx
@@ -11,7 +11,8 @@ import {
   getLegendTooltipSize,
   getLegendTooltipVisibleData,
   getLegendTooltipVisibleText,
-  getTheme
+  getTheme,
+  PatternScaleInterface
 } from '../ChartUtils';
 
 /**
@@ -24,6 +25,7 @@ export interface ChartLegendTooltipContentProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   activePoints?: any[];
@@ -128,7 +130,7 @@ export interface ChartLegendTooltipContentProps {
    * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
    * @beta
    */
-  patternScale?: string[];
+  patternScale?: PatternScaleInterface[];
   /**
    * The text prop defines the text ChartTooltip will render. The text prop may be given as a string, number, or
    * function of datum. When ChartLabel is used as the labelComponent, strings may include newline characters, which

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipLabel.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipLabel.tsx
@@ -44,6 +44,8 @@ export interface ChartLegendLabelProps extends VictoryLabelProps {
    * Note: This prop should not be set manually.
    *
    * @propType number | string | Function
+   *
+   * @private
    * @hide
    */
   children?: StringOrNumberOrCallback;
@@ -93,6 +95,7 @@ export interface ChartLegendLabelProps extends VictoryLabelProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   index?: string | number;
@@ -152,6 +155,7 @@ export interface ChartLegendLabelProps extends VictoryLabelProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   polar?: boolean;
@@ -166,6 +170,7 @@ export interface ChartLegendLabelProps extends VictoryLabelProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   scale?: { x?: any; y?: any };
@@ -207,6 +212,7 @@ export interface ChartLegendLabelProps extends VictoryLabelProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   width?: number;

--- a/packages/react-charts/src/components/ChartLine/ChartLine.tsx
+++ b/packages/react-charts/src/components/ChartLine/ChartLine.tsx
@@ -272,6 +272,7 @@ export interface ChartLineProps extends VictoryLineProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   polar?: boolean;
@@ -315,6 +316,7 @@ export interface ChartLineProps extends VictoryLineProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   sharedEvents?: { events: any[]; getEventState: Function };

--- a/packages/react-charts/src/components/ChartLine/ChartLine.tsx
+++ b/packages/react-charts/src/components/ChartLine/ChartLine.tsx
@@ -221,7 +221,7 @@ export interface ChartLineProps extends VictoryLineProps {
    * domain of a chart is static, while the minimum value depends on data or other variable information. If the domain
    * prop is set in addition to maximumDomain, domain will be used.
    *
-   * note: The x value supplied to the maxDomain prop refers to the independent variable, and the y value refers to the
+   * Note: The x value supplied to the maxDomain prop refers to the independent variable, and the y value refers to the
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
@@ -236,7 +236,7 @@ export interface ChartLineProps extends VictoryLineProps {
    * domain of a chart is static, while the maximum value depends on data or other variable information. If the domain
    * prop is set in addition to minimumDomain, domain will be used.
    *
-   * note: The x value supplied to the minDomain prop refers to the independent variable, and the y value refers to the
+   * Note: The x value supplied to the minDomain prop refers to the independent variable, and the y value refers to the
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
@@ -328,7 +328,7 @@ export interface ChartLineProps extends VictoryLineProps {
    * specified for "x" and/or "y". When this prop is false (or false for a given dimension), padding will be applied
    * without regard to quadrant. If this prop is not specified, domainPadding will be coerced to existing quadrants.
    *
-   * note: The x value supplied to the singleQuadrantDomainPadding prop refers to the independent variable, and the y
+   * Note: The x value supplied to the singleQuadrantDomainPadding prop refers to the independent variable, and the y
    * value refers to the dependent variable. This may cause confusion in horizontal charts, as the independent variable
    * will corresponds to the y axis.
    *

--- a/packages/react-charts/src/components/ChartPie/ChartPie.tsx
+++ b/packages/react-charts/src/components/ChartPie/ChartPie.tsx
@@ -27,14 +27,7 @@ import { ChartContainer } from '../ChartContainer';
 import { ChartLegend, ChartLegendOrientation } from '../ChartLegend';
 import { ChartCommonStyles, ChartThemeDefinition } from '../ChartTheme';
 import { ChartTooltip } from '../ChartTooltip';
-import {
-  getComputedLegend,
-  getDefaultPatternProps,
-  getPaddingForSide,
-  getPatternDefs,
-  getTheme,
-  PatternScaleInterface
-} from '../ChartUtils';
+import { getComputedLegend, getDefaultPatternProps, getPaddingForSide, getPatternDefs, getTheme } from '../ChartUtils';
 
 export enum ChartPieLabelPosition {
   centroid = 'centroid',
@@ -223,6 +216,20 @@ export interface ChartPieProps extends VictoryPieProps {
    */
   groupComponent?: React.ReactElement<any>;
   /**
+   * The hasPatterns prop is an optional prop that indicates whether a pattern is shown for a chart.
+   * SVG patterns are dynamically generated (unique to each chart) in order to apply colors from the selected
+   * color theme or custom color scale. Those generated patterns are applied in a specific order (via a URL), similar
+   * to the color theme ordering defined by PatternFly. If the multi-color theme was in use; for example, colorized
+   * patterns would be displayed in that same order. Create custom patterns via the patternScale prop.
+   *
+   * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
+   *
+   * @example hasPatterns={ true }
+   * @example hasPatterns={[ true, true, false ]}
+   * @beta
+   */
+  hasPatterns?: boolean | boolean[];
+  /**
    * Specifies the height the svg viewBox of the chart container. This value should be given as a
    * number of pixels.
    *
@@ -247,11 +254,6 @@ export interface ChartPieProps extends VictoryPieProps {
    * @propType number | Function
    */
   innerRadius?: NumberOrCallback;
-  /**
-   * Generate default pattern defs and populate patternScale
-   * @beta
-   */
-  isPatternDefs?: boolean;
   /**
    * The labelComponent prop takes in an entire label component which will be used
    * to create a label for the area. The new element created from the passed labelComponent
@@ -363,18 +365,16 @@ export interface ChartPieProps extends VictoryPieProps {
    */
   padding?: PaddingProps;
   /**
-   * The patternScale prop is an optional prop that defines a pattern to be applied to the children, where applicable.
-   * This prop should be given as an array of CSS colors, or as a string corresponding to a URL. Patterns will be
-   * assigned to children by index, unless they are explicitly specified in styles. Patterns will repeat when there are
-   * more children than patterns in the provided patternScale. Functionality may be overridden via the `style.data.fill`
-   * property.
+   * The patternScale prop is an optional prop that defines patterns to apply, where applicable. This prop should be
+   * given as a string array of pattern URLs. Patterns will be assigned to children by index and will repeat when there
+   * are more children than patterns in the provided patternScale. Use null to omit the pattern for a given index.
    *
    * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
    *
-   * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
+   * @example patternScale={[ 'url("#pattern1")', 'url("#pattern2")', null ]}
    * @beta
    */
-  patternScale?: PatternScaleInterface[];
+  patternScale?: string[];
   /**
    * Moves the given pattern index to top of scale, used to sync patterns with ChartDonutThreshold
    *
@@ -503,13 +503,14 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
   colorScale,
   constrainToVisibleArea = false,
   containerComponent = <ChartContainer />,
-  isPatternDefs = false,
+  hasPatterns,
   legendAllowWrap = false,
   legendComponent = <ChartLegend />,
   legendData,
   legendPosition = ChartCommonStyles.legend.position as ChartPieLegendPosition,
   patternScale,
   patternUnshiftIndex,
+
   padding,
   radius,
   standalone = true,
@@ -537,9 +538,9 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
     top: getPaddingForSide('top', padding, theme.pie.padding)
   };
 
-  const { defaultColorScale, defaultPatternScale, patternId } = getDefaultPatternProps({
+  const { defaultColorScale, defaultPatternScale, isPatternDefs, patternId } = getDefaultPatternProps({
     colorScale,
-    isPatternDefs,
+    hasPatterns,
     patternScale,
     themeColorScale: theme.pie.colorScale as string[]
   });
@@ -564,9 +565,7 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
     _style.data = {
       fill: ({ slice }: any) => {
         const pattern = defaultPatternScale[slice.index % defaultPatternScale.length];
-        return pattern && pattern.isVisible !== false
-          ? pattern.value
-          : defaultColorScale[slice.index % defaultColorScale.length].value;
+        return pattern ? pattern : defaultColorScale[slice.index % defaultColorScale.length];
       },
       ..._style.data
     };
@@ -609,10 +608,10 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
       height,
       legendComponent: legend,
       padding: defaultPadding,
-      ...(defaultPatternScale && { patternScale: defaultPatternScale }),
       position: legendPosition,
       theme,
-      width
+      width,
+      ...(defaultPatternScale && { patternScale: defaultPatternScale })
     });
   };
 

--- a/packages/react-charts/src/components/ChartPie/examples/ChartPie.md
+++ b/packages/react-charts/src/components/ChartPie/examples/ChartPie.md
@@ -26,7 +26,7 @@ import { ChartPie } from '@patternfly/react-charts';
   <ChartPie
     ariaDesc="Average number of pets"
     ariaTitle="Pie chart example"
-    constrainToVisibleArea={true}
+    constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={230}
     labels={({ datum }) => `${datum.x}: ${datum.y}`}
@@ -53,7 +53,7 @@ import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
   <ChartPie
     ariaDesc="Average number of pets"
     ariaTitle="Pie chart example"
-    constrainToVisibleArea={true}
+    constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={230}
     labels={({ datum }) => `${datum.x}: ${datum.y}`}
@@ -81,7 +81,7 @@ import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
   <ChartPie
     ariaDesc="Average number of pets"
     ariaTitle="Pie chart example"
-    constrainToVisibleArea={true}
+    constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={275}
     labels={({ datum }) => `${datum.x}: ${datum.y}`}

--- a/packages/react-charts/src/components/ChartScatter/ChartScatter.tsx
+++ b/packages/react-charts/src/components/ChartScatter/ChartScatter.tsx
@@ -221,7 +221,7 @@ export interface ChartScatterProps extends VictoryScatterProps {
    * domain of a chart is static, while the minimum value depends on data or other variable information. If the domain
    * prop is set in addition to maximumDomain, domain will be used.
    *
-   * note: The x value supplied to the maxDomain prop refers to the independent variable, and the y value refers to the
+   * Note: The x value supplied to the maxDomain prop refers to the independent variable, and the y value refers to the
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
@@ -240,7 +240,7 @@ export interface ChartScatterProps extends VictoryScatterProps {
    * domain of a chart is static, while the maximum value depends on data or other variable information. If the domain
    * prop is set in addition to minimumDomain, domain will be used.
    *
-   * note: The x value supplied to the minDomain prop refers to the independent variable, and the y value refers to the
+   * Note: The x value supplied to the minDomain prop refers to the independent variable, and the y value refers to the
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
@@ -332,7 +332,7 @@ export interface ChartScatterProps extends VictoryScatterProps {
    * specified for "x" and/or "y". When this prop is false (or false for a given dimension), padding will be applied
    * without regard to quadrant. If this prop is not specified, domainPadding will be coerced to existing quadrants.
    *
-   * note: The x value supplied to the singleQuadrantDomainPadding prop refers to the independent variable, and the y
+   * Note: The x value supplied to the singleQuadrantDomainPadding prop refers to the independent variable, and the y
    * value refers to the dependent variable. This may cause confusion in horizontal charts, as the independent variable
    * will corresponds to the y axis.
    *

--- a/packages/react-charts/src/components/ChartScatter/ChartScatter.tsx
+++ b/packages/react-charts/src/components/ChartScatter/ChartScatter.tsx
@@ -276,6 +276,7 @@ export interface ChartScatterProps extends VictoryScatterProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   polar?: boolean;
@@ -319,6 +320,7 @@ export interface ChartScatterProps extends VictoryScatterProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   sharedEvents?: { events: any[]; getEventState: Function };

--- a/packages/react-charts/src/components/ChartStack/ChartStack.tsx
+++ b/packages/react-charts/src/components/ChartStack/ChartStack.tsx
@@ -19,13 +19,7 @@ import {
 import { VictoryStack, VictoryStackProps, VictoryStackTTargetType } from 'victory-stack';
 import { ChartContainer } from '../ChartContainer';
 import { ChartThemeDefinition } from '../ChartTheme';
-import {
-  getClassName,
-  getDefaultPatternProps,
-  getTheme,
-  PatternScaleInterface,
-  renderChildrenWithPatterns
-} from '../ChartUtils';
+import { getClassName, getDefaultPatternProps, getTheme, renderChildrenWithPatterns } from '../ChartUtils';
 
 /**
  * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
@@ -188,6 +182,20 @@ export interface ChartStackProps extends VictoryStackProps {
    */
   groupComponent?: React.ReactElement<any>;
   /**
+   * The hasPatterns prop is an optional prop that indicates whether a pattern is shown for a chart.
+   * SVG patterns are dynamically generated (unique to each chart) in order to apply colors from the selected
+   * color theme or custom color scale. Those generated patterns are applied in a specific order (via a URL), similar
+   * to the color theme ordering defined by PatternFly. If the multi-color theme was in use; for example, colorized
+   * patterns would be displayed in that same order. Create custom patterns via the patternScale prop.
+   *
+   * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
+   *
+   * @example hasPatterns={ true }
+   * @example hasPatterns={[ true, true, false ]}
+   * @beta
+   */
+  hasPatterns?: boolean | boolean[];
+  /**
    * The height props specifies the height the svg viewBox of the chart container.
    * This value should be given as a number of pixels
    */
@@ -198,11 +206,6 @@ export interface ChartStackProps extends VictoryStackProps {
    * or horizontal if the prop is set to true.
    */
   horizontal?: boolean;
-  /**
-   * Generate default pattern defs and populate patternScale
-   * @beta
-   */
-  isPatternDefs?: boolean;
   /**
    * The labelComponent prop takes in an entire label component which will be used
    * to create a label for the area. The new element created from the passed labelComponent
@@ -230,7 +233,7 @@ export interface ChartStackProps extends VictoryStackProps {
    * domain of a chart is static, while the minimum value depends on data or other variable information. If the domain
    * prop is set in addition to maximumDomain, domain will be used.
    *
-   * note: The x value supplied to the maxDomain prop refers to the independent variable, and the y value refers to the
+   * Note: The x value supplied to the maxDomain prop refers to the independent variable, and the y value refers to the
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
@@ -245,7 +248,7 @@ export interface ChartStackProps extends VictoryStackProps {
    * domain of a chart is static, while the maximum value depends on data or other variable information. If the domain
    * prop is set in addition to minimumDomain, domain will be used.
    *
-   * note: The x value supplied to the minDomain prop refers to the independent variable, and the y value refers to the
+   * Note: The x value supplied to the minDomain prop refers to the independent variable, and the y value refers to the
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
@@ -277,18 +280,16 @@ export interface ChartStackProps extends VictoryStackProps {
    */
   padding?: PaddingProps;
   /**
-   * The patternScale prop is an optional prop that defines a pattern to be applied to the children, where applicable.
-   * This prop should be given as an array of CSS colors, or as a string corresponding to a URL. Patterns will be
-   * assigned to children by index, unless they are explicitly specified in styles. Patterns will repeat when there are
-   * more children than patterns in the provided patternScale. Functionality may be overridden via the `style.data.fill`
-   * property.
+   * The patternScale prop is an optional prop that defines patterns to apply, where applicable. This prop should be
+   * given as a string array of pattern URLs. Patterns will be assigned to children by index and will repeat when there
+   * are more children than patterns in the provided patternScale. Use null to omit the pattern for a given index.
    *
    * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
    *
-   * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
+   * @example patternScale={[ 'url("#pattern1")', 'url("#pattern2")', null ]}
    * @beta
    */
-  patternScale?: PatternScaleInterface[];
+  patternScale?: string[];
   /**
    * Victory components can pass a boolean polar prop to specify whether a label is part of a polar chart.
    *
@@ -345,7 +346,7 @@ export interface ChartStackProps extends VictoryStackProps {
    * specified for "x" and/or "y". When this prop is false (or false for a given dimension), padding will be applied
    * without regard to quadrant. If this prop is not specified, domainPadding will be coerced to existing quadrants.
    *
-   * note: The x value supplied to the singleQuadrantDomainPadding prop refers to the independent variable, and the y
+   * Note: The x value supplied to the singleQuadrantDomainPadding prop refers to the independent variable, and the y
    * value refers to the dependent variable. This may cause confusion in horizontal charts, as the independent variable
    * will corresponds to the y axis.
    *
@@ -412,7 +413,7 @@ export const ChartStack: React.FunctionComponent<ChartStackProps> = ({
   children,
   colorScale,
   containerComponent = <ChartContainer />,
-  isPatternDefs = false,
+  hasPatterns,
   patternScale,
   themeColor,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -433,7 +434,7 @@ export const ChartStack: React.FunctionComponent<ChartStackProps> = ({
 
   const { defaultPatternScale } = getDefaultPatternProps({
     colorScale,
-    isPatternDefs,
+    hasPatterns,
     patternScale,
     themeColorScale: theme.stack.colorScale as string[]
   });

--- a/packages/react-charts/src/components/ChartStack/ChartStack.tsx
+++ b/packages/react-charts/src/components/ChartStack/ChartStack.tsx
@@ -21,10 +21,9 @@ import { ChartContainer } from '../ChartContainer';
 import { ChartThemeDefinition } from '../ChartTheme';
 import {
   getClassName,
-  getDefaultColorScale,
-  getDefaultPatternScale,
-  getPatternId,
+  getDefaultPatternProps,
   getTheme,
+  PatternScaleInterface,
   renderChildrenWithPatterns
 } from '../ChartUtils';
 
@@ -278,13 +277,6 @@ export interface ChartStackProps extends VictoryStackProps {
    */
   padding?: PaddingProps;
   /**
-   * The optional ID to prefix pattern defs
-   *
-   * @example patternId="pattern"
-   * @beta
-   */
-  patternId?: string;
-  /**
    * The patternScale prop is an optional prop that defines a pattern to be applied to the children, where applicable.
    * This prop should be given as an array of CSS colors, or as a string corresponding to a URL. Patterns will be
    * assigned to children by index, unless they are explicitly specified in styles. Patterns will repeat when there are
@@ -296,12 +288,13 @@ export interface ChartStackProps extends VictoryStackProps {
    * @example patternScale={['url("#pattern:0")', 'url("#pattern:1")', 'url("#pattern:2")']}
    * @beta
    */
-  patternScale?: string[];
+  patternScale?: PatternScaleInterface[];
   /**
    * Victory components can pass a boolean polar prop to specify whether a label is part of a polar chart.
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   polar?: boolean;
@@ -340,6 +333,7 @@ export interface ChartStackProps extends VictoryStackProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   sharedEvents?: { events: any[]; getEventState: Function };
@@ -418,12 +412,11 @@ export const ChartStack: React.FunctionComponent<ChartStackProps> = ({
   children,
   colorScale,
   containerComponent = <ChartContainer />,
-  patternId = getPatternId(),
+  isPatternDefs = false,
   patternScale,
   themeColor,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   themeVariant,
-  isPatternDefs = false,
 
   // destructure last
   theme = getTheme(themeColor),
@@ -438,12 +431,11 @@ export const ChartStack: React.FunctionComponent<ChartStackProps> = ({
     className: getClassName({ className: containerComponent.props.className }) // Override VictoryContainer class name
   });
 
-  const defaultColorScale = getDefaultColorScale(colorScale, theme.stack.colorScale as string[]);
-  const defaultPatternScale = getDefaultPatternScale({
-    colorScale: defaultColorScale,
+  const { defaultPatternScale } = getDefaultPatternProps({
+    colorScale,
+    isPatternDefs,
     patternScale,
-    patternId,
-    isPatternDefs
+    themeColorScale: theme.stack.colorScale as string[]
   });
 
   // Note: containerComponent is required for theme
@@ -451,7 +443,6 @@ export const ChartStack: React.FunctionComponent<ChartStackProps> = ({
     <VictoryStack colorScale={colorScale} containerComponent={container} theme={theme} {...rest}>
       {renderChildrenWithPatterns({
         children,
-        patternId,
         patternScale: defaultPatternScale
       })}
     </VictoryStack>

--- a/packages/react-charts/src/components/ChartTheme/examples/ChartTheme.md
+++ b/packages/react-charts/src/components/ChartTheme/examples/ChartTheme.md
@@ -116,7 +116,7 @@ import { ChartDonut, ChartThemeColor } from '@patternfly/react-charts';
   <ChartDonut
     ariaDesc="Average number of pets"
     ariaTitle="Donut chart example"
-    constrainToVisibleArea={true}
+    constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}

--- a/packages/react-charts/src/components/ChartThreshold/ChartThreshold.tsx
+++ b/packages/react-charts/src/components/ChartThreshold/ChartThreshold.tsx
@@ -217,7 +217,7 @@ export interface ChartThresholdProps extends VictoryLineProps {
    * domain of a chart is static, while the minimum value depends on data or other variable information. If the domain
    * prop is set in addition to maximumDomain, domain will be used.
    *
-   * note: The x value supplied to the maxDomain prop refers to the independent variable, and the y value refers to the
+   * Note: The x value supplied to the maxDomain prop refers to the independent variable, and the y value refers to the
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
@@ -232,7 +232,7 @@ export interface ChartThresholdProps extends VictoryLineProps {
    * domain of a chart is static, while the maximum value depends on data or other variable information. If the domain
    * prop is set in addition to minimumDomain, domain will be used.
    *
-   * note: The x value supplied to the minDomain prop refers to the independent variable, and the y value refers to the
+   * Note: The x value supplied to the minDomain prop refers to the independent variable, and the y value refers to the
    * dependent variable. This may cause confusion in horizontal charts, as the independent variable will corresponds to
    * the y axis.
    *
@@ -324,7 +324,7 @@ export interface ChartThresholdProps extends VictoryLineProps {
    * specified for "x" and/or "y". When this prop is false (or false for a given dimension), padding will be applied
    * without regard to quadrant. If this prop is not specified, domainPadding will be coerced to existing quadrants.
    *
-   * note: The x value supplied to the singleQuadrantDomainPadding prop refers to the independent variable, and the y
+   * Note: The x value supplied to the singleQuadrantDomainPadding prop refers to the independent variable, and the y
    * value refers to the dependent variable. This may cause confusion in horizontal charts, as the independent variable
    * will corresponds to the y axis.
    *

--- a/packages/react-charts/src/components/ChartThreshold/ChartThreshold.tsx
+++ b/packages/react-charts/src/components/ChartThreshold/ChartThreshold.tsx
@@ -268,6 +268,7 @@ export interface ChartThresholdProps extends VictoryLineProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   polar?: boolean;
@@ -311,6 +312,7 @@ export interface ChartThresholdProps extends VictoryLineProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   sharedEvents?: { events: any[]; getEventState: Function };

--- a/packages/react-charts/src/components/ChartTooltip/ChartTooltip.tsx
+++ b/packages/react-charts/src/components/ChartTooltip/ChartTooltip.tsx
@@ -140,6 +140,7 @@ export interface ChartTooltipProps extends VictoryTooltipProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   height?: number;
@@ -248,6 +249,7 @@ export interface ChartTooltipProps extends VictoryTooltipProps {
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   width?: number;

--- a/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
+++ b/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
@@ -524,7 +524,7 @@ class TooltipPieChart extends React.Component {
         <ChartPie
           ariaDesc="Average number of pets"
           ariaTitle="Pie chart example"
-          constrainToVisibleArea={true}
+          constrainToVisibleArea
           data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
           height={275}
           labels={({ datum }) => `${datum.x}: ${datum.y}`}

--- a/packages/react-charts/src/components/ChartUtils/chart-legend.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-legend.ts
@@ -5,7 +5,6 @@ import { ChartLegendOrientation, ChartLegendPosition, ChartLegendProps } from '.
 import { ChartCommonStyles, ChartThemeDefinition } from '../ChartTheme';
 import { getPieOrigin } from './chart-origin';
 import * as React from 'react';
-import { PatternScaleInterface } from './chart-patterns';
 
 interface ChartLegendInterface {
   allowWrap?: boolean; // Allow legend items to wrap to the next line
@@ -17,7 +16,7 @@ interface ChartLegendInterface {
   legendComponent: React.ReactElement<any>; // The base legend component to render
   orientation?: 'horizontal' | 'vertical'; // Orientation of legend
   padding: PaddingProps; // Chart padding
-  patternScale?: PatternScaleInterface[]; // Legend symbol patterns
+  patternScale?: string[]; // Legend symbol patterns
   position: 'bottom' | 'bottom-left' | 'right'; // The legend position
   theme: ChartThemeDefinition; // The theme that will be applied to the chart
   width: number; // Overall width of SVG

--- a/packages/react-charts/src/components/ChartUtils/chart-legend.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-legend.ts
@@ -5,6 +5,7 @@ import { ChartLegendOrientation, ChartLegendPosition, ChartLegendProps } from '.
 import { ChartCommonStyles, ChartThemeDefinition } from '../ChartTheme';
 import { getPieOrigin } from './chart-origin';
 import * as React from 'react';
+import { PatternScaleInterface } from './chart-patterns';
 
 interface ChartLegendInterface {
   allowWrap?: boolean; // Allow legend items to wrap to the next line
@@ -16,7 +17,7 @@ interface ChartLegendInterface {
   legendComponent: React.ReactElement<any>; // The base legend component to render
   orientation?: 'horizontal' | 'vertical'; // Orientation of legend
   padding: PaddingProps; // Chart padding
-  patternScale?: string[]; // Legend symbol patterns
+  patternScale?: PatternScaleInterface[]; // Legend symbol patterns
   position: 'bottom' | 'bottom-left' | 'right'; // The legend position
   theme: ChartThemeDefinition; // The theme that will be applied to the chart
   width: number; // Overall width of SVG

--- a/packages/react-charts/src/components/ChartUtils/chart-patterns.tsx
+++ b/packages/react-charts/src/components/ChartUtils/chart-patterns.tsx
@@ -1,14 +1,23 @@
 import * as React from 'react';
+import merge from 'lodash/merge';
 import uniqueId from 'lodash/uniqueId';
+
+// @beta
+export interface PatternScaleInterface {
+  value?: string; // This value is output as "fill" for component styles and as "stroke" for pattern defs
+  isVisible?: boolean;
+}
 
 // @beta
 interface PatternPropsInterface {
   children?: any;
   colorScale?: any;
+  isPatternDefs?: boolean;
   offset?: number;
   patternId?: string;
-  patternScale?: string[];
-  isPatternDefs?: boolean;
+  patternScale?: PatternScaleInterface[];
+  patternUnshiftIndex?: number;
+  themeColorScale?: string[];
 }
 
 /**
@@ -230,13 +239,27 @@ export const getPatternDefsId = (prefix: string, index: number) => {
  * Helper function to return pattern defs
  * @private
  */
-export const getPatternDefs = ({ offset = 0, patternId, patternScale }: PatternPropsInterface) => {
+export const getPatternDefs = ({
+  colorScale,
+  offset = 0,
+  patternId,
+  patternUnshiftIndex = 0
+}: PatternPropsInterface) => {
+  const defaultPatterns = [...patterns];
+
+  // Move the given pattern index to top of scale, used to sync patterns with ChartDonutThreshold
+  if (patternUnshiftIndex > 0 && patternUnshiftIndex < defaultPatterns.length) {
+    defaultPatterns.unshift(defaultPatterns.splice(patternUnshiftIndex, 1)[0]);
+  }
+
   // This is wrapped in an empty tag so Victory does not apply child props to defs
   const defs = (
     <React.Fragment key={`defs`}>
       <defs>
-        {patternScale.map((c: string, index: number) => {
-          const { d, fill, stroke = c, strokeWidth, ...rest } = patterns[(index + offset) % patterns.length];
+        {colorScale.map((color: PatternScaleInterface, index: number) => {
+          const { d, fill, stroke = color.value, strokeWidth, ...rest } = defaultPatterns[
+            (index + offset) % defaultPatterns.length
+          ];
           const id = getPatternDefsId(patternId, index);
           return (
             <pattern id={id} key={id} {...rest}>
@@ -254,15 +277,41 @@ export const getPatternDefs = ({ offset = 0, patternId, patternScale }: PatternP
  * Helper function to return pattern IDs to use as color scale
  * @private
  */
-export const getPatternScale = (patternId: string, colorScale: string[]) =>
-  colorScale.map((c: any, index: number) => `url(#${getPatternDefsId(patternId, index)})`);
+export const getPatternScale = (colorScale: string[], patternId: string) =>
+  colorScale.map((val: any, index: number) => `url(#${getPatternDefsId(patternId, index)})`);
 
 /**
  * Helper function to return default color scale
  * @private
  */
-export const getDefaultColorScale = (colorScale: string[], themeColorScale: string[]) =>
-  colorScale ? colorScale : themeColorScale;
+export const getDefaultColorScale = (colorScale: string[], themeColorScale: string[]) => {
+  const result: PatternScaleInterface[] = [];
+  const colors = colorScale ? colorScale : themeColorScale;
+
+  colors.forEach(val =>
+    result.push({
+      value: val
+    })
+  );
+  return result;
+};
+
+/**
+ * Merge pattern IDs with `data.fill` property, used by interactive pie chart legend
+ * @private
+ */
+export const getDefaultData = (data: any, patternScale: PatternScaleInterface[]) => {
+  if (!patternScale) {
+    return data;
+  }
+  return data.map((datum: any, index: number) => {
+    const pattern = patternScale[index % patternScale.length];
+    return {
+      ...(pattern && pattern.isVisible !== false && { _fill: pattern.value }),
+      ...datum
+    };
+  });
+};
 
 /**
  * Helper function to return default pattern scale
@@ -270,41 +319,58 @@ export const getDefaultColorScale = (colorScale: string[], themeColorScale: stri
  */
 export const getDefaultPatternScale = ({
   colorScale,
-  patternScale,
+  isPatternDefs,
   patternId,
-  isPatternDefs
+  patternScale
 }: PatternPropsInterface) => {
-  if (patternScale) {
-    return patternScale;
-  }
+  const result: PatternScaleInterface[] = [];
+
   if (isPatternDefs) {
-    return getPatternScale(patternId, colorScale);
+    const defaultPatterns = getPatternScale(colorScale, patternId);
+    defaultPatterns.forEach(p =>
+      result.push({
+        value: p,
+        isVisible: true
+      })
+    );
   }
-  return undefined;
+  if (patternScale) {
+    merge(result, patternScale);
+  }
+  return result.length > 0 ? result : undefined;
 };
 
 /**
- * Merge pattern IDs with `data.fill` property, used by interactive pie chart legend
+ * Helper function to return default pattern props
  * @private
  */
-export const getDefaultData = (data: any, patternScale: string[]) => {
-  if (!patternScale) {
-    return data;
+export const getDefaultPatternProps = ({
+  colorScale,
+  isPatternDefs,
+  patternScale,
+  themeColorScale
+}: PatternPropsInterface) => {
+  const defaultColorScale = getDefaultColorScale(colorScale, themeColorScale);
+  let defaultPatternScale = patternScale;
+  let patternId;
+
+  if (isPatternDefs) {
+    patternId = React.useMemo(() => getPatternId(), []);
+    defaultPatternScale = getDefaultPatternScale({
+      colorScale: defaultColorScale,
+      isPatternDefs,
+      patternId,
+      patternScale
+    });
   }
-  return data.map((datum: any, index: number) => {
-    const pattern = patternScale[index % patternScale.length];
-    return {
-      ...(pattern && pattern !== null && { _fill: pattern }),
-      ...datum
-    };
-  });
+  return { defaultColorScale, defaultPatternScale, patternId };
 };
 
 /**
  * Helper function to render children with patterns
  * @private
  */
-export const renderChildrenWithPatterns = ({ children, patternId, patternScale }: PatternPropsInterface) =>
+export const renderChildrenWithPatterns = ({ children, patternScale }: PatternPropsInterface) =>
   React.Children.toArray(children).map((child, index) => {
     if (React.isValidElement(child)) {
       const { ...childProps } = child.props;
@@ -312,14 +378,13 @@ export const renderChildrenWithPatterns = ({ children, patternId, patternScale }
 
       // Merge pattern IDs with `style.data.fill` property
       if (patternScale) {
-        const fill = patternScale[index % patternScale.length];
+        const pattern = patternScale[index % patternScale.length];
         style.data = {
-          ...(fill && fill !== null && { fill }),
+          ...(pattern && pattern.isVisible !== false && { fill: pattern.value }),
           ...style.data
         };
       }
       const _child = React.cloneElement(child, {
-        patternId,
         ...(patternScale && { patternScale }),
         ...childProps,
         style // Override child props

--- a/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
@@ -4,7 +4,6 @@ import { Helpers, OrientationTypes, StringOrNumberOrCallback } from 'victory-cor
 import { ChartLegendProps } from '../ChartLegend';
 import { ChartLegendTooltipStyles, ChartThemeDefinition } from '../ChartTheme';
 import { getLegendDimensions } from './chart-legend';
-import { PatternScaleInterface } from './chart-patterns';
 
 interface ChartCursorTooltipCenterOffsetInterface {
   offsetCursorDimensionX?: boolean; // Adjust the tooltip to appear to the right of the vertical cursor
@@ -29,7 +28,7 @@ interface ChartLegendTooltipVisibleDataInterface {
   activePoints?: any[];
   colorScale?: string[];
   legendData: any;
-  patternScale?: PatternScaleInterface[]; // Legend symbol patterns
+  patternScale?: string[]; // Legend symbol patterns
   text?: StringOrNumberOrCallback | string[] | number[];
   textAsLegendData?: boolean;
   theme: ChartThemeDefinition;
@@ -239,12 +238,12 @@ export const getLegendTooltipVisibleData = ({
           theme && theme.legend && theme.legend.colorScale
             ? theme.legend.colorScale[i % theme.legend.colorScale.length]
             : undefined;
-        const pattern = patternScale ? patternScale[i % patternScale.length] : undefined;
         const color = colorScale ? colorScale[i % colorScale.length] : themeColor; // Sync color scale
+        const pattern = patternScale ? patternScale[i % patternScale.length] : undefined;
         result.push({
           name: textAsLegendData ? _text[index] : data.name,
           symbol: {
-            fill: pattern && pattern.isVisible !== false ? pattern.value : color,
+            fill: pattern ? pattern : color,
             ...data.symbol
           }
         });

--- a/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
@@ -4,6 +4,7 @@ import { Helpers, OrientationTypes, StringOrNumberOrCallback } from 'victory-cor
 import { ChartLegendProps } from '../ChartLegend';
 import { ChartLegendTooltipStyles, ChartThemeDefinition } from '../ChartTheme';
 import { getLegendDimensions } from './chart-legend';
+import { PatternScaleInterface } from './chart-patterns';
 
 interface ChartCursorTooltipCenterOffsetInterface {
   offsetCursorDimensionX?: boolean; // Adjust the tooltip to appear to the right of the vertical cursor
@@ -28,7 +29,7 @@ interface ChartLegendTooltipVisibleDataInterface {
   activePoints?: any[];
   colorScale?: string[];
   legendData: any;
-  patternScale?: string[]; // Legend symbol patterns
+  patternScale?: PatternScaleInterface[]; // Legend symbol patterns
   text?: StringOrNumberOrCallback | string[] | number[];
   textAsLegendData?: boolean;
   theme: ChartThemeDefinition;
@@ -243,7 +244,7 @@ export const getLegendTooltipVisibleData = ({
         result.push({
           name: textAsLegendData ? _text[index] : data.name,
           symbol: {
-            fill: pattern && pattern !== null ? pattern : color,
+            fill: pattern && pattern.isVisible !== false ? pattern.value : color,
             ...data.symbol
           }
         });

--- a/packages/react-charts/src/components/ChartVoronoiContainer/ChartVoronoiContainer.tsx
+++ b/packages/react-charts/src/components/ChartVoronoiContainer/ChartVoronoiContainer.tsx
@@ -37,6 +37,7 @@ export interface ChartVoronoiContainerProps extends VictoryVoronoiContainerProps
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   children?: React.ReactElement | React.ReactElement[];
@@ -137,6 +138,7 @@ export interface ChartVoronoiContainerProps extends VictoryVoronoiContainerProps
    *
    * Note: This prop should not be set manually.
    *
+   * @private
    * @hide
    */
   polar?: boolean;

--- a/packages/react-charts/src/components/Patterns/examples/patterms.md
+++ b/packages/react-charts/src/components/Patterns/examples/patterms.md
@@ -15,7 +15,6 @@ propComponents: [
   'ChartPie',
   'ChartScatter',
   'ChartStack',
-  'ChartThemeColor',
   'ChartVoronoiContainer',
 ]
 hideDarkMode: true
@@ -124,7 +123,7 @@ import { Chart, ChartAxis, ChartBar, ChartGroup, ChartThemeColor, ChartVoronoiCo
 ### Stack chart
 ```js
 import React from 'react';
-import { Chart, ChartAxis, ChartBar, ChartStack, ChartVoronoiContainer } from '@patternfly/react-charts';
+import { Chart, ChartAxis, ChartBar, ChartStack, ChartThemeColor, ChartVoronoiContainer } from '@patternfly/react-charts';
 
 <div style={{ height: '250px', width: '600px' }}>
   <Chart
@@ -161,7 +160,7 @@ import { Chart, ChartAxis, ChartBar, ChartStack, ChartVoronoiContainer } from '@
 ### Donut chart
 ```js
 import React from 'react';
-import { ChartDonut } from '@patternfly/react-charts';
+import { ChartDonut, ChartThemeColor } from '@patternfly/react-charts';
 
 <div style={{ height: '230px', width: '350px' }}>
   <ChartDonut
@@ -190,11 +189,11 @@ import { ChartDonut } from '@patternfly/react-charts';
 
 ### Donut utilization chart
 
-This demonstrates how to apply a pattern to the static, unused portion of the donut utilization chart.
+This demonstrates how to hide a pattern for the static, unused portion of the donut utilization chart.
 
 ```js
 import React from 'react';
-import { ChartDonutUtilization } from '@patternfly/react-charts';
+import { ChartDonutUtilization, ChartThemeColor } from '@patternfly/react-charts';
 
 <div style={{ height: '275px', width: '300px' }}>
   <ChartDonutUtilization 
@@ -212,7 +211,10 @@ import { ChartDonutUtilization } from '@patternfly/react-charts';
       right: 20,
       top: 20
     }}
-    showStaticPattern
+    patternScale={[
+      { isVisible: true },
+      { isVisible: false }
+    ]}
     subTitle="of 100 GBps"
     title="45%"
     themeColor={ChartThemeColor.green}
@@ -229,7 +231,7 @@ This demonstrates how to apply patterns to thresholds.
 
 ```js
 import React from 'react';
-import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts';
+import { ChartDonutThreshold, ChartDonutUtilization, ChartThemeColor } from '@patternfly/react-charts';
 
 <div style={{ height: '275px', width: '675px' }}>
   <ChartDonutThreshold
@@ -256,7 +258,6 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
       subTitle="of 100 GBps"
       title="45%"
       themeColor={ChartThemeColor.orange}
-      isPatternDefs
     />
   </ChartDonutThreshold>
 </div>
@@ -337,11 +338,6 @@ class InteractivePieLegendChart extends React.Component {
       const { hiddenSeries } = this.state; // Skip if already hidden                
       return hiddenSeries.has(index);
     };
-
-    this.isDataAvailable = () => {
-      const { hiddenSeries } = this.state;
-      return hiddenSeries.size !== this.series.length;
-    };
   };
 
   render() {
@@ -349,9 +345,9 @@ class InteractivePieLegendChart extends React.Component {
 
     const data = [];
     this.series.map((s, index) => {
-      data.push(!hiddenSeries.has(index) ? s.datapoints : [{ y: null}]);
+      data.push(!hiddenSeries.has(index) ? s.datapoints : { y: null });
     });
-
+    
     return (
       <div style={{ height: '275px', width: '500px' }}>
         <Chart
@@ -359,7 +355,6 @@ class InteractivePieLegendChart extends React.Component {
           ariaTitle="Pie chart example"
           events={this.getEvents()}
           height={275}
-          labels={({ datum }) => `${datum.x}: ${datum.y}`}
           legendComponent={<ChartLegend name={'legend'} data={this.getLegendData()} />}
           legendPosition="bottom"
           padding={{
@@ -368,7 +363,6 @@ class InteractivePieLegendChart extends React.Component {
             right: 20,
             top: 20
           }}
-          patternId="pattern_a" // Required for interactive legend functionality
           showAxis={false}
           themeColor={ChartThemeColor.multiUnordered}
           isPatternDefs
@@ -377,6 +371,7 @@ class InteractivePieLegendChart extends React.Component {
           <ChartPie
             constrainToVisibleArea={true}
             data={data}
+            labels={({ datum }) => `${datum.x}: ${datum.y}`}
             name="pie"
           />
         </Chart>
@@ -685,8 +680,13 @@ import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
       right: 140, // Adjusted to accommodate legend
       top: 20
     }}
-    patternId="pattern_b"
-    patternScale={['url("#pattern_b:0")', 'url("#pattern_b:1")', null, null, null]}
+    patternScale={[
+      { isVisible: true },
+      { isVisible: true },
+      { isVisible: false },
+      { isVisible: false },
+      { isVisible: false }
+    ]}
     themeColor={ChartThemeColor.multiUnordered}
     isPatternDefs
     width={350}
@@ -702,7 +702,7 @@ The approach uses `isPatternDefs` to generate default pattern defs using the giv
 
 ```js
 import React from 'react';
-import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
+import { ChartPie } from '@patternfly/react-charts';
 import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
 import chart_color_gold_300 from '@patternfly/react-tokens/dist/esm/chart_color_gold_300';
 import chart_color_green_300 from '@patternfly/react-tokens/dist/esm/chart_color_green_300';
@@ -711,7 +711,7 @@ import chart_color_green_300 from '@patternfly/react-tokens/dist/esm/chart_color
   <ChartPie
     ariaDesc="Average number of pets"
     ariaTitle="Pie chart example"
-    colorScale={[chart_color_blue_300.value, chart_color_gold_300.var, chart_color_green_300.value]}
+    colorScale={[chart_color_blue_300.var, chart_color_gold_300.var, chart_color_green_300.var]}
     constrainToVisibleArea={true}
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={230}
@@ -725,8 +725,11 @@ import chart_color_green_300 from '@patternfly/react-tokens/dist/esm/chart_color
       right: 140, // Adjusted to accommodate legend
       top: 20
     }}
-    patternId="pattern_c"
-    patternScale={['url("#pattern_c:0")', 'url("#pattern_c:1")', null]}
+    patternScale={[
+      { isVisible: true },
+      { isVisible: true },
+      { isVisible: false }
+    ]}
     isPatternDefs
     width={350}
   />
@@ -750,10 +753,10 @@ import chart_color_green_300 from '@patternfly/react-tokens/dist/esm/chart_color
 <div style={{ height: '230px', width: '350px' }}>
   <svg aria-hidden={true} height="0" width="0" style={{display: 'block'}}>
     <defs>
-      <pattern id="pattern_d:0" patternUnits="userSpaceOnUse" patternContentUnits="userSpaceOnUse" width="10" height="10" x="0" y="0">
+      <pattern id="pattern:0" patternUnits="userSpaceOnUse" patternContentUnits="userSpaceOnUse" width="10" height="10" x="0" y="0">
         <path d="M 0 0 L 5 10 L 10 0" stroke={chart_color_blue_300.value} strokeWidth="2" fill="none"></path>
       </pattern>
-      <pattern id="pattern_d:1" patternUnits="userSpaceOnUse" patternContentUnits="userSpaceOnUse" width="10" height="10" x="0" y="0">
+      <pattern id="pattern:1" patternUnits="userSpaceOnUse" patternContentUnits="userSpaceOnUse" width="10" height="10" x="0" y="0">
         <path d="M 0 3 L 5 3 L 5 0 M 5 10 L 5 7 L 10 7" stroke={chart_color_green_300.value} strokeWidth="2" fill="none"></path>
       </pattern>
     </defs>
@@ -774,7 +777,11 @@ import chart_color_green_300 from '@patternfly/react-tokens/dist/esm/chart_color
       right: 140, // Adjusted to accommodate legend
       top: 20
     }}
-    patternScale={['url("#pattern_d:0")', 'url("#pattern_d:1")', null]}
+    patternScale={[
+      { isVisible: true, value: 'url("#pattern:0")' },
+      { isVisible: true, value: 'url("#pattern:1")' },
+      { isVisible: false }
+    ]}
     themeColor={ChartThemeColor.multiUnordered}
     width={350}
   />

--- a/packages/react-charts/src/components/Patterns/examples/patterms.md
+++ b/packages/react-charts/src/components/Patterns/examples/patterms.md
@@ -15,7 +15,7 @@ propComponents: [
   'ChartPie',
   'ChartScatter',
   'ChartStack',
-  'ChartVoronoiContainer',
+  'ChartVoronoiContainer'
 ]
 hideDarkMode: true
 beta: true
@@ -65,8 +65,9 @@ import { ChartPie } from '@patternfly/react-charts';
   <ChartPie
     ariaDesc="Average number of pets"
     ariaTitle="Pie chart example"
-    constrainToVisibleArea={true}
+    constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
+    hasPatterns
     height={230}
     labels={({ datum }) => `${datum.x}: ${datum.y}`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
@@ -78,7 +79,6 @@ import { ChartPie } from '@patternfly/react-charts';
       right: 140, // Adjusted to accommodate legend
       top: 20
     }}
-    isPatternDefs
     width={350}
   />
 </div>
@@ -97,6 +97,7 @@ import { Chart, ChartAxis, ChartBar, ChartGroup, ChartThemeColor, ChartVoronoiCo
     domainPadding={{ x: [30, 25] }}
     legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
     legendPosition="bottom"
+    hasPatterns
     height={275}
     padding={{
       bottom: 75, // Adjusted to accommodate legend
@@ -105,7 +106,6 @@ import { Chart, ChartAxis, ChartBar, ChartGroup, ChartThemeColor, ChartVoronoiCo
       top: 50
     }}
     themeColor={ChartThemeColor.purple}
-    isPatternDefs
     width={450}
   >
     <ChartAxis />
@@ -134,6 +134,7 @@ import { Chart, ChartAxis, ChartBar, ChartStack, ChartThemeColor, ChartVoronoiCo
     legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
     legendOrientation="vertical"
     legendPosition="right"
+    hasPatterns
     height={250}
     padding={{
       bottom: 50,
@@ -142,7 +143,6 @@ import { Chart, ChartAxis, ChartBar, ChartStack, ChartThemeColor, ChartVoronoiCo
       top: 50
     }}
     themeColor={ChartThemeColor.green}
-    isPatternDefs
     width={600}
   >
     <ChartAxis />
@@ -166,8 +166,9 @@ import { ChartDonut, ChartThemeColor } from '@patternfly/react-charts';
   <ChartDonut
     ariaDesc="Average number of pets"
     ariaTitle="Donut chart example"
-    constrainToVisibleArea={true}
+    constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
+    hasPatterns
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
@@ -181,7 +182,6 @@ import { ChartDonut, ChartThemeColor } from '@patternfly/react-charts';
     subTitle="Pets"
     title="100"
     themeColor={ChartThemeColor.gold}
-    isPatternDefs
     width={350}
   />
 </div>
@@ -199,8 +199,9 @@ import { ChartDonutUtilization, ChartThemeColor } from '@patternfly/react-charts
   <ChartDonutUtilization 
     ariaDesc="Storage capacity"
     ariaTitle="Donut utilization chart example"
-    constrainToVisibleArea={true}
+    constrainToVisibleArea
     data={{ x: 'Storage capacity', y: 45 }}
+    hasPatterns
     height={275}
     labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
     legendData={[{ name: `Storage capacity: 45%` }, { name: 'Unused' }]}
@@ -211,15 +212,10 @@ import { ChartDonutUtilization, ChartThemeColor } from '@patternfly/react-charts
       right: 20,
       top: 20
     }}
-    patternScale={[
-      { isVisible: true },
-      { isVisible: false }
-    ]}
     subTitle="of 100 GBps"
     title="45%"
     themeColor={ChartThemeColor.green}
     thresholds={[{ value: 60 }, { value: 90 }]}
-    isPatternDefs
     width={300}
   />
 </div>
@@ -237,8 +233,9 @@ import { ChartDonutThreshold, ChartDonutUtilization, ChartThemeColor } from '@pa
   <ChartDonutThreshold
     ariaDesc="Storage capacity"
     ariaTitle="Donut utilization chart with static threshold example"
-    constrainToVisibleArea={true}
+    constrainToVisibleArea
     data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
+    hasPatterns
     height={275}
     labels={({ datum }) => datum.x ? datum.x : null}
     padding={{
@@ -248,7 +245,6 @@ import { ChartDonutThreshold, ChartDonutUtilization, ChartThemeColor } from '@pa
       top: 20
     }}
     width={675}
-    isPatternDefs
   >
     <ChartDonutUtilization
       data={{ x: 'Storage capacity', y: 45 }}
@@ -354,6 +350,7 @@ class InteractivePieLegendChart extends React.Component {
           ariaDesc="Average number of pets"
           ariaTitle="Pie chart example"
           events={this.getEvents()}
+          hasPatterns
           height={275}
           legendComponent={<ChartLegend name={'legend'} data={this.getLegendData()} />}
           legendPosition="bottom"
@@ -365,11 +362,10 @@ class InteractivePieLegendChart extends React.Component {
           }}
           showAxis={false}
           themeColor={ChartThemeColor.multiUnordered}
-          isPatternDefs
           width={500}
         >
           <ChartPie
-            constrainToVisibleArea={true}
+            constrainToVisibleArea
             data={data}
             labels={({ datum }) => `${datum.x}: ${datum.y}`}
             name="pie"
@@ -544,6 +540,7 @@ class InteractiveLegendChart extends React.Component {
             ariaTitle="Area chart example"
             containerComponent={container}
             events={this.getEvents()}
+            hasPatterns
             height={225}
             legendComponent={<ChartLegend name={'legend'} data={this.getLegendData()} />}
             legendPosition="bottom-left"
@@ -555,7 +552,6 @@ class InteractiveLegendChart extends React.Component {
             }}
             maxDomain={{y: 9}}
             themeColor={ChartThemeColor.multiUnordered}
-            isPatternDefs
             width={width}
           >
             <ChartAxis tickValues={['2015', '2016', '2017', '2018']} />
@@ -592,6 +588,117 @@ class InteractiveLegendChart extends React.Component {
 }
 ```
 
+### Custom pattern visibility
+
+This demonstrates how to omit patterns from pie chart segments.
+
+```js
+import React from 'react';
+import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
+
+<div style={{ height: '230px', width: '350px' }}>
+  <ChartPie
+    ariaDesc="Average number of pets"
+    ariaTitle="Pie chart example"
+    constrainToVisibleArea
+    data={[{ x: 'Cats', y: 15 }, { x: 'Dogs', y: 15 }, { x: 'Birds', y: 15 }, { x: 'Fish', y: 25 }, { x: 'Rabbits', y: 30 }]}
+    hasPatterns={[ true, true, false, false, false ]}
+    height={230}
+    labels={({ datum }) => `${datum.x}: ${datum.y}`}
+    legendData={[{ name: 'Cats: 15' }, { name: 'Dogs: 15' }, { name: 'Birds: 15' }, { name: 'Fish: 25' }, { name: 'Rabbits: 30' }]}
+    legendOrientation="vertical"
+    legendPosition="right"
+    padding={{
+      bottom: 20,
+      left: 20,
+      right: 140, // Adjusted to accommodate legend
+      top: 20
+    }}
+    themeColor={ChartThemeColor.multiUnordered}
+    width={350}
+  />
+</div>
+```
+
+### Custom color scale
+
+This demonstrates how to apply a custom color scale to patterns.
+
+```js
+import React from 'react';
+import { ChartPie } from '@patternfly/react-charts';
+import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
+import chart_color_gold_300 from '@patternfly/react-tokens/dist/esm/chart_color_gold_300';
+import chart_color_green_300 from '@patternfly/react-tokens/dist/esm/chart_color_green_300';
+
+<div style={{ height: '230px', width: '350px' }}>
+  <ChartPie
+    ariaDesc="Average number of pets"
+    ariaTitle="Pie chart example"
+    colorScale={[chart_color_blue_300.var, chart_color_gold_300.var, chart_color_green_300.var]}
+    constrainToVisibleArea
+    data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
+    hasPatterns={[ true, true, false ]}
+    height={230}
+    labels={({ datum }) => `${datum.x}: ${datum.y}`}
+    legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
+    legendOrientation="vertical"
+    legendPosition="right"
+    padding={{
+      bottom: 20,
+      left: 20,
+      right: 140, // Adjusted to accommodate legend
+      top: 20
+    }}
+    width={350}
+  />
+</div>
+```
+
+### Custom pattern defs
+
+This demonstrates how to create custom patterns.
+
+```js
+import React from 'react';
+import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
+import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
+import chart_color_green_300 from '@patternfly/react-tokens/dist/esm/chart_color_green_300';
+
+<div style={{ height: '230px', width: '350px' }}>
+  <svg aria-hidden height="0" width="0" style={{display: 'block'}}>
+    <defs>
+      <pattern id="pattern1" patternUnits="userSpaceOnUse" patternContentUnits="userSpaceOnUse" width="10" height="10" x="0" y="0">
+        <path d="M 0 0 L 5 10 L 10 0" stroke={chart_color_blue_300.value} strokeWidth="2" fill="none"></path>
+      </pattern>
+      <pattern id="pattern2" patternUnits="userSpaceOnUse" patternContentUnits="userSpaceOnUse" width="10" height="10" x="0" y="0">
+        <path d="M 0 3 L 5 3 L 5 0 M 5 10 L 5 7 L 10 7" stroke={chart_color_green_300.value} strokeWidth="2" fill="none"></path>
+      </pattern>
+    </defs>
+  </svg>
+  <ChartPie
+    ariaDesc="Average number of pets"
+    ariaTitle="Pie chart example"
+    constrainToVisibleArea
+    data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
+    height={230}
+    labels={({ datum }) => `${datum.x}: ${datum.y}`}
+    legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
+    legendOrientation="vertical"
+    legendPosition="right"
+    padding={{
+      bottom: 20,
+      left: 20,
+      right: 140, // Adjusted to accommodate legend
+      top: 20
+    }}
+    patternScale={[ 'url("#pattern1")', 'url("#pattern2")', null ]}
+    themeColor={ChartThemeColor.multiUnordered}
+    width={350}
+  />
+</div>
+```
+
 ### All patterns
 ```js
 import React from 'react';
@@ -601,7 +708,7 @@ import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
   <ChartPie
     ariaDesc="Average number of pets"
     ariaTitle="Pie chart example"
-    constrainToVisibleArea={true}
+    constrainToVisibleArea
     data={[
       { x: 'Cats', y: 6 },
       { x: 'Dogs', y: 6 },
@@ -619,6 +726,7 @@ import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
       { x: 'Deer', y: 6 },
       { x: 'Bears', y: 10 }
     ]}
+    hasPatterns
     height={325}
     labels={({ datum }) => `${datum.x}: ${datum.y}`}
     legendData={[
@@ -647,143 +755,7 @@ import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
       top: 20
     }}
     themeColor={ChartThemeColor.multiOrdered}
-    isPatternDefs
     width={600}
-  />
-</div>
-```
-
-### Custom pattern IDs
-
-This demonstrates how to omit patterns from pie chart segments.
-
-The approach uses `isPatternDefs` to generate default pattern defs using the given `patternId` prefix. The `patternScale` property is then used to apply indexed pattern IDs to each pie chart segment. If you want to omit a particular pattern from a pie segment, simply provide `null` instead.
-
-```js
-import React from 'react';
-import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
-
-<div style={{ height: '230px', width: '350px' }}>
-  <ChartPie
-    ariaDesc="Average number of pets"
-    ariaTitle="Pie chart example"
-    constrainToVisibleArea={true}
-    data={[{ x: 'Cats', y: 15 }, { x: 'Dogs', y: 15 }, { x: 'Birds', y: 15 }, { x: 'Fish', y: 25 }, { x: 'Rabbits', y: 30 }]}
-    height={230}
-    labels={({ datum }) => `${datum.x}: ${datum.y}`}
-    legendData={[{ name: 'Cats: 15' }, { name: 'Dogs: 15' }, { name: 'Birds: 15' }, { name: 'Fish: 25' }, { name: 'Rabbits: 30' }]}
-    legendOrientation="vertical"
-    legendPosition="right"
-    padding={{
-      bottom: 20,
-      left: 20,
-      right: 140, // Adjusted to accommodate legend
-      top: 20
-    }}
-    patternScale={[
-      { isVisible: true },
-      { isVisible: true },
-      { isVisible: false },
-      { isVisible: false },
-      { isVisible: false }
-    ]}
-    themeColor={ChartThemeColor.multiUnordered}
-    isPatternDefs
-    width={350}
-  />
-</div>
-```
-
-### Custom color scale
-
-This demonstrates how to apply a custom color scale.
-
-The approach uses `isPatternDefs` to generate default pattern defs using the given `patternId` prefix and custom `colorScale`. The `patternScale` property is then used to apply indexed pattern IDs to each pie chart segment. If you want to omit a particular pattern from a pie segment, simply provide `null` instead.
-
-```js
-import React from 'react';
-import { ChartPie } from '@patternfly/react-charts';
-import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
-import chart_color_gold_300 from '@patternfly/react-tokens/dist/esm/chart_color_gold_300';
-import chart_color_green_300 from '@patternfly/react-tokens/dist/esm/chart_color_green_300';
-
-<div style={{ height: '230px', width: '350px' }}>
-  <ChartPie
-    ariaDesc="Average number of pets"
-    ariaTitle="Pie chart example"
-    colorScale={[chart_color_blue_300.var, chart_color_gold_300.var, chart_color_green_300.var]}
-    constrainToVisibleArea={true}
-    data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-    height={230}
-    labels={({ datum }) => `${datum.x}: ${datum.y}`}
-    legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
-    legendOrientation="vertical"
-    legendPosition="right"
-    padding={{
-      bottom: 20,
-      left: 20,
-      right: 140, // Adjusted to accommodate legend
-      top: 20
-    }}
-    patternScale={[
-      { isVisible: true },
-      { isVisible: true },
-      { isVisible: false }
-    ]}
-    isPatternDefs
-    width={350}
-  />
-</div>
-```
-
-### Custom pattern defs
-
-This demonstrates how to create custom patterns.
-
-The approach uses custom pattern defs. The `patternScale` property is used to apply pattern IDs to each pie chart segment. If you want to omit a particular pattern from a pie segment, simply provide `null` instead.
-
-Note that `isPatternDefs` and `patternId` are not used here.
-
-```js
-import React from 'react';
-import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
-import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
-import chart_color_green_300 from '@patternfly/react-tokens/dist/esm/chart_color_green_300';
-
-<div style={{ height: '230px', width: '350px' }}>
-  <svg aria-hidden={true} height="0" width="0" style={{display: 'block'}}>
-    <defs>
-      <pattern id="pattern:0" patternUnits="userSpaceOnUse" patternContentUnits="userSpaceOnUse" width="10" height="10" x="0" y="0">
-        <path d="M 0 0 L 5 10 L 10 0" stroke={chart_color_blue_300.value} strokeWidth="2" fill="none"></path>
-      </pattern>
-      <pattern id="pattern:1" patternUnits="userSpaceOnUse" patternContentUnits="userSpaceOnUse" width="10" height="10" x="0" y="0">
-        <path d="M 0 3 L 5 3 L 5 0 M 5 10 L 5 7 L 10 7" stroke={chart_color_green_300.value} strokeWidth="2" fill="none"></path>
-      </pattern>
-    </defs>
-  </svg>
-  <ChartPie
-    ariaDesc="Average number of pets"
-    ariaTitle="Pie chart example"
-    constrainToVisibleArea={true}
-    data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-    height={230}
-    labels={({ datum }) => `${datum.x}: ${datum.y}`}
-    legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
-    legendOrientation="vertical"
-    legendPosition="right"
-    padding={{
-      bottom: 20,
-      left: 20,
-      right: 140, // Adjusted to accommodate legend
-      top: 20
-    }}
-    patternScale={[
-      { isVisible: true, value: 'url("#pattern:0")' },
-      { isVisible: true, value: 'url("#pattern:1")' },
-      { isVisible: false }
-    ]}
-    themeColor={ChartThemeColor.multiUnordered}
-    width={350}
   />
 </div>
 ```


### PR DESCRIPTION
Refactored the pattern feature to eliminate the pattern IDs required to hide / show individual patterns. This helps to simplify a few chart examples.

Previously, individual patterns were hidden using `null` values. However, that required some knowledge of our generated pattern IDs. For example:

```
patternId="pattern_b"
patternScale={['url("#pattern_b:0")', 'url("#pattern_b:1")', null]} // hide the last pattern
```

I want to simplify this using boolean flags, like so:

```
hasPatterns={[ true, true, false ]} // hide the last pattern
```

And to show patterns for all chart segments, this reduces to:

```
hasPatterns
```

That said, if devs choose to create custom patterns, they can still provide their own IDs.

```
patternScale={[ 'url("#pattern1")', 'url("#pattern2")', null ]} // hide the last pattern
```

Design issue: https://github.com/patternfly/patternfly-design/issues/1136
Closes https://github.com/patternfly/patternfly-react/issues/7541