### PR TITLE
feat(NumberInput): add status validate icons

### DIFF
--- a/packages/react-core/src/components/InputGroup/InputGroup.tsx
+++ b/packages/react-core/src/components/InputGroup/InputGroup.tsx
@@ -4,6 +4,7 @@ import { css } from '@patternfly/react-styles';
 import { FormSelect } from '../FormSelect';
 import { TextArea } from '../TextArea';
 import { TextInput } from '../TextInput';
+import { Button } from '../Button';
 
 export interface InputGroupProps extends React.HTMLProps<HTMLDivElement> {
   /** Additional classes added to the input group. */
@@ -20,7 +21,7 @@ export const InputGroup: React.FunctionComponent<InputGroupProps> = ({
   innerRef,
   ...props
 }: InputGroupProps) => {
-  const formCtrls = [FormSelect, TextArea, TextInput].map(comp => comp.displayName);
+  const formCtrls = [FormSelect, TextArea, TextInput, Button].map(comp => comp.displayName);
   const idItem = React.Children.toArray(children).find(
     (child: any) => !formCtrls.includes(child.type.displayName) && child.props.id
   ) as React.ReactElement<{ id: string }>;

--- a/packages/react-core/src/components/InputGroup/InputGroup.tsx
+++ b/packages/react-core/src/components/InputGroup/InputGroup.tsx
@@ -4,7 +4,6 @@ import { css } from '@patternfly/react-styles';
 import { FormSelect } from '../FormSelect';
 import { TextArea } from '../TextArea';
 import { TextInput } from '../TextInput';
-import { Button } from '../Button';
 
 export interface InputGroupProps extends React.HTMLProps<HTMLDivElement> {
   /** Additional classes added to the input group. */
@@ -21,7 +20,7 @@ export const InputGroup: React.FunctionComponent<InputGroupProps> = ({
   innerRef,
   ...props
 }: InputGroupProps) => {
-  const formCtrls = [FormSelect, TextArea, TextInput, Button].map(comp => comp.displayName);
+  const formCtrls = [FormSelect, TextArea, TextInput].map(comp => comp.displayName);
   const idItem = React.Children.toArray(children).find(
     (child: any) => !formCtrls.includes(child.type.displayName) && child.props.id
   ) as React.ReactElement<{ id: string }>;
@@ -32,9 +31,11 @@ export const InputGroup: React.FunctionComponent<InputGroupProps> = ({
     <div ref={inputGroupRef} className={css(styles.inputGroup, className)} {...props}>
       {idItem
         ? React.Children.map(children, (child: any) =>
-            formCtrls.includes(child.type.displayName)
-              ? React.cloneElement(child, { 'aria-describedby': idItem.props.id })
-              : child
+            !formCtrls.includes(child.type.displayName) || child.props['aria-describedby']
+              ? child
+              : React.cloneElement(child, {
+                  'aria-describedby': child.props['aria-describedby'] === '' ? undefined : idItem.props.id
+                })
           )
         : children}
     </div>

--- a/packages/react-core/src/components/InputGroup/__tests__/InputGroup.test.tsx
+++ b/packages/react-core/src/components/InputGroup/__tests__/InputGroup.test.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { InputGroup } from '../InputGroup';
+import { Button } from '../../Button';
 import { TextInput } from '../../TextInput';
-import { Button } from '@patternfly/react-core';
 
 describe('InputGroup', () => {
   test('add aria-describedby to form-control if one of the non form-controls has id', () => {
@@ -13,7 +13,7 @@ describe('InputGroup', () => {
     render(
       <InputGroup>
         <TextInput value="some data" aria-label="some text" />
-        <Button id="button-id">
+        <Button variant="primary" id="button-id">
           hello
         </Button>
       </InputGroup>

--- a/packages/react-core/src/components/InputGroup/__tests__/InputGroup.test.tsx
+++ b/packages/react-core/src/components/InputGroup/__tests__/InputGroup.test.tsx
@@ -3,21 +3,21 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { InputGroup } from '../InputGroup';
-import { Button } from '../../Button';
 import { TextInput } from '../../TextInput';
+import { Label } from '@patternfly/react-core';
 
 describe('InputGroup', () => {
   test('add aria-describedby to form-control if one of the non form-controls has id', () => {
-    // In this test, TextInput is a form-control component and Button is not.
-    // If Button has an id props, this should be used in aria-describedby.
+    // In this test, TextInput is a form-control component and Label is not.
+    // If Label has an id props, this should be used in aria-describedby.
     render(
       <InputGroup>
         <TextInput value="some data" aria-label="some text" />
-        <Button variant="primary" id="button-id">
+        <Label id="label-id">
           hello
-        </Button>
+        </Label>
       </InputGroup>
     );
-    expect(screen.getByLabelText('some text')).toHaveAttribute('aria-describedby', 'button-id');
+    expect(screen.getByLabelText('some text')).toHaveAttribute('aria-describedby', 'label-id');
   });
 });

--- a/packages/react-core/src/components/InputGroup/__tests__/InputGroup.test.tsx
+++ b/packages/react-core/src/components/InputGroup/__tests__/InputGroup.test.tsx
@@ -4,20 +4,50 @@ import { render, screen } from '@testing-library/react';
 
 import { InputGroup } from '../InputGroup';
 import { TextInput } from '../../TextInput';
-import { Label } from '@patternfly/react-core';
+import { Button } from '@patternfly/react-core';
 
 describe('InputGroup', () => {
   test('add aria-describedby to form-control if one of the non form-controls has id', () => {
-    // In this test, TextInput is a form-control component and Label is not.
-    // If Label has an id props, this should be used in aria-describedby.
+    // In this test, TextInput is a form-control component and Button is not.
+    // If Button has an id props, this should be used in aria-describedby.
     render(
       <InputGroup>
         <TextInput value="some data" aria-label="some text" />
-        <Label id="label-id">
+        <Button id="button-id">
           hello
-        </Label>
+        </Button>
       </InputGroup>
     );
-    expect(screen.getByLabelText('some text')).toHaveAttribute('aria-describedby', 'label-id');
+    expect(screen.getByLabelText('some text')).toHaveAttribute('aria-describedby', 'button-id');
+  });
+
+  test('wont add aria-describedby to form-control if describedby is empty string', () => {
+    // In this test, TextInput is a form-control component and Button is not.
+    // If Button has an id props, this should be used in aria-describedby, but this
+    // example has an empty aria-describedby to prevent that from happening.
+    render(
+      <InputGroup>
+        <TextInput value="some data" aria-describedby="" aria-label="some text" />
+        <Button id="button-id">
+          hello
+        </Button>
+      </InputGroup>
+    );
+    expect(screen.getByLabelText('some text')).not.toHaveAttribute('aria-describedby');
+  });
+
+  test('wont override aria-describedby in form-control if describedby has value', () => {
+    // In this test, TextInput is a form-control component and Button is not.
+    // If Button has an id props, this should be used in aria-describedby, but this
+    // example has a predefined aria-describedby to prevent that from happening
+    render(
+      <InputGroup>
+        <TextInput value="some data" aria-describedby="myself" aria-label="some text" />
+        <Button id="button-id">
+          hello
+        </Button>
+      </InputGroup>
+    );
+    expect(screen.getByLabelText('some text')).toHaveAttribute('aria-describedby', 'myself');
   });
 });

--- a/packages/react-core/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-core/src/components/NumberInput/NumberInput.tsx
@@ -17,10 +17,8 @@ export interface NumberInputProps extends React.HTMLProps<HTMLDivElement> {
   widthChars?: number;
   /** Indicates the whole number input should be disabled */
   isDisabled?: boolean;
-  /** Value to indicate if the input is modified to show that validation state.
-   * If set to warning, input will be modified to indicate warning state.
-   * If set to success, input will be modified to indicate valid state.
-   * If set to error,  input will be modified to indicate error state.
+  /** Value to indicate if the input is modified to show that validation state
+   * @beta
    */
   validated?: 'default' | 'error' | 'warning' | 'success' | ValidatedOptions;
   /** Callback for the minus button */
@@ -107,7 +105,7 @@ export const NumberInput: React.FunctionComponent<NumberInputProps> = ({
 
   return (
     <div
-      className={css(styles.numberInput, className, validated !== 'default' && styles.modifiers.status)}
+      className={css(styles.numberInput, validated !== 'default' && styles.modifiers.status, className)}
       {...(widthChars && {
         style: {
           '--pf-c-number-input--c-form-control--width-chars': widthChars,
@@ -135,7 +133,7 @@ export const NumberInput: React.FunctionComponent<NumberInputProps> = ({
           name={inputName}
           aria-label={inputAriaLabel}
           {...(isDisabled && { isDisabled })}
-          {...(onChange && { onChange: (v, e) => onChange(e) })}
+          {...(onChange && { onChange: (value, event) => onChange(event) })}
           onBlur={handleBlur}
           {...(!onChange && { isReadOnly: true })}
           onKeyDown={keyDownHandler}

--- a/packages/react-core/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-core/src/components/NumberInput/NumberInput.tsx
@@ -19,6 +19,7 @@ export interface NumberInputProps extends React.HTMLProps<HTMLDivElement> {
   /** Indicates the whole number input should be disabled */
   isDisabled?: boolean;
   /** Value to indicate if the input is modified to show that validation state.
+   * If set to warning, input will be modified to indicate warning state.
    * If set to success, input will be modified to indicate valid state.
    * If set to error,  input will be modified to indicate error state.
    */
@@ -108,8 +109,6 @@ export const NumberInput: React.FunctionComponent<NumberInputProps> = ({
   return (
     <div
       className={css(styles.numberInput, className, validated !== 'default' && styles.modifiers.status)}
-      // (props['aria-invalid'] ? props['aria-invalid'] : validated === 'error')
-      // || validated !== 'default' && styles.modifiers.status)}
       {...(widthChars && {
         style: {
           '--pf-c-number-input--c-form-control--width-chars': widthChars,

--- a/packages/react-core/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-core/src/components/NumberInput/NumberInput.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/NumberInput/number-input';
-import formControlStyles from '@patternfly/react-styles/css/components/FormControl/form-control';
 import { css } from '@patternfly/react-styles';
-import { ValidatedOptions } from '../../helpers/constants';
 import MinusIcon from '@patternfly/react-icons/dist/esm/icons/minus-icon';
 import PlusIcon from '@patternfly/react-icons/dist/esm/icons/plus-icon';
 import { InputGroup } from '../InputGroup';
 import { Button, ButtonProps } from '../Button';
 import { KEY_CODES } from '../../helpers';
+import { TextInput } from '../TextInput';
 
 export interface NumberInputProps extends React.HTMLProps<HTMLDivElement> {
   /** Value of the number input */
@@ -130,23 +129,18 @@ export const NumberInput: React.FunctionComponent<NumberInputProps> = ({
             <MinusIcon aria-hidden="true" />
           </span>
         </Button>
-        <input
-          className={css(
-            styles.formControl,
-            validated === ValidatedOptions.success && formControlStyles.modifiers.success,
-            validated === ValidatedOptions.warning && formControlStyles.modifiers.warning
-          )}
+        <TextInput
           type="number"
           value={value}
           name={inputName}
-          {...(validated === ValidatedOptions.error && { 'aria-invalid': true })}
           aria-label={inputAriaLabel}
-          {...(isDisabled && { disabled: isDisabled })}
-          {...(onChange && { onChange })}
+          {...(isDisabled && { isDisabled })}
+          {...(onChange && { onChange: (v, e) => onChange(e) })}
           onBlur={handleBlur}
           {...(!onChange && { readOnly: true })}
-          {...inputProps}
           onKeyDown={keyDownHandler}
+          validated={validated}
+          {...inputProps}
         />
         <Button
           variant="control"

--- a/packages/react-core/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-core/src/components/NumberInput/NumberInput.tsx
@@ -137,7 +137,7 @@ export const NumberInput: React.FunctionComponent<NumberInputProps> = ({
           {...(isDisabled && { isDisabled })}
           {...(onChange && { onChange: (v, e) => onChange(e) })}
           onBlur={handleBlur}
-          {...(!onChange && { readOnly: true })}
+          {...(!onChange && { isReadOnly: true })}
           onKeyDown={keyDownHandler}
           validated={validated}
           {...inputProps}

--- a/packages/react-core/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-core/src/components/NumberInput/NumberInput.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/NumberInput/number-input';
+import formControlStyles from '@patternfly/react-styles/css/components/FormControl/form-control';
 import { css } from '@patternfly/react-styles';
+import { ValidatedOptions } from '../../helpers/constants';
 import MinusIcon from '@patternfly/react-icons/dist/esm/icons/minus-icon';
 import PlusIcon from '@patternfly/react-icons/dist/esm/icons/plus-icon';
 import { InputGroup } from '../InputGroup';
@@ -16,6 +18,11 @@ export interface NumberInputProps extends React.HTMLProps<HTMLDivElement> {
   widthChars?: number;
   /** Indicates the whole number input should be disabled */
   isDisabled?: boolean;
+  /** Value to indicate if the input is modified to show that validation state.
+   * If set to success, input will be modified to indicate valid state.
+   * If set to error,  input will be modified to indicate error state.
+   */
+  validated?: 'success' | 'warning' | 'default' | 'error';
   /** Callback for the minus button */
   onMinus?: (event: React.MouseEvent, name?: string) => void;
   /** Callback for the text input changing */
@@ -66,6 +73,7 @@ export const NumberInput: React.FunctionComponent<NumberInputProps> = ({
   className,
   widthChars,
   isDisabled = false,
+  validated = 'default' as 'success' | 'warning' | 'default' | 'error',
   onMinus = () => {},
   onChange,
   onBlur,
@@ -99,7 +107,9 @@ export const NumberInput: React.FunctionComponent<NumberInputProps> = ({
 
   return (
     <div
-      className={css(styles.numberInput, className)}
+      className={css(styles.numberInput, className, validated !== 'default' && styles.modifiers.status)}
+      // (props['aria-invalid'] ? props['aria-invalid'] : validated === 'error')
+      // || validated !== 'default' && styles.modifiers.status)}
       {...(widthChars && {
         style: {
           '--pf-c-number-input--c-form-control--width-chars': widthChars,
@@ -122,10 +132,15 @@ export const NumberInput: React.FunctionComponent<NumberInputProps> = ({
           </span>
         </Button>
         <input
-          className={css(styles.formControl)}
+          className={css(
+            styles.formControl,
+            validated === ValidatedOptions.success && formControlStyles.modifiers.success,
+            validated === ValidatedOptions.warning && formControlStyles.modifiers.warning
+          )}
           type="number"
           value={value}
           name={inputName}
+          {...(validated === ValidatedOptions.error && { 'aria-invalid': true })}
           aria-label={inputAriaLabel}
           {...(isDisabled && { disabled: isDisabled })}
           {...(onChange && { onChange })}

--- a/packages/react-core/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-core/src/components/NumberInput/NumberInput.tsx
@@ -5,7 +5,7 @@ import MinusIcon from '@patternfly/react-icons/dist/esm/icons/minus-icon';
 import PlusIcon from '@patternfly/react-icons/dist/esm/icons/plus-icon';
 import { InputGroup } from '../InputGroup';
 import { Button, ButtonProps } from '../Button';
-import { KEY_CODES } from '../../helpers';
+import { KEY_CODES, ValidatedOptions } from '../../helpers';
 import { TextInput } from '../TextInput';
 
 export interface NumberInputProps extends React.HTMLProps<HTMLDivElement> {
@@ -22,7 +22,7 @@ export interface NumberInputProps extends React.HTMLProps<HTMLDivElement> {
    * If set to success, input will be modified to indicate valid state.
    * If set to error,  input will be modified to indicate error state.
    */
-  validated?: 'success' | 'warning' | 'default' | 'error';
+  validated?: 'default' | 'error' | 'warning' | 'success' | ValidatedOptions;
   /** Callback for the minus button */
   onMinus?: (event: React.MouseEvent, name?: string) => void;
   /** Callback for the text input changing */
@@ -73,7 +73,7 @@ export const NumberInput: React.FunctionComponent<NumberInputProps> = ({
   className,
   widthChars,
   isDisabled = false,
-  validated = 'default' as 'success' | 'warning' | 'default' | 'error',
+  validated = ValidatedOptions.default,
   onMinus = () => {},
   onChange,
   onBlur,

--- a/packages/react-core/src/components/NumberInput/__tests__/NumberInput.test.tsx
+++ b/packages/react-core/src/components/NumberInput/__tests__/NumberInput.test.tsx
@@ -69,6 +69,7 @@ describe('numberInput', () => {
       <NumberInput
         value={5}
         onMinus={jest.fn()}
+        inputProps={{ 'aria-describedby': '' }}
         minusBtnProps={{ id: 'minus-id' }}
         onPlus={jest.fn()}
         plusBtnProps={{ id: 'plus-id' }}

--- a/packages/react-core/src/components/NumberInput/__tests__/NumberInput.test.tsx
+++ b/packages/react-core/src/components/NumberInput/__tests__/NumberInput.test.tsx
@@ -9,6 +9,21 @@ describe('numberInput', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
+  test('renders success validated', () => {
+    const { asFragment } = render(<NumberInput validated='success' />);
+    expect(asFragment()).toMatchSnapshot();
+  })
+
+  test('renders error validated', () => {
+    const { asFragment } = render(<NumberInput validated='error' />);
+    expect(asFragment()).toMatchSnapshot();
+  })
+
+  test('renders warning validated', () => {
+    const { asFragment } = render(<NumberInput validated='warning' />);
+    expect(asFragment()).toMatchSnapshot();
+  })
+
   test('renders value', () => {
     const { asFragment } = render(<NumberInput value={90} />);
     expect(asFragment()).toMatchSnapshot();

--- a/packages/react-core/src/components/NumberInput/__tests__/__snapshots__/NumberInput.test.tsx.snap
+++ b/packages/react-core/src/components/NumberInput/__tests__/__snapshots__/NumberInput.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`numberInput disables lower threshold 1`] = `
         aria-disabled="true"
         aria-label="Minus"
         class="pf-c-button pf-m-control pf-m-disabled"
-        data-ouia-component-id="OUIA-Generated-Button-control-7"
+        data-ouia-component-id="OUIA-Generated-Button-control-13"
         data-ouia-component-type="PF4/Button"
         data-ouia-safe="true"
         disabled=""
@@ -47,7 +47,7 @@ exports[`numberInput disables lower threshold 1`] = `
         aria-disabled="false"
         aria-label="Plus"
         class="pf-c-button pf-m-control"
-        data-ouia-component-id="OUIA-Generated-Button-control-8"
+        data-ouia-component-id="OUIA-Generated-Button-control-14"
         data-ouia-component-type="PF4/Button"
         data-ouia-safe="true"
         type="button"
@@ -87,7 +87,7 @@ exports[`numberInput disables upper threshold 1`] = `
         aria-disabled="false"
         aria-label="Minus"
         class="pf-c-button pf-m-control"
-        data-ouia-component-id="OUIA-Generated-Button-control-9"
+        data-ouia-component-id="OUIA-Generated-Button-control-15"
         data-ouia-component-type="PF4/Button"
         data-ouia-safe="true"
         type="button"
@@ -121,7 +121,7 @@ exports[`numberInput disables upper threshold 1`] = `
         aria-disabled="true"
         aria-label="Plus"
         class="pf-c-button pf-m-control pf-m-disabled"
-        data-ouia-component-id="OUIA-Generated-Button-control-10"
+        data-ouia-component-id="OUIA-Generated-Button-control-16"
         data-ouia-component-type="PF4/Button"
         data-ouia-safe="true"
         disabled=""
@@ -162,7 +162,7 @@ exports[`numberInput passes button props successfully 1`] = `
         aria-disabled="false"
         aria-label="Minus"
         class="pf-c-button pf-m-control"
-        data-ouia-component-id="OUIA-Generated-Button-control-19"
+        data-ouia-component-id="OUIA-Generated-Button-control-25"
         data-ouia-component-type="PF4/Button"
         data-ouia-safe="true"
         id="minus-id"
@@ -197,7 +197,7 @@ exports[`numberInput passes button props successfully 1`] = `
         aria-disabled="false"
         aria-label="Plus"
         class="pf-c-button pf-m-control"
-        data-ouia-component-id="OUIA-Generated-Button-control-20"
+        data-ouia-component-id="OUIA-Generated-Button-control-26"
         data-ouia-component-type="PF4/Button"
         data-ouia-safe="true"
         id="plus-id"
@@ -238,7 +238,7 @@ exports[`numberInput passes input props successfully 1`] = `
         aria-disabled="false"
         aria-label="Minus"
         class="pf-c-button pf-m-control"
-        data-ouia-component-id="OUIA-Generated-Button-control-17"
+        data-ouia-component-id="OUIA-Generated-Button-control-23"
         data-ouia-component-type="PF4/Button"
         data-ouia-safe="true"
         type="button"
@@ -272,7 +272,7 @@ exports[`numberInput passes input props successfully 1`] = `
         aria-disabled="false"
         aria-label="Plus"
         class="pf-c-button pf-m-control"
-        data-ouia-component-id="OUIA-Generated-Button-control-18"
+        data-ouia-component-id="OUIA-Generated-Button-control-24"
         data-ouia-component-type="PF4/Button"
         data-ouia-safe="true"
         type="button"
@@ -313,7 +313,7 @@ exports[`numberInput renders custom width 1`] = `
         aria-disabled="false"
         aria-label="Minus"
         class="pf-c-button pf-m-control"
-        data-ouia-component-id="OUIA-Generated-Button-control-15"
+        data-ouia-component-id="OUIA-Generated-Button-control-21"
         data-ouia-component-type="PF4/Button"
         data-ouia-safe="true"
         type="button"
@@ -347,7 +347,7 @@ exports[`numberInput renders custom width 1`] = `
         aria-disabled="false"
         aria-label="Plus"
         class="pf-c-button pf-m-control"
-        data-ouia-component-id="OUIA-Generated-Button-control-16"
+        data-ouia-component-id="OUIA-Generated-Button-control-22"
         data-ouia-component-type="PF4/Button"
         data-ouia-safe="true"
         type="button"
@@ -462,7 +462,7 @@ exports[`numberInput renders disabled 1`] = `
         aria-disabled="true"
         aria-label="Minus"
         class="pf-c-button pf-m-control pf-m-disabled"
-        data-ouia-component-id="OUIA-Generated-Button-control-5"
+        data-ouia-component-id="OUIA-Generated-Button-control-11"
         data-ouia-component-type="PF4/Button"
         data-ouia-safe="true"
         disabled=""
@@ -498,10 +498,159 @@ exports[`numberInput renders disabled 1`] = `
         aria-disabled="true"
         aria-label="Plus"
         class="pf-c-button pf-m-control pf-m-disabled"
-        data-ouia-component-id="OUIA-Generated-Button-control-6"
+        data-ouia-component-id="OUIA-Generated-Button-control-12"
         data-ouia-component-type="PF4/Button"
         data-ouia-safe="true"
         disabled=""
+        type="button"
+      >
+        <span
+          class="pf-c-number-input__icon"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`numberInput renders error validated 1`] = `
+<DocumentFragment>
+  <div
+    class="pf-c-number-input pf-m-status"
+  >
+    <div
+      class="pf-c-input-group"
+    >
+      <button
+        aria-disabled="false"
+        aria-label="Minus"
+        class="pf-c-button pf-m-control"
+        data-ouia-component-id="OUIA-Generated-Button-control-5"
+        data-ouia-component-type="PF4/Button"
+        data-ouia-safe="true"
+        type="button"
+      >
+        <span
+          class="pf-c-number-input__icon"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+            />
+          </svg>
+        </span>
+      </button>
+      <input
+        aria-invalid="true"
+        aria-label="Input"
+        class="pf-c-form-control"
+        readonly=""
+        type="number"
+        value="0"
+      />
+      <button
+        aria-disabled="false"
+        aria-label="Plus"
+        class="pf-c-button pf-m-control"
+        data-ouia-component-id="OUIA-Generated-Button-control-6"
+        data-ouia-component-type="PF4/Button"
+        data-ouia-safe="true"
+        type="button"
+      >
+        <span
+          class="pf-c-number-input__icon"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`numberInput renders success validated 1`] = `
+<DocumentFragment>
+  <div
+    class="pf-c-number-input pf-m-status"
+  >
+    <div
+      class="pf-c-input-group"
+    >
+      <button
+        aria-disabled="false"
+        aria-label="Minus"
+        class="pf-c-button pf-m-control"
+        data-ouia-component-id="OUIA-Generated-Button-control-3"
+        data-ouia-component-type="PF4/Button"
+        data-ouia-safe="true"
+        type="button"
+      >
+        <span
+          class="pf-c-number-input__icon"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+            />
+          </svg>
+        </span>
+      </button>
+      <input
+        aria-label="Input"
+        class="pf-c-form-control pf-m-success"
+        readonly=""
+        type="number"
+        value="0"
+      />
+      <button
+        aria-disabled="false"
+        aria-label="Plus"
+        class="pf-c-button pf-m-control"
+        data-ouia-component-id="OUIA-Generated-Button-control-4"
+        data-ouia-component-type="PF4/Button"
+        data-ouia-safe="true"
         type="button"
       >
         <span
@@ -544,7 +693,7 @@ exports[`numberInput renders unit & position 1`] = `
         aria-disabled="false"
         aria-label="Minus"
         class="pf-c-button pf-m-control"
-        data-ouia-component-id="OUIA-Generated-Button-control-13"
+        data-ouia-component-id="OUIA-Generated-Button-control-19"
         data-ouia-component-type="PF4/Button"
         data-ouia-safe="true"
         type="button"
@@ -578,7 +727,7 @@ exports[`numberInput renders unit & position 1`] = `
         aria-disabled="false"
         aria-label="Plus"
         class="pf-c-button pf-m-control"
-        data-ouia-component-id="OUIA-Generated-Button-control-14"
+        data-ouia-component-id="OUIA-Generated-Button-control-20"
         data-ouia-component-type="PF4/Button"
         data-ouia-safe="true"
         type="button"
@@ -618,7 +767,7 @@ exports[`numberInput renders unit 1`] = `
         aria-disabled="false"
         aria-label="Minus"
         class="pf-c-button pf-m-control"
-        data-ouia-component-id="OUIA-Generated-Button-control-11"
+        data-ouia-component-id="OUIA-Generated-Button-control-17"
         data-ouia-component-type="PF4/Button"
         data-ouia-safe="true"
         type="button"
@@ -652,7 +801,7 @@ exports[`numberInput renders unit 1`] = `
         aria-disabled="false"
         aria-label="Plus"
         class="pf-c-button pf-m-control"
-        data-ouia-component-id="OUIA-Generated-Button-control-12"
+        data-ouia-component-id="OUIA-Generated-Button-control-18"
         data-ouia-component-type="PF4/Button"
         data-ouia-safe="true"
         type="button"
@@ -697,7 +846,7 @@ exports[`numberInput renders value 1`] = `
         aria-disabled="false"
         aria-label="Minus"
         class="pf-c-button pf-m-control"
-        data-ouia-component-id="OUIA-Generated-Button-control-3"
+        data-ouia-component-id="OUIA-Generated-Button-control-9"
         data-ouia-component-type="PF4/Button"
         data-ouia-safe="true"
         type="button"
@@ -731,7 +880,81 @@ exports[`numberInput renders value 1`] = `
         aria-disabled="false"
         aria-label="Plus"
         class="pf-c-button pf-m-control"
-        data-ouia-component-id="OUIA-Generated-Button-control-4"
+        data-ouia-component-id="OUIA-Generated-Button-control-10"
+        data-ouia-component-type="PF4/Button"
+        data-ouia-safe="true"
+        type="button"
+      >
+        <span
+          class="pf-c-number-input__icon"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`numberInput renders warning validated 1`] = `
+<DocumentFragment>
+  <div
+    class="pf-c-number-input pf-m-status"
+  >
+    <div
+      class="pf-c-input-group"
+    >
+      <button
+        aria-disabled="false"
+        aria-label="Minus"
+        class="pf-c-button pf-m-control"
+        data-ouia-component-id="OUIA-Generated-Button-control-7"
+        data-ouia-component-type="PF4/Button"
+        data-ouia-safe="true"
+        type="button"
+      >
+        <span
+          class="pf-c-number-input__icon"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style="vertical-align: -0.125em;"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+            />
+          </svg>
+        </span>
+      </button>
+      <input
+        aria-label="Input"
+        class="pf-c-form-control pf-m-warning"
+        readonly=""
+        type="number"
+        value="0"
+      />
+      <button
+        aria-disabled="false"
+        aria-label="Plus"
+        class="pf-c-button pf-m-control"
+        data-ouia-component-id="OUIA-Generated-Button-control-8"
         data-ouia-component-type="PF4/Button"
         data-ouia-safe="true"
         type="button"

--- a/packages/react-core/src/components/NumberInput/__tests__/__snapshots__/NumberInput.test.tsx.snap
+++ b/packages/react-core/src/components/NumberInput/__tests__/__snapshots__/NumberInput.test.tsx.snap
@@ -195,7 +195,6 @@ exports[`numberInput passes button props successfully 1`] = `
         </span>
       </button>
       <input
-        aria-describedby="minus-id"
         aria-invalid="false"
         aria-label="Input"
         class="pf-c-form-control"

--- a/packages/react-core/src/components/NumberInput/__tests__/__snapshots__/NumberInput.test.tsx.snap
+++ b/packages/react-core/src/components/NumberInput/__tests__/__snapshots__/NumberInput.test.tsx.snap
@@ -37,9 +37,12 @@ exports[`numberInput disables lower threshold 1`] = `
         </span>
       </button>
       <input
+        aria-invalid="false"
         aria-label="Input"
         class="pf-c-form-control"
-        readonly=""
+        data-ouia-component-id="OUIA-Generated-TextInputBase-7"
+        data-ouia-component-type="PF4/TextInput"
+        data-ouia-safe="true"
         type="number"
         value="0"
       />
@@ -111,9 +114,12 @@ exports[`numberInput disables upper threshold 1`] = `
         </span>
       </button>
       <input
+        aria-invalid="false"
         aria-label="Input"
         class="pf-c-form-control"
-        readonly=""
+        data-ouia-component-id="OUIA-Generated-TextInputBase-8"
+        data-ouia-component-type="PF4/TextInput"
+        data-ouia-safe="true"
         type="number"
         value="100"
       />
@@ -187,9 +193,13 @@ exports[`numberInput passes button props successfully 1`] = `
         </span>
       </button>
       <input
+        aria-describedby="minus-id"
+        aria-invalid="false"
         aria-label="Input"
         class="pf-c-form-control"
-        readonly=""
+        data-ouia-component-id="OUIA-Generated-TextInputBase-13"
+        data-ouia-component-type="PF4/TextInput"
+        data-ouia-safe="true"
         type="number"
         value="5"
       />
@@ -262,8 +272,12 @@ exports[`numberInput passes input props successfully 1`] = `
         </span>
       </button>
       <input
+        aria-invalid="false"
         aria-label="Input"
         class="pf-c-form-control"
+        data-ouia-component-id="OUIA-Generated-TextInputBase-12"
+        data-ouia-component-type="PF4/TextInput"
+        data-ouia-safe="true"
         name="test-name"
         type="number"
         value="5"
@@ -337,9 +351,12 @@ exports[`numberInput renders custom width 1`] = `
         </span>
       </button>
       <input
+        aria-invalid="false"
         aria-label="Input"
         class="pf-c-form-control"
-        readonly=""
+        data-ouia-component-id="OUIA-Generated-TextInputBase-11"
+        data-ouia-component-type="PF4/TextInput"
+        data-ouia-safe="true"
         type="number"
         value="5"
       />
@@ -412,9 +429,12 @@ exports[`numberInput renders defaults & extra props 1`] = `
         </span>
       </button>
       <input
+        aria-invalid="false"
         aria-label="Input"
         class="pf-c-form-control"
-        readonly=""
+        data-ouia-component-id="OUIA-Generated-TextInputBase-1"
+        data-ouia-component-type="PF4/TextInput"
+        data-ouia-safe="true"
         type="number"
         value="0"
       />
@@ -487,10 +507,13 @@ exports[`numberInput renders disabled 1`] = `
         </span>
       </button>
       <input
+        aria-invalid="false"
         aria-label="Input"
         class="pf-c-form-control"
+        data-ouia-component-id="OUIA-Generated-TextInputBase-6"
+        data-ouia-component-type="PF4/TextInput"
+        data-ouia-safe="true"
         disabled=""
-        readonly=""
         type="number"
         value="90"
       />
@@ -566,7 +589,9 @@ exports[`numberInput renders error validated 1`] = `
         aria-invalid="true"
         aria-label="Input"
         class="pf-c-form-control"
-        readonly=""
+        data-ouia-component-id="OUIA-Generated-TextInputBase-3"
+        data-ouia-component-type="PF4/TextInput"
+        data-ouia-safe="true"
         type="number"
         value="0"
       />
@@ -638,9 +663,12 @@ exports[`numberInput renders success validated 1`] = `
         </span>
       </button>
       <input
+        aria-invalid="false"
         aria-label="Input"
         class="pf-c-form-control pf-m-success"
-        readonly=""
+        data-ouia-component-id="OUIA-Generated-TextInputBase-2"
+        data-ouia-component-type="PF4/TextInput"
+        data-ouia-safe="true"
         type="number"
         value="0"
       />
@@ -717,9 +745,12 @@ exports[`numberInput renders unit & position 1`] = `
         </span>
       </button>
       <input
+        aria-invalid="false"
         aria-label="Input"
         class="pf-c-form-control"
-        readonly=""
+        data-ouia-component-id="OUIA-Generated-TextInputBase-10"
+        data-ouia-component-type="PF4/TextInput"
+        data-ouia-safe="true"
         type="number"
         value="5"
       />
@@ -791,9 +822,12 @@ exports[`numberInput renders unit 1`] = `
         </span>
       </button>
       <input
+        aria-invalid="false"
         aria-label="Input"
         class="pf-c-form-control"
-        readonly=""
+        data-ouia-component-id="OUIA-Generated-TextInputBase-9"
+        data-ouia-component-type="PF4/TextInput"
+        data-ouia-safe="true"
         type="number"
         value="5"
       />
@@ -870,9 +904,12 @@ exports[`numberInput renders value 1`] = `
         </span>
       </button>
       <input
+        aria-invalid="false"
         aria-label="Input"
         class="pf-c-form-control"
-        readonly=""
+        data-ouia-component-id="OUIA-Generated-TextInputBase-5"
+        data-ouia-component-type="PF4/TextInput"
+        data-ouia-safe="true"
         type="number"
         value="90"
       />
@@ -944,9 +981,12 @@ exports[`numberInput renders warning validated 1`] = `
         </span>
       </button>
       <input
+        aria-invalid="false"
         aria-label="Input"
         class="pf-c-form-control pf-m-warning"
-        readonly=""
+        data-ouia-component-id="OUIA-Generated-TextInputBase-4"
+        data-ouia-component-type="PF4/TextInput"
+        data-ouia-safe="true"
         type="number"
         value="0"
       />

--- a/packages/react-core/src/components/NumberInput/__tests__/__snapshots__/NumberInput.test.tsx.snap
+++ b/packages/react-core/src/components/NumberInput/__tests__/__snapshots__/NumberInput.test.tsx.snap
@@ -43,6 +43,7 @@ exports[`numberInput disables lower threshold 1`] = `
         data-ouia-component-id="OUIA-Generated-TextInputBase-7"
         data-ouia-component-type="PF4/TextInput"
         data-ouia-safe="true"
+        readonly=""
         type="number"
         value="0"
       />
@@ -120,6 +121,7 @@ exports[`numberInput disables upper threshold 1`] = `
         data-ouia-component-id="OUIA-Generated-TextInputBase-8"
         data-ouia-component-type="PF4/TextInput"
         data-ouia-safe="true"
+        readonly=""
         type="number"
         value="100"
       />
@@ -200,6 +202,7 @@ exports[`numberInput passes button props successfully 1`] = `
         data-ouia-component-id="OUIA-Generated-TextInputBase-13"
         data-ouia-component-type="PF4/TextInput"
         data-ouia-safe="true"
+        readonly=""
         type="number"
         value="5"
       />
@@ -357,6 +360,7 @@ exports[`numberInput renders custom width 1`] = `
         data-ouia-component-id="OUIA-Generated-TextInputBase-11"
         data-ouia-component-type="PF4/TextInput"
         data-ouia-safe="true"
+        readonly=""
         type="number"
         value="5"
       />
@@ -435,6 +439,7 @@ exports[`numberInput renders defaults & extra props 1`] = `
         data-ouia-component-id="OUIA-Generated-TextInputBase-1"
         data-ouia-component-type="PF4/TextInput"
         data-ouia-safe="true"
+        readonly=""
         type="number"
         value="0"
       />
@@ -514,6 +519,7 @@ exports[`numberInput renders disabled 1`] = `
         data-ouia-component-type="PF4/TextInput"
         data-ouia-safe="true"
         disabled=""
+        readonly=""
         type="number"
         value="90"
       />
@@ -592,6 +598,7 @@ exports[`numberInput renders error validated 1`] = `
         data-ouia-component-id="OUIA-Generated-TextInputBase-3"
         data-ouia-component-type="PF4/TextInput"
         data-ouia-safe="true"
+        readonly=""
         type="number"
         value="0"
       />
@@ -669,6 +676,7 @@ exports[`numberInput renders success validated 1`] = `
         data-ouia-component-id="OUIA-Generated-TextInputBase-2"
         data-ouia-component-type="PF4/TextInput"
         data-ouia-safe="true"
+        readonly=""
         type="number"
         value="0"
       />
@@ -751,6 +759,7 @@ exports[`numberInput renders unit & position 1`] = `
         data-ouia-component-id="OUIA-Generated-TextInputBase-10"
         data-ouia-component-type="PF4/TextInput"
         data-ouia-safe="true"
+        readonly=""
         type="number"
         value="5"
       />
@@ -828,6 +837,7 @@ exports[`numberInput renders unit 1`] = `
         data-ouia-component-id="OUIA-Generated-TextInputBase-9"
         data-ouia-component-type="PF4/TextInput"
         data-ouia-safe="true"
+        readonly=""
         type="number"
         value="5"
       />
@@ -910,6 +920,7 @@ exports[`numberInput renders value 1`] = `
         data-ouia-component-id="OUIA-Generated-TextInputBase-5"
         data-ouia-component-type="PF4/TextInput"
         data-ouia-safe="true"
+        readonly=""
         type="number"
         value="90"
       />
@@ -987,6 +998,7 @@ exports[`numberInput renders warning validated 1`] = `
         data-ouia-component-id="OUIA-Generated-TextInputBase-4"
         data-ouia-component-type="PF4/TextInput"
         data-ouia-safe="true"
+        readonly=""
         type="number"
         value="0"
       />

--- a/packages/react-core/src/components/NumberInput/examples/NumberInput.md
+++ b/packages/react-core/src/components/NumberInput/examples/NumberInput.md
@@ -270,6 +270,11 @@ class DisabledNumberInput extends React.Component {
     );
   }
 }
+
+```
+### With status
+
+```ts file="./WithStatus.tsx"
 ```
 
 ### Varying sizes

--- a/packages/react-core/src/components/NumberInput/examples/NumberInput.md
+++ b/packages/react-core/src/components/NumberInput/examples/NumberInput.md
@@ -57,6 +57,49 @@ class BasicNumberInput extends React.Component {
 }
 ```
 
+### Without onChange
+
+```js
+import React from 'react';
+import { NumberInput } from '@patternfly/react-core';
+
+class BasicNumberInput extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      value: 90
+    };
+
+    this.onMinus = () => {
+      this.setState({
+        value: this.state.value - 1
+      });
+    };
+
+    this.onPlus = () => {
+      this.setState({
+        value: this.state.value + 1
+      });
+    };
+  }
+
+  render() {
+    const { value } = this.state;
+    return (
+      <NumberInput
+        value={value}
+        onMinus={this.onMinus}
+        onPlus={this.onPlus}
+        inputName="input"
+        inputAriaLabel="number input"
+        minusBtnAriaLabel="minus"
+        plusBtnAriaLabel="plus"
+      />
+    );
+  }
+}
+```
+
 ### With unit
 
 ```js

--- a/packages/react-core/src/components/NumberInput/examples/NumberInput.md
+++ b/packages/react-core/src/components/NumberInput/examples/NumberInput.md
@@ -57,49 +57,6 @@ class BasicNumberInput extends React.Component {
 }
 ```
 
-### Without onChange
-
-```js
-import React from 'react';
-import { NumberInput } from '@patternfly/react-core';
-
-class BasicNumberInput extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      value: 90
-    };
-
-    this.onMinus = () => {
-      this.setState({
-        value: this.state.value - 1
-      });
-    };
-
-    this.onPlus = () => {
-      this.setState({
-        value: this.state.value + 1
-      });
-    };
-  }
-
-  render() {
-    const { value } = this.state;
-    return (
-      <NumberInput
-        value={value}
-        onMinus={this.onMinus}
-        onPlus={this.onPlus}
-        inputName="input"
-        inputAriaLabel="number input"
-        minusBtnAriaLabel="minus"
-        plusBtnAriaLabel="plus"
-      />
-    );
-  }
-}
-```
-
 ### With unit
 
 ```js

--- a/packages/react-core/src/components/NumberInput/examples/WithStatus.tsx
+++ b/packages/react-core/src/components/NumberInput/examples/WithStatus.tsx
@@ -38,7 +38,8 @@ export const WithStatus: React.FunctionComponent = () => {
   };
   return (
     <>
-In the following example, the validated status will update based on the value of the number input and how far from the number 5 it is.
+      In the following example, the validated status will update based on the value of the number input and how far from
+      the number 5 it is.
       <br />
       <NumberInput
         validated={validated}

--- a/packages/react-core/src/components/NumberInput/examples/WithStatus.tsx
+++ b/packages/react-core/src/components/NumberInput/examples/WithStatus.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { NumberInput } from '@patternfly/react-core';
-import { ValidatedOptions } from '../../../helpers';
+import { NumberInput, ValidatedOptions } from '@patternfly/react-core';
 
 export const WithStatus: React.FunctionComponent = () => {
   const max = 10;

--- a/packages/react-core/src/components/NumberInput/examples/WithStatus.tsx
+++ b/packages/react-core/src/components/NumberInput/examples/WithStatus.tsx
@@ -2,8 +2,11 @@ import React from 'react';
 import { NumberInput } from '@patternfly/react-core';
 
 export const WithStatus: React.FunctionComponent = () => {
+  const max = 10;
+  const min = 0;
+
   const [validated, setValidated] = React.useState<'success' | 'error' | 'warning'>('success');
-  const [value, setValue] = React.useState<number>(5);
+  const [value, setValue] = React.useReducer((state, newVal) => Math.max(min, Math.min(max, Number(newVal))), 5);
 
   const onPlus = () => {
     const newVal = value + 1;
@@ -13,6 +16,12 @@ export const WithStatus: React.FunctionComponent = () => {
 
   const onMinus = () => {
     const newVal = value - 1;
+    setValue(newVal);
+    validate(newVal);
+  };
+
+  const onChange = event => {
+    const newVal = isNaN(event.target.value) ? 5 : Number(event.target.value);
     setValue(newVal);
     validate(newVal);
   };
@@ -38,6 +47,7 @@ export const WithStatus: React.FunctionComponent = () => {
         max={10}
         onMinus={onMinus}
         onPlus={onPlus}
+        onChange={onChange}
         inputName="input"
         inputAriaLabel="number input"
         minusBtnAriaLabel="minus"

--- a/packages/react-core/src/components/NumberInput/examples/WithStatus.tsx
+++ b/packages/react-core/src/components/NumberInput/examples/WithStatus.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { NumberInput } from '@patternfly/react-core';
+import { ValidatedOptions } from '../../../helpers';
 
 export const WithStatus: React.FunctionComponent = () => {
   const max = 10;
   const min = 0;
 
-  const [validated, setValidated] = React.useState<'success' | 'error' | 'warning'>('success');
+  const [validated, setValidated] = React.useState<ValidatedOptions>(ValidatedOptions.success);
   const [value, setValue] = React.useReducer((state, newVal) => Math.max(min, Math.min(max, Number(newVal))), 5);
 
   const onPlus = () => {
@@ -29,11 +30,11 @@ export const WithStatus: React.FunctionComponent = () => {
   const validate = newVal => {
     const diff = Math.abs(5 - newVal);
     if (diff > 3) {
-      setValidated('error');
+      setValidated(ValidatedOptions.error);
     } else if (diff > 1) {
-      setValidated('warning');
+      setValidated(ValidatedOptions.warning);
     } else {
-      setValidated('success');
+      setValidated(ValidatedOptions.success);
     }
   };
   return (

--- a/packages/react-core/src/components/NumberInput/examples/WithStatus.tsx
+++ b/packages/react-core/src/components/NumberInput/examples/WithStatus.tsx
@@ -38,7 +38,7 @@ export const WithStatus: React.FunctionComponent = () => {
   };
   return (
     <>
-      Status will change to warning/error depending on how far from 5.
+In the following example, the validated status will update based on the value of the number input and how far from the number 5 it is.
       <br />
       <NumberInput
         validated={validated}

--- a/packages/react-core/src/components/NumberInput/examples/WithStatus.tsx
+++ b/packages/react-core/src/components/NumberInput/examples/WithStatus.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { NumberInput } from '@patternfly/react-core';
+
+export const WithStatus: React.FunctionComponent = () => {
+  const [validated, setValidated] = React.useState<'success' | 'error' | 'warning'>('success');
+  const [value, setValue] = React.useState<number>(5);
+
+  const onPlus = () => {
+    const newVal = value + 1;
+    setValue(newVal);
+    validate(newVal);
+  };
+
+  const onMinus = () => {
+    const newVal = value - 1;
+    setValue(newVal);
+    validate(newVal);
+  };
+
+  const validate = newVal => {
+    const diff = Math.abs(5 - newVal);
+    if (diff > 3) {
+      setValidated('error');
+    } else if (diff > 1) {
+      setValidated('warning');
+    } else {
+      setValidated('success');
+    }
+  };
+  return (
+    <>
+      Status will change to warning/error depending on how far from 5.
+      <br />
+      <NumberInput
+        validated={validated}
+        value={value}
+        min={0}
+        max={10}
+        onMinus={onMinus}
+        onPlus={onPlus}
+        inputName="input"
+        inputAriaLabel="number input"
+        minusBtnAriaLabel="minus"
+        plusBtnAriaLabel="plus"
+      />
+    </>
+  );
+};


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7730 

used `validated` property based on TextInput using that property for such styling.

example: https://patternfly-react-pr-7806.surge.sh/components/number-input#with-status

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
