### PR TITLE
chore(OverflowMenu): use position and isFlipEnabled props correctly in docs

### DIFF
--- a/packages/react-core/src/components/OverflowMenu/examples/OverflowMenu.md
+++ b/packages/react-core/src/components/OverflowMenu/examples/OverflowMenu.md
@@ -61,6 +61,8 @@ class SimpleOverflowMenu extends React.Component {
             isOpen={isOpen}
             isPlain
             dropdownItems={dropdownItems}
+            isFlipEnabled
+            menuAppendTo="parent"
           />
         </OverflowMenuControl>
       </OverflowMenu>
@@ -153,6 +155,8 @@ class OverflowMenuGroupTypes extends React.Component {
             isOpen={isOpen}
             isPlain
             dropdownItems={dropdownItems}
+            isFlipEnabled
+            menuAppendTo="parent"
           />
         </OverflowMenuControl>
       </OverflowMenu>
@@ -239,6 +243,8 @@ class OverflowMenuAdditionalOptions extends React.Component {
             isOpen={isOpen}
             isPlain
             dropdownItems={dropdownItems}
+            isFlipEnabled
+            menuAppendTo="parent"
           />
         </OverflowMenuControl>
       </OverflowMenu>
@@ -301,6 +307,8 @@ class OverflowMenuPersist extends React.Component {
             isOpen={isOpen}
             isPlain
             dropdownItems={dropdownItems}
+            isFlipEnabled
+            menuAppendTo="parent"
           />
         </OverflowMenuControl>
       </OverflowMenu>

--- a/packages/react-core/src/components/Toolbar/examples/Toolbar.md
+++ b/packages/react-core/src/components/Toolbar/examples/Toolbar.md
@@ -811,6 +811,7 @@ import {
   Dropdown,
   DropdownItem,
   DropdownSeparator,
+  DropdownPosition,
   KebabToggle,
   SearchInput
 } from '@patternfly/react-core';
@@ -1036,6 +1037,7 @@ class ToolbarWithFilterExample extends React.Component {
             isOpen={kebabIsOpen}
             isPlain
             dropdownItems={dropdownItems}
+            position={DropdownPosition.right}
           />
         </ToolbarItem>
       </React.Fragment>
@@ -1080,6 +1082,7 @@ import {
   DropdownToggle,
   DropdownToggleCheckbox,
   DropdownItem,
+  DropdownPosition,
   Divider,
   OverflowMenu,
   OverflowMenuContent,
@@ -1293,6 +1296,7 @@ class ToolbarStacked extends React.Component {
                     isOpen={kebabIsOpen}
                     isPlain
                     dropdownItems={dropdownItems}
+                    position={DropdownPosition.right}
                   />
                 </OverflowMenuControl>
               </OverflowMenu>

--- a/packages/react-core/src/demos/Card/Card.md
+++ b/packages/react-core/src/demos/Card/Card.md
@@ -518,6 +518,8 @@ class CardViewBasic extends React.Component {
                 isOpen={isLowerToolbarKebabDropdownOpen}
                 isPlain
                 dropdownItems={toolbarKebabDropdownItems}
+                isFlipEnabled
+                menuAppendTo="parent"
               />
             </OverflowMenuControl>
           </OverflowMenu>

--- a/packages/react-core/src/demos/PrimaryDetail.md
+++ b/packages/react-core/src/demos/PrimaryDetail.md
@@ -1246,6 +1246,8 @@ class PrimaryDetailCardView extends React.Component {
                 isOpen={isLowerToolbarKebabDropdownOpen}
                 isPlain
                 dropdownItems={toolbarKebabDropdownItems}
+                isFlipEnabled
+                menuAppendTo="parent"
               />
             </OverflowMenuControl>
           </OverflowMenu>

--- a/packages/react-core/src/demos/PrimaryDetail.md
+++ b/packages/react-core/src/demos/PrimaryDetail.md
@@ -1340,13 +1340,13 @@ class PrimaryDetailCardView extends React.Component {
           </TextContent>
         </PageSection>
         <PageSection isFilled padding={{ default: 'noPadding' }}>
+          <Toolbar id="card-view-data-toolbar-group-types" usePageInsets clearAllFilters={this.onDelete}>
+            <ToolbarContent>{toolbarItems}</ToolbarContent>
+          </Toolbar>
+          <Divider component="div" />
+        </PageSection>
+        <PageSection isFilled padding={{ default: 'noPadding' }}>
           <Drawer isExpanded={isDrawerExpanded} className={'pf-m-inline-on-2xl'}>
-            <DrawerSection>
-              <Toolbar id="card-view-data-toolbar-group-types" usePageInsets clearAllFilters={this.onDelete}>
-                <ToolbarContent>{toolbarItems}</ToolbarContent>
-              </Toolbar>
-              <Divider component="div" />
-            </DrawerSection>
             <DrawerContent panelContent={panelContent} className={'pf-m-no-background'}>
               <DrawerContentBody hasPadding>{drawerContent}</DrawerContentBody>
             </DrawerContent>
@@ -1665,6 +1665,8 @@ class PrimaryDetailDataListInCard extends React.Component {
                 }
                 isOpen={isDropdownOpen}
                 dropdownItems={dropdownItems}
+                isFlipEnabled
+                menuAppendTo="parent"
               />
             </ToolbarItem>
           </ToolbarContent>

--- a/packages/react-integration/demo-app-ts/src/components/demos/OverflowMenuDemo/OverflowMenuDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/OverflowMenuDemo/OverflowMenuDemo.tsx
@@ -77,6 +77,8 @@ export class OverflowMenuDemo extends React.Component {
             isOpen={isSimpleOpen}
             isPlain
             dropdownItems={dropdownItems}
+            isFlipEnabled
+            menuAppendTo="parent"
           />
         </OverflowMenuControl>
       </OverflowMenu>
@@ -158,6 +160,8 @@ export class OverflowMenuDemo extends React.Component {
             isOpen={isAdditionalOptionsOpen}
             isPlain
             dropdownItems={dropdownItems}
+            isFlipEnabled
+            menuAppendTo="parent"
           />
         </OverflowMenuControl>
       </OverflowMenu>
@@ -213,6 +217,8 @@ export class OverflowMenuDemo extends React.Component {
             isOpen={isPersistOpen}
             isPlain
             dropdownItems={dropdownItems}
+            isFlipEnabled
+            menuAppendTo="parent"
           />
         </OverflowMenuControl>
       </OverflowMenu>

--- a/packages/react-table/src/demos/Table.md
+++ b/packages/react-table/src/demos/Table.md
@@ -2331,6 +2331,8 @@ ComposableTableSortable = () => {
             }
             isPlain
             isGrouped
+            menuAppendTo='parent'
+            isFlipEnabled
           />
         </ToolbarItem>
         <OverflowMenu breakpoint="lg">
@@ -2351,6 +2353,8 @@ ComposableTableSortable = () => {
               toggle={<KebabToggle onToggle={() => setIsKebabDropdownOpen(!isKebabDropdownOpen)} />}
               isOpen={isKebabDropdownOpen}
               dropdownItems={kebabDropdownItems}
+              isFlipEnabled
+              menuAppendTo="parent"
             />
           </OverflowMenuControl>
         </OverflowMenu>


### PR DESCRIPTION
Addresses #7398 

Update various examples to pass `menuAppendTo='parent'` and `isFlipEnabled` to Dropdowns housed in OverflowMenus when it makes sense.

Examples updated:

- OverflowMenu
- Toolbar
- Card view demo
- Primary detail demo
- Sortable table demo

*note: the Dropdown menu has been configured so that isFlipEnabled flips the menus up/down depending on the available vertical space. The consumer can use the `position` prop to right align the menu when appropriate. That is the recommendation made to the issue reporter in this case.