### PR TITLE
chore(Table): clean up a11y violations in table docs

### DIFF
--- a/packages/react-table/src/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/packages/react-table/src/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -2720,6 +2720,7 @@ exports[`Table Compound Expandable table 1`] = `
           <button
             aria-expanded="true"
             class="pf-c-table__button"
+            id="expandable-toggle-0-0"
             type="button"
           >
             <span
@@ -2737,6 +2738,7 @@ exports[`Table Compound Expandable table 1`] = `
           <button
             aria-expanded="false"
             class="pf-c-table__button"
+            id="expandable-toggle-0-1"
             type="button"
           >
             <span
@@ -2781,6 +2783,7 @@ exports[`Table Compound Expandable table 1`] = `
           <button
             aria-expanded="false"
             class="pf-c-table__button"
+            id="expandable-toggle-2-0"
             type="button"
           >
             <span
@@ -2798,6 +2801,7 @@ exports[`Table Compound Expandable table 1`] = `
           <button
             aria-expanded="false"
             class="pf-c-table__button"
+            id="expandable-toggle-2-1"
             type="button"
           >
             <span

--- a/packages/react-table/src/components/Table/base/types.tsx
+++ b/packages/react-table/src/components/Table/base/types.tsx
@@ -81,6 +81,8 @@ export interface TdExpandType {
   columnIndex?: number;
   /** On toggling the expansion */
   onToggle?: OnCollapse;
+  /** Id prefix for expandable rows **/
+  expandId?: string;
 }
 
 export interface TdCompoundExpandType {
@@ -88,6 +90,8 @@ export interface TdCompoundExpandType {
   isExpanded: boolean;
   /** Callback on toggling of the expansion */
   onToggle?: OnExpand;
+  /** Id prefix for expandable cells **/
+  expandId?: string;
 }
 
 export interface TdFavoritesType {

--- a/packages/react-table/src/components/Table/base/types.tsx
+++ b/packages/react-table/src/components/Table/base/types.tsx
@@ -92,6 +92,10 @@ export interface TdCompoundExpandType {
   onToggle?: OnExpand;
   /** Id prefix for expandable cells **/
   expandId?: string;
+  /** The row index */
+  rowIndex?: number;
+  /** The column index */
+  columnIndex?: number;
 }
 
 export interface TdFavoritesType {

--- a/packages/react-table/src/components/Table/examples/LegacyTableActions.tsx
+++ b/packages/react-table/src/components/Table/examples/LegacyTableActions.tsx
@@ -68,7 +68,7 @@ export const LegacyTableActions: React.FunctionComponent = () => {
   );
 
   const columns: TableProps['cells'] = [
-    { title: 'Repositories', cellTransforms: [headerCol()] },
+    { title: 'Repositories', cellTransforms: [headerCol('actions')] },
     'Branches',
     'Pull requests',
     'Workspaces',

--- a/packages/react-table/src/components/Table/examples/LegacyTableCompoundExpandable.tsx
+++ b/packages/react-table/src/components/Table/examples/LegacyTableCompoundExpandable.tsx
@@ -167,6 +167,8 @@ export const LegacyTableCompoundExpandable: React.FunctionComponent = () => {
       }}
       rows={rows}
       cells={columns}
+      expandId="compound-expandable-table-toggle"
+      contentId="compound-expandable-table-content"
     >
       <TableHeader />
       <TableBody />

--- a/packages/react-table/src/components/Table/examples/LegacyTableExpandable.tsx
+++ b/packages/react-table/src/components/Table/examples/LegacyTableExpandable.tsx
@@ -163,6 +163,8 @@ export const LegacyTableExpandable: React.FunctionComponent = () => {
         }}
         rows={rows}
         cells={columns}
+        expandId="expandable-table-toggle"
+        contentId="expandable-table-content"
       >
         <TableHeader />
         <TableBody />

--- a/packages/react-table/src/components/Table/examples/LegacyTableSelectableRadio.tsx
+++ b/packages/react-table/src/components/Table/examples/LegacyTableSelectableRadio.tsx
@@ -24,7 +24,7 @@ export const LegacyTableSelectableRadio: React.FunctionComponent = () => {
   const [selectedRepoName, setSelectedRepoName] = React.useState<string | null>(null);
 
   const columns: TableProps['cells'] = [
-    { title: 'Repositories', cellTransforms: [headerCol()] },
+    { title: 'Repositories', cellTransforms: [headerCol('selectable-radio')] },
     'Branches',
     { title: 'Pull requests' },
     'Workspaces',

--- a/packages/react-table/src/components/Table/examples/Table.md
+++ b/packages/react-table/src/components/Table/examples/Table.md
@@ -6,7 +6,7 @@ propComponents: ['Table', 'TableHeader', 'TableBody', 'ISortBy']
 ouia: true
 ---
 
-# Table
+# Legacy Table
 
 Note: Table lives in its own package at [@patternfly/react-table](https://www.npmjs.com/package/@patternfly/react-table)!
 
@@ -30,7 +30,7 @@ import SortAmountDownIcon from '@patternfly/react-icons/dist/esm/icons/sort-amou
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 
-### Table Columns
+## Table Columns
 
 Array items for columns provided to the `Table`'s `cells` prop, can be simple strings or objects.
 
@@ -88,7 +88,7 @@ columns: [
 
 Many of the subsequent examples demonstrate how to apply different transformations to enable `Table` features.
 
-### Table Rows
+## Table Rows
 
 Array items for rows provided to the `Table`'s `rows` prop, can be simple strings or objects.
 

--- a/packages/react-table/src/components/Table/utils/decorators/compoundExpand.tsx
+++ b/packages/react-table/src/components/Table/utils/decorators/compoundExpand.tsx
@@ -13,7 +13,7 @@ export const compoundExpand: ITransform = (
   }
   const { title, props } = value;
   const {
-    extraParams: { onExpand }
+    extraParams: { onExpand, expandId = 'expand-toggle' }
   } = column;
   const extraData = {
     rowIndex,
@@ -21,7 +21,6 @@ export const compoundExpand: ITransform = (
     column,
     property
   };
-
   /**
    * @param {React.MouseEvent} event - Mouse event
    */
@@ -38,6 +37,7 @@ export const compoundExpand: ITransform = (
         onClick={onToggle}
         aria-expanded={props.isOpen}
         aria-controls={props.ariaControls}
+        id={`${expandId}-${rowIndex}-${columnIndex}`}
       >
         <TableText>{title}</TableText>
       </button>

--- a/packages/react-table/src/components/Table/utils/headerUtils.tsx
+++ b/packages/react-table/src/components/Table/utils/headerUtils.tsx
@@ -168,6 +168,7 @@ const favoritesTransforms = ({
           transforms:
             onSort && canSortFavorites
               ? [
+                  scopeColTransformer,
                   sortableFavorites({
                     onSort,
                     // favorites should be just before the first user-defined column

--- a/packages/react-table/src/components/TableComposable/Td.tsx
+++ b/packages/react-table/src/components/TableComposable/Td.tsx
@@ -150,9 +150,12 @@ const TdBase: React.FunctionComponent<TdProps> = ({
             }
           } as IFormatterValueType,
           {
+            rowIndex: compoundExpandProp?.rowIndex,
+            columnIndex: compoundExpandProp?.columnIndex,
             column: {
               extraParams: {
-                onExpand: compoundExpandProp?.onToggle
+                onExpand: compoundExpandProp?.onToggle,
+                expandId: compoundExpandProp?.expandId
               }
             }
           }

--- a/packages/react-table/src/components/TableComposable/Td.tsx
+++ b/packages/react-table/src/components/TableComposable/Td.tsx
@@ -134,7 +134,8 @@ const TdBase: React.FunctionComponent<TdProps> = ({
           },
           column: {
             extraParams: {
-              onCollapse: expand?.onToggle
+              onCollapse: expand?.onToggle,
+              expandId: expand?.expandId
             }
           }
         })

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTableCompoundExpandable.tsx
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTableCompoundExpandable.tsx
@@ -44,10 +44,17 @@ export const ComposableTableCompoundExpandable: React.FunctionComponent = () => 
     }
     setExpandedCells(newExpandedCells);
   };
-  const compoundExpandParams = (repo: Repository, columnKey: ColumnKey): TdProps['compoundExpand'] => ({
+  const compoundExpandParams = (
+    repo: Repository,
+    columnKey: ColumnKey,
+    rowIndex: number,
+    columnIndex: number
+  ): TdProps['compoundExpand'] => ({
     isExpanded: expandedCells[repo.name] === columnKey,
     onToggle: () => setCellExpanded(repo, columnKey, expandedCells[repo.name] !== columnKey),
-    expandId: 'composable-compound-expandable-example'
+    expandId: 'composable-compound-expandable-example',
+    rowIndex,
+    columnIndex
   });
 
   return (
@@ -62,7 +69,7 @@ export const ComposableTableCompoundExpandable: React.FunctionComponent = () => 
           <Th />
         </Tr>
       </Thead>
-      {repositories.map(repo => {
+      {repositories.map((repo: Repository, rowIndex: number) => {
         const expandedCellKey = expandedCells[repo.name];
         const isRowExpanded = !!expandedCellKey;
         return (
@@ -71,16 +78,24 @@ export const ComposableTableCompoundExpandable: React.FunctionComponent = () => 
               <Td width={25} dataLabel={columnNames.name} component="th">
                 <a href="#">{repo.name}</a>
               </Td>
-              <Td width={10} dataLabel={columnNames.branches} compoundExpand={compoundExpandParams(repo, 'branches')}>
+              <Td
+                width={10}
+                dataLabel={columnNames.branches}
+                compoundExpand={compoundExpandParams(repo, 'branches', rowIndex, 1)}
+              >
                 <CodeBranchIcon key="icon" /> {repo.branches}
               </Td>
-              <Td width={10} dataLabel={columnNames.prs} compoundExpand={compoundExpandParams(repo, 'prs')}>
+              <Td
+                width={10}
+                dataLabel={columnNames.prs}
+                compoundExpand={compoundExpandParams(repo, 'prs', rowIndex, 2)}
+              >
                 <CodeIcon key="icon" /> {repo.prs}
               </Td>
               <Td
                 width={10}
                 dataLabel={columnNames.workspaces}
-                compoundExpand={compoundExpandParams(repo, 'workspaces')}
+                compoundExpand={compoundExpandParams(repo, 'workspaces', rowIndex, 3)}
               >
                 <CubeIcon key="icon" /> {repo.workspaces}
               </Td>

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTableCompoundExpandable.tsx
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTableCompoundExpandable.tsx
@@ -46,7 +46,8 @@ export const ComposableTableCompoundExpandable: React.FunctionComponent = () => 
   };
   const compoundExpandParams = (repo: Repository, columnKey: ColumnKey): TdProps['compoundExpand'] => ({
     isExpanded: expandedCells[repo.name] === columnKey,
-    onToggle: () => setCellExpanded(repo, columnKey, expandedCells[repo.name] !== columnKey)
+    onToggle: () => setCellExpanded(repo, columnKey, expandedCells[repo.name] !== columnKey),
+    expandId: 'composable-compound-expandable-example'
   });
 
   return (

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTableExpandable.tsx
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTableExpandable.tsx
@@ -160,7 +160,8 @@ export const ComposableTableExpandable: React.FunctionComponent = () => {
                       ? {
                           rowIndex,
                           isExpanded: isRepoExpanded(repo),
-                          onToggle: () => setRepoExpanded(repo, !isRepoExpanded(repo))
+                          onToggle: () => setRepoExpanded(repo, !isRepoExpanded(repo)),
+                          expandId: 'composable-expandable-example'
                         }
                       : undefined
                   }

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTableNestedExpandable.tsx
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTableNestedExpandable.tsx
@@ -109,7 +109,7 @@ export const ComposableTableNestedExpandable: React.FunctionComponent = () => {
               <Td dataLabel={columnNames.visual}>{team.members.visual}</Td>
               <Td dataLabel={columnNames.contact}>
                 <Button variant="link" component="a" href={`mailto:${team.email}`} isInline>
-                  Message us!
+                  Email team {rowIndex}
                 </Button>
               </Td>
             </Tr>

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTableNestedExpandable.tsx
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTableNestedExpandable.tsx
@@ -99,7 +99,8 @@ export const ComposableTableNestedExpandable: React.FunctionComponent = () => {
                 expand={{
                   rowIndex,
                   isExpanded: isTeamExpanded(team),
-                  onToggle: () => setTeamExpanded(team, !isTeamExpanded(team))
+                  onToggle: () => setTeamExpanded(team, !isTeamExpanded(team)),
+                  expandId: 'composable-nested-expandable-example'
                 }}
               />
               <Td dataLabel={columnNames.team}>{team.name}</Td>

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTableNestedTableExpandable.tsx
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTableNestedTableExpandable.tsx
@@ -158,7 +158,8 @@ export const ComposableTableExpandable: React.FunctionComponent = () => {
                   ? {
                       rowIndex,
                       isExpanded: isRepoExpanded(repo),
-                      onToggle: () => setRepoExpanded(repo, !isRepoExpanded(repo))
+                      onToggle: () => setRepoExpanded(repo, !isRepoExpanded(repo)),
+                      expandId: 'composable-nested-table-expandable-example'
                     }
                   : undefined
               }

--- a/packages/react-table/src/demos/Table.md
+++ b/packages/react-table/src/demos/Table.md
@@ -27,6 +27,8 @@ import BarsIcon from '@patternfly/react-icons/dist/esm/icons/bars-icon';
 import AttentionBellIcon from '@patternfly/react-icons/dist/esm/icons/attention-bell-icon';
 import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 
+## Demos
+
 ### Bulk select
 
 ```js isFullscreen
@@ -886,10 +888,13 @@ class ColumnManagementAction extends React.Component {
           <ToolbarItem variant="pagination">
             <Pagination
               itemCount={37}
-              widgetId="pagination-options-menu-bottom"
+              widgetId="pagination-options-menu"
               page={1}
               variant={PaginationVariant.top}
               isCompact
+              titles={{
+                paginationTitle: `Column management top pagination`
+              }}
             />
           </ToolbarItem>
         </ToolbarContent>
@@ -923,6 +928,9 @@ class ColumnManagementAction extends React.Component {
           widgetId="pagination-options-menu-bottom"
           page={1}
           variant={PaginationVariant.bottom}
+          titles={{
+            paginationTitle: `Column management bottom pagination`
+          }}
         />
         {this.renderModal()}
       </React.Fragment>
@@ -1601,7 +1609,7 @@ class ColumnManagementAction extends React.Component {
 
     const toolbarItems = (
       <React.Fragment>
-        <span id="page-layout-table-column-management-action-toolbar-top-select-checkbox-label" hidden>
+        <span id="page-layout-table-draggable-column-management-action-toolbar-top-select-checkbox-label" hidden>
           Choose one
         </span>
         <ToolbarContent>
@@ -1609,10 +1617,10 @@ class ColumnManagementAction extends React.Component {
             <OverflowMenu breakpoint="md">
               <OverflowMenuItem isPersistent>
                 <Select
-                  id="page-layout-table-column-management-action-toolbar-top-select-checkbox-toggle"
+                  id="page-layout-table-draggable-column-management-action-toolbar-top-select-checkbox-toggle"
                   variant={SelectVariant.single}
                   aria-label="Select Input"
-                  aria-labelledby="page-layout-table-column-management-action-toolbar-top-select-checkbox-label page-layout-table-column-management-action-toolbar-top-select-checkbox-toggle"
+                  aria-labelledby="page-layout-table-draggable-column-management-action-toolbar-top-select-checkbox-label page-layout-table-column-management-action-toolbar-top-select-checkbox-toggle"
                   placeholderText={
                     <>
                       <FilterIcon /> Name
@@ -1622,7 +1630,7 @@ class ColumnManagementAction extends React.Component {
               </OverflowMenuItem>
               <OverflowMenuItem>
                 <OptionsMenu
-                  id="page-layout-table-column-management-action-toolbar-top-options-menu-toggle"
+                  id="page-layout-table-draggable-column-management-action-toolbar-top-options-menu-toggle"
                   isPlain
                   menuItems={[]}
                   toggle={
@@ -1649,10 +1657,13 @@ class ColumnManagementAction extends React.Component {
           <ToolbarItem variant="pagination">
             <Pagination
               itemCount={37}
-              widgetId="pagination-options-menu-bottom"
+              widgetId="pagination-options-menu"
               page={1}
               variant={PaginationVariant.top}
               isCompact
+              titles={{
+                paginationTitle: `Draggable column management top pagination`
+              }}
             />
           </ToolbarItem>
         </ToolbarContent>
@@ -1665,11 +1676,11 @@ class ColumnManagementAction extends React.Component {
           gridBreakPoint="grid-xl"
           header={
             <React.Fragment>
-              <Toolbar id="page-layout-table-column-management-action-toolbar-top">{toolbarItems}</Toolbar>
+              <Toolbar id="page-layout-table-draggable-column-management-action-toolbar-top">{toolbarItems}</Toolbar>
             </React.Fragment>
           }
           aria-label="This is a table with checkboxes"
-          id="page-layout-table-column-management-action-table"
+          id="page-layout-table-draggable-column-management-action-table"
           onSelect={this.onSelect}
           cells={columns}
           rows={rows}
@@ -1681,11 +1692,14 @@ class ColumnManagementAction extends React.Component {
         </Table>
         <Pagination
           isCompact
-          id="page-layout-table-column-management-action-toolbar-bottom"
+          id="page-layout-table-draggable-column-management-action-toolbar-bottom"
           itemCount={37}
           widgetId="pagination-options-menu-bottom"
           page={1}
           variant={PaginationVariant.bottom}
+          titles={{
+            paginationTitle: `Draggable column management bottom pagination`
+          }}
         />
         {this.renderModal()}
       </React.Fragment>
@@ -2641,7 +2655,7 @@ class ComplexPaginationTableDemo extends React.Component {
         onPerPageSelect={(_evt, value) => this.fetch(1, value)}
         variant={variant}
         titles={{
-          paginationTitle: `${variant} pagination`
+          paginationTitle: `Pagination demo ${variant} pagination`
         }}
       />
     );

--- a/packages/react-table/src/demos/table-demos/CompoundExpansion.jsx
+++ b/packages/react-table/src/demos/table-demos/CompoundExpansion.jsx
@@ -171,10 +171,12 @@ export const CompoundExpandable = () => {
     }
     setExpandedCells(newExpandedCells);
   };
-  const compoundExpandParams = (repo, columnKey) => ({
+  const compoundExpandParams = (repo, columnKey, rowIndex, columnIndex) => ({
     isExpanded: expandedCells[repo.name] === columnKey,
     onToggle: () => setCellExpanded(repo, columnKey, expandedCells[repo.name] !== columnKey),
-    expandId: 'compound-expandable-demo'
+    expandId: 'compound-expandable-demo',
+    rowIndex,
+    columnIndex
   });
 
   return (
@@ -193,7 +195,7 @@ export const CompoundExpandable = () => {
                 <Th />
               </Tr>
             </Thead>
-            {repositories.map(repo => {
+            {repositories.map((repo, rowIndex) => {
               const expandedCellKey = expandedCells[repo.name];
               const isRowExpanded = !!expandedCellKey;
               return (
@@ -202,7 +204,10 @@ export const CompoundExpandable = () => {
                     <Td dataLabel={columnNames.name} component="th">
                       <a href="#">{repo.name}</a>
                     </Td>
-                    <Td dataLabel={columnNames.branches} compoundExpand={compoundExpandParams(repo, 'branches')}>
+                    <Td
+                      dataLabel={columnNames.branches}
+                      compoundExpand={compoundExpandParams(repo, 'branches', rowIndex, 1)}
+                    >
                       <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                         <FlexItem>
                           <CodeBranchIcon key="icon" />
@@ -210,7 +215,7 @@ export const CompoundExpandable = () => {
                         <FlexItem>{repo.branches}</FlexItem>
                       </Flex>
                     </Td>
-                    <Td dataLabel={columnNames.prs} compoundExpand={compoundExpandParams(repo, 'prs')}>
+                    <Td dataLabel={columnNames.prs} compoundExpand={compoundExpandParams(repo, 'prs', rowIndex, 2)}>
                       <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                         <FlexItem>
                           <CodeIcon key="icon" />
@@ -218,7 +223,10 @@ export const CompoundExpandable = () => {
                         <FlexItem>{repo.prs}</FlexItem>
                       </Flex>{' '}
                     </Td>
-                    <Td dataLabel={columnNames.workspaces} compoundExpand={compoundExpandParams(repo, 'workspaces')}>
+                    <Td
+                      dataLabel={columnNames.workspaces}
+                      compoundExpand={compoundExpandParams(repo, 'workspaces', rowIndex, 3)}
+                    >
                       <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                         <FlexItem>
                           <CubeIcon key="icon" />

--- a/packages/react-table/src/demos/table-demos/CompoundExpansion.jsx
+++ b/packages/react-table/src/demos/table-demos/CompoundExpansion.jsx
@@ -173,7 +173,8 @@ export const CompoundExpandable = () => {
   };
   const compoundExpandParams = (repo, columnKey) => ({
     isExpanded: expandedCells[repo.name] === columnKey,
-    onToggle: () => setCellExpanded(repo, columnKey, expandedCells[repo.name] !== columnKey)
+    onToggle: () => setCellExpanded(repo, columnKey, expandedCells[repo.name] !== columnKey),
+    expandId: 'compound-expandable-demo'
   });
 
   return (

--- a/packages/react-table/src/demos/table-demos/ExpandCollapseAll.jsx
+++ b/packages/react-table/src/demos/table-demos/ExpandCollapseAll.jsx
@@ -138,6 +138,7 @@ class ExpandCollapseAllTableDemo extends React.Component {
                 canSelectAll={false}
                 canCollapseAll={true}
                 collapseAllAriaLabel={collapseAllAriaLabel}
+                expandId="expand-collapse-all-demo"
               >
                 <TableHeader />
                 <TableBody />


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7578 

Cleans up `id` props duplicated across demos/examples
Cleans up non-unique aria-labels on similar elements across demos/examples
