### PR TITLE
Update TypeScript dependencies

### DIFF
--- a/packages/react-catalog-view-extension/package.json
+++ b/packages/react-catalog-view-extension/package.json
@@ -44,7 +44,7 @@
     "sass": "^1.42.1",
     "shx": "^0.3.2",
     "tslib": "^2.0.0",
-    "typescript": "^4.0.0"
+    "typescript": "^4.7.4"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",

--- a/packages/react-charts/package.json
+++ b/packages/react-charts/package.json
@@ -63,6 +63,6 @@
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",
     "rimraf": "^2.6.2",
-    "typescript": "^4.0.0"
+    "typescript": "^4.7.4"
   }
 }

--- a/packages/react-code-editor/package.json
+++ b/packages/react-code-editor/package.json
@@ -44,6 +44,6 @@
   },
   "devDependencies": {
     "rimraf": "^2.6.2",
-    "typescript": "^4.0.0"
+    "typescript": "^4.7.4"
   }
 }

--- a/packages/react-console/package.json
+++ b/packages/react-console/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.6.2",
-    "typescript": "^4.0.0"
+    "typescript": "^4.7.4"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -54,7 +54,7 @@
     "rollup": "^2.58.0",
     "rollup-plugin-scss": "^3.0.0",
     "rollup-plugin-terser": "^7.0.0",
-    "typescript": "^4.0.0"
+    "typescript": "^4.7.4"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -37,7 +37,7 @@
     "glob": "^7.1.2",
     "rimraf": "^2.6.2",
     "tslib": "^2.0.0",
-    "typescript": "^4.0.0"
+    "typescript": "^4.7.4"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",

--- a/packages/react-inline-edit-extension/package.json
+++ b/packages/react-inline-edit-extension/package.json
@@ -42,6 +42,6 @@
   "devDependencies": {
     "rimraf": "^2.6.2",
     "tslib": "^2.0.0",
-    "typescript": "^4.0.0"
+    "typescript": "^4.7.4"
   }
 }

--- a/packages/react-integration/demo-app-ts/package.json
+++ b/packages/react-integration/demo-app-ts/package.json
@@ -26,7 +26,7 @@
     "html-webpack-plugin": "^4.4.1",
     "local-web-server": "^2.6.1",
     "mini-css-extract-plugin": "^0.11.1",
-    "ts-loader": "^8.0.4",
+    "ts-loader": "^8.3.0",
     "typescript": "^4.7.4",
     "url-loader": "^4.1.0",
     "webpack": "^4.43.0",

--- a/packages/react-integration/demo-app-ts/package.json
+++ b/packages/react-integration/demo-app-ts/package.json
@@ -27,7 +27,7 @@
     "local-web-server": "^2.6.1",
     "mini-css-extract-plugin": "^0.11.1",
     "ts-loader": "^8.0.4",
-    "typescript": "^4.0.0",
+    "typescript": "^4.7.4",
     "url-loader": "^4.1.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.12"

--- a/packages/react-integration/package.json
+++ b/packages/react-integration/package.json
@@ -35,7 +35,7 @@
     "monaco-editor-webpack-plugin": "^2.1.0",
     "react-monaco-editor": "^0.41.2",
     "ts-loader": "^8.0.17",
-    "typescript": "^4.0.0",
+    "typescript": "^4.7.4",
     "webpack": "^4.43.0"
   }
 }

--- a/packages/react-integration/package.json
+++ b/packages/react-integration/package.json
@@ -34,7 +34,7 @@
     "junit-merge": "^2.0.0",
     "monaco-editor-webpack-plugin": "^2.1.0",
     "react-monaco-editor": "^0.41.2",
-    "ts-loader": "^8.0.17",
+    "ts-loader": "^8.3.0",
     "typescript": "^4.7.4",
     "webpack": "^4.43.0"
   }

