### PR TITLE
chore(Truncate): component unit test revamp

### DIFF
--- a/packages/react-core/src/components/Truncate/__tests__/Truncate.test.tsx
+++ b/packages/react-core/src/components/Truncate/__tests__/Truncate.test.tsx
@@ -5,6 +5,7 @@ import { Truncate } from '../Truncate';
 jest.mock('../../Tooltip', () => ({
   Tooltip: ({ content, position, children, ...props }) => (
     <div data-testid="Tooltip-mock" {...props}>
+      <div data-testid="Tooltip-mock-content-container">Test {content}</div>
       <p>{`position: ${position}`}</p>
       {children}
     </div>
@@ -145,12 +146,12 @@ test('renders tooltip position', () => {
 test('renders tooltip content', () => {
   render(
     <Truncate
-      content={''}
+      content={'Another Tooltip'}
       tooltipPosition='top'
     />
   );
 
-  const input = screen.getByTestId('Tooltip-mock');
+  const input = screen.getByText('Test Another Tooltip');
 
   expect(input).toBeVisible();
 });

--- a/packages/react-core/src/components/Truncate/__tests__/Truncate.test.tsx
+++ b/packages/react-core/src/components/Truncate/__tests__/Truncate.test.tsx
@@ -1,6 +1,108 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { Truncate } from '../Truncate';
+
+jest.mock('../../Tooltip', () => ({
+  Tooltip: ({ content, tooltipPosition, children, ...props }) => (
+    <>
+      <div {...props}>{children}</div>
+    </>
+  )
+}));
+
+test('renders with class pf-c-truncate', () => {
+  render(
+    <Truncate
+      content={''}
+      aria-label='test-id'
+    />
+  );
+
+  const test = screen.getByLabelText('test-id');
+
+  expect(test).toHaveClass('pf-c-truncate');
+});
+
+test('renders with custom class name passed via prop', () => {
+  render(
+    <Truncate
+      content={''}
+      aria-label='test-id'
+      className='custom-classname'
+    />
+  );
+
+  const test = screen.getByLabelText('test-id');
+
+  expect(test).toHaveClass('custom-classname');
+});
+
+test('renders truncate with empty content', () => {
+  render(
+    <Truncate
+      content={''}
+      aria-label='test-id'
+    />
+  );
+
+  const test = screen.getByLabelText('test-id');
+
+  expect(test).toHaveTextContent('');
+});
+
+test('renders truncate with content', () => {
+  render(
+    <Truncate
+      content={'Test'}
+      aria-label='test-id'
+    />
+  );
+
+  const test = screen.getByLabelText('test-id');
+
+  expect(test).toHaveTextContent('Test');
+});
+
+test('renders pf-c-truncate__start when trailingNumChars prop passed', () => {
+  render(
+    <Truncate
+      content={'Testing truncate content'}
+      trailingNumChars={3}
+      position='middle'
+    />
+  );
+
+  const start = screen.getByText('Testing truncate cont');
+
+  expect(start).toHaveClass('pf-c-truncate__start');
+});
+
+test('renders pf-c-truncate__end when trailingNumChars prop passed', () => {
+  render(
+    <Truncate
+      content={'Testing truncate content'}
+      trailingNumChars={3}
+      position='middle'
+    />
+  );
+
+  const end = screen.getByText('ent');
+
+  expect(end).toHaveClass('pf-c-truncate__end');
+});
+
+test('only renders pf-c-truncate__start if truncate position is the end', () => {
+  render(
+    <Truncate
+      content={'Testing truncate content'}
+      position='end'
+    />
+  );
+
+  const start = screen.getByText('Testing truncate content');
+
+  expect(start).toHaveClass('pf-c-truncate__start');
+});
 
 test('renders default truncation', () => {
   const { asFragment } = render(
@@ -9,7 +111,7 @@ test('renders default truncation', () => {
   expect(asFragment()).toMatchSnapshot();
 });
 
-test('renders start truncation', () => {
+test('renders start truncation with &lrm; at end', () => {
   const { asFragment } = render(
     <Truncate
       content={'Vestibulum interdum risus et enim faucibus, sit amet molestie est accumsan.'}
@@ -27,4 +129,27 @@ test('renders middle truncation', () => {
     />
   );
   expect(asFragment()).toMatchSnapshot();
+});
+
+test('renders tooltip placement', () => {
+  const { asFragment } = render(
+    <Truncate
+      content={''}
+      tooltipPosition='auto'
+    />
+  );
+
+  expect(asFragment()).toMatchSnapshot();
+});
+
+test('renders with inherited element props spread to the component', () => {
+  render(
+    <Truncate
+      content={'Test'}
+      data-testid="test-id"
+      aria-label="labelling-id"
+    />
+  );
+
+  expect(screen.getByTestId('test-id')).toHaveAccessibleName('labelling-id');
 });

--- a/packages/react-core/src/components/Truncate/__tests__/Truncate.test.tsx
+++ b/packages/react-core/src/components/Truncate/__tests__/Truncate.test.tsx
@@ -3,10 +3,11 @@ import { render, screen } from '@testing-library/react';
 import { Truncate } from '../Truncate';
 
 jest.mock('../../Tooltip', () => ({
-  Tooltip: ({ content, tooltipPosition, children, ...props }) => (
-    <>
-      <div {...props}>{children}</div>
-    </>
+  Tooltip: ({ content, position, children, ...props }) => (
+    <div data-testid="Tooltip-mock" {...props}>
+      <p>{`position: ${position}`}</p>
+      {children}
+    </div>
   )
 }));
 
@@ -63,45 +64,17 @@ test('renders truncate with content', () => {
   expect(test).toHaveTextContent('Test');
 });
 
-test('renders pf-c-truncate__start when trailingNumChars prop passed', () => {
+test('only renders pf-c-truncate__start with default position', () => {
   render(
     <Truncate
       content={'Testing truncate content'}
-      trailingNumChars={3}
-      position='middle'
-    />
-  );
-
-  const start = screen.getByText('Testing truncate cont');
-
-  expect(start).toHaveClass('pf-c-truncate__start');
-});
-
-test('renders pf-c-truncate__end when trailingNumChars prop passed', () => {
-  render(
-    <Truncate
-      content={'Testing truncate content'}
-      trailingNumChars={3}
-      position='middle'
-    />
-  );
-
-  const end = screen.getByText('ent');
-
-  expect(end).toHaveClass('pf-c-truncate__end');
-});
-
-test('only renders pf-c-truncate__start if truncate position is the end', () => {
-  render(
-    <Truncate
-      content={'Testing truncate content'}
-      position='end'
     />
   );
 
   const start = screen.getByText('Testing truncate content');
 
   expect(start).toHaveClass('pf-c-truncate__start');
+  expect(start).not.toHaveClass('pf-c-truncate__end');
 });
 
 test('renders default truncation', () => {
@@ -122,24 +95,64 @@ test('renders start truncation with &lrm; at end', () => {
 });
 
 test('renders middle truncation', () => {
-  const { asFragment } = render(
+  render(
     <Truncate
       content={'Vestibulum interdum risus et enim faucibus, sit amet molestie est accumsan.'}
       position={'middle'}
     />
   );
-  expect(asFragment()).toMatchSnapshot();
+
+  const start = screen.getByText('Vestibulum interdum risus et enim faucibus, sit amet molestie est ac');
+
+  expect(start).toHaveClass('pf-c-truncate__start');
+
+  const end = screen.getByText('cumsan.');
+
+  expect(end).toHaveClass('pf-c-truncate__end');
 });
 
-test('renders tooltip placement', () => {
-  const { asFragment } = render(
+test('renders different content when trailingNumChars is passed with middle truncate', () => {
+  render(
     <Truncate
-      content={''}
-      tooltipPosition='auto'
+      content={'Vestibulum interdum risus et enim faucibus, sit amet molestie est accumsan.'}
+      trailingNumChars={3}
+      position='middle'
     />
   );
 
-  expect(asFragment()).toMatchSnapshot();
+  const start = screen.getByText('Vestibulum interdum risus et enim faucibus, sit amet molestie est accums');
+
+  expect(start).toHaveClass('pf-c-truncate__start');
+
+  const end = screen.getByText('an.');
+
+  expect(end).toHaveClass('pf-c-truncate__end');
+});
+
+test('renders tooltip position', () => {
+  render(
+    <Truncate
+      content={''}
+      tooltipPosition='top'
+    />
+  );
+
+  const input = screen.getByText('position: top');
+  
+  expect(input).toBeVisible();
+});
+
+test('renders tooltip content', () => {
+  render(
+    <Truncate
+      content={''}
+      tooltipPosition='top'
+    />
+  );
+
+  const input = screen.getByTestId('Tooltip-mock');
+
+  expect(input).toBeVisible();
 });
 
 test('renders with inherited element props spread to the component', () => {

--- a/packages/react-core/src/components/Truncate/__tests__/__snapshots__/Truncate.test.tsx.snap
+++ b/packages/react-core/src/components/Truncate/__tests__/__snapshots__/Truncate.test.tsx.snap
@@ -3,8 +3,11 @@
 exports[`renders default truncation 1`] = `
 <DocumentFragment>
   <div
-    position="top"
+    data-testid="Tooltip-mock"
   >
+    <p>
+      position: top
+    </p>
     <span
       class="pf-c-truncate"
     >
@@ -18,34 +21,14 @@ exports[`renders default truncation 1`] = `
 </DocumentFragment>
 `;
 
-exports[`renders middle truncation 1`] = `
-<DocumentFragment>
-  <div
-    position="top"
-  >
-    <span
-      class="pf-c-truncate"
-    >
-      <span
-        class="pf-c-truncate__start"
-      >
-        Vestibulum interdum risus et enim faucibus, sit amet molestie est ac
-      </span>
-      <span
-        class="pf-c-truncate__end"
-      >
-        cumsan.
-      </span>
-    </span>
-  </div>
-</DocumentFragment>
-`;
-
 exports[`renders start truncation with &lrm; at end 1`] = `
 <DocumentFragment>
   <div
-    position="top"
+    data-testid="Tooltip-mock"
   >
+    <p>
+      position: top
+    </p>
     <span
       class="pf-c-truncate"
     >
@@ -54,22 +37,6 @@ exports[`renders start truncation with &lrm; at end 1`] = `
       >
         Vestibulum interdum risus et enim faucibus, sit amet molestie est accumsan.‎
       </span>
-    </span>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`renders tooltip placement 1`] = `
-<DocumentFragment>
-  <div
-    position="auto"
-  >
-    <span
-      class="pf-c-truncate"
-    >
-      <span
-        class="pf-c-truncate__start"
-      />
     </span>
   </div>
 </DocumentFragment>

--- a/packages/react-core/src/components/Truncate/__tests__/__snapshots__/Truncate.test.tsx.snap
+++ b/packages/react-core/src/components/Truncate/__tests__/__snapshots__/Truncate.test.tsx.snap
@@ -2,47 +2,75 @@
 
 exports[`renders default truncation 1`] = `
 <DocumentFragment>
-  <span
-    class="pf-c-truncate"
+  <div
+    position="top"
   >
     <span
-      class="pf-c-truncate__start"
+      class="pf-c-truncate"
     >
-      Vestibulum interdum risus et enim faucibus, sit amet molestie est accumsan.
+      <span
+        class="pf-c-truncate__start"
+      >
+        Vestibulum interdum risus et enim faucibus, sit amet molestie est accumsan.
+      </span>
     </span>
-  </span>
+  </div>
 </DocumentFragment>
 `;
 
 exports[`renders middle truncation 1`] = `
 <DocumentFragment>
-  <span
-    class="pf-c-truncate"
+  <div
+    position="top"
   >
     <span
-      class="pf-c-truncate__start"
+      class="pf-c-truncate"
     >
-      Vestibulum interdum risus et enim faucibus, sit amet molestie est ac
+      <span
+        class="pf-c-truncate__start"
+      >
+        Vestibulum interdum risus et enim faucibus, sit amet molestie est ac
+      </span>
+      <span
+        class="pf-c-truncate__end"
+      >
+        cumsan.
+      </span>
     </span>
-    <span
-      class="pf-c-truncate__end"
-    >
-      cumsan.
-    </span>
-  </span>
+  </div>
 </DocumentFragment>
 `;
 
-exports[`renders start truncation 1`] = `
+exports[`renders start truncation with &lrm; at end 1`] = `
 <DocumentFragment>
-  <span
-    class="pf-c-truncate"
+  <div
+    position="top"
   >
     <span
-      class="pf-c-truncate__end"
+      class="pf-c-truncate"
     >
-      Vestibulum interdum risus et enim faucibus, sit amet molestie est accumsan.‎
+      <span
+        class="pf-c-truncate__end"
+      >
+        Vestibulum interdum risus et enim faucibus, sit amet molestie est accumsan.‎
+      </span>
     </span>
-  </span>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`renders tooltip placement 1`] = `
+<DocumentFragment>
+  <div
+    position="auto"
+  >
+    <span
+      class="pf-c-truncate"
+    >
+      <span
+        class="pf-c-truncate__start"
+      />
+    </span>
+  </div>
 </DocumentFragment>
 `;

--- a/packages/react-core/src/components/Truncate/__tests__/__snapshots__/Truncate.test.tsx.snap
+++ b/packages/react-core/src/components/Truncate/__tests__/__snapshots__/Truncate.test.tsx.snap
@@ -5,6 +5,11 @@ exports[`renders default truncation 1`] = `
   <div
     data-testid="Tooltip-mock"
   >
+    <div
+      data-testid="Tooltip-mock-content-container"
+    >
+      Test Vestibulum interdum risus et enim faucibus, sit amet molestie est accumsan.
+    </div>
     <p>
       position: top
     </p>
@@ -26,6 +31,11 @@ exports[`renders start truncation with &lrm; at end 1`] = `
   <div
     data-testid="Tooltip-mock"
   >
+    <div
+      data-testid="Tooltip-mock-content-container"
+    >
+      Test Vestibulum interdum risus et enim faucibus, sit amet molestie est accumsan.
+    </div>
     <p>
       position: top
     </p>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7643 . Unit tests revamp -- note that there was an issue with the `position` prop where if `position=start`, then only `pf-c-truncate__end` would render. However, `getByText` could not detect the inputted text as a result of `&lrm;` so a snapshot test was performed instead.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: N/A.
