### PR TITLE
fix(MenuToggle): undo type change causing errors

### DIFF
--- a/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
+++ b/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
@@ -14,7 +14,7 @@ export interface SplitButtonOptions {
 }
 
 export interface MenuToggleProps
-  extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<MenuToggleElement>, MenuToggleElement>, 'ref'> {
+  extends Omit<React.DetailedHTMLProps<React.ButtonHTMLAttributes<MenuToggleElement>, MenuToggleElement>, 'ref'> {
   /** Content rendered inside the toggle */
   children?: React.ReactNode;
   /** Additional classes added to the toggle */


### PR DESCRIPTION
This should fix a type error reported in our latest release candidate.
