### PR TITLE
chore(List): converted all examples to typescript

### DIFF
--- a/packages/react-core/src/components/List/examples/List.md
+++ b/packages/react-core/src/components/List/examples/List.md
@@ -5,97 +5,35 @@ cssPrefix: pf-c-list
 propComponents: ['List', 'ListItem']
 ---
 
-import BookOpen from '@patternfly/react-icons/dist/esm/icons/book-open-icon';
-import Key from '@patternfly/react-icons/dist/esm/icons/key-icon';
-import Desktop from '@patternfly/react-icons/dist/esm/icons/desktop-icon';
+import BookOpenIcon from '@patternfly/react-icons/dist/esm/icons/book-open-icon';
+import KeyIcon from '@patternfly/react-icons/dist/esm/icons/key-icon';
+import DesktopIcon from '@patternfly/react-icons/dist/esm/icons/desktop-icon';
 
 ## Examples
 ### Basic
-```js
-import React from 'react';
-import { List, ListItem } from '@patternfly/react-core';
-
-<List>
-  <ListItem>First</ListItem>
-  <ListItem>Second</ListItem>
-  <ListItem>Third</ListItem>
-</List>
+```ts file="./ListBasic.tsx"
 ```
 
 ### Inline
-```js
-import React from 'react';
-import { List, ListItem, ListVariant } from '@patternfly/react-core';
-
-<List variant={ListVariant.inline}>
-  <ListItem>First</ListItem>
-  <ListItem>Second</ListItem>
-  <ListItem>Third</ListItem>
-</List>
+```ts file="./ListInline.tsx"
 ```
 
 ### Ordered
-```js
-import React from 'react';
-import { List, ListItem, ListComponent, OrderType } from '@patternfly/react-core';
-
-<List component={ListComponent.ol} type={OrderType.number}>
-  <ListItem>First</ListItem>
-  <ListItem>Second</ListItem>
-  <ListItem>Third</ListItem>
-</List>
+```ts file="./ListOrdered.tsx"
 ```
 
 ### Plain
-```js
-import React from 'react';
-import { List, ListItem } from '@patternfly/react-core';
-
-<List isPlain>
-  <ListItem>First</ListItem>
-  <ListItem>Second</ListItem>
-  <ListItem>Third</ListItem>
-</List>
+```ts file="./ListPlain.tsx"
 ```
 
 ### With horizontal rules
-```js
-import React from 'react';
-import { List, ListItem } from '@patternfly/react-core';
-
-<List isPlain isBordered>
-  <ListItem>First</ListItem>
-  <ListItem>Second</ListItem>
-  <ListItem>Third</ListItem>
-</List>
+```ts file="./ListHorizontalRules.tsx"
 ```
 
 ### With icons
-```js
-import React from 'react';
-import { List, ListItem } from '@patternfly/react-core';
-import BookOpen from '@patternfly/react-icons/dist/esm/icons/book-open-icon';
-import Key from '@patternfly/react-icons/dist/esm/icons/key-icon';
-import Desktop from '@patternfly/react-icons/dist/esm/icons/desktop-icon';
-
-<List isPlain>
-  <ListItem icon={<BookOpen />}>First</ListItem>
-  <ListItem icon={<Key />}>Second</ListItem>
-  <ListItem icon={<Desktop />}>Third</ListItem>
-</List>
+```ts file="./ListIcons.tsx"
 ```
 
 ### With large icons
