### PR TITLE
fix(LogViewer): render correctly when there is '\n' in the string array

### DIFF
--- a/packages/react-log-viewer/src/LogViewer/LogViewer.tsx
+++ b/packages/react-log-viewer/src/LogViewer/LogViewer.tsx
@@ -143,7 +143,7 @@ const LogViewerBase: React.FunctionComponent<LogViewerProps> = memo(
 
     /* Parse data every time it changes */
     useEffect(() => {
-      setParsedData(Array.isArray(data) ? data : parseConsoleOutput(data));
+      setParsedData(parseConsoleOutput(data));
     }, [data]);
 
     useEffect(() => {

--- a/packages/react-log-viewer/src/LogViewer/utils/utils.tsx
+++ b/packages/react-log-viewer/src/LogViewer/utils/utils.tsx
@@ -38,9 +38,10 @@ export const searchForKeyword = (searchedInput: string, parsedData: string[], it
   }
 };
 
-export const parseConsoleOutput = (data: string) => {
+export const parseConsoleOutput = (data: string[] | string) => {
   const stringToSplitWith = '\n';
-  const stringSplitting = data.toString();
+  const parsedData = Array.isArray(data) ? data.join(stringToSplitWith) : data;
+  const stringSplitting = parsedData.toString();
   const cleanString = stringSplitting.split(stringToSplitWith);
 
   return cleanString;


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7673 
The log viewer only processed the string data before and split them if there are `\n` in it. Now it also checks the string array data and splits them if needed.
