### PR TITLE
chore(Charts): clean up a11y violations in docs

### DIFF
--- a/packages/react-charts/src/components/ChartAxis/ChartAxis.test.tsx
+++ b/packages/react-charts/src/components/ChartAxis/ChartAxis.test.tsx
@@ -7,7 +7,7 @@ import { ChartLine } from '../ChartLine';
 
 Object.values([true, false]).forEach(() => {
   test('ChartAxis', () => {
-    const { asFragment } = render(<ChartAxis />);
+    const { asFragment } = render(<ChartAxis axisLabelId="test" />);
     expect(asFragment()).toMatchSnapshot();
   });
 });
@@ -49,8 +49,8 @@ test('renders component data', () => {
           ]}
         />
       </ChartGroup>
-      <ChartAxis tickValues={[2, 3, 4]} />
-      <ChartAxis dependentAxis tickValues={[2, 5, 8]} />
+      <ChartAxis tickValues={[2, 3, 4]} axisLabelId="test" />
+      <ChartAxis dependentAxis tickValues={[2, 5, 8]} axisLabelId="test2" />
     </Chart>
   );
   expect(asFragment()).toMatchSnapshot();

--- a/packages/react-charts/src/components/ChartAxis/ChartAxis.test.tsx
+++ b/packages/react-charts/src/components/ChartAxis/ChartAxis.test.tsx
@@ -4,10 +4,11 @@ import { Chart } from '../Chart';
 import { ChartAxis } from './ChartAxis';
 import { ChartGroup } from '../ChartGroup';
 import { ChartLine } from '../ChartLine';
+import { ChartLabel } from '../ChartLabel';
 
 Object.values([true, false]).forEach(() => {
   test('ChartAxis', () => {
-    const { asFragment } = render(<ChartAxis axisLabelId="test" />);
+    const { asFragment } = render(<ChartAxis tickLabelComponent={<ChartLabel id="test" />} />);
     expect(asFragment()).toMatchSnapshot();
   });
 });
@@ -49,8 +50,8 @@ test('renders component data', () => {
           ]}
         />
       </ChartGroup>
-      <ChartAxis tickValues={[2, 3, 4]} axisLabelId="test" />
-      <ChartAxis dependentAxis tickValues={[2, 5, 8]} axisLabelId="test2" />
+      <ChartAxis tickValues={[2, 3, 4]} tickLabelComponent={<ChartLabel id="test" />} />
+      <ChartAxis dependentAxis tickValues={[2, 5, 8]} tickLabelComponent={<ChartLabel id="test2" />} />
     </Chart>
   );
   expect(asFragment()).toMatchSnapshot();

--- a/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
+++ b/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
@@ -12,15 +12,14 @@ import {
   RangePropType,
   ScalePropType,
   StringOrNumberOrList,
-  LabelProps,
-  VictoryLabel,
-  StringOrNumberOrCallback
+  LabelProps
 } from 'victory-core';
 import { VictoryAxis, VictoryAxisProps, VictoryAxisTTargetType } from 'victory-axis';
 import { ChartContainer } from '../ChartContainer';
 import { ChartThemeDefinition } from '../ChartTheme';
 import { getAxisTheme, getTheme } from '../ChartUtils';
 import { getUniqueId } from '@patternfly/react-core';
+import { ChartLabel } from '../ChartLabel';
 
 /**
  * ChartAxis renders a single axis which can be used on its own or composed with Chart.
@@ -56,10 +55,6 @@ export interface ChartAxisProps extends VictoryAxisProps {
    * ChartLabel will be created with props described above
    */
   axisLabelComponent?: React.ReactElement<any>;
-  /**
-   * The id prop specifies a HTML ID that will be applied to the rendered text element in the label axis.
-   */
-  axisLabelId?: StringOrNumberOrCallback;
   /**
    * The axisValue prop may be used instead of axisAngle to position the dependent axis. Ths prop is useful when
    * dependent axes should line up with values on the independent axis.
@@ -454,11 +449,10 @@ export interface ChartAxisProps extends VictoryAxisProps {
 export const ChartAxis: React.FunctionComponent<ChartAxisProps> = ({
   containerComponent = <ChartContainer />,
   showGrid = false,
-  axisLabelId = () => getUniqueId('chart-axis-tickLabels'),
   themeColor,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   themeVariant,
-
+  tickLabelComponent = <ChartLabel />,
   // destructure last
   theme = getTheme(themeColor),
   ...rest
@@ -469,12 +463,18 @@ export const ChartAxis: React.FunctionComponent<ChartAxisProps> = ({
     ...containerComponent.props
   });
 
+  const getTickLabelComponent = () =>
+    React.cloneElement(tickLabelComponent, {
+      id: () => getUniqueId('chart-axis-tickLabels'),
+      ...tickLabelComponent.props
+    });
+
   // Note: containerComponent is required for theme
   return (
     <VictoryAxis
       containerComponent={container}
       theme={showGrid ? getAxisTheme(themeColor) : theme}
-      tickLabelComponent={<VictoryLabel id={axisLabelId} />}
+      tickLabelComponent={getTickLabelComponent()}
       {...rest}
     />
   );

--- a/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
+++ b/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
@@ -12,12 +12,14 @@ import {
   RangePropType,
   ScalePropType,
   StringOrNumberOrList,
-  LabelProps
+  LabelProps,
+  VictoryLabel
 } from 'victory-core';
 import { VictoryAxis, VictoryAxisProps, VictoryAxisTTargetType } from 'victory-axis';
 import { ChartContainer } from '../ChartContainer';
 import { ChartThemeDefinition } from '../ChartTheme';
 import { getAxisTheme, getTheme } from '../ChartUtils';
+import { getUniqueId } from '@patternfly/react-core';
 
 /**
  * ChartAxis renders a single axis which can be used on its own or composed with Chart.
@@ -462,7 +464,14 @@ export const ChartAxis: React.FunctionComponent<ChartAxisProps> = ({
   });
 
   // Note: containerComponent is required for theme
-  return <VictoryAxis containerComponent={container} theme={showGrid ? getAxisTheme(themeColor) : theme} {...rest} />;
+  return (
+    <VictoryAxis
+      containerComponent={container}
+      theme={showGrid ? getAxisTheme(themeColor) : theme}
+      tickLabelComponent={<VictoryLabel id={() => getUniqueId('chart-axis-tickLabels')} />}
+      {...rest}
+    />
+  );
 };
 ChartAxis.displayName = 'ChartAxis';
 

--- a/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
+++ b/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
@@ -57,6 +57,10 @@ export interface ChartAxisProps extends VictoryAxisProps {
    */
   axisLabelComponent?: React.ReactElement<any>;
   /**
+   * The id prop specifies a HTML ID that will be applied to the rendered text element in the label axis.
+   */
+  axisLabelId?: StringOrNumberOrCallback;
+  /**
    * The axisValue prop may be used instead of axisAngle to position the dependent axis. Ths prop is useful when
    * dependent axes should line up with values on the independent axis.
    */
