### PR TITLE
fix(Select): update logic should only apply to typeahead

### DIFF
--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -297,39 +297,41 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
       this.setState({ viewMoreNextIndex: -1 });
     }
 
-    const checkUpdatedChildren = (prevChildren: React.ReactElement[], currChildren: React.ReactElement[]) =>
-      Array.from(prevChildren).some((prevChild: React.ReactElement, index: number) => {
-        const prevChildProps = prevChild.props;
-        const currChild = currChildren[index];
-        const { props: currChildProps } = currChild;
+    if (this.props.variant === 'typeahead' || this.props.variant === 'typeaheadmulti') {
+      const checkUpdatedChildren = (prevChildren: React.ReactElement[], currChildren: React.ReactElement[]) =>
+        Array.from(prevChildren).some((prevChild: React.ReactElement, index: number) => {
+          const prevChildProps = prevChild.props;
+          const currChild = currChildren[index];
+          const { props: currChildProps } = currChild;
 
-        if (prevChildProps && currChildProps) {
-          return (
-            prevChildProps.value !== currChildProps.value ||
-            prevChildProps.label !== currChildProps.label ||
-            prevChildProps.isDisabled !== currChildProps.isDisabled ||
-            prevChildProps.isPlaceholder !== currChildProps.isPlaceholder
-          );
-        } else {
-          return prevChild !== currChild;
-        }
-      });
+          if (prevChildProps && currChildProps) {
+            return (
+              prevChildProps.value !== currChildProps.value ||
+              prevChildProps.label !== currChildProps.label ||
+              prevChildProps.isDisabled !== currChildProps.isDisabled ||
+              prevChildProps.isPlaceholder !== currChildProps.isPlaceholder
+            );
+          } else {
+            return prevChild !== currChild;
+          }
+        });
 
-    const hasUpdatedChildren =
-      prevProps.children.length !== this.props.children.length ||
-      checkUpdatedChildren(prevProps.children, this.props.children) ||
-      (this.props.isGrouped &&
-        Array.from(prevProps.children).some(
-          (prevChild: React.ReactElement, index: number) =>
-            prevChild.type === SelectGroup &&
-            prevChild.props.children &&
-            this.props.children[index].props.children &&
-            (prevChild.props.children.length !== this.props.children[index].props.children.length ||
-              checkUpdatedChildren(prevChild.props.children, this.props.children[index].props.children))
-        ));
+      const hasUpdatedChildren =
+        prevProps.children.length !== this.props.children.length ||
+        checkUpdatedChildren(prevProps.children, this.props.children) ||
+        (this.props.isGrouped &&
+          Array.from(prevProps.children).some(
+            (prevChild: React.ReactElement, index: number) =>
+              prevChild.type === SelectGroup &&
+              prevChild.props.children &&
+              this.props.children[index].props.children &&
+              (prevChild.props.children.length !== this.props.children[index].props.children.length ||
+                checkUpdatedChildren(prevChild.props.children, this.props.children[index].props.children))
+          ));
 
-    if (hasUpdatedChildren) {
-      this.updateTypeAheadFilteredChildren(prevState.typeaheadInputValue || '', null);
+      if (hasUpdatedChildren) {
+        this.updateTypeAheadFilteredChildren(prevState.typeaheadInputValue || '', null);
+      }
     }
 
     // for menus with favorites,


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: release slack console error (.some not a function)

...and also will convert children to an array copy to prevent single children from throwing an error regarding `.some`.

