### PR TITLE
bug(Wizard): keep currentStep state aligned with startAtStep prop

### DIFF
--- a/packages/react-core/src/components/Wizard/Wizard.tsx
+++ b/packages/react-core/src/components/Wizard/Wizard.tsx
@@ -352,6 +352,12 @@ export class Wizard extends React.Component<WizardProps, WizardState> {
     }
   }
 
+  componentDidUpdate(prevProps: Readonly<WizardProps>) {
+    if (prevProps.startAtStep !== this.props.startAtStep) {
+      this.setState({ currentStep: this.props.startAtStep });
+    }
+  }
+
   render() {
     const {
       /* eslint-disable @typescript-eslint/no-unused-vars */

--- a/packages/react-core/src/components/Wizard/__tests__/Wizard.test.tsx
+++ b/packages/react-core/src/components/Wizard/__tests__/Wizard.test.tsx
@@ -314,3 +314,34 @@ describe('Wizard', () => {
 
     expect(screen.getByRole('button',{ name: "A-2" })).toBeDisabled();
   });
+
+test('startAtStep can be used to externally control the current step of the wizard', () => {
+  const WizardTest = () => {
+    const [step, setStep] = React.useState(1);
+
+    const incrementStep = () => {
+      setStep(prevStep => prevStep + 1);
+    };
+
+    const steps: WizardStep[] = [
+      { name: 'A', component: <p>Step 1</p> },
+      { name: 'B', component: <p>Step 2</p> },
+      { name: 'C', component: <p>Step 3</p> }
+    ];
+
+    return (
+      <>
+        <Wizard steps={steps} startAtStep={step} />
+        <button onClick={() => incrementStep()}>Increment step</button>
+      </>
+    );
+  };
+
+  render(<WizardTest />);
+
+  expect(screen.queryByText('Step 2')).not.toBeInTheDocument();
+
+  userEvent.click(screen.getByRole('button', { name: 'Increment step'}))
+
+  expect(screen.getByText('Step 2')).toBeVisible();
+});


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7184 

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
