### PR TITLE
feat(TreeView): allow selection without expansion

### DIFF
--- a/packages/react-core/src/components/TreeView/TreeView.tsx
+++ b/packages/react-core/src/components/TreeView/TreeView.tsx
@@ -106,7 +106,7 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
           title={item.title}
           id={item.id}
           isExpanded={allExpanded}
-          hasSelectableNodes={hasSelectableNodes}
+          isSelectable={hasSelectableNodes}
           defaultExpanded={item.defaultExpanded !== undefined ? item.defaultExpanded : defaultAllExpanded}
           onSelect={onSelect}
           onCheck={onCheck}

--- a/packages/react-core/src/components/TreeView/TreeView.tsx
+++ b/packages/react-core/src/components/TreeView/TreeView.tsx
@@ -45,6 +45,8 @@ export interface TreeViewProps {
   hasBadges?: boolean;
   /** Flag indicating if tree view has guide lines. */
   hasGuides?: boolean;
+  /** Flag indicating that tree nodes should be independently selectable, even when having children */
+  hasSelectableNodes?: boolean;
   /** Variant presentation styles for the tree view. */
   variant?: 'default' | 'compact' | 'compactNoBackground';
   /** Icon for all leaf or unexpanded node items */
@@ -79,6 +81,7 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
   hasChecks = false,
   hasBadges = false,
   hasGuides = false,
+  hasSelectableNodes = false,
   variant = 'default',
   defaultAllExpanded = false,
   allExpanded,
@@ -103,6 +106,7 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
           title={item.title}
           id={item.id}
           isExpanded={allExpanded}
+          hasSelectableNodes={hasSelectableNodes}
           defaultExpanded={item.defaultExpanded !== undefined ? item.defaultExpanded : defaultAllExpanded}
           onSelect={onSelect}
           onCheck={onCheck}
@@ -129,6 +133,7 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
                 hasChecks={hasChecks}
                 hasBadges={hasBadges}
                 hasGuides={hasGuides}
+                hasSelectableNodes={hasSelectableNodes}
                 variant={variant}
                 allExpanded={allExpanded}
                 defaultAllExpanded={defaultAllExpanded}

--- a/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
+++ b/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
@@ -116,8 +116,7 @@ const TreeViewListItemBase: React.FunctionComponent<TreeViewListItemProps> = ({
           evt.stopPropagation();
         }
       }}
-      {...(hasCheck && { 'aria-labelledby': `label-${randomId}` })}
-      {...((hasCheck || hasSelectableNodes) && { id: `${randomId}-toggle-button` })}
+      {...((hasCheck || hasSelectableNodes) && { 'aria-labelledby': `label-${randomId}` })}
       tabIndex={-1}
     >
       <span className={css(styles.treeViewNodeToggleIcon)}>
@@ -205,7 +204,7 @@ const TreeViewListItemBase: React.FunctionComponent<TreeViewListItemProps> = ({
                 }
               }}
               tabIndex={hasSelectableNodes ? 1 : -1}
-              {...(hasCheck && { htmlFor: randomId, id: `label-${randomId}` })}
+              {...((hasCheck || hasSelectableNodes) && { htmlFor: randomId, id: `label-${randomId}` })}
             >
               <span className={css(styles.treeViewNodeContainer)}>
                 {children && renderToggle(randomId)}

--- a/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
+++ b/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
@@ -204,7 +204,8 @@ const TreeViewListItemBase: React.FunctionComponent<TreeViewListItemProps> = ({
                 }
               }}
               tabIndex={hasSelectableNodes ? 1 : -1}
-              {...((hasCheck || hasSelectableNodes) && { htmlFor: randomId, id: `label-${randomId}` })}
+              {...(hasCheck && { htmlFor: randomId })}
+              {...((hasCheck || (hasSelectableNodes && children)) && { id: `label-${randomId}` })}
             >
               <span className={css(styles.treeViewNodeContainer)}>
                 {children && renderToggle(randomId)}

--- a/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
+++ b/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
@@ -96,8 +96,14 @@ const TreeViewListItemBase: React.FunctionComponent<TreeViewListItemProps> = ({
     }
   }, [isExpanded, defaultExpanded]);
 
-  const Component = hasCheck || hasSelectableNodes ? 'div' : 'button';
-  const ToggleComponent = hasCheck || hasSelectableNodes ? 'button' : 'div';
+  const Component = hasCheck ? 'div' : 'button';
+  let ToggleComponent: 'div' | 'span' | 'button' = 'div';
+  if (hasSelectableNodes) {
+    ToggleComponent = 'span';
+  }
+  if (hasCheck) {
+    ToggleComponent = 'button';
+  }
   const renderToggle = (randomId: string) => (
     <ToggleComponent
       className={css(styles.treeViewNodeToggle)}

--- a/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
+++ b/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
@@ -117,6 +117,7 @@ const TreeViewListItemBase: React.FunctionComponent<TreeViewListItemProps> = ({
         }
       }}
       {...(hasCheck && { 'aria-labelledby': `label-${randomId}` })}
+      id={`${randomId}-button`}
       tabIndex={-1}
     >
       <span className={css(styles.treeViewNodeToggleIcon)}>

