### PR TITLE
fix(charts): Style prop fix for ChartLegendTooltip

### DIFF
--- a/packages/react-charts/src/components/ChartCursorTooltip/ChartCursorTooltip.tsx
+++ b/packages/react-charts/src/components/ChartCursorTooltip/ChartCursorTooltip.tsx
@@ -9,7 +9,6 @@ import {
   VictoryStyleObject
 } from 'victory-core';
 import { VictoryTooltip } from 'victory-tooltip';
-import { ChartLabel } from '../ChartLabel';
 import { ChartThemeDefinition } from '../ChartTheme';
 import { ChartTooltip, ChartTooltipProps } from '../ChartTooltip';
 import { getTheme, getCursorTooltipCenterOffset, getCursorTooltipPoniterOrientation } from '../ChartUtils';
@@ -274,7 +273,6 @@ export interface ChartCursorTooltipProps extends ChartTooltipProps {
 export const ChartCursorTooltip: React.FunctionComponent<ChartCursorTooltipProps> = ({
   constrainToVisibleArea = true,
   flyoutComponent = <ChartCursorFlyout />,
-  labelComponent = <ChartLabel />,
   labelTextAnchor = 'start',
   showPointer = true,
   style,
@@ -314,7 +312,6 @@ export const ChartCursorTooltip: React.FunctionComponent<ChartCursorTooltipProps
       centerOffset={centerOffset}
       constrainToVisibleArea={constrainToVisibleArea}
       flyoutComponent={getFlyoutComponent()}
-      labelComponent={labelComponent}
       labelTextAnchor={labelTextAnchor}
       pointerOrientation={pointerOrientation}
       style={newStyle}

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
@@ -280,6 +280,8 @@ export interface ChartLegendTooltipProps extends ChartCursorTooltipProps {
    * The theme prop specifies a theme to use for determining styles and layout properties for a component. Any styles or
    * props defined in theme may be overwritten by props specified on the component instance.
    *
+   * Note: Theme may be overridden when flyout is rendered
+   *
    * @propType object
    */
   theme?: ChartThemeDefinition;
@@ -357,7 +359,9 @@ export const ChartLegendTooltip: React.FunctionComponent<ChartLegendTooltipProps
   const pointerLength = theme && theme.tooltip ? Helpers.evaluateProp(theme.tooltip.pointerLength) : 10;
   const legendTooltipProps = () => ({
     legendData: getLegendTooltipVisibleData({ activePoints, legendData, text, theme }),
-    legendProps: getLegendTooltipDataProps(labelComponent.props.legendComponent),
+    legendProps: getLegendTooltipDataProps(
+      labelComponent.props.legendComponent ? labelComponent.props.legendComponent.props : undefined
+    ),
     text: getLegendTooltipVisibleText({ activePoints, legendData, text }),
     theme
   });

--- a/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
+++ b/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
@@ -20,6 +20,8 @@ import {
   ChartLabel,
   ChartLegend,
   ChartLegendTooltip,
+  ChartLegendTooltipContent,
+  ChartLegendTooltipLabel,
   ChartLine,
   ChartPie,
   ChartPoint,
@@ -108,7 +110,7 @@ This demonstrates how to combine cursor and voronoi containers to display toolti
 
 ```js
 import React from 'react';
-import { Chart, ChartAxis, ChartGroup, ChartLine, ChartThemeColor, ChartTooltip, ChartVoronoiContainer, createContainer } from '@patternfly/react-charts';
+import { Chart, ChartAxis, ChartGroup, ChartLine, ChartThemeColor, createContainer } from '@patternfly/react-charts';
 
 class CombinedCursorVoronoiContainer extends React.Component {
   render() {
@@ -197,10 +199,7 @@ This demonstrates how to embed a legend within a tooltip. Combining cursor and v
 
 ```js
 import React from 'react';
-import { Chart, ChartAxis, ChartGroup, ChartLegendTooltip, ChartLine, ChartThemeColor, ChartVoronoiContainer, createContainer } from '@patternfly/react-charts';
-
-import chart_voronoi_labels_Fill from '@patternfly/react-tokens/dist/esm/chart_voronoi_labels_Fill';
-import global_FontWeight_bold from '@patternfly/react-tokens/dist/esm/global_FontWeight_bold';
+import { Chart, ChartAxis, ChartGroup, ChartLegendTooltip, ChartLine, ChartThemeColor, createContainer } from '@patternfly/react-charts';
 
 class EmbeddedLegend extends React.Component {
   render() {
@@ -294,7 +293,7 @@ This demonstrates how to embed HTML within a tooltip. Combining cursor and voron
 
 ```js
 import React from 'react';
-import { Chart, ChartArea, ChartAxis, ChartCursorFlyout, ChartCursorTooltip, ChartGroup, ChartPoint, ChartThemeColor, ChartVoronoiContainer } from '@patternfly/react-charts';
+import { Chart, ChartArea, ChartAxis, ChartCursorFlyout, ChartCursorTooltip, ChartGroup, ChartPoint, ChartThemeColor } from '@patternfly/react-charts';
 // import '@patternfly/patternfly/patternfly-charts.css'; // Required for mix-blend-mode CSS property
 
 class EmbeddedHtml extends React.Component {
@@ -411,6 +410,104 @@ class EmbeddedHtml extends React.Component {
                 { name: 'Birds', x: '2019', y: 4 }
               ]}
               interpolation="monotoneX"
+            />
+          </ChartGroup>
+        </Chart>
+      </div>
+    );
+  }
+}
+```
+
+### Embedded legend with custom font size
+
+This demonstrates how to embed a legend within a tooltip, but with a custom font size. Combining cursor and voronoi containers is required to display tooltips with a vertical cursor.
+
+```js
+import React from 'react';
+import { Chart, ChartAxis, ChartGroup, ChartLegendTooltip, ChartLegend, ChartLine, ChartLegendTooltipContent, ChartLegendTooltipLabel, ChartThemeColor, createContainer } from '@patternfly/react-charts';
+
+class EmbeddedLegendAlt extends React.Component {
+  render() {
+    // Note: Container order is important
+    const CursorVoronoiContainer = createContainer("voronoi", "cursor");
+    const legendData = [{ childName: 'cats', name: 'Cats' }, { childName: 'dogs', name: 'Dogs', symbol: { type: 'dash' }}, { childName: 'birds', name: 'Birds' }, { childName: 'mice', name: 'Mice' }];
+
+    const legend = <ChartLegend style={{ labels: { fontSize: 20 } }} />;
+    const legendTooltipLabel = <ChartLegendTooltipLabel style={{ fontSize: 20 }} />;
+    const legendTooltipContent = <ChartLegendTooltipContent legendComponent={legend} titleComponent={legendTooltipLabel} />;
+
+    return (
+      <div style={{ height: '275px', width: '450px' }}>
+        <Chart
+          ariaDesc="Average number of pets"
+          containerComponent={
+            <CursorVoronoiContainer
+              cursorDimension="x"
+              labels={({ datum }) => `${datum.y !== null ? datum.y : 'no data'}`}
+              labelComponent={<ChartLegendTooltip labelComponent={legendTooltipContent} legendData={legendData} title={(datum) => datum.x} />}
+              mouseFollowTooltips
+              voronoiDimension="x"
+              voronoiPadding={50}
+            />
+          }
+          legendData={legendData}
+          legendPosition="bottom"
+          height={275}
+          maxDomain={{y: 10}}
+          minDomain={{y: 0}}
+          padding={{
+            bottom: 75, // Adjusted to accommodate legend
+            left: 50,
+            right: 50,
+            top: 50
+          }}
+          themeColor={ChartThemeColor.gold}
+          width={450}
+        >
+          <ChartAxis tickValues={[2, 3, 4]} />
+          <ChartAxis dependentAxis showGrid tickValues={[2, 5, 8]} />
+          <ChartGroup>
+            <ChartLine
+              data={[
+                { name: 'Cats', x: '2015', y: 1 },
+                { name: 'Cats', x: '2016', y: 2 },
+                { name: 'Cats', x: '2017', y: 5 },
+                { name: 'Cats', x: '2018', y: 3 }
+              ]}
+              name="cats"
+            />
+            <ChartLine
+              data={[
+                { name: 'Dogs', x: '2015', y: 2 },
+                { name: 'Dogs', x: '2016', y: 1 },
+                { name: 'Dogs', x: '2017', y: 7 },
+                { name: 'Dogs', x: '2018', y: 4 }
+              ]}
+              name="dogs"
+              style={{
+                data: {
+                  strokeDasharray: '3,3'
+                }
+              }}
+            />
+            <ChartLine
+              data={[
+                { name: 'Birds', x: '2015', y: 3 },
+                { name: 'Birds', x: '2016', y: 4 },
+                { name: 'Birds', x: '2017', y: 9 },
+                { name: 'Birds', x: '2018', y: 5 }
+              ]}
+              name="birds"
+            />
+            <ChartLine
+              data={[
+                { name: 'Mice', x: '2015', y: 3 },
+                { name: 'Mice', x: '2016', y: null },
+                { name: 'Mice', x: '2017', y: 8 },
+                { name: 'Mice', x: '2018', y: 7 }
+              ]}
+              name="mice"
             />
           </ChartGroup>
         </Chart>

--- a/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
@@ -5,6 +5,8 @@ import { ChartLegendProps } from '../ChartLegend';
 import { ChartLegendTooltipStyles, ChartThemeDefinition } from '../ChartTheme';
 import { getLegendDimensions } from './chart-legend';
 
+import merge from 'lodash/merge';
+
 interface ChartCursorTooltipCenterOffsetInterface {
   offsetCursorDimensionX?: boolean; // Adjust the tooltip to appear to the right of the vertical cursor
   offsetCursorDimensionY?: boolean; // Adjust the tooltip to appear above the horizontal cursor
@@ -88,25 +90,28 @@ export const getCursorTooltipPoniterOrientation = ({
  * Returns props associated with legend data
  * @private
  */
-export const getLegendTooltipDataProps = (defaultProps: ChartLegendProps) => ({
-  borderPadding: 0,
-  gutter: 0,
-  orientation: 'vertical',
-  padding: 0,
-  rowGutter: 0,
-  style: {
-    labels: {
-      fill: ChartLegendTooltipStyles.label.fill,
-      lineHeight: 0.275,
-      padding: 0
+export const getLegendTooltipDataProps = (defaultProps: ChartLegendProps) =>
+  merge(
+    {
+      borderPadding: 0,
+      gutter: 0,
+      orientation: 'vertical',
+      padding: 0,
+      rowGutter: 0,
+      style: {
+        labels: {
+          fill: ChartLegendTooltipStyles.label.fill,
+          lineHeight: 0.275,
+          padding: 0
+        },
+        title: {
+          fill: ChartLegendTooltipStyles.label.fill,
+          padding: 0
+        }
+      }
     },
-    title: {
-      fill: ChartLegendTooltipStyles.label.fill,
-      padding: 0
-    }
-  },
-  ...defaultProps
-});
+    { ...defaultProps }
+  );
 
 /**
  * Returns the legend height and width


### PR DESCRIPTION
Ensures style props are applied (merged) properly to `ChartLegendTolltip` components. Also added an example showing how to override sub-component styles.

Example:
https://patternfly-react-pr-7666.surge.sh/charts/tooltips#embedded-legend-with-custom-font-size

Closes https://github.com/patternfly/patternfly-react/issues/7633