### PR TITLE
chore: fix various a11y violations in examples (3)

### DIFF
--- a/packages/react-core/src/components/Accordion/examples/AccordionBordered.tsx
+++ b/packages/react-core/src/components/Accordion/examples/AccordionBordered.tsx
@@ -11,7 +11,7 @@ import {
 import ArrowRightIcon from '@patternfly/react-icons/dist/esm/icons/arrow-right-icon';
 
 export const AccordionBordered: React.FunctionComponent = () => {
-  const [expanded, setExpanded] = React.useState('ex-toggle4');
+  const [expanded, setExpanded] = React.useState('bordered-toggle4');
   const [isDisplayLarge, setIsDisplayLarge] = React.useState(false);
 
   const displaySize = isDisplayLarge ? 'large' : 'default';
@@ -29,14 +29,14 @@ export const AccordionBordered: React.FunctionComponent = () => {
         <AccordionItem>
           <AccordionToggle
             onClick={() => {
-              onToggle('ex-toggle1');
+              onToggle('bordered-toggle1');
             }}
-            isExpanded={expanded === 'ex-toggle1'}
-            id="ex-toggle1"
+            isExpanded={expanded === 'bordered-toggle1'}
+            id="bordered-toggle1"
           >
             Item one
           </AccordionToggle>
-          <AccordionContent id="ex-expand1" isHidden={expanded !== 'ex-toggle1'}>
+          <AccordionContent id="bordered-expand1" isHidden={expanded !== 'bordered-toggle1'}>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
               dolore magna aliqua.
@@ -47,14 +47,14 @@ export const AccordionBordered: React.FunctionComponent = () => {
         <AccordionItem>
           <AccordionToggle
             onClick={() => {
-              onToggle('ex-toggle2');
+              onToggle('bordered-toggle2');
             }}
-            isExpanded={expanded === 'ex-toggle2'}
-            id="ex-toggle2"
+            isExpanded={expanded === 'bordered-toggle2'}
+            id="bordered-toggle2"
           >
             Item two
           </AccordionToggle>
-          <AccordionContent id="ex-expand2" isHidden={expanded !== 'ex-toggle2'}>
+          <AccordionContent id="bordered-expand2" isHidden={expanded !== 'bordered-toggle2'}>
             <p>
               Vivamus et tortor sed arcu congue vehicula eget et diam. Praesent nec dictum lorem. Aliquam id diam
               ultrices, faucibus erat id, maximus nunc.
@@ -65,14 +65,14 @@ export const AccordionBordered: React.FunctionComponent = () => {
         <AccordionItem>
           <AccordionToggle
             onClick={() => {
-              onToggle('ex-toggle3');
+              onToggle('bordered-toggle3');
             }}
-            isExpanded={expanded === 'ex-toggle3'}
-            id="ex-toggle3"
+            isExpanded={expanded === 'bordered-toggle3'}
+            id="bordered-toggle3"
           >
             Item three
           </AccordionToggle>
-          <AccordionContent id="ex-expand3" isHidden={expanded !== 'ex-toggle3'}>
+          <AccordionContent id="bordered-expand3" isHidden={expanded !== 'bordered-toggle3'}>
             <p>Morbi vitae urna quis nunc convallis hendrerit. Aliquam congue orci quis ultricies tempus.</p>
           </AccordionContent>
         </AccordionItem>
@@ -80,14 +80,14 @@ export const AccordionBordered: React.FunctionComponent = () => {
         <AccordionItem>
           <AccordionToggle
             onClick={() => {
-              onToggle('ex-toggle4');
+              onToggle('bordered-toggle4');
             }}
-            isExpanded={expanded === 'ex-toggle4'}
-            id="ex-toggle4"
+            isExpanded={expanded === 'bordered-toggle4'}
+            id="bordered-toggle4"
           >
             Item four
           </AccordionToggle>
-          <AccordionContent id="ex-expand4" isHidden={expanded !== 'ex-toggle4'} isCustomContent>
+          <AccordionContent id="bordered-expand4" isHidden={expanded !== 'bordered-toggle4'} isCustomContent>
             <AccordionExpandedContentBody>
               Donec vel posuere orci. Phasellus quis tortor a ex hendrerit efficitur. Aliquam lacinia ligula pharetra,
               sagittis ex ut, pellentesque diam. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices
@@ -107,14 +107,14 @@ export const AccordionBordered: React.FunctionComponent = () => {
         <AccordionItem>
           <AccordionToggle
             onClick={() => {
-              onToggle('ex-toggle5');
+              onToggle('bordered-toggle5');
             }}
-            isExpanded={expanded === 'ex-toggle5'}
-            id="ex-toggle5"
+            isExpanded={expanded === 'bordered-toggle5'}
+            id="bordered-toggle5"
           >
             Item five
           </AccordionToggle>
-          <AccordionContent id="ex-expand5" isHidden={expanded !== 'ex-toggle5'}>
+          <AccordionContent id="bordered-expand5" isHidden={expanded !== 'bordered-toggle5'}>
             <p>Vivamus finibus dictum ex id ultrices. Mauris dictum neque a iaculis blandit.</p>
           </AccordionContent>
         </AccordionItem>

--- a/packages/react-core/src/components/Accordion/examples/AccordionDefinitionList.tsx
+++ b/packages/react-core/src/components/Accordion/examples/AccordionDefinitionList.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Accordion, AccordionItem, AccordionContent, AccordionToggle } from '@patternfly/react-core';
 
 export const AccordionDefinitionList: React.FunctionComponent = () => {
-  const [expanded, setExpanded] = React.useState('ex-toggle2');
+  const [expanded, setExpanded] = React.useState('def-list-toggle2');
 
   const onToggle = (id: string) => {
     if (id === expanded) {
@@ -17,14 +17,14 @@ export const AccordionDefinitionList: React.FunctionComponent = () => {
       <AccordionItem>
         <AccordionToggle
           onClick={() => {
-            onToggle('ex-toggle1');
+            onToggle('def-list-toggle1');
           }}
-          isExpanded={expanded === 'ex-toggle1'}
-          id="ex-toggle1"
+          isExpanded={expanded === 'def-list-toggle1'}
+          id="def-list-toggle1"
         >
           Item one
         </AccordionToggle>
-        <AccordionContent id="ex-expand1" isHidden={expanded !== 'ex-toggle1'}>
+        <AccordionContent id="def-list-expand1" isHidden={expanded !== 'def-list-toggle1'}>
           <p>
             Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
             dolore magna aliqua.
@@ -35,14 +35,14 @@ export const AccordionDefinitionList: React.FunctionComponent = () => {
       <AccordionItem>
         <AccordionToggle
           onClick={() => {
-            onToggle('ex-toggle2');
+            onToggle('def-list-toggle2');
           }}
-          isExpanded={expanded === 'ex-toggle2'}
-          id="ex-toggle2"
+          isExpanded={expanded === 'def-list-toggle2'}
+          id="def-list-toggle2"
         >
           Item two
         </AccordionToggle>
-        <AccordionContent id="ex-expand2" isHidden={expanded !== 'ex-toggle2'}>
+        <AccordionContent id="def-list-expand2" isHidden={expanded !== 'def-list-toggle2'}>
           <p>
             Vivamus et tortor sed arcu congue vehicula eget et diam. Praesent nec dictum lorem. Aliquam id diam
             ultrices, faucibus erat id, maximus nunc.
@@ -53,14 +53,14 @@ export const AccordionDefinitionList: React.FunctionComponent = () => {
       <AccordionItem>
         <AccordionToggle
           onClick={() => {
-            onToggle('ex-toggle3');
+            onToggle('def-list-toggle3');
           }}
-          isExpanded={expanded === 'ex-toggle3'}
-          id="ex-toggle3"
+          isExpanded={expanded === 'def-list-toggle3'}
+          id="def-list-toggle3"
         >
           Item three
         </AccordionToggle>
-        <AccordionContent id="ex-expand3" isHidden={expanded !== 'ex-toggle3'}>
+        <AccordionContent id="def-list-expand3" isHidden={expanded !== 'def-list-toggle3'}>
           <p>Morbi vitae urna quis nunc convallis hendrerit. Aliquam congue orci quis ultricies tempus.</p>
         </AccordionContent>
       </AccordionItem>
@@ -68,14 +68,14 @@ export const AccordionDefinitionList: React.FunctionComponent = () => {
       <AccordionItem>
         <AccordionToggle
           onClick={() => {
-            onToggle('ex-toggle4');
+            onToggle('def-list-toggle4');
           }}
-          isExpanded={expanded === 'ex-toggle4'}
-          id="ex-toggle4"
+          isExpanded={expanded === 'def-list-toggle4'}
+          id="def-list-toggle4"
         >
           Item four
         </AccordionToggle>
-        <AccordionContent id="ex-expand4" isHidden={expanded !== 'ex-toggle4'}>
+        <AccordionContent id="def-list-expand4" isHidden={expanded !== 'def-list-toggle4'}>
           <p>
             Donec vel posuere orci. Phasellus quis tortor a ex hendrerit efficitur. Aliquam lacinia ligula pharetra,
             sagittis ex ut, pellentesque diam. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere
@@ -91,14 +91,14 @@ export const AccordionDefinitionList: React.FunctionComponent = () => {
       <AccordionItem>
         <AccordionToggle
           onClick={() => {
-            onToggle('ex-toggle5');
+            onToggle('def-list-toggle5');
           }}
-          isExpanded={expanded === 'ex-toggle5'}
-          id="ex-toggle5"
+          isExpanded={expanded === 'def-list-toggle5'}
+          id="def-list-toggle5"
         >
           Item five
         </AccordionToggle>
-        <AccordionContent id="ex-expand5" isHidden={expanded !== 'ex-toggle5'}>
+        <AccordionContent id="def-list-expand5" isHidden={expanded !== 'def-list-toggle5'}>
           <p>Vivamus finibus dictum ex id ultrices. Mauris dictum neque a iaculis blandit.</p>
         </AccordionContent>
       </AccordionItem>

--- a/packages/react-core/src/components/ActionList/examples/ActionListMultipleGroups.tsx
+++ b/packages/react-core/src/components/ActionList/examples/ActionListMultipleGroups.tsx
@@ -5,24 +5,24 @@ export const ActionListMultipleGroups: React.FunctionComponent = () => (
   <ActionList>
     <ActionListGroup>
       <ActionListItem>
-        <Button variant="primary" id="next-button">
+        <Button variant="primary" id="multi-group-next-button">
           Next
         </Button>
       </ActionListItem>
       <ActionListItem>
-        <Button variant="secondary" id="back-button">
+        <Button variant="secondary" id="multi-group-back-button">
           Back
         </Button>
       </ActionListItem>
     </ActionListGroup>
     <ActionListGroup>
       <ActionListItem>
-        <Button variant="primary" id="submit-button">
+        <Button variant="primary" id="multi-group-submit-button">
           Submit
         </Button>
       </ActionListItem>
       <ActionListItem>
-        <Button variant="link" id="cancel-button">
+        <Button variant="link" id="multi-group-cancel-button">
           Cancel
         </Button>
       </ActionListItem>

--- a/packages/react-core/src/components/ActionList/examples/ActionListSingleGroup.tsx
+++ b/packages/react-core/src/components/ActionList/examples/ActionListSingleGroup.tsx
@@ -47,12 +47,12 @@ export const ActionListSingleGroup: React.FunctionComponent = () => {
     <React.Fragment>
       <ActionList>
         <ActionListItem>
-          <Button variant="primary" id="next-button">
+          <Button variant="primary" id="single-group-next-button">
             Next
           </Button>
         </ActionListItem>
         <ActionListItem>
-          <Button variant="secondary" id="back-button">
+          <Button variant="secondary" id="single-group-back-button">
             Back
           </Button>
         </ActionListItem>
@@ -61,12 +61,12 @@ export const ActionListSingleGroup: React.FunctionComponent = () => {
       With kebab
       <ActionList>
         <ActionListItem>
-          <Button variant="primary" id="next-button2">
+          <Button variant="primary" id="single-group-next-button2">
             Next
           </Button>
         </ActionListItem>
         <ActionListItem>
-          <Button variant="secondary" id="back-button2">
+          <Button variant="secondary" id="single-group-back-button2">
             Back
           </Button>
         </ActionListItem>

--- a/packages/react-core/src/components/ActionList/examples/ActionListWithCancelButton.tsx
+++ b/packages/react-core/src/components/ActionList/examples/ActionListWithCancelButton.tsx
@@ -6,12 +6,12 @@ export const ActionListWithCancelButton: React.FunctionComponent = () => (
     In modals, forms, data lists
     <ActionList>
       <ActionListItem>
-        <Button variant="primary" id="save-button">
+        <Button variant="primary" id="with-cancel-save-button">
           Save
         </Button>
       </ActionListItem>
       <ActionListItem>
-        <Button variant="link" id="cancel-button">
+        <Button variant="link" id="with-cancel-cancel-button">
           Cancel
         </Button>
       </ActionListItem>
@@ -21,19 +21,19 @@ export const ActionListWithCancelButton: React.FunctionComponent = () => (
     <ActionList>
       <ActionListGroup>
         <ActionListItem>
-          <Button variant="primary" id="next-button">
+          <Button variant="primary" id="with-cancel-next-button">
             Next
           </Button>
         </ActionListItem>
         <ActionListItem>
-          <Button variant="secondary" id="back-button">
+          <Button variant="secondary" id="with-cancel-back-button">
             Back
           </Button>
         </ActionListItem>
       </ActionListGroup>
       <ActionListGroup>
         <ActionListItem>
-          <Button variant="link" id="cancel-button2">
+          <Button variant="link" id="with-cancel-cancel-button2">
             Cancel
           </Button>
         </ActionListItem>

--- a/packages/react-core/src/components/ActionList/examples/ActionListWithIcons.tsx
+++ b/packages/react-core/src/components/ActionList/examples/ActionListWithIcons.tsx
@@ -6,12 +6,12 @@ import CheckIcon from '@patternfly/react-icons/dist/esm/icons/check-icon';
 export const ActionListWithIcons: React.FunctionComponent = () => (
   <ActionList isIconList>
     <ActionListItem>
-      <Button variant="plain" id="times-button" aria-label="times icon button">
+      <Button variant="plain" id="with-icons-times-button" aria-label="times icon button">
         <TimesIcon />
       </Button>
     </ActionListItem>
     <ActionListItem>
-      <Button variant="plain" id="check-button" aria-label="check icon button">
+      <Button variant="plain" id="with-icons-check-button" aria-label="check icon button">
         <CheckIcon />
       </Button>
     </ActionListItem>

--- a/packages/react-core/src/components/Card/examples/CardSelectableA11yHighlight.tsx
+++ b/packages/react-core/src/components/Card/examples/CardSelectableA11yHighlight.tsx
@@ -28,13 +28,13 @@ export const CardSelectableA11yHighlight: React.FunctionComponent = () => {
   return (
     <React.Fragment>
       <Card
-        id="selectable-first-card"
+        id="a11y-selectable-first-card"
         onKeyDown={onKeyDown}
         onClick={onClick}
         hasSelectableInput
         onSelectableInputChange={onChange}
         isSelectableRaised
-        isSelected={selected === 'selectable-first-card'}
+        isSelected={selected === 'a11y-selectable-first-card'}
       >
         <CardTitle>Selectable card with proper accessibility considerations</CardTitle>
         <CardBody>
@@ -44,11 +44,11 @@ export const CardSelectableA11yHighlight: React.FunctionComponent = () => {
       </Card>
       <br />
       <Card
-        id="selectable-second-card"
+        id="a11y-selectable-second-card"
         onKeyDown={onKeyDown}
         onClick={onClick}
         isSelectableRaised
-        isSelected={selected === 'selectable-second-card'}
+        isSelected={selected === 'a11y-selectable-second-card'}
       >
         <CardTitle>Selectable card without proper accessibility considerations</CardTitle>
         <CardBody>

--- a/packages/react-core/src/components/CodeBlock/examples/CodeBlockBasic.tsx
+++ b/packages/react-core/src/components/CodeBlock/examples/CodeBlockBasic.tsx
@@ -32,7 +32,7 @@ url: https://raw.githubusercontent.com/Azure-Samples/helm-charts/master/docs`;
     <React.Fragment>
       <CodeBlockAction>
         <ClipboardCopyButton
-          id="copy-button"
+          id="basic-copy-button"
           textId="code-content"
           aria-label="Copy to clipboard"
           onClick={e => onClick(e, code)}

--- a/packages/react-core/src/components/CodeBlock/examples/CodeBlockExpandable.tsx
+++ b/packages/react-core/src/components/CodeBlock/examples/CodeBlockExpandable.tsx
@@ -53,7 +53,7 @@ url: https://raw.githubusercontent.com/Azure-Samples/helm-charts/master/docs`;
     <React.Fragment>
       <CodeBlockAction>
         <ClipboardCopyButton
-          id="copy-button"
+          id="expandable-copy-button"
           textId="code-content"
           aria-label="Copy to clipboard"
           onClick={e => onClick(e, copyBlock)}

--- a/packages/react-core/src/components/ContextSelector/ContextSelector.tsx
+++ b/packages/react-core/src/components/ContextSelector/ContextSelector.tsx
@@ -62,6 +62,8 @@ export interface ContextSelectorProps extends Omit<ToggleMenuBaseProps, 'menuApp
    * appended inline, e.g. `menuAppendTo="parent"`
    */
   isFlipEnabled?: boolean;
+  /** Id of the context selector */
+  id?: string;
 }
 
 export class ContextSelector extends React.Component<ContextSelectorProps, { ouiaStateId: string }> {
@@ -104,9 +106,6 @@ export class ContextSelector extends React.Component<ContextSelectorProps, { oui
   };
 
   render() {
-    const newId = getUniqueId();
-    const toggleId = `pf-context-selector-toggle-id-${newId}`;
-    const screenReaderLabelId = `pf-context-selector-label-id-${newId}`;
     const {
       children,
       className,
@@ -129,14 +128,21 @@ export class ContextSelector extends React.Component<ContextSelectorProps, { oui
       footer,
       disableFocusTrap,
       isFlipEnabled,
+      id,
       ...props
     } = this.props;
+
+    const uniqueId = id || getUniqueId();
+    const toggleId = `pf-context-selector-toggle-id-${uniqueId}`;
+    const screenReaderLabelId = `pf-context-selector-label-id-${uniqueId}`;
+
     const menuContainer = (
       <div
         className={css(styles.contextSelectorMenu)}
         // This removes the `position: absolute`styling from the `.pf-c-context-selector__menu`
         // allowing the menu to flip correctly
         {...(isFlipEnabled && { style: { position: 'revert' } })}
+        id={uniqueId}
       >
         {isOpen && (
           <FocusTrap

--- a/packages/react-core/src/components/ContextSelector/ContextSelector.tsx
+++ b/packages/react-core/src/components/ContextSelector/ContextSelector.tsx
@@ -9,14 +9,10 @@ import { Button, ButtonVariant } from '../Button';
 import { TextInput } from '../TextInput';
 import { InputGroup } from '../InputGroup';
 import { KEY_CODES } from '../../helpers/constants';
-import { FocusTrap } from '../../helpers';
+import { FocusTrap, getUniqueId } from '../../helpers';
 import { ToggleMenuBaseProps } from '../../helpers/Popper/Popper';
 import { Popper } from '../../helpers/Popper/Popper';
 import { getOUIAProps, OUIAProps, getDefaultOUIAId } from '../../helpers';
-
-// seed for the aria-labelledby ID
-let currentId = 0;
-const newId = currentId++;
 
 export interface ContextSelectorProps extends Omit<ToggleMenuBaseProps, 'menuAppendTo'>, OUIAProps {
   /** content rendered inside the Context Selector */
@@ -108,9 +104,9 @@ export class ContextSelector extends React.Component<ContextSelectorProps, { oui
   };
 
   render() {
+    const newId = getUniqueId();
     const toggleId = `pf-context-selector-toggle-id-${newId}`;
     const screenReaderLabelId = `pf-context-selector-label-id-${newId}`;
-    const searchButtonId = `pf-context-selector-search-button-id-${newId}`;
     const {
       children,
       className,
@@ -155,12 +151,11 @@ export class ContextSelector extends React.Component<ContextSelectorProps, { oui
                   placeholder={searchInputPlaceholder}
                   onChange={onSearchInputChange}
                   onKeyPress={this.onEnterPressed}
-                  aria-labelledby={searchButtonId}
+                  aria-label={searchButtonAriaLabel}
                 />
                 <Button
                   variant={ButtonVariant.control}
                   aria-label={searchButtonAriaLabel}
-                  id={searchButtonId}
                   onClick={onSearchButtonClick}
                 >
                   <SearchIcon aria-hidden="true" />

--- a/packages/react-core/src/components/ContextSelector/ContextSelectorMenuList.tsx
+++ b/packages/react-core/src/components/ContextSelector/ContextSelectorMenuList.tsx
@@ -29,7 +29,8 @@ export class ContextSelectorMenuList extends React.Component<ContextSelectorMenu
     return React.Children.map(this.props.children, (child, index) =>
       React.cloneElement(child as React.ReactElement<any>, {
         sendRef: this.sendRef,
-        index
+        index,
+        role: 'menuitem'
       })
     );
   }

--- a/packages/react-core/src/components/ContextSelector/__tests__/ContextSelector.test.tsx
+++ b/packages/react-core/src/components/ContextSelector/__tests__/ContextSelector.test.tsx
@@ -16,12 +16,12 @@ const items = [
 
 describe('ContextSelector', () => {
   test('Renders ContextSelector', () => {
-    const { asFragment } = render(<ContextSelector>{items}</ContextSelector>);
+    const { asFragment } = render(<ContextSelector id="render">{items}</ContextSelector>);
     expect(asFragment()).toMatchSnapshot();
   });
 
   test('Renders ContextSelector open', () => {
-    const { asFragment } = render(<ContextSelector isOpen>{items}</ContextSelector>);
+    const { asFragment } = render(<ContextSelector isOpen id="render-open">{items}</ContextSelector>);
     expect(asFragment()).toMatchSnapshot();
   });
 

--- a/packages/react-core/src/components/ContextSelector/__tests__/__snapshots__/ContextSelector.test.tsx.snap
+++ b/packages/react-core/src/components/ContextSelector/__tests__/__snapshots__/ContextSelector.test.tsx.snap
@@ -10,9 +10,9 @@ exports[`ContextSelector Renders ContextSelector 1`] = `
   >
     <button
       aria-expanded="false"
-      aria-labelledby="pf-context-selector-label-id-pf-1656359990828zeg91exmb9 pf-context-selector-toggle-id-pf-1656359990828zeg91exmb9"
+      aria-labelledby="pf-context-selector-label-id-render pf-context-selector-toggle-id-render"
       class="pf-c-context-selector__toggle"
-      id="pf-context-selector-toggle-id-pf-1656359990828zeg91exmb9"
+      id="pf-context-selector-toggle-id-render"
       type="button"
     >
       <span
@@ -50,9 +50,9 @@ exports[`ContextSelector Renders ContextSelector open 1`] = `
   >
     <button
       aria-expanded="true"
-      aria-labelledby="pf-context-selector-label-id-pf-1656359990915lw8vliqgaij pf-context-selector-toggle-id-pf-1656359990915lw8vliqgaij"
+      aria-labelledby="pf-context-selector-label-id-render-open pf-context-selector-toggle-id-render-open"
       class="pf-c-context-selector__toggle"
-      id="pf-context-selector-toggle-id-pf-1656359990915lw8vliqgaij"
+      id="pf-context-selector-toggle-id-render-open"
       type="button"
     >
       <span
@@ -78,6 +78,7 @@ exports[`ContextSelector Renders ContextSelector open 1`] = `
     </button>
     <div
       class="pf-c-context-selector__menu"
+      id="render-open"
     >
       <div>
         <div

--- a/packages/react-core/src/components/ContextSelector/__tests__/__snapshots__/ContextSelector.test.tsx.snap
+++ b/packages/react-core/src/components/ContextSelector/__tests__/__snapshots__/ContextSelector.test.tsx.snap
@@ -10,9 +10,9 @@ exports[`ContextSelector Renders ContextSelector 1`] = `
   >
     <button
       aria-expanded="false"
-      aria-labelledby="pf-context-selector-label-id-0 pf-context-selector-toggle-id-0"
+      aria-labelledby="pf-context-selector-label-id-pf-1656358540398c91arxuhow pf-context-selector-toggle-id-pf-1656358540398c91arxuhow"
       class="pf-c-context-selector__toggle"
-      id="pf-context-selector-toggle-id-0"
+      id="pf-context-selector-toggle-id-pf-1656358540398c91arxuhow"
       type="button"
     >
       <span
@@ -50,9 +50,9 @@ exports[`ContextSelector Renders ContextSelector open 1`] = `
   >
     <button
       aria-expanded="true"
-      aria-labelledby="pf-context-selector-label-id-0 pf-context-selector-toggle-id-0"
+      aria-labelledby="pf-context-selector-label-id-pf-1656358540423uq2ltw89gts pf-context-selector-toggle-id-pf-1656358540423uq2ltw89gts"
       class="pf-c-context-selector__toggle"
-      id="pf-context-selector-toggle-id-0"
+      id="pf-context-selector-toggle-id-pf-1656358540423uq2ltw89gts"
       type="button"
     >
       <span
@@ -87,9 +87,8 @@ exports[`ContextSelector Renders ContextSelector open 1`] = `
             class="pf-c-input-group"
           >
             <input
-              aria-describedby="pf-context-selector-search-button-id-0"
               aria-invalid="false"
-              aria-labelledby="pf-context-selector-search-button-id-0"
+              aria-label="Search menu items"
               class="pf-c-form-control"
               data-ouia-component-id="OUIA-Generated-TextInputBase-1"
               data-ouia-component-type="PF4/TextInput"
@@ -105,7 +104,6 @@ exports[`ContextSelector Renders ContextSelector open 1`] = `
               data-ouia-component-id="OUIA-Generated-Button-control-1"
               data-ouia-component-type="PF4/Button"
               data-ouia-safe="true"
-              id="pf-context-selector-search-button-id-0"
               type="button"
             >
               <svg
@@ -133,6 +131,7 @@ exports[`ContextSelector Renders ContextSelector open 1`] = `
           >
             <button
               class="pf-c-context-selector__menu-list-item"
+              role="menuitem"
             >
               My Project
             </button>
@@ -142,6 +141,7 @@ exports[`ContextSelector Renders ContextSelector open 1`] = `
           >
             <button
               class="pf-c-context-selector__menu-list-item"
+              role="menuitem"
             >
               OpenShift Cluster
             </button>
@@ -151,6 +151,7 @@ exports[`ContextSelector Renders ContextSelector open 1`] = `
           >
             <button
               class="pf-c-context-selector__menu-list-item"
+              role="menuitem"
             >
               Production Ansible
             </button>
@@ -160,6 +161,7 @@ exports[`ContextSelector Renders ContextSelector open 1`] = `
           >
             <button
               class="pf-c-context-selector__menu-list-item"
+              role="menuitem"
             >
               AWS
             </button>
@@ -169,6 +171,7 @@ exports[`ContextSelector Renders ContextSelector open 1`] = `
           >
             <button
               class="pf-c-context-selector__menu-list-item"
+              role="menuitem"
             >
               Azure
             </button>

--- a/packages/react-core/src/components/ContextSelector/__tests__/__snapshots__/ContextSelector.test.tsx.snap
+++ b/packages/react-core/src/components/ContextSelector/__tests__/__snapshots__/ContextSelector.test.tsx.snap
@@ -10,9 +10,9 @@ exports[`ContextSelector Renders ContextSelector 1`] = `
   >
     <button
       aria-expanded="false"
-      aria-labelledby="pf-context-selector-label-id-pf-1656358540398c91arxuhow pf-context-selector-toggle-id-pf-1656358540398c91arxuhow"
+      aria-labelledby="pf-context-selector-label-id-pf-1656359990828zeg91exmb9 pf-context-selector-toggle-id-pf-1656359990828zeg91exmb9"
       class="pf-c-context-selector__toggle"
-      id="pf-context-selector-toggle-id-pf-1656358540398c91arxuhow"
+      id="pf-context-selector-toggle-id-pf-1656359990828zeg91exmb9"
       type="button"
     >
       <span
@@ -50,9 +50,9 @@ exports[`ContextSelector Renders ContextSelector open 1`] = `
   >
     <button
       aria-expanded="true"
-      aria-labelledby="pf-context-selector-label-id-pf-1656358540423uq2ltw89gts pf-context-selector-toggle-id-pf-1656358540423uq2ltw89gts"
+      aria-labelledby="pf-context-selector-label-id-pf-1656359990915lw8vliqgaij pf-context-selector-toggle-id-pf-1656359990915lw8vliqgaij"
       class="pf-c-context-selector__toggle"
-      id="pf-context-selector-toggle-id-pf-1656358540423uq2ltw89gts"
+      id="pf-context-selector-toggle-id-pf-1656359990915lw8vliqgaij"
       type="button"
     >
       <span

--- a/packages/react-core/src/components/ContextSelector/__tests__/__snapshots__/ContextSelectorMenuList.test.tsx.snap
+++ b/packages/react-core/src/components/ContextSelector/__tests__/__snapshots__/ContextSelectorMenuList.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`Renders ContextSelectorMenuList closed 1`] = `
     >
       <button
         class="pf-c-context-selector__menu-list-item"
+        role="menuitem"
       >
         My Project
       </button>
@@ -21,6 +22,7 @@ exports[`Renders ContextSelectorMenuList closed 1`] = `
     >
       <button
         class="pf-c-context-selector__menu-list-item"
+        role="menuitem"
       >
         OpenShift Cluster
       </button>
@@ -30,6 +32,7 @@ exports[`Renders ContextSelectorMenuList closed 1`] = `
     >
       <button
         class="pf-c-context-selector__menu-list-item"
+        role="menuitem"
       >
         Production Ansible
       </button>
@@ -39,6 +42,7 @@ exports[`Renders ContextSelectorMenuList closed 1`] = `
     >
       <button
         class="pf-c-context-selector__menu-list-item"
+        role="menuitem"
       >
         AWS
       </button>
@@ -48,6 +52,7 @@ exports[`Renders ContextSelectorMenuList closed 1`] = `
     >
       <button
         class="pf-c-context-selector__menu-list-item"
+        role="menuitem"
       >
         Azure
       </button>
@@ -68,6 +73,7 @@ exports[`Renders ContextSelectorMenuList open 1`] = `
     >
       <button
         class="pf-c-context-selector__menu-list-item"
+        role="menuitem"
       >
         My Project
       </button>
@@ -77,6 +83,7 @@ exports[`Renders ContextSelectorMenuList open 1`] = `
     >
       <button
         class="pf-c-context-selector__menu-list-item"
+        role="menuitem"
       >
         OpenShift Cluster
       </button>
@@ -86,6 +93,7 @@ exports[`Renders ContextSelectorMenuList open 1`] = `
     >
       <button
         class="pf-c-context-selector__menu-list-item"
+        role="menuitem"
       >
         Production Ansible
       </button>
@@ -95,6 +103,7 @@ exports[`Renders ContextSelectorMenuList open 1`] = `
     >
       <button
         class="pf-c-context-selector__menu-list-item"
+        role="menuitem"
       >
         AWS
       </button>
@@ -104,6 +113,7 @@ exports[`Renders ContextSelectorMenuList open 1`] = `
     >
       <button
         class="pf-c-context-selector__menu-list-item"
+        role="menuitem"
       >
         Azure
       </button>

--- a/packages/react-core/src/components/DataList/examples/DataListCompact.tsx
+++ b/packages/react-core/src/components/DataList/examples/DataListCompact.tsx
@@ -3,24 +3,24 @@ import { DataList, DataListItem, DataListItemRow, DataListItemCells, DataListCel
 
 export const DataListCompact: React.FunctionComponent = () => (
   <DataList aria-label="Compact data list example" isCompact>
-    <DataListItem aria-labelledby="simple-item1">
+    <DataListItem aria-labelledby="compact-item1">
       <DataListItemRow>
         <DataListItemCells
           dataListCells={[
             <DataListCell key="primary content">
-              <span id="simple-item1">Primary content</span>
+              <span id="compact-item1">Primary content</span>
             </DataListCell>,
             <DataListCell key="secondary content">Secondary content</DataListCell>
           ]}
         />
       </DataListItemRow>
     </DataListItem>
-    <DataListItem aria-labelledby="simple-item2">
+    <DataListItem aria-labelledby="compact-item2">
       <DataListItemRow>
         <DataListItemCells
           dataListCells={[
             <DataListCell isFilled={false} key="secondary content fill">
-              <span id="simple-item2">Secondary content (pf-m-no-fill)</span>
+              <span id="compact-item2">Secondary content (pf-m-no-fill)</span>
             </DataListCell>,
             <DataListCell isFilled={false} alignRight key="secondary content align">
               Secondary content (pf-m-align-right pf-m-no-fill)

--- a/packages/react-core/src/components/DataList/examples/DataListControllingText.tsx
+++ b/packages/react-core/src/components/DataList/examples/DataListControllingText.tsx
@@ -9,13 +9,13 @@ import {
 } from '@patternfly/react-core';
 
 export const DataListControllingText: React.FunctionComponent = () => (
-  <DataList aria-label="Simple data list example">
-    <DataListItem aria-labelledby="simple-item1">
+  <DataList aria-label="Controlling text data list example">
+    <DataListItem aria-labelledby="controlling-text-item1">
       <DataListItemRow>
         <DataListItemCells
           dataListCells={[
             <DataListCell key="primary content" wrapModifier={DataListWrapModifier.breakWord}>
-              <span id="simple-item1">Primary content</span>
+              <span id="controlling-text-item1">Primary content</span>
             </DataListCell>,
             <DataListCell key="secondary content" wrapModifier={DataListWrapModifier.truncate}>
               Really really really really really really really really really really really really really really long

--- a/packages/react-core/src/components/DataList/examples/DataListDraggable.tsx
+++ b/packages/react-core/src/components/DataList/examples/DataListDraggable.tsx
@@ -10,7 +10,8 @@ import {
   DataListItemCells,
   DragDrop,
   Draggable,
-  Droppable
+  Droppable,
+  getUniqueId
 } from '@patternfly/react-core';
 
 interface ItemType {
@@ -20,7 +21,7 @@ interface ItemType {
 
 const getItems = (count: number) =>
   Array.from({ length: count }, (_, idx) => idx).map(idx => ({
-    id: `item-${idx}`,
+    id: `draggable-item-${idx}`,
     content: `item ${idx} `.repeat(idx === 4 ? 20 : 1)
   }));
 
@@ -60,27 +61,29 @@ export const DataListDraggable: React.FunctionComponent = () => {
     }
   }
 
+  const uniqueId = getUniqueId();
+
   return (
     <DragDrop onDrag={onDrag} onDragMove={onDragMove} onDrop={onDrop}>
       <Droppable hasNoWrapper>
         <DataList aria-label="draggable data list example" isCompact>
           {items.map(({ id, content }) => (
             <Draggable key={id} hasNoWrapper>
-              <DataListItem aria-labelledby={id} ref={React.createRef()}>
+              <DataListItem aria-labelledby={`draggable-${id}`} ref={React.createRef()}>
                 <DataListItemRow>
                   <DataListControl>
                     <DataListDragButton
                       aria-label="Reorder"
-                      aria-labelledby={id}
-                      aria-describedby="Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
+                      aria-labelledby={`draggable-${id}`}
+                      aria-describedby={`description-${uniqueId}`}
                       aria-pressed="false"
                     />
-                    <DataListCheck aria-labelledby={id} name={id} otherControls />
+                    <DataListCheck aria-labelledby={`draggable-${id}`} name={id} otherControls />
                   </DataListControl>
                   <DataListItemCells
                     dataListCells={[
                       <DataListCell key={id}>
-                        <span id={id}>{content}</span>
+                        <span id={`draggable-${id}`}>{content}</span>
                       </DataListCell>
                     ]}
                   />
@@ -92,6 +95,10 @@ export const DataListDraggable: React.FunctionComponent = () => {
       </Droppable>
       <div className="pf-screen-reader" aria-live="assertive">
         {liveText}
+      </div>
+      <div className="pf-screen-reader" id={`description-${uniqueId}`}>
+        Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm
+        the drag, or any other key to cancel the drag operation.
       </div>
     </DragDrop>
   );

--- a/packages/react-core/src/components/DataList/examples/DataListExpandable.tsx
+++ b/packages/react-core/src/components/DataList/examples/DataListExpandable.tsx
@@ -104,7 +104,7 @@ export const DataListExpandable: React.FunctionComponent = () => {
             </DataListAction>
           </DataListItemRow>
           <DataListContent
-            aria-label="Primary Content Details"
+            aria-label="First expandable content details"
             id="ex-expand1"
             isHidden={!expanded.includes('ex-toggle1')}
           >
@@ -164,7 +164,7 @@ export const DataListExpandable: React.FunctionComponent = () => {
             </DataListAction>
           </DataListItemRow>
           <DataListContent
-            aria-label="Primary Content Details"
+            aria-label="Second expandable content details"
             id="ex-expand2"
             isHidden={!expanded.includes('ex-toggle2')}
           >
@@ -224,7 +224,7 @@ export const DataListExpandable: React.FunctionComponent = () => {
             </DataListAction>
           </DataListItemRow>
           <DataListContent
-            aria-label="Primary Content Details"
+            aria-label="Third expandable content details"
             id="ex-expand3"
             isHidden={!expanded.includes('ex-toggle3')}
             hasNoPadding

--- a/packages/react-core/src/components/DataList/examples/DataListSmGridBreakpoint.tsx
+++ b/packages/react-core/src/components/DataList/examples/DataListSmGridBreakpoint.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { DataList, DataListItem, DataListItemRow, DataListItemCells, DataListCell } from '@patternfly/react-core';
 
 export const DataListSmGridBreakpoint: React.FunctionComponent = () => (
-  <DataList aria-label="Simple data list example" gridBreakpoint="sm">
-    <DataListItem aria-labelledby="simple-item1">
+  <DataList aria-label="Small grid breakpoint list example" gridBreakpoint="sm">
+    <DataListItem aria-labelledby="sm-grid-item1">
       <DataListItemRow>
         <DataListItemCells
           dataListCells={[
             <DataListCell key="primary content">
-              <span id="simple-item1">Primary content</span>
+              <span id="sm-grid-item1">Primary content</span>
             </DataListCell>,
             <DataListCell key="secondary content">
               Really really really really really really really really really really really really really really long

--- a/packages/react-core/src/components/DualListSelector/DualListSelector.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelector.tsx
@@ -6,7 +6,7 @@ import AngleLeftIcon from '@patternfly/react-icons/dist/esm/icons/angle-left-ico
 import AngleDoubleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-double-right-icon';
 import AngleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-right-icon';
 import { DualListSelectorPane } from './DualListSelectorPane';
-import { getUniqueId, PickOptional } from '../../helpers';
+import { GenerateId, PickOptional } from '../../helpers';
 import { DualListSelectorTreeItemData } from './DualListSelectorTree';
 import {
   flattenTree,
@@ -140,7 +140,6 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
     chosenOptions: [],
     chosenOptionsTitle: 'Chosen options',
     chosenOptionsSearchAriaLabel: 'Chosen search input',
-    id: getUniqueId('dual-list-selector'),
     controlsAriaLabel: 'Selector controls',
     addAllAriaLabel: 'Add all',
     addSelectedAriaLabel: 'Add selected',
@@ -678,94 +677,99 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
 
     return (
       <DualListSelectorContext.Provider value={{ isTree }}>
-        <div className={css(styles.dualListSelector, className)} id={id} {...props}>
-          {children === '' ? (
-            <>
-              <DualListSelectorPane
-                isSearchable={isSearchable}
-                onFilterUpdate={this.onFilterUpdate}
-                searchInputAriaLabel={availableOptionsSearchAriaLabel}
-                filterOption={filterOption}
-                onSearchInputChanged={onAvailableOptionsSearchInputChanged}
-                status={availableOptionsStatusToDisplay}
-                title={availableOptionsTitle}
-                options={available}
-                selectedOptions={isTree ? availableTreeOptionsChecked : availableOptionsSelected}
-                onOptionSelect={this.onOptionSelect}
-                onOptionCheck={(e, isChecked, itemData) => this.onTreeOptionCheck(e, isChecked, itemData, false)}
-                actions={availableOptionsActions}
-                id={`${id}-available-pane`}
-                isDisabled={isDisabled}
-              />
-              <DualListSelectorControlsWrapper aria-label={controlsAriaLabel}>
-                <DualListSelectorControl
-                  isDisabled={
-                    (isTree ? availableTreeOptionsChecked.length === 0 : availableOptionsSelected.length === 0) ||
-                    isDisabled
-                  }
-                  onClick={isTree ? this.addTreeSelected : this.addSelected}
-                  ref={this.addSelectedButtonRef}
-                  aria-label={addSelectedAriaLabel}
-                  tooltipContent={addSelectedTooltip}
-                  tooltipProps={addSelectedTooltipProps}
-                >
-                  <AngleRightIcon />
-                </DualListSelectorControl>
-                <DualListSelectorControl
-                  isDisabled={availableOptions.length === 0 || isDisabled}
-                  onClick={isTree ? this.addAllTreeVisible : this.addAllVisible}
-                  ref={this.addAllButtonRef}
-                  aria-label={addAllAriaLabel}
-                  tooltipContent={addAllTooltip}
-                  tooltipProps={addAllTooltipProps}
-                >
-                  <AngleDoubleRightIcon />
-                </DualListSelectorControl>
-                <DualListSelectorControl
-                  isDisabled={chosenOptions.length === 0 || isDisabled}
-                  onClick={isTree ? this.removeAllTreeVisible : this.removeAllVisible}
-                  aria-label={removeAllAriaLabel}
-                  ref={this.removeAllButtonRef}
-                  tooltipContent={removeAllTooltip}
-                  tooltipProps={removeAllTooltipProps}
-                >
-                  <AngleDoubleLeftIcon />
-                </DualListSelectorControl>
-                <DualListSelectorControl
-                  onClick={isTree ? this.removeTreeSelected : this.removeSelected}
-                  isDisabled={
-                    (isTree ? chosenTreeOptionsChecked.length === 0 : chosenOptionsSelected.length === 0) || isDisabled
-                  }
-                  ref={this.removeSelectedButtonRef}
-                  aria-label={removeSelectedAriaLabel}
-                  tooltipContent={removeSelectedTooltip}
-                  tooltipProps={removeSelectedTooltipProps}
-                >
-                  <AngleLeftIcon />
-                </DualListSelectorControl>
-              </DualListSelectorControlsWrapper>
-              <DualListSelectorPane
-                isChosen
-                isSearchable={isSearchable}
-                onFilterUpdate={this.onFilterUpdate}
-                searchInputAriaLabel={chosenOptionsSearchAriaLabel}
-                filterOption={filterOption}
-                onSearchInputChanged={onChosenOptionsSearchInputChanged}
-                title={chosenOptionsTitle}
-                status={chosenOptionsStatusToDisplay}
-                options={chosen}
-                selectedOptions={isTree ? chosenTreeOptionsChecked : chosenOptionsSelected}
-                onOptionSelect={this.onOptionSelect}
-                onOptionCheck={(e, isChecked, itemData) => this.onTreeOptionCheck(e, isChecked, itemData, true)}
-                actions={chosenOptionsActions}
-                id={`${id}-chosen-pane`}
-                isDisabled={isDisabled}
-              />
-            </>
-          ) : (
-            children
+        <GenerateId>
+          {randomId => (
+            <div className={css(styles.dualListSelector, className)} id={id || randomId} {...props}>
+              {children === '' ? (
+                <>
+                  <DualListSelectorPane
+                    isSearchable={isSearchable}
+                    onFilterUpdate={this.onFilterUpdate}
+                    searchInputAriaLabel={availableOptionsSearchAriaLabel}
+                    filterOption={filterOption}
+                    onSearchInputChanged={onAvailableOptionsSearchInputChanged}
+                    status={availableOptionsStatusToDisplay}
+                    title={availableOptionsTitle}
+                    options={available}
+                    selectedOptions={isTree ? availableTreeOptionsChecked : availableOptionsSelected}
+                    onOptionSelect={this.onOptionSelect}
+                    onOptionCheck={(e, isChecked, itemData) => this.onTreeOptionCheck(e, isChecked, itemData, false)}
+                    actions={availableOptionsActions}
+                    id={`${id || randomId}-available-pane`}
+                    isDisabled={isDisabled}
+                  />
+                  <DualListSelectorControlsWrapper aria-label={controlsAriaLabel}>
+                    <DualListSelectorControl
+                      isDisabled={
+                        (isTree ? availableTreeOptionsChecked.length === 0 : availableOptionsSelected.length === 0) ||
+                        isDisabled
+                      }
+                      onClick={isTree ? this.addTreeSelected : this.addSelected}
+                      ref={this.addSelectedButtonRef}
+                      aria-label={addSelectedAriaLabel}
+                      tooltipContent={addSelectedTooltip}
+                      tooltipProps={addSelectedTooltipProps}
+                    >
+                      <AngleRightIcon />
+                    </DualListSelectorControl>
+                    <DualListSelectorControl
+                      isDisabled={availableOptions.length === 0 || isDisabled}
+                      onClick={isTree ? this.addAllTreeVisible : this.addAllVisible}
+                      ref={this.addAllButtonRef}
+                      aria-label={addAllAriaLabel}
+                      tooltipContent={addAllTooltip}
+                      tooltipProps={addAllTooltipProps}
+                    >
+                      <AngleDoubleRightIcon />
+                    </DualListSelectorControl>
+                    <DualListSelectorControl
+                      isDisabled={chosenOptions.length === 0 || isDisabled}
+                      onClick={isTree ? this.removeAllTreeVisible : this.removeAllVisible}
+                      aria-label={removeAllAriaLabel}
+                      ref={this.removeAllButtonRef}
+                      tooltipContent={removeAllTooltip}
+                      tooltipProps={removeAllTooltipProps}
+                    >
+                      <AngleDoubleLeftIcon />
+                    </DualListSelectorControl>
+                    <DualListSelectorControl
+                      onClick={isTree ? this.removeTreeSelected : this.removeSelected}
+                      isDisabled={
+                        (isTree ? chosenTreeOptionsChecked.length === 0 : chosenOptionsSelected.length === 0) ||
+                        isDisabled
+                      }
+                      ref={this.removeSelectedButtonRef}
+                      aria-label={removeSelectedAriaLabel}
+                      tooltipContent={removeSelectedTooltip}
+                      tooltipProps={removeSelectedTooltipProps}
+                    >
+                      <AngleLeftIcon />
+                    </DualListSelectorControl>
+                  </DualListSelectorControlsWrapper>
+                  <DualListSelectorPane
+                    isChosen
+                    isSearchable={isSearchable}
+                    onFilterUpdate={this.onFilterUpdate}
+                    searchInputAriaLabel={chosenOptionsSearchAriaLabel}
+                    filterOption={filterOption}
+                    onSearchInputChanged={onChosenOptionsSearchInputChanged}
+                    title={chosenOptionsTitle}
+                    status={chosenOptionsStatusToDisplay}
+                    options={chosen}
+                    selectedOptions={isTree ? chosenTreeOptionsChecked : chosenOptionsSelected}
+                    onOptionSelect={this.onOptionSelect}
+                    onOptionCheck={(e, isChecked, itemData) => this.onTreeOptionCheck(e, isChecked, itemData, true)}
+                    actions={chosenOptionsActions}
+                    id={`${id || randomId}-chosen-pane`}
+                    isDisabled={isDisabled}
+                  />
+                </>
+              ) : (
+                children
+              )}
+            </div>
           )}
-        </div>
+        </GenerateId>
       </DualListSelectorContext.Provider>
     );
   }

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorControlsWrapper.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorControlsWrapper.tsx
@@ -76,7 +76,7 @@ DualListSelectorControlsWrapperBase.displayName = 'DualListSelectorControlsWrapp
 
 export const DualListSelectorControlsWrapper = React.forwardRef(
   (props: DualListSelectorControlsWrapperProps, ref: React.Ref<HTMLDivElement>) => (
-    <DualListSelectorControlsWrapperBase innerRef={ref as React.MutableRefObject<any>} {...props} role="region" />
+    <DualListSelectorControlsWrapperBase innerRef={ref as React.MutableRefObject<any>} {...props} role="group" />
   )
 );
 

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorControlsWrapper.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorControlsWrapper.tsx
@@ -76,7 +76,7 @@ DualListSelectorControlsWrapperBase.displayName = 'DualListSelectorControlsWrapp
 
 export const DualListSelectorControlsWrapper = React.forwardRef(
   (props: DualListSelectorControlsWrapperProps, ref: React.Ref<HTMLDivElement>) => (
-    <DualListSelectorControlsWrapperBase innerRef={ref as React.MutableRefObject<any>} {...props} />
+    <DualListSelectorControlsWrapperBase innerRef={ref as React.MutableRefObject<any>} {...props} role="region" />
   )
 );
 

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorControlsWrapper.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorControlsWrapper.tsx
@@ -76,7 +76,7 @@ DualListSelectorControlsWrapperBase.displayName = 'DualListSelectorControlsWrapp
 
 export const DualListSelectorControlsWrapper = React.forwardRef(
   (props: DualListSelectorControlsWrapperProps, ref: React.Ref<HTMLDivElement>) => (
-    <DualListSelectorControlsWrapperBase innerRef={ref as React.MutableRefObject<any>} {...props} role="group" />
+    <DualListSelectorControlsWrapperBase innerRef={ref as React.MutableRefObject<any>} role="group" {...props} />
   )
 );
 

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorList.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorList.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { DualListSelectorListContext } from './DualListSelectorContext';
 
 export interface DualListSelectorListProps extends React.HTMLProps<HTMLUListElement> {
+  /** Content rendered inside the dual list selector list */
   children?: React.ReactNode;
 }
 
@@ -31,13 +32,18 @@ export const DualListSelectorList: React.FunctionComponent<DualListSelectorListP
     onOptionSelect(e, index, id);
   };
 
+  const hasOptions = () =>
+    options.length !== 0 || (children !== undefined && (children as React.ReactNode[]).length !== 0);
+
   return (
     <ul
       className={css(styles.dualListSelectorList)}
-      role={isTree ? 'tree' : 'listbox'}
-      aria-multiselectable="true"
-      aria-labelledby={ariaLabelledBy}
-      aria-activedescendant={focusedOption}
+      {...(hasOptions() && {
+        role: isTree ? 'tree' : 'listbox',
+        'aria-multiselectable': true,
+        'aria-labelledby': ariaLabelledBy,
+        'aria-activedescendant': focusedOption
+      })}
       aria-disabled={isDisabled ? 'true' : undefined}
       {...props}
     >

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorTree.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorTree.tsx
@@ -35,7 +35,7 @@ export interface DualListSelectorTreeItemData {
   isDisabled?: boolean;
 }
 
-export interface DualListSelectorTreeProps {
+export interface DualListSelectorTreeProps extends Omit<React.HTMLProps<HTMLUListElement>, 'data'> {
   /** Data of the tree view */
   data: DualListSelectorTreeItemData[] | (() => DualListSelectorTreeItemData[]);
   /** ID of the tree view */
@@ -46,8 +46,9 @@ export interface DualListSelectorTreeProps {
   hasBadges?: boolean;
   /** Sets the default expanded behavior */
   defaultAllExpanded?: boolean;
-  /** Callback fired when an option is checked */
+  /** Flag indicating if the dual list selector tree is in the disabled state */
   isDisabled?: boolean;
+  /** Callback fired when an option is checked */
   onOptionCheck?: (
     event: React.MouseEvent | React.ChangeEvent<HTMLInputElement> | React.KeyboardEvent,
     isChecked: boolean,

--- a/packages/react-core/src/components/DualListSelector/__tests__/__snapshots__/DualListSelector.test.tsx.snap
+++ b/packages/react-core/src/components/DualListSelector/__tests__/__snapshots__/DualListSelector.test.tsx.snap
@@ -99,7 +99,7 @@ exports[`DualListSelector basic 1`] = `
     <div
       aria-label="Selector controls"
       class="pf-c-dual-list-selector__controls"
-      role="region"
+      role="group"
       tabindex="0"
     >
       <div
@@ -357,7 +357,7 @@ exports[`DualListSelector basic with disabled controls 1`] = `
     <div
       aria-label="Selector controls"
       class="pf-c-dual-list-selector__controls"
-      role="region"
+      role="group"
       tabindex="0"
     >
       <div
@@ -627,7 +627,7 @@ exports[`DualListSelector with actions 1`] = `
     <div
       aria-label="Selector controls"
       class="pf-c-dual-list-selector__controls"
-      role="region"
+      role="group"
       tabindex="0"
     >
       <div
@@ -949,7 +949,7 @@ exports[`DualListSelector with custom status 1`] = `
     <div
       aria-label="Selector controls"
       class="pf-c-dual-list-selector__controls"
-      role="region"
+      role="group"
       tabindex="0"
     >
       <div
@@ -1219,7 +1219,7 @@ exports[`DualListSelector with search inputs 1`] = `
     <div
       aria-label="Selector controls"
       class="pf-c-dual-list-selector__controls"
-      role="region"
+      role="group"
       tabindex="0"
     >
       <div
@@ -1566,7 +1566,7 @@ exports[`DualListSelector with tree 1`] = `
     <div
       aria-label="Selector controls"
       class="pf-c-dual-list-selector__controls"
-      role="region"
+      role="group"
       tabindex="0"
     >
       <div

--- a/packages/react-core/src/components/DualListSelector/__tests__/__snapshots__/DualListSelector.test.tsx.snap
+++ b/packages/react-core/src/components/DualListSelector/__tests__/__snapshots__/DualListSelector.test.tsx.snap
@@ -99,6 +99,7 @@ exports[`DualListSelector basic 1`] = `
     <div
       aria-label="Selector controls"
       class="pf-c-dual-list-selector__controls"
+      role="region"
       tabindex="0"
     >
       <div
@@ -248,11 +249,7 @@ exports[`DualListSelector basic 1`] = `
         tabindex="0"
       >
         <ul
-          aria-activedescendant=""
-          aria-labelledby="firstTest-chosen-pane-status"
-          aria-multiselectable="true"
           class="pf-c-dual-list-selector__list"
-          role="listbox"
         />
       </div>
     </div>
@@ -360,6 +357,7 @@ exports[`DualListSelector basic with disabled controls 1`] = `
     <div
       aria-label="Selector controls"
       class="pf-c-dual-list-selector__controls"
+      role="region"
       tabindex="0"
     >
       <div
@@ -510,12 +508,8 @@ exports[`DualListSelector basic with disabled controls 1`] = `
         tabindex="0"
       >
         <ul
-          aria-activedescendant=""
           aria-disabled="true"
-          aria-labelledby="disabledTest-chosen-pane-status"
-          aria-multiselectable="true"
           class="pf-c-dual-list-selector__list"
-          role="listbox"
         />
       </div>
     </div>
@@ -633,6 +627,7 @@ exports[`DualListSelector with actions 1`] = `
     <div
       aria-label="Selector controls"
       class="pf-c-dual-list-selector__controls"
+      role="region"
       tabindex="0"
     >
       <div
@@ -954,6 +949,7 @@ exports[`DualListSelector with custom status 1`] = `
     <div
       aria-label="Selector controls"
       class="pf-c-dual-list-selector__controls"
+      role="region"
       tabindex="0"
     >
       <div
@@ -1103,11 +1099,7 @@ exports[`DualListSelector with custom status 1`] = `
         tabindex="0"
       >
         <ul
-          aria-activedescendant=""
-          aria-labelledby="thirdTest-chosen-pane-status"
-          aria-multiselectable="true"
           class="pf-c-dual-list-selector__list"
-          role="listbox"
         />
       </div>
     </div>
@@ -1227,6 +1219,7 @@ exports[`DualListSelector with search inputs 1`] = `
     <div
       aria-label="Selector controls"
       class="pf-c-dual-list-selector__controls"
+      role="region"
       tabindex="0"
     >
       <div
@@ -1389,11 +1382,7 @@ exports[`DualListSelector with search inputs 1`] = `
         tabindex="0"
       >
         <ul
-          aria-activedescendant=""
-          aria-labelledby="secondTest-chosen-pane-status"
-          aria-multiselectable="true"
           class="pf-c-dual-list-selector__list"
-          role="listbox"
         />
       </div>
     </div>
@@ -1577,6 +1566,7 @@ exports[`DualListSelector with tree 1`] = `
     <div
       aria-label="Selector controls"
       class="pf-c-dual-list-selector__controls"
+      role="region"
       tabindex="0"
     >
       <div
@@ -1726,11 +1716,7 @@ exports[`DualListSelector with tree 1`] = `
         tabindex="0"
       >
         <ul
-          aria-activedescendant=""
-          aria-labelledby="tree-test-chosen-pane-status"
-          aria-multiselectable="true"
           class="pf-c-dual-list-selector__list"
-          role="tree"
         />
       </div>
     </div>

--- a/packages/react-core/src/components/DualListSelector/examples/DualListSelector.md
+++ b/packages/react-core/src/components/DualListSelector/examples/DualListSelector.md
@@ -8,6 +8,8 @@ propComponents:
     'DualListSelectorPane',
     'DualListSelectorControl',
     'DualListSelectorControlsWrapper',
+    'DualListSelectorList',
+    'DualListSelectorListItem',
     'DualListSelectorTree',
     'DualListSelectorTreeItemData',
   ]

--- a/packages/react-core/src/components/DualListSelector/examples/DualListSelector.md
+++ b/packages/react-core/src/components/DualListSelector/examples/DualListSelector.md
@@ -46,7 +46,7 @@ import PficonSortCommonAscIcon from '@patternfly/react-icons/dist/esm/icons/pfic
 
 ### With tree
 
-```ts file="./DualListSelectorTree.tsx"
+```ts file="./DualListSelectorTreeExample.tsx"
 ```
 
 ### Composable dual list selector

--- a/packages/react-core/src/components/DualListSelector/examples/DualListSelectorComposable.tsx
+++ b/packages/react-core/src/components/DualListSelector/examples/DualListSelectorComposable.tsx
@@ -151,7 +151,7 @@ export const DualListSelectorComposable: React.FunctionComponent = () => {
           )}
         </DualListSelectorList>
       </DualListSelectorPane>
-      <DualListSelectorControlsWrapper aria-label="Selector controls">
+      <DualListSelectorControlsWrapper>
         <DualListSelectorControl
           isDisabled={!availableOptions.some(option => option.selected)}
           onClick={() => moveSelected(true)}

--- a/packages/react-core/src/components/DualListSelector/examples/DualListSelectorComposableDragDrop.tsx
+++ b/packages/react-core/src/components/DualListSelector/examples/DualListSelectorComposableDragDrop.tsx
@@ -121,7 +121,7 @@ export const DualListSelectorComposableDragDrop: React.FunctionComponent = () =>
           )}
         </DualListSelectorList>
       </DualListSelectorPane>
-      <DualListSelectorControlsWrapper aria-label="Selector controls">
+      <DualListSelectorControlsWrapper>
         <DualListSelectorControl
           isDisabled={!availableOptions.some(option => option.selected)}
           onClick={() => moveSelected(true)}

--- a/packages/react-core/src/components/DualListSelector/examples/DualListSelectorComposableTree.tsx
+++ b/packages/react-core/src/components/DualListSelector/examples/DualListSelectorComposableTree.tsx
@@ -255,7 +255,7 @@ export const DualListSelectorComposableTree: React.FunctionComponent<ExampleProp
   return (
     <DualListSelector isTree>
       {buildPane(false)}
-      <DualListSelectorControlsWrapper aria-label="Selector controls">
+      <DualListSelectorControlsWrapper>
         <DualListSelectorControl
           isDisabled={!checkedLeafIds.filter(x => !chosenLeafIds.includes(x)).length}
           onClick={() => moveChecked(true)}

--- a/packages/react-core/src/components/DualListSelector/examples/DualListSelectorTreeExample.tsx
+++ b/packages/react-core/src/components/DualListSelector/examples/DualListSelectorTreeExample.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { DualListSelector } from '@patternfly/react-core';
 
-export const DualListSelectorTree: React.FunctionComponent = () => {
+export const DualListSelectorTreeExample: React.FunctionComponent = () => {
   const [availableOptions, setAvailableOptions] = React.useState<React.ReactNode[]>([
     {
       id: 'F1',

--- a/packages/react-core/src/components/FileUpload/examples/FileUploadCustomUpload.tsx
+++ b/packages/react-core/src/components/FileUpload/examples/FileUploadCustomUpload.tsx
@@ -94,7 +94,7 @@ export const CustomPreviewFileUpload: React.FunctionComponent = () => {
       ))}
       <br />
       <FileUploadField
-        id="custom-file-upload"
+        id="custom-file-upload-example"
         type="text"
         value={value}
         filename={filename ? 'example-filename.txt' : ''}

--- a/packages/react-core/src/components/FileUpload/examples/FileUploadSimpleText.tsx
+++ b/packages/react-core/src/components/FileUpload/examples/FileUploadSimpleText.tsx
@@ -32,7 +32,7 @@ export const SimpleTextFileUpload: React.FunctionComponent = () => {
 
   return (
     <FileUpload
-      id="text-file-with-edits-allowed"
+      id="text-file-simple"
       type="text"
       value={value}
       filename={filename}

--- a/packages/react-core/src/components/FileUpload/examples/FileUploadTextWithEdits.tsx
+++ b/packages/react-core/src/components/FileUpload/examples/FileUploadTextWithEdits.tsx
@@ -32,7 +32,7 @@ export const TextFileWithEditsAllowed: React.FunctionComponent = () => {
 
   return (
     <FileUpload
-      id="text-file-with-edits-allowed"
+      id="text-file-with-edits-allowed-example"
       type="text"
       value={value}
       filename={filename}

--- a/packages/react-core/src/components/FileUpload/examples/FileUploadTextWithRestrictions.tsx
+++ b/packages/react-core/src/components/FileUpload/examples/FileUploadTextWithRestrictions.tsx
@@ -39,13 +39,13 @@ export const TextFileUploadWithRestrictions: React.FunctionComponent = () => {
   return (
     <Form>
       <FormGroup
-        fieldId="text-file-with-restrictions"
+        fieldId="text-file-with-restrictions-example"
         helperText="Upload a CSV file"
         helperTextInvalid="Must be a CSV file no larger than 1 KB"
         validated={isRejected ? 'error' : 'default'}
       >
         <FileUpload
-          id="text-file-with-restrictions"
+          id="text-file-with-restrictions-example"
           type="text"
           value={value}
           filename={filename}

--- a/packages/react-core/src/components/InputGroup/examples/InputGroupBasic.tsx
+++ b/packages/react-core/src/components/InputGroup/examples/InputGroupBasic.tsx
@@ -5,7 +5,7 @@ import { InputGroup, InputGroupText, InputGroupTextVariant, TextInput, Validated
 export const InputGroupBasic: React.FunctionComponent = () => (
   <React.Fragment>
     <InputGroup>
-      <TextInput id="textInput6" type="email" aria-label="email input field" />
+      <TextInput id="textInput-basic-1" type="email" aria-label="email input field" />
       <InputGroupText id="email-example">@example.com</InputGroupText>
     </InputGroup>
     <br />
@@ -15,14 +15,14 @@ export const InputGroupBasic: React.FunctionComponent = () => (
       </InputGroupText>
       <TextInput
         validated={ValidatedOptions.error}
-        id="textInput7"
+        id="textInput-basic-2"
         type="email"
         aria-label="Error state username example"
       />
     </InputGroup>
     <br />
     <InputGroup>
-      <TextInput name="textIndex12" id="textInput12" type="text" aria-label="percentage" />
+      <TextInput name="textInput-basic-3" id="textInput-basic-3" type="text" aria-label="percentage" />
       <InputGroupText id="plain-example" variant={InputGroupTextVariant.plain}>
         %
       </InputGroupText>

--- a/packages/react-core/src/components/InputGroup/examples/InputGroupWithDropdown.tsx
+++ b/packages/react-core/src/components/InputGroup/examples/InputGroupWithDropdown.tsx
@@ -33,7 +33,7 @@ export const InputGroupWithDropdown: React.FunctionComponent = () => {
           isOpen={isOpen}
           dropdownItems={dropdownItems}
         />
-        <TextInput id="textInput3" aria-label="input with dropdown and button" />
+        <TextInput id="textInput-with-dropdown" aria-label="input with dropdown and button" />
         <Button id="inputDropdownButton1" variant="control">
           Button
         </Button>

--- a/packages/react-core/src/components/InputGroup/examples/InputGroupWithPopover.tsx
+++ b/packages/react-core/src/components/InputGroup/examples/InputGroupWithPopover.tsx
@@ -5,7 +5,12 @@ import { Button, InputGroup, TextInput, Popover, PopoverPosition } from '@patter
 export const InputGroupWithPopover: React.FunctionComponent = () => (
   <React.Fragment>
     <InputGroup>
-      <TextInput name="textInput10" id="textInput10" type="text" aria-label="input example with popover" />
+      <TextInput
+        name="textInput-with-popover-1"
+        id="textInput-with-popover-1"
+        type="text"
+        aria-label="first input example with popover"
+      />
       <Popover
         aria-label="popover example"
         position={PopoverPosition.top}
@@ -18,7 +23,12 @@ export const InputGroupWithPopover: React.FunctionComponent = () => (
     </InputGroup>
     <br />
     <InputGroup>
-      <TextInput name="textInput12" id="textInput12" type="text" aria-label="input example with popover" />
+      <TextInput
+        name="textInput-with-popover-2"
+        id="textInput-with-popover-2"
+        type="text"
+        aria-label="second input example with popover"
+      />
       <Popover
         aria-label="popover example"
         position={PopoverPosition.top}

--- a/packages/react-core/src/components/InputGroup/examples/InputGroupWithSiblings.tsx
+++ b/packages/react-core/src/components/InputGroup/examples/InputGroupWithSiblings.tsx
@@ -17,7 +17,7 @@ export const InputGroupWithSiblings: React.FunctionComponent = () => (
         Button
       </Button>
       <Button variant="control">Button</Button>
-      <TextArea name="textarea3" id="textarea3" aria-label="textarea with 3 buttons" />
+      <TextArea name="textarea2" id="textarea2" aria-label="textarea with 3 buttons" />
       <Button variant="control">Button</Button>
     </InputGroup>
     <br />
@@ -25,7 +25,12 @@ export const InputGroupWithSiblings: React.FunctionComponent = () => (
       <InputGroupText>
         <DollarSignIcon />
       </InputGroupText>
-      <TextInput id="textInput5" type="number" aria-label="Dollar amount input example" />
+      <TextInput
+        id="textInput-with-siblings"
+        name="textInput-with-siblings"
+        type="number"
+        aria-label="Dollar amount input example"
+      />
       <InputGroupText>.00</InputGroupText>
     </InputGroup>
   </React.Fragment>

--- a/packages/react-core/src/components/InputGroup/examples/InputGroupWithTextarea.tsx
+++ b/packages/react-core/src/components/InputGroup/examples/InputGroupWithTextarea.tsx
@@ -4,7 +4,7 @@ import { Button, TextArea, InputGroup } from '@patternfly/react-core';
 export const InputGroupWithTextarea: React.FunctionComponent = () => (
   <React.Fragment>
     <InputGroup>
-      <TextArea name="textarea2" id="textarea2" aria-label="textarea with button" />
+      <TextArea name="inputGroup-with-textarea" id="inputGroup-with-textarea" aria-label="textarea with button" />
       <Button id="textAreaButton2" variant="control">
         Button
       </Button>

--- a/packages/react-core/src/components/NotificationDrawer/examples/NotificationDrawer.md
+++ b/packages/react-core/src/components/NotificationDrawer/examples/NotificationDrawer.md
@@ -80,11 +80,11 @@ class BasicNotificationDrawer extends React.Component {
         <NotificationDrawerHeader count={3} onClose={this.onDrawerClose}>
           <Dropdown
             onSelect={this.onSelect}
-            toggle={<KebabToggle onToggle={this.onToggle(0)} id="toggle-id-0" />}
+            toggle={<KebabToggle onToggle={this.onToggle(0)} id="basic-kebab-toggle" />}
             isOpen={isOpen0}
             isPlain
             dropdownItems={dropdownItems}
-            id="notification-0"
+            id="basic-notification-0"
             position={DropdownPosition.right}
           />
         </NotificationDrawerHeader>
@@ -99,11 +99,11 @@ class BasicNotificationDrawer extends React.Component {
                 <Dropdown
                   position={DropdownPosition.right}
                   onSelect={this.onSelect}
-                  toggle={<KebabToggle onToggle={this.onToggle(1)} id="toggle-id-1" />}
+                  toggle={<KebabToggle onToggle={this.onToggle(1)} id="basic-toggle-id-1" />}
                   isOpen={isOpen1}
                   isPlain
                   dropdownItems={dropdownItems}
-                  id="notification-1"
+                  id="basic-notification-1"
                 />
               </NotificationDrawerListItemHeader>
               <NotificationDrawerListItemBody timestamp="5 minutes ago">
@@ -119,11 +119,11 @@ class BasicNotificationDrawer extends React.Component {
                 <Dropdown
                   position={DropdownPosition.right}
                   onSelect={this.onSelect}
-                  toggle={<KebabToggle onToggle={this.onToggle(2)} id="toggle-id-2" />}
+                  toggle={<KebabToggle onToggle={this.onToggle(2)} id="basic-toggle-id-2" />}
                   isOpen={isOpen2}
                   isPlain
                   dropdownItems={dropdownItems}
-                  id="notification-2"
+                  id="basic-notification-2"
                 />
               </NotificationDrawerListItemHeader>
               <NotificationDrawerListItemBody timestamp="10 minutes ago">
@@ -141,11 +141,11 @@ class BasicNotificationDrawer extends React.Component {
                 <Dropdown
                   position={DropdownPosition.right}
                   onSelect={this.onSelect}
-                  toggle={<KebabToggle onToggle={this.onToggle(3)} id="toggle-id-3" />}
+                  toggle={<KebabToggle onToggle={this.onToggle(3)} id="basic-toggle-id-3" />}
                   isOpen={isOpen3}
                   isPlain
                   dropdownItems={dropdownItems}
-                  id="notification-3"
+                  id="basic-notification-3"
                 />
               </NotificationDrawerListItemHeader>
               <NotificationDrawerListItemBody timestamp="10 minutes ago">
@@ -162,11 +162,11 @@ class BasicNotificationDrawer extends React.Component {
                 <Dropdown
                   position={DropdownPosition.right}
                   onSelect={this.onSelect}
-                  toggle={<KebabToggle onToggle={this.onToggle(4)} id="toggle-id-4" />}
+                  toggle={<KebabToggle onToggle={this.onToggle(4)} id="basic-toggle-id-4" />}
                   isOpen={isOpen4}
                   isPlain
                   dropdownItems={dropdownItems}
-                  id="notification-4"
+                  id="basic-notification-4"
                 />
               </NotificationDrawerListItemHeader>
               <NotificationDrawerListItemBody timestamp="20 minutes ago">
@@ -183,11 +183,11 @@ class BasicNotificationDrawer extends React.Component {
                   position={DropdownPosition.right}
                   direction={DropdownDirection.up}
                   onSelect={this.onSelect}
-                  toggle={<KebabToggle onToggle={this.onToggle(5)} id="toggle-id-5" />}
+                  toggle={<KebabToggle onToggle={this.onToggle(5)} id="basic-toggle-id-5" />}
                   isOpen={isOpen5}
                   isPlain
                   dropdownItems={dropdownItems}
-                  id="notification-5"
+                  id="basic-notification-5"
                 />
               </NotificationDrawerListItemHeader>
               <NotificationDrawerListItemBody timestamp="30 minutes ago">
@@ -199,11 +199,11 @@ class BasicNotificationDrawer extends React.Component {
                 <Dropdown
                   position={DropdownPosition.right}
                   onSelect={this.onSelect}
-                  toggle={<KebabToggle onToggle={this.onToggle(6)} id="toggle-id-6" />}
+                  toggle={<KebabToggle onToggle={this.onToggle(6)} id="basic-toggle-id-6" />}
                   isOpen={isOpen6}
                   isPlain
                   dropdownItems={dropdownItems}
-                  id="notification-6"
+                  id="basic-notification-6"
                 />
               </NotificationDrawerListItemHeader>
               <NotificationDrawerListItemBody timestamp="35 minutes ago">
@@ -253,8 +253,8 @@ class GroupNotificationDrawer extends React.Component {
     this.state = {
       isOpenMap: null,
       firstGroupExpanded: false,
-      secondGroupExpanded: true,
-      thirdGroupExpanded: false
+      secondGroupExpanded: false,
+      thirdGroupExpanded: true
     };
     this.onToggle = (id, isOpen) => {
       this.setState({
@@ -299,11 +299,11 @@ class GroupNotificationDrawer extends React.Component {
         <NotificationDrawerHeader count={4}>
           <Dropdown
             onSelect={this.onSelect}
-            toggle={<KebabToggle onToggle={isOpen => this.onToggle('toggle-id-0', isOpen)} id="toggle-id-0" />}
-            isOpen={isOpenMap && isOpenMap['toggle-id-0']}
+            toggle={<KebabToggle onToggle={isOpen => this.onToggle('groups-kebab-toggle-1', isOpen)} id="groups-kebab-toggle-1" />}
+            isOpen={isOpenMap && isOpenMap['groups-kebab-toggle-1']}
             isPlain
             dropdownItems={dropdownItems}
-            id="notification-0"
+            id="grouped-notification-1"
             position={DropdownPosition.right}
           />
         </NotificationDrawerHeader>
@@ -326,12 +326,12 @@ class GroupNotificationDrawer extends React.Component {
                       position={DropdownPosition.right}
                       onSelect={this.onSelect}
                       toggle={
-                        <KebabToggle onToggle={isOpen => this.onToggle('toggle-id-5', isOpen)} id="toggle-id-5" />
+                        <KebabToggle onToggle={isOpen => this.onToggle('groups-notification-kebab-toggle-2', isOpen)} id="groups-kebab-toggle-2" />
                       }
-                      isOpen={isOpenMap && isOpenMap['toggle-id-5']}
+                      isOpen={isOpenMap && isOpenMap['groups-notification-kebab-toggle-2']}
                       isPlain
                       dropdownItems={dropdownItems}
-                      id="notification-5"
+                      id="grouped-notification-2"
                     />
                   </NotificationDrawerListItemHeader>
                   <NotificationDrawerListItemBody timestamp="5 minutes ago">
@@ -348,12 +348,12 @@ class GroupNotificationDrawer extends React.Component {
                       position={DropdownPosition.right}
                       onSelect={this.onSelect}
                       toggle={
-                        <KebabToggle onToggle={isOpen => this.onToggle('toggle-id-6', isOpen)} id="toggle-id-6" />
+                        <KebabToggle onToggle={isOpen => this.onToggle('groups-kebab-toggle-3', isOpen)} id="groups-kebab-toggle-3" />
                       }
-                      isOpen={isOpenMap && isOpenMap['toggle-id-6']}
+                      isOpen={isOpenMap && isOpenMap['groups-kebab-toggle-3']}
                       isPlain
                       dropdownItems={dropdownItems}
-                      id="notification-6"
+                      id="grouped-notification-3"
                     />
                   </NotificationDrawerListItemHeader>
                   <NotificationDrawerListItemBody timestamp="10 minutes ago">
@@ -371,12 +371,12 @@ class GroupNotificationDrawer extends React.Component {
                       position={DropdownPosition.right}
                       onSelect={this.onSelect}
                       toggle={
-                        <KebabToggle onToggle={isOpen => this.onToggle('toggle-id-7', isOpen)} id="toggle-id-7" />
+                        <KebabToggle onToggle={isOpen => this.onToggle('groups-kebab-toggle-4', isOpen)} id="groups-kebab-toggle-4" />
                       }
-                      isOpen={isOpenMap && isOpenMap['toggle-id-7']}
+                      isOpen={isOpenMap && isOpenMap['groups-kebab-toggle-4']}
                       isPlain
                       dropdownItems={dropdownItems}
-                      id="notification-7"
+                      id="grouped-notification-4"
                     />
                   </NotificationDrawerListItemHeader>
                   <NotificationDrawerListItemBody timestamp="20 minutes ago">
@@ -394,12 +394,12 @@ class GroupNotificationDrawer extends React.Component {
                       direction={DropdownDirection.up}
                       onSelect={this.onSelect}
                       toggle={
-                        <KebabToggle onToggle={isOpen => this.onToggle('toggle-id-8', isOpen)} id="toggle-id-8" />
+                        <KebabToggle onToggle={isOpen => this.onToggle('groups-kebab-toggle-5', isOpen)} id="groups-kebab-toggle-5" />
                       }
-                      isOpen={isOpenMap && isOpenMap['toggle-id-8']}
+                      isOpen={isOpenMap && isOpenMap['groups-kebab-toggle-5']}
                       isPlain
                       dropdownItems={dropdownItems}
-                      id="notification-8"
+                      id="grouped-notification-5"
                     />
                   </NotificationDrawerListItemHeader>
                   <NotificationDrawerListItemBody timestamp="30 minutes ago">
@@ -408,113 +408,15 @@ class GroupNotificationDrawer extends React.Component {
                 </NotificationDrawerListItem>
               </NotificationDrawerList>
             </NotificationDrawerGroup>
+
             <NotificationDrawerGroup
-              title="Second notification group"
+              title="Second notification group. This is a long title to show how the title will be truncated if it is long and will be shown in a single line."
               isExpanded={secondGroupExpanded}
-              count={2}
-              onExpand={this.toggleSecondDrawer}
-            >
-              <NotificationDrawerList isHidden={!secondGroupExpanded}>
-                <NotificationDrawerListItem variant="info">
-                  <NotificationDrawerListItemHeader
-                    variant="info"
-                    title="Unread info notification title"
-                    srTitle="Info notification:"
-                  >
-                    <Dropdown
-                      position={DropdownPosition.right}
-                      onSelect={this.onSelect}
-                      toggle={
-                        <KebabToggle onToggle={isOpen => this.onToggle('toggle-id-9', isOpen)} id="toggle-id-9" />
-                      }
-                      isOpen={isOpenMap && isOpenMap['toggle-id-9']}
-                      isPlain
-                      dropdownItems={dropdownItems}
-                      id="notification-9"
-                    />
-                  </NotificationDrawerListItemHeader>
-                  <NotificationDrawerListItemBody timestamp="5 minutes ago">
-                    This is an info notification description.
-                  </NotificationDrawerListItemBody>
-                </NotificationDrawerListItem>
-                <NotificationDrawerListItem variant="danger">
-                  <NotificationDrawerListItemHeader
-                    variant="danger"
-                    title="Unread danger notification title. This is a long title to show how the title will wrap if it is long and wraps to multiple lines."
-                    srTitle="Danger notification:"
-                  >
-                    <Dropdown
-                      position={DropdownPosition.right}
-                      onSelect={this.onSelect}
-                      toggle={
-                        <KebabToggle onToggle={isOpen => this.onToggle('toggle-id-10', isOpen)} id="toggle-id-10" />
-                      }
-                      isOpen={isOpenMap && isOpenMap['toggle-id-10']}
-                      isPlain
-                      dropdownItems={dropdownItems}
-                      id="notification-10"
-                    />
-                  </NotificationDrawerListItemHeader>
-                  <NotificationDrawerListItemBody timestamp="10 minutes ago">
-                    This is a danger notification description. This is a long description to show how the title will
-                    wrap if it is long and wraps to multiple lines.
-                  </NotificationDrawerListItemBody>
-                </NotificationDrawerListItem>
-                <NotificationDrawerListItem variant="warning" isRead>
-                  <NotificationDrawerListItemHeader
-                    variant="warning"
-                    title="Read warning notification title"
-                    srTitle="Warning notification:"
-                  >
-                    <Dropdown
-                      position={DropdownPosition.right}
-                      onSelect={this.onSelect}
-                      toggle={
-                        <KebabToggle onToggle={isOpen => this.onToggle('toggle-id-11', isOpen)} id="toggle-id-11" />
-                      }
-                      isOpen={isOpenMap && isOpenMap['toggle-id-11']}
-                      isPlain
-                      dropdownItems={dropdownItems}
-                      id="notification-11"
-                    />
-                  </NotificationDrawerListItemHeader>
-                  <NotificationDrawerListItemBody timestamp="20 minutes ago">
-                    This is a warning notification description.
-                  </NotificationDrawerListItemBody>
-                </NotificationDrawerListItem>
-                <NotificationDrawerListItem variant="success" isRead>
-                  <NotificationDrawerListItemHeader
-                    variant="success"
-                    title="Read success notification title"
-                    srTitle="Success notification:"
-                  >
-                    <Dropdown
-                      position={DropdownPosition.right}
-                      direction={DropdownDirection.up}
-                      onSelect={this.onSelect}
-                      toggle={
-                        <KebabToggle onToggle={isOpen => this.onToggle('toggle-id-12', isOpen)} id="toggle-id-12" />
-                      }
-                      isOpen={isOpenMap && isOpenMap['toggle-id-12']}
-                      isPlain
-                      dropdownItems={dropdownItems}
-                      id="notification-12"
-                    />
-                  </NotificationDrawerListItemHeader>
-                  <NotificationDrawerListItemBody timestamp="30 minutes ago">
-                    This is a success notification description.
-                  </NotificationDrawerListItemBody>
-                </NotificationDrawerListItem>
-              </NotificationDrawerList>
-            </NotificationDrawerGroup>
-            <NotificationDrawerGroup
-              title="Third notification group. This is a long title to show how the title will be truncated if it is long and will be shown in a single line."
-              isExpanded={thirdGroupExpanded}
               count={0}
-              onExpand={this.toggleThirdDrawer}
+              onExpand={this.toggleSecondDrawer}
               truncateTitle={1}
             >
-              <NotificationDrawerList isHidden={!thirdGroupExpanded}>
+              <NotificationDrawerList isHidden={!secondGroupExpanded}>
                 <EmptyState variant={EmptyStateVariant.full}>
                   <EmptyStateIcon icon={SearchIcon} />
                   <Title headingLevel="h2" size="lg">
@@ -528,6 +430,105 @@ class GroupNotificationDrawer extends React.Component {
                     <Button variant="link">Action</Button>
                   </EmptyStatePrimary>
                 </EmptyState>
+              </NotificationDrawerList>
+            </NotificationDrawerGroup>
+            <NotificationDrawerGroup
+              title="Third notification group"
+              isExpanded={thirdGroupExpanded}
+              count={2}
+              onExpand={this.toggleThirdDrawer}
+            >
+              <NotificationDrawerList isHidden={!thirdGroupExpanded}>
+                <NotificationDrawerListItem variant="info">
+                  <NotificationDrawerListItemHeader
+                    variant="info"
+                    title="Unread info notification title"
+                    srTitle="Info notification:"
+                  >
+                    <Dropdown
+                      position={DropdownPosition.right}
+                      onSelect={this.onSelect}
+                      toggle={
+                        <KebabToggle onToggle={isOpen => this.onToggle('groups-kebab-toggle-6', isOpen)} id="groups-kebab-toggle-6" />
+                      }
+                      isOpen={isOpenMap && isOpenMap['groups-kebab-toggle-6']}
+                      isPlain
+                      dropdownItems={dropdownItems}
+                      id="grouped-notification-6"
+                    />
+                  </NotificationDrawerListItemHeader>
+                  <NotificationDrawerListItemBody timestamp="5 minutes ago">
+                    This is an info notification description.
+                  </NotificationDrawerListItemBody>
+                </NotificationDrawerListItem>
+                <NotificationDrawerListItem variant="danger">
+                  <NotificationDrawerListItemHeader
+                    variant="danger"
+                    title="Unread danger notification title. This is a long title to show how the title will wrap if it is long and wraps to multiple lines."
+                    srTitle="Danger notification:"
+                  >
+                    <Dropdown
+                      position={DropdownPosition.right}
+                      onSelect={this.onSelect}
+                      toggle={
+                        <KebabToggle onToggle={isOpen => this.onToggle('groups-kebab-toggle-7', isOpen)} id="groups-kebab-toggle-7" />
+                      }
+                      isOpen={isOpenMap && isOpenMap['groups-kebab-toggle-7']}
+                      isPlain
+                      dropdownItems={dropdownItems}
+                      id="grouped-notification-7"
+                    />
+                  </NotificationDrawerListItemHeader>
+                  <NotificationDrawerListItemBody timestamp="10 minutes ago">
+                    This is a danger notification description. This is a long description to show how the title will
+                    wrap if it is long and wraps to multiple lines.
+                  </NotificationDrawerListItemBody>
+                </NotificationDrawerListItem>
+                <NotificationDrawerListItem variant="warning" isRead>
+                  <NotificationDrawerListItemHeader
+                    variant="warning"
+                    title="Read warning notification title"
+                    srTitle="Warning notification:"
+                  >
+                    <Dropdown
+                      position={DropdownPosition.right}
+                      onSelect={this.onSelect}
+                      toggle={
+                        <KebabToggle onToggle={isOpen => this.onToggle('groups-kebab-toggle-8', isOpen)} id="groups-kebab-toggle-8" />
+                      }
+                      isOpen={isOpenMap && isOpenMap['groups-kebab-toggle-8']}
+                      isPlain
+                      dropdownItems={dropdownItems}
+                      id="grouped-notification-8"
+                    />
+                  </NotificationDrawerListItemHeader>
+                  <NotificationDrawerListItemBody timestamp="20 minutes ago">
+                    This is a warning notification description.
+                  </NotificationDrawerListItemBody>
+                </NotificationDrawerListItem>
+                <NotificationDrawerListItem variant="success" isRead>
+                  <NotificationDrawerListItemHeader
+                    variant="success"
+                    title="Read success notification title"
+                    srTitle="Success notification:"
+                  >
+                    <Dropdown
+                      position={DropdownPosition.right}
+                      direction={DropdownDirection.up}
+                      onSelect={this.onSelect}
+                      toggle={
+                        <KebabToggle onToggle={isOpen => this.onToggle('groups-kebab-toggle-9', isOpen)} id="groups-kebab-toggle-9" />
+                      }
+                      isOpen={isOpenMap && isOpenMap['groups-kebab-toggle-9']}
+                      isPlain
+                      dropdownItems={dropdownItems}
+                      id="grouped-notification-9"
+                    />
+                  </NotificationDrawerListItemHeader>
+                  <NotificationDrawerListItemBody timestamp="30 minutes ago">
+                    This is a success notification description.
+                  </NotificationDrawerListItemBody>
+                </NotificationDrawerListItem>
               </NotificationDrawerList>
             </NotificationDrawerGroup>
           </NotificationDrawerGroupList>

--- a/packages/react-integration/cypress/integration/contextselector.spec.ts
+++ b/packages/react-integration/cypress/integration/contextselector.spec.ts
@@ -3,10 +3,6 @@ describe('Context Selector Demo Test', () => {
     cy.visit('http://localhost:3000/context-selector-demo-nav-link');
   });
 
-  it('Verify toggle class', () => {
-    cy.get('#pf-context-selector-toggle-id-0').should('have.class', 'pf-c-context-selector__toggle');
-  });
-
   it('Verify toggle button works', () => {
     cy.get('.pf-c-context-selector__toggle').click();
     cy.get('.pf-c-context-selector__menu').should('exist');

--- a/packages/react-integration/cypress/integration/duallistselectorwithactions.spec.ts
+++ b/packages/react-integration/cypress/integration/duallistselectorwithactions.spec.ts
@@ -51,11 +51,7 @@ describe('Dual List Selector With Actions Demo Test', () => {
       'aria-label',
       'Demo chosen options search'
     );
-    cy.get('.pf-m-chosen .pf-c-dual-list-selector__list').should(
-      'have.attr',
-      'aria-labelledby',
-      'dual-list-selector-demo-chosen-pane-status'
-    );
+    cy.get('.pf-m-chosen .pf-c-dual-list-selector__list').should('not.have.attr', 'aria-labelledby');
   });
 
   it('Verify selecting options', () => {


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7610 

- Notification drawer examples
- Input group examples
- Dual list selector examples
- Data list examples
- File upload examples
- Card examples
- Context selector examples
- Code block examples
- Accordion examples
- Action list examples

few notes:

- Context selector needed a more reliable way to generate unique ids. So I updated how they were randomly generated and also passed an `id` to the unit test cases so they would be the same across snapshots. Also, the items inside context selector menus did not have the `role='menuitem'` so I added it.
- In the Dual list selector, the `aria-multiselectable`, `aria-labelledby`, `aria-activedescendant`, and `role=tree|listbox` should only be applied when they have the requisite valid children with valid roles. In the case of empty lists, they should not have those roles (according to the axe tests).
- The DualListSelectorTree example had the same name as the DualListSelectorTree component, which was causing a conflict when generating the prop descriptions tables, so i renamed the example to DualListSelectorTreeExample.