--- a/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
+++ b/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
@@ -34,7 +34,7 @@ export interface TreeViewListItemProps {
   /** Flag indicating if a tree view item has a badge */
   hasBadge?: boolean;
   /** Flag indicating that tree nodes should be independently selectable, even when having children */
-  hasSelectableNodes?: boolean;
+  isSelectable?: boolean;
   /** Optional prop for custom badge */
   customBadgeContent?: React.ReactNode;
   /** Additional properties of the tree view item badge */
@@ -75,7 +75,7 @@ const TreeViewListItemBase: React.FunctionComponent<TreeViewListItemProps> = ({
   hasBadge = false,
   customBadgeContent,
   badgeProps = { isRead: true },
-  hasSelectableNodes = false,
+  isSelectable = false,
   isCompact,
   activeItems = [],
   itemData,
@@ -99,24 +99,24 @@ const TreeViewListItemBase: React.FunctionComponent<TreeViewListItemProps> = ({
   let Component: 'label' | 'div' | 'button' = 'button';
   if (hasCheck) {
     Component = 'label';
-  } else if (hasSelectableNodes) {
+  } else if (isSelectable) {
     Component = 'div';
   }
 
-  const ToggleComponent = hasCheck || hasSelectableNodes ? 'button' : 'span';
+  const ToggleComponent = hasCheck || isSelectable ? 'button' : 'span';
 
   const renderToggle = (randomId: string) => (
     <ToggleComponent
       className={css(styles.treeViewNodeToggle)}
       onClick={(evt: React.MouseEvent) => {
-        if (hasSelectableNodes || hasCheck) {
+        if (isSelectable || hasCheck) {
           setIsExpanded(!internalIsExpanded);
         }
-        if (hasSelectableNodes) {
+        if (isSelectable) {
           evt.stopPropagation();
         }
       }}
-      {...((hasCheck || hasSelectableNodes) && { 'aria-labelledby': `label-${randomId}` })}
+      {...((hasCheck || isSelectable) && { 'aria-labelledby': `label-${randomId}` })}
       tabIndex={-1}
     >
       <span className={css(styles.treeViewNodeToggleIcon)}>
@@ -182,13 +182,13 @@ const TreeViewListItemBase: React.FunctionComponent<TreeViewListItemProps> = ({
       tabIndex={-1}
     >
       <div className={css(styles.treeViewContent)}>
-        <GenerateId prefix={hasSelectableNodes ? 'selectable-id' : 'checkbox-id'}>
+        <GenerateId prefix={isSelectable ? 'selectable-id' : 'checkbox-id'}>
           {randomId => (
             <Component
               className={css(
                 styles.treeViewNode,
-                children && (hasSelectableNodes || hasCheck) && styles.modifiers.selectable,
-                (!children || hasSelectableNodes) &&
+                children && (isSelectable || hasCheck) && styles.modifiers.selectable,
+                (!children || isSelectable) &&
                   activeItems &&
                   activeItems.length > 0 &&
                   activeItems.some(item => compareItems && item && compareItems(item, itemData))
@@ -198,14 +198,14 @@ const TreeViewListItemBase: React.FunctionComponent<TreeViewListItemProps> = ({
               onClick={(evt: React.MouseEvent) => {
                 if (!hasCheck) {
                   onSelect && onSelect(evt, itemData, parentItem);
-                  if (!hasSelectableNodes && children && evt.isDefaultPrevented() !== true) {
+                  if (!isSelectable && children && evt.isDefaultPrevented() !== true) {
                     setIsExpanded(!internalIsExpanded);
                   }
                 }
               }}
-              tabIndex={hasSelectableNodes ? 0 : -1}
+              tabIndex={isSelectable ? 0 : -1}
               {...(hasCheck && { htmlFor: randomId })}
-              {...((hasCheck || (hasSelectableNodes && children)) && { id: `label-${randomId}` })}
+              {...((hasCheck || (isSelectable && children)) && { id: `label-${randomId}` })}
             >
               <span className={css(styles.treeViewNodeContainer)}>
                 {children && renderToggle(randomId)}

--- a/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
+++ b/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
@@ -96,14 +96,9 @@ const TreeViewListItemBase: React.FunctionComponent<TreeViewListItemProps> = ({
     }
   }, [isExpanded, defaultExpanded]);
 
-  const Component = hasCheck ? 'div' : 'button';
-  let ToggleComponent: 'div' | 'span' | 'button' = 'div';
-  if (hasSelectableNodes) {
-    ToggleComponent = 'span';
-  }
-  if (hasCheck) {
-    ToggleComponent = 'button';
-  }
+  const Component = hasCheck ? 'label' : 'button';
+  const ToggleComponent = hasCheck ? 'button' : 'span';
+
   const renderToggle = (randomId: string) => (
     <ToggleComponent
       className={css(styles.treeViewNodeToggle)}
@@ -143,20 +138,18 @@ const TreeViewListItemBase: React.FunctionComponent<TreeViewListItemProps> = ({
       {internalIsExpanded && (expandedIcon || icon)}
     </span>
   );
-  const renderNodeContent = (randomId: string) => {
+  const renderNodeContent = () => {
     const content = (
       <>
         {isCompact && title && <span className={css(styles.treeViewNodeTitle)}>{title}</span>}
         {hasCheck ? (
-          <label className={css(styles.treeViewNodeText)} htmlFor={randomId} id={`label-${randomId}`}>
-            {name}
-          </label>
+          <span className={css(styles.treeViewNodeText)}>{name}</span>
         ) : (
           <span className={css(styles.treeViewNodeText)}>{name}</span>
         )}
       </>
     );
-    return isCompact ? <div className={css(styles.treeViewNodeContent)}>{content}</div> : content;
+    return isCompact ? <span className={css(styles.treeViewNodeContent)}>{content}</span> : content;
   };
   const badgeRendered = (
     <>
@@ -188,7 +181,7 @@ const TreeViewListItemBase: React.FunctionComponent<TreeViewListItemProps> = ({
             <Component
               className={css(
                 styles.treeViewNode,
-                hasSelectableNodes && styles.modifiers.selectable,
+                children && (hasSelectableNodes || hasCheck) && styles.modifiers.selectable,
                 (!children || hasSelectableNodes) &&
                   activeItems &&
                   activeItems.length > 0 &&
@@ -205,14 +198,15 @@ const TreeViewListItemBase: React.FunctionComponent<TreeViewListItemProps> = ({
                 }
               }}
               tabIndex={-1}
+              {...(hasCheck && { htmlFor: randomId, id: `label-${randomId}` })}
             >
-              <div className={css(styles.treeViewNodeContainer)}>
+              <span className={css(styles.treeViewNodeContainer)}>
                 {children && renderToggle(randomId)}
                 {hasCheck && renderCheck(randomId)}
                 {icon && iconRendered}
-                {renderNodeContent(randomId)}
+                {renderNodeContent()}
                 {badgeRendered}
-              </div>
+              </span>
             </Component>
           )}
         </GenerateId>

--- a/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
+++ b/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
@@ -117,7 +117,7 @@ const TreeViewListItemBase: React.FunctionComponent<TreeViewListItemProps> = ({
         }
       }}
       {...(hasCheck && { 'aria-labelledby': `label-${randomId}` })}
-      id={`${randomId}-button`}
+      {...((hasCheck || hasSelectableNodes) && { id: `${randomId}-toggle-button` })}
       tabIndex={-1}
     >
       <span className={css(styles.treeViewNodeToggleIcon)}>

--- a/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
+++ b/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
@@ -96,8 +96,14 @@ const TreeViewListItemBase: React.FunctionComponent<TreeViewListItemProps> = ({
     }
   }, [isExpanded, defaultExpanded]);
 
-  const Component = hasCheck ? 'label' : 'button';
-  const ToggleComponent = hasCheck ? 'button' : 'span';
+  let Component: 'label' | 'div' | 'button' = 'button';
+  if (hasCheck) {
+    Component = 'label';
+  } else if (hasSelectableNodes) {
+    Component = 'div';
+  }
+
+  const ToggleComponent = hasCheck || hasSelectableNodes ? 'button' : 'span';
 
   const renderToggle = (randomId: string) => (
     <ToggleComponent
@@ -197,7 +203,7 @@ const TreeViewListItemBase: React.FunctionComponent<TreeViewListItemProps> = ({
                   }
                 }
               }}
-              tabIndex={-1}
+              tabIndex={hasSelectableNodes ? 1 : -1}
               {...(hasCheck && { htmlFor: randomId, id: `label-${randomId}` })}
             >
               <span className={css(styles.treeViewNodeContainer)}>

--- a/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
+++ b/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
@@ -182,7 +182,7 @@ const TreeViewListItemBase: React.FunctionComponent<TreeViewListItemProps> = ({
       tabIndex={-1}
     >
       <div className={css(styles.treeViewContent)}>
-        <GenerateId prefix="checkbox-id">
+        <GenerateId prefix={hasSelectableNodes ? 'selectable-id' : 'checkbox-id'}>
           {randomId => (
             <Component
               className={css(
@@ -203,7 +203,7 @@ const TreeViewListItemBase: React.FunctionComponent<TreeViewListItemProps> = ({
                   }
                 }
               }}
-              tabIndex={hasSelectableNodes ? 1 : -1}
+              tabIndex={hasSelectableNodes ? 0 : -1}
               {...(hasCheck && { htmlFor: randomId })}
               {...((hasCheck || (hasSelectableNodes && children)) && { id: `label-${randomId}` })}
             >

--- a/packages/react-core/src/components/TreeView/__tests__/__snapshots__/TreeView.test.tsx.snap
+++ b/packages/react-core/src/components/TreeView/__tests__/__snapshots__/TreeView.test.tsx.snap
@@ -23,10 +23,10 @@ exports[`renders compact no background successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="0"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -47,8 +47,8 @@ exports[`renders compact no background successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
-              <div
+              </span>
+              <span
                 class="pf-c-tree-view__node-content"
               >
                 <span
@@ -56,8 +56,8 @@ exports[`renders compact no background successfully 1`] = `
                 >
                   ApplicationLauncher
                 </span>
-              </div>
-            </div>
+              </span>
+            </span>
           </button>
         </div>
         <ul
@@ -77,10 +77,10 @@ exports[`renders compact no background successfully 1`] = `
                 class="pf-c-tree-view__node"
                 tabindex="-1"
               >
-                <div
+                <span
                   class="pf-c-tree-view__node-container"
                 >
-                  <div
+                  <span
                     class="pf-c-tree-view__node-toggle"
                     tabindex="-1"
                   >
@@ -101,8 +101,8 @@ exports[`renders compact no background successfully 1`] = `
                         />
                       </svg>
                     </span>
-                  </div>
-                  <div
+                  </span>
+                  <span
                     class="pf-c-tree-view__node-content"
                   >
                     <span
@@ -110,8 +110,8 @@ exports[`renders compact no background successfully 1`] = `
                     >
                       Application 1
                     </span>
-                  </div>
-                </div>
+                  </span>
+                </span>
               </button>
             </div>
           </li>
@@ -128,10 +128,10 @@ exports[`renders compact no background successfully 1`] = `
                 class="pf-c-tree-view__node"
                 tabindex="-1"
               >
-                <div
+                <span
                   class="pf-c-tree-view__node-container"
                 >
-                  <div
+                  <span
                     class="pf-c-tree-view__node-toggle"
                     tabindex="-1"
                   >
@@ -152,8 +152,8 @@ exports[`renders compact no background successfully 1`] = `
                         />
                       </svg>
                     </span>
-                  </div>
-                  <div
+                  </span>
+                  <span
                     class="pf-c-tree-view__node-content"
                   >
                     <span
@@ -161,8 +161,8 @@ exports[`renders compact no background successfully 1`] = `
                     >
                       Application 2
                     </span>
-                  </div>
-                </div>
+                  </span>
+                </span>
               </button>
             </div>
           </li>
@@ -181,10 +181,10 @@ exports[`renders compact no background successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -205,8 +205,8 @@ exports[`renders compact no background successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
-              <div
+              </span>
+              <span
                 class="pf-c-tree-view__node-content"
               >
                 <span
@@ -214,8 +214,8 @@ exports[`renders compact no background successfully 1`] = `
                 >
                   Cost Management
                 </span>
-              </div>
-            </div>
+              </span>
+            </span>
           </button>
         </div>
       </li>
@@ -232,10 +232,10 @@ exports[`renders compact no background successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -256,8 +256,8 @@ exports[`renders compact no background successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
-              <div
+              </span>
+              <span
                 class="pf-c-tree-view__node-content"
               >
                 <span
@@ -265,8 +265,8 @@ exports[`renders compact no background successfully 1`] = `
                 >
                   Sources
                 </span>
-              </div>
-            </div>
+              </span>
+            </span>
           </button>
         </div>
       </li>
@@ -283,10 +283,10 @@ exports[`renders compact no background successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -307,8 +307,8 @@ exports[`renders compact no background successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
-              <div
+              </span>
+              <span
                 class="pf-c-tree-view__node-content"
               >
                 <span
@@ -316,8 +316,8 @@ exports[`renders compact no background successfully 1`] = `
                 >
                   Really really really long folder name that overflows the container it is in
                 </span>
-              </div>
-            </div>
+              </span>
+            </span>
           </button>
         </div>
       </li>
@@ -349,10 +349,10 @@ exports[`renders compact successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="0"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -373,8 +373,8 @@ exports[`renders compact successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
-              <div
+              </span>
+              <span
                 class="pf-c-tree-view__node-content"
               >
                 <span
@@ -382,8 +382,8 @@ exports[`renders compact successfully 1`] = `
                 >
                   ApplicationLauncher
                 </span>
-              </div>
-            </div>
+              </span>
+            </span>
           </button>
         </div>
         <ul
@@ -403,10 +403,10 @@ exports[`renders compact successfully 1`] = `
                 class="pf-c-tree-view__node"
                 tabindex="-1"
               >
-                <div
+                <span
                   class="pf-c-tree-view__node-container"
                 >
-                  <div
+                  <span
                     class="pf-c-tree-view__node-toggle"
                     tabindex="-1"
                   >
@@ -427,8 +427,8 @@ exports[`renders compact successfully 1`] = `
                         />
                       </svg>
                     </span>
-                  </div>
-                  <div
+                  </span>
+                  <span
                     class="pf-c-tree-view__node-content"
                   >
                     <span
@@ -436,8 +436,8 @@ exports[`renders compact successfully 1`] = `
                     >
                       Application 1
                     </span>
-                  </div>
-                </div>
+                  </span>
+                </span>
               </button>
             </div>
           </li>
@@ -454,10 +454,10 @@ exports[`renders compact successfully 1`] = `
                 class="pf-c-tree-view__node"
                 tabindex="-1"
               >
-                <div
+                <span
                   class="pf-c-tree-view__node-container"
                 >
-                  <div
+                  <span
                     class="pf-c-tree-view__node-toggle"
                     tabindex="-1"
                   >
@@ -478,8 +478,8 @@ exports[`renders compact successfully 1`] = `
                         />
                       </svg>
                     </span>
-                  </div>
-                  <div
+                  </span>
+                  <span
                     class="pf-c-tree-view__node-content"
                   >
                     <span
@@ -487,8 +487,8 @@ exports[`renders compact successfully 1`] = `
                     >
                       Application 2
                     </span>
-                  </div>
-                </div>
+                  </span>
+                </span>
               </button>
             </div>
           </li>
@@ -507,10 +507,10 @@ exports[`renders compact successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -531,8 +531,8 @@ exports[`renders compact successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
-              <div
+              </span>
+              <span
                 class="pf-c-tree-view__node-content"
               >
                 <span
@@ -540,8 +540,8 @@ exports[`renders compact successfully 1`] = `
                 >
                   Cost Management
                 </span>
-              </div>
-            </div>
+              </span>
+            </span>
           </button>
         </div>
       </li>
@@ -558,10 +558,10 @@ exports[`renders compact successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -582,8 +582,8 @@ exports[`renders compact successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
-              <div
+              </span>
+              <span
                 class="pf-c-tree-view__node-content"
               >
                 <span
@@ -591,8 +591,8 @@ exports[`renders compact successfully 1`] = `
                 >
                   Sources
                 </span>
-              </div>
-            </div>
+              </span>
+            </span>
           </button>
         </div>
       </li>
@@ -609,10 +609,10 @@ exports[`renders compact successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -633,8 +633,8 @@ exports[`renders compact successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
-              <div
+              </span>
+              <span
                 class="pf-c-tree-view__node-content"
               >
                 <span
@@ -642,8 +642,8 @@ exports[`renders compact successfully 1`] = `
                 >
                   Really really really long folder name that overflows the container it is in
                 </span>
-              </div>
-            </div>
+              </span>
+            </span>
           </button>
         </div>
       </li>
@@ -675,10 +675,10 @@ exports[`renders guides successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="0"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -699,13 +699,13 @@ exports[`renders guides successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
+              </span>
               <span
                 class="pf-c-tree-view__node-text"
               >
                 ApplicationLauncher
               </span>
-            </div>
+            </span>
           </button>
         </div>
         <ul
@@ -725,10 +725,10 @@ exports[`renders guides successfully 1`] = `
                 class="pf-c-tree-view__node"
                 tabindex="-1"
               >
-                <div
+                <span
                   class="pf-c-tree-view__node-container"
                 >
-                  <div
+                  <span
                     class="pf-c-tree-view__node-toggle"
                     tabindex="-1"
                   >
@@ -749,13 +749,13 @@ exports[`renders guides successfully 1`] = `
                         />
                       </svg>
                     </span>
-                  </div>
+                  </span>
                   <span
                     class="pf-c-tree-view__node-text"
                   >
                     Application 1
                   </span>
-                </div>
+                </span>
               </button>
             </div>
           </li>
@@ -772,10 +772,10 @@ exports[`renders guides successfully 1`] = `
                 class="pf-c-tree-view__node"
                 tabindex="-1"
               >
-                <div
+                <span
                   class="pf-c-tree-view__node-container"
                 >
-                  <div
+                  <span
                     class="pf-c-tree-view__node-toggle"
                     tabindex="-1"
                   >
@@ -796,13 +796,13 @@ exports[`renders guides successfully 1`] = `
                         />
                       </svg>
                     </span>
-                  </div>
+                  </span>
                   <span
                     class="pf-c-tree-view__node-text"
                   >
                     Application 2
                   </span>
-                </div>
+                </span>
               </button>
             </div>
           </li>
@@ -821,10 +821,10 @@ exports[`renders guides successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -845,13 +845,13 @@ exports[`renders guides successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
+              </span>
               <span
                 class="pf-c-tree-view__node-text"
               >
                 Cost Management
               </span>
-            </div>
+            </span>
           </button>
         </div>
       </li>
@@ -868,10 +868,10 @@ exports[`renders guides successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -892,13 +892,13 @@ exports[`renders guides successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
+              </span>
               <span
                 class="pf-c-tree-view__node-text"
               >
                 Sources
               </span>
-            </div>
+            </span>
           </button>
         </div>
       </li>
@@ -915,10 +915,10 @@ exports[`renders guides successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -939,13 +939,13 @@ exports[`renders guides successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
+              </span>
               <span
                 class="pf-c-tree-view__node-text"
               >
                 Really really really long folder name that overflows the container it is in
               </span>
-            </div>
+            </span>
           </button>
         </div>
       </li>
@@ -977,10 +977,10 @@ exports[`tree view renders active successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="0"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -1001,13 +1001,13 @@ exports[`tree view renders active successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
+              </span>
               <span
                 class="pf-c-tree-view__node-text"
               >
                 ApplicationLauncher
               </span>
-            </div>
+            </span>
           </button>
         </div>
         <ul
@@ -1027,10 +1027,10 @@ exports[`tree view renders active successfully 1`] = `
                 class="pf-c-tree-view__node"
                 tabindex="-1"
               >
-                <div
+                <span
                   class="pf-c-tree-view__node-container"
                 >
-                  <div
+                  <span
                     class="pf-c-tree-view__node-toggle"
                     tabindex="-1"
                   >
@@ -1051,13 +1051,13 @@ exports[`tree view renders active successfully 1`] = `
                         />
                       </svg>
                     </span>
-                  </div>
+                  </span>
                   <span
                     class="pf-c-tree-view__node-text"
                   >
                     Application 1
                   </span>
-                </div>
+                </span>
               </button>
             </div>
           </li>
@@ -1074,10 +1074,10 @@ exports[`tree view renders active successfully 1`] = `
                 class="pf-c-tree-view__node"
                 tabindex="-1"
               >
-                <div
+                <span
                   class="pf-c-tree-view__node-container"
                 >
-                  <div
+                  <span
                     class="pf-c-tree-view__node-toggle"
                     tabindex="-1"
                   >
@@ -1098,13 +1098,13 @@ exports[`tree view renders active successfully 1`] = `
                         />
                       </svg>
                     </span>
-                  </div>
+                  </span>
                   <span
                     class="pf-c-tree-view__node-text"
                   >
                     Application 2
                   </span>
-                </div>
+                </span>
               </button>
             </div>
           </li>
@@ -1123,10 +1123,10 @@ exports[`tree view renders active successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -1147,13 +1147,13 @@ exports[`tree view renders active successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
+              </span>
               <span
                 class="pf-c-tree-view__node-text"
               >
                 Cost Management
               </span>
-            </div>
+            </span>
           </button>
         </div>
       </li>
@@ -1170,10 +1170,10 @@ exports[`tree view renders active successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -1194,13 +1194,13 @@ exports[`tree view renders active successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
+              </span>
               <span
                 class="pf-c-tree-view__node-text"
               >
                 Sources
               </span>
-            </div>
+            </span>
           </button>
         </div>
       </li>
@@ -1217,10 +1217,10 @@ exports[`tree view renders active successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -1241,13 +1241,13 @@ exports[`tree view renders active successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
+              </span>
               <span
                 class="pf-c-tree-view__node-text"
               >
                 Really really really long folder name that overflows the container it is in
               </span>
-            </div>
+            </span>
           </button>
         </div>
       </li>
@@ -1279,10 +1279,10 @@ exports[`tree view renders badges successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="0"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -1303,7 +1303,7 @@ exports[`tree view renders badges successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
+              </span>
               <span
                 class="pf-c-tree-view__node-text"
               >
@@ -1318,7 +1318,7 @@ exports[`tree view renders badges successfully 1`] = `
                   2
                 </span>
               </span>
-            </div>
+            </span>
           </button>
         </div>
         <ul
@@ -1338,10 +1338,10 @@ exports[`tree view renders badges successfully 1`] = `
                 class="pf-c-tree-view__node"
                 tabindex="-1"
               >
-                <div
+                <span
                   class="pf-c-tree-view__node-container"
                 >
-                  <div
+                  <span
                     class="pf-c-tree-view__node-toggle"
                     tabindex="-1"
                   >
@@ -1362,7 +1362,7 @@ exports[`tree view renders badges successfully 1`] = `
                         />
                       </svg>
                     </span>
-                  </div>
+                  </span>
                   <span
                     class="pf-c-tree-view__node-text"
                   >
@@ -1377,7 +1377,7 @@ exports[`tree view renders badges successfully 1`] = `
                       2
                     </span>
                   </span>
-                </div>
+                </span>
               </button>
             </div>
           </li>
@@ -1394,10 +1394,10 @@ exports[`tree view renders badges successfully 1`] = `
                 class="pf-c-tree-view__node"
                 tabindex="-1"
               >
-                <div
+                <span
                   class="pf-c-tree-view__node-container"
                 >
-                  <div
+                  <span
                     class="pf-c-tree-view__node-toggle"
                     tabindex="-1"
                   >
@@ -1418,7 +1418,7 @@ exports[`tree view renders badges successfully 1`] = `
                         />
                       </svg>
                     </span>
-                  </div>
+                  </span>
                   <span
                     class="pf-c-tree-view__node-text"
                   >
@@ -1433,7 +1433,7 @@ exports[`tree view renders badges successfully 1`] = `
                       2
                     </span>
                   </span>
-                </div>
+                </span>
               </button>
             </div>
           </li>
@@ -1452,10 +1452,10 @@ exports[`tree view renders badges successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -1476,7 +1476,7 @@ exports[`tree view renders badges successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
+              </span>
               <span
                 class="pf-c-tree-view__node-text"
               >
@@ -1491,7 +1491,7 @@ exports[`tree view renders badges successfully 1`] = `
                   1
                 </span>
               </span>
-            </div>
+            </span>
           </button>
         </div>
       </li>
@@ -1508,10 +1508,10 @@ exports[`tree view renders badges successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -1532,7 +1532,7 @@ exports[`tree view renders badges successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
+              </span>
               <span
                 class="pf-c-tree-view__node-text"
               >
@@ -1547,7 +1547,7 @@ exports[`tree view renders badges successfully 1`] = `
                   1
                 </span>
               </span>
-            </div>
+            </span>
           </button>
         </div>
       </li>
@@ -1564,10 +1564,10 @@ exports[`tree view renders badges successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -1588,7 +1588,7 @@ exports[`tree view renders badges successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
+              </span>
               <span
                 class="pf-c-tree-view__node-text"
               >
@@ -1603,7 +1603,7 @@ exports[`tree view renders badges successfully 1`] = `
                   1
                 </span>
               </span>
-            </div>
+            </span>
           </button>
         </div>
       </li>
@@ -1635,10 +1635,10 @@ exports[`tree view renders basic successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="0"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -1659,13 +1659,13 @@ exports[`tree view renders basic successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
+              </span>
               <span
                 class="pf-c-tree-view__node-text"
               >
                 ApplicationLauncher
               </span>
-            </div>
+            </span>
           </button>
         </div>
         <ul
@@ -1685,10 +1685,10 @@ exports[`tree view renders basic successfully 1`] = `
                 class="pf-c-tree-view__node"
                 tabindex="-1"
               >
-                <div
+                <span
                   class="pf-c-tree-view__node-container"
                 >
-                  <div
+                  <span
                     class="pf-c-tree-view__node-toggle"
                     tabindex="-1"
                   >
@@ -1709,13 +1709,13 @@ exports[`tree view renders basic successfully 1`] = `
                         />
                       </svg>
                     </span>
-                  </div>
+                  </span>
                   <span
                     class="pf-c-tree-view__node-text"
                   >
                     Application 1
                   </span>
-                </div>
+                </span>
               </button>
             </div>
           </li>
@@ -1732,10 +1732,10 @@ exports[`tree view renders basic successfully 1`] = `
                 class="pf-c-tree-view__node"
                 tabindex="-1"
               >
-                <div
+                <span
                   class="pf-c-tree-view__node-container"
                 >
-                  <div
+                  <span
                     class="pf-c-tree-view__node-toggle"
                     tabindex="-1"
                   >
@@ -1756,13 +1756,13 @@ exports[`tree view renders basic successfully 1`] = `
                         />
                       </svg>
                     </span>
-                  </div>
+                  </span>
                   <span
                     class="pf-c-tree-view__node-text"
                   >
                     Application 2
                   </span>
-                </div>
+                </span>
               </button>
             </div>
           </li>
@@ -1781,10 +1781,10 @@ exports[`tree view renders basic successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -1805,13 +1805,13 @@ exports[`tree view renders basic successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
+              </span>
               <span
                 class="pf-c-tree-view__node-text"
               >
                 Cost Management
               </span>
-            </div>
+            </span>
           </button>
         </div>
       </li>
@@ -1828,10 +1828,10 @@ exports[`tree view renders basic successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -1852,13 +1852,13 @@ exports[`tree view renders basic successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
+              </span>
               <span
                 class="pf-c-tree-view__node-text"
               >
                 Sources
               </span>
-            </div>
+            </span>
           </button>
         </div>
       </li>
@@ -1875,10 +1875,10 @@ exports[`tree view renders basic successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -1899,13 +1899,13 @@ exports[`tree view renders basic successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
+              </span>
               <span
                 class="pf-c-tree-view__node-text"
               >
                 Really really really long folder name that overflows the container it is in
               </span>
-            </div>
+            </span>
           </button>
         </div>
       </li>
@@ -1933,11 +1933,13 @@ exports[`tree view renders checkboxes successfully 1`] = `
         <div
           class="pf-c-tree-view__content"
         >
-          <div
-            class="pf-c-tree-view__node"
+          <label
+            class="pf-c-tree-view__node pf-m-selectable"
+            for="checkbox-id18"
+            id="label-checkbox-id18"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
               <button
@@ -1972,15 +1974,13 @@ exports[`tree view renders checkboxes successfully 1`] = `
                   type="checkbox"
                 />
               </span>
-              <label
+              <span
                 class="pf-c-tree-view__node-text"
-                for="checkbox-id18"
-                id="label-checkbox-id18"
               >
                 ApplicationLauncher
-              </label>
-            </div>
-          </div>
+              </span>
+            </span>
+          </label>
         </div>
         <ul
           class="pf-c-tree-view__list"
@@ -1995,11 +1995,13 @@ exports[`tree view renders checkboxes successfully 1`] = `
             <div
               class="pf-c-tree-view__content"
             >
-              <div
-                class="pf-c-tree-view__node"
+              <label
+                class="pf-c-tree-view__node pf-m-selectable"
+                for="checkbox-id19"
+                id="label-checkbox-id19"
                 tabindex="-1"
               >
-                <div
+                <span
                   class="pf-c-tree-view__node-container"
                 >
                   <button
@@ -2034,15 +2036,13 @@ exports[`tree view renders checkboxes successfully 1`] = `
                       type="checkbox"
                     />
                   </span>
-                  <label
+                  <span
                     class="pf-c-tree-view__node-text"
-                    for="checkbox-id19"
-                    id="label-checkbox-id19"
                   >
                     Application 1
-                  </label>
-                </div>
-              </div>
+                  </span>
+                </span>
+              </label>
             </div>
           </li>
           <li
@@ -2054,11 +2054,13 @@ exports[`tree view renders checkboxes successfully 1`] = `
             <div
               class="pf-c-tree-view__content"
             >
-              <div
-                class="pf-c-tree-view__node"
+              <label
+                class="pf-c-tree-view__node pf-m-selectable"
+                for="checkbox-id20"
+                id="label-checkbox-id20"
                 tabindex="-1"
               >
-                <div
+                <span
                   class="pf-c-tree-view__node-container"
                 >
                   <button
@@ -2093,15 +2095,13 @@ exports[`tree view renders checkboxes successfully 1`] = `
                       type="checkbox"
                     />
                   </span>
-                  <label
+                  <span
                     class="pf-c-tree-view__node-text"
-                    for="checkbox-id20"
-                    id="label-checkbox-id20"
                   >
                     Application 2
-                  </label>
-                </div>
-              </div>
+                  </span>
+                </span>
+              </label>
             </div>
           </li>
         </ul>
@@ -2115,11 +2115,13 @@ exports[`tree view renders checkboxes successfully 1`] = `
         <div
           class="pf-c-tree-view__content"
         >
-          <div
-            class="pf-c-tree-view__node"
+          <label
+            class="pf-c-tree-view__node pf-m-selectable"
+            for="checkbox-id21"
+            id="label-checkbox-id21"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
               <button
@@ -2154,15 +2156,13 @@ exports[`tree view renders checkboxes successfully 1`] = `
                   type="checkbox"
                 />
               </span>
-              <label
+              <span
                 class="pf-c-tree-view__node-text"
-                for="checkbox-id21"
-                id="label-checkbox-id21"
               >
                 Cost Management
-              </label>
-            </div>
-          </div>
+              </span>
+            </span>
+          </label>
         </div>
       </li>
       <li
@@ -2174,11 +2174,13 @@ exports[`tree view renders checkboxes successfully 1`] = `
         <div
           class="pf-c-tree-view__content"
         >
-          <div
-            class="pf-c-tree-view__node"
+          <label
+            class="pf-c-tree-view__node pf-m-selectable"
+            for="checkbox-id22"
+            id="label-checkbox-id22"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
               <button
@@ -2213,15 +2215,13 @@ exports[`tree view renders checkboxes successfully 1`] = `
                   type="checkbox"
                 />
               </span>
-              <label
+              <span
                 class="pf-c-tree-view__node-text"
-                for="checkbox-id22"
-                id="label-checkbox-id22"
               >
                 Sources
-              </label>
-            </div>
-          </div>
+              </span>
+            </span>
+          </label>
         </div>
       </li>
       <li
@@ -2233,11 +2233,13 @@ exports[`tree view renders checkboxes successfully 1`] = `
         <div
           class="pf-c-tree-view__content"
         >
-          <div
-            class="pf-c-tree-view__node"
+          <label
+            class="pf-c-tree-view__node pf-m-selectable"
+            for="checkbox-id23"
+            id="label-checkbox-id23"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
               <button
@@ -2272,15 +2274,13 @@ exports[`tree view renders checkboxes successfully 1`] = `
                   type="checkbox"
                 />
               </span>
-              <label
+              <span
                 class="pf-c-tree-view__node-text"
-                for="checkbox-id23"
-                id="label-checkbox-id23"
               >
                 Really really really long folder name that overflows the container it is in
-              </label>
-            </div>
-          </div>
+              </span>
+            </span>
+          </label>
         </div>
       </li>
     </ul>
@@ -2311,10 +2311,10 @@ exports[`tree view renders icons successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="0"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -2335,7 +2335,7 @@ exports[`tree view renders icons successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
+              </span>
               <span
                 class="pf-c-tree-view__node-icon"
               >
@@ -2358,7 +2358,7 @@ exports[`tree view renders icons successfully 1`] = `
               >
                 ApplicationLauncher
               </span>
-            </div>
+            </span>
           </button>
         </div>
         <ul
@@ -2378,10 +2378,10 @@ exports[`tree view renders icons successfully 1`] = `
                 class="pf-c-tree-view__node"
                 tabindex="-1"
               >
-                <div
+                <span
                   class="pf-c-tree-view__node-container"
                 >
-                  <div
+                  <span
                     class="pf-c-tree-view__node-toggle"
                     tabindex="-1"
                   >
@@ -2402,7 +2402,7 @@ exports[`tree view renders icons successfully 1`] = `
                         />
                       </svg>
                     </span>
-                  </div>
+                  </span>
                   <span
                     class="pf-c-tree-view__node-icon"
                   >
@@ -2425,7 +2425,7 @@ exports[`tree view renders icons successfully 1`] = `
                   >
                     Application 1
                   </span>
-                </div>
+                </span>
               </button>
             </div>
           </li>
@@ -2442,10 +2442,10 @@ exports[`tree view renders icons successfully 1`] = `
                 class="pf-c-tree-view__node"
                 tabindex="-1"
               >
-                <div
+                <span
                   class="pf-c-tree-view__node-container"
                 >
-                  <div
+                  <span
                     class="pf-c-tree-view__node-toggle"
                     tabindex="-1"
                   >
@@ -2466,7 +2466,7 @@ exports[`tree view renders icons successfully 1`] = `
                         />
                       </svg>
                     </span>
-                  </div>
+                  </span>
                   <span
                     class="pf-c-tree-view__node-icon"
                   >
@@ -2489,7 +2489,7 @@ exports[`tree view renders icons successfully 1`] = `
                   >
                     Application 2
                   </span>
-                </div>
+                </span>
               </button>
             </div>
           </li>
@@ -2508,10 +2508,10 @@ exports[`tree view renders icons successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -2532,7 +2532,7 @@ exports[`tree view renders icons successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
+              </span>
               <span
                 class="pf-c-tree-view__node-icon"
               >
@@ -2555,7 +2555,7 @@ exports[`tree view renders icons successfully 1`] = `
               >
                 Cost Management
               </span>
-            </div>
+            </span>
           </button>
         </div>
       </li>
@@ -2572,10 +2572,10 @@ exports[`tree view renders icons successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -2596,7 +2596,7 @@ exports[`tree view renders icons successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
+              </span>
               <span
                 class="pf-c-tree-view__node-icon"
               >
@@ -2619,7 +2619,7 @@ exports[`tree view renders icons successfully 1`] = `
               >
                 Sources
               </span>
-            </div>
+            </span>
           </button>
         </div>
       </li>
@@ -2636,10 +2636,10 @@ exports[`tree view renders icons successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -2660,7 +2660,7 @@ exports[`tree view renders icons successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
+              </span>
               <span
                 class="pf-c-tree-view__node-icon"
               >
@@ -2683,7 +2683,7 @@ exports[`tree view renders icons successfully 1`] = `
               >
                 Really really really long folder name that overflows the container it is in
               </span>
-            </div>
+            </span>
           </button>
         </div>
       </li>
@@ -2711,11 +2711,13 @@ exports[`tree view renders individual flag options successfully 1`] = `
         <div
           class="pf-c-tree-view__content"
         >
-          <div
-            class="pf-c-tree-view__node"
+          <label
+            class="pf-c-tree-view__node pf-m-selectable"
+            for="checkbox-id36"
+            id="label-checkbox-id36"
             tabindex="0"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
               <button
@@ -2767,15 +2769,13 @@ exports[`tree view renders individual flag options successfully 1`] = `
                   />
                 </svg>
               </span>
-              <label
+              <span
                 class="pf-c-tree-view__node-text"
-                for="checkbox-id36"
-                id="label-checkbox-id36"
               >
                 ApplicationLauncher
-              </label>
-            </div>
-          </div>
+              </span>
+            </span>
+          </label>
         </div>
         <ul
           class="pf-c-tree-view__list"
@@ -2794,10 +2794,10 @@ exports[`tree view renders individual flag options successfully 1`] = `
                 class="pf-c-tree-view__node"
                 tabindex="-1"
               >
-                <div
+                <span
                   class="pf-c-tree-view__node-container"
                 >
-                  <div
+                  <span
                     class="pf-c-tree-view__node-toggle"
                     tabindex="-1"
                   >
@@ -2818,13 +2818,13 @@ exports[`tree view renders individual flag options successfully 1`] = `
                         />
                       </svg>
                     </span>
-                  </div>
+                  </span>
                   <span
                     class="pf-c-tree-view__node-text"
                   >
                     Application 1
                   </span>
-                </div>
+                </span>
               </button>
             </div>
           </li>
@@ -2841,10 +2841,10 @@ exports[`tree view renders individual flag options successfully 1`] = `
                 class="pf-c-tree-view__node"
                 tabindex="-1"
               >
-                <div
+                <span
                   class="pf-c-tree-view__node-container"
                 >
-                  <div
+                  <span
                     class="pf-c-tree-view__node-toggle"
                     tabindex="-1"
                   >
@@ -2865,7 +2865,7 @@ exports[`tree view renders individual flag options successfully 1`] = `
                         />
                       </svg>
                     </span>
-                  </div>
+                  </span>
                   <span
                     class="pf-c-tree-view__node-text"
                   >
@@ -2880,7 +2880,7 @@ exports[`tree view renders individual flag options successfully 1`] = `
                       2
                     </span>
                   </span>
-                </div>
+                </span>
               </button>
             </div>
           </li>
@@ -2899,10 +2899,10 @@ exports[`tree view renders individual flag options successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -2923,7 +2923,7 @@ exports[`tree view renders individual flag options successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
+              </span>
               <span
                 class="pf-c-tree-view__node-text"
               >
@@ -2938,7 +2938,7 @@ exports[`tree view renders individual flag options successfully 1`] = `
                   1
                 </span>
               </span>
-            </div>
+            </span>
           </button>
           <div
             class="pf-c-tree-view__action"
@@ -2982,10 +2982,10 @@ exports[`tree view renders individual flag options successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -3006,13 +3006,13 @@ exports[`tree view renders individual flag options successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
+              </span>
               <span
                 class="pf-c-tree-view__node-text"
               >
                 Sources
               </span>
-            </div>
+            </span>
           </button>
         </div>
       </li>
@@ -3029,10 +3029,10 @@ exports[`tree view renders individual flag options successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -3053,13 +3053,13 @@ exports[`tree view renders individual flag options successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
+              </span>
               <span
                 class="pf-c-tree-view__node-text"
               >
                 Really really really long folder name that overflows the container it is in
               </span>
-            </div>
+            </span>
           </button>
         </div>
       </li>
@@ -3113,10 +3113,10 @@ exports[`tree view renders toolbar successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="0"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -3137,13 +3137,13 @@ exports[`tree view renders toolbar successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
+              </span>
               <span
                 class="pf-c-tree-view__node-text"
               >
                 ApplicationLauncher
               </span>
-            </div>
+            </span>
           </button>
         </div>
         <ul
@@ -3163,10 +3163,10 @@ exports[`tree view renders toolbar successfully 1`] = `
                 class="pf-c-tree-view__node"
                 tabindex="-1"
               >
-                <div
+                <span
                   class="pf-c-tree-view__node-container"
                 >
-                  <div
+                  <span
                     class="pf-c-tree-view__node-toggle"
                     tabindex="-1"
                   >
@@ -3187,13 +3187,13 @@ exports[`tree view renders toolbar successfully 1`] = `
                         />
                       </svg>
                     </span>
-                  </div>
+                  </span>
                   <span
                     class="pf-c-tree-view__node-text"
                   >
                     Application 1
                   </span>
-                </div>
+                </span>
               </button>
             </div>
           </li>
@@ -3210,10 +3210,10 @@ exports[`tree view renders toolbar successfully 1`] = `
                 class="pf-c-tree-view__node"
                 tabindex="-1"
               >
-                <div
+                <span
                   class="pf-c-tree-view__node-container"
                 >
-                  <div
+                  <span
                     class="pf-c-tree-view__node-toggle"
                     tabindex="-1"
                   >
@@ -3234,13 +3234,13 @@ exports[`tree view renders toolbar successfully 1`] = `
                         />
                       </svg>
                     </span>
-                  </div>
+                  </span>
                   <span
                     class="pf-c-tree-view__node-text"
                   >
                     Application 2
                   </span>
-                </div>
+                </span>
               </button>
             </div>
           </li>
@@ -3259,10 +3259,10 @@ exports[`tree view renders toolbar successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -3283,13 +3283,13 @@ exports[`tree view renders toolbar successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
+              </span>
               <span
                 class="pf-c-tree-view__node-text"
               >
                 Cost Management
               </span>
-            </div>
+            </span>
           </button>
         </div>
       </li>
@@ -3306,10 +3306,10 @@ exports[`tree view renders toolbar successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -3330,13 +3330,13 @@ exports[`tree view renders toolbar successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
+              </span>
               <span
                 class="pf-c-tree-view__node-text"
               >
                 Sources
               </span>
-            </div>
+            </span>
           </button>
         </div>
       </li>
@@ -3353,10 +3353,10 @@ exports[`tree view renders toolbar successfully 1`] = `
             class="pf-c-tree-view__node"
             tabindex="-1"
           >
-            <div
+            <span
               class="pf-c-tree-view__node-container"
             >
-              <div
+              <span
                 class="pf-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -3377,13 +3377,13 @@ exports[`tree view renders toolbar successfully 1`] = `
                     />
                   </svg>
                 </span>
-              </div>
+              </span>
               <span
                 class="pf-c-tree-view__node-text"
               >
                 Really really really long folder name that overflows the container it is in
               </span>
-            </div>
+            </span>
           </button>
         </div>
       </li>

--- a/packages/react-core/src/components/TreeView/__tests__/__snapshots__/TreeView.test.tsx.snap
+++ b/packages/react-core/src/components/TreeView/__tests__/__snapshots__/TreeView.test.tsx.snap
@@ -1945,7 +1945,6 @@ exports[`tree view renders checkboxes successfully 1`] = `
               <button
                 aria-labelledby="label-checkbox-id18"
                 class="pf-c-tree-view__node-toggle"
-                id="checkbox-id18-toggle-button"
                 tabindex="0"
               >
                 <span
@@ -2008,7 +2007,6 @@ exports[`tree view renders checkboxes successfully 1`] = `
                   <button
                     aria-labelledby="label-checkbox-id19"
                     class="pf-c-tree-view__node-toggle"
-                    id="checkbox-id19-toggle-button"
                     tabindex="-1"
                   >
                     <span
@@ -2068,7 +2066,6 @@ exports[`tree view renders checkboxes successfully 1`] = `
                   <button
                     aria-labelledby="label-checkbox-id20"
                     class="pf-c-tree-view__node-toggle"
-                    id="checkbox-id20-toggle-button"
                     tabindex="-1"
                   >
                     <span
@@ -2130,7 +2127,6 @@ exports[`tree view renders checkboxes successfully 1`] = `
               <button
                 aria-labelledby="label-checkbox-id21"
                 class="pf-c-tree-view__node-toggle"
-                id="checkbox-id21-toggle-button"
                 tabindex="-1"
               >
                 <span
@@ -2190,7 +2186,6 @@ exports[`tree view renders checkboxes successfully 1`] = `
               <button
                 aria-labelledby="label-checkbox-id22"
                 class="pf-c-tree-view__node-toggle"
-                id="checkbox-id22-toggle-button"
                 tabindex="-1"
               >
                 <span
@@ -2250,7 +2245,6 @@ exports[`tree view renders checkboxes successfully 1`] = `
               <button
                 aria-labelledby="label-checkbox-id23"
                 class="pf-c-tree-view__node-toggle"
-                id="checkbox-id23-toggle-button"
                 tabindex="-1"
               >
                 <span
@@ -2729,7 +2723,6 @@ exports[`tree view renders individual flag options successfully 1`] = `
               <button
                 aria-labelledby="label-checkbox-id36"
                 class="pf-c-tree-view__node-toggle"
-                id="checkbox-id36-toggle-button"
                 tabindex="-1"
               >
                 <span

--- a/packages/react-core/src/components/TreeView/__tests__/__snapshots__/TreeView.test.tsx.snap
+++ b/packages/react-core/src/components/TreeView/__tests__/__snapshots__/TreeView.test.tsx.snap
@@ -1945,6 +1945,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
               <button
                 aria-labelledby="label-checkbox-id18"
                 class="pf-c-tree-view__node-toggle"
+                id="checkbox-id18-toggle-button"
                 tabindex="0"
               >
                 <span
@@ -2007,6 +2008,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
                   <button
                     aria-labelledby="label-checkbox-id19"
                     class="pf-c-tree-view__node-toggle"
+                    id="checkbox-id19-toggle-button"
                     tabindex="-1"
                   >
                     <span
@@ -2066,6 +2068,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
                   <button
                     aria-labelledby="label-checkbox-id20"
                     class="pf-c-tree-view__node-toggle"
+                    id="checkbox-id20-toggle-button"
                     tabindex="-1"
                   >
                     <span
@@ -2127,6 +2130,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
               <button
                 aria-labelledby="label-checkbox-id21"
                 class="pf-c-tree-view__node-toggle"
+                id="checkbox-id21-toggle-button"
                 tabindex="-1"
               >
                 <span
@@ -2186,6 +2190,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
               <button
                 aria-labelledby="label-checkbox-id22"
                 class="pf-c-tree-view__node-toggle"
+                id="checkbox-id22-toggle-button"
                 tabindex="-1"
               >
                 <span
@@ -2245,6 +2250,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
               <button
                 aria-labelledby="label-checkbox-id23"
                 class="pf-c-tree-view__node-toggle"
+                id="checkbox-id23-toggle-button"
                 tabindex="-1"
               >
                 <span
@@ -2723,6 +2729,7 @@ exports[`tree view renders individual flag options successfully 1`] = `
               <button
                 aria-labelledby="label-checkbox-id36"
                 class="pf-c-tree-view__node-toggle"
+                id="checkbox-id36-toggle-button"
                 tabindex="-1"
               >
                 <span

--- a/packages/react-core/src/components/TreeView/examples/TreeView.md
+++ b/packages/react-core/src/components/TreeView/examples/TreeView.md
@@ -119,22 +119,15 @@ The `hasSelectableNodes` modifier will separate the expansion and selection beha
 import React from 'react';
 import { TreeView, Button } from '@patternfly/react-core';
 
-class DefaultTreeView extends React.Component {
+class SelectableNodesTreeView extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = { activeItems: {}, allExpanded: null };
+    this.state = { activeItems: {} };
 
     this.onSelect = (evt, treeViewItem) => {
       this.setState({
         activeItems: [treeViewItem]
-      });
-    };
-
-    this.onToggle = evt => {
-      const { allExpanded } = this.state;
-      this.setState({
-        allExpanded: allExpanded !== undefined ? !allExpanded : true
       });
     };
   }
@@ -202,19 +195,13 @@ class DefaultTreeView extends React.Component {
       }
     ];
     return (
-      <React.Fragment>
-        <Button variant="link" onClick={this.onToggle}>
-          {allExpanded && 'Collapse all'}
-          {!allExpanded && 'Expand all'}
-        </Button>
-        <TreeView
-          hasSelectableNodes
-          data={options}
-          activeItems={activeItems}
-          onSelect={this.onSelect}
-          allExpanded={allExpanded}
-        />
-      </React.Fragment>
+      <TreeView
+        hasSelectableNodes
+        data={options}
+        activeItems={activeItems}
+        onSelect={this.onSelect}
+        allExpanded={allExpanded}
+      />
     );
   }
 }

--- a/packages/react-core/src/components/TreeView/examples/TreeView.md
+++ b/packages/react-core/src/components/TreeView/examples/TreeView.md
@@ -138,28 +138,28 @@ class SelectableNodesTreeView extends React.Component {
     const options = [
       {
         name: 'Application launcher',
-        id: 'example1-AppLaunch',
+        id: 'SelNodesTreeView-AppLaunch',
         children: [
           {
             name: 'Application 1',
-            id: 'example1-App1',
+            id: 'SelNodesTreeView-App1',
             children: [
-              { name: 'Settings', id: 'example1-App1Settings' },
-              { name: 'Current', id: 'example1-App1Current' }
+              { name: 'Settings', id: 'SelNodesTreeView-App1Settings' },
+              { name: 'Current', id: 'SelNodesTreeView-App1Current' }
             ]
           },
           {
             name: 'Application 2',
-            id: 'example1-App2',
+            id: 'SelNodesTreeView-App2',
             children: [
-              { name: 'Settings', id: 'example1-App2Settings' },
+              { name: 'Settings', id: 'SelNodesTreeView-App2Settings' },
               {
                 name: 'Loader',
-                id: 'example1-App2Loader',
+                id: 'SelNodesTreeView-App2Loader',
                 children: [
-                  { name: 'Loading App 1', id: 'example1-LoadApp1' },
-                  { name: 'Loading App 2', id: 'example1-LoadApp2' },
-                  { name: 'Loading App 3', id: 'example1-LoadApp3' }
+                  { name: 'Loading App 1', id: 'SelNodesTreeView-LoadApp1' },
+                  { name: 'Loading App 2', id: 'SelNodesTreeView-LoadApp2' },
+                  { name: 'Loading App 3', id: 'SelNodesTreeView-LoadApp3' }
                 ]
               }
             ]
@@ -169,29 +169,33 @@ class SelectableNodesTreeView extends React.Component {
       },
       {
         name: 'Cost management',
-        id: 'example1-Cost',
+        id: 'SelNodesTreeView-Cost',
         children: [
           {
             name: 'Application 3',
-            id: 'example1-App3',
+            id: 'SelNodesTreeView-App3',
             children: [
-              { name: 'Settings', id: 'example1-App3Settings' },
-              { name: 'Current', id: 'example1-App3Current' }
+              { name: 'Settings', id: 'SelNodesTreeView-App3Settings' },
+              { name: 'Current', id: 'SelNodesTreeView-App3Current' }
             ]
           }
         ]
       },
       {
         name: 'Sources',
-        id: 'example1-Sources',
+        id: 'SelNodesTreeView-Sources',
         children: [
-          { name: 'Application 4', id: 'example1-App4', children: [{ name: 'Settings', id: 'example1-App4Settings' }] }
+          {
+            name: 'Application 4',
+            id: 'SelNodesTreeView-App4',
+            children: [{ name: 'Settings', id: 'SelNodesTreeView-App4Settings' }]
+          }
         ]
       },
       {
         name: 'Really really really long folder name that overflows the container it is in',
-        id: 'example1-Long',
-        children: [{ name: 'Application 5', id: 'example1-App5' }]
+        id: 'SelNodesTreeView-Long',
+        children: [{ name: 'Application 5', id: 'SelNodesTreeView-App5' }]
       }
     ];
     return (

--- a/packages/react-core/src/components/TreeView/examples/TreeView.md
+++ b/packages/react-core/src/components/TreeView/examples/TreeView.md
@@ -88,7 +88,9 @@ class DefaultTreeView extends React.Component {
       {
         name: 'Sources',
         id: 'example1-Sources',
-        children: [{ name: 'Application 4', id: 'example1-App4', children: [{ name: 'Settings', id: 'example1-App4Settings' }] }]
+        children: [
+          { name: 'Application 4', id: 'example1-App4', children: [{ name: 'Settings', id: 'example1-App4Settings' }] }
+        ]
       },
       {
         name: 'Really really really long folder name that overflows the container it is in',
@@ -103,6 +105,115 @@ class DefaultTreeView extends React.Component {
           {!allExpanded && 'Expand all'}
         </Button>
         <TreeView data={options} activeItems={activeItems} onSelect={this.onSelect} allExpanded={allExpanded} />
+      </React.Fragment>
+    );
+  }
+}
+```
+
+### With separate selection and expansion
+
+The `hasSelectableNodes` modifier will separate the expansion and selection behaviors, allowing a parent node to be selected or deselected with toggling its expansion.
+
+```js
+import React from 'react';
+import { TreeView, Button } from '@patternfly/react-core';
+
+class DefaultTreeView extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = { activeItems: {}, allExpanded: null };
+
+    this.onSelect = (evt, treeViewItem) => {
+      this.setState({
+        activeItems: [treeViewItem]
+      });
+    };
+
+    this.onToggle = evt => {
+      const { allExpanded } = this.state;
+      this.setState({
+        allExpanded: allExpanded !== undefined ? !allExpanded : true
+      });
+    };
+  }
+
+  render() {
+    const { activeItems, allExpanded } = this.state;
+
+    const options = [
+      {
+        name: 'Application launcher',
+        id: 'example1-AppLaunch',
+        children: [
+          {
+            name: 'Application 1',
+            id: 'example1-App1',
+            children: [
+              { name: 'Settings', id: 'example1-App1Settings' },
+              { name: 'Current', id: 'example1-App1Current' }
+            ]
+          },
+          {
+            name: 'Application 2',
+            id: 'example1-App2',
+            children: [
+              { name: 'Settings', id: 'example1-App2Settings' },
+              {
+                name: 'Loader',
+                id: 'example1-App2Loader',
+                children: [
+                  { name: 'Loading App 1', id: 'example1-LoadApp1' },
+                  { name: 'Loading App 2', id: 'example1-LoadApp2' },
+                  { name: 'Loading App 3', id: 'example1-LoadApp3' }
+                ]
+              }
+            ]
+          }
+        ],
+        defaultExpanded: true
+      },
+      {
+        name: 'Cost management',
+        id: 'example1-Cost',
+        children: [
+          {
+            name: 'Application 3',
+            id: 'example1-App3',
+            children: [
+              { name: 'Settings', id: 'example1-App3Settings' },
+              { name: 'Current', id: 'example1-App3Current' }
+            ]
+          }
+        ]
+      },
+      {
+        name: 'Sources',
+        id: 'example1-Sources',
+        children: [
+          { name: 'Application 4', id: 'example1-App4', children: [{ name: 'Settings', id: 'example1-App4Settings' }] }
+        ]
+      },
+      {
+        name: 'Really really really long folder name that overflows the container it is in',
+        id: 'example1-Long',
+        children: [{ name: 'Application 5', id: 'example1-App5' }]
+      }
+    ];
+    return (
+      <React.Fragment>
+        <Button variant="link" onClick={this.onToggle}>
+          {allExpanded && 'Collapse all'}
+          {!allExpanded && 'Expand all'}
+        </Button>
+        <TreeView
+          hasSelectableNodes
+          data={options}
+          activeItems={activeItems}
+          onSelect={this.onSelect}
+          allExpanded={allExpanded}
+        />
       </React.Fragment>
     );
   }
@@ -168,7 +279,13 @@ class SearchTreeView extends React.Component {
       {
         name: 'Sources',
         id: 'example2-Sources',
-        children: [{ name: 'Application 4', id: 'example2-App4', children: [{ name: 'Settingexample2-s', id: 'example2-App4Settings' }] }]
+        children: [
+          {
+            name: 'Application 4',
+            id: 'example2-App4',
+            children: [{ name: 'Settingexample2-s', id: 'example2-App4Settings' }]
+          }
+        ]
       },
       {
         name: 'Really really really long folder name that overflows the container it is in',
@@ -357,7 +474,9 @@ class CheckboxTreeView extends React.Component {
         name: 'Really really really long folder name that overflows the container it is in',
         id: 'example3-Long',
         checkProps: { 'aria-label': 'long-check', checked: false },
-        children: [{ name: 'Application 5', id: 'example3-App5', checkProps: { 'aria-label': 'app-5-check', checked: false } }]
+        children: [
+          { name: 'Application 5', id: 'example3-App5', checkProps: { 'aria-label': 'app-5-check', checked: false } }
+        ]
       }
     ];
 
@@ -522,7 +641,9 @@ class IconTreeView extends React.Component {
       {
         name: 'Sources',
         id: 'example4-Sources',
-        children: [{ name: 'Application 4', id: 'example4-App4', children: [{ name: 'Settings', id: 'example4-App4Settings' }] }]
+        children: [
+          { name: 'Application 4', id: 'example4-App4', children: [{ name: 'Settings', id: 'example4-App4Settings' }] }
+        ]
       },
       {
         name: 'Really really really long folder name that overflows the container it is in',
@@ -613,7 +734,9 @@ class BadgesTreeView extends React.Component {
       {
         name: 'Sources',
         id: 'example5-Sources',
-        children: [{ name: 'Application 4', id: 'example5-App4', children: [{ name: 'Settings', id: 'example5-App4Settings' }] }]
+        children: [
+          { name: 'Application 4', id: 'example5-App4', children: [{ name: 'Settings', id: 'example5-App4Settings' }] }
+        ]
       },
       {
         name: 'Really really really long folder name that overflows the container it is in',
@@ -842,7 +965,9 @@ class IconTreeView extends React.Component {
       {
         name: 'Sources',
         id: 'example7-Sources',
-        children: [{ name: 'Application 4', id: 'example7-App4', children: [{ name: 'Settings', id: 'example7-App4Settings' }] }]
+        children: [
+          { name: 'Application 4', id: 'example7-App4', children: [{ name: 'Settings', id: 'example7-App4Settings' }] }
+        ]
       },
       {
         name: 'Really really really long folder name that overflows the container it is in',
@@ -911,7 +1036,9 @@ const GuidesTreeView: React.FunctionComponent = () => {
     {
       name: 'Sources',
       id: 'example8-Sources',
-      children: [{ name: 'Application 4', id: 'example8-App4', children: [{ name: 'Settings', id: 'example8-App4Settings' }] }]
+      children: [
+        { name: 'Application 4', id: 'example8-App4', children: [{ name: 'Settings', id: 'example8-App4Settings' }] }
+      ]
     },
     {
       name: 'Really really really long folder name that overflows the container it is in',


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7378

Adds `hasSelectableNodes` prop that separates expansion & selection behaviors - clicking the row will select it while clicking the toggle button will trigger the expansion. This flag will also allow parent nodes to be selected (in addition to leaf nodes) and apply the current style modifier to them.
