### PR TITLE
fix(CodeEditor): remove monaco-editor-webpack-plugin as peer dependency

### DIFF
--- a/packages/react-code-editor/package.json
+++ b/packages/react-code-editor/package.json
@@ -37,7 +37,6 @@
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "monaco-editor-webpack-plugin": "^2.1.0",
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0",
     "react-monaco-editor": "^0.41.2"


### PR DESCRIPTION
The `monaco-editor-webpack-plugin` dependency is never used directly by any of the code in PatternFly, so it is not required to specify it as a peer dependency.

This also helps projects that do not use WebPack (such as [ours](https://github.com/keycloak/keycloak-admin-ui/)) since NPM installs peer dependencies [by default](https://github.blog/2021-02-02-npm-7-is-now-generally-available/#peer-dependencies). This change prevents unnecessary packages from getting installed by accident.

Closes #7676