### PR TITLE
docs(Dropdown): deprecate isHovered

### DIFF
--- a/packages/react-core/src/components/Dropdown/DropdownItem.tsx
+++ b/packages/react-core/src/components/Dropdown/DropdownItem.tsx
@@ -27,7 +27,7 @@ export interface DropdownItemProps extends InternalDropdownItemProps, OUIAProps 
   isAriaDisabled?: boolean;
   /** Render dropdown item as non-interactive item */
   isPlainText?: boolean;
-  /** Forces display of the hover state of the element */
+  /** @deprecated Forces display of the hover state of the element */
   isHovered?: boolean;
   /** Default hyperlink location */
   href?: string;
@@ -56,7 +56,6 @@ export const DropdownItem: React.FunctionComponent<DropdownItemProps> = ({
   isDisabled = false,
   isAriaDisabled = false,
   isPlainText = false,
-  isHovered = false,
   href,
   tooltip,
   tooltipProps = {},
@@ -88,7 +87,6 @@ export const DropdownItem: React.FunctionComponent<DropdownItemProps> = ({
           isDisabled={isDisabled}
           isAriaDisabled={isAriaDisabled}
           isPlainText={isPlainText}
-          isHovered={isHovered}
           href={href}
           tooltip={tooltip}
           tooltipProps={tooltipProps}

--- a/packages/react-core/src/components/Dropdown/InternalDropdownItem.tsx
+++ b/packages/react-core/src/components/Dropdown/InternalDropdownItem.tsx
@@ -25,8 +25,6 @@ export interface InternalDropdownItemProps extends React.HTMLProps<HTMLAnchorEle
   isAriaDisabled?: boolean;
   /** Render dropdown item as a non-interactive item */
   isPlainText?: boolean;
-  /** Forces display of the hover state of the element */
-  isHovered?: boolean;
   /** Default hyperlink location */
   href?: string;
   /** Tooltip to display when hovered over the item */
@@ -67,7 +65,6 @@ export class InternalDropdownItem extends React.Component<InternalDropdownItemPr
 
   static defaultProps: InternalDropdownItemProps = {
     className: '',
-    isHovered: false,
     component: 'a',
     role: 'none',
     isDisabled: false,
@@ -163,7 +160,6 @@ export class InternalDropdownItem extends React.Component<InternalDropdownItemPr
     const {
       className,
       children,
-      isHovered,
       context,
       onClick,
       component,


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7305

Deprecates the `isHovered` property (which hasn't been functional in a while) on the exported component and removes it from prop interfaces of internal components.
