### PR TITLE
Primary Detail: use new raised card variant in demo, add bulk select

### DIFF
--- a/packages/react-core/src/demos/PrimaryDetail.md
+++ b/packages/react-core/src/demos/PrimaryDetail.md
@@ -1057,14 +1057,6 @@ class PrimaryDetailCardView extends React.Component {
       });
     };
 
-    this.deleteItem = item => _event => {
-      const filter = getter => val => getter(val) !== item.id;
-      this.setState({
-        res: this.state.res.filter(filter(({ id }) => id)),
-        selectedItems: this.state.selectedItems.filter(filter(id => id))
-      });
-    };
-
     this.checkAllSelected = (selected, total) => {
       if (selected && selected < total) {
         return null;
@@ -1266,9 +1258,11 @@ class PrimaryDetailCardView extends React.Component {
 
     this.deleteItem = item => _event => {
       const filter = getter => val => getter(val) !== item.id;
+      const filteredCards = this.state.res.filter(filter(({ id }) => id));
       this.setState({
-        res: this.state.res.filter(filter(({ id }) => id)),
-        selectedItems: this.state.selectedItems.filter(filter(id => id))
+        res: filteredCards,
+        selectedItems: this.state.selectedItems.filter(filter(id => id)),
+        totalItemCount: this.state.totalItemCount - 1
       });
     };
   }
@@ -1340,7 +1334,7 @@ class PrimaryDetailCardView extends React.Component {
         Select none (0 items)
       </DropdownItem>,
       <DropdownItem key="item-2" onClick={this.selectPage}>
-        Select page ({this.state.perPage} items)
+        Select page ({this.state.res.length} items)
       </DropdownItem>,
       <DropdownItem key="item-3" onClick={this.selectAll}>
         Select all ({this.state.totalItemCount} items)
@@ -1364,7 +1358,9 @@ class PrimaryDetailCardView extends React.Component {
             ]}
             onToggle={this.onSplitButtonToggle}
           >
-            {numSelected !== 0 && <React.Fragment>{numSelected} selected</React.Fragment>}
+            {numSelected !== 0 && (
+              <React.Fragment>{allSelected ? this.state.totalItemCount : numSelected} selected</React.Fragment>
+            )}
           </DropdownToggle>
         }
         isOpen={splitButtonDropdownIsOpen}

--- a/packages/react-core/src/demos/PrimaryDetail.md
+++ b/packages/react-core/src/demos/PrimaryDetail.md
@@ -1069,6 +1069,13 @@ class PrimaryDetailCardView extends React.Component {
       });
     };
 
