### PR TITLE
fix(Calendar month) aria labels for dates outside of the selected month are inaccurate

### DIFF
--- a/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
+++ b/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
@@ -345,7 +345,9 @@ export const CalendarMonth = ({
                       tabIndex={isFocused ? 0 : -1}
                       disabled={!isValid}
                       aria-label={
-                        cellAriaLabel ? cellAriaLabel(date) : `${dayFormatted} ${monthFormatted} ${yearFormatted}`
+                        cellAriaLabel
+                          ? cellAriaLabel(date)
+                          : `${dayFormat(date)} ${monthFormat(date)} ${yearFormat(date)}`
                       }
                       {...(isFocused && { ref: focusRef })}
                     >

--- a/packages/react-core/src/components/CalendarMonth/__tests__/CalendarMonth.test.tsx
+++ b/packages/react-core/src/components/CalendarMonth/__tests__/CalendarMonth.test.tsx
@@ -27,3 +27,31 @@ test('Renders the last date in a month when a custom weekStart is passed', () =>
   const lastDate = screen.queryByRole('button', { name: '31 January 2023' });
   expect(lastDate).toBeVisible();
 });
+
+test('Previous month dates have correct month in aria label', () => {
+  render(<CalendarMonth date={new Date(2024, 5)} />);
+
+  const previousMonthDate = screen.queryByRole('button', { name: '31 May 2024' });
+  expect(previousMonthDate).toBeVisible();
+});
+
+test('Next month dates have correct month in aria label', () => {
+  render(<CalendarMonth date={new Date(2024, 6)} />);
+
+  const nextMonthDate = screen.queryByRole('button', { name: '1 August 2024' });
+  expect(nextMonthDate).toBeVisible();
+});
+
+test('Previous year dates have correct month in aria label', () => {
+  render(<CalendarMonth date={new Date(2024, 0)} />);
+
+  const previousYearDate = screen.queryByRole('button', { name: '31 December 2023' });
+  expect(previousYearDate).toBeVisible();
+});
+
+test('Next month dates have correct month in aria label', () => {
+  render(<CalendarMonth date={new Date(2024, 11)} />);
+
+  const nextYearDate = screen.queryByRole('button', { name: '1 January 2025' });
+  expect(nextYearDate).toBeVisible();
+});

--- a/packages/react-core/src/components/CalendarMonth/__tests__/CalendarMonth.test.tsx
+++ b/packages/react-core/src/components/CalendarMonth/__tests__/CalendarMonth.test.tsx
@@ -12,7 +12,7 @@ test('Renders the first date in a month when a custom weekStart is passed', () =
 
   render(<CalendarMonth cellAriaLabel={formatAria} weekStart={1} date={new Date(2023, 0)} />);
 
-  const firstDate = screen.queryByRole('button', { name: '1 January 2023' });
+  const firstDate = screen.getByRole('button', { name: '1 January 2023' });
   expect(firstDate).toBeVisible();
 });
 
@@ -24,34 +24,34 @@ test('Renders the last date in a month when a custom weekStart is passed', () =>
 
   render(<CalendarMonth cellAriaLabel={formatAria} weekStart={1} date={new Date(2023, 0)} />);
 
-  const lastDate = screen.queryByRole('button', { name: '31 January 2023' });
+  const lastDate = screen.getByRole('button', { name: '31 January 2023' });
   expect(lastDate).toBeVisible();
 });
 
 test('Previous month dates have correct month in aria label', () => {
   render(<CalendarMonth date={new Date(2024, 5)} />);
 
-  const previousMonthDate = screen.queryByRole('button', { name: '31 May 2024' });
+  const previousMonthDate = screen.getByRole('button', { name: '31 May 2024' });
   expect(previousMonthDate).toBeVisible();
 });
 
 test('Next month dates have correct month in aria label', () => {
   render(<CalendarMonth date={new Date(2024, 6)} />);
 
-  const nextMonthDate = screen.queryByRole('button', { name: '1 August 2024' });
+  const nextMonthDate = screen.getByRole('button', { name: '1 August 2024' });
   expect(nextMonthDate).toBeVisible();
 });
 
-test('Previous year dates have correct month in aria label', () => {
+test('Previous year dates have correct year in aria label', () => {
   render(<CalendarMonth date={new Date(2024, 0)} />);
 
-  const previousYearDate = screen.queryByRole('button', { name: '31 December 2023' });
+  const previousYearDate = screen.getByRole('button', { name: '31 December 2023' });
   expect(previousYearDate).toBeVisible();
 });
 
-test('Next month dates have correct month in aria label', () => {
+test('Next year dates have correct year in aria label', () => {
   render(<CalendarMonth date={new Date(2024, 11)} />);
 
-  const nextYearDate = screen.queryByRole('button', { name: '1 January 2025' });
+  const nextYearDate = screen.getByRole('button', { name: '1 January 2025' });
   expect(nextYearDate).toBeVisible();
 });


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7718

There was same issue with years in aria label. 31 December 2023 date had "31 January 2024" aria label. This should be also resolved by this pull request.
