### PR TITLE
fix(Menu): can navigate via keyboard for checkbox variant

### DIFF
--- a/packages/react-core/src/components/Menu/Menu.tsx
+++ b/packages/react-core/src/components/Menu/Menu.tsx
@@ -272,10 +272,13 @@ class MenuBase extends React.Component<MenuProps, MenuState> {
             additionalKeyHandler={this.handleExtraKeys}
             createNavigableElements={this.createNavigableElements}
             isActiveElement={(element: Element) =>
+              document.activeElement.closest('li') === element ||
               document.activeElement.parentElement === element ||
               (document.activeElement.closest('ol') && document.activeElement.closest('ol').firstChild === element)
             }
-            getFocusableElement={(navigableElement: Element) => navigableElement.firstChild as Element}
+            getFocusableElement={(navigableElement: Element) =>
+              navigableElement.querySelector('input') || (navigableElement.firstChild as Element)
+            }
             noHorizontalArrowHandling={
               document.activeElement &&
               (document.activeElement.classList.contains('pf-c-breadcrumb__link') ||

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleCheckboxSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleCheckboxSelect.tsx
@@ -13,7 +13,7 @@ export const ComposableSimpleCheckboxSelect: React.FunctionComponent = () => {
         if (isOpen && menuRef.current.contains(event.target as Node)) {
           if (event.key === 'Escape' || event.key === 'Tab') {
             setIsOpen(!isOpen);
-            toggleRef.current.focus();
+            toggleRef?.current?.focus();
           }
         }
       }
@@ -23,7 +23,7 @@ export const ComposableSimpleCheckboxSelect: React.FunctionComponent = () => {
 
   const handleClickOutside = React.useCallback(
     event => {
-      if (isOpen && !menuRef.current.contains(event.target as Node)) {
+      if (isOpen && !menuRef?.current?.contains(event.target as Node)) {
         setIsOpen(false);
       }
     },
@@ -43,7 +43,7 @@ export const ComposableSimpleCheckboxSelect: React.FunctionComponent = () => {
     ev.stopPropagation(); // Stop handleClickOutside from handling
     setTimeout(() => {
       if (menuRef.current) {
-        const firstElement = menuRef.current.querySelector('li > button:not(:disabled)');
+        const firstElement = menuRef.current.querySelector('li input:not(:disabled)');
         firstElement && (firstElement as HTMLElement).focus();
       }
     }, 0);
@@ -94,5 +94,5 @@ export const ComposableSimpleCheckboxSelect: React.FunctionComponent = () => {
       </MenuContent>
     </Menu>
   );
-  return <Popper trigger={toggle} popper={menu} isVisible={isOpen} />;
+  return <Popper appendTo={toggleRef.current} trigger={toggle} popper={menu} isVisible={isOpen} />;
 };


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7382

[Menu with checkbox example](https://patternfly-react-pr-7743.surge.sh/components/menu#with-checkbox)
[Composable menu simple checkbox select](https://patternfly-react-pr-7743.surge.sh/demos/composable-menu#composable-simple-checkbox-select)

Updated the menu component logic as well as the composable menu with checkboxes demo

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
