### PR TITLE
feat(Wizard): allow for an optional step in the wizard

### DIFF
--- a/packages/react-core/src/components/Wizard/Wizard.tsx
+++ b/packages/react-core/src/components/Wizard/Wizard.tsx
@@ -34,6 +34,8 @@ export interface WizardStep {
   hideCancelButton?: boolean;
   /** (Unused if footer is controlled) True to hide the Back button */
   hideBackButton?: boolean;
+  /** Force to disable the step in the navigation.*/
+  isDisabled?: boolean;
 }
 
 export type WizardStepFunctionType = (
@@ -174,7 +176,15 @@ export class Wizard extends React.Component<WizardProps, WizardState> {
       }
       return onClose();
     } else {
-      const newStep = currentStep + 1;
+      let newStep = currentStep;
+
+      for (let nextStep = currentStep; nextStep <= maxSteps; nextStep++) {
+        if (!flattenedSteps[nextStep].isDisabled) {
+          newStep = nextStep + 1;
+          break;
+        }
+      }
+
       this.setState({
         currentStep: newStep
       });
@@ -195,7 +205,15 @@ export class Wizard extends React.Component<WizardProps, WizardState> {
         currentStep: adjustedStep
       });
     } else {
-      const newStep = currentStep - 1 <= 0 ? 0 : currentStep - 1;
+      let newStep = currentStep;
+
+      for (let prevStep = currentStep; prevStep >= 0; prevStep--) {
+        if (!flattenedSteps[prevStep - 2].isDisabled) {
+          newStep = prevStep - 1 <= 1 ? 1 : prevStep - 1;
+          break;
+        }
+      }
+
       this.setState({
         currentStep: newStep
       });
@@ -396,7 +414,7 @@ export class Wizard extends React.Component<WizardProps, WizardState> {
                         return;
                       }
                       navItemStep = this.getFlattenedStepsIndex(flattenedSteps, childStep.name);
-                      enabled = childStep.canJumpTo;
+                      enabled = childStep.canJumpTo && !childStep.isDisabled;
                       return (
                         <WizardNavItem
                           key={`child_${indexChild}`}
@@ -414,7 +432,8 @@ export class Wizard extends React.Component<WizardProps, WizardState> {
               );
             }
             navItemStep = this.getFlattenedStepsIndex(flattenedSteps, step.name);
-            enabled = step.canJumpTo;
+            enabled = step.canJumpTo && !step.isDisabled;
+
             return (
               <WizardNavItem
                 {...step.stepNavItemProps}

--- a/packages/react-core/src/components/Wizard/examples/Wizard.md
+++ b/packages/react-core/src/components/Wizard/examples/Wizard.md
@@ -38,6 +38,31 @@ class SimpleWizard extends React.Component {
 }
 ```
 
+### Basic with step disabled
+
+```js
+import React from 'react';
+import { Button, Wizard } from '@patternfly/react-core';
+
+class SimpleWizard extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    const steps = [
+      { name: 'First step', component: <p>Step 1 content</p> },
+      { name: 'Second step', component: <p>Step 2 content</p>, isDisabled: true },
+      { name: 'Third step', component: <p>Step 3 content</p> },
+      { name: 'Fourth step', component: <p>Step 4 content</p>, isDisabled: true },
+      { name: 'Review', component: <p>Review step content</p>, nextButtonText: 'Finish' }
+    ];
+    const title = 'Basic wizard';
+    return <Wizard navAriaLabel={`${title} steps`} mainAriaLabel={`${title} content`} steps={steps} height={400} />;
+  }
+}
+```
+
 ### Anchors for nav items
 
 ```js
@@ -161,7 +186,7 @@ class SimpleWizard extends React.Component {
         name: 'First step',
         steps: [
           { name: 'Substep A', component: <p>Substep A content</p> },
-          { name: 'Substep B', component: <p>Substep B content</p> }
+          { name: 'Substep B', component: <p>Substep B content</p>,  isDisabled: true }
         ]
       },
       { name: 'Second step', component: <p>Step 2 content</p> },


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7302
We can disable one or more steps or sub-steps consequently.

During my first attempt, I tried to modify the prop **canJumpTo** but we had a conflict with the progressive wizard examples