### PR TITLE
fix(Table): update hoverable example to single select

### DIFF
--- a/packages/react-table/src/components/Table/examples/LegacyTableHoverable.tsx
+++ b/packages/react-table/src/components/Table/examples/LegacyTableHoverable.tsx
@@ -32,14 +32,7 @@ export const LegacyTableHoverable: React.FunctionComponent = () => {
 
   // In this example, selected rows are tracked by the repo names from each row. This could be any unique identifier.
   // This is to prevent state from being based on row order index in case we later add sorting.
-  const [selectedRepoNames, setSelectedRepoNames] = React.useState<string[]>([]);
-  const setRepoSelected = (repo: Repository, isSelecting = true) =>
-    setSelectedRepoNames(prevSelected => {
-      const otherSelectedRepoNames = prevSelected.filter(r => r !== repo.name);
-      return isSelecting ? [...otherSelectedRepoNames, repo.name] : otherSelectedRepoNames;
-    });
-  const isRepoSelected = (repo: Repository) => selectedRepoNames.includes(repo.name);
-
+  const [selectedRepoName, setSelectedRepoName] = React.useState('');
   const columns: TableProps['cells'] = [
     {
       title: 'Repositories',
@@ -105,7 +98,7 @@ export const LegacyTableHoverable: React.FunctionComponent = () => {
     return {
       cells,
       isHoverable: true,
-      isRowSelected: isRepoSelected(repo)
+      isRowSelected: selectedRepoName === repo.name
     };
   });
 
@@ -116,7 +109,7 @@ export const LegacyTableHoverable: React.FunctionComponent = () => {
         onRowClick={(_event, row, rowProps) => {
           if (rowProps) {
             const repo = repositories[rowProps.rowIndex];
-            setRepoSelected(repo, !isRepoSelected(repo));
+            setSelectedRepoName(repo.name);
           }
         }}
       />

--- a/packages/react-table/src/components/TableComposable/Tr.tsx
+++ b/packages/react-table/src/components/TableComposable/Tr.tsx
@@ -74,7 +74,7 @@ const TrBase: React.FunctionComponent<TrProps> = ({
 
   React.useEffect(() => {
     if (isSelectable && !rowIsHidden) {
-      setComputedAriaLabel(`${isRowSelected ? 'Selected' : 'Unselected'}, selectable row.`);
+      setComputedAriaLabel(`${isRowSelected ? 'Row selected' : ''}`);
       registerSelectableRow();
     } else {
       setComputedAriaLabel(undefined);

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTableHoverable.tsx
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTableHoverable.tsx
@@ -27,13 +27,7 @@ export const ComposableTableHoverable: React.FunctionComponent = () => {
 
   // In this example, selected rows are tracked by the repo names from each row. This could be any unique identifier.
   // This is to prevent state from being based on row order index in case we later add sorting.
-  const [selectedRepoNames, setSelectedRepoNames] = React.useState<string[]>([]);
-  const setRepoSelected = (repo: Repository, isSelecting = true) =>
-    setSelectedRepoNames(prevSelected => {
-      const otherSelectedRepoNames = prevSelected.filter(r => r !== repo.name);
-      return isSelecting ? [...otherSelectedRepoNames, repo.name] : otherSelectedRepoNames;
-    });
-  const isRepoSelected = (repo: Repository) => selectedRepoNames.includes(repo.name);
+  const [selectedRepoName, setSelectedRepoName] = React.useState('');
 
   return (
     <TableComposable aria-label="Hoverable table" hasSelectableRowCaption>
@@ -50,10 +44,10 @@ export const ComposableTableHoverable: React.FunctionComponent = () => {
         {repositories.map(repo => (
           <Tr
             key={repo.name}
-            onRowClick={() => setRepoSelected(repo, !isRepoSelected(repo))}
+            onRowClick={() => setSelectedRepoName(repo.name)}
             isSelectable
             isHoverable
-            isRowSelected={isRepoSelected(repo)}
+            isRowSelected={selectedRepoName === repo.name}
           >
             <Td dataLabel={columnNames.name}>{repo.name}</Td>
             <Td dataLabel={columnNames.branches}>{repo.branches}</Td>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7689 

Updated the text that gets announced in the `output` element on the Tr component to either be "Row selected" or an empty string, as otherwise both the unselected row and the new selected row would have the text announced ("Unselected row" followed immediately by "Selected row").

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
