### PR TITLE
fix(Menu/Nav): flyout variants work with VO navigation

### DIFF
--- a/packages/react-core/src/components/Menu/MenuItem.tsx
+++ b/packages/react-core/src/components/Menu/MenuItem.tsx
@@ -189,11 +189,12 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
     }
   }, [flyoutVisible, flyoutTarget]);
 
-  const handleFlyout = (event: React.KeyboardEvent) => {
-    const key = event.key;
+  const handleFlyout = (event: React.KeyboardEvent | React.MouseEvent) => {
+    const key = (event as React.KeyboardEvent).key;
     const target = event.target;
+    const type = event.type;
 
-    if (key === ' ' || key === 'Enter' || key === 'ArrowRight') {
+    if (key === ' ' || key === 'Enter' || key === 'ArrowRight' || type === 'click') {
       event.stopPropagation();
       if (!flyoutVisible) {
         showFlyout(true);
@@ -248,7 +249,7 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
   if (isOnPath) {
     additionalProps['aria-expanded'] = true;
   } else if (hasFlyout) {
-    additionalProps['aria-haspopup'] = true;
+    additionalProps['aria-haspopup'] = 'menu';
     additionalProps['aria-expanded'] = flyoutVisible;
   }
   const getAriaCurrent = () => {
@@ -305,12 +306,13 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
             className={css(styles.menuItem, getIsSelected() && !hasCheck && styles.modifiers.selected, className)}
             aria-current={getAriaCurrent()}
             {...(!hasCheck && { disabled: isDisabled })}
-            {...(!hasCheck && { role: 'menuitem' })}
+            {...(!hasCheck && !flyoutMenu && { role: 'menuitem' })}
             ref={innerRef}
             {...(!hasCheck && {
               onClick: (event: any) => {
                 onItemSelect(event, onSelect);
                 _drill && _drill();
+                flyoutMenu && handleFlyout(event);
               }
             })}
             {...(hasCheck && { htmlFor: randomId })}

--- a/packages/react-core/src/components/Nav/NavItem.tsx
+++ b/packages/react-core/src/components/Nav/NavItem.tsx
@@ -150,6 +150,11 @@ export const NavItem: React.FunctionComponent<NavItemProps> = ({
     </span>
   );
 
+  const ariaFlyoutProps = {
+    'aria-haspopup': 'menu',
+    'aria-expanded': flyoutVisible
+  };
+
   const renderDefaultLink = (context: any): React.ReactNode => {
     const preventLinkDefault = preventDefault || !to;
     return (
@@ -164,6 +169,7 @@ export const NavItem: React.FunctionComponent<NavItemProps> = ({
         )}
         aria-current={isActive ? 'page' : null}
         tabIndex={isNavOpen ? null : '-1'}
+        {...(hasFlyout && { ...ariaFlyoutProps })}
         {...props}
       >
         {children}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7461

- Because VO's `VO modifier + space` registers as a click event, I added a check for a "click" mouse event for the `handleFlyout` method. 
    - If there are no issues with this addition, this could also open up the possibility for allowing flyout menus to be opened vis mouse hover or mouse click as well.
- I updated the logic for adding a role of "menuitem" to the menu buttons so that it does not get applied if the menu item has a flyout menu. Previously menu items with flyouts weren't announcing that there was a popup, now they do (and VO still registers the item as part of the menu list)
- I added the same `aria-expanded` and `aria-haspopup` props to the Nav Item, following the logic from Menu Item. This will at least provide context that the nav item a) has a popup menu, and b) is expanded/collapsed, and you can choose between clicking the link with VO + space, or opening the flyout with just space. I believe this is about as close as we can get to resolving the flyout issue for the Nav component unless one of the following is done:
    - We recommend that flyouts not be put on nav items that are also links that can be clicked (I don't think this would really be feasible)
    - We move the toggle icon out of the `<a>` element to make it a sibling instead, and make it an actual button that can be used to click on and open the flyout. Similar to the [W3C flyout button as toggle example](https://www.w3.org/WAI/tutorials/menus/flyout/#use-button-as-toggle) (this would require an update in Core).

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
N/A
