### PR TITLE
feat(VisualizationSurface): replace react-measure with react-resize-detector

### DIFF
--- a/packages/react-topology/package.json
+++ b/packages/react-topology/package.json
@@ -34,7 +34,6 @@
     "@types/d3": "^5.7.2",
     "@types/d3-force": "^1.2.1",
     "@types/dagre": "0.7.42",
-    "@types/react-measure": "^2.0.6",
     "@types/webcola": "3.2.0",
     "d3": "^5.16.0",
     "dagre": "0.8.2",
@@ -43,7 +42,7 @@
     "mobx-react": "^6.2.0",
     "point-in-svg-path": "^1.0.1",
     "popper.js": "^1.16.1",
-    "react-measure": "^2.3.0",
+    "react-resize-detector": "^7.1.2",
     "tslib": "^2.0.0",
     "webcola": "3.4.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2055,12 +2055,6 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.2.0":
-  version "7.9.2"
-  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz"
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
 "@babel/runtime@^7.4.5", "@babel/runtime@^7.8.7":
   version "7.11.2"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz"
@@ -4093,12 +4087,6 @@
   version "17.0.11"
   resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.11.tgz"
   integrity sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react-measure@^2.0.6":
-  version "2.0.6"
-  resolved "https://registry.npmjs.org/@types/react-measure/-/react-measure-2.0.6.tgz"
   dependencies:
     "@types/react" "*"
 
@@ -9104,10 +9092,6 @@ get-intrinsic@^1.0.2:
     function-bind "^1.1.1"
     has "^1.0.3"
     has-symbols "^1.0.3"
-
-get-node-dimensions@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/get-node-dimensions/-/get-node-dimensions-1.2.1.tgz"
 
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.2"
@@ -14341,15 +14325,6 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz"
 
-react-measure@^2.3.0:
-  version "2.5.0"
-  resolved "https://registry.npmjs.org/react-measure/-/react-measure-2.5.0.tgz"
-  dependencies:
-    "@babel/runtime" "^7.2.0"
-    get-node-dimensions "^1.2.1"
-    prop-types "^15.6.2"
-    resize-observer-polyfill "^1.5.0"
-
 react-monaco-editor@0.48.0:
   version "0.48.0"
   resolved "https://registry.yarnpkg.com/react-monaco-editor/-/react-monaco-editor-0.48.0.tgz#f2b547c619f0ba3b49d3c8a0e0168ff9d0aa70dc"
@@ -14363,6 +14338,13 @@ react-monaco-editor@^0.41.2:
   dependencies:
     monaco-editor "*"
     prop-types "^15.7.2"
+
+react-resize-detector@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-7.1.2.tgz#8ef975dd8c3d56f9a5160ac382ef7136dcd2d86c"
+  integrity sha512-zXnPJ2m8+6oq9Nn8zsep/orts9vQv3elrpA+R8XTcW7DVVUJ9vwDwMXaBtykAYjMnkCIaOoK9vObyR7ZgFNlOw==
+  dependencies:
+    lodash "^4.17.21"
 
 react-router-dom@^4.3.1:
   version "4.3.1"
@@ -14936,7 +14918,7 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
 
-resize-observer-polyfill@^1.5.0, resize-observer-polyfill@^1.5.1:
+resize-observer-polyfill@^1.5.1:
   version "1.5.1"
   resolved "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz"
 


### PR DESCRIPTION
Replaces [`react-measure`](https://www.npmjs.com/package/react-measure) with [`react-resize-detector`](https://www.npmjs.com/package/react-resize-detector) due to lack of support for React 18. The `react-resize-detector` package is also a lot more popular and actively maintained, and comes with built-in functionality to debounce events.

This is needed to help close #7142 