### PR TITLE
feat(MenuToggle): add split button variants

### DIFF
--- a/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
+++ b/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
@@ -6,6 +6,13 @@ import { BadgeProps } from '../Badge';
 
 export type MenuToggleElement = HTMLDivElement | HTMLButtonElement;
 
+export interface SplitButtonOptions {
+  /** Elements to display before the toggle button. When included, renders the menu toggle as a split button. */
+  items?: React.ReactNode[];
+  /** Variant of split button toggle */
+  variant?: 'action' | 'checkbox';
+}
+
 export interface MenuToggleProps
   extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<MenuToggleElement>, MenuToggleElement>, 'ref'> {
   /** Content rendered inside the toggle */
@@ -20,10 +27,8 @@ export interface MenuToggleProps
   isFullHeight?: boolean;
   /** Flag indicating the toggle takes up the full width of its parent */
   isFullWidth?: boolean;
-  /** Elements to display before the toggle button. When included, renders the menu toggle as a split button. */
-  splitButtonItems?: React.ReactNode[];
-  /** Variant of split button toggle */
-  splitButtonVariant?: 'action' | 'checkbox';
+  /** Object use to configure a split button menu toggle */
+  splitButtonOptions?: SplitButtonOptions;
   /** Variant styles of the menu toggle */
   variant?: 'default' | 'plain' | 'primary' | 'plainText' | 'secondary' | 'typeahead';
   /** Optional icon rendered inside the toggle, before the children content */
@@ -41,9 +46,7 @@ export class MenuToggleBase extends React.Component<MenuToggleProps> {
     isExpanded: false,
     isDisabled: false,
     isFullWidth: false,
-    isFullHeight: false,
-    variant: 'default',
-    splitButtonVariant: 'checkbox'
+    isFullHeight: false
   };
 
   render() {
@@ -56,8 +59,7 @@ export class MenuToggleBase extends React.Component<MenuToggleProps> {
       isDisabled,
       isFullHeight,
       isFullWidth,
-      splitButtonItems,
-      splitButtonVariant,
+      splitButtonOptions,
       variant,
       innerRef,
       onClick,
@@ -119,20 +121,21 @@ export class MenuToggleBase extends React.Component<MenuToggleProps> {
       return <div ref={innerRef as React.Ref<HTMLDivElement>} className={css(commonStyles)} {...componentProps} />;
     }
 
-    if (splitButtonItems) {
+    if (splitButtonOptions) {
       return (
         <div
           className={css(
             commonStyles,
             styles.modifiers.splitButton,
-            splitButtonVariant === 'action' && styles.modifiers.action
+            splitButtonOptions?.variant === 'action' && styles.modifiers.action
           )}
         >
-          {splitButtonItems}
+          {splitButtonOptions?.items}
           <button
             className={css(styles.menuToggleButton)}
             type="button"
             aria-expanded={isExpanded}
+            aria-label={ariaLabel}
             disabled={isDisabled}
             {...otherProps}
           >

--- a/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
+++ b/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
@@ -151,7 +151,7 @@ export class MenuToggleBase extends React.Component<MenuToggleProps> {
         ref={innerRef as React.Ref<HTMLButtonElement>}
         disabled={isDisabled}
         onClick={onClick}
-        {...otherProps}
+        {...componentProps}
       />
     );
   }

--- a/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
+++ b/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
@@ -8,7 +8,7 @@ export type MenuToggleElement = HTMLDivElement | HTMLButtonElement;
 
 export interface SplitButtonOptions {
   /** Elements to display before the toggle button. When included, renders the menu toggle as a split button. */
-  items?: React.ReactNode[];
+  items: React.ReactNode[];
   /** Variant of split button toggle */
   variant?: 'action' | 'checkbox';
 }
@@ -27,7 +27,7 @@ export interface MenuToggleProps
   isFullHeight?: boolean;
   /** Flag indicating the toggle takes up the full width of its parent */
   isFullWidth?: boolean;
-  /** Object use to configure a split button menu toggle */
+  /** Object used to configure a split button menu toggle */
   splitButtonOptions?: SplitButtonOptions;
   /** Variant styles of the menu toggle */
   variant?: 'default' | 'plain' | 'primary' | 'plainText' | 'secondary' | 'typeahead';

--- a/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
+++ b/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
@@ -20,6 +20,10 @@ export interface MenuToggleProps
   isFullHeight?: boolean;
   /** Flag indicating the toggle takes up the full width of its parent */
   isFullWidth?: boolean;
+  /** Elements to display before the toggle button. When included, renders the menu toggle as a split button. */
+  splitButtonItems?: React.ReactNode[];
+  /** Variant of split button toggle */
+  splitButtonVariant?: 'action' | 'checkbox';
   /** Variant styles of the menu toggle */
   variant?: 'default' | 'plain' | 'primary' | 'plainText' | 'secondary' | 'typeahead';
   /** Optional icon rendered inside the toggle, before the children content */
@@ -38,7 +42,8 @@ export class MenuToggleBase extends React.Component<MenuToggleProps> {
     isDisabled: false,
     isFullWidth: false,
     isFullHeight: false,
-    variant: 'default'
+    variant: 'default',
+    splitButtonVariant: 'checkbox'
   };
 
   render() {
@@ -51,6 +56,8 @@ export class MenuToggleBase extends React.Component<MenuToggleProps> {
       isDisabled,
       isFullHeight,
       isFullWidth,
+      splitButtonItems,
+      splitButtonVariant,
       variant,
       innerRef,
       onClick,
@@ -71,7 +78,7 @@ export class MenuToggleBase extends React.Component<MenuToggleProps> {
     const content = (
       <>
         {icon && <span className={css(styles.menuToggleIcon)}>{icon}</span>}
-        {isTypeahead ? children : <span className="pf-c-menu-toggle__text">{children}</span>}
+        {isTypeahead ? children : <span className={css(styles.menuToggleText)}>{children}</span>}
         {badge && <span className={css(styles.menuToggleCount)}>{badge}</span>}
         {isTypeahead ? (
           <button
@@ -89,46 +96,62 @@ export class MenuToggleBase extends React.Component<MenuToggleProps> {
       </>
     );
 
+    const commonStyles = css(
+      styles.menuToggle,
+      isExpanded && styles.modifiers.expanded,
+      variant === 'primary' && styles.modifiers.primary,
+      variant === 'secondary' && styles.modifiers.secondary,
+      (isPlain || isPlainText) && styles.modifiers.plain,
+      isPlainText && styles.modifiers.text,
+      isFullHeight && styles.modifiers.fullHeight,
+      isFullWidth && styles.modifiers.fullWidth,
+      isDisabled && styles.modifiers.disabled,
+      className
+    );
+
     const componentProps = {
-      className: css(
-        styles.menuToggle,
-        isExpanded && styles.modifiers.expanded,
-        variant === 'primary' && styles.modifiers.primary,
-        (isPlain || isPlainText) && styles.modifiers.plain,
-        isPlainText && styles.modifiers.text,
-        isFullHeight && styles.modifiers.fullHeight,
-        isTypeahead && styles.modifiers.typeahead,
-        isFullWidth && styles.modifiers.fullWidth,
-        className
-      ),
       children: isPlain ? children : content,
       ...(isDisabled && { disabled: true }),
       ...otherProps
     };
 
     if (isTypeahead) {
-      return <div ref={innerRef as React.Ref<HTMLDivElement>} {...componentProps} />;
+      return <div ref={innerRef as React.Ref<HTMLDivElement>} className={css(commonStyles)} {...componentProps} />;
+    }
+
+    if (splitButtonItems) {
+      return (
+        <div
+          className={css(
+            commonStyles,
+            styles.modifiers.splitButton,
+            splitButtonVariant === 'action' && styles.modifiers.action
+          )}
+        >
+          {splitButtonItems}
+          <button
+            className={css(styles.menuToggleButton)}
+            type="button"
+            aria-expanded={isExpanded}
+            disabled={isDisabled}
+            {...otherProps}
+          >
+            {toggleControls}
+          </button>
+        </div>
+      );
     }
 
     return (
       <button
-        className={css(
-          styles.menuToggle,
-          isExpanded && styles.modifiers.expanded,
-          variant === 'primary' && styles.modifiers.primary,
-          variant === 'secondary' && styles.modifiers.secondary,
-          (isPlain || isPlainText) && styles.modifiers.plain,
-          isPlainText && styles.modifiers.text,
-          isFullHeight && styles.modifiers.fullHeight,
-          isFullWidth && styles.modifiers.fullWidth,
-          className
-        )}
-        ref={innerRef as React.Ref<HTMLButtonElement>}
+        className={css(commonStyles)}
         type="button"
         aria-label={ariaLabel}
         aria-expanded={isExpanded}
+        ref={innerRef as React.Ref<HTMLButtonElement>}
+        disabled={isDisabled}
         onClick={onClick}
-        {...componentProps}
+        {...otherProps}
       />
     );
   }

--- a/packages/react-core/src/components/MenuToggle/MenuToggleAction.tsx
+++ b/packages/react-core/src/components/MenuToggle/MenuToggleAction.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import styles from '@patternfly/react-styles/css/components/MenuToggle/menu-toggle';
+import { css } from '@patternfly/react-styles';
+
+export interface MenuToggleActionProps {
+  /** Additional classes added to the MenuToggleAction */
+  className?: string;
+  /** Flag to show if the action button is disabled */
+  isDisabled?: boolean;
+  /** A callback for when the action button is clicked */
+  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  /** Element to be rendered inside the <button> */
+  children?: React.ReactNode;
+  /** Id of the action button */
+  id?: string;
+  /** Aria-label of the action button */
+  'aria-label'?: string;
+}
+
+export class MenuToggleAction extends React.Component<MenuToggleActionProps> {
+  static displayName = 'MenuToggleAction';
+  static defaultProps: MenuToggleActionProps = {
+    className: '',
+    isDisabled: false,
+    onClick: () => {}
+  };
+
+  render() {
+    const { id, className, onClick, isDisabled, children, ...props } = this.props;
+
+    return (
+      <button
+        id={id}
+        className={css(styles.menuToggleButton, className)}
+        onClick={onClick}
+        type="button"
+        disabled={isDisabled}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  }
+}

--- a/packages/react-core/src/components/MenuToggle/MenuToggleAction.tsx
+++ b/packages/react-core/src/components/MenuToggle/MenuToggleAction.tsx
@@ -13,8 +13,6 @@ export interface MenuToggleActionProps {
   children?: React.ReactNode;
   /** Id of the action button */
   id?: string;
-  /** Aria-label of the action button */
-  'aria-label'?: string;
 }
 
 export class MenuToggleAction extends React.Component<MenuToggleActionProps> {

--- a/packages/react-core/src/components/MenuToggle/MenuToggleCheckbox.tsx
+++ b/packages/react-core/src/components/MenuToggle/MenuToggleCheckbox.tsx
@@ -13,18 +13,20 @@ export interface MenuToggleCheckboxProps
   isValid?: boolean;
   /** Flag to show if the checkbox is disabled */
   isDisabled?: boolean;
-  /** Flag to show if the checkbox is checked */
+  /** Flag to show if the checkbox is checked when it is controlled by React state.
+   * To make the checkbox uncontrolled instead use the defaultChecked prop, but do not use both.
+   */
   isChecked?: boolean | null;
-  /** Alternate Flag to show if the checkbox is checked */
-  checked?: boolean | null;
+  /** Flag to set the default checked value of the checkbox when it is uncontrolled by React state.
+   * To make the checkbox controlled instead use the isChecked prop, but do not use both.
+   */
+  defaultChecked?: boolean | null;
   /** A callback for when the checkbox selection changes */
   onChange?: (checked: boolean, event: React.FormEvent<HTMLInputElement>) => void;
   /** Element to be rendered inside the <span> */
   children?: React.ReactNode;
   /** Id of the checkbox */
   id: string;
-  /** Aria-label of the checkbox */
-  'aria-label': string;
 }
 
 export class MenuToggleCheckbox extends React.Component<MenuToggleCheckboxProps, { ouiaStateId: string }> {
@@ -48,14 +50,14 @@ export class MenuToggleCheckbox extends React.Component<MenuToggleCheckboxProps,
   };
 
   calculateChecked = () => {
-    const { isChecked, checked } = this.props;
+    const { isChecked, defaultChecked } = this.props;
     if (isChecked === null) {
       // return false here and the indeterminate state will be set to true through the ref
       return false;
     } else if (isChecked !== undefined) {
       return isChecked;
     }
-    return checked;
+    return defaultChecked;
   };
 
   render() {
@@ -69,27 +71,28 @@ export class MenuToggleCheckbox extends React.Component<MenuToggleCheckboxProps,
       ouiaSafe,
       /* eslint-disable @typescript-eslint/no-unused-vars */
       onChange,
-      checked,
+      defaultChecked,
+      id,
       /* eslint-enable @typescript-eslint/no-unused-vars */
       ...props
     } = this.props;
     const text = children && (
-      <span className={css(styles.checkLabel, className)} aria-hidden="true" id={props.id}>
+      <span className={css(styles.checkLabel, className)} aria-hidden="true" id={id}>
         {children}
       </span>
     );
     return (
-      <label className={css(styles.check, !children && styles.modifiers.standalone, className)} htmlFor={props.id}>
+      <label className={css(styles.check, !children && styles.modifiers.standalone, className)} htmlFor={id}>
         <input
           className={css(styles.checkInput)}
           {...props}
           {...(this.calculateChecked() !== undefined && { onChange: this.handleChange })}
-          name={props.id}
+          name={id}
           type="checkbox"
           ref={elem => elem && (elem.indeterminate = isChecked === null)}
           aria-invalid={!isValid}
           disabled={isDisabled}
-          checked={this.calculateChecked()}
+          {...(defaultChecked !== undefined ? { defaultChecked } : { checked: isChecked })}
           {...getOUIAProps(
             MenuToggleCheckbox.displayName,
             ouiaId !== undefined ? ouiaId : this.state.ouiaStateId,

--- a/packages/react-core/src/components/MenuToggle/MenuToggleCheckbox.tsx
+++ b/packages/react-core/src/components/MenuToggle/MenuToggleCheckbox.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import styles from '@patternfly/react-styles/css/components/Check/check';
+import { css } from '@patternfly/react-styles';
+import { PickOptional } from '../../helpers/typeUtils';
+import { getOUIAProps, OUIAProps, getDefaultOUIAId } from '../../helpers';
+
+export interface MenuToggleCheckboxProps
+  extends Omit<React.HTMLProps<HTMLInputElement>, 'type' | 'onChange' | 'disabled' | 'checked'>,
+    OUIAProps {
+  /** Additional classes added to the MenuToggleCheckbox */
+  className?: string;
+  /** Flag to show if the checkbox selection is valid or invalid */
+  isValid?: boolean;
+  /** Flag to show if the checkbox is disabled */
+  isDisabled?: boolean;
+  /** Flag to show if the checkbox is checked */
+  isChecked?: boolean | null;
+  /** Alternate Flag to show if the checkbox is checked */
+  checked?: boolean | null;
+  /** A callback for when the checkbox selection changes */
+  onChange?: (checked: boolean, event: React.FormEvent<HTMLInputElement>) => void;
+  /** Element to be rendered inside the <span> */
+  children?: React.ReactNode;
+  /** Id of the checkbox */
+  id: string;
+  /** Aria-label of the checkbox */
+  'aria-label': string;
+}
+
+export class MenuToggleCheckbox extends React.Component<MenuToggleCheckboxProps, { ouiaStateId: string }> {
+  static displayName = 'MenuToggleCheckbox';
+  static defaultProps: PickOptional<MenuToggleCheckboxProps> = {
+    className: '',
+    isValid: true,
+    isDisabled: false,
+    onChange: () => undefined as any
+  };
+
+  constructor(props: MenuToggleCheckboxProps) {
+    super(props);
+    this.state = {
+      ouiaStateId: getDefaultOUIAId(MenuToggleCheckbox.displayName)
+    };
+  }
+
+  handleChange = (event: React.FormEvent<HTMLInputElement>) => {
+    this.props.onChange((event.target as HTMLInputElement).checked, event);
+  };
+
+  calculateChecked = () => {
+    const { isChecked, checked } = this.props;
+    if (isChecked === null) {
+      // return false here and the indeterminate state will be set to true through the ref
+      return false;
+    } else if (isChecked !== undefined) {
+      return isChecked;
+    }
+    return checked;
+  };
+
+  render() {
+    const {
+      className,
+      isValid,
+      isDisabled,
+      isChecked,
+      children,
+      ouiaId,
+      ouiaSafe,
+      /* eslint-disable @typescript-eslint/no-unused-vars */
+      onChange,
+      checked,
+      /* eslint-enable @typescript-eslint/no-unused-vars */
+      ...props
+    } = this.props;
+    const text = children && (
+      <span className={css(styles.checkLabel, className)} aria-hidden="true" id={props.id}>
+        {children}
+      </span>
+    );
+    return (
+      <label className={css(styles.check, !children && styles.modifiers.standalone, className)} htmlFor={props.id}>
+        <input
+          className={css(styles.checkInput)}
+          {...props}
+          {...(this.calculateChecked() !== undefined && { onChange: this.handleChange })}
+          name={props.id}
+          type="checkbox"
+          ref={elem => elem && (elem.indeterminate = isChecked === null)}
+          aria-invalid={!isValid}
+          disabled={isDisabled}
+          checked={this.calculateChecked()}
+          {...getOUIAProps(
+            MenuToggleCheckbox.displayName,
+            ouiaId !== undefined ? ouiaId : this.state.ouiaStateId,
+            ouiaSafe
+          )}
+        />
+        {text}
+      </label>
+    );
+  }
+}

--- a/packages/react-core/src/components/MenuToggle/MenuToggleCheckbox.tsx
+++ b/packages/react-core/src/components/MenuToggle/MenuToggleCheckbox.tsx
@@ -32,7 +32,6 @@ export interface MenuToggleCheckboxProps
 export class MenuToggleCheckbox extends React.Component<MenuToggleCheckboxProps, { ouiaStateId: string }> {
   static displayName = 'MenuToggleCheckbox';
   static defaultProps: PickOptional<MenuToggleCheckboxProps> = {
-    className: '',
     isValid: true,
     isDisabled: false,
     onChange: () => undefined as any
@@ -85,7 +84,6 @@ export class MenuToggleCheckbox extends React.Component<MenuToggleCheckboxProps,
       <label className={css(styles.check, !children && styles.modifiers.standalone, className)} htmlFor={id}>
         <input
           className={css(styles.checkInput)}
-          {...props}
           {...(this.calculateChecked() !== undefined && { onChange: this.handleChange })}
           name={id}
           type="checkbox"
@@ -98,6 +96,7 @@ export class MenuToggleCheckbox extends React.Component<MenuToggleCheckboxProps,
             ouiaId !== undefined ? ouiaId : this.state.ouiaStateId,
             ouiaSafe
           )}
+          {...props}
         />
         {text}
       </label>

--- a/packages/react-core/src/components/MenuToggle/MenuToggleCheckbox.tsx
+++ b/packages/react-core/src/components/MenuToggle/MenuToggleCheckbox.tsx
@@ -72,7 +72,6 @@ export class MenuToggleCheckbox extends React.Component<MenuToggleCheckboxProps,
       onChange,
       defaultChecked,
       id,
-      /* eslint-enable @typescript-eslint/no-unused-vars */
       ...props
     } = this.props;
     const text = children && (

--- a/packages/react-core/src/components/MenuToggle/__tests__/__snapshots__/MenuToggle.test.tsx.snap
+++ b/packages/react-core/src/components/MenuToggle/__tests__/__snapshots__/MenuToggle.test.tsx.snap
@@ -178,7 +178,7 @@ exports[`menu toggle shows isDisabled 1`] = `
 <DocumentFragment>
   <button
     aria-expanded="false"
-    class="pf-c-menu-toggle"
+    class="pf-c-menu-toggle pf-m-disabled"
     disabled=""
     type="button"
   >

--- a/packages/react-core/src/components/MenuToggle/examples/MenuToggle.md
+++ b/packages/react-core/src/components/MenuToggle/examples/MenuToggle.md
@@ -2,7 +2,7 @@
 id: Menu toggle
 section: components
 cssPrefix: pf-c-menu-toggle
-propComponents: ['MenuToggle', 'MenuToggleAction', 'MenuToggleCheckbox']
+propComponents: ['MenuToggle', 'MenuToggleAction', 'MenuToggleCheckbox', 'SplitButtonOptions']
 beta: true
 ---
 

--- a/packages/react-core/src/components/MenuToggle/examples/MenuToggle.md
+++ b/packages/react-core/src/components/MenuToggle/examples/MenuToggle.md
@@ -2,7 +2,7 @@
 id: Menu toggle
 section: components
 cssPrefix: pf-c-menu-toggle
-propComponents: ['MenuToggle']
+propComponents: ['MenuToggle', 'MenuToggleAction', 'MenuToggleCheckbox']
 beta: true
 ---
 
@@ -137,6 +137,40 @@ import { MenuToggle } from '@patternfly/react-core';
 </React.Fragment>
 ```
 
+### Split button (checkbox)
+    
+```ts file='MenuToggleSplitButtonCheckbox.tsx'
+```
+
+### Split button (checkbox with toggle text)
+    
+```ts file='MenuToggleSplitButtonCheckboxWithText.tsx'
+```
+
+### Split button (checkbox, primary)
+    
+```ts file='MenuToggleSplitButtonCheckboxPrimary.tsx'
+```
+
+### Split button (checkbox, secondary)
+    
+```ts file='MenuToggleSplitButtonCheckboxSecondary.tsx'
+```
+
+### Split button (action)
+    
+```ts file='MenuToggleSplitButtonAction.tsx'
+```
+
+### Split button (action, primary)
+    
+```ts file='MenuToggleSplitButtonActionPrimary.tsx'
+```
+
+### Split button (action, secondary)
+    
+```ts file='MenuToggleSplitButtonActionSecondary.tsx'
+```
 
 ### With icon/image and text
 
@@ -191,5 +225,4 @@ const fullWidth: React.FunctionComponent = () => {
     </MenuToggle>
   );
 }
-    
 ```

--- a/packages/react-core/src/components/MenuToggle/examples/MenuToggleSplitButtonAction.tsx
+++ b/packages/react-core/src/components/MenuToggle/examples/MenuToggleSplitButtonAction.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { MenuToggleAction, MenuToggle } from '@patternfly/react-core';
+
+export const MenuToggleSplitButtonAction: React.FunctionComponent = () => (
+  <React.Fragment>
+    <MenuToggle
+      isDisabled
+      splitButtonVariant="action"
+      splitButtonItems={[
+        <MenuToggleAction
+          id="split-button-action-disabled-example-with-toggle-button"
+          key="split-action-disabled"
+          aria-label="Action"
+          isDisabled
+        >
+          Action
+        </MenuToggleAction>
+      ]}
+      aria-label="Menu toggle with action split button"
+    />{' '}
+    <MenuToggle
+      splitButtonVariant="action"
+      splitButtonItems={[
+        <MenuToggleAction id="split-button-action-example-with-toggle-button" key="split-action" aria-label="Action">
+          Action
+        </MenuToggleAction>
+      ]}
+      aria-label="Menu toggle with action split button"
+    />{' '}
+    <MenuToggle
+      isExpanded
+      splitButtonVariant="action"
+      splitButtonItems={[
+        <MenuToggleAction
+          id="split-button-action-expanded-example-with-toggle-button"
+          key="split-action-expanded"
+          aria-label="Action"
+        >
+          Action
+        </MenuToggleAction>
+      ]}
+      aria-label="Menu toggle with action split button"
+    />
+  </React.Fragment>
+);

--- a/packages/react-core/src/components/MenuToggle/examples/MenuToggleSplitButtonAction.tsx
+++ b/packages/react-core/src/components/MenuToggle/examples/MenuToggleSplitButtonAction.tsx
@@ -5,40 +5,46 @@ export const MenuToggleSplitButtonAction: React.FunctionComponent = () => (
   <React.Fragment>
     <MenuToggle
       isDisabled
-      splitButtonVariant="action"
-      splitButtonItems={[
-        <MenuToggleAction
-          id="split-button-action-disabled-example-with-toggle-button"
-          key="split-action-disabled"
-          aria-label="Action"
-          isDisabled
-        >
-          Action
-        </MenuToggleAction>
-      ]}
+      splitButtonOptions={{
+        variant: 'action',
+        items: [
+          <MenuToggleAction
+            id="split-button-action-disabled-example-with-toggle-button"
+            key="split-action-disabled"
+            aria-label="Action"
+            isDisabled
+          >
+            Action
+          </MenuToggleAction>
+        ]
+      }}
       aria-label="Menu toggle with action split button"
     />{' '}
     <MenuToggle
-      splitButtonVariant="action"
-      splitButtonItems={[
-        <MenuToggleAction id="split-button-action-example-with-toggle-button" key="split-action" aria-label="Action">
-          Action
-        </MenuToggleAction>
-      ]}
+      splitButtonOptions={{
+        variant: 'action',
+        items: [
+          <MenuToggleAction id="split-button-action-example-with-toggle-button" key="split-action" aria-label="Action">
+            Action
+          </MenuToggleAction>
+        ]
+      }}
       aria-label="Menu toggle with action split button"
     />{' '}
     <MenuToggle
       isExpanded
-      splitButtonVariant="action"
-      splitButtonItems={[
-        <MenuToggleAction
-          id="split-button-action-expanded-example-with-toggle-button"
-          key="split-action-expanded"
-          aria-label="Action"
-        >
-          Action
-        </MenuToggleAction>
-      ]}
+      splitButtonOptions={{
+        variant: 'action',
+        items: [
+          <MenuToggleAction
+            id="split-button-action-expanded-example-with-toggle-button"
+            key="split-action-expanded"
+            aria-label="Action"
+          >
+            Action
+          </MenuToggleAction>
+        ]
+      }}
       aria-label="Menu toggle with action split button"
     />
   </React.Fragment>

--- a/packages/react-core/src/components/MenuToggle/examples/MenuToggleSplitButtonActionPrimary.tsx
+++ b/packages/react-core/src/components/MenuToggle/examples/MenuToggleSplitButtonActionPrimary.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { MenuToggleAction, MenuToggle } from '@patternfly/react-core';
+
+export const MenuToggleSplitButtonActionPrimary: React.FunctionComponent = () => (
+  <React.Fragment>
+    <MenuToggle
+      isDisabled
+      splitButtonVariant="action"
+      variant="primary"
+      splitButtonItems={[
+        <MenuToggleAction
+          id="split-button-action-primary-disabled-example-with-toggle-button"
+          key="split-action-primary-disabled"
+          aria-label="Action"
+          isDisabled
+        >
+          Action
+        </MenuToggleAction>
+      ]}
+      aria-label="Menu toggle with action split button"
+    />{' '}
+    <MenuToggle
+      splitButtonVariant="action"
+      variant="primary"
+      splitButtonItems={[
+        <MenuToggleAction
+          id="split-button-action-primary-example-with-toggle-button"
+          key="split-action-primary"
+          aria-label="Action"
+        >
+          Action
+        </MenuToggleAction>
+      ]}
+      aria-label="Menu toggle with action split button"
+    />{' '}
+    <MenuToggle
+      isExpanded
+      splitButtonVariant="action"
+      variant="primary"
+      splitButtonItems={[
+        <MenuToggleAction
+          id="split-button-action-primary-expanded-example-with-toggle-button"
+          key="split-action-primary-expanded"
+          aria-label="Action"
+        >
+          Action
+        </MenuToggleAction>
+      ]}
+      aria-label="Menu toggle with action split button"
+    />
+  </React.Fragment>
+);

--- a/packages/react-core/src/components/MenuToggle/examples/MenuToggleSplitButtonActionPrimary.tsx
+++ b/packages/react-core/src/components/MenuToggle/examples/MenuToggleSplitButtonActionPrimary.tsx
@@ -5,47 +5,53 @@ export const MenuToggleSplitButtonActionPrimary: React.FunctionComponent = () =>
   <React.Fragment>
     <MenuToggle
       isDisabled
-      splitButtonVariant="action"
       variant="primary"
-      splitButtonItems={[
-        <MenuToggleAction
-          id="split-button-action-primary-disabled-example-with-toggle-button"
-          key="split-action-primary-disabled"
-          aria-label="Action"
-          isDisabled
-        >
-          Action
-        </MenuToggleAction>
-      ]}
+      splitButtonOptions={{
+        variant: 'action',
+        items: [
+          <MenuToggleAction
+            id="split-button-action-primary-disabled-example-with-toggle-button"
+            key="split-action-primary-disabled"
+            aria-label="Action"
+            isDisabled
+          >
+            Action
+          </MenuToggleAction>
+        ]
+      }}
       aria-label="Menu toggle with action split button"
     />{' '}
     <MenuToggle
-      splitButtonVariant="action"
       variant="primary"
-      splitButtonItems={[
-        <MenuToggleAction
-          id="split-button-action-primary-example-with-toggle-button"
-          key="split-action-primary"
-          aria-label="Action"
-        >
-          Action
-        </MenuToggleAction>
-      ]}
+      splitButtonOptions={{
+        variant: 'action',
+        items: [
+          <MenuToggleAction
+            id="split-button-action-primary-example-with-toggle-button"
+            key="split-action-primary"
+            aria-label="Action"
+          >
+            Action
+          </MenuToggleAction>
+        ]
+      }}
       aria-label="Menu toggle with action split button"
     />{' '}
     <MenuToggle
       isExpanded
-      splitButtonVariant="action"
       variant="primary"
-      splitButtonItems={[
-        <MenuToggleAction
-          id="split-button-action-primary-expanded-example-with-toggle-button"
-          key="split-action-primary-expanded"
-          aria-label="Action"
-        >
-          Action
-        </MenuToggleAction>
-      ]}
+      splitButtonOptions={{
+        variant: 'action',
+        items: [
+          <MenuToggleAction
+            id="split-button-action-primary-expanded-example-with-toggle-button"
+            key="split-action-primary-expanded"
+            aria-label="Action"
+          >
+            Action
+          </MenuToggleAction>
+        ]
+      }}
       aria-label="Menu toggle with action split button"
     />
   </React.Fragment>

--- a/packages/react-core/src/components/MenuToggle/examples/MenuToggleSplitButtonActionSecondary.tsx
+++ b/packages/react-core/src/components/MenuToggle/examples/MenuToggleSplitButtonActionSecondary.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { MenuToggleAction, MenuToggle } from '@patternfly/react-core';
+
+export const MenuToggleSplitButtonActionSecondary: React.FunctionComponent = () => (
+  <React.Fragment>
+    <MenuToggle
+      isDisabled
+      splitButtonVariant="action"
+      variant="secondary"
+      splitButtonItems={[
+        <MenuToggleAction
+          id="split-button-action-secondary-disabled-example-with-toggle-button"
+          key="split-action-secondary-disabled"
+          aria-label="Action"
+          isDisabled
+        >
+          Action
+        </MenuToggleAction>
+      ]}
+      aria-label="Menu toggle with action split button"
+    />{' '}
+    <MenuToggle
+      splitButtonVariant="action"
+      variant="secondary"
+      splitButtonItems={[
+        <MenuToggleAction
+          id="split-button-action-secondary-example-with-toggle-button"
+          key="split-action-secondary"
+          aria-label="Action"
+        >
+          Action
+        </MenuToggleAction>
+      ]}
+      aria-label="Menu toggle with action split button"
+    />{' '}
+    <MenuToggle
+      isExpanded
+      splitButtonVariant="action"
+      variant="secondary"
+      splitButtonItems={[
+        <MenuToggleAction
+          id="split-button-action-secondary-expanded-example-with-toggle-button"
+          key="split-action-secondary-expanded"
+          aria-label="Action"
+        >
+          Action
+        </MenuToggleAction>
+      ]}
+      aria-label="Menu toggle with action split button"
+    />
+  </React.Fragment>
+);

--- a/packages/react-core/src/components/MenuToggle/examples/MenuToggleSplitButtonActionSecondary.tsx
+++ b/packages/react-core/src/components/MenuToggle/examples/MenuToggleSplitButtonActionSecondary.tsx
@@ -5,47 +5,53 @@ export const MenuToggleSplitButtonActionSecondary: React.FunctionComponent = () 
   <React.Fragment>
     <MenuToggle
       isDisabled
-      splitButtonVariant="action"
       variant="secondary"
-      splitButtonItems={[
-        <MenuToggleAction
-          id="split-button-action-secondary-disabled-example-with-toggle-button"
-          key="split-action-secondary-disabled"
-          aria-label="Action"
-          isDisabled
-        >
-          Action
-        </MenuToggleAction>
-      ]}
+      splitButtonOptions={{
+        variant: 'action',
+        items: [
+          <MenuToggleAction
+            id="split-button-action-secondary-disabled-example-with-toggle-button"
+            key="split-action-secondary-disabled"
+            aria-label="Action"
+            isDisabled
+          >
+            Action
+          </MenuToggleAction>
+        ]
+      }}
       aria-label="Menu toggle with action split button"
     />{' '}
     <MenuToggle
-      splitButtonVariant="action"
       variant="secondary"
-      splitButtonItems={[
-        <MenuToggleAction
-          id="split-button-action-secondary-example-with-toggle-button"
-          key="split-action-secondary"
-          aria-label="Action"
-        >
-          Action
-        </MenuToggleAction>
-      ]}
+      splitButtonOptions={{
+        variant: 'action',
+        items: [
+          <MenuToggleAction
+            id="split-button-action-secondary-example-with-toggle-button"
+            key="split-action-secondary"
+            aria-label="Action"
+          >
+            Action
+          </MenuToggleAction>
+        ]
+      }}
       aria-label="Menu toggle with action split button"
     />{' '}
     <MenuToggle
       isExpanded
-      splitButtonVariant="action"
       variant="secondary"
-      splitButtonItems={[
-        <MenuToggleAction
-          id="split-button-action-secondary-expanded-example-with-toggle-button"
-          key="split-action-secondary-expanded"
-          aria-label="Action"
-        >
-          Action
-        </MenuToggleAction>
-      ]}
+      splitButtonOptions={{
+        variant: 'action',
+        items: [
+          <MenuToggleAction
+            id="split-button-action-secondary-expanded-example-with-toggle-button"
+            key="split-action-secondary-expanded"
+            aria-label="Action"
+          >
+            Action
+          </MenuToggleAction>
+        ]
+      }}
       aria-label="Menu toggle with action split button"
     />
   </React.Fragment>

--- a/packages/react-core/src/components/MenuToggle/examples/MenuToggleSplitButtonCheckbox.tsx
+++ b/packages/react-core/src/components/MenuToggle/examples/MenuToggleSplitButtonCheckbox.tsx
@@ -5,31 +5,35 @@ export const MenuToggleSplitButtonCheckbox: React.FunctionComponent = () => (
   <React.Fragment>
     <MenuToggle
       isDisabled
-      splitButtonItems={[
-        <MenuToggleCheckbox
-          id="split-button-checkbox-disabled-example"
-          key="split-checkbox-disabled"
-          aria-label="Select all"
-          isDisabled
-        />
-      ]}
+      splitButtonOptions={{
+        items: [
+          <MenuToggleCheckbox
+            id="split-button-checkbox-disabled-example"
+            key="split-checkbox-disabled"
+            aria-label="Select all"
+            isDisabled
+          />
+        ]
+      }}
       aria-label="Menu toggle with checkbox split button"
     />{' '}
     <MenuToggle
-      splitButtonItems={[
-        <MenuToggleCheckbox id="split-button-checkbox-example" key="split-checkbox" aria-label="Select all" />
-      ]}
+      splitButtonOptions={{
+        items: [<MenuToggleCheckbox id="split-button-checkbox-example" key="split-checkbox" aria-label="Select all" />]
+      }}
       aria-label="Menu toggle with checkbox split button"
     />{' '}
     <MenuToggle
       isExpanded
-      splitButtonItems={[
-        <MenuToggleCheckbox
-          id="split-button-checkbox-expanded-example"
-          key="split-checkbox-expanded"
-          aria-label="Select all"
-        />
-      ]}
+      splitButtonOptions={{
+        items: [
+          <MenuToggleCheckbox
+            id="split-button-checkbox-expanded-example"
+            key="split-checkbox-expanded"
+            aria-label="Select all"
+          />
+        ]
+      }}
       aria-label="Menu toggle with checkbox split button"
     />
   </React.Fragment>

--- a/packages/react-core/src/components/MenuToggle/examples/MenuToggleSplitButtonCheckbox.tsx
+++ b/packages/react-core/src/components/MenuToggle/examples/MenuToggleSplitButtonCheckbox.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { MenuToggleCheckbox, MenuToggle } from '@patternfly/react-core';
+
+export const MenuToggleSplitButtonCheckbox: React.FunctionComponent = () => (
+  <React.Fragment>
+    <MenuToggle
+      isDisabled
+      splitButtonItems={[
+        <MenuToggleCheckbox
+          id="split-button-checkbox-disabled-example"
+          key="split-checkbox-disabled"
+          aria-label="Select all"
+          isDisabled
+        />
+      ]}
+      aria-label="Menu toggle with checkbox split button"
+    />{' '}
+    <MenuToggle
+      splitButtonItems={[
+        <MenuToggleCheckbox id="split-button-checkbox-example" key="split-checkbox" aria-label="Select all" />
+      ]}
+      aria-label="Menu toggle with checkbox split button"
+    />{' '}
+    <MenuToggle
+      isExpanded
+      splitButtonItems={[
+        <MenuToggleCheckbox
+          id="split-button-checkbox-expanded-example"
+          key="split-checkbox-expanded"
+          aria-label="Select all"
+        />
+      ]}
+      aria-label="Menu toggle with checkbox split button"
+    />
+  </React.Fragment>
+);

--- a/packages/react-core/src/components/MenuToggle/examples/MenuToggleSplitButtonCheckboxPrimary.tsx
+++ b/packages/react-core/src/components/MenuToggle/examples/MenuToggleSplitButtonCheckboxPrimary.tsx
@@ -6,43 +6,49 @@ export const MenuToggleSplitButtonCheckboxPrimary: React.FunctionComponent = () 
     <MenuToggle
       isDisabled
       variant="primary"
-      splitButtonItems={[
-        <MenuToggleCheckbox
-          id="split-button-checkbox-primary-disabled-example"
-          key="split-checkbox-primary-disabled"
-          aria-label="Select all"
-          isDisabled
-        >
-          10 selected
-        </MenuToggleCheckbox>
-      ]}
+      splitButtonOptions={{
+        items: [
+          <MenuToggleCheckbox
+            id="split-button-checkbox-primary-disabled-example"
+            key="split-checkbox-primary-disabled"
+            aria-label="Select all"
+            isDisabled
+          >
+            10 selected
+          </MenuToggleCheckbox>
+        ]
+      }}
       aria-label="Primary menu toggle with checkbox split button"
     />{' '}
     <MenuToggle
       variant="primary"
-      splitButtonItems={[
-        <MenuToggleCheckbox
-          id="split-button-checkbox-primary-example"
-          key="split-checkbox-primary"
-          aria-label="Select all"
-        >
-          10 selected
-        </MenuToggleCheckbox>
-      ]}
+      splitButtonOptions={{
+        items: [
+          <MenuToggleCheckbox
+            id="split-button-checkbox-primary-example"
+            key="split-checkbox-primary"
+            aria-label="Select all"
+          >
+            10 selected
+          </MenuToggleCheckbox>
+        ]
+      }}
       aria-label="Primary menu toggle with checkbox split button"
     />{' '}
     <MenuToggle
       isExpanded
       variant="primary"
-      splitButtonItems={[
-        <MenuToggleCheckbox
-          id="split-button-checkbox-primary-expanded-example"
-          key="split-checkbox-expanded"
-          aria-label="Select all"
-        >
-          10 selected
-        </MenuToggleCheckbox>
-      ]}
+      splitButtonOptions={{
+        items: [
+          <MenuToggleCheckbox
+            id="split-button-checkbox-primary-expanded-example"
+            key="split-checkbox-expanded"
+            aria-label="Select all"
+          >
+            10 selected
+          </MenuToggleCheckbox>
+        ]
+      }}
       aria-label="Primary menu toggle with checkbox split button"
     />
   </React.Fragment>

--- a/packages/react-core/src/components/MenuToggle/examples/MenuToggleSplitButtonCheckboxPrimary.tsx
+++ b/packages/react-core/src/components/MenuToggle/examples/MenuToggleSplitButtonCheckboxPrimary.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { MenuToggleCheckbox, MenuToggle } from '@patternfly/react-core';
+
+export const MenuToggleSplitButtonCheckboxPrimary: React.FunctionComponent = () => (
+  <React.Fragment>
+    <MenuToggle
+      isDisabled
+      variant="primary"
+      splitButtonItems={[
+        <MenuToggleCheckbox
+          id="split-button-checkbox-primary-disabled-example"
+          key="split-checkbox-primary-disabled"
+          aria-label="Select all"
+          isDisabled
+        >
+          10 selected
+        </MenuToggleCheckbox>
+      ]}
+      aria-label="Primary menu toggle with checkbox split button"
+    />{' '}
+    <MenuToggle
+      variant="primary"
+      splitButtonItems={[
+        <MenuToggleCheckbox
+          id="split-button-checkbox-primary-example"
+          key="split-checkbox-primary"
+          aria-label="Select all"
+        >
+          10 selected
+        </MenuToggleCheckbox>
+      ]}
+      aria-label="Primary menu toggle with checkbox split button"
+    />{' '}
+    <MenuToggle
+      isExpanded
+      variant="primary"
+      splitButtonItems={[
+        <MenuToggleCheckbox
+          id="split-button-checkbox-primary-expanded-example"
+          key="split-checkbox-expanded"
+          aria-label="Select all"
+        >
+          10 selected
+        </MenuToggleCheckbox>
+      ]}
+      aria-label="Primary menu toggle with checkbox split button"
+    />
+  </React.Fragment>
+);

--- a/packages/react-core/src/components/MenuToggle/examples/MenuToggleSplitButtonCheckboxSecondary.tsx
+++ b/packages/react-core/src/components/MenuToggle/examples/MenuToggleSplitButtonCheckboxSecondary.tsx
@@ -6,43 +6,49 @@ export const MenuToggleSplitButtonCheckboxSecondary: React.FunctionComponent = (
     <MenuToggle
       isDisabled
       variant="secondary"
-      splitButtonItems={[
-        <MenuToggleCheckbox
-          id="split-button-checkbox-secondary-disabled-example"
-          key="split-checkbox-secondary-disabled"
-          aria-label="Select all"
-          isDisabled
-        >
-          10 selected
-        </MenuToggleCheckbox>
-      ]}
+      splitButtonOptions={{
+        items: [
+          <MenuToggleCheckbox
+            id="split-button-checkbox-secondary-disabled-example"
+            key="split-checkbox-secondary-disabled"
+            aria-label="Select all"
+            isDisabled
+          >
+            10 selected
+          </MenuToggleCheckbox>
+        ]
+      }}
       aria-label="Secondary menu toggle with checkbox split button"
     />{' '}
     <MenuToggle
       variant="secondary"
-      splitButtonItems={[
-        <MenuToggleCheckbox
-          id="split-button-checkbox-secondary-example"
-          key="split-checkbox-secondary"
-          aria-label="Select all"
-        >
-          10 selected
-        </MenuToggleCheckbox>
-      ]}
+      splitButtonOptions={{
+        items: [
+          <MenuToggleCheckbox
+            id="split-button-checkbox-secondary-example"
+            key="split-checkbox-secondary"
+            aria-label="Select all"
+          >
+            10 selected
+          </MenuToggleCheckbox>
+        ]
+      }}
       aria-label="Secondary menu toggle with checkbox split button"
     />{' '}
     <MenuToggle
       isExpanded
       variant="secondary"
-      splitButtonItems={[
-        <MenuToggleCheckbox
-          id="split-button-checkbox-secondary-expanded-example"
-          key="split-checkbox-secondary-expanded"
-          aria-label="Select all"
-        >
-          10 selected
-        </MenuToggleCheckbox>
-      ]}
+      splitButtonOptions={{
+        items: [
+          <MenuToggleCheckbox
+            id="split-button-checkbox-secondary-expanded-example"
+            key="split-checkbox-secondary-expanded"
+            aria-label="Select all"
+          >
+            10 selected
+          </MenuToggleCheckbox>
+        ]
+      }}
       aria-label="Secondary menu toggle with checkbox split button"
     />
   </React.Fragment>

--- a/packages/react-core/src/components/MenuToggle/examples/MenuToggleSplitButtonCheckboxSecondary.tsx
+++ b/packages/react-core/src/components/MenuToggle/examples/MenuToggleSplitButtonCheckboxSecondary.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { MenuToggleCheckbox, MenuToggle } from '@patternfly/react-core';
+
+export const MenuToggleSplitButtonCheckboxSecondary: React.FunctionComponent = () => (
+  <React.Fragment>
+    <MenuToggle
+      isDisabled
+      variant="secondary"
+      splitButtonItems={[
+        <MenuToggleCheckbox
+          id="split-button-checkbox-secondary-disabled-example"
+          key="split-checkbox-secondary-disabled"
+          aria-label="Select all"
+          isDisabled
+        >
+          10 selected
+        </MenuToggleCheckbox>
+      ]}
+      aria-label="Secondary menu toggle with checkbox split button"
+    />{' '}
+    <MenuToggle
+      variant="secondary"
+      splitButtonItems={[
+        <MenuToggleCheckbox
+          id="split-button-checkbox-secondary-example"
+          key="split-checkbox-secondary"
+          aria-label="Select all"
+        >
+          10 selected
+        </MenuToggleCheckbox>
+      ]}
+      aria-label="Secondary menu toggle with checkbox split button"
+    />{' '}
+    <MenuToggle
+      isExpanded
+      variant="secondary"
+      splitButtonItems={[
+        <MenuToggleCheckbox
+          id="split-button-checkbox-secondary-expanded-example"
+          key="split-checkbox-secondary-expanded"
+          aria-label="Select all"
+        >
+          10 selected
+        </MenuToggleCheckbox>
+      ]}
+      aria-label="Secondary menu toggle with checkbox split button"
+    />
+  </React.Fragment>
+);

--- a/packages/react-core/src/components/MenuToggle/examples/MenuToggleSplitButtonCheckboxWithText.tsx
+++ b/packages/react-core/src/components/MenuToggle/examples/MenuToggleSplitButtonCheckboxWithText.tsx
@@ -5,41 +5,47 @@ export const MenuToggleSplitButtonCheckboxWithText: React.FunctionComponent = ()
   <React.Fragment>
     <MenuToggle
       isDisabled
-      splitButtonItems={[
-        <MenuToggleCheckbox
-          id="split-button-checkbox-with-text-disabled-example"
-          key="split-checkbox-with-text-disabled"
-          aria-label="Select all"
-          isDisabled
-        >
-          10 selected
-        </MenuToggleCheckbox>
-      ]}
+      splitButtonOptions={{
+        items: [
+          <MenuToggleCheckbox
+            id="split-button-checkbox-with-text-disabled-example"
+            key="split-checkbox-with-text-disabled"
+            aria-label="Select all"
+            isDisabled
+          >
+            10 selected
+          </MenuToggleCheckbox>
+        ]
+      }}
       aria-label="Menu toggle with checkbox split button and text"
     />{' '}
     <MenuToggle
-      splitButtonItems={[
-        <MenuToggleCheckbox
-          id="split-button-checkbox-with-text-example"
-          key="split-checkbox-with-text"
-          aria-label="Select all"
-        >
-          10 selected
-        </MenuToggleCheckbox>
-      ]}
+      splitButtonOptions={{
+        items: [
+          <MenuToggleCheckbox
+            id="split-button-checkbox-with-text-example"
+            key="split-checkbox-with-text"
+            aria-label="Select all"
+          >
+            10 selected
+          </MenuToggleCheckbox>
+        ]
+      }}
       aria-label="Menu toggle with checkbox split button and text"
     />{' '}
     <MenuToggle
       isExpanded
-      splitButtonItems={[
-        <MenuToggleCheckbox
-          id="split-button-checkbox-with-text-expanded-example"
-          key="split-checkbox-with-text-expanded"
-          aria-label="Select all"
-        >
-          10 selected
-        </MenuToggleCheckbox>
-      ]}
+      splitButtonOptions={{
+        items: [
+          <MenuToggleCheckbox
+            id="split-button-checkbox-with-text-expanded-example"
+            key="split-checkbox-with-text-expanded"
+            aria-label="Select all"
+          >
+            10 selected
+          </MenuToggleCheckbox>
+        ]
+      }}
       aria-label="Menu toggle with checkbox split button and text"
     />
   </React.Fragment>

--- a/packages/react-core/src/components/MenuToggle/examples/MenuToggleSplitButtonCheckboxWithText.tsx
+++ b/packages/react-core/src/components/MenuToggle/examples/MenuToggleSplitButtonCheckboxWithText.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { MenuToggleCheckbox, MenuToggle } from '@patternfly/react-core';
+
+export const MenuToggleSplitButtonCheckboxWithText: React.FunctionComponent = () => (
+  <React.Fragment>
+    <MenuToggle
+      isDisabled
+      splitButtonItems={[
+        <MenuToggleCheckbox
+          id="split-button-checkbox-with-text-disabled-example"
+          key="split-checkbox-with-text-disabled"
+          aria-label="Select all"
+          isDisabled
+        >
+          10 selected
+        </MenuToggleCheckbox>
+      ]}
+      aria-label="Menu toggle with checkbox split button and text"
+    />{' '}
+    <MenuToggle
+      splitButtonItems={[
+        <MenuToggleCheckbox
+          id="split-button-checkbox-with-text-example"
+          key="split-checkbox-with-text"
+          aria-label="Select all"
+        >
+          10 selected
+        </MenuToggleCheckbox>
+      ]}
+      aria-label="Menu toggle with checkbox split button and text"
+    />{' '}
+    <MenuToggle
+      isExpanded
+      splitButtonItems={[
+        <MenuToggleCheckbox
+          id="split-button-checkbox-with-text-expanded-example"
+          key="split-checkbox-with-text-expanded"
+          aria-label="Select all"
+        >
+          10 selected
+        </MenuToggleCheckbox>
+      ]}
+      aria-label="Menu toggle with checkbox split button and text"
+    />
+  </React.Fragment>
+);

--- a/packages/react-core/src/components/MenuToggle/index.ts
+++ b/packages/react-core/src/components/MenuToggle/index.ts
@@ -1,1 +1,3 @@
 export * from './MenuToggle';
+export * from './MenuToggleAction';
+export * from './MenuToggleCheckbox';


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7085 


The toggle button is a little bit wider than in html demos, it's because I used `<CaretDownIcon />` instead of `<i class="fas fa-caret-down" aria-hidden="true"></i>`. I'm not sure if this will be a problem since the difference is just a couple of pixels. Would appreciate if someone could review also this fact.