@@ -188,7 +192,6 @@ export interface ChartAxisProps extends VictoryAxisProps {
    * pixels will depend on the size of the container the chart is rendered into.
    */
   height?: number;
-  axisLabelId?: StringOrNumberOrCallback;
   /**
    * If true, this value will flip the domain of a given axis.
    */

--- a/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
+++ b/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
@@ -13,7 +13,8 @@ import {
   ScalePropType,
   StringOrNumberOrList,
   LabelProps,
-  VictoryLabel
+  VictoryLabel,
+  StringOrNumberOrCallback
 } from 'victory-core';
 import { VictoryAxis, VictoryAxisProps, VictoryAxisTTargetType } from 'victory-axis';
 import { ChartContainer } from '../ChartContainer';
@@ -187,6 +188,7 @@ export interface ChartAxisProps extends VictoryAxisProps {
    * pixels will depend on the size of the container the chart is rendered into.
    */
   height?: number;
+  axisLabelId?: StringOrNumberOrCallback;
   /**
    * If true, this value will flip the domain of a given axis.
    */
@@ -449,6 +451,7 @@ export interface ChartAxisProps extends VictoryAxisProps {
 export const ChartAxis: React.FunctionComponent<ChartAxisProps> = ({
   containerComponent = <ChartContainer />,
   showGrid = false,
+  axisLabelId = () => getUniqueId('chart-axis-tickLabels'),
   themeColor,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   themeVariant,
@@ -468,7 +471,7 @@ export const ChartAxis: React.FunctionComponent<ChartAxisProps> = ({
     <VictoryAxis
       containerComponent={container}
       theme={showGrid ? getAxisTheme(themeColor) : theme}
-      tickLabelComponent={<VictoryLabel id={() => getUniqueId('chart-axis-tickLabels')} />}
+      tickLabelComponent={<VictoryLabel id={axisLabelId} />}
       {...rest}
     />
   );

--- a/packages/react-charts/src/components/ChartAxis/__snapshots__/ChartAxis.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartAxis/__snapshots__/ChartAxis.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`ChartAxis 1`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+            style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
             text-anchor="middle"
             x="50"
           >
@@ -77,7 +77,7 @@ exports[`ChartAxis 1`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+            style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
             text-anchor="middle"
             x="120"
           >
@@ -108,7 +108,7 @@ exports[`ChartAxis 1`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+            style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
             text-anchor="middle"
             x="190"
           >
@@ -139,7 +139,7 @@ exports[`ChartAxis 1`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+            style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
             text-anchor="middle"
             x="260"
           >
@@ -170,7 +170,7 @@ exports[`ChartAxis 1`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+            style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
             text-anchor="middle"
             x="330"
           >
@@ -201,7 +201,7 @@ exports[`ChartAxis 1`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+            style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
             text-anchor="middle"
             x="400"
           >
@@ -270,7 +270,7 @@ exports[`ChartAxis 2`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+            style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
             text-anchor="middle"
             x="50"
           >
@@ -301,7 +301,7 @@ exports[`ChartAxis 2`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+            style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
             text-anchor="middle"
             x="120"
           >
@@ -332,7 +332,7 @@ exports[`ChartAxis 2`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+            style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
             text-anchor="middle"
             x="190"
           >
@@ -363,7 +363,7 @@ exports[`ChartAxis 2`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+            style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
             text-anchor="middle"
             x="260"
           >
@@ -394,7 +394,7 @@ exports[`ChartAxis 2`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+            style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
             text-anchor="middle"
             x="330"
           >
@@ -425,7 +425,7 @@ exports[`ChartAxis 2`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+            style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
             text-anchor="middle"
             x="400"
           >
@@ -595,7 +595,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
               text-anchor="middle"
               x="128.33333333333331"
             >
@@ -626,7 +626,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
               text-anchor="middle"
               x="176.66666666666666"
             >
@@ -657,7 +657,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
               text-anchor="middle"
               x="224.99999999999997"
             >
@@ -702,7 +702,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: end;"
               text-anchor="end"
               x="35"
             >
@@ -733,7 +733,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: end;"
               text-anchor="end"
               x="35"
             >
@@ -764,7 +764,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: end;"
               text-anchor="end"
               x="35"
             >

--- a/packages/react-charts/src/components/ChartAxis/__snapshots__/ChartAxis.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartAxis/__snapshots__/ChartAxis.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`ChartAxis 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="chart-axis-tickLabels-16575673051903j45w87qdl7"
+          id="test"
           x="50"
           y="276.97"
         >
@@ -70,7 +70,7 @@ exports[`ChartAxis 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="chart-axis-tickLabels-16575673051982gnohpxjjws"
+          id="test"
           x="120"
           y="276.97"
         >
@@ -101,7 +101,7 @@ exports[`ChartAxis 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="chart-axis-tickLabels-1657567305201avi34hn6335"
+          id="test"
           x="190"
           y="276.97"
         >
@@ -132,7 +132,7 @@ exports[`ChartAxis 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="chart-axis-tickLabels-16575673052719gxhz0cra5g"
+          id="test"
           x="260"
           y="276.97"
         >
@@ -163,7 +163,7 @@ exports[`ChartAxis 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="chart-axis-tickLabels-1657567305276nzlbnz6m21"
+          id="test"
           x="330"
           y="276.97"
         >
@@ -194,7 +194,7 @@ exports[`ChartAxis 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="chart-axis-tickLabels-1657567305279z0s74w17vxi"
+          id="test"
           x="400"
           y="276.97"
         >
@@ -263,7 +263,7 @@ exports[`ChartAxis 2`] = `
         <text
           direction="inherit"
           dx="0"
-          id="chart-axis-tickLabels-16575673054261gv7qwv0avk"
+          id="test"
           x="50"
           y="276.97"
         >
@@ -294,7 +294,7 @@ exports[`ChartAxis 2`] = `
         <text
           direction="inherit"
           dx="0"
-          id="chart-axis-tickLabels-16575673054301rq6jva18xn"
+          id="test"
           x="120"
           y="276.97"
         >
@@ -325,7 +325,7 @@ exports[`ChartAxis 2`] = `
         <text
           direction="inherit"
           dx="0"
-          id="chart-axis-tickLabels-16575673054794r0d78iezqi"
+          id="test"
           x="190"
           y="276.97"
         >
@@ -356,7 +356,7 @@ exports[`ChartAxis 2`] = `
         <text
           direction="inherit"
           dx="0"
-          id="chart-axis-tickLabels-1657567305481vhpnyx1val"
+          id="test"
           x="260"
           y="276.97"
         >
@@ -387,7 +387,7 @@ exports[`ChartAxis 2`] = `
         <text
           direction="inherit"
           dx="0"
-          id="chart-axis-tickLabels-1657567305484ph2xs6mlel"
+          id="test"
           x="330"
           y="276.97"
         >
@@ -418,7 +418,7 @@ exports[`ChartAxis 2`] = `
         <text
           direction="inherit"
           dx="0"
-          id="chart-axis-tickLabels-1657567305486ybarlg6hw7o"
+          id="test"
           x="400"
           y="276.97"
         >
@@ -588,7 +588,7 @@ exports[`renders component data 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-tickLabels-1657567305644ehf4lt7zpsn"
+            id="test"
             x="128.33333333333331"
             y="176.97"
           >
@@ -619,7 +619,7 @@ exports[`renders component data 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-tickLabels-16575673056463etifr2tfxl"
+            id="test"
             x="176.66666666666666"
             y="176.97"
           >
@@ -650,7 +650,7 @@ exports[`renders component data 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-tickLabels-1657567305647sg4squwxb9r"
+            id="test"
             x="224.99999999999997"
             y="176.97"
           >
@@ -695,7 +695,7 @@ exports[`renders component data 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-tickLabels-16575673056788kyyf2a25k8"
+            id="test2"
             x="35"
             y="142.47"
           >
@@ -726,7 +726,7 @@ exports[`renders component data 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-tickLabels-1657567305682xqdyxahqndj"
+            id="test2"
             x="35"
             y="104.97"
           >
@@ -757,7 +757,7 @@ exports[`renders component data 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-tickLabels-1657567305698qq1eq3l4by"
+            id="test2"
             x="35"
             y="67.47"
           >

--- a/packages/react-charts/src/components/ChartAxis/__snapshots__/ChartAxis.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartAxis/__snapshots__/ChartAxis.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`ChartAxis 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="axis-tickLabels-0"
+          id="chart-axis-tickLabels-16575673051903j45w87qdl7"
           x="50"
           y="276.97"
         >
@@ -70,7 +70,7 @@ exports[`ChartAxis 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="axis-tickLabels-1"
+          id="chart-axis-tickLabels-16575673051982gnohpxjjws"
           x="120"
           y="276.97"
         >
@@ -101,7 +101,7 @@ exports[`ChartAxis 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="axis-tickLabels-2"
+          id="chart-axis-tickLabels-1657567305201avi34hn6335"
           x="190"
           y="276.97"
         >
@@ -132,7 +132,7 @@ exports[`ChartAxis 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="axis-tickLabels-3"
+          id="chart-axis-tickLabels-16575673052719gxhz0cra5g"
           x="260"
           y="276.97"
         >
@@ -163,7 +163,7 @@ exports[`ChartAxis 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="axis-tickLabels-4"
+          id="chart-axis-tickLabels-1657567305276nzlbnz6m21"
           x="330"
           y="276.97"
         >
@@ -194,7 +194,7 @@ exports[`ChartAxis 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="axis-tickLabels-5"
+          id="chart-axis-tickLabels-1657567305279z0s74w17vxi"
           x="400"
           y="276.97"
         >
@@ -263,7 +263,7 @@ exports[`ChartAxis 2`] = `
         <text
           direction="inherit"
           dx="0"
-          id="axis-tickLabels-0"
+          id="chart-axis-tickLabels-16575673054261gv7qwv0avk"
           x="50"
           y="276.97"
         >
@@ -294,7 +294,7 @@ exports[`ChartAxis 2`] = `
         <text
           direction="inherit"
           dx="0"
-          id="axis-tickLabels-1"
+          id="chart-axis-tickLabels-16575673054301rq6jva18xn"
           x="120"
           y="276.97"
         >
@@ -325,7 +325,7 @@ exports[`ChartAxis 2`] = `
         <text
           direction="inherit"
           dx="0"
-          id="axis-tickLabels-2"
+          id="chart-axis-tickLabels-16575673054794r0d78iezqi"
           x="190"
           y="276.97"
         >
@@ -356,7 +356,7 @@ exports[`ChartAxis 2`] = `
         <text
           direction="inherit"
           dx="0"
-          id="axis-tickLabels-3"
+          id="chart-axis-tickLabels-1657567305481vhpnyx1val"
           x="260"
           y="276.97"
         >
@@ -387,7 +387,7 @@ exports[`ChartAxis 2`] = `
         <text
           direction="inherit"
           dx="0"
-          id="axis-tickLabels-4"
+          id="chart-axis-tickLabels-1657567305484ph2xs6mlel"
           x="330"
           y="276.97"
         >
@@ -418,7 +418,7 @@ exports[`ChartAxis 2`] = `
         <text
           direction="inherit"
           dx="0"
-          id="axis-tickLabels-5"
+          id="chart-axis-tickLabels-1657567305486ybarlg6hw7o"
           x="400"
           y="276.97"
         >
@@ -588,7 +588,7 @@ exports[`renders component data 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-1-tickLabels-0"
+            id="chart-axis-tickLabels-1657567305644ehf4lt7zpsn"
             x="128.33333333333331"
             y="176.97"
           >
@@ -619,7 +619,7 @@ exports[`renders component data 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-1-tickLabels-1"
+            id="chart-axis-tickLabels-16575673056463etifr2tfxl"
             x="176.66666666666666"
             y="176.97"
           >
@@ -650,7 +650,7 @@ exports[`renders component data 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-1-tickLabels-2"
+            id="chart-axis-tickLabels-1657567305647sg4squwxb9r"
             x="224.99999999999997"
             y="176.97"
           >
@@ -695,7 +695,7 @@ exports[`renders component data 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-2-tickLabels-0"
+            id="chart-axis-tickLabels-16575673056788kyyf2a25k8"
             x="35"
             y="142.47"
           >
@@ -726,7 +726,7 @@ exports[`renders component data 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-2-tickLabels-1"
+            id="chart-axis-tickLabels-1657567305682xqdyxahqndj"
             x="35"
             y="104.97"
           >
@@ -757,7 +757,7 @@ exports[`renders component data 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-2-tickLabels-2"
+            id="chart-axis-tickLabels-1657567305698qq1eq3l4by"
             x="35"
             y="67.47"
           >

--- a/packages/react-charts/src/components/ChartBullet/ChartBullet.test.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBullet.test.tsx
@@ -2,10 +2,13 @@ import * as React from 'react';
 import { render } from '@testing-library/react';
 import { ChartBullet } from './ChartBullet';
 import { ChartAxis } from '../ChartAxis';
+import { ChartLabel } from '../ChartLabel';
 
 Object.values([true, false]).forEach(() => {
   test('ChartBulletQualitativeRange', () => {
-    const { asFragment } = render(<ChartBullet axisComponent={<ChartAxis axisLabelId="test" />} />);
+    const { asFragment } = render(
+      <ChartBullet axisComponent={<ChartAxis tickLabelComponent={<ChartLabel id="test" />} />} />
+    );
     expect(asFragment()).toMatchSnapshot();
   });
 });
@@ -24,7 +27,7 @@ test('renders component data', () => {
         { name: 'Range', y: 75 }
       ]}
       width={450}
-      axisComponent={<ChartAxis axisLabelId="test2" />}
+      axisComponent={<ChartAxis tickLabelComponent={<ChartLabel id="test2" />} />}
     />
   );
   expect(asFragment()).toMatchSnapshot();

--- a/packages/react-charts/src/components/ChartBullet/ChartBullet.test.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBullet.test.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
 import { ChartBullet } from './ChartBullet';
+import { ChartAxis } from '../ChartAxis';
 
 Object.values([true, false]).forEach(() => {
   test('ChartBulletQualitativeRange', () => {
-    const { asFragment } = render(<ChartBullet />);
+    const { asFragment } = render(<ChartBullet axisComponent={<ChartAxis axisLabelId="test" />} />);
     expect(asFragment()).toMatchSnapshot();
   });
 });
@@ -23,6 +24,7 @@ test('renders component data', () => {
         { name: 'Range', y: 75 }
       ]}
       width={450}
+      axisComponent={<ChartAxis axisLabelId="test2" />}
     />
   );
   expect(asFragment()).toMatchSnapshot();

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletGroupTitle.test.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletGroupTitle.test.tsx
@@ -1,15 +1,18 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
 import { ChartBulletGroupTitle } from './ChartBulletGroupTitle';
+import { ChartLabel } from '../ChartLabel';
 
 Object.values([true, false]).forEach(() => {
   test('ChartBulletGroupTitle', () => {
-    const { asFragment } = render(<ChartBulletGroupTitle />);
+    const { asFragment } = render(<ChartBulletGroupTitle titleComponent={<ChartLabel id="test" />} />);
     expect(asFragment()).toMatchSnapshot();
   });
 });
 
 test('renders component data', () => {
-  const { asFragment } = render(<ChartBulletGroupTitle title="Text label" subTitle="Measure details" />);
+  const { asFragment } = render(
+    <ChartBulletGroupTitle title="Text label" subTitle="Measure details" titleComponent={<ChartLabel id="test2" />} />
+  );
   expect(asFragment()).toMatchSnapshot();
 });

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletTitle.test.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletTitle.test.tsx
@@ -1,15 +1,18 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
 import { ChartBulletTitle } from './ChartBulletTitle';
+import { ChartLabel } from '../ChartLabel';
 
 Object.values([true, false]).forEach(() => {
   test('ChartBulletTitle', () => {
-    const { asFragment } = render(<ChartBulletTitle />);
+    const { asFragment } = render(<ChartBulletTitle titleComponent={<ChartLabel id="test" />} />);
     expect(asFragment()).toMatchSnapshot();
   });
 });
 
 test('renders component data', () => {
-  const { asFragment } = render(<ChartBulletTitle title="Text label" subTitle="Measure details" />);
+  const { asFragment } = render(
+    <ChartBulletTitle title="Text label" subTitle="Measure details" titleComponent={<ChartLabel id="test2" />} />
+  );
   expect(asFragment()).toMatchSnapshot();
 });

--- a/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBullet.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBullet.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`ChartBulletQualitativeRange 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="axis-tickLabels-0"
+            id="chart-axis-tickLabels-1657567306911uma9gzqs55k"
             x="50"
             y="111.97"
           >
@@ -127,7 +127,7 @@ exports[`ChartBulletQualitativeRange 2`] = `
           <text
             direction="inherit"
             dx="0"
-            id="axis-tickLabels-0"
+            id="chart-axis-tickLabels-1657567307055mqe7gz74p7n"
             x="50"
             y="111.97"
           >
@@ -224,7 +224,7 @@ exports[`renders component data 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="axis-tickLabels-0"
+            id="chart-axis-tickLabels-1657567307148esbje5181ic"
             x="50"
             y="111.97"
           >
@@ -255,7 +255,7 @@ exports[`renders component data 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="axis-tickLabels-1"
+            id="chart-axis-tickLabels-16575673071958goejmsq9bg"
             x="400"
             y="111.97"
           >
@@ -286,7 +286,7 @@ exports[`renders component data 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="axis-tickLabels-2"
+            id="chart-axis-tickLabels-1657567307198xtavp03vtco"
             x="137.5"
             y="111.97"
           >
@@ -317,7 +317,7 @@ exports[`renders component data 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="axis-tickLabels-3"
+            id="chart-axis-tickLabels-1657567307232sp9i5gebswj"
             x="225"
             y="111.97"
           >
@@ -348,7 +348,7 @@ exports[`renders component data 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="axis-tickLabels-4"
+            id="chart-axis-tickLabels-1657567307234oc5j7natgpg"
             x="312.5"
             y="111.97"
           >

--- a/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBullet.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBullet.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`ChartBulletQualitativeRange 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
               text-anchor="middle"
               x="50"
             >
@@ -134,7 +134,7 @@ exports[`ChartBulletQualitativeRange 2`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
               text-anchor="middle"
               x="50"
             >
@@ -231,7 +231,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
               text-anchor="middle"
               x="50"
             >
@@ -262,7 +262,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
               text-anchor="middle"
               x="400"
             >
@@ -293,7 +293,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
               text-anchor="middle"
               x="137.5"
             >
@@ -324,7 +324,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
               text-anchor="middle"
               x="225"
             >
@@ -355,7 +355,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
               text-anchor="middle"
               x="312.5"
             >

--- a/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBullet.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBullet.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`ChartBulletQualitativeRange 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-tickLabels-1657567306911uma9gzqs55k"
+            id="test"
             x="50"
             y="111.97"
           >
@@ -127,7 +127,7 @@ exports[`ChartBulletQualitativeRange 2`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-tickLabels-1657567307055mqe7gz74p7n"
+            id="test"
             x="50"
             y="111.97"
           >
@@ -224,7 +224,7 @@ exports[`renders component data 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-tickLabels-1657567307148esbje5181ic"
+            id="test2"
             x="50"
             y="111.97"
           >
@@ -255,7 +255,7 @@ exports[`renders component data 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-tickLabels-16575673071958goejmsq9bg"
+            id="test2"
             x="400"
             y="111.97"
           >
@@ -286,7 +286,7 @@ exports[`renders component data 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-tickLabels-1657567307198xtavp03vtco"
+            id="test2"
             x="137.5"
             y="111.97"
           >
@@ -317,7 +317,7 @@ exports[`renders component data 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-tickLabels-1657567307232sp9i5gebswj"
+            id="test2"
             x="225"
             y="111.97"
           >
@@ -348,7 +348,7 @@ exports[`renders component data 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-tickLabels-1657567307234oc5j7natgpg"
+            id="test2"
             x="312.5"
             y="111.97"
           >

--- a/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletGroupTitle.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletGroupTitle.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`renders component data 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="chart-legend-label-1657567310592ssa8n4bme1e"
+        id="test2"
         x="225"
         y="48.675000000000004"
       >

--- a/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletGroupTitle.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletGroupTitle.test.tsx.snap
@@ -70,6 +70,7 @@ exports[`renders component data 1`] = `
       <text
         direction="inherit"
         dx="0"
+        id="chart-legend-label-1657567310592ssa8n4bme1e"
         x="225"
         y="48.675000000000004"
       >

--- a/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletTitle.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletTitle.test.tsx.snap
@@ -70,6 +70,7 @@ exports[`renders component data 1`] = `
       <text
         direction="inherit"
         dx="0"
+        id="chart-legend-label-1657567310144iexp622xu3q"
         x="36"
         y="70.1"
       >

--- a/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletTitle.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletTitle.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`renders component data 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="chart-legend-label-1657567310144iexp622xu3q"
+        id="test2"
         x="36"
         y="70.1"
       >

--- a/packages/react-charts/src/components/ChartBullet/examples/ChartBullet.md
+++ b/packages/react-charts/src/components/ChartBullet/examples/ChartBullet.md
@@ -509,8 +509,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
 
 <div style={{ height: '500px', width: '600px' }}>
   <ChartContainer 
-      ariaDesc="Storage capacity"
-      ariaTitle="Bullet chart example"
+      title="Bullet chart example"
       height={500}
       width={600}
     >
@@ -604,8 +603,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
 
 <div style={{ height: '600px', width: '500px' }}>
   <ChartContainer 
-      ariaDesc="Storage capacity"
-      ariaTitle="Bullet chart example"
+      title="Bullet chart example"
       height={600}
       width={500}
     >
@@ -703,8 +701,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
 
 <div style={{ height: '600px', width: '600px' }}>
   <ChartContainer 
-      ariaDesc="Storage capacity"
-      ariaTitle="Bullet chart example"
+      title="Bullet chart example"
       height={600}
       width={600}
     >
@@ -800,8 +797,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
 
 <div style={{ height: '600px', width: '500px' }}>
   <ChartContainer 
-      ariaDesc="Storage capacity"
-      ariaTitle="Bullet chart example"
+      title="Bullet chart example"
       height={600}
       width={500}
     >

--- a/packages/react-charts/src/components/ChartContainer/ChartContainer.test.tsx
+++ b/packages/react-charts/src/components/ChartContainer/ChartContainer.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { render } from '@testing-library/react';
 import { ChartContainer } from './ChartContainer';
 import { ChartLegend } from '../ChartLegend';
+import { ChartLabel } from '../ChartLabel';
 
 Object.values([true, false]).forEach(() => {
   test('ChartContainer', () => {
@@ -19,6 +20,7 @@ test('renders container via ChartLegend', () => {
         standalone={false}
         title="Average number of pets"
         width={200}
+        labelComponent={<ChartLabel id="test" />}
       />
     </ChartContainer>
   );

--- a/packages/react-charts/src/components/ChartContainer/__snapshots__/ChartContainer.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartContainer/__snapshots__/ChartContainer.test.tsx.snap
@@ -108,7 +108,7 @@ exports[`renders container via ChartLegend 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="legend-labels-0"
+          id="test"
           x="30.8"
           y="39.875"
         >
@@ -125,7 +125,7 @@ exports[`renders container via ChartLegend 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="legend-labels-1"
+          id="test"
           x="99.58125"
           y="39.875"
         >

--- a/packages/react-charts/src/components/ChartContainer/__snapshots__/ChartContainer.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartContainer/__snapshots__/ChartContainer.test.tsx.snap
@@ -91,7 +91,7 @@ exports[`renders container via ChartLegend 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="chart-legend-label-16575673098257x0ymdesatx"
+          id="legend-title-all"
           x="2"
           y="13.969999999999999"
         >
@@ -108,7 +108,7 @@ exports[`renders container via ChartLegend 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="chart-legend-label-1657567309827vyreni56m2p"
+          id="legend-labels-0"
           x="30.8"
           y="39.875"
         >
@@ -125,7 +125,7 @@ exports[`renders container via ChartLegend 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="chart-legend-label-165756730982835uk6d0zrd3"
+          id="legend-labels-1"
           x="99.58125"
           y="39.875"
         >

--- a/packages/react-charts/src/components/ChartContainer/__snapshots__/ChartContainer.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartContainer/__snapshots__/ChartContainer.test.tsx.snap
@@ -91,7 +91,7 @@ exports[`renders container via ChartLegend 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="legend-title-all"
+          id="chart-legend-label-16575673098257x0ymdesatx"
           x="2"
           y="13.969999999999999"
         >
@@ -108,7 +108,7 @@ exports[`renders container via ChartLegend 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="legend-labels-0"
+          id="chart-legend-label-1657567309827vyreni56m2p"
           x="30.8"
           y="39.875"
         >
@@ -125,7 +125,7 @@ exports[`renders container via ChartLegend 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="legend-labels-1"
+          id="chart-legend-label-165756730982835uk6d0zrd3"
           x="99.58125"
           y="39.875"
         >

--- a/packages/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
+++ b/packages/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
@@ -749,7 +749,7 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
 </div>
 ```
 
-### Small with right aligned subtitle
+### Small with thresholds and right aligned subtitle
 ```js
 import React from 'react';
 import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts';

--- a/packages/react-charts/src/components/ChartLabel/ChartLabel.test.tsx
+++ b/packages/react-charts/src/components/ChartLabel/ChartLabel.test.tsx
@@ -4,12 +4,12 @@ import { ChartLabel } from './ChartLabel';
 
 Object.values([true, false]).forEach(() => {
   test('ChartLabel', () => {
-    const { asFragment } = render(<ChartLabel />);
+    const { asFragment } = render(<ChartLabel id="test" />);
     expect(asFragment()).toMatchSnapshot();
   });
 });
 
 test('renders component text', () => {
-  const { asFragment } = render(<ChartLabel text="This is a test" />);
+  const { asFragment } = render(<ChartLabel text="This is a test" id="test2" />);
   expect(asFragment()).toMatchSnapshot();
 });

--- a/packages/react-charts/src/components/ChartLabel/ChartLabel.tsx
+++ b/packages/react-charts/src/components/ChartLabel/ChartLabel.tsx
@@ -103,6 +103,7 @@ export interface ChartLabelProps extends VictoryLabelProps {
    * Event handlers are currently only called with their corresponding events.
    */
   events?: React.DOMAttributes<any>;
+  id?: StringOrNumberOrCallback;
   /**
    * The index prop represents the index of the datum in the data array.
    *
@@ -224,6 +225,7 @@ export interface ChartLabelProps extends VictoryLabelProps {
 export const ChartLabel: React.FunctionComponent<ChartLabelProps> = ({
   style,
   textAnchor,
+  id = () => getUniqueId('chart-legend-label'),
   ...rest
 }: ChartLabelProps) => {
   const applyDefaultStyle = (customStyle: React.CSSProperties) =>
@@ -241,14 +243,7 @@ export const ChartLabel: React.FunctionComponent<ChartLabelProps> = ({
     );
   const newStyle = Array.isArray(style) ? style.map(applyDefaultStyle) : applyDefaultStyle(style);
 
-  return (
-    <VictoryLabel
-      style={newStyle as any}
-      textAnchor={textAnchor}
-      {...rest}
-      id={() => getUniqueId('chart-legend-label')}
-    />
-  );
+  return <VictoryLabel style={newStyle as any} textAnchor={textAnchor} {...rest} id={id} />;
 };
 ChartLabel.displayName = 'ChartLabel';
 

--- a/packages/react-charts/src/components/ChartLabel/ChartLabel.tsx
+++ b/packages/react-charts/src/components/ChartLabel/ChartLabel.tsx
@@ -11,6 +11,7 @@ import {
   VictoryLabelProps
 } from 'victory-core';
 import { ChartCommonStyles } from '../ChartTheme';
+import { getUniqueId } from '@patternfly/react-core';
 
 export enum ChartLabelDirection {
   rtl = 'rtl',
@@ -240,7 +241,14 @@ export const ChartLabel: React.FunctionComponent<ChartLabelProps> = ({
     );
   const newStyle = Array.isArray(style) ? style.map(applyDefaultStyle) : applyDefaultStyle(style);
 
-  return <VictoryLabel style={newStyle as any} textAnchor={textAnchor} {...rest} />;
+  return (
+    <VictoryLabel
+      style={newStyle as any}
+      textAnchor={textAnchor}
+      {...rest}
+      id={() => getUniqueId('chart-legend-label')}
+    />
+  );
 };
 ChartLabel.displayName = 'ChartLabel';
 

--- a/packages/react-charts/src/components/ChartLabel/ChartLabel.tsx
+++ b/packages/react-charts/src/components/ChartLabel/ChartLabel.tsx
@@ -103,6 +103,9 @@ export interface ChartLabelProps extends VictoryLabelProps {
    * Event handlers are currently only called with their corresponding events.
    */
   events?: React.DOMAttributes<any>;
+  /**
+   * The id prop specifies a HTML ID that will be applied to the rendered text element.
+   */
   id?: StringOrNumberOrCallback;
   /**
    * The index prop represents the index of the datum in the data array.

--- a/packages/react-charts/src/components/ChartLabel/__snapshots__/ChartLabel.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartLabel/__snapshots__/ChartLabel.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`renders component text 1`] = `
   <text
     direction="inherit"
     dx="0"
+    id="chart-legend-label-1657567310361f99ojtbci5m"
     x="0"
     y="4.97"
   >

--- a/packages/react-charts/src/components/ChartLabel/__snapshots__/ChartLabel.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartLabel/__snapshots__/ChartLabel.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`renders component text 1`] = `
   <text
     direction="inherit"
     dx="0"
-    id="chart-legend-label-1657567310361f99ojtbci5m"
+    id="test2"
     x="0"
     y="4.97"
   >

--- a/packages/react-charts/src/components/ChartLegend/ChartLegend.test.tsx
+++ b/packages/react-charts/src/components/ChartLegend/ChartLegend.test.tsx
@@ -1,17 +1,24 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
 import { ChartLegend } from './ChartLegend';
+import { ChartLabel } from '../ChartLabel';
 
 Object.values([true, false]).forEach(() => {
   test('ChartLegend', () => {
-    const { asFragment } = render(<ChartLegend />);
+    const { asFragment } = render(<ChartLegend titleComponent={<ChartLabel id="test" />} />);
     expect(asFragment()).toMatchSnapshot();
   });
 });
 
 test('renders component data', () => {
   const { asFragment } = render(
-    <ChartLegend data={[{ name: 'Cats' }, { name: 'Dogs' }]} title="Average number of pets" height={50} width={200} />
+    <ChartLegend
+      data={[{ name: 'Cats' }, { name: 'Dogs' }]}
+      title="Average number of pets"
+      height={50}
+      width={200}
+      titleComponent={<ChartLabel id="test2" />}
+    />
   );
   expect(asFragment()).toMatchSnapshot();
 });

--- a/packages/react-charts/src/components/ChartLegend/ChartLegend.test.tsx
+++ b/packages/react-charts/src/components/ChartLegend/ChartLegend.test.tsx
@@ -5,7 +5,9 @@ import { ChartLabel } from '../ChartLabel';
 
 Object.values([true, false]).forEach(() => {
   test('ChartLegend', () => {
-    const { asFragment } = render(<ChartLegend titleComponent={<ChartLabel id="test" />} />);
+    const { asFragment } = render(
+      <ChartLegend titleComponent={<ChartLabel id="test" />} labelComponent={<ChartLabel id="test2" />} />
+    );
     expect(asFragment()).toMatchSnapshot();
   });
 });
@@ -17,7 +19,8 @@ test('renders component data', () => {
       title="Average number of pets"
       height={50}
       width={200}
-      titleComponent={<ChartLabel id="test2" />}
+      titleComponent={<ChartLabel id="test3" />}
+      labelComponent={<ChartLabel id="test4" />}
     />
   );
   expect(asFragment()).toMatchSnapshot();

--- a/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
+++ b/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
@@ -22,6 +22,7 @@ import { ChartLabel } from '../ChartLabel';
 import { ChartPoint } from '../ChartPoint';
 import { ChartThemeDefinition } from '../ChartTheme';
 import { getTheme } from '../ChartUtils';
+import { getUniqueId } from '@patternfly/react-core';
 
 export enum ChartLegendOrientation {
   horizontal = 'horizontal',
@@ -367,16 +368,28 @@ export const ChartLegend: React.FunctionComponent<ChartLegendProps> = ({
     ...containerComponent.props
   });
 
+  const getLabelComponent = () =>
+    React.cloneElement(labelComponent, {
+      id: () => getUniqueId('chart-legendLabels'),
+      ...labelComponent.props
+    });
+
+  const getTitleComponent = () =>
+    React.cloneElement(titleComponent, {
+      id: () => getUniqueId('chart-titleLabels'),
+      ...titleComponent.props
+    });
+
   // Note: containerComponent is required for theme
   return (
     <VictoryLegend
       colorScale={colorScale}
       containerComponent={container}
       dataComponent={dataComponent}
-      labelComponent={labelComponent}
+      labelComponent={getLabelComponent()}
       style={getDefaultStyle()}
       theme={theme}
-      titleComponent={titleComponent}
+      titleComponent={getTitleComponent()}
       {...rest}
     />
   );

--- a/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
+++ b/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
@@ -388,6 +388,7 @@ hoistNonReactStatics(ChartLegend, VictoryLegend, { getBaseProps: true });
 
 (ChartLegend as any).getBaseProps = (props: any) => {
   const theme = getTheme(null);
+
   return (VictoryLegend as any).getBaseProps(
     {
       titleComponent: <ChartLabel />, // Workaround for getBaseProps error

--- a/packages/react-charts/src/components/ChartLegend/__snapshots__/ChartLegend.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartLegend/__snapshots__/ChartLegend.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`ChartLegend 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="legend-labels-0"
+        id="test2"
         x="30.8"
         y="18.97"
       >
@@ -63,7 +63,7 @@ exports[`ChartLegend 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="legend-labels-1"
+        id="test2"
         x="116.73125"
         y="18.97"
       >
@@ -138,7 +138,7 @@ exports[`ChartLegend 2`] = `
       <text
         direction="inherit"
         dx="0"
-        id="legend-labels-0"
+        id="test2"
         x="30.8"
         y="18.97"
       >
@@ -155,7 +155,7 @@ exports[`ChartLegend 2`] = `
       <text
         direction="inherit"
         dx="0"
-        id="legend-labels-1"
+        id="test2"
         x="116.73125"
         y="18.97"
       >
@@ -247,7 +247,7 @@ exports[`renders component data 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="legend-labels-0"
+        id="test4"
         x="30.8"
         y="39.875"
       >
@@ -264,7 +264,7 @@ exports[`renders component data 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="legend-labels-1"
+        id="test4"
         x="99.58125"
         y="39.875"
       >

--- a/packages/react-charts/src/components/ChartLegend/__snapshots__/ChartLegend.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartLegend/__snapshots__/ChartLegend.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`ChartLegend 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="legend-labels-0"
+        id="chart-legend-label-1657567309890d7iuqtesav"
         x="30.8"
         y="18.97"
       >
@@ -63,7 +63,7 @@ exports[`ChartLegend 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="legend-labels-1"
+        id="chart-legend-label-16575673099094k094tpvoha"
         x="116.73125"
         y="18.97"
       >
@@ -138,7 +138,7 @@ exports[`ChartLegend 2`] = `
       <text
         direction="inherit"
         dx="0"
-        id="legend-labels-0"
+        id="chart-legend-label-1657567309934ybuvzv535di"
         x="30.8"
         y="18.97"
       >
@@ -155,7 +155,7 @@ exports[`ChartLegend 2`] = `
       <text
         direction="inherit"
         dx="0"
-        id="legend-labels-1"
+        id="chart-legend-label-16575673099357khwoyuenlg"
         x="116.73125"
         y="18.97"
       >
@@ -230,7 +230,7 @@ exports[`renders component data 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="legend-title-all"
+        id="chart-legend-label-1657567309959lfgv5b36ns"
         x="2"
         y="13.969999999999999"
       >
@@ -247,7 +247,7 @@ exports[`renders component data 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="legend-labels-0"
+        id="chart-legend-label-1657567309960640j3usc6lp"
         x="30.8"
         y="39.875"
       >
@@ -264,7 +264,7 @@ exports[`renders component data 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="legend-labels-1"
+        id="chart-legend-label-1657567309962qwmphg5q16a"
         x="99.58125"
         y="39.875"
       >

--- a/packages/react-charts/src/components/ChartLegend/__snapshots__/ChartLegend.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartLegend/__snapshots__/ChartLegend.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`ChartLegend 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="chart-legend-label-1657567309890d7iuqtesav"
+        id="legend-labels-0"
         x="30.8"
         y="18.97"
       >
@@ -63,7 +63,7 @@ exports[`ChartLegend 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="chart-legend-label-16575673099094k094tpvoha"
+        id="legend-labels-1"
         x="116.73125"
         y="18.97"
       >
@@ -138,7 +138,7 @@ exports[`ChartLegend 2`] = `
       <text
         direction="inherit"
         dx="0"
-        id="chart-legend-label-1657567309934ybuvzv535di"
+        id="legend-labels-0"
         x="30.8"
         y="18.97"
       >
@@ -155,7 +155,7 @@ exports[`ChartLegend 2`] = `
       <text
         direction="inherit"
         dx="0"
-        id="chart-legend-label-16575673099357khwoyuenlg"
+        id="legend-labels-1"
         x="116.73125"
         y="18.97"
       >
@@ -230,7 +230,7 @@ exports[`renders component data 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="chart-legend-label-1657567309959lfgv5b36ns"
+        id="legend-title-all"
         x="2"
         y="13.969999999999999"
       >
@@ -247,7 +247,7 @@ exports[`renders component data 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="chart-legend-label-1657567309960640j3usc6lp"
+        id="legend-labels-0"
         x="30.8"
         y="39.875"
       >
@@ -264,7 +264,7 @@ exports[`renders component data 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="chart-legend-label-1657567309962qwmphg5q16a"
+        id="legend-labels-1"
         x="99.58125"
         y="39.875"
       >

--- a/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
+++ b/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
@@ -680,7 +680,7 @@ class LegendLinkPieChart extends React.Component {
         <Chart
           ariaDesc="Average number of pets"
           ariaTitle="Line chart example"
-          containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
+          containerComponent={<ChartVoronoiContainer role="figure" labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
           legendComponent={this.getLegend([
             { name: 'Cats' }, 
             { name: 'Dogs' }, 

--- a/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
+++ b/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
@@ -660,7 +660,7 @@ class LegendLinkPieChart extends React.Component {
 
     // Custom legend label compoenent
     this.LegendLabel = ({datum, ...rest}) => (
-      <a href="#" aria-label="Learn more about...">
+      <a href="#" aria-label={`Learn more about ${rest.text}`}>
         <ChartLabel {...rest} />
       </a>
     );
@@ -676,11 +676,11 @@ class LegendLinkPieChart extends React.Component {
 
   render() {
     return (
-      <div style={{ height: '275px', width: '450px' }}>
+      <div aria-describedby="withLinks-desc" aria-labelledby="withLinks-title" style={{ height: '275px', width: '450px' }}>
         <Chart
-          ariaDesc="Average number of pets"
+          ariaDesc="Average number of pets per year"
           ariaTitle="Line chart example"
-          containerComponent={<ChartVoronoiContainer role="figure" labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
+          containerComponent={<ChartVoronoiContainer containerId="withLinks" role="figure" labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
           legendComponent={this.getLegend([
             { name: 'Cats' }, 
             { name: 'Dogs' }, 
@@ -700,8 +700,8 @@ class LegendLinkPieChart extends React.Component {
           }}
           width={450}
         >
-          <ChartAxis tickValues={[2, 3, 4]} />
-          <ChartAxis dependentAxis showGrid tickValues={[2, 5, 8]} />
+          <ChartAxis tickValues={[2, 3, 4]} tickLabelComponent={<ChartLabel ariaLabel="X axis - the year polled" />} />
+          <ChartAxis dependentAxis showGrid tickValues={[2, 5, 8]} tickLabelComponent={<ChartLabel ariaLabel="Y axis - average number of pets" />} />
           <ChartGroup>
             <ChartLine
               data={[

--- a/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
+++ b/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
@@ -652,7 +652,7 @@ This demonstrates an approach for applying links to a legend using a custom labe
 
 ```js
 import React from 'react';
-import { Chart, ChartAxis, ChartContainer, ChartGroup, ChartLabel, ChartLegend, ChartLine } from '@patternfly/react-charts';
+import { Chart, ChartAxis, ChartGroup, ChartLabel, ChartLegend, ChartLine, ChartVoronoiContainer } from '@patternfly/react-charts';
 
 class LegendLinkPieChart extends React.Component {
   constructor(props) {
@@ -680,7 +680,7 @@ class LegendLinkPieChart extends React.Component {
         <Chart
           ariaDesc="Average number of pets"
           ariaTitle="Line chart example"
-          containerComponent={<ChartContainer role="group" labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
+          containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
           legendComponent={this.getLegend([
             { name: 'Cats' }, 
             { name: 'Dogs' }, 

--- a/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
+++ b/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
@@ -676,7 +676,7 @@ class LegendLinkPieChart extends React.Component {
 
   render() {
     return (
-      <div aria-describedby="withLinks-desc" aria-labelledby="withLinks-title" style={{ height: '275px', width: '450px' }}>
+      <div role="article" aria-describedby="withLinks-desc" aria-labelledby="withLinks-title" style={{ height: '275px', width: '450px' }}>
         <Chart
           ariaDesc="Average number of pets per year"
           ariaTitle="Line chart example"

--- a/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
+++ b/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
@@ -26,6 +26,7 @@ import {
   ChartAxis,
   ChartBar,
   ChartBullet,
+  ChartContainer,
   ChartDonut,
   ChartGroup,
   ChartLabel,
@@ -651,8 +652,7 @@ This demonstrates an approach for applying links to a legend using a custom labe
 
 ```js
 import React from 'react';
-import { Chart, ChartAxis, ChartGroup, ChartLabel, ChartLegend, ChartLine, ChartVoronoiContainer } from '@patternfly/react-charts';
-import { Tooltip } from '@patternfly/react-core';
+import { Chart, ChartAxis, ChartContainer, ChartGroup, ChartLabel, ChartLegend, ChartLine } from '@patternfly/react-charts';
 
 class LegendLinkPieChart extends React.Component {
   constructor(props) {
@@ -680,7 +680,7 @@ class LegendLinkPieChart extends React.Component {
         <Chart
           ariaDesc="Average number of pets"
           ariaTitle="Line chart example"
-          containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
+          containerComponent={<ChartContainer role="group" labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
           legendComponent={this.getLegend([
             { name: 'Cats' }, 
             { name: 'Dogs' }, 

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.test.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.test.tsx
@@ -52,8 +52,8 @@ test('allows tooltip via container component', () => {
       themeColor={ChartThemeColor.green}
       width={450}
     >
-      <ChartAxis tickValues={[2, 3, 4]} />
-      <ChartAxis dependentAxis showGrid tickValues={[2, 5, 8]} />
+      <ChartAxis tickValues={[2, 3, 4]} axisLabelId="test" />
+      <ChartAxis dependentAxis showGrid tickValues={[2, 5, 8]} axisLabelId="test2" />
       <ChartGroup>
         <ChartLine
           data={[

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.test.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.test.tsx
@@ -8,6 +8,7 @@ import { ChartThemeColor } from '../ChartTheme';
 import { createContainer } from '../ChartUtils';
 import { ChartLegendTooltip } from './ChartLegendTooltip';
 import { ChartLabel } from '../ChartLabel';
+import { ChartLegend } from '../ChartLegend';
 
 Object.values([true, false]).forEach(() => {
   test('ChartLegendTooltip', () => {
@@ -41,6 +42,7 @@ test('allows tooltip via container component', () => {
       }
       legendData={legendData}
       legendPosition="bottom"
+      legendComponent={<ChartLegend labelComponent={<ChartLabel id="test" />} />}
       height={275}
       maxDomain={{ y: 10 }}
       minDomain={{ y: 0 }}

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.test.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.test.tsx
@@ -7,6 +7,7 @@ import { ChartLine } from '../ChartLine';
 import { ChartThemeColor } from '../ChartTheme';
 import { createContainer } from '../ChartUtils';
 import { ChartLegendTooltip } from './ChartLegendTooltip';
+import { ChartLabel } from '../ChartLabel';
 
 Object.values([true, false]).forEach(() => {
   test('ChartLegendTooltip', () => {
@@ -52,8 +53,8 @@ test('allows tooltip via container component', () => {
       themeColor={ChartThemeColor.green}
       width={450}
     >
-      <ChartAxis tickValues={[2, 3, 4]} axisLabelId="test" />
-      <ChartAxis dependentAxis showGrid tickValues={[2, 5, 8]} axisLabelId="test2" />
+      <ChartAxis tickValues={[2, 3, 4]} tickLabelComponent={<ChartLabel id="test" />} />
+      <ChartAxis dependentAxis showGrid tickValues={[2, 5, 8]} tickLabelComponent={<ChartLabel id="test2" />} />
       <ChartGroup>
         <ChartLine
           data={[

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipLabel.test.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipLabel.test.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
 import { ChartLegendTooltipLabel } from './ChartLegendTooltipLabel';
+import { ChartLabel } from '../ChartLabel';
 
 Object.values([true, false]).forEach(() => {
   test('ChartLegendTooltipLabel', () => {
-    const { asFragment } = render(<ChartLegendTooltipLabel />);
+    const { asFragment } = render(<ChartLegendTooltipLabel legendLabelComponent={<ChartLabel id="test" />} />);
     expect(asFragment()).toMatchSnapshot();
   });
 });
@@ -16,6 +17,12 @@ test('renders component text', () => {
     { name: 'Birds' },
     { name: 'Mice' }
   ];
-  const { asFragment } = render(<ChartLegendTooltipLabel legendData={legendData} text={['1, 2, 3, 4']} />);
+  const { asFragment } = render(
+    <ChartLegendTooltipLabel
+      legendData={legendData}
+      text={['1, 2, 3, 4']}
+      legendLabelComponent={<ChartLabel id="test2" />}
+    />
+  );
   expect(asFragment()).toMatchSnapshot();
 });

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipLabel.test.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipLabel.test.tsx
@@ -22,7 +22,7 @@ test('renders component text', () => {
       legendData={legendData}
       text={['1, 2, 3, 4']}
       legendLabelComponent={<ChartLabel id="test2" />}
-      valueLabelId="test3"
+      valueLabelComponent={<ChartLabel id="test3" />}
     />
   );
   expect(asFragment()).toMatchSnapshot();

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipLabel.test.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipLabel.test.tsx
@@ -22,6 +22,7 @@ test('renders component text', () => {
       legendData={legendData}
       text={['1, 2, 3, 4']}
       legendLabelComponent={<ChartLabel id="test2" />}
+      valueLabelId="test3"
     />
   );
   expect(asFragment()).toMatchSnapshot();

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipLabel.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipLabel.tsx
@@ -202,6 +202,10 @@ export interface ChartLegendLabelProps extends VictoryLabelProps {
    */
   transform?: string | {} | (() => string | {});
   /**
+   * The id prop specifies a HTML ID that will be applied to the rendered text element of the value label.
+   */
+  valueLabelId?: StringOrNumberOrCallback;
+  /**
    * The verticalAnchor prop defines how the text is vertically positioned relative to the given `x` and `y`
    * coordinates. Options are "start", "middle" and "end".
    *
@@ -236,6 +240,7 @@ export const ChartLegendTooltipLabel: React.FunctionComponent<ChartLegendLabelPr
   style,
   text,
   textAnchor = 'end',
+  valueLabelId,
   x,
   y,
 
@@ -269,7 +274,17 @@ export const ChartLegendTooltipLabel: React.FunctionComponent<ChartLegendLabelPr
 
   const getValueLabelComponent = () => {
     const _x = x + Helpers.evaluateProp(dx);
-    return <ChartLabel style={getStyle(style)} text={text} textAnchor={textAnchor} x={_x} y={y} {...rest} />;
+    return (
+      <ChartLabel
+        style={getStyle(style)}
+        text={text}
+        textAnchor={textAnchor}
+        x={_x}
+        y={y}
+        {...rest}
+        {...(valueLabelId && { id: valueLabelId })}
+      />
+    );
   };
 
   const legendLabel = getLegendLabelComponent();

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipLabel.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipLabel.tsx
@@ -131,7 +131,7 @@ export interface ChartLegendLabelProps extends VictoryLabelProps {
     };
   }[];
   /**
-   * The valueLabelComponent prop takes a component instance which will be used to render each legend tooltip.
+   * The legendLabelComponent prop takes a component instance which will be used to render each legend tooltip.
    */
   legendLabelComponent?: React.ReactElement<any>;
   /**
@@ -202,9 +202,9 @@ export interface ChartLegendLabelProps extends VictoryLabelProps {
    */
   transform?: string | {} | (() => string | {});
   /**
-   * The id prop specifies a HTML ID that will be applied to the rendered text element of the value label.
+   * The valueLabelComponent prop takes a component instance which will be used to render each legend tooltip.
    */
-  valueLabelId?: StringOrNumberOrCallback;
+  valueLabelComponent?: React.ReactElement<any>;
   /**
    * The verticalAnchor prop defines how the text is vertically positioned relative to the given `x` and `y`
    * coordinates. Options are "start", "middle" and "end".
@@ -240,7 +240,7 @@ export const ChartLegendTooltipLabel: React.FunctionComponent<ChartLegendLabelPr
   style,
   text,
   textAnchor = 'end',
-  valueLabelId,
+  valueLabelComponent = <ChartLabel />,
   x,
   y,
 
@@ -274,17 +274,15 @@ export const ChartLegendTooltipLabel: React.FunctionComponent<ChartLegendLabelPr
 
   const getValueLabelComponent = () => {
     const _x = x + Helpers.evaluateProp(dx);
-    return (
-      <ChartLabel
-        style={getStyle(style)}
-        text={text}
-        textAnchor={textAnchor}
-        x={_x}
-        y={y}
-        {...rest}
-        {...(valueLabelId && { id: valueLabelId })}
-      />
-    );
+
+    return React.cloneElement(valueLabelComponent, {
+      style: getStyle(style),
+      text,
+      textAnchor,
+      x: _x,
+      y,
+      ...rest
+    });
   };
 
   const legendLabel = getLegendLabelComponent();

--- a/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltip.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltip.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`allows tooltip via container component 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-tickLabels-1657567306070m9r7pzvwt0f"
+            id="test"
             x="50"
             y="226.97"
           >
@@ -83,7 +83,7 @@ exports[`allows tooltip via container component 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-tickLabels-1657567306076obuy4si2898"
+            id="test"
             x="166.66666666666666"
             y="226.97"
           >
@@ -114,7 +114,7 @@ exports[`allows tooltip via container component 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-tickLabels-16575673062002am4dxzmzes"
+            id="test"
             x="283.3333333333333"
             y="226.97"
           >
@@ -145,7 +145,7 @@ exports[`allows tooltip via container component 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-tickLabels-1657567306206z361gmqrqlo"
+            id="test"
             x="400"
             y="226.97"
           >
@@ -200,7 +200,7 @@ exports[`allows tooltip via container component 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-tickLabels-165756730625143we6i6yt2n"
+            id="test2"
             x="35"
             y="174.97"
           >
@@ -241,7 +241,7 @@ exports[`allows tooltip via container component 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-tickLabels-1657567306263wpnymx69q3j"
+            id="test2"
             x="35"
             y="129.97"
           >
@@ -282,7 +282,7 @@ exports[`allows tooltip via container component 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-tickLabels-1657567306266azuarce1ish"
+            id="test2"
             x="35"
             y="84.97"
           >
@@ -460,7 +460,7 @@ exports[`allows tooltip via container component 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="chart-legend-label-1657567306361l1kt0h3pk"
+          id="chart-legend-3-labels-0"
           x="114.8"
           y="250.97"
         >
@@ -477,7 +477,7 @@ exports[`allows tooltip via container component 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="chart-legend-label-1657567306362dy176i6bfrt"
+          id="chart-legend-3-labels-1"
           x="183.58125"
           y="250.97"
         >
@@ -494,7 +494,7 @@ exports[`allows tooltip via container component 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="chart-legend-label-1657567306363ermq83yudpv"
+          id="chart-legend-3-labels-2"
           x="256.015625"
           y="250.97"
         >
@@ -511,7 +511,7 @@ exports[`allows tooltip via container component 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="chart-legend-label-1657567306364h8r0983n20t"
+          id="chart-legend-3-labels-3"
           x="327.57500000000005"
           y="250.97"
         >

--- a/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltip.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltip.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`allows tooltip via container component 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-0-tickLabels-0"
+            id="chart-axis-tickLabels-1657567306070m9r7pzvwt0f"
             x="50"
             y="226.97"
           >
@@ -83,7 +83,7 @@ exports[`allows tooltip via container component 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-0-tickLabels-1"
+            id="chart-axis-tickLabels-1657567306076obuy4si2898"
             x="166.66666666666666"
             y="226.97"
           >
@@ -114,7 +114,7 @@ exports[`allows tooltip via container component 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-0-tickLabels-2"
+            id="chart-axis-tickLabels-16575673062002am4dxzmzes"
             x="283.3333333333333"
             y="226.97"
           >
@@ -145,7 +145,7 @@ exports[`allows tooltip via container component 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-0-tickLabels-3"
+            id="chart-axis-tickLabels-1657567306206z361gmqrqlo"
             x="400"
             y="226.97"
           >
@@ -200,7 +200,7 @@ exports[`allows tooltip via container component 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-1-tickLabels-0"
+            id="chart-axis-tickLabels-165756730625143we6i6yt2n"
             x="35"
             y="174.97"
           >
@@ -241,7 +241,7 @@ exports[`allows tooltip via container component 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-1-tickLabels-1"
+            id="chart-axis-tickLabels-1657567306263wpnymx69q3j"
             x="35"
             y="129.97"
           >
@@ -282,7 +282,7 @@ exports[`allows tooltip via container component 1`] = `
           <text
             direction="inherit"
             dx="0"
-            id="chart-axis-1-tickLabels-2"
+            id="chart-axis-tickLabels-1657567306266azuarce1ish"
             x="35"
             y="84.97"
           >
@@ -460,7 +460,7 @@ exports[`allows tooltip via container component 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="chart-legend-3-labels-0"
+          id="chart-legend-label-1657567306361l1kt0h3pk"
           x="114.8"
           y="250.97"
         >
@@ -477,7 +477,7 @@ exports[`allows tooltip via container component 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="chart-legend-3-labels-1"
+          id="chart-legend-label-1657567306362dy176i6bfrt"
           x="183.58125"
           y="250.97"
         >
@@ -494,7 +494,7 @@ exports[`allows tooltip via container component 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="chart-legend-3-labels-2"
+          id="chart-legend-label-1657567306363ermq83yudpv"
           x="256.015625"
           y="250.97"
         >
@@ -511,7 +511,7 @@ exports[`allows tooltip via container component 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="chart-legend-3-labels-3"
+          id="chart-legend-label-1657567306364h8r0983n20t"
           x="327.57500000000005"
           y="250.97"
         >

--- a/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltip.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltip.test.tsx.snap
@@ -460,7 +460,7 @@ exports[`allows tooltip via container component 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="chart-legend-3-labels-0"
+          id="test"
           x="114.8"
           y="250.97"
         >
@@ -477,7 +477,7 @@ exports[`allows tooltip via container component 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="chart-legend-3-labels-1"
+          id="test"
           x="183.58125"
           y="250.97"
         >
@@ -494,7 +494,7 @@ exports[`allows tooltip via container component 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="chart-legend-3-labels-2"
+          id="test"
           x="256.015625"
           y="250.97"
         >
@@ -511,7 +511,7 @@ exports[`allows tooltip via container component 1`] = `
         <text
           direction="inherit"
           dx="0"
-          id="chart-legend-3-labels-3"
+          id="test"
           x="327.57500000000005"
           y="250.97"
         >

--- a/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltip.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltip.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`allows tooltip via container component 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
               text-anchor="middle"
               x="50"
             >
@@ -90,7 +90,7 @@ exports[`allows tooltip via container component 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
               text-anchor="middle"
               x="166.66666666666666"
             >
@@ -121,7 +121,7 @@ exports[`allows tooltip via container component 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
               text-anchor="middle"
               x="283.3333333333333"
             >
@@ -152,7 +152,7 @@ exports[`allows tooltip via container component 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
               text-anchor="middle"
               x="400"
             >
@@ -207,7 +207,7 @@ exports[`allows tooltip via container component 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: end;"
               text-anchor="end"
               x="35"
             >
@@ -248,7 +248,7 @@ exports[`allows tooltip via container component 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: end;"
               text-anchor="end"
               x="35"
             >
@@ -289,7 +289,7 @@ exports[`allows tooltip via container component 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: \\"RedHatText\\",\\"Overpass\\",overpass,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-chart-global--label--stroke, transparent); fill: var(--pf-chart-axis--tick-label--Fill, #4f5255); text-anchor: end;"
               text-anchor="end"
               x="35"
             >

--- a/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltipLabel.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltipLabel.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`renders component text 1`] = `
   <text
     direction="inherit"
     dx="0"
-    id="chart-legend-label-1657567309962czxp7sn92xa"
+    id="test2"
     x="0"
     y="4.97"
   >
@@ -26,7 +26,7 @@ exports[`renders component text 1`] = `
   <text
     direction="inherit"
     dx="0"
-    id="chart-legend-label-16575673100112z6ciqonm8v"
+    id="chart-legend-label-1657570012648lw36vli8e1"
     x="NaN"
     y="4.97"
   >

--- a/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltipLabel.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltipLabel.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`renders component text 1`] = `
   <text
     direction="inherit"
     dx="0"
+    id="chart-legend-label-1657567309962czxp7sn92xa"
     x="0"
     y="4.97"
   >
@@ -25,6 +26,7 @@ exports[`renders component text 1`] = `
   <text
     direction="inherit"
     dx="0"
+    id="chart-legend-label-16575673100112z6ciqonm8v"
     x="NaN"
     y="4.97"
   >

--- a/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltipLabel.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltipLabel.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`renders component text 1`] = `
   <text
     direction="inherit"
     dx="0"
-    id="chart-legend-label-1657570012648lw36vli8e1"
+    id="test3"
     x="NaN"
     y="4.97"
   >

--- a/packages/react-charts/src/components/ChartPoint/ChartPoint.test.tsx
+++ b/packages/react-charts/src/components/ChartPoint/ChartPoint.test.tsx
@@ -7,7 +7,11 @@ import { ChartLabel } from '../ChartLabel';
 Object.values([true, false]).forEach(() => {
   test('ChartPoint', () => {
     const { asFragment } = render(
-      <ChartLegend dataComponent={<ChartPoint />} titleComponent={<ChartLabel id="test" />} />
+      <ChartLegend
+        dataComponent={<ChartPoint />}
+        labelComponent={<ChartLabel id="test" />}
+        titleComponent={<ChartLabel id="test2" />}
+      />
     );
     expect(asFragment()).toMatchSnapshot();
   });
@@ -20,7 +24,8 @@ test('renders component data', () => {
       title="Average number of pets"
       height={50}
       width={200}
-      titleComponent={<ChartLabel id="test2" />}
+      titleComponent={<ChartLabel id="test3" />}
+      labelComponent={<ChartLabel id="test4" />}
     />
   );
   expect(asFragment()).toMatchSnapshot();

--- a/packages/react-charts/src/components/ChartPoint/ChartPoint.test.tsx
+++ b/packages/react-charts/src/components/ChartPoint/ChartPoint.test.tsx
@@ -2,10 +2,13 @@ import * as React from 'react';
 import { render } from '@testing-library/react';
 import { ChartLegend } from '../ChartLegend';
 import { ChartPoint } from './ChartPoint';
+import { ChartLabel } from '../ChartLabel';
 
 Object.values([true, false]).forEach(() => {
   test('ChartPoint', () => {
-    const { asFragment } = render(<ChartLegend dataComponent={<ChartPoint />} />);
+    const { asFragment } = render(
+      <ChartLegend dataComponent={<ChartPoint />} titleComponent={<ChartLabel id="test" />} />
+    );
     expect(asFragment()).toMatchSnapshot();
   });
 });
@@ -17,6 +20,7 @@ test('renders component data', () => {
       title="Average number of pets"
       height={50}
       width={200}
+      titleComponent={<ChartLabel id="test2" />}
     />
   );
   expect(asFragment()).toMatchSnapshot();

--- a/packages/react-charts/src/components/ChartPoint/__snapshots__/ChartPoint.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartPoint/__snapshots__/ChartPoint.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`ChartPoint 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="legend-labels-0"
+        id="test"
         x="30.8"
         y="18.97"
       >
@@ -63,7 +63,7 @@ exports[`ChartPoint 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="legend-labels-1"
+        id="test"
         x="116.73125"
         y="18.97"
       >
@@ -138,7 +138,7 @@ exports[`ChartPoint 2`] = `
       <text
         direction="inherit"
         dx="0"
-        id="legend-labels-0"
+        id="test"
         x="30.8"
         y="18.97"
       >
@@ -155,7 +155,7 @@ exports[`ChartPoint 2`] = `
       <text
         direction="inherit"
         dx="0"
-        id="legend-labels-1"
+        id="test"
         x="116.73125"
         y="18.97"
       >
@@ -257,7 +257,7 @@ exports[`renders component data 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="legend-labels-0"
+        id="test4"
         x="30.8"
         y="39.875"
       >
@@ -274,7 +274,7 @@ exports[`renders component data 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="legend-labels-1"
+        id="test4"
         x="99.58125"
         y="39.875"
       >

--- a/packages/react-charts/src/components/ChartPoint/__snapshots__/ChartPoint.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartPoint/__snapshots__/ChartPoint.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`ChartPoint 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="chart-legend-label-1657567309744anu9zomm5bp"
+        id="legend-labels-0"
         x="30.8"
         y="18.97"
       >
@@ -63,7 +63,7 @@ exports[`ChartPoint 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="chart-legend-label-1657567309747as9bng1166b"
+        id="legend-labels-1"
         x="116.73125"
         y="18.97"
       >
@@ -138,7 +138,7 @@ exports[`ChartPoint 2`] = `
       <text
         direction="inherit"
         dx="0"
-        id="chart-legend-label-1657567309777hrf6k009nwt"
+        id="legend-labels-0"
         x="30.8"
         y="18.97"
       >
@@ -155,7 +155,7 @@ exports[`ChartPoint 2`] = `
       <text
         direction="inherit"
         dx="0"
-        id="chart-legend-label-1657567309778d248o52tj3i"
+        id="legend-labels-1"
         x="116.73125"
         y="18.97"
       >
@@ -240,7 +240,7 @@ exports[`renders component data 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="chart-legend-label-1657567309825x5dhjolz0af"
+        id="legend-title-all"
         x="2"
         y="13.969999999999999"
       >
@@ -257,7 +257,7 @@ exports[`renders component data 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="chart-legend-label-1657567309826cclso1omp3a"
+        id="legend-labels-0"
         x="30.8"
         y="39.875"
       >
@@ -274,7 +274,7 @@ exports[`renders component data 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="chart-legend-label-16575673098283xz8uyq051n"
+        id="legend-labels-1"
         x="99.58125"
         y="39.875"
       >

--- a/packages/react-charts/src/components/ChartPoint/__snapshots__/ChartPoint.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartPoint/__snapshots__/ChartPoint.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`ChartPoint 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="legend-labels-0"
+        id="chart-legend-label-1657567309744anu9zomm5bp"
         x="30.8"
         y="18.97"
       >
@@ -63,7 +63,7 @@ exports[`ChartPoint 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="legend-labels-1"
+        id="chart-legend-label-1657567309747as9bng1166b"
         x="116.73125"
         y="18.97"
       >
@@ -138,7 +138,7 @@ exports[`ChartPoint 2`] = `
       <text
         direction="inherit"
         dx="0"
-        id="legend-labels-0"
+        id="chart-legend-label-1657567309777hrf6k009nwt"
         x="30.8"
         y="18.97"
       >
@@ -155,7 +155,7 @@ exports[`ChartPoint 2`] = `
       <text
         direction="inherit"
         dx="0"
-        id="legend-labels-1"
+        id="chart-legend-label-1657567309778d248o52tj3i"
         x="116.73125"
         y="18.97"
       >
@@ -240,7 +240,7 @@ exports[`renders component data 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="legend-title-all"
+        id="chart-legend-label-1657567309825x5dhjolz0af"
         x="2"
         y="13.969999999999999"
       >
@@ -257,7 +257,7 @@ exports[`renders component data 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="legend-labels-0"
+        id="chart-legend-label-1657567309826cclso1omp3a"
         x="30.8"
         y="39.875"
       >
@@ -274,7 +274,7 @@ exports[`renders component data 1`] = `
       <text
         direction="inherit"
         dx="0"
-        id="legend-labels-1"
+        id="chart-legend-label-16575673098283xz8uyq051n"
         x="99.58125"
         y="39.875"
       >

--- a/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
+++ b/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
@@ -51,8 +51,8 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartVoronoiContainer } from '
 
 <div style={{ height: '200px', width: '800px' }}>
   <Chart
-    ariaDesc="Average number of pets"
-    ariaTitle="Area chart example"
+    ariaDesc="Average number of pets - possibly more information to summarize the data in the chart."
+    ariaTitle="Area chart example chart title"
     containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
     legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }]}
     legendOrientation="vertical"
@@ -120,8 +120,8 @@ class CombinedCursorVoronoiContainer extends React.Component {
     return (
       <div style={{ height: '275px', width: '450px' }}>
         <Chart
-          ariaDesc="Average number of pets"
-          ariaTitle="Line chart example"
+          ariaDesc="Average number of pets - possibly more information to summarize the data in the chart."
+          ariaTitle="Line chart example chart title"
           containerComponent={
             <CursorVoronoiContainer
               cursorDimension="x"
@@ -210,7 +210,8 @@ class EmbeddedLegend extends React.Component {
     return (
       <div style={{ height: '275px', width: '450px' }}>
         <Chart
-          ariaDesc="Average number of pets"
+          ariaDesc="Average number of pets - possibly more information to summarize the data in the chart."
+          ariaTitle="Embedded legend example chart title"
           containerComponent={
             <CursorVoronoiContainer
               cursorDimension="x"
@@ -346,8 +347,8 @@ class EmbeddedHtml extends React.Component {
     return (
       <div ref={this.containerRef} style={{ height: '225px', width: '650px' }}>
         <Chart
-          ariaDesc="Average number of pets"
-          ariaTitle="Area chart example"
+          ariaDesc="Average number of pets - possibly more information to summarize the data in the chart."
+          ariaTitle="Embedded html example chart title"
           containerComponent={
             <CursorVoronoiContainer
               cursorDimension="x"
@@ -440,7 +441,8 @@ class EmbeddedLegendAlt extends React.Component {
     return (
       <div style={{ height: '275px', width: '450px' }}>
         <Chart
-          ariaDesc="Average number of pets"
+          ariaDesc="Average number of pets - possibly more information to summarize the data in the chart."
+          ariaTitle="Embeded legend with custom font size example chart title"
           containerComponent={
             <CursorVoronoiContainer
               cursorDimension="x"
@@ -527,8 +529,8 @@ import { Chart, ChartAxis, ChartBar, ChartStack, ChartThemeColor, ChartTooltip }
 
 <div style={{ height: '275px', width: '450px' }}>
   <Chart
-    ariaDesc="Average number of pets"
-    ariaTitle="Stack chart example"
+    ariaDesc="Average number of pets - possibly more information to summarize the data in the chart."
+    ariaTitle="Data label example chart title"
     domainPadding={{ x: [30, 25] }}
     legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
     legendPosition="bottom-left"
@@ -619,8 +621,8 @@ class TooltipPieChart extends React.Component {
     return (
       <div style={{ height: '275px', width: '300px' }}>
         <ChartPie
-          ariaDesc="Average number of pets"
-          ariaTitle="Pie chart example"
+          ariaDesc="Average number of pets - possibly more information to summarize the data in the chart."
+          ariaTitle="Legend example chart title"
           constrainToVisibleArea
           data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
           height={275}
@@ -680,8 +682,8 @@ class TooltipThemeChart extends React.Component {
     return (
       <div style={{ height: '250px', width: '600px' }}>
         <Chart
-          ariaDesc="Average number of pets"
-          ariaTitle="Line chart example"
+          ariaDesc="Average number of pets - possibly more information to summarize the data in the chart."
+          ariaTitle="Left aligned example chart title"
           containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea voronoiDimension="x"/>}
           legendData={[{ name: 'Cats' }, { name: 'Dogs', symbol: { type: 'dash' } }, { name: 'Birds' }, { name: 'Mice' }]}
           legendOrientation="vertical"
@@ -757,8 +759,8 @@ import { ChartArea, ChartContainer, ChartGroup, ChartLabel, ChartThemeColor, Cha
 <div className="ws-react-charts-tooltip-overflow">
   <div style={{ height: '100px', width: '400px' }}>
     <ChartGroup
-      ariaDesc="Average number of pets"
-      ariaTitle="Sparkline chart example"
+      ariaDesc="Average number of pets - possibly more information to summarize the data in the chart."
+      ariaTitle="CSS overflow example chart title"
       containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} />}
       height={100}
       maxDomain={{y: 9}}
@@ -776,7 +778,7 @@ import { ChartArea, ChartContainer, ChartGroup, ChartLabel, ChartThemeColor, Cha
       />
     </ChartGroup>
   </div>
-  <ChartContainer>
+  <ChartContainer title="CPU utilization">
     <ChartLabel text="CPU utilization" dy={15}/>
   </ChartContainer>
 </div>
@@ -811,8 +813,8 @@ class TooltipChart extends React.Component {
           <Tooltip content={<div>My custom tooltip</div>} isVisible={isVisible} position={TooltipPosition.right} trigger="manual">
             <ChartDonutThreshold
               allowTooltip={false}
-              ariaDesc="Storage capacity"
-              ariaTitle="Donut utilization chart with static threshold example"
+              ariaDesc="Storage capacity  - possibly more information to summarize the data in the chart."
+              ariaTitle="Wrapped example chart title"
               data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
               labels={() => null}
             >

--- a/packages/react-charts/src/components/ChartVoronoiContainer/ChartVoronoiContainer.tsx
+++ b/packages/react-charts/src/components/ChartVoronoiContainer/ChartVoronoiContainer.tsx
@@ -259,7 +259,13 @@ export const ChartVoronoiContainer: React.FunctionComponent<ChartVoronoiContaine
   // Note: theme is required by voronoiContainerMixin
   return (
     // Note: className is valid, but Victory is missing a type
-    <VictoryVoronoiContainer className={chartClassName} labelComponent={chartLabelComponent} theme={theme} {...rest} />
+    <VictoryVoronoiContainer
+      className={chartClassName}
+      labelComponent={chartLabelComponent}
+      theme={theme}
+      role="group"
+      {...rest}
+    />
   );
 };
 ChartVoronoiContainer.displayName = 'ChartVoronoiContainer';

--- a/packages/react-charts/src/components/ChartVoronoiContainer/ChartVoronoiContainer.tsx
+++ b/packages/react-charts/src/components/ChartVoronoiContainer/ChartVoronoiContainer.tsx
@@ -259,13 +259,7 @@ export const ChartVoronoiContainer: React.FunctionComponent<ChartVoronoiContaine
   // Note: theme is required by voronoiContainerMixin
   return (
     // Note: className is valid, but Victory is missing a type
-    <VictoryVoronoiContainer
-      className={chartClassName}
-      labelComponent={chartLabelComponent}
-      theme={theme}
-      role="group"
-      {...rest}
-    />
+    <VictoryVoronoiContainer className={chartClassName} labelComponent={chartLabelComponent} theme={theme} {...rest} />
   );
 };
 ChartVoronoiContainer.displayName = 'ChartVoronoiContainer';

--- a/packages/react-charts/src/components/Sparkline/examples/sparkline.md
+++ b/packages/react-charts/src/components/Sparkline/examples/sparkline.md
@@ -50,7 +50,7 @@ import { ChartArea, ChartContainer, ChartGroup, ChartLabel, ChartVoronoiContaine
       />
     </ChartGroup>
   </div>
-  <ChartContainer>
+  <ChartContainer title="CPU utilization">
     <ChartLabel text="CPU utilization" dy={15}/>
   </ChartContainer>
 </div>
@@ -86,7 +86,7 @@ import { ChartArea, ChartContainer, ChartGroup, ChartLabel, ChartThemeColor, Cha
       />
     </ChartGroup>
   </div>
-  <ChartContainer>
+  <ChartContainer title="CPU utilization">
     <ChartLabel text="CPU utilization" dy={15}/>
   </ChartContainer>
 </div>

--- a/packages/react-docs/patternfly-a11y.config.js
+++ b/packages/react-docs/patternfly-a11y.config.js
@@ -21,8 +21,5 @@ module.exports = {
     'bypass',
     'nested-interactive'
   ].join(','),
-  ignoreIncomplete: true,
-  // tree-table examples are skipped because aria-level, aria-posinset, aria-setsize are intentionally
-  // being used slightly unconventionally in those examples
-  skip: /^\/charts\//
+  ignoreIncomplete: true
 };


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7675 

Duplicate IDs in axis labels and/or legend labels
- Stack chart
- Tooltip chart
- Scatter chart
- Line chart
- Bullet chart
- Area chart
- Legend chart
- Bar chart
- Pie chart
- Donut chart

Duplicate id due to reused example names:
- Donut utilization chart

SVGs need accessible text
- Tooltip chart
- Sparkline chart
- Bullet chart

Legend chart examples - interactive controls cannot be nested. Fixed this by updating the ChartContainer's rendered svg's role from 'img' to 'group'
