### PR TITLE
fix(charts): remove uniqueId generation for labels and axis ticks

### DIFF
--- a/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
+++ b/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
@@ -18,7 +18,6 @@ import { VictoryAxis, VictoryAxisProps, VictoryAxisTTargetType } from 'victory-a
 import { ChartContainer } from '../ChartContainer';
 import { ChartThemeDefinition } from '../ChartTheme';
 import { getAxisTheme, getTheme } from '../ChartUtils';
-import { getUniqueId } from '@patternfly/react-core';
 import { ChartLabel } from '../ChartLabel';
 
 /**
@@ -465,7 +464,6 @@ export const ChartAxis: React.FunctionComponent<ChartAxisProps> = ({
 
   const getTickLabelComponent = () =>
     React.cloneElement(tickLabelComponent, {
-      id: () => getUniqueId('chart-axis-tickLabels'),
       ...tickLabelComponent.props
     });
 

--- a/packages/react-charts/src/components/ChartLabel/ChartLabel.tsx
+++ b/packages/react-charts/src/components/ChartLabel/ChartLabel.tsx
@@ -245,7 +245,7 @@ export const ChartLabel: React.FunctionComponent<ChartLabelProps> = ({
     );
   const newStyle = Array.isArray(style) ? style.map(applyDefaultStyle) : applyDefaultStyle(style);
 
-  return <VictoryLabel style={newStyle as any} textAnchor={textAnchor} {...(id && { id })} {...rest} />;
+  return <VictoryLabel style={newStyle as any} textAnchor={textAnchor} id={id} {...rest} />;
 };
 ChartLabel.displayName = 'ChartLabel';
 

--- a/packages/react-charts/src/components/ChartLabel/ChartLabel.tsx
+++ b/packages/react-charts/src/components/ChartLabel/ChartLabel.tsx
@@ -245,7 +245,7 @@ export const ChartLabel: React.FunctionComponent<ChartLabelProps> = ({
     );
   const newStyle = Array.isArray(style) ? style.map(applyDefaultStyle) : applyDefaultStyle(style);
 
-  return <VictoryLabel style={newStyle as any} textAnchor={textAnchor} {...rest} {...(id && { id })} />;
+  return <VictoryLabel style={newStyle as any} textAnchor={textAnchor} {...(id && { id })} {...rest} />;
 };
 ChartLabel.displayName = 'ChartLabel';
 

--- a/packages/react-charts/src/components/ChartLabel/ChartLabel.tsx
+++ b/packages/react-charts/src/components/ChartLabel/ChartLabel.tsx
@@ -227,7 +227,6 @@ export interface ChartLabelProps extends VictoryLabelProps {
 export const ChartLabel: React.FunctionComponent<ChartLabelProps> = ({
   style,
   textAnchor,
-  id,
   ...rest
 }: ChartLabelProps) => {
   const applyDefaultStyle = (customStyle: React.CSSProperties) =>
@@ -245,7 +244,7 @@ export const ChartLabel: React.FunctionComponent<ChartLabelProps> = ({
     );
   const newStyle = Array.isArray(style) ? style.map(applyDefaultStyle) : applyDefaultStyle(style);
 
-  return <VictoryLabel style={newStyle as any} textAnchor={textAnchor} id={id} {...rest} />;
+  return <VictoryLabel style={newStyle as any} textAnchor={textAnchor} {...rest} />;
 };
 ChartLabel.displayName = 'ChartLabel';
 

--- a/packages/react-charts/src/components/ChartLabel/ChartLabel.tsx
+++ b/packages/react-charts/src/components/ChartLabel/ChartLabel.tsx
@@ -11,7 +11,6 @@ import {
   VictoryLabelProps
 } from 'victory-core';
 import { ChartCommonStyles } from '../ChartTheme';
-import { getUniqueId } from '@patternfly/react-core';
 
 export enum ChartLabelDirection {
   rtl = 'rtl',
@@ -228,7 +227,7 @@ export interface ChartLabelProps extends VictoryLabelProps {
 export const ChartLabel: React.FunctionComponent<ChartLabelProps> = ({
   style,
   textAnchor,
-  id = () => getUniqueId('chart-legend-label'),
+  id,
   ...rest
 }: ChartLabelProps) => {
   const applyDefaultStyle = (customStyle: React.CSSProperties) =>
@@ -246,7 +245,7 @@ export const ChartLabel: React.FunctionComponent<ChartLabelProps> = ({
     );
   const newStyle = Array.isArray(style) ? style.map(applyDefaultStyle) : applyDefaultStyle(style);
 
-  return <VictoryLabel style={newStyle as any} textAnchor={textAnchor} {...rest} id={id} />;
+  return <VictoryLabel style={newStyle as any} textAnchor={textAnchor} {...rest} {...(id && { id })} />;
 };
 ChartLabel.displayName = 'ChartLabel';
 

--- a/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
+++ b/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
@@ -22,7 +22,6 @@ import { ChartLabel } from '../ChartLabel';
 import { ChartPoint } from '../ChartPoint';
 import { ChartThemeDefinition } from '../ChartTheme';
 import { getTheme } from '../ChartUtils';
-import { getUniqueId } from '@patternfly/react-core';
 
 export enum ChartLegendOrientation {
   horizontal = 'horizontal',
@@ -370,13 +369,11 @@ export const ChartLegend: React.FunctionComponent<ChartLegendProps> = ({
 
   const getLabelComponent = () =>
     React.cloneElement(labelComponent, {
-      id: () => getUniqueId('chart-legendLabels'),
       ...labelComponent.props
     });
 
   const getTitleComponent = () =>
     React.cloneElement(titleComponent, {
-      id: () => getUniqueId('chart-titleLabels'),
       ...titleComponent.props
     });
 

--- a/packages/react-docs/patternfly-a11y.config.js
+++ b/packages/react-docs/patternfly-a11y.config.js
@@ -21,5 +21,6 @@ module.exports = {
     'bypass',
     'nested-interactive'
   ].join(','),
-  ignoreIncomplete: true
+  ignoreIncomplete: true,
+  skip: /^\/charts\//
 };


### PR DESCRIPTION
This will prevent snapshot tests from generating new ids every time they run.

I will need to go back and generate unique ids in each of the charts examples that don't specify them as a follow up to this PR, but that should not block the release.
