### PR TITLE
chore(charts): add interface descriptions

### DIFF
--- a/packages/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/react-charts/src/components/Chart/Chart.tsx
@@ -35,8 +35,10 @@ import {
 } from '../ChartUtils';
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
- * and https://github.com/FormidableLabs/victory/blob/master/packages/victory-chart/src/index.d.ts
+ * Chart is a wrapper component that reconciles the domain for all its children, controls the layout of the chart,
+ * and coordinates animations and shared events.
+ *
+ * See https://github.com/FormidableLabs/victory/blob/main/packages/victory-chart/src/victory-chart.tsx
  */
 export interface ChartProps extends VictoryChartProps {
   /**

--- a/packages/react-charts/src/components/ChartArea/ChartArea.tsx
+++ b/packages/react-charts/src/components/ChartArea/ChartArea.tsx
@@ -30,8 +30,12 @@ export enum ChartAreaSortOrder {
 }
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
- * and https://github.com/FormidableLabs/victory/blob/master/packages/victory-area/src/index.d.ts
+ * ChartArea renders a dataset as a single area path. Since ChartArea renders only a single element to represent a
+ * dataset rather than individual elements for each data point, some of its behavior is different from other Victory
+ * based components. Pay special attention to style and events props, and take advantage of ChartVoronoiContainer to
+ * enable tooltips. ChartArea can be composed with Chart to create area charts.
+ *
+ * See https://github.com/FormidableLabs/victory/blob/main/packages/victory-area/src/victory-area.tsx
  */
 export interface ChartAreaProps extends VictoryAreaProps {
   /**

--- a/packages/react-charts/src/components/ChartArea/examples/ChartArea.md
+++ b/packages/react-charts/src/components/ChartArea/examples/ChartArea.md
@@ -7,7 +7,7 @@ propComponents: [
   'ChartAxis',
   'ChartGroup',
   'ChartThreshold',
-  'ChartVoronoiContainer',
+  'ChartVoronoiContainer'
 ]
 hideDarkMode: true
 ---
@@ -275,8 +275,8 @@ class MultiColorChart extends React.Component {
 Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 
 components used in the examples above, Victory pass-thru props are also documented here:
 
- - For `Chart` props, see [VictoryChart](https://formidable.com/open-source/victory/docs/victory-chart)
- - For `ChartArea` props, see [VictoryArea](https://formidable.com/open-source/victory/docs/victory-area)
- - For `ChartAxis` props, see [VictoryAxis](https://formidable.com/open-source/victory/docs/victory-axis)
- - For `ChartGroup` props, see [VictoryGroup](https://formidable.com/open-source/victory/docs/victory-group)
- - For `ChartVoronoiContainer` props, see [VictoryVoronoiContainer](https://formidable.com/open-source/victory/docs/victory-voronoi-container)
+- For `Chart` props, see [VictoryChart](https://formidable.com/open-source/victory/docs/victory-chart)
+- For `ChartArea` props, see [VictoryArea](https://formidable.com/open-source/victory/docs/victory-area)
+- For `ChartAxis` props, see [VictoryAxis](https://formidable.com/open-source/victory/docs/victory-axis)
+- For `ChartGroup` props, see [VictoryGroup](https://formidable.com/open-source/victory/docs/victory-group)
+- For `ChartVoronoiContainer` props, see [VictoryVoronoiContainer](https://formidable.com/open-source/victory/docs/victory-voronoi-container)

--- a/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
+++ b/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
@@ -20,8 +20,9 @@ import { ChartThemeDefinition } from '../ChartTheme';
 import { getAxisTheme, getTheme } from '../ChartUtils';
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
- * and https://github.com/FormidableLabs/victory/blob/master/packages/victory-axis/src/index.d.ts
+ * ChartAxis renders a single axis which can be used on its own or composed with Chart.
+ *
+ * See https://github.com/FormidableLabs/victory/blob/main/packages/victory-axis/src/index.d.ts
  */
 export interface ChartAxisProps extends VictoryAxisProps {
   /**

--- a/packages/react-charts/src/components/ChartBar/ChartBar.tsx
+++ b/packages/react-charts/src/components/ChartBar/ChartBar.tsx
@@ -25,8 +25,9 @@ import { ChartThemeDefinition } from '../ChartTheme';
 import { getTheme } from '../ChartUtils';
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
- * and https://github.com/FormidableLabs/victory/blob/master/packages/victory-bar/src/index.d.ts
+ * ChartBar renders a dataset as series of bars. ChartBar can be composed with Chart to create bar charts.
+ *
+ * See https://github.com/FormidableLabs/victory/blob/main/packages/victory-bar/src/index.d.ts
  */
 export interface ChartBarProps extends VictoryBarProps {
   /**

--- a/packages/react-charts/src/components/ChartBar/examples/ChartBar.md
+++ b/packages/react-charts/src/components/ChartBar/examples/ChartBar.md
@@ -217,8 +217,8 @@ import { Chart, ChartBar, ChartVoronoiContainer } from '@patternfly/react-charts
 Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 
 components used in the examples above, Victory pass-thru props are also documented here:
 
- - For `Chart` props, see [VictoryChart](https://formidable.com/open-source/victory/docs/victory-chart)
- - For `ChartAxis` props, see [VictoryAxis](https://formidable.com/open-source/victory/docs/victory-axis)
- - For `ChartBar` props, see [VictoryBar](https://formidable.com/open-source/victory/docs/victory-bar)
- - For `ChartGroup` props, see [VictoryGroup](https://formidable.com/open-source/victory/docs/victory-group)
- - For `ChartVoronoiContainer` props, see [VictoryVoronoiContainer](https://formidable.com/open-source/victory/docs/victory-voronoi-container)
+- For `Chart` props, see [VictoryChart](https://formidable.com/open-source/victory/docs/victory-chart)
+- For `ChartAxis` props, see [VictoryAxis](https://formidable.com/open-source/victory/docs/victory-axis)
+- For `ChartBar` props, see [VictoryBar](https://formidable.com/open-source/victory/docs/victory-bar)
+- For `ChartGroup` props, see [VictoryGroup](https://formidable.com/open-source/victory/docs/victory-group)
+- For `ChartVoronoiContainer` props, see [VictoryVoronoiContainer](https://formidable.com/open-source/victory/docs/victory-voronoi-container)

--- a/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
@@ -28,8 +28,9 @@ import { ChartTooltip } from '../ChartTooltip';
 import { getComputedLegend, getPaddingForSide } from '../ChartUtils';
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
- * and https://github.com/FormidableLabs/victory/blob/master/packages/victory-chart/src/index.d.ts
+ * ChartBullet renders a dataset as a bullet chart.
+ *
+ * See https://github.com/FormidableLabs/victory/blob/main/packages/victory-chart/src/victory-chart.tsx
  */
 export interface ChartBulletProps {
   /**

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletComparativeErrorMeasure.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletComparativeErrorMeasure.tsx
@@ -8,8 +8,9 @@ import { getBulletComparativeErrorMeasureTheme } from '../ChartUtils';
 import { ChartBulletComparativeMeasure } from './ChartBulletComparativeMeasure';
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
- * and https://github.com/FormidableLabs/victory/blob/master/packages/victory-bar/src/index.d.ts
+ * ChartBulletComparativeErrorMeasure renders a dataset as a comparative error measure.
+ *
+ * See https://github.com/FormidableLabs/victory/blob/main/packages/victory-bar/src/index.d.ts
  */
 export interface ChartBulletComparativeErrorMeasureProps {
   /**

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletComparativeMeasure.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletComparativeMeasure.tsx
@@ -10,8 +10,9 @@ import { ChartTooltip } from '../ChartTooltip';
 import { getBulletComparativeMeasureTheme } from '../ChartUtils';
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
- * and https://github.com/FormidableLabs/victory/blob/master/packages/victory-bar/src/index.d.ts
+ * ChartBulletComparativeMeasure renders a dataset as a comparative measure.
+ *
+ * See https://github.com/FormidableLabs/victory/blob/main/packages/victory-bar/src/index.d.ts
  */
 export interface ChartBulletComparativeMeasureProps {
   /**

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletComparativeWarningMeasure.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletComparativeWarningMeasure.tsx
@@ -8,8 +8,9 @@ import { getBulletComparativeWarningMeasureTheme } from '../ChartUtils';
 import { ChartBulletComparativeMeasure } from './ChartBulletComparativeMeasure';
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
- * and https://github.com/FormidableLabs/victory/blob/master/packages/victory-bar/src/index.d.ts
+ * ChartBulletComparativeWarningMeasure renders a dataset as a comparative warning measure.
+ *
+ * See https://github.com/FormidableLabs/victory/blob/main/packages/victory-bar/src/index.d.ts
  */
 export interface ChartBulletComparativeWarningMeasureProps {
   /**

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletGroupTitle.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletGroupTitle.tsx
@@ -12,7 +12,7 @@ import {
 } from '../ChartUtils';
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
+ * ChartBulletGroupTitle renders a group title.
  */
 export interface ChartBulletGroupTitleProps {
   /**

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletPrimaryDotMeasure.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletPrimaryDotMeasure.tsx
@@ -10,8 +10,9 @@ import { ChartTooltip } from '../ChartTooltip';
 import { getBulletPrimaryDotMeasureTheme } from '../ChartUtils';
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
- * and https://github.com/FormidableLabs/victory/blob/master/packages/victory-scatter/src/index.d.ts
+ * ChartBulletPrimaryDotMeasure renders a dataset as the primary dot measure.
+ *
+ * See https://github.com/FormidableLabs/victory/blob/main/packages/victory-scatter/src/index.d.ts
  */
 export interface ChartBulletPrimaryDotMeasureProps {
   /**

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletPrimarySegmentedMeasure.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletPrimarySegmentedMeasure.tsx
@@ -10,8 +10,9 @@ import { ChartTooltip } from '../ChartTooltip';
 import { getBulletPrimaryNegativeMeasureTheme, getBulletPrimarySegmentedMeasureTheme } from '../ChartUtils';
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
- * and https://github.com/FormidableLabs/victory/blob/master/packages/victory-bar/src/index.d.ts
+ * ChartBulletPrimarySegmentedMeasure renders a dataset as the primary segmented measure.
+ *
+ * See https://github.com/FormidableLabs/victory/blob/main/packages/victory-bar/src/index.d.ts
  */
 export interface ChartBulletPrimarySegmentedMeasureProps {
   /**

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletQualitativeRange.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletQualitativeRange.tsx
@@ -10,8 +10,9 @@ import { ChartTooltip } from '../ChartTooltip';
 import { getBulletQualitativeRangeTheme } from '../ChartUtils';
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
- * and https://github.com/FormidableLabs/victory/blob/master/packages/victory-bar/src/index.d.ts
+ * ChartBulletQualitativeRange renders a dataset as the qualitative range.
+ *
+ * See https://github.com/FormidableLabs/victory/blob/main/packages/victory-bar/src/index.d.ts
  */
 export interface ChartBulletQualitativeRangeProps {
   /**

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletTitle.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletTitle.tsx
@@ -7,7 +7,7 @@ import { ChartBulletStyles, ChartCommonStyles, ChartThemeDefinition } from '../C
 import { getBulletTheme, getBulletLabelX, getBulletLabelY, getPaddingForSide } from '../ChartUtils';
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
+ * ChartBulletTitle renders the bullet chart title.
  */
 export interface ChartBulletTitleProps {
   /**

--- a/packages/react-charts/src/components/ChartBullet/examples/ChartBullet.md
+++ b/packages/react-charts/src/components/ChartBullet/examples/ChartBullet.md
@@ -903,6 +903,6 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
 Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 
 components used in the examples above, Victory pass-thru props are also documented here:
 
- - For `ChartAxis` props, see [VictoryAxis](https://formidable.com/open-source/victory/docs/victory-axis)
- - For `ChartBullet` props, see [VictoryBar](https://formidable.com/open-source/victory/docs/victory-bar)
- - For `ChartContainer` props, see [VictoryContainer](https://formidable.com/open-source/victory/docs/victory-container)
+- For `ChartAxis` props, see [VictoryAxis](https://formidable.com/open-source/victory/docs/victory-axis)
+- For `ChartBullet` props, see [VictoryBar](https://formidable.com/open-source/victory/docs/victory-bar)
+- For `ChartContainer` props, see [VictoryContainer](https://formidable.com/open-source/victory/docs/victory-container)

--- a/packages/react-charts/src/components/ChartContainer/ChartContainer.tsx
+++ b/packages/react-charts/src/components/ChartContainer/ChartContainer.tsx
@@ -5,9 +5,10 @@ import { ChartThemeDefinition } from '../ChartTheme';
 import { getClassName, getTheme } from '../ChartUtils';
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
+ * ChartContainer provides a top-level <svg> element for other Victory based components to render within. By default,
+ * ChartContainer renders responsive SVGs.
  *
- * Note: VictoryContainer may support other props (e.g., children), but they're undocumented and not typed
+ * See https://github.com/FormidableLabs/victory/blob/main/packages/victory-core/src/victory-container/victory-container.tsx
  */
 export interface ChartContainerProps extends VictoryContainerProps {
   /**

--- a/packages/react-charts/src/components/ChartCursorContainer/ChartCursorContainer.tsx
+++ b/packages/react-charts/src/components/ChartCursorContainer/ChartCursorContainer.tsx
@@ -14,8 +14,11 @@ import { ChartThemeDefinition } from '../ChartTheme';
 import { getClassName, getTheme } from '../ChartUtils';
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
- * and https://github.com/FormidableLabs/victory/blob/master/packages/victory-cursor-container/src/index.d.ts
+ * ChartCursorContainer adds a cursor to a chart to inspect coordinates. The cursor moves with the mouse along the
+ * visible domain of the chart. ChartCursorContainer may be used with any Victory component that works with an x-y
+ * coordinate system, and should be added as the containerComponent of the top-level component.
+ *
+ * See https://github.com/FormidableLabs/victory/blob/main/packages/victory-cursor-container/src/index.d.ts
  */
 export interface ChartCursorContainerProps extends VictoryCursorContainerProps {
   /**

--- a/packages/react-charts/src/components/ChartCursorTooltip/ChartCursorTooltip.tsx
+++ b/packages/react-charts/src/components/ChartCursorTooltip/ChartCursorTooltip.tsx
@@ -18,8 +18,7 @@ import { ChartCursorFlyout } from './ChartCursorFlyout';
 /**
  * This tooltip has default values intended for use with a cursor container.
  *
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
- * and https://github.com/FormidableLabs/victory/blob/master/packages/victory-tooltip/src/index.d.ts
+ * See https://github.com/FormidableLabs/victory/blob/main/packages/victory-tooltip/src/index.d.ts
  */
 export interface ChartCursorTooltipProps extends ChartTooltipProps {
   /**

--- a/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -53,8 +53,9 @@ export enum ChartDonutSubTitlePosition {
 }
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
- * and https://github.com/FormidableLabs/victory/blob/master/packages/victory-pie/src/index.d.ts
+ * ChartDonut renders a dataset as a donut chart.
+ *
+ * See https://github.com/FormidableLabs/victory/blob/main/packages/victory-pie/src/index.d.ts
  */
 export interface ChartDonutProps extends ChartPieProps {
   /**

--- a/packages/react-charts/src/components/ChartDonut/examples/ChartDonut.md
+++ b/packages/react-charts/src/components/ChartDonut/examples/ChartDonut.md
@@ -242,4 +242,4 @@ import { ChartDonut } from '@patternfly/react-charts';
 Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 
 components used in the examples above, Victory pass-thru props are also documented here:
 
- - For `ChartDonut` props, see [VictoryPie](https://formidable.com/open-source/victory/docs/victory-pie)
+- For `ChartDonut` props, see [VictoryPie](https://formidable.com/open-source/victory/docs/victory-pie)

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
@@ -52,8 +52,9 @@ export enum ChartDonutThresholdSubTitlePosition {
 }
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
- * and https://github.com/FormidableLabs/victory/blob/master/packages/victory-pie/src/index.d.ts
+ * ChartDonutThreshold renders a dataset as a donut threshold chart.
+ *
+ * See https://github.com/FormidableLabs/victory/blob/main/packages/victory-pie/src/index.d.ts
  */
 export interface ChartDonutThresholdProps extends ChartDonutProps {
   /**

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
@@ -51,8 +51,9 @@ export enum ChartDonutUtilizationSubTitlePosition {
 }
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
- * and https://github.com/FormidableLabs/victory/blob/master/packages/victory-pie/src/index.d.ts
+ * ChartDonutUtilization renders a dataset as a donut utilization chart.
+ *
+ * See https://github.com/FormidableLabs/victory/blob/main/packages/victory-pie/src/index.d.ts
  */
 export interface ChartDonutUtilizationProps extends ChartDonutProps {
   /**

--- a/packages/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
+++ b/packages/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
@@ -794,5 +794,5 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
 Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 
 components used in the examples above, Victory pass-thru props are also documented here:
 
- - For `ChartDonutThreshold` props, see [VictoryPie](https://formidable.com/open-source/victory/docs/victory-pie)
- - For `ChartDonutUtilization` props, see [VictoryPie](https://formidable.com/open-source/victory/docs/victory-pie)
+- For `ChartDonutThreshold` props, see [VictoryPie](https://formidable.com/open-source/victory/docs/victory-pie)
+- For `ChartDonutUtilization` props, see [VictoryPie](https://formidable.com/open-source/victory/docs/victory-pie)

--- a/packages/react-charts/src/components/ChartGroup/ChartGroup.tsx
+++ b/packages/react-charts/src/components/ChartGroup/ChartGroup.tsx
@@ -35,8 +35,14 @@ export enum ChartGroupSortOrder {
 }
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
- * and https://github.com/FormidableLabs/victory/blob/master/packages/victory-group/src/index.d.ts
+ * ChartGroup is a wrapper component that renders a given set of children with some shared props. ChartGroup reconciles
+ * the domain and layout for all its children, and coordinates animations and shared events. ChartGroup may also be used
+ * to supply common data and styles to all its children. This is especially useful when adding markers to a line, or
+ * adding voronoi tooltips to data. ChartGroup may also be used to apply an offset to a group of children, as with
+ * grouped bar charts, or may be used to stack several components on the same level, e.g., stacked area charts with
+ * data markers.
+ *
+ * See https://github.com/FormidableLabs/victory/blob/main/packages/victory-group/src/index.d.ts
  */
 export interface ChartGroupProps extends VictoryGroupProps {
   /**

--- a/packages/react-charts/src/components/ChartLabel/ChartLabel.tsx
+++ b/packages/react-charts/src/components/ChartLabel/ChartLabel.tsx
@@ -25,7 +25,9 @@ export enum ChartLabelPlacement {
 }
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
+ * ChartLabel renders the label components that are used across all Victory based components.
+ *
+ * See https://github.com/FormidableLabs/victory/blob/main/packages/victory-core/src/victory-label/victory-label.tsx
  */
 export interface ChartLabelProps extends VictoryLabelProps {
   /**

--- a/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
+++ b/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
@@ -40,8 +40,9 @@ export enum ChartLegendRowGutter {
 }
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
- * and See https://github.com/FormidableLabs/victory/blob/master/packages/victory-legend/src/index.d.ts
+ * ChartLegend renders a chart legend component.
+ *
+ * See https://github.com/FormidableLabs/victory/blob/main/packages/victory-legend/src/index.d.ts
  */
 export interface ChartLegendProps extends VictoryLegendProps {
   /**

--- a/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
+++ b/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
@@ -2,7 +2,20 @@
 id: Legends
 section: charts
 propComponents: [
-  'ChartLegend'
+  'Chart',
+  'ChartArea',
+  'ChartAxis',
+  'ChartBar',
+  'ChartBullet',
+  'ChartDonut',
+  'ChartGroup',
+  'ChartLabel',
+  'ChartLegend',
+  'ChartLegendTooltip',
+  'ChartLine',
+  'ChartPie',
+  'ChartScatter',
+  'ChartVoronoiContainer'
 ]
 hideDarkMode: true
 ---
@@ -814,4 +827,16 @@ class LegendLayoutPieChart extends React.Component {
 Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 
 components used in the examples above, Victory pass-thru props are also documented here:
 
- - For `ChartLegend` props, see [VictoryLegend](https://formidable.com/open-source/victory/docs/victory-legend)
+- For `Chart` props, see [VictoryChart](https://formidable.com/open-source/victory/docs/victory-chart)
+- For `ChartArea` props, see [VictoryArea](https://formidable.com/open-source/victory/docs/victory-area)
+- For `ChartAxis` props, see [VictoryAxis](https://formidable.com/open-source/victory/docs/victory-axis)
+- For `ChartBar` props, see [VictoryBar](https://formidable.com/open-source/victory/docs/victory-bar)
+- For `ChartBullet` props, see [VictoryBar](https://formidable.com/open-source/victory/docs/victory-bar)
+- For `ChartDonut` props, see [VictoryPie](https://formidable.com/open-source/victory/docs/victory-pie)
+- For `ChartGroup` props, see [VictoryGroup](https://formidable.com/open-source/victory/docs/victory-group)
+- For `ChartLabel` props, see [VictoryLabel](https://formidable.com/open-source/victory/docs/victory-label)
+- For `ChartLegend` props, see [VictoryLegend](https://formidable.com/open-source/victory/docs/victory-legend)
+- For `ChartLine` props, see [VictoryLine](https://formidable.com/open-source/victory/docs/victory-line)
+- For `ChartPie` props, see [VictoryPie](https://formidable.com/open-source/victory/docs/victory-pie)
+- For `ChartScatter` props, see [VictoryScatter](https://formidable.com/open-source/victory/docs/victory-scatter)
+- For `ChartVoronoiContainer` props, see [VictoryVoronoiContainer](https://formidable.com/open-source/victory/docs/victory-voronoi-container)

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
@@ -25,8 +25,7 @@ import {
  * The ChartLegendTooltip is based on ChartCursorTooltip, which is intended to be used with a voronoi cursor
  * container. This works best with charts such as area and line, for example.
  *
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
- * and https://github.com/FormidableLabs/victory/blob/master/packages/victory-tooltip/src/index.d.ts
+ * See https://github.com/FormidableLabs/victory/blob/main/packages/victory-tooltip/src/index.d.ts
  */
 export interface ChartLegendTooltipProps extends ChartCursorTooltipProps {
   /**

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipContent.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipContent.tsx
@@ -15,8 +15,9 @@ import {
 } from '../ChartUtils';
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
- * and https://github.com/FormidableLabs/victory/blob/master/packages/victory-legend/src/index.d.ts
+ * ChartLegendTooltipContent renders a legend tooltip component.
+ *
+ * See https://github.com/FormidableLabs/victory/blob/main/packages/victory-legend/src/index.d.ts
  */
 export interface ChartLegendTooltipContentProps {
   /**

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipLabel.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipLabel.tsx
@@ -15,7 +15,9 @@ import { ChartLabel } from '../ChartLabel';
 import { ChartLegendTooltipStyles } from '../ChartTheme';
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
+ * ChartLegendLabel renders a legend tooltip label
+ *
+ * See https://github.com/FormidableLabs/victory/tree/main/packages/victory-core/src/victory-label
  */
 export interface ChartLegendLabelProps extends VictoryLabelProps {
   /**

--- a/packages/react-charts/src/components/ChartLine/ChartLine.tsx
+++ b/packages/react-charts/src/components/ChartLine/ChartLine.tsx
@@ -30,8 +30,12 @@ export enum ChartLineSortOrder {
 }
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
- * and https://github.com/FormidableLabs/victory/blob/master/packages/victory-line/src/index.d.ts
+ * ChartLine renders a dataset as a single line path. Since ChartLine renders only a single element to represent a
+ * dataset rather than individual elements for each data point, some of its behavior is different from other Victory
+ * based components. Pay special attention to style and events props, and take advantage of ChartVoronoiContainer to
+ * enable tooltips. ChartLine can be composed with Chart to create line charts.
+ *
+ * See https://github.com/FormidableLabs/victory/blob/main/packages/victory-line/src/victory-line.tsx
  */
 export interface ChartLineProps extends VictoryLineProps {
   /**

--- a/packages/react-charts/src/components/ChartLine/examples/ChartLine.md
+++ b/packages/react-charts/src/components/ChartLine/examples/ChartLine.md
@@ -306,9 +306,9 @@ class MultiColorChart extends React.Component {
 Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 
 components used in the examples above, Victory pass-thru props are also documented here:
 
- - For `Chart` props, see [VictoryChart](https://formidable.com/open-source/victory/docs/victory-chart)
- - For `ChartAxis` props, see [VictoryAxis](https://formidable.com/open-source/victory/docs/victory-axis)
- - For `ChartGroup` props, see [VictoryGroup](https://formidable.com/open-source/victory/docs/victory-group)
- - For `ChartLine` props, see [Victoryline](https://formidable.com/open-source/victory/docs/victory-line)
- - For `ChartVoronoiContainer` props, see [VictoryVoronoiContainer](https://formidable.com/open-source/victory/docs/victory-voronoi-container)
- - For `VictoryZoomContainer` props, see [VictoryZoomContainerline](https://formidable.com/open-source/victory/docs/victory-zoom-container)
+- For `Chart` props, see [VictoryChart](https://formidable.com/open-source/victory/docs/victory-chart)
+- For `ChartAxis` props, see [VictoryAxis](https://formidable.com/open-source/victory/docs/victory-axis)
+- For `ChartGroup` props, see [VictoryGroup](https://formidable.com/open-source/victory/docs/victory-group)
+- For `ChartLine` props, see [Victoryline](https://formidable.com/open-source/victory/docs/victory-line)
+- For `ChartVoronoiContainer` props, see [VictoryVoronoiContainer](https://formidable.com/open-source/victory/docs/victory-voronoi-container)
+- For `VictoryZoomContainer` props, see [VictoryZoomContainerline](https://formidable.com/open-source/victory/docs/victory-zoom-container)

--- a/packages/react-charts/src/components/ChartPie/ChartPie.tsx
+++ b/packages/react-charts/src/components/ChartPie/ChartPie.tsx
@@ -46,8 +46,9 @@ export enum ChartPieSortOrder {
 }
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
- * and https://github.com/FormidableLabs/victory/blob/master/packages/victory-pie/src/index.d.ts
+ * ChartPie renders a dataset as a pie chart.
+ *
+ * See https://github.com/FormidableLabs/victory/blob/main/packages/victory-pie/src/index.d.ts
  */
 export interface ChartPieProps extends VictoryPieProps {
   /**

--- a/packages/react-charts/src/components/ChartPie/examples/ChartPie.md
+++ b/packages/react-charts/src/components/ChartPie/examples/ChartPie.md
@@ -109,4 +109,4 @@ import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
 Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 
 components used in the examples above, Victory pass-thru props are also documented here:
 
- - For `ChartPie` props, see [VictoryPie](https://formidable.com/open-source/victory/docs/victory-pie)
+- For `ChartPie` props, see [VictoryPie](https://formidable.com/open-source/victory/docs/victory-pie)

--- a/packages/react-charts/src/components/ChartScatter/ChartScatter.tsx
+++ b/packages/react-charts/src/components/ChartScatter/ChartScatter.tsx
@@ -30,8 +30,9 @@ export enum ChartScatterSortOrder {
 }
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
- * and https://github.com/FormidableLabs/victory/blob/master/packages/victory-scatter/src/index.d.ts
+ * ChartScatter renders a dataset as a series of points. ChartScatter can be composed with Chart to create scatter plots.
+ *
+ * See https://github.com/FormidableLabs/victory/blob/main/packages/victory-scatter/src/index.d.ts
  */
 export interface ChartScatterProps extends VictoryScatterProps {
   /**

--- a/packages/react-charts/src/components/ChartStack/ChartStack.tsx
+++ b/packages/react-charts/src/components/ChartStack/ChartStack.tsx
@@ -22,8 +22,11 @@ import { ChartThemeDefinition } from '../ChartTheme';
 import { getClassName, getDefaultPatternProps, getTheme, renderChildrenWithPatterns } from '../ChartUtils';
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
- * and https://github.com/FormidableLabs/victory/blob/master/packages/victory-stack/src/index.d.ts
+ * ChartStack is a wrapper component that renders a given set of children in a stacked layout. Like other wrapper
+ * components, ChartStack also reconciles the domain and layout for all its children, and coordinates animations and
+ * shared events.
+ *
+ * See https://github.com/FormidableLabs/victory/blob/main/packages/victory-stack/src/index.d.ts
  */
 export interface ChartStackProps extends VictoryStackProps {
   /**

--- a/packages/react-charts/src/components/ChartStack/examples/ChartStack.md
+++ b/packages/react-charts/src/components/ChartStack/examples/ChartStack.md
@@ -422,9 +422,9 @@ class MultiColorChart extends React.Component {
 Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 
 components used in the examples above, Victory pass-thru props are also documented here:
 
- - For `Chart` props, see [VictoryChart](https://formidable.com/open-source/victory/docs/victory-chart)
- - For `ChartArea` props, see [VictoryArea](https://formidable.com/open-source/victory/docs/victory-area)
- - For `ChartAxis` props, see [VictoryAxis](https://formidable.com/open-source/victory/docs/victory-axis)
- - For `ChartBar` props, see [VictoryBar](https://formidable.com/open-source/victory/docs/victory-bar)
- - For `ChartStack` props, see [VictoryStack](https://formidable.com/open-source/victory/docs/victory-stack)
- - For `ChartTooltip` props, see [VictoryTooltip](https://formidable.com/open-source/victory/docs/victory-tooltip)
+- For `Chart` props, see [VictoryChart](https://formidable.com/open-source/victory/docs/victory-chart)
+- For `ChartArea` props, see [VictoryArea](https://formidable.com/open-source/victory/docs/victory-area)
+- For `ChartAxis` props, see [VictoryAxis](https://formidable.com/open-source/victory/docs/victory-axis)
+- For `ChartBar` props, see [VictoryBar](https://formidable.com/open-source/victory/docs/victory-bar)
+- For `ChartStack` props, see [VictoryStack](https://formidable.com/open-source/victory/docs/victory-stack)
+- For `ChartTooltip` props, see [VictoryTooltip](https://formidable.com/open-source/victory/docs/victory-tooltip)

--- a/packages/react-charts/src/components/ChartThreshold/ChartThreshold.tsx
+++ b/packages/react-charts/src/components/ChartThreshold/ChartThreshold.tsx
@@ -26,8 +26,9 @@ import { ChartThemeDefinition } from '../ChartTheme';
 import { getThresholdTheme } from '../ChartUtils';
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
- * and https://github.com/FormidableLabs/victory/blob/master/packages/victory-line/src/index.d.ts
+ * CharThreshold renders a dataset as a threshold chart.
+ *
+ * See https://github.com/FormidableLabs/victory/blob/main/packages/victory-line/src/victory-line.tsx
  */
 export interface ChartThresholdProps extends VictoryLineProps {
   /**

--- a/packages/react-charts/src/components/ChartTooltip/ChartTooltip.tsx
+++ b/packages/react-charts/src/components/ChartTooltip/ChartTooltip.tsx
@@ -14,8 +14,15 @@ import { ChartThemeDefinition } from '../ChartTheme';
 import { getTheme } from '../ChartUtils';
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
- * and https://github.com/FormidableLabs/victory/blob/master/packages/victory-tooltip/src/index.d.ts
+ * ChartTooltip renders a tooltip component with a set of default events. When ChartTooltip is used as a label component
+ * for any Victory based component that renders data, it will attach events to rendered data components that will
+ * activate the tooltip when hovered or focused. ChartTooltipTooltip renders text as well as a configurable Flyout
+ * container.
+ *
+ * Note: When providing tooltips for ChartLine or ChartArea, it is necessary to use ChartVoronoiContainer, as these
+ * components only render a single element for the entire dataset.
+ *
+ * See https://github.com/FormidableLabs/victory/blob/main/packages/victory-tooltip/src/index.d.ts
  */
 export interface ChartTooltipProps extends VictoryTooltipProps {
   /**

--- a/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
+++ b/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
@@ -746,4 +746,4 @@ class TooltipChart extends React.Component {
 Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 
 components used in the examples above, Victory pass-thru props are also documented here:
 
- - For `ChartTooltip` props, see [VictoryTooltip](https://formidable.com/open-source/victory/docs/victory-tooltip)
+- For `ChartTooltip` props, see [VictoryTooltip](https://formidable.com/open-source/victory/docs/victory-tooltip)

--- a/packages/react-charts/src/components/ChartVoronoiContainer/ChartVoronoiContainer.tsx
+++ b/packages/react-charts/src/components/ChartVoronoiContainer/ChartVoronoiContainer.tsx
@@ -12,8 +12,13 @@ export enum ChartVoronoiDimension {
 }
 
 /**
- * See https://github.com/FormidableLabs/victory/blob/master/packages/victory-core/src/index.d.ts
- * and https://github.com/FormidableLabs/victory/blob/master/packages/victory-voronoi-container/src/index.d.ts
+ * ChartVoronoiContainer adds the ability to associate a mouse position with the data point(s) closest to it. When this
+ * container is added to a chart, changes in mouse position will add the active prop to data and label components
+ * closest to the current mouse position. The closeness of data points to a given position is determined by calculating
+ * a voronoi diagram based on the data of every child VictoryVoronoiContainer renders. This container is useful for
+ * adding hover interactions, like tooltips, to small data points, or charts with dense or overlapping data.
+ *
+ * See https://github.com/FormidableLabs/victory/blob/main/packages/victory-voronoi-container/src/index.d.ts
  */
 export interface ChartVoronoiContainerProps extends VictoryVoronoiContainerProps {
   /**

--- a/packages/react-charts/src/components/Sparkline/examples/sparkline.md
+++ b/packages/react-charts/src/components/Sparkline/examples/sparkline.md
@@ -104,7 +104,7 @@ import { ChartArea, ChartContainer, ChartGroup, ChartLabel, ChartThemeColor, Cha
 Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 
 components used in the examples above, Victory pass-thru props are also documented here:
 
- - For `ChartArea` props, see [VictoryArea](https://formidable.com/open-source/victory/docs/victory-area)
- - For `ChartGroup` props, see [VictoryGroup](https://formidable.com/open-source/victory/docs/victory-group)
- - For `ChartLabel` props, see [VictoryLabel](https://formidable.com/open-source/victory/docs/victory-label)
- - For `ChartVoronoiContainer` props, see [VictoryVoronoiContainer](https://formidable.com/open-source/victory/docs/victory-voronoi-container)
+- For `ChartArea` props, see [VictoryArea](https://formidable.com/open-source/victory/docs/victory-area)
+- For `ChartGroup` props, see [VictoryGroup](https://formidable.com/open-source/victory/docs/victory-group)
+- For `ChartLabel` props, see [VictoryLabel](https://formidable.com/open-source/victory/docs/victory-label)
+- For `ChartVoronoiContainer` props, see [VictoryVoronoiContainer](https://formidable.com/open-source/victory/docs/victory-voronoi-container)


### PR DESCRIPTION
Add descriptions to chart interfaces to help indicate how components and properties are used.

Eventually, we would like to display these descriptions in the example docs via https://github.com/patternfly/patternfly-org/issues/3041.

Closes https://github.com/patternfly/patternfly-react/issues/7638