+    this.checkAllSelected = (selected, total) => {
+      if (selected && selected < total) {
+        return null;
+      }
+      return selected === total;
+    };
+
     this.onNameSelect = (event, selection) => {
       const checked = event.target.checked;
       this.setState(prevState => {
@@ -1120,6 +1127,22 @@ class PrimaryDetailCardView extends React.Component {
       }
     };
 
+    this.onCheckboxClick = productId => {
+      this.setState(prevState => {
+        return prevState.selectedItems.includes(productId * 1) || this.state.selectedItems.includes(productId * 1)
+          ? {
+              selectedItems: [...this.state.selectedItems.filter(id => productId * 1 != id)],
+              areAllSelected: this.checkAllSelected(prevState.selectedItems.length - 1, prevState.totalItemCount),
+              isDrawerExpanded: true
+            }
+          : {
+              selectedItems: [...prevState.selectedItems, productId * 1],
+              areAllSelected: this.checkAllSelected(prevState.selectedItems.length + 1, prevState.totalItemCount),
+              isDrawerExpanded: true
+            };
+      });
+    };
+
     this.onCardClick = event => {
       if (event.currentTarget.id === this.state.activeCard) {
         return;
@@ -1159,12 +1182,9 @@ class PrimaryDetailCardView extends React.Component {
 
       collection = this.getAllItems();
 
-      console.log(totalItemCount, perPage);
-
       this.setState(
         {
           selectedItems: collection,
-          isChecked: checked,
           areAllSelected: totalItemCount === perPage ? true : false
         },
         this.updateSelected
@@ -1193,7 +1213,9 @@ class PrimaryDetailCardView extends React.Component {
         {
           selectedItems: [],
           isChecked: false,
-          areAllSelected: false
+          areAllSelected: false,
+          isDrawerExpanded: false,
+          activeCard: null
         },
         this.updateSelected
       );
@@ -1201,7 +1223,7 @@ class PrimaryDetailCardView extends React.Component {
 
     this.splitCheckboxSelectAll = e => {
       const { checked } = e.target;
-      const { isChecked, res } = this.state;
+      const { isChecked, res, selectedItems } = this.state;
       let collection = [];
 
       if (checked) {
@@ -1212,7 +1234,9 @@ class PrimaryDetailCardView extends React.Component {
         {
           selectedItems: collection,
           isChecked: isChecked,
-          areAllSelected: checked
+          areAllSelected: checked,
+          isDrawerExpanded: false,
+          activeCard: null
         },
         this.updateSelected
       );
@@ -1220,7 +1244,11 @@ class PrimaryDetailCardView extends React.Component {
 
     this.onSplitButtonSelect = event => {
       this.setState((prevState, props) => {
-        return { splitButtonDropdownIsOpen: !prevState.splitButtonDropdownIsOpen };
+        return {
+          splitButtonDropdownIsOpen: !prevState.splitButtonDropdownIsOpen,
+          isDrawerExpanded: false,
+          activeCard: null
+        };
       });
     };
 
@@ -1440,7 +1468,7 @@ class PrimaryDetailCardView extends React.Component {
           <React.Fragment>
             <Card
               isHoverable
-              key={key}
+              key={product.name}
               id={'card-view-' + key}
               onKeyDown={this.onKeyDown}
               onClick={this.onCardClick}
@@ -1473,6 +1501,7 @@ class PrimaryDetailCardView extends React.Component {
                   />
                   <Checkbox
                     checked={isChecked}
+                    onChange={() => this.onCheckboxClick(product.id)}
                     value={product.id}
                     isChecked={selectedItems.includes(product.id)}
                     aria-label="card checkbox example"
@@ -1508,10 +1537,10 @@ class PrimaryDetailCardView extends React.Component {
               </p>
             </FlexItem>
             <FlexItem>
-              <Progress value={activeCard * 10} title="Title" />
+              <Progress value={activeCard && activeCard.charAt(activeCard.length - 1) * 10} title="Title" />
             </FlexItem>
             <FlexItem>
-              <Progress value={activeCard * 5} title="Title" />
+              <Progress value={activeCard && activeCard.charAt(activeCard.length - 1) * 5} title="Title" />
             </FlexItem>
           </Flex>
         </DrawerPanelBody>

--- a/packages/react-core/src/demos/PrimaryDetail.md
+++ b/packages/react-core/src/demos/PrimaryDetail.md
@@ -965,6 +965,7 @@ import {
   DropdownToggle,
   DropdownToggleCheckbox,
   DropdownItem,
+  DropdownPosition,
   DropdownSeparator,
   Drawer,
   DrawerActions,
@@ -974,14 +975,10 @@ import {
   DrawerContentBody,
   DrawerHead,
   DrawerPanelContent,
-  DrawerSection,
   Flex,
   FlexItem,
   Gallery,
   KebabToggle,
-  OverflowMenu,
-  OverflowMenuControl,
-  OverflowMenuItem,
   PageSection,
   PageSectionVariants,
   Pagination,
@@ -995,8 +992,7 @@ import {
   Toolbar,
   ToolbarItem,
   ToolbarContent,
-  ToolbarFilter,
-  ToolbarToggleGroup
+  ToolbarFilter
 } from '@patternfly/react-core';
 import DashboardWrapper from './examples/DashboardWrapper';
 import TrashIcon from '@patternfly/react-icons/dist/esm/icons/trash-icon';
@@ -1043,7 +1039,7 @@ class PrimaryDetailCardView extends React.Component {
       }));
     };
 
-    this.onToolbarDropdownSelect = event => {
+    this.onToolbarDropdownSelect = _event => {
       this.setState({
         isLowerToolbarDropdownOpen: !this.state.isLowerToolbarDropdownOpen
       });
@@ -1055,13 +1051,13 @@ class PrimaryDetailCardView extends React.Component {
       });
     };
 
-    this.onToolbarKebabDropdownSelect = event => {
+    this.onToolbarKebabDropdownSelect = _event => {
       this.setState({
         isLowerToolbarKebabDropdownOpen: !this.state.isLowerToolbarKebabDropdownOpen
       });
     };
 
-    this.deleteItem = item => event => {
+    this.deleteItem = item => _event => {
       const filter = getter => val => getter(val) !== item.id;
       this.setState({
         res: this.state.res.filter(filter(({ id }) => id)),
@@ -1079,7 +1075,7 @@ class PrimaryDetailCardView extends React.Component {
     this.onNameSelect = (event, selection) => {
       const checked = event.target.checked;
       this.setState(prevState => {
-        const prevSelections = prevState.filters['products'];
+        const prevSelections = prevState.filters.products;
         return {
           filters: {
             ...prevState.filters,
@@ -1128,10 +1124,10 @@ class PrimaryDetailCardView extends React.Component {
     };
 
     this.onCheckboxClick = productId => {
-      this.setState(prevState => {
-        return prevState.selectedItems.includes(productId * 1) || this.state.selectedItems.includes(productId * 1)
+      this.setState(prevState =>
+        prevState.selectedItems.includes(productId * 1) || this.state.selectedItems.includes(productId * 1)
           ? {
-              selectedItems: [...this.state.selectedItems.filter(id => productId * 1 != id)],
+              selectedItems: [...this.state.selectedItems.filter(id => productId * 1 !== id)],
               areAllSelected: this.checkAllSelected(prevState.selectedItems.length - 1, prevState.totalItemCount),
               isDrawerExpanded: true
             }
@@ -1139,8 +1135,8 @@ class PrimaryDetailCardView extends React.Component {
               selectedItems: [...prevState.selectedItems, productId * 1],
               areAllSelected: this.checkAllSelected(prevState.selectedItems.length + 1, prevState.totalItemCount),
               isDrawerExpanded: true
-            };
-      });
+            }
+      );
     };
 
     this.onCardClick = event => {
@@ -1175,9 +1171,8 @@ class PrimaryDetailCardView extends React.Component {
       this.setState({ page });
     };
 
-    this.selectPage = e => {
-      const { checked } = e.target;
-      const { isChecked, totalItemCount, perPage } = this.state;
+    this.selectPage = () => {
+      const { totalItemCount, perPage } = this.state;
       let collection = [];
 
       collection = this.getAllItems();
@@ -1192,10 +1187,10 @@ class PrimaryDetailCardView extends React.Component {
     };
 
     this.selectAll = () => {
-      const { isChecked } = this.state;
-
       let collection = [];
-      for (var i = 0; i <= 9; i++) collection = [...collection, i];
+      for (let i = 0; i <= 9; i++) {
+        collection = [...collection, i];
+      }
 
       this.setState(
         {
@@ -1208,7 +1203,6 @@ class PrimaryDetailCardView extends React.Component {
     };
 
     this.selectNone = () => {
-      const { isChecked, selectedItems } = this.state;
       this.setState(
         {
           selectedItems: [],
@@ -1223,33 +1217,33 @@ class PrimaryDetailCardView extends React.Component {
 
     this.splitCheckboxSelectAll = e => {
       const { checked } = e.target;
-      const { isChecked, res, selectedItems } = this.state;
+      const { isChecked } = this.state;
       let collection = [];
 
       if (checked) {
-        for (var i = 0; i <= 9; i++) collection = [...collection, i];
+        for (let i = 0; i <= 9; i++) {
+          collection = [...collection, i];
+        }
       }
 
       this.setState(
         {
           selectedItems: collection,
-          isChecked: isChecked,
           areAllSelected: checked,
           isDrawerExpanded: false,
-          activeCard: null
+          activeCard: null,
+          isChecked
         },
         this.updateSelected
       );
     };
 
-    this.onSplitButtonSelect = event => {
-      this.setState((prevState, props) => {
-        return {
-          splitButtonDropdownIsOpen: !prevState.splitButtonDropdownIsOpen,
-          isDrawerExpanded: false,
-          activeCard: null
-        };
-      });
+    this.onSplitButtonSelect = _event => {
+      this.setState((prevState, _props) => ({
+        splitButtonDropdownIsOpen: !prevState.splitButtonDropdownIsOpen,
+        isDrawerExpanded: false,
+        activeCard: null
+      }));
     };
 
     this.onSplitButtonToggle = isOpen => {
@@ -1264,13 +1258,13 @@ class PrimaryDetailCardView extends React.Component {
       });
     };
 
-    this.onCardKebabDropdownSelect = (key, event) => {
+    this.onCardKebabDropdownSelect = (key, _event) => {
       this.setState({
         [key]: !this.state[key]
       });
     };
 
-    this.deleteItem = item => event => {
+    this.deleteItem = item => _event => {
       const filter = getter => val => getter(val) !== item.id;
       this.setState({
         res: this.state.res.filter(filter(({ id }) => id)),
@@ -1384,15 +1378,8 @@ class PrimaryDetailCardView extends React.Component {
       isDrawerExpanded,
       isChecked,
       selectedItems,
-      areAllSelected,
-      splitButtonDropdownIsOpen,
       activeCard,
-      isUpperToolbarDropdownOpen,
-      isLowerToolbarDropdownOpen,
-      isUpperToolbarKebabDropdownOpen,
       isLowerToolbarKebabDropdownOpen,
-      isCardKebabDropdownOpen,
-      activeItem,
       filters,
       res
     } = this.state;
@@ -1417,36 +1404,30 @@ class PrimaryDetailCardView extends React.Component {
 
     const toolbarItems = (
       <React.Fragment>
-        <ToolbarItem variant="overflow-menu">
-          <OverflowMenu breakpoint="xl">
-            <OverflowMenuItem isPersistent>{this.buildSelectDropdown()}</OverflowMenuItem>
-            <OverflowMenuItem isPersistent>{this.buildFilterDropdown()}</OverflowMenuItem>
-            <OverflowMenuItem isPersistent>
-              <Button variant="primary">Create a Project</Button>
-            </OverflowMenuItem>
-            <OverflowMenuControl hasAdditionalOptions>
-              <Dropdown
-                onSelect={this.onToolbarKebabDropdownSelect}
-                toggle={
-                  <KebabToggle onToggle={this.onToolbarKebabDropdownToggle} id="card-view-data-toolbar-dropdown" />
-                }
-                isOpen={isLowerToolbarKebabDropdownOpen}
-                isPlain
-                dropdownItems={toolbarKebabDropdownItems}
-                isFlipEnabled
-                menuAppendTo="parent"
-              />
-            </OverflowMenuControl>
-          </OverflowMenu>
+        <ToolbarItem>{this.buildSelectDropdown()}</ToolbarItem>
+        <ToolbarItem>
+          <Button variant="primary">Create instance</Button>
+        </ToolbarItem>
+        <ToolbarItem>
+          <Button variant="secondary">Action</Button>
+        </ToolbarItem>
+        <ToolbarItem hasAdditionalOptions>
+          <Dropdown
+            onSelect={this.onToolbarKebabDropdownSelect}
+            toggle={<KebabToggle onToggle={this.onToolbarKebabDropdownToggle} id="card-view-data-toolbar-dropdown" />}
+            isOpen={isLowerToolbarKebabDropdownOpen}
+            isPlain
+            dropdownItems={toolbarKebabDropdownItems}
+            isFlipEnabled
+            menuAppendTo="parent"
+          />
         </ToolbarItem>
       </React.Fragment>
     );
 
     const filtered =
       filters.products.length > 0
-        ? res.filter(card => {
-            return filters.products.length === 0 || filters.products.includes(card.name);
-          })
+        ? res.filter(card => filters.products.length === 0 || filters.products.includes(card.name))
         : res;
 
     const icons = {
@@ -1465,54 +1446,50 @@ class PrimaryDetailCardView extends React.Component {
     const drawerContent = (
       <Gallery hasGutter role="region" aria-label="Selectable card container">
         {filtered.map((product, key) => (
-          <React.Fragment>
-            <Card
-              isHoverable
-              key={product.name}
-              id={'card-view-' + key}
-              onKeyDown={this.onKeyDown}
-              onClick={this.onCardClick}
-              onSelectableInputChange={this.onChange}
-              isSelectableRaised
-              isSelected={activeCard === 'card-view-' + key}
-              hasSelectableInput
-            >
-              <CardHeader>
-                <img src={icons[product.icon]} alt={`${product.name} icon`} style={{ height: '50px' }} />
-                <CardActions>
-                  <Dropdown
-                    isPlain
-                    position="right"
-                    onSelect={e => this.onCardKebabDropdownSelect(key, e)}
-                    toggle={
-                      <KebabToggle
-                        onToggle={isCardKebabDropdownOpen =>
-                          this.onCardKebabDropdownToggle(key, isCardKebabDropdownOpen)
-                        }
-                      />
-                    }
-                    isOpen={this.state[key]}
-                    dropdownItems={[
-                      <DropdownItem key="trash" onClick={this.deleteItem(product)} position="right">
-                        <TrashIcon />
-                        Delete
-                      </DropdownItem>
-                    ]}
-                  />
-                  <Checkbox
-                    checked={isChecked}
-                    onChange={() => this.onCheckboxClick(product.id)}
-                    value={product.id}
-                    isChecked={selectedItems.includes(product.id)}
-                    aria-label="card checkbox example"
-                    id={`check-${product.id}`}
-                  />
-                </CardActions>
-              </CardHeader>
-              <CardTitle>{product.name}</CardTitle>
-              <CardBody>{product.description}</CardBody>
-            </Card>
-          </React.Fragment>
+          <Card
+            isHoverable
+            key={product.name}
+            id={'card-view-' + key}
+            onKeyDown={this.onKeyDown}
+            onClick={this.onCardClick}
+            onSelectableInputChange={this.onChange}
+            isSelectableRaised
+            isSelected={activeCard === 'card-view-' + key}
+            hasSelectableInput
+          >
+            <CardHeader>
+              <img src={icons[product.icon]} alt={`${product.name} icon`} style={{ height: '50px' }} />
+              <CardActions>
+                <Dropdown
+                  isPlain
+                  position="right"
+                  onSelect={e => this.onCardKebabDropdownSelect(key, e)}
+                  toggle={
+                    <KebabToggle
+                      onToggle={isCardKebabDropdownOpen => this.onCardKebabDropdownToggle(key, isCardKebabDropdownOpen)}
+                    />
+                  }
+                  isOpen={this.state[key]}
+                  dropdownItems={[
+                    <DropdownItem key="trash" onClick={this.deleteItem(product)} position="right">
+                      <TrashIcon />
+                      Delete
+                    </DropdownItem>
+                  ]}
+                />
+                <Checkbox
+                  checked={isChecked}
+                  onChange={() => this.onCheckboxClick(product.id)}
+                  value={product.id}
+                  isChecked={selectedItems.includes(product.id)}
+                  aria-label="card checkbox example"
+                  id={`check-${product.id}`}
+                />
+              </CardActions>
+            </CardHeader>
+            <CardTitle>{product.name}</CardTitle>
+            <CardBody>{product.description}</CardBody>
+          </Card>
         ))}
       </Gallery>
     );

--- a/packages/react-core/src/demos/PrimaryDetail.md
+++ b/packages/react-core/src/demos/PrimaryDetail.md
@@ -1101,38 +1101,26 @@ class PrimaryDetailCardView extends React.Component {
       });
     };
 
-    this.onKeyDown = event => {
-      if (event.target !== event.currentTarget || event.currentTarget.id === this.state.activeCard) {
-        return;
-      }
-      if ([13, 32].includes(event.keyCode)) {
-        event.preventDefault();
-        const newSelected = event.currentTarget.id;
-        this.setState({
-          activeCard: newSelected,
-          isDrawerExpanded: true
-        });
-      }
-    };
-
-    this.onCheckboxClick = productId => {
+    this.onCheckboxClick = (event, productId) => {
+      event.stopPropagation();
       this.setState(prevState =>
         prevState.selectedItems.includes(productId * 1) || this.state.selectedItems.includes(productId * 1)
           ? {
               selectedItems: [...this.state.selectedItems.filter(id => productId * 1 !== id)],
-              areAllSelected: this.checkAllSelected(prevState.selectedItems.length - 1, prevState.totalItemCount),
-              isDrawerExpanded: true
+              areAllSelected: this.checkAllSelected(prevState.selectedItems.length - 1, prevState.totalItemCount)
             }
           : {
               selectedItems: [...prevState.selectedItems, productId * 1],
-              areAllSelected: this.checkAllSelected(prevState.selectedItems.length + 1, prevState.totalItemCount),
-              isDrawerExpanded: true
+              areAllSelected: this.checkAllSelected(prevState.selectedItems.length + 1, prevState.totalItemCount)
             }
       );
     };
 
     this.onCardClick = event => {
       if (event.currentTarget.id === this.state.activeCard) {
+        this.setState({
+          isDrawerExpanded: !this.state.isDrawerExpanded
+        });
         return;
       }
 
@@ -1244,7 +1232,8 @@ class PrimaryDetailCardView extends React.Component {
       });
     };
 
-    this.onCardKebabDropdownToggle = (key, isCardKebabDropdownOpen) => {
+    this.onCardKebabDropdownToggle = (event, key, isCardKebabDropdownOpen) => {
+      event.stopPropagation();
       this.setState({
         [key]: isCardKebabDropdownOpen
       });
@@ -1262,8 +1251,30 @@ class PrimaryDetailCardView extends React.Component {
       this.setState({
         res: filteredCards,
         selectedItems: this.state.selectedItems.filter(filter(id => id)),
-        totalItemCount: this.state.totalItemCount - 1
+        totalItemCount: this.state.totalItemCount - 1,
+        isDrawerExpanded: false
       });
+    };
+
+    this.onKeyDown = event => {
+      if (event.target !== event.currentTarget) {
+        return;
+      }
+
+      if ([13, 32].includes(event.keyCode)) {
+        if (event.currentTarget.id === this.state.activeCard) {
+          this.setState({
+            isDrawerExpanded: !this.state.isDrawerExpanded
+          });
+          return;
+        }
+        event.preventDefault();
+        const newSelected = event.currentTarget.id;
+        this.setState({
+          activeCard: newSelected,
+          isDrawerExpanded: true
+        });
+      }
     };
   }
 
@@ -1462,7 +1473,9 @@ class PrimaryDetailCardView extends React.Component {
                   onSelect={e => this.onCardKebabDropdownSelect(key, e)}
                   toggle={
                     <KebabToggle
-                      onToggle={isCardKebabDropdownOpen => this.onCardKebabDropdownToggle(key, isCardKebabDropdownOpen)}
+                      onToggle={(isCardKebabDropdownOpen, event) =>
+                        this.onCardKebabDropdownToggle(event, key, isCardKebabDropdownOpen)
+                      }
                     />
                   }
                   isOpen={this.state[key]}
@@ -1475,7 +1488,7 @@ class PrimaryDetailCardView extends React.Component {
                 />
                 <Checkbox
                   checked={isChecked}
-                  onChange={() => this.onCheckboxClick(product.id)}
+                  onClick={event => this.onCheckboxClick(event, product.id)}
                   value={product.id}
                   isChecked={selectedItems.includes(product.id)}
                   aria-label="card checkbox example"

--- a/packages/react-core/src/demos/PrimaryDetail.md
+++ b/packages/react-core/src/demos/PrimaryDetail.md
@@ -1119,7 +1119,8 @@ class PrimaryDetailCardView extends React.Component {
     this.onCardClick = event => {
       if (event.currentTarget.id === this.state.activeCard) {
         this.setState({
-          isDrawerExpanded: !this.state.isDrawerExpanded
+          isDrawerExpanded: !this.state.isDrawerExpanded,
+          activeCard: null
         });
         return;
       }
@@ -1245,14 +1246,16 @@ class PrimaryDetailCardView extends React.Component {
       });
     };
 
-    this.deleteItem = item => _event => {
+    this.deleteItem = (event, item) => {
+      event.stopPropagation();
       const filter = getter => val => getter(val) !== item.id;
       const filteredCards = this.state.res.filter(filter(({ id }) => id));
       this.setState({
         res: filteredCards,
         selectedItems: this.state.selectedItems.filter(filter(id => id)),
         totalItemCount: this.state.totalItemCount - 1,
-        isDrawerExpanded: false
+        isDrawerExpanded: false,
+        activeCard: null
       });
     };
 
@@ -1264,7 +1267,8 @@ class PrimaryDetailCardView extends React.Component {
       if ([13, 32].includes(event.keyCode)) {
         if (event.currentTarget.id === this.state.activeCard) {
           this.setState({
-            isDrawerExpanded: !this.state.isDrawerExpanded
+            isDrawerExpanded: !this.state.isDrawerExpanded,
+            activeCard: null
           });
           return;
         }
@@ -1480,7 +1484,7 @@ class PrimaryDetailCardView extends React.Component {
                   }
                   isOpen={this.state[key]}
                   dropdownItems={[
-                    <DropdownItem key="trash" onClick={this.deleteItem(product)} position="right">
+                    <DropdownItem key="trash" onClick={e => this.deleteItem(e, product)} position="right">
                       <TrashIcon />
                       Delete
                     </DropdownItem>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7312 

Added some work here that applies towards #7657 - this demo now supports bulk select, and the ability to delete cards. 

However in order to fully align this demo with core, a lot of additional logic/functionality is required, which is out of scope of the original issue to use the new raised variant for the card. For that reason I opened #7657

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: #7657