--- a/packages/react-log-viewer/package.json
+++ b/packages/react-log-viewer/package.json
@@ -41,6 +41,6 @@
   },
   "devDependencies": {
     "rimraf": "^2.6.2",
-    "typescript": "^4.0.0"
+    "typescript": "^4.7.4"
   }
 }

--- a/packages/react-styles/package.json
+++ b/packages/react-styles/package.json
@@ -26,7 +26,7 @@
     "glob": "^7.1.2",
     "jsdom": "^15.1.0",
     "rimraf": "^2.6.2",
-    "typescript": "^4.0.0"
+    "typescript": "^4.7.4"
   },
   "license": "MIT"
 }

--- a/packages/react-table/package.json
+++ b/packages/react-table/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.6.2",
-    "typescript": "^4.0.0"
+    "typescript": "^4.7.4"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",

--- a/packages/react-topology/package.json
+++ b/packages/react-topology/package.json
@@ -53,6 +53,6 @@
   },
   "devDependencies": {
     "rimraf": "^2.6.2",
-    "typescript": "^4.0.0"
+    "typescript": "^4.7.4"
   }
 }

--- a/packages/react-virtualized-extension/package.json
+++ b/packages/react-virtualized-extension/package.json
@@ -45,6 +45,6 @@
     "@types/dom-helpers": "^3.4.1",
     "@types/react-virtualized": "^9.21.5",
     "rimraf": "^2.6.2",
-    "typescript": "^4.0.0"
+    "typescript": "^4.7.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16772,6 +16772,11 @@ typescript@4.3.5, typescript@^4.0.0:
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz"
   integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
+typescript@^4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+
 typical@^2.6.0, typical@^2.6.1:
   version "2.6.1"
   resolved "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5854,7 +5854,7 @@ chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4.2:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
   dependencies:
@@ -7799,8 +7799,9 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
     once "^1.4.0"
 
 enhanced-resolve@^4.0.0:
-  version "4.1.1"
-  resolved "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz"
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz#2f3cfd84dbe3b487f18f2db2ef1e064a571ca5ec"
+  integrity sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==
   dependencies:
     graceful-fs "^4.1.2"
     memory-fs "^0.5.0"
@@ -11674,7 +11675,7 @@ loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz"
 
-loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
+loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz"
   dependencies:
@@ -16644,26 +16645,16 @@ tryer@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz"
 
-ts-loader@^8.0.17:
-  version "8.0.17"
-  resolved "https://registry.npmjs.org/ts-loader/-/ts-loader-8.0.17.tgz"
-  integrity sha512-OeVfSshx6ot/TCxRwpBHQ/4lRzfgyTkvi7ghDVrLXOHzTbSK413ROgu/xNqM72i3AFeAIJgQy78FwSMKmOW68w==
+ts-loader@^8.3.0:
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-8.4.0.tgz#e845ea0f38d140bdc3d7d60293ca18d12ff2720f"
+  integrity sha512-6nFY3IZ2//mrPc+ImY3hNWx1vCHyEhl6V+wLmL4CZcm6g1CqX7UKrkc6y0i4FwcfOhxyMPCfaEvh20f4r9GNpw==
   dependencies:
     chalk "^4.1.0"
     enhanced-resolve "^4.0.0"
     loader-utils "^2.0.0"
     micromatch "^4.0.0"
     semver "^7.3.4"
-
-ts-loader@^8.0.4:
-  version "8.0.4"
-  resolved "https://registry.npmjs.org/ts-loader/-/ts-loader-8.0.4.tgz"
-  dependencies:
-    chalk "^2.3.0"
-    enhanced-resolve "^4.0.0"
-    loader-utils "^1.0.2"
-    micromatch "^4.0.0"
-    semver "^6.0.0"
 
 ts-patch@^1.4.2:
   version "1.4.2"


### PR DESCRIPTION
In order to update Victory chart packages for https://github.com/patternfly/patternfly-react/issues/7614, PatternFly must first update TypeScript from 4.3.5 to 4.7.4.

Closes https://github.com/patternfly/patternfly-react/issues/7662
