### PR TITLE
chore(NotificationDrawer): Clean up demo imports

### DIFF
--- a/packages/react-core/src/demos/NotificationDrawer/NotificationDrawer.md
+++ b/packages/react-core/src/demos/NotificationDrawer/NotificationDrawer.md
@@ -12,7 +12,6 @@ import QuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/question-
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import imgBrand from '@patternfly/react-core/src/components/Brand/examples/pfLogo.svg';
 import imgAvatar from '@patternfly/react-core/src/components/Avatar/examples/avatarImg.svg';
-import AttentionBellIcon from '@patternfly/react-icons/dist/esm/icons/attention-bell-icon';
 
 ## Demos
 
@@ -43,8 +42,7 @@ import {
   EmptyStateBody,
   EmptyStateIcon,
   EmptyStatePrimary,
-  Gallery,
-  GalleryItem,
+  EmptyStateVariant,
   KebabToggle,
   Nav,
   NavItem,
@@ -83,6 +81,7 @@ import QuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/question-
 import BarsIcon from '@patternfly/react-icons/dist/js/icons/bars-icon';
 import imgBrand from '@patternfly/react-core/src/components/Brand/examples/pfLogo.svg';
 import imgAvatar from '@patternfly/react-core/src/components/Avatar/examples/avatarImg.svg';
+import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 
 class BasicNotificationDrawer extends React.Component {
   constructor(props) {

--- a/packages/react-core/src/demos/NotificationDrawer/NotificationDrawer.md
+++ b/packages/react-core/src/demos/NotificationDrawer/NotificationDrawer.md
@@ -32,13 +32,10 @@ import {
   BreadcrumbItem,
   Button,
   ButtonVariant,
-  Card,
-  CardBody,
-  Drawer,
-  DrawerContent,
-  DrawerContentBody,
   Dropdown,
   DropdownGroup,
+  DropdownPosition,
+  DropdownDirection,
   DropdownToggle,
   DropdownItem,
   DropdownSeparator,
@@ -79,7 +76,6 @@ import {
   ToolbarGroup,
   ToolbarContent
 } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import BellIcon from '@patternfly/react-icons/dist/esm/icons/bell-icon';
 import CogIcon from '@patternfly/react-icons/dist/esm/icons/cog-icon';
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
@@ -87,7 +83,6 @@ import QuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/question-
 import BarsIcon from '@patternfly/react-icons/dist/js/icons/bars-icon';
 import imgBrand from '@patternfly/react-core/src/components/Brand/examples/pfLogo.svg';
 import imgAvatar from '@patternfly/react-core/src/components/Avatar/examples/avatarImg.svg';
-import { Table, TableHeader, TableBody } from '@patternfly/react-table';
 
 class BasicNotificationDrawer extends React.Component {
   constructor(props) {
@@ -548,13 +543,10 @@ import {
   BreadcrumbItem,
   Button,
   ButtonVariant,
-  Card,
-  CardBody,
-  Drawer,
-  DrawerContent,
-  DrawerContentBody,
   Dropdown,
   DropdownGroup,
+  DropdownPosition,
+  DropdownDirection,
   DropdownToggle,
   DropdownItem,
   DropdownSeparator,
@@ -562,8 +554,7 @@ import {
   EmptyStateBody,
   EmptyStateIcon,
   EmptyStatePrimary,
-  Gallery,
-  GalleryItem,
+  EmptyStateVariant,
   KebabToggle,
   Nav,
   NavItem,
@@ -597,16 +588,14 @@ import {
   ToolbarGroup,
   ToolbarContent
 } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import BellIcon from '@patternfly/react-icons/dist/esm/icons/bell-icon';
 import CogIcon from '@patternfly/react-icons/dist/esm/icons/cog-icon';
-import AttentionBellIcon from '@patternfly/react-icons/dist/esm/icons/attention-bell-icon';
 import BarsIcon from '@patternfly/react-icons/dist/esm/icons/bars-icon';
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
+import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import QuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/question-circle-icon';
 import imgBrand from '@patternfly/react-core/src/components/Brand/examples/pfLogo.svg';
 import imgAvatar from '@patternfly/react-core/src/components/Avatar/examples/avatarImg.svg';
-import { Table, TableHeader, TableBody } from '@patternfly/react-table';
 
 class GroupedNotificationDrawer extends React.Component {
   constructor(props) {


### PR DESCRIPTION
Closes #7723

Clean up unused imports
Add missing imports - now the demos should open up correctly in the codesandbox