### PR TITLE
chore(Tooltip): test revamp

### DIFF
--- a/packages/react-core/src/components/Tooltip/__tests__/Tooltip.test.tsx
+++ b/packages/react-core/src/components/Tooltip/__tests__/Tooltip.test.tsx
@@ -5,18 +5,31 @@ import { TooltipArrow } from "../TooltipArrow";
 import { TooltipContent } from "../TooltipContent";
 import userEvent from '@testing-library/user-event';
 
+jest.mock('../../../helpers', () => ({
+  Popper: ({ enableFlip, appendTo, distance, flipBehavior, ...props }) => (
+    <div data-testid="popper-mock" {...props}>
+      <div data-testid="enableFlip">{enableFlip}</div>
+      <div data-testid="distance">{distance}</div>
+      <div data-testid="flipBehavior">{flipBehavior}</div>
+      <p>{`enableFlip: ${enableFlip}`}</p>
+      <p>Append to class name: {appendTo && `${appendTo.className}`}</p>
+    </div>
+  )
+}));
+
 /** Testing tooltip content */
 
 test('tooltip content renders', () => {
-  const { asFragment } = render(
+  render(
     <TooltipContent
       children={
-          <div>Test</div>
+        <div>Test</div>
       }
+      data-testid='Tooltip'
     />
   );
 
-  expect(asFragment()).toMatchSnapshot();
+  expect(screen.getByTestId('Tooltip')).toBeVisible();
 });
   
 test('renders pf-c-tooltip__content class', () => {
@@ -157,7 +170,6 @@ test('renders with inherited element props spread to the component', () => {
 test('tooltip renders', () => {
   const { asFragment } = render(
     <Tooltip
-      position="top"
       content={
         <div>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
@@ -231,6 +243,30 @@ test('renders tooltip on DOM without userEvent when isVisible prop passed', asyn
 
   const tooltip = await screen.findByLabelText("test-label");
   expect(tooltip).toHaveClass("pf-c-tooltip");
+});
+
+test('passes Popper enableFlip set to true', async () => {
+  render(
+    <Tooltip
+      enableFlip
+      content={
+        <div>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
+        </div>
+      }
+    >
+      <div>Toggle tooltip</div>
+    </Tooltip>
+  );
+
+  const user = screen.getByText("Toggle tooltip");
+  userEvent.hover(user);
+
+  // const scr = screen.getByTestId('enableFlip');
+  const input = await screen.findByText('enableFlip: true');
+
+  // expect(scr).toBeVisible();
+  expect(input).toBeVisible();
 });
 
 test('renders default classname pf-c-tooltip', async () => {
@@ -337,3 +373,22 @@ test('renders animationDuration styling', async () => {
   const style = window.getComputedStyle(tooltip);
   expect(style.transition).toBe("opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)");
 });
+
+// enable flip: mock out popper - test against props that popper is receiving and what it should receive like in truncate
+// just like when tooltip for truncate, you can set up popper mock to get the enableFlip
+
+// appendTo is passed straight to popper -- same with distance
+
+// aria - has assertions against what the accessible name is
+// test against trigger prop for popper!!!
+// maybe just have popper render trigger with custom data test id and have assertions based on that and the accessible name
+
+// flipBehavior is straight to popper
+
+// id - same thing w aria prop AND make sure it's getting passed to the proper place
+// not rly a good rtl to test for IDs -> have it render what trigger returns and make assertions based on accessible name -> test aria prop and id prop
+// select using data test-id bc content is a div
+
+// reference is straight to popper
+// but also note: aria-live uses reference -> might have to use toHave attribute
+

--- a/packages/react-core/src/components/Tooltip/__tests__/Tooltip.test.tsx
+++ b/packages/react-core/src/components/Tooltip/__tests__/Tooltip.test.tsx
@@ -1,6 +1,158 @@
 import * as React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { Tooltip } from '../Tooltip';
+import { TooltipArrow } from "../TooltipArrow";
+import { TooltipContent } from "../TooltipContent";
+import userEvent from '@testing-library/user-event';
+
+/** Testing tooltip content */
+
+test('tooltip content renders', () => {
+  const { asFragment } = render(
+    <TooltipContent
+      children={
+          <div>Test</div>
+      }
+    />
+  );
+
+  expect(asFragment()).toMatchSnapshot();
+});
+  
+test('renders pf-c-tooltip__content class', () => {
+  render(
+    <TooltipContent
+      aria-label="test-label"
+      children={
+          <div>Test</div>
+      }
+    />
+  );
+
+  const tooltip = screen.getByLabelText('test-label');
+
+  expect(tooltip).toHaveClass('pf-c-tooltip__content');
+});
+  
+test('renders custom class', () => {
+  render(
+    <TooltipContent
+      className="custom-classname"
+      aria-label="test-label"
+      children={
+          <div>Test</div>
+      }
+    />
+  );
+  
+  const tooltip = screen.getByLabelText('test-label');
+
+  expect(tooltip).toHaveClass('custom-classname');
+});
+
+test('renders with children', () => {
+  render(
+    <TooltipContent
+        children={
+          <div>Test</div>
+        }
+    />
+  );
+
+  expect(screen.getByText('Test')).toBeVisible();
+});
+
+test('renders tooltip content with default alignment', () => {
+  render(
+    <TooltipContent
+      aria-label="test-label"
+      children={
+        <div>Test</div>
+      }
+    />
+  );
+  
+  expect(screen.getByLabelText('test-label')).not.toHaveClass('pf-m-text-align-left');
+});
+
+test('renders tooltip content with left alignment', () => {
+  render(
+    <TooltipContent
+      aria-label="test-label"
+      isLeftAligned
+      children={
+        <div>Test</div>
+      }
+    />
+  );
+  
+  expect(screen.getByLabelText('test-label')).toHaveClass('pf-m-text-align-left');
+});
+
+test('renders with inherited element props spread to the component', () => {
+  render(
+    <TooltipContent
+      aria-label="test-label"
+    >
+      Test
+    </TooltipContent>
+  );
+
+  const tooltip = screen.getByText('Test');
+
+  expect(tooltip).toHaveAccessibleName('test-label');
+});
+
+/** Testing tooltip arrow */
+
+test('tooltip arrow renders', () => {
+  const { asFragment } = render(
+    <TooltipArrow />
+  );
+
+  expect(asFragment()).toMatchSnapshot();
+});
+
+test('renders pf-c-tooltip__arrow class', () => {
+  render(
+    <TooltipArrow
+      aria-label="test-label"
+    />
+  );
+
+  const tooltip = screen.getByLabelText('test-label');
+
+  expect(tooltip).toHaveClass('pf-c-tooltip__arrow');
+});
+
+test('renders custom class', () => {
+  render(
+    <TooltipArrow
+      className="custom-classname"
+      aria-label="test-label"
+    />
+  );
+
+  const tooltip = screen.getByLabelText('test-label');
+
+  expect(tooltip).toHaveClass('custom-classname');
+});
+
+test('renders with inherited element props spread to the component', () => {
+  render(
+    <TooltipArrow
+      aria-label="test-label"
+    >
+      Test
+    </TooltipArrow>
+  );
+
+  const tooltip = screen.getByText('Test');
+
+  expect(tooltip).toHaveAccessibleName('test-label');
+});
+
+/** Testing remaining tooltip props */
 
 test('tooltip renders', () => {
   const { asFragment } = render(
@@ -16,4 +168,172 @@ test('tooltip renders', () => {
     </Tooltip>
   );
   expect(asFragment()).toMatchSnapshot();
+});
+
+test('renders tooltip content', async () => {
+  render(
+    <Tooltip
+      aria-label="test-label"
+      content={
+        <div>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
+        </div>
+      }
+    >
+      <div>Toggle tooltip</div>
+    </Tooltip>
+  );
+
+  const user = screen.getByText("Toggle tooltip");
+  userEvent.hover(user);
+
+  const tooltip = await screen.findByText("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.");
+
+  expect(tooltip).toBeVisible();
+});
+
+test('renders tooltip position', async () => {
+  render(
+    <Tooltip
+      position="top"
+      aria-label="test-label"
+      content={
+        <div>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
+        </div>
+      }
+    >
+      <div>Toggle tooltip</div>
+    </Tooltip>
+  );
+
+  const user = screen.getByText("Toggle tooltip");
+  userEvent.hover(user);
+
+  const tooltip = await screen.findByLabelText("test-label");
+  expect(tooltip).toHaveClass("pf-m-top");
+});
+
+test('renders tooltip on DOM without userEvent when isVisible prop passed', async () => {
+  render(
+    <Tooltip
+      aria-label="test-label"
+      isVisible
+      content={
+        <div>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
+        </div>
+      }
+    >
+      <div>Toggle tooltip</div>
+    </Tooltip>
+  );
+
+  const tooltip = await screen.findByLabelText("test-label");
+  expect(tooltip).toHaveClass("pf-c-tooltip");
+});
+
+test('renders default classname pf-c-tooltip', async () => {
+  render(
+    <Tooltip
+      aria-label="test-label"
+      content={
+        <div>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
+        </div>
+      }
+    >
+      <div>Toggle tooltip</div>
+    </Tooltip>
+  );
+
+  const user = screen.getByText("Toggle tooltip");
+  userEvent.hover(user);
+
+  const tooltip = await screen.findByLabelText("test-label");
+  expect(tooltip).toHaveClass("pf-c-tooltip");
+});
+
+test('renders custom classname', async () => {
+  render(
+    <Tooltip
+      aria-label="test-label"
+      className="custom-class"
+      content={
+        <div>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
+        </div>
+      }
+    >
+      <div>Toggle tooltip</div>
+    </Tooltip>
+  );
+
+  const user = screen.getByText("Toggle tooltip");
+  userEvent.hover(user);
+
+  const tooltip = await screen.findByLabelText("test-label");
+  expect(tooltip).toHaveClass("custom-class");
+});
+
+test('renders zIndex styling', async () => {
+  render(
+    <Tooltip
+      aria-label="test-label"
+      content={
+        <div>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
+        </div>
+      }
+    >
+      <div>Toggle tooltip</div>
+    </Tooltip>
+  );
+
+  const user = screen.getByText("Toggle tooltip");
+  userEvent.hover(user);
+
+  const tooltip = await screen.findByLabelText("test-label");
+  const style = window.getComputedStyle(tooltip);
+  expect(style.zIndex).toBe("9999");
+});
+
+test('renders children', async () => {
+  render(
+    <Tooltip
+      aria-label="test-label"
+      content={
+        <div>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
+        </div>
+      }
+    >
+      <div>Toggle tooltip</div>
+    </Tooltip>
+  );
+
+  const user = screen.getByText("Toggle tooltip");
+  expect(user).toBeVisible();
+});
+
+test('renders animationDuration styling', async () => {
+  render(
+    <Tooltip
+      aria-label="test-label"
+      content={
+        <div>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
+        </div>
+      }
+    >
+      <div>Toggle tooltip</div>
+    </Tooltip>
+  );
+
+  const user = screen.getByText("Toggle tooltip");
+  userEvent.hover(user);
+
+  const tooltip = await screen.findByLabelText("test-label");
+  const style = window.getComputedStyle(tooltip);
+  expect(style.transition).toBe("opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)");
 });

--- a/packages/react-core/src/components/Tooltip/__tests__/Tooltip.test.tsx
+++ b/packages/react-core/src/components/Tooltip/__tests__/Tooltip.test.tsx
@@ -5,16 +5,22 @@ import { TooltipArrow } from "../TooltipArrow";
 import { TooltipContent } from "../TooltipContent";
 import userEvent from '@testing-library/user-event';
 
-jest.mock('../../../helpers', () => ({
-  Popper: ({ enableFlip, appendTo, distance, flipBehavior, ...props }) => (
-    <div data-testid="popper-mock" {...props}>
+jest.mock('../../../helpers/Popper/Popper', () => ({
+  Popper: ({ trigger, enableFlip, appendTo, distance, flipBehavior, isVisible, placement, popper, zIndex, ...props }) => (
+    <div data-testid="popper-mock">
+      <div data-testid="trigger">{trigger}</div>
+      <div data-testid="content">{isVisible && popper}</div>
+      <div data-testid="placement">{placement}</div>
       <div data-testid="enableFlip">{enableFlip}</div>
       <div data-testid="distance">{distance}</div>
       <div data-testid="flipBehavior">{flipBehavior}</div>
+      <div data-testid="appendTo">{appendTo}</div>
+      <div data-testid="zIndex">{zIndex}</div>
       <p>{`enableFlip: ${enableFlip}`}</p>
       <p>Append to class name: {appendTo && `${appendTo.className}`}</p>
     </div>
-  )
+  ),
+  getOpacityTransition: () => {}
 }));
 
 /** Testing tooltip content */
@@ -182,10 +188,11 @@ test('tooltip renders', () => {
   expect(asFragment()).toMatchSnapshot();
 });
 
-test('renders tooltip content', async () => {
+test('renders tooltip content when isVisible', async () => {
   render(
     <Tooltip
       aria-label="test-label"
+      isVisible
       content={
         <div>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
@@ -195,19 +202,15 @@ test('renders tooltip content', async () => {
       <div>Toggle tooltip</div>
     </Tooltip>
   );
-
-  const user = screen.getByText("Toggle tooltip");
-  userEvent.hover(user);
 
   const tooltip = await screen.findByText("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.");
 
   expect(tooltip).toBeVisible();
 });
 
-test('renders tooltip position', async () => {
+test('does not render tooltip content by default', () => {
   render(
     <Tooltip
-      position="top"
       aria-label="test-label"
       content={
         <div>
@@ -219,14 +222,51 @@ test('renders tooltip position', async () => {
     </Tooltip>
   );
 
-  const user = screen.getByText("Toggle tooltip");
-  userEvent.hover(user);
+  const tooltip = screen.queryByText("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.");
 
-  const tooltip = await screen.findByLabelText("test-label");
-  expect(tooltip).toHaveClass("pf-m-top");
+  expect(tooltip).not.toBeInTheDocument();
 });
 
-test('renders tooltip on DOM without userEvent when isVisible prop passed', async () => {
+test('renders tooltip position when isVisible', () => {
+  render(
+    <Tooltip
+      position="top"
+      aria-label="test-label"
+      isVisible
+      content={
+        <div>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
+        </div>
+      }
+    >
+      <div>Toggle tooltip</div>
+    </Tooltip>
+  );
+
+  const tooltip = screen.getByTestId("placement");
+  expect(tooltip).toHaveTextContent("top");
+});
+
+test('passes Popper enableFlip set to true', async () => {
+  render(
+    <Tooltip
+      enableFlip
+      content={
+        <div>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
+        </div>
+      }
+    >
+      <div>Toggle tooltip</div>
+    </Tooltip>
+  );
+
+  const input = await screen.findByText('enableFlip: true');
+
+  expect(input).toBeVisible();
+});
+
+test('renders default classname pf-c-tooltip when isVisible', async () => {
   render(
     <Tooltip
       aria-label="test-label"
@@ -245,56 +285,12 @@ test('renders tooltip on DOM without userEvent when isVisible prop passed', asyn
   expect(tooltip).toHaveClass("pf-c-tooltip");
 });
 
-test('passes Popper enableFlip set to true', async () => {
-  render(
-    <Tooltip
-      enableFlip
-      content={
-        <div>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
-        </div>
-      }
-    >
-      <div>Toggle tooltip</div>
-    </Tooltip>
-  );
-
-  const user = screen.getByText("Toggle tooltip");
-  userEvent.hover(user);
-
-  // const scr = screen.getByTestId('enableFlip');
-  const input = await screen.findByText('enableFlip: true');
-
-  // expect(scr).toBeVisible();
-  expect(input).toBeVisible();
-});
-
-test('renders default classname pf-c-tooltip', async () => {
-  render(
-    <Tooltip
-      aria-label="test-label"
-      content={
-        <div>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
-        </div>
-      }
-    >
-      <div>Toggle tooltip</div>
-    </Tooltip>
-  );
-
-  const user = screen.getByText("Toggle tooltip");
-  userEvent.hover(user);
-
-  const tooltip = await screen.findByLabelText("test-label");
-  expect(tooltip).toHaveClass("pf-c-tooltip");
-});
-
-test('renders custom classname', async () => {
+test('renders custom classname when isVisible', async () => {
   render(
     <Tooltip
       aria-label="test-label"
       className="custom-class"
+      isVisible
       content={
         <div>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
@@ -304,18 +300,23 @@ test('renders custom classname', async () => {
       <div>Toggle tooltip</div>
     </Tooltip>
   );
-
-  const user = screen.getByText("Toggle tooltip");
-  userEvent.hover(user);
 
   const tooltip = await screen.findByLabelText("test-label");
   expect(tooltip).toHaveClass("custom-class");
 });
 
-test('renders zIndex styling', async () => {
+// entrydelay test
+
+// exitdelay test
+
+// appendto test
+
+
+test('renders zIndex styling when isVisible', () => {
   render(
     <Tooltip
       aria-label="test-label"
+      isVisible
       content={
         <div>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
@@ -326,13 +327,56 @@ test('renders zIndex styling', async () => {
     </Tooltip>
   );
 
-  const user = screen.getByText("Toggle tooltip");
-  userEvent.hover(user);
+  const input = screen.getByTestId('zIndex');
 
-  const tooltip = await screen.findByLabelText("test-label");
-  const style = window.getComputedStyle(tooltip);
-  expect(style.zIndex).toBe("9999");
+  expect(input).toHaveTextContent('9999');
 });
+
+// maxwidth
+
+test('renders default distance when isVisible', () => {
+  render(
+    <Tooltip
+      aria-label="test-label"
+      isVisible
+      content={
+        <div>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
+        </div>
+      }
+    >
+      <div>Toggle tooltip</div>
+    </Tooltip>
+  );
+
+  const input = screen.getByTestId('distance');
+
+  expect(input).toHaveTextContent('15');
+});
+
+// aria
+
+test('renders default flipBehavior when isVisible', () => {
+  render(
+    <Tooltip
+      aria-label="test-label"
+      isVisible
+      content={
+        <div>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
+        </div>
+      }
+    >
+      <div>Toggle tooltip</div>
+    </Tooltip>
+  );
+
+  const input = screen.getByTestId('flipBehavior');
+
+  expect(input).toHaveTextContent('toprightbottomlefttoprightbottom');
+});
+
+// id
 
 test('renders children', async () => {
   render(
@@ -352,38 +396,38 @@ test('renders children', async () => {
   expect(user).toBeVisible();
 });
 
-test('renders animationDuration styling', async () => {
-  render(
-    <Tooltip
-      aria-label="test-label"
-      content={
-        <div>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
-        </div>
-      }
-    >
-      <div>Toggle tooltip</div>
-    </Tooltip>
-  );
+// test('renders animationDuration styling', async () => {
+//   render(
+//     <Tooltip
+//       aria-label="test-label"
+//       content={
+//         <div>
+//           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
+//         </div>
+//       }
+//     >
+//       <div>Toggle tooltip</div>
+//     </Tooltip>
+//   );
 
-  const user = screen.getByText("Toggle tooltip");
-  userEvent.hover(user);
+//   const user = screen.getByText("Toggle tooltip");
+//   userEvent.hover(user);
 
-  const tooltip = await screen.findByLabelText("test-label");
-  const style = window.getComputedStyle(tooltip);
-  expect(style.transition).toBe("opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)");
-});
+//   const tooltip = await screen.findByLabelText("test-label");
+//   const style = window.getComputedStyle(tooltip);
+//   expect(style.transition).toBe("opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)");
+// });
 
-// enable flip: mock out popper - test against props that popper is receiving and what it should receive like in truncate
-// just like when tooltip for truncate, you can set up popper mock to get the enableFlip
+// reference
 
-// appendTo is passed straight to popper -- same with distance
+// aria-live
+
+
+// appendTo is passed straight to popper
 
 // aria - has assertions against what the accessible name is
 // test against trigger prop for popper!!!
 // maybe just have popper render trigger with custom data test id and have assertions based on that and the accessible name
-
-// flipBehavior is straight to popper
 
 // id - same thing w aria prop AND make sure it's getting passed to the proper place
 // not rly a good rtl to test for IDs -> have it render what trigger returns and make assertions based on accessible name -> test aria prop and id prop

--- a/packages/react-core/src/components/Tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/react-core/src/components/Tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
@@ -1,5 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`tooltip arrow renders 1`] = `
+<DocumentFragment>
+  <div
+    class="pf-c-tooltip__arrow"
+  />
+</DocumentFragment>
+`;
+
+exports[`tooltip content renders 1`] = `
+<DocumentFragment>
+  <div
+    class="pf-c-tooltip__content"
+  >
+    <div>
+      Test
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`tooltip renders 1`] = `
 <DocumentFragment>
   <div>

--- a/packages/react-core/src/components/Tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/react-core/src/components/Tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
@@ -8,22 +8,53 @@ exports[`tooltip arrow renders 1`] = `
 </DocumentFragment>
 `;
 
-exports[`tooltip content renders 1`] = `
-<DocumentFragment>
-  <div
-    class="pf-c-tooltip__content"
-  >
-    <div>
-      Test
-    </div>
-  </div>
-</DocumentFragment>
-`;
-
 exports[`tooltip renders 1`] = `
 <DocumentFragment>
-  <div>
-    Toggle tooltip
+  <div
+    data-testid="popper-mock"
+  >
+    <div
+      data-testid="trigger"
+    >
+      <div>
+        Toggle tooltip
+      </div>
+    </div>
+    <div
+      data-testid="content"
+    />
+    <div
+      data-testid="placement"
+    >
+      top
+    </div>
+    <div
+      data-testid="enableFlip"
+    />
+    <div
+      data-testid="distance"
+    >
+      15
+    </div>
+    <div
+      data-testid="flipBehavior"
+    >
+      toprightbottomlefttoprightbottom
+    </div>
+    <div
+      data-testid="appendTo"
+    />
+    <div
+      data-testid="zIndex"
+    >
+      9999
+    </div>
+    <p>
+      enableFlip: true
+    </p>
+    <p>
+      Append to class name: undefined
+    </p>
   </div>
 </DocumentFragment>
 `;


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7687 . Tooltip test revamps WIP

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
- Kept `TooltipArrow` and `TooltipContent` tests in the main `Tooltip` test page
    - Used `TooltipContent` to test content prop
- Could not test `enableFlip`
    - Is there a support for scrolling on RTL?
- Could not test `entryDelay` and `exitDelay`
    - Styling for `transition` read as "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11) 0ms"
    - Changing the delay did not change the last numeric value which should be `transition-delay`
- Could not test `appendTo`
- Could not test `maxWidth`
- Could not test `distance`
- Could not test `aria`
- Could not test `flippedBehavior`
- Could not test `id`
- Could not test `reference`