### PR TITLE
feat(Dropdown): added secondary styling to split action button

### DIFF
--- a/packages/react-core/src/components/Dropdown/DropdownToggle.tsx
+++ b/packages/react-core/src/components/Dropdown/DropdownToggle.tsx
@@ -120,6 +120,7 @@ export const DropdownToggle: React.FunctionComponent<DropdownToggleProps> = ({
           styles.modifiers.splitButton,
           splitButtonVariant === 'action' && styles.modifiers.action,
           (toggleVariant === 'primary' || isPrimary) && splitButtonVariant === 'action' && styles.modifiers.primary,
+          toggleVariant === 'secondary' && splitButtonVariant === 'action' && styles.modifiers.secondary,
           isDisabled && styles.modifiers.disabled
         )}
       >

--- a/packages/react-core/src/components/Dropdown/__tests__/DropdownToggle.test.tsx
+++ b/packages/react-core/src/components/Dropdown/__tests__/DropdownToggle.test.tsx
@@ -200,7 +200,6 @@ describe('DropdownToggle', () => {
       const dropdownToggle = screen.getByRole('button').parentElement;
 
       expect(dropdownToggle).toHaveClass('pf-m-secondary');
-      expect(asFragment()).toMatchSnapshot();
     });
 
     test('class changes', () => {

--- a/packages/react-core/src/components/Dropdown/__tests__/DropdownToggle.test.tsx
+++ b/packages/react-core/src/components/Dropdown/__tests__/DropdownToggle.test.tsx
@@ -184,6 +184,25 @@ describe('DropdownToggle', () => {
       expect(asFragment()).toMatchSnapshot();
     });
 
+    test('action split button - renders secondary variant', () => {
+      const { asFragment } = render(
+        <DropdownToggle
+          id="Dropdown Toggle"
+          toggleVariant="secondary"
+          splitButtonItems={[<div key="1">test</div>]}
+          splitButtonVariant="action"
+          parentRef={document.createElement('div')}
+        >
+          Dropdown
+        </DropdownToggle>
+      );
+
+      const dropdownToggle = screen.getByRole('button').parentElement;
+
+      expect(dropdownToggle).toHaveClass('pf-m-secondary');
+      expect(asFragment()).toMatchSnapshot();
+    });
+
     test('class changes', () => {
       const { asFragment } = render(
         <DropdownContext.Provider

--- a/packages/react-core/src/components/Dropdown/__tests__/__snapshots__/DropdownToggle.test.tsx.snap
+++ b/packages/react-core/src/components/Dropdown/__tests__/__snapshots__/DropdownToggle.test.tsx.snap
@@ -45,51 +45,6 @@ exports[`DropdownToggle state action split button - renders primary variant 1`] 
 </DocumentFragment>
 `;
 
-exports[`DropdownToggle state action split button - renders secondary variant 1`] = `
-<DocumentFragment>
-  <div
-    class="pf-c-dropdown__toggle pf-m-split-button pf-m-action pf-m-secondary"
-  >
-    <div>
-      test
-    </div>
-    <button
-      aria-expanded="false"
-      aria-label="Select"
-      class="pf-c-dropdown__toggle-button pf-m-secondary"
-      data-ouia-component-id="OUIA-Generated-DropdownToggle-13"
-      data-ouia-component-type="PF4/DropdownToggle"
-      data-ouia-safe="true"
-      id="Dropdown Toggle"
-      type="button"
-    >
-      <span
-        class=""
-      >
-        Dropdown
-      </span>
-      <span
-        class=""
-      >
-        <svg
-          aria-hidden="true"
-          fill="currentColor"
-          height="1em"
-          role="img"
-          style="vertical-align: -0.125em;"
-          viewBox="0 0 320 512"
-          width="1em"
-        >
-          <path
-            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-          />
-        </svg>
-      </span>
-    </button>
-  </div>
-</DocumentFragment>
-`;
-
 exports[`DropdownToggle state active 1`] = `
 <DocumentFragment>
   <button

--- a/packages/react-core/src/components/Dropdown/__tests__/__snapshots__/DropdownToggle.test.tsx.snap
+++ b/packages/react-core/src/components/Dropdown/__tests__/__snapshots__/DropdownToggle.test.tsx.snap
@@ -45,6 +45,51 @@ exports[`DropdownToggle state action split button - renders primary variant 1`] 
 </DocumentFragment>
 `;
 
+exports[`DropdownToggle state action split button - renders secondary variant 1`] = `
+<DocumentFragment>
+  <div
+    class="pf-c-dropdown__toggle pf-m-split-button pf-m-action pf-m-secondary"
+  >
+    <div>
+      test
+    </div>
+    <button
+      aria-expanded="false"
+      aria-label="Select"
+      class="pf-c-dropdown__toggle-button pf-m-secondary"
+      data-ouia-component-id="OUIA-Generated-DropdownToggle-13"
+      data-ouia-component-type="PF4/DropdownToggle"
+      data-ouia-safe="true"
+      id="Dropdown Toggle"
+      type="button"
+    >
+      <span
+        class=""
+      >
+        Dropdown
+      </span>
+      <span
+        class=""
+      >
+        <svg
+          aria-hidden="true"
+          fill="currentColor"
+          height="1em"
+          role="img"
+          style="vertical-align: -0.125em;"
+          viewBox="0 0 320 512"
+          width="1em"
+        >
+          <path
+            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+          />
+        </svg>
+      </span>
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`DropdownToggle state active 1`] = `
 <DocumentFragment>
   <button
@@ -198,7 +243,7 @@ exports[`DropdownToggle state class changes 1`] = `
   <button
     aria-expanded="false"
     class="pf-c-dropdown__toggle"
-    data-ouia-component-id="OUIA-Generated-DropdownToggle-13"
+    data-ouia-component-id="OUIA-Generated-DropdownToggle-14"
     data-ouia-component-type="PF4/DropdownToggle"
     data-ouia-safe="true"
     id="Dropdown Toggle"

--- a/packages/react-core/src/components/Dropdown/examples/Dropdown.md
+++ b/packages/react-core/src/components/Dropdown/examples/Dropdown.md
@@ -113,6 +113,11 @@ import avatarImg from '../../Avatar/examples/avatarImg.svg';
 ```ts file="./DropdownSplitButtonActionPrimary.tsx"
 ```
 
+### Split button secondary action
+
+```ts file="./DropdownSplitButtonActionSecondary.tsx"
+```
+
 ### Basic panel
 
 ```ts file="./DropdownBasicPanel.tsx"

--- a/packages/react-core/src/components/Dropdown/examples/DropdownSplitButtonActionSecondary.tsx
+++ b/packages/react-core/src/components/Dropdown/examples/DropdownSplitButtonActionSecondary.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { Dropdown, DropdownToggle, DropdownToggleAction, DropdownItem } from '@patternfly/react-core';
+import CogIcon from '@patternfly/react-icons/dist/esm/icons/cog-icon';
+import BellIcon from '@patternfly/react-icons/dist/esm/icons/bell-icon';
+import CubesIcon from '@patternfly/react-icons/dist/esm/icons/cubes-icon';
+
+export const DropdownSplitButtonActionSecondary: React.FunctionComponent = () => {
+  const [isActionOpen, setIsActionOpen] = React.useState(false);
+  const [isCogOpen, setIsCogOpen] = React.useState(false);
+
+  const onActionToggle = (isActionOpen: boolean) => {
+    setIsActionOpen(isActionOpen);
+  };
+  const onCogToggle = (isCogOpen: boolean) => {
+    setIsCogOpen(isCogOpen);
+  };
+
+  const onActionClick = () => {
+    window.alert('You selected an action button!');
+  };
+  const onCogClick = () => {
+    window.alert('You selected the Cog!');
+  };
+
+  const onActionFocus = () => {
+    const element = document.getElementById('toggle-split-button-action-secondary');
+    element.focus();
+  };
+  const onCogFocus = () => {
+    const element = document.getElementById('toggle-split-button-cog-secondary');
+    element.focus();
+  };
+
+  const onActionSelect = () => {
+    setIsActionOpen(false);
+    onActionFocus();
+  };
+  const onCogSelect = () => {
+    setIsCogOpen(false);
+    onCogFocus();
+  };
+
+  const dropdownItems = [
+    <DropdownItem key="action" component="button" onClick={onActionClick}>
+      Action
+    </DropdownItem>,
+    <DropdownItem key="disabled link" component="button" isDisabled onClick={onActionClick}>
+      Disabled action
+    </DropdownItem>,
+    <DropdownItem key="other action" component="button" onClick={onActionClick}>
+      Other action
+    </DropdownItem>
+  ];
+
+  const dropdownIconItems = [
+    <DropdownItem key="action" component="button" icon={<CogIcon />} onClick={onActionClick}>
+      Action
+    </DropdownItem>,
+    <DropdownItem key="disabled link" component="button" icon={<BellIcon />} isDisabled onClick={onActionClick}>
+      Disabled action
+    </DropdownItem>,
+    <DropdownItem key="other action" component="button" icon={<CubesIcon />} onClick={onActionClick}>
+      Other action
+    </DropdownItem>
+  ];
+
+  return (
+    <React.Fragment>
+      <Dropdown
+        onSelect={onActionSelect}
+        toggle={
+          <DropdownToggle
+            id="toggle-split-button-action-secondary"
+            splitButtonItems={[
+              <DropdownToggleAction key="action" onClick={onActionClick}>
+                Action
+              </DropdownToggleAction>
+            ]}
+            toggleVariant="secondary"
+            splitButtonVariant="action"
+            onToggle={onActionToggle}
+          />
+        }
+        isOpen={isActionOpen}
+        dropdownItems={dropdownItems}
+      />{' '}
+      <Dropdown
+        onSelect={onCogSelect}
+        toggle={
+          <DropdownToggle
+            id="toggle-split-button-cog-secondary"
+            splitButtonItems={[
+              <DropdownToggleAction key="cog-action" aria-label="Action" onClick={onCogClick}>
+                <CogIcon />
+              </DropdownToggleAction>
+            ]}
+            toggleVariant="secondary"
+            splitButtonVariant="action"
+            onToggle={onCogToggle}
+          />
+        }
+        isOpen={isCogOpen}
+        dropdownItems={dropdownIconItems}
+      />
+    </React.Fragment>
+  );
+};


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7536 . Secondary styling option has been added to `DropdownToggle` component for split action button. An example was created and a unit test/snapshot was added.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: N/A