-```js
-import React from 'react';
-import { List, ListItem } from '@patternfly/react-core';
-import BookOpen from '@patternfly/react-icons/dist/esm/icons/book-open-icon';
-import Key from '@patternfly/react-icons/dist/esm/icons/key-icon';
-import Desktop from '@patternfly/react-icons/dist/esm/icons/desktop-icon';
-
-<List isPlain iconSize="large">
-  <ListItem icon={<BookOpen />}>First</ListItem>
-  <ListItem icon={<Key />}>Second</ListItem>
-  <ListItem icon={<Desktop />}>Third</ListItem>
-</List>
+```ts file="./ListLargeIcons.tsx"
 ```

--- a/packages/react-core/src/components/List/examples/ListBasic.tsx
+++ b/packages/react-core/src/components/List/examples/ListBasic.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { List, ListItem } from '@patternfly/react-core';
+
+export const ListBasic: React.FunctionComponent = () => (
+  <List>
+    <ListItem>First</ListItem>
+    <ListItem>Second</ListItem>
+    <ListItem>Third</ListItem>
+  </List>
+);

--- a/packages/react-core/src/components/List/examples/ListHorizontalRules.tsx
+++ b/packages/react-core/src/components/List/examples/ListHorizontalRules.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { List, ListItem } from '@patternfly/react-core';
+
+export const ListHorizontalRules: React.FunctionComponent = () => (
+  <List isPlain isBordered>
+    <ListItem>First</ListItem>
+    <ListItem>Second</ListItem>
+    <ListItem>Third</ListItem>
+  </List>
+);

--- a/packages/react-core/src/components/List/examples/ListIcons.tsx
+++ b/packages/react-core/src/components/List/examples/ListIcons.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { List, ListItem } from '@patternfly/react-core';
+import BookOpenIcon from '@patternfly/react-icons/dist/esm/icons/book-open-icon';
+import KeyIcon from '@patternfly/react-icons/dist/esm/icons/key-icon';
+import DesktopIcon from '@patternfly/react-icons/dist/esm/icons/desktop-icon';
+
+export const ListIcons: React.FunctionComponent = () => (
+  <List isPlain>
+    <ListItem icon={<BookOpenIcon />}>First</ListItem>
+    <ListItem icon={<KeyIcon />}>Second</ListItem>
+    <ListItem icon={<DesktopIcon />}>Third</ListItem>
+  </List>
+);

--- a/packages/react-core/src/components/List/examples/ListInline.tsx
+++ b/packages/react-core/src/components/List/examples/ListInline.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { List, ListItem, ListVariant } from '@patternfly/react-core';
+
+export const ListInline: React.FunctionComponent = () => (
+  <List variant={ListVariant.inline}>
+    <ListItem>First</ListItem>
+    <ListItem>Second</ListItem>
+    <ListItem>Third</ListItem>
+  </List>
+);

--- a/packages/react-core/src/components/List/examples/ListLargeIcons.tsx
+++ b/packages/react-core/src/components/List/examples/ListLargeIcons.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { List, ListItem } from '@patternfly/react-core';
+import BookOpenIcon from '@patternfly/react-icons/dist/esm/icons/book-open-icon';
+import KeyIcon from '@patternfly/react-icons/dist/esm/icons/key-icon';
+import DesktopIcon from '@patternfly/react-icons/dist/esm/icons/desktop-icon';
+
+export const ListLargeIcons: React.FunctionComponent = () => (
+  <List isPlain iconSize="large">
+    <ListItem icon={<BookOpenIcon />}>First</ListItem>
+    <ListItem icon={<KeyIcon />}>Second</ListItem>
+    <ListItem icon={<DesktopIcon />}>Third</ListItem>
+  </List>
+);

--- a/packages/react-core/src/components/List/examples/ListOrdered.tsx
+++ b/packages/react-core/src/components/List/examples/ListOrdered.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { List, ListItem, ListComponent, OrderType } from '@patternfly/react-core';
+
+export const ListOrdered: React.FunctionComponent = () => (
+  <List component={ListComponent.ol} type={OrderType.number}>
+    <ListItem>First</ListItem>
+    <ListItem>Second</ListItem>
+    <ListItem>Third</ListItem>
+  </List>
+);

--- a/packages/react-core/src/components/List/examples/ListPlain.tsx
+++ b/packages/react-core/src/components/List/examples/ListPlain.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { List, ListItem } from '@patternfly/react-core';
+
+export const ListPlain: React.FunctionComponent = () => (
+  <List isPlain>
+    <ListItem>First</ListItem>
+    <ListItem>Second</ListItem>
+    <ListItem>Third</ListItem>
+  </List>
+);


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7549 . List examples have all been converted from JS to TS.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: This is not a critical issue. However, when writing out the TS examples for **ListIcons.tsx** and **ListLargeIcons.tsx**, there was an error on line 6110 of `node_modules/typescript/lib/typescript.js` regarding `replace` being undefined in the `normalizeSlashes` function. This was solved by changing the name of the imports of the icons from `BookOpen` to `BookOpenIcon` in both the markdown and the TS file, which works since the icons are export default. I'm not entirely sure as to what was going on but this issue was resolved with that solution.
