### PR TITLE
Add id prop to fix docs a11y violations

### DIFF
--- a/packages/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/react-charts/src/components/Chart/Chart.tsx
@@ -229,10 +229,13 @@ export interface ChartProps extends VictoryChartProps {
    */
   horizontal?: boolean;
   /**
-   * This prop specifies an ID that will be applied to child text elements, assisting with
-   * accessibility for screen readers.
+   * This prop specifies an ID prefix that will be applied to child text elements. This is only necessary when
+   * multiple charts appear in a page, ensuring unique IDs for each chart.
+   *
+   * Note: This should not be confused with a container's containerId prop.
+   * See https://formidable.com/open-source/victory/docs/common-container-props#containerid
    */
-  id?: string;
+  idPrefix?: string;
   /**
    * When the innerRadius prop is set, polar charts will be hollow rather than circular.
    *
@@ -470,7 +473,7 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
   children,
   colorScale,
   hasPatterns,
-  id,
+  idPrefix,
   legendAllowWrap = false,
   legendComponent = <ChartLegend />,
   legendData,
@@ -529,7 +532,7 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
 
   const legend = React.cloneElement(legendComponent, {
     data: legendData,
-    ...(id && { id: `${id}-${(legendComponent as any).type.displayName}` }),
+    ...(idPrefix && { idPrefix: `${idPrefix}-${(legendComponent as any).type.displayName}` }),
     orientation: legendOrientation,
     theme,
     ...legendComponent.props
@@ -589,9 +592,9 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
         return React.cloneElement(child, {
           colorScale,
           ...(defaultPatternScale && { patternScale: defaultPatternScale }),
-          ...(id &&
-            typeof (child as any).id !== undefined && {
-              id: `${id}-${(child as any).type.displayName}-${index}`
+          ...(idPrefix &&
+            typeof (child as any).idPrefix !== undefined && {
+              idPrefix: `${idPrefix}-${(child as any).type.displayName}-${index}`
             }),
           theme,
           ...childProps,

--- a/packages/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/react-charts/src/components/Chart/Chart.tsx
@@ -229,14 +229,6 @@ export interface ChartProps extends VictoryChartProps {
    */
   horizontal?: boolean;
   /**
-   * This prop specifies an ID prefix that will be applied to child text elements. This is only necessary when
-   * multiple charts appear in a page, ensuring unique IDs for each chart.
-   *
-   * Note: This should not be confused with a container's containerId prop.
-   * See https://formidable.com/open-source/victory/docs/common-container-props#containerid
-   */
-  idPrefix?: string;
-  /**
    * When the innerRadius prop is set, polar charts will be hollow rather than circular.
    *
    * @propType number | Function
@@ -317,6 +309,12 @@ export interface ChartProps extends VictoryChartProps {
    * minDomain={{ y: 0 }}
    */
   minDomain?: number | { x?: number; y?: number };
+  /**
+   * The name prop is typically used to reference a component instance when defining shared events. However, this
+   * optional prop may also be applied to child elements as an ID prefix. This is a workaround to ensure Victory
+   * based components output unique IDs when multiple charts appear in a page.
+   */
+  name?: string;
   /**
    * The padding props specifies the amount of padding in number of pixels between
    * the edge of the chart and any rendered child components. This prop can be given
@@ -473,11 +471,11 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
   children,
   colorScale,
   hasPatterns,
-  idPrefix,
   legendAllowWrap = false,
   legendComponent = <ChartLegend />,
   legendData,
   legendPosition = ChartCommonStyles.legend.position as ChartLegendPosition,
+  name,
   padding,
   patternScale,
   showAxis = true,
@@ -532,7 +530,7 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
 
   const legend = React.cloneElement(legendComponent, {
     data: legendData,
-    ...(idPrefix && { idPrefix: `${idPrefix}-${(legendComponent as any).type.displayName}` }),
+    ...(name && { name: `${name}-${(legendComponent as any).type.displayName}` }),
     orientation: legendOrientation,
     theme,
     ...legendComponent.props
@@ -592,9 +590,9 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
         return React.cloneElement(child, {
           colorScale,
           ...(defaultPatternScale && { patternScale: defaultPatternScale }),
-          ...(idPrefix &&
-            typeof (child as any).idPrefix !== undefined && {
-              idPrefix: `${idPrefix}-${(child as any).type.displayName}-${index}`
+          ...(name &&
+            typeof (child as any).name !== undefined && {
+              name: `${name}-${(child as any).type.displayName}-${index}`
             }),
           theme,
           ...childProps,

--- a/packages/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/react-charts/src/components/Chart/Chart.tsx
@@ -229,6 +229,11 @@ export interface ChartProps extends VictoryChartProps {
    */
   horizontal?: boolean;
   /**
+   * This prop specifies an ID that will be applied to child text elements, assisting with
+   * accessibility for screen readers.
+   */
+  id?: string;
+  /**
    * When the innerRadius prop is set, polar charts will be hollow rather than circular.
    *
    * @propType number | Function
@@ -465,6 +470,7 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
   children,
   colorScale,
   hasPatterns,
+  id,
   legendAllowWrap = false,
   legendComponent = <ChartLegend />,
   legendData,
@@ -523,6 +529,7 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
 
   const legend = React.cloneElement(legendComponent, {
     data: legendData,
+    ...(id && { id: `${id}-${(legendComponent as any).type.displayName}` }),
     orientation: legendOrientation,
     theme,
     ...legendComponent.props
@@ -576,13 +583,17 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
 
   // Render children
   const renderChildren = () =>
-    React.Children.toArray(children).map(child => {
+    React.Children.toArray(children).map((child, index) => {
       if (React.isValidElement(child)) {
         const { ...childProps } = child.props;
         return React.cloneElement(child, {
           colorScale,
-          theme,
           ...(defaultPatternScale && { patternScale: defaultPatternScale }),
+          ...(id &&
+            typeof (child as any).id !== undefined && {
+              id: `${id}-${(child as any).type.displayName}-${index}`
+            }),
+          theme,
           ...childProps,
           ...((child as any).type.displayName === 'ChartPie' && {
             data: getDefaultData(childProps.data, defaultPatternScale)

--- a/packages/react-charts/src/components/ChartArea/examples/ChartArea.md
+++ b/packages/react-charts/src/components/ChartArea/examples/ChartArea.md
@@ -39,8 +39,8 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartVoronoiContainer } from '
     legendOrientation="vertical"
     legendPosition="right"
     height={200}
-    idPrefix="chart1"
     maxDomain={{y: 9}}
+    name="chart1"
     padding={{
       bottom: 50,
       left: 50,
@@ -119,7 +119,7 @@ class BottomAlignedLegend extends React.Component {
           legendData={legendData}
           legendPosition="bottom"
           height={250}
-          idPrefix="chart2"
+          name="chart2"
           padding={{
             bottom: 100, // Adjusted to accommodate legend
             left: 50,
@@ -215,7 +215,7 @@ class MultiColorChart extends React.Component {
           legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }]}
           legendPosition="bottom-left"
           height={225}
-          idPrefix="chart3"
+          name="chart3"
           padding={{
             bottom: 75, // Adjusted to accommodate legend
             left: 50,

--- a/packages/react-charts/src/components/ChartArea/examples/ChartArea.md
+++ b/packages/react-charts/src/components/ChartArea/examples/ChartArea.md
@@ -39,6 +39,7 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartVoronoiContainer } from '
     legendOrientation="vertical"
     legendPosition="right"
     height={200}
+    id="chart1"
     maxDomain={{y: 9}}
     padding={{
       bottom: 50,
@@ -118,6 +119,7 @@ class BottomAlignedLegend extends React.Component {
           legendData={legendData}
           legendPosition="bottom"
           height={250}
+          id="chart2"
           padding={{
             bottom: 100, // Adjusted to accommodate legend
             left: 50,
@@ -213,6 +215,7 @@ class MultiColorChart extends React.Component {
           legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }]}
           legendPosition="bottom-left"
           height={225}
+          id="chart3"
           padding={{
             bottom: 75, // Adjusted to accommodate legend
             left: 50,

--- a/packages/react-charts/src/components/ChartArea/examples/ChartArea.md
+++ b/packages/react-charts/src/components/ChartArea/examples/ChartArea.md
@@ -39,7 +39,7 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartVoronoiContainer } from '
     legendOrientation="vertical"
     legendPosition="right"
     height={200}
-    id="chart1"
+    idPrefix="chart1"
     maxDomain={{y: 9}}
     padding={{
       bottom: 50,
@@ -119,7 +119,7 @@ class BottomAlignedLegend extends React.Component {
           legendData={legendData}
           legendPosition="bottom"
           height={250}
-          id="chart2"
+          idPrefix="chart2"
           padding={{
             bottom: 100, // Adjusted to accommodate legend
             left: 50,
@@ -215,7 +215,7 @@ class MultiColorChart extends React.Component {
           legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }]}
           legendPosition="bottom-left"
           height={225}
-          id="chart3"
+          idPrefix="chart3"
           padding={{
             bottom: 75, // Adjusted to accommodate legend
             left: 50,

--- a/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
+++ b/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
@@ -187,14 +187,6 @@ export interface ChartAxisProps extends VictoryAxisProps {
    */
   height?: number;
   /**
-   * This prop specifies an ID prefix that will be applied to child text elements. This is only necessary when
-   * multiple charts appear in a page, ensuring unique IDs for each chart.
-   *
-   * Note: This should not be confused with a container's containerId prop.
-   * See https://formidable.com/open-source/victory/docs/common-container-props#containerid
-   */
-  idPrefix?: string;
-  /**
    * If true, this value will flip the domain of a given axis.
    */
   invertAxis?: boolean;
@@ -240,7 +232,9 @@ export interface ChartAxisProps extends VictoryAxisProps {
    */
   minDomain?: number | { x?: number; y?: number };
   /**
-   * ChartAxis uses the standard name prop
+   * The name prop is typically used to reference a component instance when defining shared events. However, this
+   * optional prop may also be applied to child elements as an ID prefix. This is a workaround to ensure Victory
+   * based components output unique IDs when multiple charts appear in a page.
    */
   name?: string;
   /**
@@ -455,7 +449,7 @@ export interface ChartAxisProps extends VictoryAxisProps {
 
 export const ChartAxis: React.FunctionComponent<ChartAxisProps> = ({
   containerComponent = <ChartContainer />,
-  idPrefix,
+  name,
   showGrid = false,
   themeColor,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -473,8 +467,8 @@ export const ChartAxis: React.FunctionComponent<ChartAxisProps> = ({
 
   const getTickLabelComponent = () =>
     React.cloneElement(tickLabelComponent, {
-      ...(idPrefix && {
-        id: (props: any) => `${idPrefix}-${(tickLabelComponent as any).type.displayName}-${props.index}`
+      ...(name && {
+        id: (props: any) => `${name}-${(tickLabelComponent as any).type.displayName}-${props.index}`
       }),
       ...tickLabelComponent.props
     });

--- a/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
+++ b/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
@@ -187,10 +187,13 @@ export interface ChartAxisProps extends VictoryAxisProps {
    */
   height?: number;
   /**
-   * This prop specifies an ID that will be applied to child text elements, assisting with
-   * accessibility for screen readers.
+   * This prop specifies an ID prefix that will be applied to child text elements. This is only necessary when
+   * multiple charts appear in a page, ensuring unique IDs for each chart.
+   *
+   * Note: This should not be confused with a container's containerId prop.
+   * See https://formidable.com/open-source/victory/docs/common-container-props#containerid
    */
-  id?: string;
+  idPrefix?: string;
   /**
    * If true, this value will flip the domain of a given axis.
    */
@@ -452,7 +455,7 @@ export interface ChartAxisProps extends VictoryAxisProps {
 
 export const ChartAxis: React.FunctionComponent<ChartAxisProps> = ({
   containerComponent = <ChartContainer />,
-  id,
+  idPrefix,
   showGrid = false,
   themeColor,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -470,7 +473,9 @@ export const ChartAxis: React.FunctionComponent<ChartAxisProps> = ({
 
   const getTickLabelComponent = () =>
     React.cloneElement(tickLabelComponent, {
-      ...(id && { id: (props: any) => `${id}-${(tickLabelComponent as any).type.displayName}-${props.index}` }),
+      ...(idPrefix && {
+        id: (props: any) => `${idPrefix}-${(tickLabelComponent as any).type.displayName}-${props.index}`
+      }),
       ...tickLabelComponent.props
     });
 

--- a/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
+++ b/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
@@ -187,6 +187,11 @@ export interface ChartAxisProps extends VictoryAxisProps {
    */
   height?: number;
   /**
+   * This prop specifies an ID that will be applied to child text elements, assisting with
+   * accessibility for screen readers.
+   */
+  id?: string;
+  /**
    * If true, this value will flip the domain of a given axis.
    */
   invertAxis?: boolean;
@@ -447,6 +452,7 @@ export interface ChartAxisProps extends VictoryAxisProps {
 
 export const ChartAxis: React.FunctionComponent<ChartAxisProps> = ({
   containerComponent = <ChartContainer />,
+  id,
   showGrid = false,
   themeColor,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -464,6 +470,7 @@ export const ChartAxis: React.FunctionComponent<ChartAxisProps> = ({
 
   const getTickLabelComponent = () =>
     React.cloneElement(tickLabelComponent, {
+      ...(id && { id: (props: any) => `${id}-${(tickLabelComponent as any).type.displayName}-${props.index}` }),
       ...tickLabelComponent.props
     });
 

--- a/packages/react-charts/src/components/ChartBar/examples/ChartBar.md
+++ b/packages/react-charts/src/components/ChartBar/examples/ChartBar.md
@@ -40,7 +40,7 @@ import { Chart, ChartAxis, ChartBar, ChartGroup, ChartVoronoiContainer } from '@
     legendOrientation="vertical"
     legendPosition="right"
     height={250}
-    idPrefix="chart1"
+    name="chart1"
     padding={{
       bottom: 50,
       left: 50,
@@ -82,7 +82,7 @@ class EmbeddedLegend extends React.Component {
           legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
           legendPosition="bottom"
           height={275}
-          idPrefix="chart2"
+          name="chart2"
           padding={{
             bottom: 75, // Adjusted to accommodate legend
             left: 50,
@@ -157,7 +157,7 @@ import { VictoryZoomContainer } from 'victory-zoom-container';
     legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
     legendPosition="bottom-left"
     height={400}
-    idPrefix="chart3"
+    name="chart3"
     padding={{
       bottom: 75, // Adjusted to accommodate legend
       left: 50,
@@ -195,7 +195,7 @@ import { Chart, ChartBar, ChartVoronoiContainer } from '@patternfly/react-charts
     legendOrientation="vertical"
     legendPosition="right"
     height={250}
-    idPrefix="chart4"
+    name="chart4"
     padding={{
       bottom: 50,
       left: 50,

--- a/packages/react-charts/src/components/ChartBar/examples/ChartBar.md
+++ b/packages/react-charts/src/components/ChartBar/examples/ChartBar.md
@@ -40,6 +40,7 @@ import { Chart, ChartAxis, ChartBar, ChartGroup, ChartVoronoiContainer } from '@
     legendOrientation="vertical"
     legendPosition="right"
     height={250}
+    idPrefix="chart1"
     padding={{
       bottom: 50,
       left: 50,
@@ -81,6 +82,7 @@ class EmbeddedLegend extends React.Component {
           legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
           legendPosition="bottom"
           height={275}
+          idPrefix="chart2"
           padding={{
             bottom: 75, // Adjusted to accommodate legend
             left: 50,
@@ -155,6 +157,7 @@ import { VictoryZoomContainer } from 'victory-zoom-container';
     legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
     legendPosition="bottom-left"
     height={400}
+    idPrefix="chart3"
     padding={{
       bottom: 75, // Adjusted to accommodate legend
       left: 50,
@@ -192,6 +195,7 @@ import { Chart, ChartBar, ChartVoronoiContainer } from '@patternfly/react-charts
     legendOrientation="vertical"
     legendPosition="right"
     height={250}
+    idPrefix="chart4"
     padding={{
       bottom: 50,
       left: 50,

--- a/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
@@ -193,14 +193,6 @@ export interface ChartBulletProps {
    */
   horizontal?: boolean;
   /**
-   * This prop specifies an ID prefix that will be applied to child text elements. This is only necessary when
-   * multiple charts appear in a page, ensuring unique IDs for each chart.
-   *
-   * Note: This should not be confused with a container's containerId prop.
-   * See https://formidable.com/open-source/victory/docs/common-container-props#containerid
-   */
-  idPrefix?: string;
-  /**
    * Invert the color scales used to represent primary measures and qualitative ranges.
    */
   invert?: boolean;
@@ -283,6 +275,12 @@ export interface ChartBulletProps {
    * Note: The x domain is expected to be `x: 0` in order to position all measures properly
    */
   minDomain?: number | { x?: number; y?: number };
+  /**
+   * The name prop is typically used to reference a component instance when defining shared events. However, this
+   * optional prop may also be applied to child elements as an ID prefix. This is a workaround to ensure Victory
+   * based components output unique IDs when multiple charts appear in a page.
+   */
+  name?: string;
   /**
    * The padding props specifies the amount of padding in number of pixels between
    * the edge of the chart and any rendered child components. This prop can be given
@@ -502,7 +500,6 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
   groupSubTitle,
   groupTitle,
   horizontal = true,
-  idPrefix,
   invert = false,
   labels,
   legendAllowWrap = false,
@@ -511,6 +508,7 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
   legendPosition = 'bottom' as ChartLegendPosition,
   maxDomain,
   minDomain,
+  name,
   padding,
   primaryDotMeasureComponent = <ChartBulletPrimaryDotMeasure />,
   primaryDotMeasureData,
@@ -664,7 +662,7 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
       ...(comparativeErrorMeasureLegendData ? comparativeErrorMeasureLegendData : []),
       ...(qualitativeRangeLegendData ? qualitativeRangeLegendData : [])
     ],
-    ...(idPrefix && { idPrefix: `${idPrefix}-${(legendComponent as any).type.displayName}` }),
+    ...(name && { name: `${name}-${(legendComponent as any).type.displayName}` }),
     itemsPerRow: legendItemsPerRow,
     orientation: legendOrientation,
     position: legendPosition,
@@ -825,7 +823,7 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
           y: (domain as any).x
         },
     height: chartSize.height,
-    ...(idPrefix && { idPrefix: `${idPrefix}-${(axisComponent as any).type.displayName}` }),
+    ...(name && { name: `${name}-${(axisComponent as any).type.displayName}` }),
     // Adjust for padding
     offsetX: !horizontal ? defaultPadding.left * 0.5 + (defaultPadding.right * 0.5 - (defaultPadding.right - 55)) : 0,
     offsetY: horizontal ? 80 - defaultPadding.top * 0.5 + (defaultPadding.bottom * 0.5 - 25) : 0,

--- a/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
@@ -193,6 +193,11 @@ export interface ChartBulletProps {
    */
   horizontal?: boolean;
   /**
+   * This prop specifies an ID that will be applied to child text elements, assisting with
+   * accessibility for screen readers.
+   */
+  id?: string;
+  /**
    * Invert the color scales used to represent primary measures and qualitative ranges.
    */
   invert?: boolean;
@@ -494,6 +499,7 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
   groupSubTitle,
   groupTitle,
   horizontal = true,
+  id,
   invert = false,
   labels,
   legendAllowWrap = false,
@@ -655,6 +661,7 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
       ...(comparativeErrorMeasureLegendData ? comparativeErrorMeasureLegendData : []),
       ...(qualitativeRangeLegendData ? qualitativeRangeLegendData : [])
     ],
+    ...(id && { id: `${id}-${(legendComponent as any).type.displayName}` }),
     itemsPerRow: legendItemsPerRow,
     orientation: legendOrientation,
     position: legendPosition,
@@ -815,6 +822,7 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
           y: (domain as any).x
         },
     height: chartSize.height,
+    ...(id && { id: `${id}-${(axisComponent as any).type.displayName}` }),
     // Adjust for padding
     offsetX: !horizontal ? defaultPadding.left * 0.5 + (defaultPadding.right * 0.5 - (defaultPadding.right - 55)) : 0,
     offsetY: horizontal ? 80 - defaultPadding.top * 0.5 + (defaultPadding.bottom * 0.5 - 25) : 0,

--- a/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
@@ -193,10 +193,13 @@ export interface ChartBulletProps {
    */
   horizontal?: boolean;
   /**
-   * This prop specifies an ID that will be applied to child text elements, assisting with
-   * accessibility for screen readers.
+   * This prop specifies an ID prefix that will be applied to child text elements. This is only necessary when
+   * multiple charts appear in a page, ensuring unique IDs for each chart.
+   *
+   * Note: This should not be confused with a container's containerId prop.
+   * See https://formidable.com/open-source/victory/docs/common-container-props#containerid
    */
-  id?: string;
+  idPrefix?: string;
   /**
    * Invert the color scales used to represent primary measures and qualitative ranges.
    */
@@ -499,7 +502,7 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
   groupSubTitle,
   groupTitle,
   horizontal = true,
-  id,
+  idPrefix,
   invert = false,
   labels,
   legendAllowWrap = false,
@@ -661,7 +664,7 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
       ...(comparativeErrorMeasureLegendData ? comparativeErrorMeasureLegendData : []),
       ...(qualitativeRangeLegendData ? qualitativeRangeLegendData : [])
     ],
-    ...(id && { id: `${id}-${(legendComponent as any).type.displayName}` }),
+    ...(idPrefix && { idPrefix: `${idPrefix}-${(legendComponent as any).type.displayName}` }),
     itemsPerRow: legendItemsPerRow,
     orientation: legendOrientation,
     position: legendPosition,
@@ -822,7 +825,7 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
           y: (domain as any).x
         },
     height: chartSize.height,
-    ...(id && { id: `${id}-${(axisComponent as any).type.displayName}` }),
+    ...(idPrefix && { idPrefix: `${idPrefix}-${(axisComponent as any).type.displayName}` }),
     // Adjust for padding
     offsetX: !horizontal ? defaultPadding.left * 0.5 + (defaultPadding.right * 0.5 - (defaultPadding.right - 55)) : 0,
     offsetY: horizontal ? 80 - defaultPadding.top * 0.5 + (defaultPadding.bottom * 0.5 - 25) : 0,

--- a/packages/react-charts/src/components/ChartBullet/examples/ChartBullet.md
+++ b/packages/react-charts/src/components/ChartBullet/examples/ChartBullet.md
@@ -33,6 +33,7 @@ import { ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureData={[{ name: 'Warning', y: 88 }]}
     constrainToVisibleArea
     height={150}
+    id="chart1"
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     maxDomain={{y: 100}}
     primarySegmentedMeasureData={[{ name: 'Measure', y: 60 }]}
@@ -55,6 +56,7 @@ import { ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
     constrainToVisibleArea
     height={200}
+    id="chart2"
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     maxDomain={{y: 100}}
     padding={{
@@ -117,6 +119,7 @@ class BulletChart extends React.Component {
           comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
           constrainToVisibleArea
           height={250}
+          id="chart3"
           labels={({ datum }) => `${datum.name}: ${datum.y}`}
           legendAllowWrap
           legendPosition="bottom-left"
@@ -155,6 +158,7 @@ import { ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
     constrainToVisibleArea
     height={200}
+    id="chart4"
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     maxDomain={{y: 100}}
     padding={{
@@ -193,6 +197,7 @@ import { ChartAxis, ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
     constrainToVisibleArea
     height={200}
+    id="chart5"
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     legendItemsPerRow={3}
     padding={{
@@ -230,6 +235,7 @@ import { ChartBullet } from '@patternfly/react-charts';
     constrainToVisibleArea
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     height={200}
+    id="chart6"
     maxDomain={{y: 125}}
     minDomain={{y: 50}}
     padding={{
@@ -266,6 +272,7 @@ import { ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
     constrainToVisibleArea
     height={200}
+    id="chart7"
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     maxDomain={{y: 75}}
     minDomain={{y: -25}}
@@ -303,6 +310,7 @@ import { ChartBullet } from '@patternfly/react-charts';
     constrainToVisibleArea
     invert
     height={200}
+    id="chart8"
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     legendPosition="right"
     legendOrientation="vertical"
@@ -341,6 +349,7 @@ import { ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
     constrainToVisibleArea
     height={200}
+    id="chart9"
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     legendItemsPerRow={4}
     maxDomain={{y: 75}}
@@ -375,6 +384,7 @@ import { ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
     constrainToVisibleArea
     height={500}
+    id="chart10"
     horizontal={false}
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     maxDomain={{y: 100}}
@@ -408,6 +418,7 @@ import { ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
     constrainToVisibleArea
     height={500}
+    id="chart11"
     horizontal={false}
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     maxDomain={{y: 125}}
@@ -461,6 +472,7 @@ import { ChartAxis, ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureData={[{ name: 'Warning', y: 88 }]}
     constrainToVisibleArea
     height={150}
+    id="chart12"
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     maxDomain={{y: 100}}
     primarySegmentedMeasureData={[{ name: 'Measure', y: 60 }]}
@@ -483,6 +495,7 @@ import { ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureData={[{ name: 'Warning', y: 88 }]}
     comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
     height={200}
+    id="chart13"
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     maxDomain={{y: 100}}
     padding={{
@@ -517,6 +530,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       comparativeWarningMeasureData={[{name: 'Warning', y: 78}]}
       constrainToVisibleArea
       height={500}
+      id="chart14"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
@@ -536,6 +550,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       comparativeWarningMeasureData={[{name: 'Warning', y: 88}]}
       constrainToVisibleArea
       height={500}
+      id="chart15"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
@@ -555,6 +570,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       comparativeWarningMeasureData={[{name: 'Warning', y: 98}]}
       constrainToVisibleArea
       height={500}
+      id="chart16"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
@@ -575,6 +591,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
       constrainToVisibleArea
       height={500}
+      id="chart17"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
@@ -612,6 +629,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
       constrainToVisibleArea
       height={600}
+      id="chart18"
       horizontal={false}
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
@@ -634,6 +652,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       comparativeWarningMeasureData={[{name: 'Warning', y: 88}]}
       constrainToVisibleArea
       height={600}
+      id="chart19"
       horizontal={false}
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
@@ -655,6 +674,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       constrainToVisibleArea
       height={600}
       horizontal={false}
+      id="chart20"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
@@ -675,6 +695,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       constrainToVisibleArea
       height={600}
       horizontal={false}
+      id="chart21"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
@@ -711,6 +732,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       groupSubTitle="Measure details"
       groupTitle="Text label"
       height={575}
+      id="chart22"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
@@ -730,6 +752,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       comparativeWarningMeasureData={[{name: 'Warning', y: 88}]}
       constrainToVisibleArea
       height={600}
+      id="chart23"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
@@ -749,6 +772,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       comparativeWarningMeasureData={[{name: 'Warning', y: 98}]}
       constrainToVisibleArea
       height={600}
+      id="chart24"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
@@ -769,6 +793,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
       constrainToVisibleArea
       height={600}
+      id="chart25"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
@@ -809,6 +834,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       groupTitle="Text label"
       height={600}
       horizontal={false}
+      id="chart26"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
@@ -831,6 +857,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       constrainToVisibleArea
       height={600}
       horizontal={false}
+      id="chart27"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
@@ -851,6 +878,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       constrainToVisibleArea
       height={600}
       horizontal={false}
+      id="chart28"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
@@ -871,6 +899,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       constrainToVisibleArea
       height={600}
       horizontal={false}
+      id="chart29"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{

--- a/packages/react-charts/src/components/ChartBullet/examples/ChartBullet.md
+++ b/packages/react-charts/src/components/ChartBullet/examples/ChartBullet.md
@@ -33,9 +33,9 @@ import { ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureData={[{ name: 'Warning', y: 88 }]}
     constrainToVisibleArea
     height={150}
-    idPrefix="chart1"
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     maxDomain={{y: 100}}
+    name="chart1"
     primarySegmentedMeasureData={[{ name: 'Measure', y: 60 }]}
     qualitativeRangeData={[{ name: 'Range', y: 50 }, { name: 'Range', y: 75 }]}
     width={600}
@@ -56,9 +56,9 @@ import { ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
     constrainToVisibleArea
     height={200}
-    idPrefix="chart2"
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     maxDomain={{y: 100}}
+    name="chart2"
     padding={{
       bottom: 50,
       left: 150, // Adjusted to accommodate labels
@@ -119,11 +119,11 @@ class BulletChart extends React.Component {
           comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
           constrainToVisibleArea
           height={250}
-          idPrefix="chart3"
           labels={({ datum }) => `${datum.name}: ${datum.y}`}
           legendAllowWrap
           legendPosition="bottom-left"
           maxDomain={{y: 100}}
+          name="chart3"
           padding={{
             bottom: 50,
             left: 50,
@@ -158,9 +158,9 @@ import { ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
     constrainToVisibleArea
     height={200}
-    idPrefix="chart4"
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     maxDomain={{y: 100}}
+    name="chart4"
     padding={{
       bottom: 50,
       left: 150, // Adjusted to accommodate labels
@@ -197,9 +197,9 @@ import { ChartAxis, ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
     constrainToVisibleArea
     height={200}
-    idPrefix="chart5"
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     legendItemsPerRow={3}
+    name="chart5"
     padding={{
       bottom: 50,
       left: 150, // Adjusted to accommodate labels
@@ -235,9 +235,9 @@ import { ChartBullet } from '@patternfly/react-charts';
     constrainToVisibleArea
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     height={200}
-    idPrefix="chart6"
     maxDomain={{y: 125}}
     minDomain={{y: 50}}
+    name="chart6"
     padding={{
       bottom: 50,
       left: 150, // Adjusted to accommodate labels
@@ -272,10 +272,10 @@ import { ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
     constrainToVisibleArea
     height={200}
-    idPrefix="chart7"
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     maxDomain={{y: 75}}
     minDomain={{y: -25}}
+    name="chart7"
     padding={{
       bottom: 50,
       left: 150, // Adjusted to accommodate labels
@@ -310,12 +310,12 @@ import { ChartBullet } from '@patternfly/react-charts';
     constrainToVisibleArea
     invert
     height={200}
-    idPrefix="chart8"
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     legendPosition="right"
     legendOrientation="vertical"
     maxDomain={{y: 0}}
     minDomain={{y: -100}}
+    name="chart8"
     padding={{
       bottom: 50,
       left: 150, // Adjusted to accommodate labels
@@ -349,11 +349,11 @@ import { ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
     constrainToVisibleArea
     height={200}
-    idPrefix="chart9"
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     legendItemsPerRow={4}
     maxDomain={{y: 75}}
     minDomain={{y: -25}}
+    name="chart9"
     padding={{
       bottom: 50,
       left: 150, // Adjusted to accommodate labels
@@ -384,10 +384,10 @@ import { ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
     constrainToVisibleArea
     height={500}
-    idPrefix="chart10"
     horizontal={false}
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     maxDomain={{y: 100}}
+    name="chart10"
     padding={{
       bottom: 125, // Adjusted to accommodate legend
       left: 400,
@@ -418,11 +418,11 @@ import { ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
     constrainToVisibleArea
     height={500}
-    idPrefix="chart11"
     horizontal={false}
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     maxDomain={{y: 125}}
     minDomain={{y: 50}}
+    name="chart11"
     padding={{
       bottom: 125, // Adjusted to accommodate legend
       left: 400,
@@ -472,9 +472,9 @@ import { ChartAxis, ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureData={[{ name: 'Warning', y: 88 }]}
     constrainToVisibleArea
     height={150}
-    idPrefix="chart12"
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     maxDomain={{y: 100}}
+    name="chart12"
     primarySegmentedMeasureData={[{ name: 'Measure', y: 60 }]}
     qualitativeRangeData={[{ name: 'Range', y: 50 }, { name: 'Range', y: 75 }]}
     width={600}
@@ -495,9 +495,9 @@ import { ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureData={[{ name: 'Warning', y: 88 }]}
     comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
     height={200}
-    idPrefix="chart13"
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     maxDomain={{y: 100}}
+    name="chart13"
     padding={{
       bottom: 50,
       left: 150, // Adjusted to accomodate labels
@@ -530,9 +530,9 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       comparativeWarningMeasureData={[{name: 'Warning', y: 78}]}
       constrainToVisibleArea
       height={500}
-      idPrefix="chart14"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
+      name="chart14"
       padding={{
         bottom: 100, // Adjusted to accommodate legend
         left: 150, // Adjusted to accommodate labels
@@ -550,9 +550,9 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       comparativeWarningMeasureData={[{name: 'Warning', y: 88}]}
       constrainToVisibleArea
       height={500}
-      idPrefix="chart15"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
+      name="chart15"
       padding={{
         bottom: 100, // Adjusted to accommodate legend
         left: 150, // Adjusted to accommodate labels
@@ -570,9 +570,9 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       comparativeWarningMeasureData={[{name: 'Warning', y: 98}]}
       constrainToVisibleArea
       height={500}
-      idPrefix="chart16"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
+      name="chart16"
       padding={{
         bottom: 100, // Adjusted to accommodate legend
         left: 150, // Adjusted to accommodate labels
@@ -591,9 +591,9 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
       constrainToVisibleArea
       height={500}
-      idPrefix="chart17"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
+      name="chart17"
       padding={{
         bottom: 100, // Adjusted to accommodate legend
         left: 150, // Adjusted to accommodate labels
@@ -629,10 +629,10 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
       constrainToVisibleArea
       height={600}
-      idPrefix="chart18"
       horizontal={false}
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
+      name="chart18"
       padding={{
         bottom: 125, // Adjusted to accommodate legend
         left: 50,
@@ -652,10 +652,10 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       comparativeWarningMeasureData={[{name: 'Warning', y: 88}]}
       constrainToVisibleArea
       height={600}
-      idPrefix="chart19"
       horizontal={false}
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
+      name="chart19"
       padding={{
         bottom: 125, // Adjusted to accommodate legend
         left: 300,
@@ -674,9 +674,9 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       constrainToVisibleArea
       height={600}
       horizontal={false}
-      idPrefix="chart20"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
+      name="chart20"
       padding={{
         bottom: 125, // Adjusted to accommodate legend
         left: 550,
@@ -695,9 +695,9 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       constrainToVisibleArea
       height={600}
       horizontal={false}
-      idPrefix="chart21"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
+      name="chart21"
       padding={{
         bottom: 125, // Adjusted to accommodate legend
         left: 800,
@@ -732,9 +732,9 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       groupSubTitle="Measure details"
       groupTitle="Text label"
       height={575}
-      idPrefix="chart22"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
+      name="chart22"
       padding={{
         bottom: 100, // Adjusted to accommodate legend
         left: 150, // Adjusted to accommodate labels
@@ -752,9 +752,9 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       comparativeWarningMeasureData={[{name: 'Warning', y: 88}]}
       constrainToVisibleArea
       height={600}
-      idPrefix="chart23"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
+      name="chart23"
       padding={{
         bottom: 100, // Adjusted to accommodate legend
         left: 150, // Adjusted to accommodate labels
@@ -772,9 +772,9 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       comparativeWarningMeasureData={[{name: 'Warning', y: 98}]}
       constrainToVisibleArea
       height={600}
-      idPrefix="chart24"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
+      name="chart24"
       padding={{
         bottom: 100, // Adjusted to accommodate legend
         left: 150, // Adjusted to accommodate labels
@@ -793,9 +793,9 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
       constrainToVisibleArea
       height={600}
-      idPrefix="chart25"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
+      name="chart25"
       padding={{
         bottom: 100, // Adjusted to accommodate legend
         left: 150, // Adjusted to accommodate labels
@@ -834,9 +834,9 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       groupTitle="Text label"
       height={600}
       horizontal={false}
-      idPrefix="chart26"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
+      name="chart26"
       padding={{
         bottom: 125, // Adjusted to accommodate legend
         left: 50,
@@ -857,9 +857,9 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       constrainToVisibleArea
       height={600}
       horizontal={false}
-      idPrefix="chart27"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
+      name="chart27"
       padding={{
         bottom: 125, // Adjusted to accommodate legend
         left: 300,
@@ -878,9 +878,9 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       constrainToVisibleArea
       height={600}
       horizontal={false}
-      idPrefix="chart28"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
+      name="chart28"
       padding={{
         bottom: 125, // Adjusted to accommodate legend
         left: 550,
@@ -899,9 +899,9 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       constrainToVisibleArea
       height={600}
       horizontal={false}
-      idPrefix="chart29"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
+      name="chart29"
       padding={{
         bottom: 125, // Adjusted to accommodate legend
         left: 800,

--- a/packages/react-charts/src/components/ChartBullet/examples/ChartBullet.md
+++ b/packages/react-charts/src/components/ChartBullet/examples/ChartBullet.md
@@ -33,7 +33,7 @@ import { ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureData={[{ name: 'Warning', y: 88 }]}
     constrainToVisibleArea
     height={150}
-    id="chart1"
+    idPrefix="chart1"
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     maxDomain={{y: 100}}
     primarySegmentedMeasureData={[{ name: 'Measure', y: 60 }]}
@@ -56,7 +56,7 @@ import { ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
     constrainToVisibleArea
     height={200}
-    id="chart2"
+    idPrefix="chart2"
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     maxDomain={{y: 100}}
     padding={{
@@ -119,7 +119,7 @@ class BulletChart extends React.Component {
           comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
           constrainToVisibleArea
           height={250}
-          id="chart3"
+          idPrefix="chart3"
           labels={({ datum }) => `${datum.name}: ${datum.y}`}
           legendAllowWrap
           legendPosition="bottom-left"
@@ -158,7 +158,7 @@ import { ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
     constrainToVisibleArea
     height={200}
-    id="chart4"
+    idPrefix="chart4"
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     maxDomain={{y: 100}}
     padding={{
@@ -197,7 +197,7 @@ import { ChartAxis, ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
     constrainToVisibleArea
     height={200}
-    id="chart5"
+    idPrefix="chart5"
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     legendItemsPerRow={3}
     padding={{
@@ -235,7 +235,7 @@ import { ChartBullet } from '@patternfly/react-charts';
     constrainToVisibleArea
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     height={200}
-    id="chart6"
+    idPrefix="chart6"
     maxDomain={{y: 125}}
     minDomain={{y: 50}}
     padding={{
@@ -272,7 +272,7 @@ import { ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
     constrainToVisibleArea
     height={200}
-    id="chart7"
+    idPrefix="chart7"
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     maxDomain={{y: 75}}
     minDomain={{y: -25}}
@@ -310,7 +310,7 @@ import { ChartBullet } from '@patternfly/react-charts';
     constrainToVisibleArea
     invert
     height={200}
-    id="chart8"
+    idPrefix="chart8"
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     legendPosition="right"
     legendOrientation="vertical"
@@ -349,7 +349,7 @@ import { ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
     constrainToVisibleArea
     height={200}
-    id="chart9"
+    idPrefix="chart9"
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     legendItemsPerRow={4}
     maxDomain={{y: 75}}
@@ -384,7 +384,7 @@ import { ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
     constrainToVisibleArea
     height={500}
-    id="chart10"
+    idPrefix="chart10"
     horizontal={false}
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     maxDomain={{y: 100}}
@@ -418,7 +418,7 @@ import { ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
     constrainToVisibleArea
     height={500}
-    id="chart11"
+    idPrefix="chart11"
     horizontal={false}
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     maxDomain={{y: 125}}
@@ -472,7 +472,7 @@ import { ChartAxis, ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureData={[{ name: 'Warning', y: 88 }]}
     constrainToVisibleArea
     height={150}
-    id="chart12"
+    idPrefix="chart12"
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     maxDomain={{y: 100}}
     primarySegmentedMeasureData={[{ name: 'Measure', y: 60 }]}
@@ -495,7 +495,7 @@ import { ChartBullet } from '@patternfly/react-charts';
     comparativeWarningMeasureData={[{ name: 'Warning', y: 88 }]}
     comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
     height={200}
-    id="chart13"
+    idPrefix="chart13"
     labels={({ datum }) => `${datum.name}: ${datum.y}`}
     maxDomain={{y: 100}}
     padding={{
@@ -530,7 +530,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       comparativeWarningMeasureData={[{name: 'Warning', y: 78}]}
       constrainToVisibleArea
       height={500}
-      id="chart14"
+      idPrefix="chart14"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
@@ -550,7 +550,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       comparativeWarningMeasureData={[{name: 'Warning', y: 88}]}
       constrainToVisibleArea
       height={500}
-      id="chart15"
+      idPrefix="chart15"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
@@ -570,7 +570,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       comparativeWarningMeasureData={[{name: 'Warning', y: 98}]}
       constrainToVisibleArea
       height={500}
-      id="chart16"
+      idPrefix="chart16"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
@@ -591,7 +591,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
       constrainToVisibleArea
       height={500}
-      id="chart17"
+      idPrefix="chart17"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
@@ -629,7 +629,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
       constrainToVisibleArea
       height={600}
-      id="chart18"
+      idPrefix="chart18"
       horizontal={false}
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
@@ -652,7 +652,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       comparativeWarningMeasureData={[{name: 'Warning', y: 88}]}
       constrainToVisibleArea
       height={600}
-      id="chart19"
+      idPrefix="chart19"
       horizontal={false}
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
@@ -674,7 +674,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       constrainToVisibleArea
       height={600}
       horizontal={false}
-      id="chart20"
+      idPrefix="chart20"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
@@ -695,7 +695,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       constrainToVisibleArea
       height={600}
       horizontal={false}
-      id="chart21"
+      idPrefix="chart21"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
@@ -732,7 +732,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       groupSubTitle="Measure details"
       groupTitle="Text label"
       height={575}
-      id="chart22"
+      idPrefix="chart22"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
@@ -752,7 +752,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       comparativeWarningMeasureData={[{name: 'Warning', y: 88}]}
       constrainToVisibleArea
       height={600}
-      id="chart23"
+      idPrefix="chart23"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
@@ -772,7 +772,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       comparativeWarningMeasureData={[{name: 'Warning', y: 98}]}
       constrainToVisibleArea
       height={600}
-      id="chart24"
+      idPrefix="chart24"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
@@ -793,7 +793,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
       constrainToVisibleArea
       height={600}
-      id="chart25"
+      idPrefix="chart25"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
@@ -834,7 +834,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       groupTitle="Text label"
       height={600}
       horizontal={false}
-      id="chart26"
+      idPrefix="chart26"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
@@ -857,7 +857,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       constrainToVisibleArea
       height={600}
       horizontal={false}
-      id="chart27"
+      idPrefix="chart27"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
@@ -878,7 +878,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       constrainToVisibleArea
       height={600}
       horizontal={false}
-      id="chart28"
+      idPrefix="chart28"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
@@ -899,7 +899,7 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       constrainToVisibleArea
       height={600}
       horizontal={false}
-      id="chart29"
+      idPrefix="chart29"
       labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{

--- a/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -265,6 +265,11 @@ export interface ChartDonutProps extends ChartPieProps {
    */
   height?: number;
   /**
+   * This prop specifies an ID that will be applied to child text elements, assisting with
+   * accessibility for screen readers.
+   */
+  id?: string;
+  /**
    * When creating a donut chart, this prop determines the number of pixels between
    * the center of the chart and the inner edge.
    *
@@ -585,6 +590,7 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
   ariaTitle,
   capHeight = 1.1,
   containerComponent = <ChartContainer />,
+  id,
   innerRadius,
   legendAllowWrap,
   legendPosition = ChartCommonStyles.legend.position as ChartPieLegendPosition,
@@ -650,6 +656,7 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
     const subTitleProps = textComponent.props ? textComponent.props : {};
 
     return React.cloneElement(textComponent, {
+      ...(id && { id: `${id}-${(textComponent as any).type.displayName}` }),
       key: 'pf-chart-donut-subtitle',
       style: ChartDonutStyles.label.subTitle,
       text: subTitle,
@@ -682,6 +689,7 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
 
     return React.cloneElement(titleComponent, {
       ...(Array.isArray(titles) && { capHeight }), // Use capHeight with multiple labels
+      ...(id && { id: `${id}-${(titleComponent as any).type.displayName}` }),
       key: 'pf-chart-donut-title',
       style: styles,
       text: titles,
@@ -709,6 +717,7 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
     <ChartPie
       allowTooltip={allowTooltip}
       height={height}
+      id={id}
       innerRadius={chartInnerRadius > 0 ? chartInnerRadius : 0}
       key="pf-chart-donut-pie"
       legendAllowWrap={legendAllowWrap}

--- a/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -265,14 +265,6 @@ export interface ChartDonutProps extends ChartPieProps {
    */
   height?: number;
   /**
-   * This prop specifies an ID prefix that will be applied to child text elements. This is only necessary when
-   * multiple charts appear in a page, ensuring unique IDs for each chart.
-   *
-   * Note: This should not be confused with a container's containerId prop.
-   * See https://formidable.com/open-source/victory/docs/common-container-props#containerid
-   */
-  idPrefix?: string;
-  /**
    * When creating a donut chart, this prop determines the number of pixels between
    * the center of the chart and the inner edge.
    *
@@ -361,7 +353,9 @@ export interface ChartDonutProps extends ChartPieProps {
    */
   legendPosition?: 'bottom' | 'right';
   /**
-   * The name prop is used to reference a component instance when defining shared events.
+   * The name prop is typically used to reference a component instance when defining shared events. However, this
+   * optional prop may also be applied to child elements as an ID prefix. This is a workaround to ensure Victory
+   * based components output unique IDs when multiple charts appear in a page.
    */
   name?: string;
   /**
@@ -593,10 +587,10 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
   ariaTitle,
   capHeight = 1.1,
   containerComponent = <ChartContainer />,
-  idPrefix,
   innerRadius,
   legendAllowWrap,
   legendPosition = ChartCommonStyles.legend.position as ChartPieLegendPosition,
+  name,
   padAngle,
   padding,
   radius,
@@ -659,7 +653,7 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
     const subTitleProps = textComponent.props ? textComponent.props : {};
 
     return React.cloneElement(textComponent, {
-      ...(idPrefix && { id: `${idPrefix}-${(textComponent as any).type.displayName}-subTitle` }),
+      ...(name && { id: `${name}-${(textComponent as any).type.displayName}-subTitle` }),
       key: 'pf-chart-donut-subtitle',
       style: ChartDonutStyles.label.subTitle,
       text: subTitle,
@@ -692,7 +686,7 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
 
     return React.cloneElement(titleComponent, {
       ...(Array.isArray(titles) && { capHeight }), // Use capHeight with multiple labels
-      ...(idPrefix && { id: `${idPrefix}-${(titleComponent as any).type.displayName}-title` }),
+      ...(name && { id: `${name}-${(titleComponent as any).type.displayName}-title` }),
       key: 'pf-chart-donut-title',
       style: styles,
       text: titles,
@@ -720,11 +714,11 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
     <ChartPie
       allowTooltip={allowTooltip}
       height={height}
-      idPrefix={idPrefix}
       innerRadius={chartInnerRadius > 0 ? chartInnerRadius : 0}
       key="pf-chart-donut-pie"
       legendAllowWrap={legendAllowWrap}
       legendPosition={legendPosition}
+      name={name}
       padAngle={padAngle !== undefined ? padAngle : getPadAngle}
       padding={padding}
       radius={chartRadius > 0 ? chartRadius : 0}

--- a/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -656,7 +656,7 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
     const subTitleProps = textComponent.props ? textComponent.props : {};
 
     return React.cloneElement(textComponent, {
-      ...(id && { id: `${id}-${(textComponent as any).type.displayName}` }),
+      ...(id && { id: `${id}-${(textComponent as any).type.displayName}-subTitle` }),
       key: 'pf-chart-donut-subtitle',
       style: ChartDonutStyles.label.subTitle,
       text: subTitle,
@@ -689,7 +689,7 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
 
     return React.cloneElement(titleComponent, {
       ...(Array.isArray(titles) && { capHeight }), // Use capHeight with multiple labels
-      ...(id && { id: `${id}-${(titleComponent as any).type.displayName}` }),
+      ...(id && { id: `${id}-${(titleComponent as any).type.displayName}-title` }),
       key: 'pf-chart-donut-title',
       style: styles,
       text: titles,

--- a/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -265,10 +265,13 @@ export interface ChartDonutProps extends ChartPieProps {
    */
   height?: number;
   /**
-   * This prop specifies an ID that will be applied to child text elements, assisting with
-   * accessibility for screen readers.
+   * This prop specifies an ID prefix that will be applied to child text elements. This is only necessary when
+   * multiple charts appear in a page, ensuring unique IDs for each chart.
+   *
+   * Note: This should not be confused with a container's containerId prop.
+   * See https://formidable.com/open-source/victory/docs/common-container-props#containerid
    */
-  id?: string;
+  idPrefix?: string;
   /**
    * When creating a donut chart, this prop determines the number of pixels between
    * the center of the chart and the inner edge.
@@ -590,7 +593,7 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
   ariaTitle,
   capHeight = 1.1,
   containerComponent = <ChartContainer />,
-  id,
+  idPrefix,
   innerRadius,
   legendAllowWrap,
   legendPosition = ChartCommonStyles.legend.position as ChartPieLegendPosition,
@@ -656,7 +659,7 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
     const subTitleProps = textComponent.props ? textComponent.props : {};
 
     return React.cloneElement(textComponent, {
-      ...(id && { id: `${id}-${(textComponent as any).type.displayName}-subTitle` }),
+      ...(idPrefix && { id: `${idPrefix}-${(textComponent as any).type.displayName}-subTitle` }),
       key: 'pf-chart-donut-subtitle',
       style: ChartDonutStyles.label.subTitle,
       text: subTitle,
@@ -689,7 +692,7 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
 
     return React.cloneElement(titleComponent, {
       ...(Array.isArray(titles) && { capHeight }), // Use capHeight with multiple labels
-      ...(id && { id: `${id}-${(titleComponent as any).type.displayName}-title` }),
+      ...(idPrefix && { id: `${idPrefix}-${(titleComponent as any).type.displayName}-title` }),
       key: 'pf-chart-donut-title',
       style: styles,
       text: titles,
@@ -717,7 +720,7 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
     <ChartPie
       allowTooltip={allowTooltip}
       height={height}
-      id={id}
+      idPrefix={idPrefix}
       innerRadius={chartInnerRadius > 0 ? chartInnerRadius : 0}
       key="pf-chart-donut-pie"
       legendAllowWrap={legendAllowWrap}

--- a/packages/react-charts/src/components/ChartDonut/examples/ChartDonut.md
+++ b/packages/react-charts/src/components/ChartDonut/examples/ChartDonut.md
@@ -30,6 +30,7 @@ import { ChartDonut } from '@patternfly/react-charts';
     ariaTitle="Donut chart example"
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
+    id="chart1"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     subTitle="Pets"
     title="100"
@@ -48,6 +49,7 @@ import { ChartDonut } from '@patternfly/react-charts';
     ariaTitle="Donut chart example"
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
+    id="chart2"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
@@ -76,6 +78,7 @@ import { ChartDonut, ChartThemeColor } from '@patternfly/react-charts';
     ariaTitle="Donut chart example"
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
+    id="chart3"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
@@ -107,6 +110,7 @@ import { ChartDonut } from '@patternfly/react-charts';
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     donutOrientation="top"
     height={275}
+    id="chart4"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendPosition="bottom"
@@ -136,6 +140,7 @@ import { ChartDonut } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={150}
+    id="chart5"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     subTitle="Pets"
     title="100"
@@ -156,6 +161,7 @@ import { ChartDonut } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={150}
+    id="chart6"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
@@ -185,6 +191,7 @@ import { ChartDonut } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={165}
+    id="chart7"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
@@ -215,6 +222,7 @@ import { ChartDonut } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={200}
+    id="chart8"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendPosition="bottom"

--- a/packages/react-charts/src/components/ChartDonut/examples/ChartDonut.md
+++ b/packages/react-charts/src/components/ChartDonut/examples/ChartDonut.md
@@ -30,8 +30,8 @@ import { ChartDonut } from '@patternfly/react-charts';
     ariaTitle="Donut chart example"
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-    idPrefix="chart1"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
+    name="chart1"
     subTitle="Pets"
     title="100"
   />
@@ -49,11 +49,11 @@ import { ChartDonut } from '@patternfly/react-charts';
     ariaTitle="Donut chart example"
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-    idPrefix="chart2"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
     legendPosition="right"
+    name="chart2"
     padding={{
       bottom: 20,
       left: 20,
@@ -78,11 +78,11 @@ import { ChartDonut, ChartThemeColor } from '@patternfly/react-charts';
     ariaTitle="Donut chart example"
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-    idPrefix="chart3"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
     legendPosition="right"
+    name="chart3"
     padding={{
       bottom: 20,
       left: 20,
@@ -110,11 +110,11 @@ import { ChartDonut } from '@patternfly/react-charts';
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     donutOrientation="top"
     height={275}
-    idPrefix="chart4"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendPosition="bottom"
     legendWidth={225}
+    name="chart4"
     padding={{
       bottom: 65, // Adjusted to accommodate legend
       left: 20,
@@ -140,8 +140,8 @@ import { ChartDonut } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={150}
-    idPrefix="chart5"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
+    name="chart5"
     subTitle="Pets"
     title="100"
     width={150}
@@ -161,11 +161,11 @@ import { ChartDonut } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={150}
-    idPrefix="chart6"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
     legendPosition="right"
+    name="chart6"
     padding={{
       bottom: 20,
       left: 20,
@@ -191,11 +191,11 @@ import { ChartDonut } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={165}
-    idPrefix="chart7"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
     legendPosition="right"
+    name="chart7"
     padding={{
       bottom: 25, // Adjusted to accommodate subTitle
       left: 20,
@@ -222,10 +222,10 @@ import { ChartDonut } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={200}
-    idPrefix="chart8"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendPosition="bottom"
+    name="chart8"
     padding={{
       bottom: 70, // Adjusted to accommodate legend
       left: 20,

--- a/packages/react-charts/src/components/ChartDonut/examples/ChartDonut.md
+++ b/packages/react-charts/src/components/ChartDonut/examples/ChartDonut.md
@@ -30,7 +30,7 @@ import { ChartDonut } from '@patternfly/react-charts';
     ariaTitle="Donut chart example"
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-    id="chart1"
+    idPrefix="chart1"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     subTitle="Pets"
     title="100"
@@ -49,7 +49,7 @@ import { ChartDonut } from '@patternfly/react-charts';
     ariaTitle="Donut chart example"
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-    id="chart2"
+    idPrefix="chart2"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
@@ -78,7 +78,7 @@ import { ChartDonut, ChartThemeColor } from '@patternfly/react-charts';
     ariaTitle="Donut chart example"
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-    id="chart3"
+    idPrefix="chart3"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
@@ -110,7 +110,7 @@ import { ChartDonut } from '@patternfly/react-charts';
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     donutOrientation="top"
     height={275}
-    id="chart4"
+    idPrefix="chart4"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendPosition="bottom"
@@ -140,7 +140,7 @@ import { ChartDonut } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={150}
-    id="chart5"
+    idPrefix="chart5"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     subTitle="Pets"
     title="100"
@@ -161,7 +161,7 @@ import { ChartDonut } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={150}
-    id="chart6"
+    idPrefix="chart6"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
@@ -191,7 +191,7 @@ import { ChartDonut } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={165}
-    id="chart7"
+    idPrefix="chart7"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
@@ -222,7 +222,7 @@ import { ChartDonut } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={200}
-    id="chart8"
+    idPrefix="chart8"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendPosition="bottom"

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
@@ -268,10 +268,13 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    */
   height?: number;
   /**
-   * This prop specifies an ID that will be applied to child text elements, assisting with
-   * accessibility for screen readers.
+   * This prop specifies an ID prefix that will be applied to child text elements. This is only necessary when
+   * multiple charts appear in a page, ensuring unique IDs for each chart.
+   *
+   * Note: This should not be confused with a container's containerId prop.
+   * See https://formidable.com/open-source/victory/docs/common-container-props#containerid
    */
-  id?: string;
+  idPrefix?: string;
   /**
    * When creating a donut chart, this prop determines the number of pixels between
    * the center of the chart and the inner edge.
@@ -477,7 +480,7 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
   containerComponent = <ChartContainer />,
   data = [],
   hasPatterns,
-  id,
+  idPrefix,
   invert = false,
   labels = [], // Don't show any tooltip labels by default, let consumer override if needed
   padding,
@@ -552,9 +555,9 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
           data: childData,
           endAngle: 360 * (datum[0]._y ? datum[0]._y / 100 : 0),
           height,
-          ...(id &&
+          ...(idPrefix &&
             typeof (child as any).id !== undefined && {
-              id: `${id}-${(child as any).type.displayName}-${index}`
+              idPrefix: `${idPrefix}-${(child as any).type.displayName}-${index}`
             }),
           invert,
           isStatic: false,

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
@@ -551,7 +551,7 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
           height,
           ...(name &&
             typeof (child as any).name !== undefined && {
-              name: `${name}-${(child as any).type.displayName}-${index}`
+              name: `${name}-${(child as any).type.displayName}`
             }),
           invert,
           isStatic: false,

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
@@ -550,7 +550,7 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
           endAngle: 360 * (datum[0]._y ? datum[0]._y / 100 : 0),
           height,
           ...(name &&
-            typeof (child as any).id !== undefined && {
+            typeof (child as any).name !== undefined && {
               name: `${name}-${(child as any).type.displayName}-${index}`
             }),
           invert,

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
@@ -268,14 +268,6 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    */
   height?: number;
   /**
-   * This prop specifies an ID prefix that will be applied to child text elements. This is only necessary when
-   * multiple charts appear in a page, ensuring unique IDs for each chart.
-   *
-   * Note: This should not be confused with a container's containerId prop.
-   * See https://formidable.com/open-source/victory/docs/common-container-props#containerid
-   */
-  idPrefix?: string;
-  /**
    * When creating a donut chart, this prop determines the number of pixels between
    * the center of the chart and the inner edge.
    *
@@ -304,7 +296,9 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    */
   labels?: string[] | number[] | ((data: any) => string | number | null);
   /**
-   * The name prop is used to reference a component instance when defining shared events.
+   * The name prop is typically used to reference a component instance when defining shared events. However, this
+   * optional prop may also be applied to child elements as an ID prefix. This is a workaround to ensure Victory
+   * based components output unique IDs when multiple charts appear in a page.
    */
   name?: string;
   /**
@@ -480,9 +474,9 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
   containerComponent = <ChartContainer />,
   data = [],
   hasPatterns,
-  idPrefix,
   invert = false,
   labels = [], // Don't show any tooltip labels by default, let consumer override if needed
+  name,
   padding,
   radius,
   standalone = true,
@@ -555,9 +549,9 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
           data: childData,
           endAngle: 360 * (datum[0]._y ? datum[0]._y / 100 : 0),
           height,
-          ...(idPrefix &&
+          ...(name &&
             typeof (child as any).id !== undefined && {
-              idPrefix: `${idPrefix}-${(child as any).type.displayName}-${index}`
+              name: `${name}-${(child as any).type.displayName}-${index}`
             }),
           invert,
           isStatic: false,

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
@@ -268,6 +268,11 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    */
   height?: number;
   /**
+   * This prop specifies an ID that will be applied to child text elements, assisting with
+   * accessibility for screen readers.
+   */
+  id?: string;
+  /**
    * When creating a donut chart, this prop determines the number of pixels between
    * the center of the chart and the inner edge.
    *
@@ -472,6 +477,7 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
   containerComponent = <ChartContainer />,
   data = [],
   hasPatterns,
+  id,
   invert = false,
   labels = [], // Don't show any tooltip labels by default, let consumer override if needed
   padding,
@@ -546,6 +552,10 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
           data: childData,
           endAngle: 360 * (datum[0]._y ? datum[0]._y / 100 : 0),
           height,
+          ...(id &&
+            typeof (child as any).id !== undefined && {
+              id: `${id}-${(child as any).type.displayName}-${index}`
+            }),
           invert,
           isStatic: false,
           key: `pf-chart-donut-threshold-child-${index}`,

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
@@ -269,6 +269,11 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    */
   height?: number;
   /**
+   * This prop specifies an ID that will be applied to child text elements, assisting with
+   * accessibility for screen readers.
+   */
+  id?: string;
+  /**
    * When creating a donut chart, this prop determines the number of pixels between
    * the center of the chart and the inner edge.
    *

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
@@ -269,14 +269,6 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    */
   height?: number;
   /**
-   * This prop specifies an ID prefix that will be applied to child text elements. This is only necessary when
-   * multiple charts appear in a page, ensuring unique IDs for each chart.
-   *
-   * Note: This should not be confused with a container's containerId prop.
-   * See https://formidable.com/open-source/victory/docs/common-container-props#containerid
-   */
-  idPrefix?: string;
-  /**
    * When creating a donut chart, this prop determines the number of pixels between
    * the center of the chart and the inner edge.
    *
@@ -382,7 +374,9 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    */
   labels?: string[] | number[] | ((data: any) => string | number | null);
   /**
-   * The name prop is used to reference a component instance when defining shared events.
+   * The name prop is typically used to reference a component instance when defining shared events. However, this
+   * optional prop may also be applied to child elements as an ID prefix. This is a workaround to ensure Victory
+   * based components output unique IDs when multiple charts appear in a page.
    */
   name?: string;
   /**

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
@@ -269,10 +269,13 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    */
   height?: number;
   /**
-   * This prop specifies an ID that will be applied to child text elements, assisting with
-   * accessibility for screen readers.
+   * This prop specifies an ID prefix that will be applied to child text elements. This is only necessary when
+   * multiple charts appear in a page, ensuring unique IDs for each chart.
+   *
+   * Note: This should not be confused with a container's containerId prop.
+   * See https://formidable.com/open-source/victory/docs/common-container-props#containerid
    */
-  id?: string;
+  idPrefix?: string;
   /**
    * When creating a donut chart, this prop determines the number of pixels between
    * the center of the chart and the inner edge.

--- a/packages/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
+++ b/packages/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
@@ -31,6 +31,7 @@ import { ChartDonutUtilization } from '@patternfly/react-charts';
     ariaTitle="Donut utilization chart example"
     constrainToVisibleArea
     data={{ x: 'GBps capacity', y: 75 }}
+    id="chart1"
     labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
     subTitle="of 100 GBps"
     title="75%"
@@ -76,6 +77,7 @@ class DonutUtilizationChart extends React.Component {
           ariaTitle="Donut utilization chart example"
           constrainToVisibleArea
           data={{ x: 'GBps capacity', y: used }}
+          id="chart2"
           labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
           legendData={[{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }]}
           legendOrientation="vertical"
@@ -134,6 +136,7 @@ class InvertedDonutUtilizationChart extends React.Component {
           ariaTitle="Donut utilization chart example"
           constrainToVisibleArea
           data={{ x: 'GBps capacity', y: used }}
+          id="chart3"
           invert
           labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
           legendData={[{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }]}
@@ -194,6 +197,7 @@ class VerticalLegendUtilizationChart extends React.Component {
           constrainToVisibleArea
           data={{ x: 'Storage capacity', y: used }}
           height={300}
+          id="chart4"
           labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
           legendData={[{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }]}
           legendOrientation="vertical"
@@ -228,6 +232,7 @@ import { ChartDonutUtilization } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={{ x: 'Storage capacity', y: 45 }}
     height={275}
+    id="chart5"
     labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
     legendData={[{ name: `Storage capacity: 45%` }, { name: 'Unused' }]}
     legendPosition="bottom"
@@ -257,6 +262,7 @@ import { ChartDonutUtilization } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={{ x: 'Storage capacity', y: 75 }}
     height={175}
+    id="chart6"
     labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
     subTitle="of 100 GBps"
     title="75%"
@@ -304,6 +310,7 @@ class UtilizationChart extends React.Component {
           constrainToVisibleArea
           data={{ x: 'Storage capacity', y: used }}
           height={175}
+          id="chart7"
           labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
           legendData={[{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }]}
           legendOrientation="vertical"
@@ -339,6 +346,7 @@ import { ChartDonutUtilization } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={{ x: 'Storage capacity', y: 45 }}
     height={185}
+    id="chart8"
     labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
     legendData={[{ name: `Storage capacity: 45%` }, { name: 'Unused' }]}
     legendOrientation="vertical"
@@ -369,6 +377,7 @@ import { ChartDonutUtilization } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={{ x: 'Storage capacity', y: 45 }}
     height={200}
+    id="chart9"
     labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
     legendData={[{ name: `Storage capacity: 45%` }, { name: 'Unused' }]}
     legendPosition="bottom"
@@ -399,6 +408,7 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
     ariaTitle="Donut utilization chart with static threshold example"
     constrainToVisibleArea
     data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
+    id="chart10"
     labels={({ datum }) => datum.x ? datum.x : null}
   >
     <ChartDonutUtilization
@@ -444,6 +454,7 @@ class ThresholdChart extends React.Component {
           ariaTitle="Donut utilization chart with static threshold example"
           constrainToVisibleArea
           data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
+          id="chart11"
           labels={({ datum }) => datum.x ? datum.x : null}
           padding={{
             bottom: 20,
@@ -507,6 +518,7 @@ class InvertedThresholdChart extends React.Component {
           ariaTitle="Donut utilization chart with static threshold example"
           constrainToVisibleArea
           data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 20%', y: 20 }]}
+          id="chart12"
           invert
           labels={({ datum }) => datum.x ? datum.x : null}
           padding={{
@@ -567,6 +579,7 @@ class CustomLegendThresholdChart extends React.Component {
           constrainToVisibleArea
           data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
           height={350}
+          id="chart13"
           labels={({ datum }) => datum.x ? datum.x : null}
           padding={{
             bottom: 125, // Adjusted to accommodate legend
@@ -606,6 +619,7 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
     constrainToVisibleArea
     data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
     height={275}
+    id="chart14"
     labels={({ datum }) => datum.x ? datum.x : null}
     padding={{
       bottom: 65, // Adjusted to accommodate legend
@@ -639,6 +653,7 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
     constrainToVisibleArea
     data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
     height={185}
+    id="chart15"
     labels={({ datum }) => datum.x ? datum.x : null}
     width={185}
   >
@@ -686,6 +701,7 @@ class ThresholdChart extends React.Component {
           constrainToVisibleArea
           data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
           height={185}
+          id="chart16"
           labels={({ datum }) => datum.x ? datum.x : null}
           padding={{
             bottom: 20,
@@ -726,6 +742,7 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
     constrainToVisibleArea
     data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
     height={200}
+    id="chart17"
     labels={({ datum }) => datum.x ? datum.x : null}
     padding={{
       bottom: 30, // Adjusted to accommodate label
@@ -761,6 +778,7 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
     constrainToVisibleArea
     data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
     height={225}
+    id="chart18"
     labels={({ datum }) => datum.x ? datum.x : null}
     padding={{
       bottom: 60, // Adjusted to accommodate legend

--- a/packages/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
+++ b/packages/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
@@ -31,8 +31,8 @@ import { ChartDonutUtilization } from '@patternfly/react-charts';
     ariaTitle="Donut utilization chart example"
     constrainToVisibleArea
     data={{ x: 'GBps capacity', y: 75 }}
-    idPrefix="chart1"
     labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
+    name="chart1"
     subTitle="of 100 GBps"
     title="75%"
   />
@@ -77,10 +77,10 @@ class DonutUtilizationChart extends React.Component {
           ariaTitle="Donut utilization chart example"
           constrainToVisibleArea
           data={{ x: 'GBps capacity', y: used }}
-          idPrefix="chart2"
           labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
           legendData={[{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }]}
           legendOrientation="vertical"
+          name="chart2"
           padding={{
             bottom: 20,
             left: 20,
@@ -136,11 +136,11 @@ class InvertedDonutUtilizationChart extends React.Component {
           ariaTitle="Donut utilization chart example"
           constrainToVisibleArea
           data={{ x: 'GBps capacity', y: used }}
-          idPrefix="chart3"
           invert
           labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
           legendData={[{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }]}
           legendOrientation="vertical"
+          name="chart3"
           padding={{
             bottom: 20,
             left: 20,
@@ -197,11 +197,11 @@ class VerticalLegendUtilizationChart extends React.Component {
           constrainToVisibleArea
           data={{ x: 'Storage capacity', y: used }}
           height={300}
-          idPrefix="chart4"
           labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
           legendData={[{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }]}
           legendOrientation="vertical"
           legendPosition="bottom"
+          name="chart4"
           padding={{
             bottom: 75, // Adjusted to accommodate legend
             left: 20,
@@ -232,10 +232,10 @@ import { ChartDonutUtilization } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={{ x: 'Storage capacity', y: 45 }}
     height={275}
-    idPrefix="chart5"
     labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
     legendData={[{ name: `Storage capacity: 45%` }, { name: 'Unused' }]}
     legendPosition="bottom"
+    name="chart5"
     padding={{
       bottom: 65, // Adjusted to accommodate legend
       left: 20,
@@ -262,8 +262,8 @@ import { ChartDonutUtilization } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={{ x: 'Storage capacity', y: 75 }}
     height={175}
-    idPrefix="chart6"
     labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
+    name="chart6"
     subTitle="of 100 GBps"
     title="75%"
     width={175}
@@ -310,10 +310,10 @@ class UtilizationChart extends React.Component {
           constrainToVisibleArea
           data={{ x: 'Storage capacity', y: used }}
           height={175}
-          idPrefix="chart7"
           labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
           legendData={[{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }]}
           legendOrientation="vertical"
+          name="chart7"
           padding={{
             bottom: 20,
             left: 20,
@@ -346,10 +346,10 @@ import { ChartDonutUtilization } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={{ x: 'Storage capacity', y: 45 }}
     height={185}
-    idPrefix="chart8"
     labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
     legendData={[{ name: `Storage capacity: 45%` }, { name: 'Unused' }]}
     legendOrientation="vertical"
+    name="chart8"
     padding={{
       bottom: 25, // Adjusted to accommodate subTitle
       left: 20,
@@ -377,10 +377,10 @@ import { ChartDonutUtilization } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={{ x: 'Storage capacity', y: 45 }}
     height={200}
-    idPrefix="chart9"
     labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
     legendData={[{ name: `Storage capacity: 45%` }, { name: 'Unused' }]}
     legendPosition="bottom"
+    name="chart9"
     padding={{
       bottom: 45, // Adjusted to accommodate legend
       left: 20,
@@ -408,8 +408,8 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
     ariaTitle="Donut utilization chart with static threshold example"
     constrainToVisibleArea
     data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
-    idPrefix="chart10"
     labels={({ datum }) => datum.x ? datum.x : null}
+    name="chart10"
   >
     <ChartDonutUtilization
       data={{ x: 'Storage capacity', y: 45 }}
@@ -454,8 +454,8 @@ class ThresholdChart extends React.Component {
           ariaTitle="Donut utilization chart with static threshold example"
           constrainToVisibleArea
           data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
-          idPrefix="chart11"
           labels={({ datum }) => datum.x ? datum.x : null}
+          name="chart11"
           padding={{
             bottom: 20,
             left: 20,
@@ -518,9 +518,9 @@ class InvertedThresholdChart extends React.Component {
           ariaTitle="Donut utilization chart with static threshold example"
           constrainToVisibleArea
           data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 20%', y: 20 }]}
-          idPrefix="chart12"
           invert
           labels={({ datum }) => datum.x ? datum.x : null}
+          name="chart12"
           padding={{
             bottom: 20,
             left: 20,
@@ -579,8 +579,8 @@ class CustomLegendThresholdChart extends React.Component {
           constrainToVisibleArea
           data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
           height={350}
-          idPrefix="chart13"
           labels={({ datum }) => datum.x ? datum.x : null}
+          name="chart13"
           padding={{
             bottom: 125, // Adjusted to accommodate legend
             left: 20,
@@ -619,8 +619,8 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
     constrainToVisibleArea
     data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
     height={275}
-    idPrefix="chart14"
     labels={({ datum }) => datum.x ? datum.x : null}
+    name="chart14"
     padding={{
       bottom: 65, // Adjusted to accommodate legend
       left: 20,
@@ -653,8 +653,8 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
     constrainToVisibleArea
     data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
     height={185}
-    idPrefix="chart15"
     labels={({ datum }) => datum.x ? datum.x : null}
+    name="chart15"
     width={185}
   >
     <ChartDonutUtilization
@@ -701,8 +701,8 @@ class ThresholdChart extends React.Component {
           constrainToVisibleArea
           data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
           height={185}
-          idPrefix="chart16"
           labels={({ datum }) => datum.x ? datum.x : null}
+          name="chart16"
           padding={{
             bottom: 20,
             left: 20,
@@ -742,8 +742,8 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
     constrainToVisibleArea
     data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
     height={200}
-    idPrefix="chart17"
     labels={({ datum }) => datum.x ? datum.x : null}
+    name="chart17"
     padding={{
       bottom: 30, // Adjusted to accommodate label
       left: 20,
@@ -778,8 +778,8 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
     constrainToVisibleArea
     data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
     height={225}
-    idPrefix="chart18"
     labels={({ datum }) => datum.x ? datum.x : null}
+    name="chart18"
     padding={{
       bottom: 60, // Adjusted to accommodate legend
       left: 20,

--- a/packages/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
+++ b/packages/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
@@ -31,7 +31,7 @@ import { ChartDonutUtilization } from '@patternfly/react-charts';
     ariaTitle="Donut utilization chart example"
     constrainToVisibleArea
     data={{ x: 'GBps capacity', y: 75 }}
-    id="chart1"
+    idPrefix="chart1"
     labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
     subTitle="of 100 GBps"
     title="75%"
@@ -77,7 +77,7 @@ class DonutUtilizationChart extends React.Component {
           ariaTitle="Donut utilization chart example"
           constrainToVisibleArea
           data={{ x: 'GBps capacity', y: used }}
-          id="chart2"
+          idPrefix="chart2"
           labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
           legendData={[{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }]}
           legendOrientation="vertical"
@@ -136,7 +136,7 @@ class InvertedDonutUtilizationChart extends React.Component {
           ariaTitle="Donut utilization chart example"
           constrainToVisibleArea
           data={{ x: 'GBps capacity', y: used }}
-          id="chart3"
+          idPrefix="chart3"
           invert
           labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
           legendData={[{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }]}
@@ -197,7 +197,7 @@ class VerticalLegendUtilizationChart extends React.Component {
           constrainToVisibleArea
           data={{ x: 'Storage capacity', y: used }}
           height={300}
-          id="chart4"
+          idPrefix="chart4"
           labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
           legendData={[{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }]}
           legendOrientation="vertical"
@@ -232,7 +232,7 @@ import { ChartDonutUtilization } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={{ x: 'Storage capacity', y: 45 }}
     height={275}
-    id="chart5"
+    idPrefix="chart5"
     labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
     legendData={[{ name: `Storage capacity: 45%` }, { name: 'Unused' }]}
     legendPosition="bottom"
@@ -262,7 +262,7 @@ import { ChartDonutUtilization } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={{ x: 'Storage capacity', y: 75 }}
     height={175}
-    id="chart6"
+    idPrefix="chart6"
     labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
     subTitle="of 100 GBps"
     title="75%"
@@ -310,7 +310,7 @@ class UtilizationChart extends React.Component {
           constrainToVisibleArea
           data={{ x: 'Storage capacity', y: used }}
           height={175}
-          id="chart7"
+          idPrefix="chart7"
           labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
           legendData={[{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }]}
           legendOrientation="vertical"
@@ -346,7 +346,7 @@ import { ChartDonutUtilization } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={{ x: 'Storage capacity', y: 45 }}
     height={185}
-    id="chart8"
+    idPrefix="chart8"
     labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
     legendData={[{ name: `Storage capacity: 45%` }, { name: 'Unused' }]}
     legendOrientation="vertical"
@@ -377,7 +377,7 @@ import { ChartDonutUtilization } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={{ x: 'Storage capacity', y: 45 }}
     height={200}
-    id="chart9"
+    idPrefix="chart9"
     labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
     legendData={[{ name: `Storage capacity: 45%` }, { name: 'Unused' }]}
     legendPosition="bottom"
@@ -408,7 +408,7 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
     ariaTitle="Donut utilization chart with static threshold example"
     constrainToVisibleArea
     data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
-    id="chart10"
+    idPrefix="chart10"
     labels={({ datum }) => datum.x ? datum.x : null}
   >
     <ChartDonutUtilization
@@ -454,7 +454,7 @@ class ThresholdChart extends React.Component {
           ariaTitle="Donut utilization chart with static threshold example"
           constrainToVisibleArea
           data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
-          id="chart11"
+          idPrefix="chart11"
           labels={({ datum }) => datum.x ? datum.x : null}
           padding={{
             bottom: 20,
@@ -518,7 +518,7 @@ class InvertedThresholdChart extends React.Component {
           ariaTitle="Donut utilization chart with static threshold example"
           constrainToVisibleArea
           data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 20%', y: 20 }]}
-          id="chart12"
+          idPrefix="chart12"
           invert
           labels={({ datum }) => datum.x ? datum.x : null}
           padding={{
@@ -579,7 +579,7 @@ class CustomLegendThresholdChart extends React.Component {
           constrainToVisibleArea
           data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
           height={350}
-          id="chart13"
+          idPrefix="chart13"
           labels={({ datum }) => datum.x ? datum.x : null}
           padding={{
             bottom: 125, // Adjusted to accommodate legend
@@ -619,7 +619,7 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
     constrainToVisibleArea
     data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
     height={275}
-    id="chart14"
+    idPrefix="chart14"
     labels={({ datum }) => datum.x ? datum.x : null}
     padding={{
       bottom: 65, // Adjusted to accommodate legend
@@ -653,7 +653,7 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
     constrainToVisibleArea
     data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
     height={185}
-    id="chart15"
+    idPrefix="chart15"
     labels={({ datum }) => datum.x ? datum.x : null}
     width={185}
   >
@@ -701,7 +701,7 @@ class ThresholdChart extends React.Component {
           constrainToVisibleArea
           data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
           height={185}
-          id="chart16"
+          idPrefix="chart16"
           labels={({ datum }) => datum.x ? datum.x : null}
           padding={{
             bottom: 20,
@@ -742,7 +742,7 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
     constrainToVisibleArea
     data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
     height={200}
-    id="chart17"
+    idPrefix="chart17"
     labels={({ datum }) => datum.x ? datum.x : null}
     padding={{
       bottom: 30, // Adjusted to accommodate label
@@ -778,7 +778,7 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
     constrainToVisibleArea
     data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
     height={225}
-    id="chart18"
+    idPrefix="chart18"
     labels={({ datum }) => datum.x ? datum.x : null}
     padding={{
       bottom: 60, // Adjusted to accommodate legend

--- a/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
+++ b/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
@@ -156,10 +156,13 @@ export interface ChartLegendProps extends VictoryLegendProps {
    */
   gutter?: number | { left: number; right: number };
   /**
-   * This prop specifies an ID that will be applied to child text elements, assisting with
-   * accessibility for screen readers.
+   * This prop specifies an ID prefix that will be applied to child text elements. This is only necessary when
+   * multiple charts appear in a page, ensuring unique IDs for each chart.
+   *
+   * Note: This should not be confused with a container's containerId prop.
+   * See https://formidable.com/open-source/victory/docs/common-container-props#containerid
    */
-  id?: string;
+  idPrefix?: string;
   /**
    * The itemsPerRow prop determines how many items to render in each row
    * of a horizontal legend, or in each column of a vertical legend. This
@@ -329,7 +332,7 @@ export const ChartLegend: React.FunctionComponent<ChartLegendProps> = ({
   colorScale,
   containerComponent = <ChartContainer />,
   dataComponent = <ChartPoint />,
-  id,
+  idPrefix,
   labelComponent = <ChartLabel />,
   patternScale,
   responsive = true,
@@ -375,7 +378,7 @@ export const ChartLegend: React.FunctionComponent<ChartLegendProps> = ({
 
   const getLabelComponent = () =>
     React.cloneElement(labelComponent, {
-      ...(id && { id: (props: any) => `${id}-${(labelComponent as any).type.displayName}-${props.index}` }),
+      ...(idPrefix && { id: (props: any) => `${idPrefix}-${(labelComponent as any).type.displayName}-${props.index}` }),
       ...labelComponent.props
     });
 

--- a/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
+++ b/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
@@ -156,6 +156,11 @@ export interface ChartLegendProps extends VictoryLegendProps {
    */
   gutter?: number | { left: number; right: number };
   /**
+   * This prop specifies an ID that will be applied to child text elements, assisting with
+   * accessibility for screen readers.
+   */
+  id?: string;
+  /**
    * The itemsPerRow prop determines how many items to render in each row
    * of a horizontal legend, or in each column of a vertical legend. This
    * prop should be given as an integer. When this prop is not given,
@@ -324,6 +329,7 @@ export const ChartLegend: React.FunctionComponent<ChartLegendProps> = ({
   colorScale,
   containerComponent = <ChartContainer />,
   dataComponent = <ChartPoint />,
+  id,
   labelComponent = <ChartLabel />,
   patternScale,
   responsive = true,
@@ -369,6 +375,7 @@ export const ChartLegend: React.FunctionComponent<ChartLegendProps> = ({
 
   const getLabelComponent = () =>
     React.cloneElement(labelComponent, {
+      ...(id && { id: (props: any) => `${id}-${(labelComponent as any).type.displayName}-${props.index}` }),
       ...labelComponent.props
     });
 

--- a/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
+++ b/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
@@ -156,14 +156,6 @@ export interface ChartLegendProps extends VictoryLegendProps {
    */
   gutter?: number | { left: number; right: number };
   /**
-   * This prop specifies an ID prefix that will be applied to child text elements. This is only necessary when
-   * multiple charts appear in a page, ensuring unique IDs for each chart.
-   *
-   * Note: This should not be confused with a container's containerId prop.
-   * See https://formidable.com/open-source/victory/docs/common-container-props#containerid
-   */
-  idPrefix?: string;
-  /**
    * The itemsPerRow prop determines how many items to render in each row
    * of a horizontal legend, or in each column of a vertical legend. This
    * prop should be given as an integer. When this prop is not given,
@@ -180,6 +172,12 @@ export interface ChartLegendProps extends VictoryLegendProps {
    * ChartLabel will be created with the props described above.
    */
   labelComponent?: React.ReactElement<any>;
+  /**
+   * The name prop is typically used to reference a component instance when defining shared events. However, this
+   * optional prop may also be applied to child elements as an ID prefix. This is a workaround to ensure Victory
+   * based components output unique IDs when multiple charts appear in a page.
+   */
+  name?: string;
   /**
    * The orientation prop takes a string that defines whether legend data
    * are displayed in a row or column. When orientation is "horizontal",
@@ -332,8 +330,8 @@ export const ChartLegend: React.FunctionComponent<ChartLegendProps> = ({
   colorScale,
   containerComponent = <ChartContainer />,
   dataComponent = <ChartPoint />,
-  idPrefix,
   labelComponent = <ChartLabel />,
+  name,
   patternScale,
   responsive = true,
   style,
@@ -378,7 +376,7 @@ export const ChartLegend: React.FunctionComponent<ChartLegendProps> = ({
 
   const getLabelComponent = () =>
     React.cloneElement(labelComponent, {
-      ...(idPrefix && { id: (props: any) => `${idPrefix}-${(labelComponent as any).type.displayName}-${props.index}` }),
+      ...(name && { id: (props: any) => `${name}-${(labelComponent as any).type.displayName}-${props.index}` }),
       ...labelComponent.props
     });
 

--- a/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
+++ b/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
@@ -62,6 +62,7 @@ import { ChartDonut } from '@patternfly/react-charts';
     ariaTitle="Donut chart example"
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
+    idPrefix="chart1"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
@@ -93,6 +94,7 @@ import { Chart, ChartAxis, ChartBar, ChartGroup, ChartThemeColor, ChartVoronoiCo
     legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
     legendPosition="bottom"
     height={275}
+    idPrefix="chart2"
     padding={{
       bottom: 75, // Adjusted to accommodate legend
       left: 50,
@@ -158,6 +160,7 @@ class BulletChart extends React.Component {
             comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
             constrainToVisibleArea
             height={250}
+            idPrefix="chart3"
             labels={({ datum }) => `${datum.name}: ${datum.y}`}
             legendAllowWrap
             legendPosition="bottom-left"
@@ -198,6 +201,7 @@ import { Chart, ChartAxis, ChartGroup, ChartLegend, ChartLine, ChartThemeColor, 
     ariaTitle="Line chart example"
     containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
     height={275}
+    idPrefix="chart4"
     maxDomain={{y: 10}}
     minDomain={{y: 0}}
     padding={{
@@ -423,6 +427,7 @@ class InteractiveLegendChart extends React.Component {
             containerComponent={container}
             events={this.getEvents()}
             height={225}
+            idPrefix="chart5"
             legendComponent={<ChartLegend name={'legend'} data={this.getLegendData()} />}
             legendPosition="bottom-left"
             padding={{
@@ -561,6 +566,7 @@ class InteractivePieLegendChart extends React.Component {
           ariaTitle="Pie chart example"
           events={this.getEvents()}
           height={275}
+          idPrefix="chart6"
           legendComponent={<ChartLegend name={'legend'} data={this.getLegendData()} />}
           legendPosition="bottom"
           padding={{
@@ -624,6 +630,7 @@ class TooltipPieChart extends React.Component {
           constrainToVisibleArea
           data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
           height={275}
+          idPrefix="chart7"
           labels={({ datum }) => `${datum.x}: ${datum.y}`}
           legendComponent={this.getLegend([
             { name: 'Cats: 35' }, 
@@ -690,6 +697,7 @@ class LegendLinkPieChart extends React.Component {
           legendData={[{ name: 'Cats' }, { name: 'Dogs', symbol: { type: 'dash' } }, { name: 'Birds' }, { name: 'Mice' }]}
           legendPosition="bottom"
           height={275}
+          idPrefix="chart8"
           maxDomain={{y: 10}}
           minDomain={{y: 0}}
           padding={{
@@ -791,6 +799,7 @@ class LegendLayoutPieChart extends React.Component {
           constrainToVisibleArea
           data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
           height={230}
+          idPrefix="chart9"
           labels={({ datum }) => `${datum.x}: ${datum.y}`}
           legendComponent={this.getLegend([
             { name: 'Cats' }, 

--- a/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
+++ b/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
@@ -62,11 +62,11 @@ import { ChartDonut } from '@patternfly/react-charts';
     ariaTitle="Donut chart example"
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-    idPrefix="chart1"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
     legendPosition="right"
+    name="chart1"
     padding={{
       bottom: 20,
       left: 20,
@@ -94,7 +94,7 @@ import { Chart, ChartAxis, ChartBar, ChartGroup, ChartThemeColor, ChartVoronoiCo
     legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
     legendPosition="bottom"
     height={275}
-    idPrefix="chart2"
+    name="chart2"
     padding={{
       bottom: 75, // Adjusted to accommodate legend
       left: 50,
@@ -160,11 +160,11 @@ class BulletChart extends React.Component {
             comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
             constrainToVisibleArea
             height={250}
-            idPrefix="chart3"
             labels={({ datum }) => `${datum.name}: ${datum.y}`}
             legendAllowWrap
             legendPosition="bottom-left"
             maxDomain={{y: 100}}
+            name="chart3"
             padding={{
               bottom: 50,
               left: 50,
@@ -201,9 +201,9 @@ import { Chart, ChartAxis, ChartGroup, ChartLegend, ChartLine, ChartThemeColor, 
     ariaTitle="Line chart example"
     containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
     height={275}
-    idPrefix="chart4"
     maxDomain={{y: 10}}
     minDomain={{y: 0}}
+    name="chart4"
     padding={{
       bottom: 75, // Adjusted to accommodate legend
       left: 50,
@@ -336,7 +336,7 @@ class InteractiveLegendChart extends React.Component {
     this.getEvents = () => getInteractiveLegendEvents({
       chartNames: this.getChartNames(),
       isHidden: this.isHidden,
-      legendName: 'legend',
+      legendName: 'chart5-ChartLegend',
       onLegendClick: this.handleLegendClick
     });
 
@@ -427,9 +427,9 @@ class InteractiveLegendChart extends React.Component {
             containerComponent={container}
             events={this.getEvents()}
             height={225}
-            idPrefix="chart5"
-            legendComponent={<ChartLegend name={'legend'} data={this.getLegendData()} />}
+            legendComponent={<ChartLegend name={'chart5-ChartLegend'} data={this.getLegendData()} />}
             legendPosition="bottom-left"
+            name="chart5"
             padding={{
               bottom: 75, // Adjusted to accommodate legend
               left: 50,
@@ -521,7 +521,7 @@ class InteractivePieLegendChart extends React.Component {
     this.getEvents = () => getInteractiveLegendEvents({
       chartNames: this.getChartNames(),
       isHidden: this.isHidden,
-      legendName: 'legend',
+      legendName: 'chart6-ChartLegend',
       onLegendClick: this.handleLegendClick
     });
 
@@ -566,9 +566,9 @@ class InteractivePieLegendChart extends React.Component {
           ariaTitle="Pie chart example"
           events={this.getEvents()}
           height={275}
-          idPrefix="chart6"
-          legendComponent={<ChartLegend name={'legend'} data={this.getLegendData()} />}
+          legendComponent={<ChartLegend name={'chart6-ChartLegend'} data={this.getLegendData()} />}
           legendPosition="bottom"
+          name="chart6"
           padding={{
             bottom: 65,
             left: 20,
@@ -630,7 +630,6 @@ class TooltipPieChart extends React.Component {
           constrainToVisibleArea
           data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
           height={275}
-          idPrefix="chart7"
           labels={({ datum }) => `${datum.x}: ${datum.y}`}
           legendComponent={this.getLegend([
             { name: 'Cats: 35' }, 
@@ -638,6 +637,7 @@ class TooltipPieChart extends React.Component {
             { name: 'Birds: 10' }
           ])}
           legendPosition="bottom"
+          name="chart7"
           padding={{
             bottom: 65,
             left: 20,
@@ -697,9 +697,9 @@ class LegendLinkPieChart extends React.Component {
           legendData={[{ name: 'Cats' }, { name: 'Dogs', symbol: { type: 'dash' } }, { name: 'Birds' }, { name: 'Mice' }]}
           legendPosition="bottom"
           height={275}
-          idPrefix="chart8"
           maxDomain={{y: 10}}
           minDomain={{y: 0}}
+          name="chart8"
           padding={{
             bottom: 75, // Adjusted to accommodate legend
             left: 50,
@@ -792,14 +792,13 @@ class LegendLayoutPieChart extends React.Component {
 
   render() {
     return (
-      <div style={{ height: '230px', width: '350px' }}>
+      <div style={{ height: '230px', width: '375px' }}>
         <ChartDonut
           ariaDesc="Average number of pets"
           ariaTitle="Pie chart example"
           constrainToVisibleArea
           data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
           height={230}
-          idPrefix="chart9"
           labels={({ datum }) => `${datum.x}: ${datum.y}`}
           legendComponent={this.getLegend([
             { name: 'Cats' }, 
@@ -808,6 +807,7 @@ class LegendLayoutPieChart extends React.Component {
           ], [ 35, 55, 10 ])}
           legendOrientation="vertical"
           legendPosition="right"
+          name="chart9"
           padding={{
             bottom: 20,
             left: 20,
@@ -817,7 +817,7 @@ class LegendLayoutPieChart extends React.Component {
           subTitle="Pets"
           title="100"
           themeColor={ChartThemeColor.multiOrdered}
-          width={350}
+          width={375}
         />
       </div>
     );

--- a/packages/react-charts/src/components/ChartLine/examples/ChartLine.md
+++ b/packages/react-charts/src/components/ChartLine/examples/ChartLine.md
@@ -38,6 +38,7 @@ import { Chart, ChartAxis, ChartGroup, ChartLine, ChartVoronoiContainer } from '
     legendOrientation="vertical"
     legendPosition="right"
     height={250}
+    idPrefix="chart1"
     maxDomain={{y: 10}}
     minDomain={{y: 0}}
     padding={{
@@ -125,6 +126,7 @@ class BottomAlignedLegend extends React.Component {
           legendData={legendData}
           legendPosition="bottom"
           height={275}
+          idPrefix="chart2"
           maxDomain={{y: 10}}
           minDomain={{y: 0}}
           padding={{
@@ -234,6 +236,7 @@ class MultiColorChart extends React.Component {
             legendData={[{ name: 'Cats' }, { name: 'Dogs', symbol: { type: 'dash' } }, { name: 'Birds' }, { name: 'Mice' }]}
             legendPosition="bottom-left"
             height={275}
+            idPrefix="chart3"
             maxDomain={{y: 10}}
             minDomain={{y: 0}}
             padding={{

--- a/packages/react-charts/src/components/ChartLine/examples/ChartLine.md
+++ b/packages/react-charts/src/components/ChartLine/examples/ChartLine.md
@@ -38,9 +38,9 @@ import { Chart, ChartAxis, ChartGroup, ChartLine, ChartVoronoiContainer } from '
     legendOrientation="vertical"
     legendPosition="right"
     height={250}
-    idPrefix="chart1"
     maxDomain={{y: 10}}
     minDomain={{y: 0}}
+    name="chart1"
     padding={{
       bottom: 50,
       left: 50,
@@ -126,9 +126,9 @@ class BottomAlignedLegend extends React.Component {
           legendData={legendData}
           legendPosition="bottom"
           height={275}
-          idPrefix="chart2"
           maxDomain={{y: 10}}
           minDomain={{y: 0}}
+          name="chart2"
           padding={{
             bottom: 75, // Adjusted to accommodate legend
             left: 50,
@@ -236,9 +236,9 @@ class MultiColorChart extends React.Component {
             legendData={[{ name: 'Cats' }, { name: 'Dogs', symbol: { type: 'dash' } }, { name: 'Birds' }, { name: 'Mice' }]}
             legendPosition="bottom-left"
             height={275}
-            idPrefix="chart3"
             maxDomain={{y: 10}}
             minDomain={{y: 0}}
+            name="chart3"
             padding={{
               bottom: 75, // Adjusted to accommodate legend
               left: 50,

--- a/packages/react-charts/src/components/ChartPie/ChartPie.tsx
+++ b/packages/react-charts/src/components/ChartPie/ChartPie.tsx
@@ -248,14 +248,6 @@ export interface ChartPieProps extends VictoryPieProps {
    */
   height?: number;
   /**
-   * This prop specifies an ID prefix that will be applied to child text elements. This is only necessary when
-   * multiple charts appear in a page, ensuring unique IDs for each chart.
-   *
-   * Note: This should not be confused with a container's containerId prop.
-   * See https://formidable.com/open-source/victory/docs/common-container-props#containerid
-   */
-  idPrefix?: string;
-  /**
    * When creating a donut chart, this prop determines the number of pixels between
    * the center of the chart and the inner edge. When this prop is set to zero
    * a regular pie chart is rendered.
@@ -346,7 +338,9 @@ export interface ChartPieProps extends VictoryPieProps {
    */
   legendPosition?: 'bottom' | 'right';
   /**
-   * The name prop is used to reference a component instance when defining shared events.
+   * The name prop is typically used to reference a component instance when defining shared events. However, this
+   * optional prop may also be applied to child elements as an ID prefix. This is a workaround to ensure Victory
+   * based components output unique IDs when multiple charts appear in a page.
    */
   name?: string;
   /**
@@ -513,11 +507,11 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
   constrainToVisibleArea = false,
   containerComponent = <ChartContainer />,
   hasPatterns,
-  idPrefix,
   legendAllowWrap = false,
   legendComponent = <ChartLegend />,
   legendData,
   legendPosition = ChartCommonStyles.legend.position as ChartPieLegendPosition,
+  name,
   patternScale,
   patternUnshiftIndex,
 
@@ -601,7 +595,7 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
   const legend = React.cloneElement(legendComponent, {
     colorScale,
     data: legendData,
-    ...(idPrefix && { idPrefix: `${idPrefix}-${(legendComponent as any).type.displayName}` }),
+    ...(name && { name: `${name}-${(legendComponent as any).type.displayName}` }),
     key: 'pf-chart-pie-legend',
     orientation: legendOrientation,
     theme,

--- a/packages/react-charts/src/components/ChartPie/ChartPie.tsx
+++ b/packages/react-charts/src/components/ChartPie/ChartPie.tsx
@@ -248,6 +248,11 @@ export interface ChartPieProps extends VictoryPieProps {
    */
   height?: number;
   /**
+   * This prop specifies an ID that will be applied to child text elements, assisting with
+   * accessibility for screen readers.
+   */
+  id?: string;
+  /**
    * When creating a donut chart, this prop determines the number of pixels between
    * the center of the chart and the inner edge. When this prop is set to zero
    * a regular pie chart is rendered.
@@ -505,6 +510,7 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
   constrainToVisibleArea = false,
   containerComponent = <ChartContainer />,
   hasPatterns,
+  id,
   legendAllowWrap = false,
   legendComponent = <ChartLegend />,
   legendData,
@@ -592,6 +598,7 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
   const legend = React.cloneElement(legendComponent, {
     colorScale,
     data: legendData,
+    ...(id && { id: `${id}-${(legendComponent as any).type.displayName}` }),
     key: 'pf-chart-pie-legend',
     orientation: legendOrientation,
     theme,

--- a/packages/react-charts/src/components/ChartPie/ChartPie.tsx
+++ b/packages/react-charts/src/components/ChartPie/ChartPie.tsx
@@ -248,10 +248,13 @@ export interface ChartPieProps extends VictoryPieProps {
    */
   height?: number;
   /**
-   * This prop specifies an ID that will be applied to child text elements, assisting with
-   * accessibility for screen readers.
+   * This prop specifies an ID prefix that will be applied to child text elements. This is only necessary when
+   * multiple charts appear in a page, ensuring unique IDs for each chart.
+   *
+   * Note: This should not be confused with a container's containerId prop.
+   * See https://formidable.com/open-source/victory/docs/common-container-props#containerid
    */
-  id?: string;
+  idPrefix?: string;
   /**
    * When creating a donut chart, this prop determines the number of pixels between
    * the center of the chart and the inner edge. When this prop is set to zero
@@ -510,7 +513,7 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
   constrainToVisibleArea = false,
   containerComponent = <ChartContainer />,
   hasPatterns,
-  id,
+  idPrefix,
   legendAllowWrap = false,
   legendComponent = <ChartLegend />,
   legendData,
@@ -598,7 +601,7 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
   const legend = React.cloneElement(legendComponent, {
     colorScale,
     data: legendData,
-    ...(id && { id: `${id}-${(legendComponent as any).type.displayName}` }),
+    ...(idPrefix && { idPrefix: `${idPrefix}-${(legendComponent as any).type.displayName}` }),
     key: 'pf-chart-pie-legend',
     orientation: legendOrientation,
     theme,

--- a/packages/react-charts/src/components/ChartPie/examples/ChartPie.md
+++ b/packages/react-charts/src/components/ChartPie/examples/ChartPie.md
@@ -29,11 +29,11 @@ import { ChartPie } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={230}
-    idPrefix="chart1"
     labels={({ datum }) => `${datum.x}: ${datum.y}`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
     legendPosition="right"
+    name="chart1"
     padding={{
       bottom: 20,
       left: 20,
@@ -57,11 +57,11 @@ import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={230}
-    idPrefix="chart2"
     labels={({ datum }) => `${datum.x}: ${datum.y}`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
     legendPosition="right"
+    name="chart2"
     padding={{
       bottom: 20,
       left: 20,
@@ -86,10 +86,10 @@ import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={275}
-    idPrefix="chart3"
     labels={({ datum }) => `${datum.x}: ${datum.y}`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendPosition="bottom"
+    name="chart3"
     padding={{
       bottom: 65,
       left: 20,

--- a/packages/react-charts/src/components/ChartPie/examples/ChartPie.md
+++ b/packages/react-charts/src/components/ChartPie/examples/ChartPie.md
@@ -29,6 +29,7 @@ import { ChartPie } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={230}
+    id="chart1"
     labels={({ datum }) => `${datum.x}: ${datum.y}`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
@@ -56,6 +57,7 @@ import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={230}
+    id="chart2"
     labels={({ datum }) => `${datum.x}: ${datum.y}`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
@@ -84,6 +86,7 @@ import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={275}
+    id="chart3"
     labels={({ datum }) => `${datum.x}: ${datum.y}`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendPosition="bottom"

--- a/packages/react-charts/src/components/ChartPie/examples/ChartPie.md
+++ b/packages/react-charts/src/components/ChartPie/examples/ChartPie.md
@@ -29,7 +29,7 @@ import { ChartPie } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={230}
-    id="chart1"
+    idPrefix="chart1"
     labels={({ datum }) => `${datum.x}: ${datum.y}`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
@@ -57,7 +57,7 @@ import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={230}
-    id="chart2"
+    idPrefix="chart2"
     labels={({ datum }) => `${datum.x}: ${datum.y}`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
@@ -86,7 +86,7 @@ import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={275}
-    id="chart3"
+    idPrefix="chart3"
     labels={({ datum }) => `${datum.x}: ${datum.y}`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendPosition="bottom"

--- a/packages/react-charts/src/components/ChartScatter/examples/ChartScatter.md
+++ b/packages/react-charts/src/components/ChartScatter/examples/ChartScatter.md
@@ -47,6 +47,7 @@ import { Chart, ChartAxis, ChartGroup, ChartScatter, ChartVoronoiContainer } fro
       />
     }
     height={275}
+    idPrefix="chart1"
     maxDomain={{y: 8}}
     minDomain={{y: 0}}
     width={450}
@@ -160,6 +161,7 @@ class ScatterLineChart extends React.Component {
             legendData={this.series.map(s => s.legendItem)}
             legendPosition="bottom-left"
             height={275}
+            idPrefix="chart2"
             maxDomain={{y: 10}}
             minDomain={{y: 0}}
             padding={{
@@ -283,6 +285,7 @@ class ScatterAreaChart extends React.Component {
               />
             }
             height={225}
+            idPrefix="chart3"
             legendData={this.series.map(s => s.legendItem)}
             legendPosition="bottom-left"
             padding={{

--- a/packages/react-charts/src/components/ChartScatter/examples/ChartScatter.md
+++ b/packages/react-charts/src/components/ChartScatter/examples/ChartScatter.md
@@ -47,9 +47,9 @@ import { Chart, ChartAxis, ChartGroup, ChartScatter, ChartVoronoiContainer } fro
       />
     }
     height={275}
-    idPrefix="chart1"
     maxDomain={{y: 8}}
     minDomain={{y: 0}}
+    name="chart1"
     width={450}
   >
     <ChartAxis />
@@ -130,7 +130,7 @@ class ScatterLineChart extends React.Component {
         { name: 'Mice', x: '2017', y: 8 },
         { name: 'Mice', x: '2018', y: 7 }
       ],
-      legendItem: { name: 'Birds' }
+      legendItem: { name: 'Mice' }
     }];
   }
 
@@ -161,9 +161,9 @@ class ScatterLineChart extends React.Component {
             legendData={this.series.map(s => s.legendItem)}
             legendPosition="bottom-left"
             height={275}
-            idPrefix="chart2"
             maxDomain={{y: 10}}
             minDomain={{y: 0}}
+            name="chart2"
             padding={{
               bottom: 75, // Adjusted to accommodate legend
               left: 50,
@@ -285,9 +285,9 @@ class ScatterAreaChart extends React.Component {
               />
             }
             height={225}
-            idPrefix="chart3"
             legendData={this.series.map(s => s.legendItem)}
             legendPosition="bottom-left"
+            name="chart3"
             padding={{
               bottom: 75, // Adjusted to accommodate legend
               left: 50,

--- a/packages/react-charts/src/components/ChartStack/examples/ChartStack.md
+++ b/packages/react-charts/src/components/ChartStack/examples/ChartStack.md
@@ -50,6 +50,7 @@ import { Chart, ChartAxis, ChartBar, ChartStack, ChartVoronoiContainer } from '@
     legendOrientation="vertical"
     legendPosition="right"
     height={250}
+    idPrefix="chart1"
     padding={{
       bottom: 50,
       left: 50,
@@ -84,6 +85,7 @@ import { Chart, ChartAxis, ChartBar, ChartStack, ChartThemeColor, ChartVoronoiCo
     legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
     legendPosition="bottom"
     height={275}
+    idPrefix="chart2"
     padding={{
       bottom: 75, // Adjusted to accommodate legend
       left: 50,
@@ -121,6 +123,7 @@ import { Chart, ChartBar, ChartAxis, ChartStack, ChartThemeColor, ChartTooltip }
     legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
     legendPosition="bottom-left"
     height={275}
+    idPrefix="chart3"
     padding={{
       bottom: 75, // Adjusted to accommodate legend
       left: 50,
@@ -268,6 +271,7 @@ class MonthlyResponsiveStack extends React.Component {
             legendData={[{ name: 'Sockets' }, { name: 'Cores' }, { name: 'Nodes' }]}
             legendPosition="bottom"
             height={225}
+            idPrefix="chart4"
             padding={{
               bottom: 75, // Adjusted to accommodate legend
               left: 50,
@@ -349,6 +353,7 @@ class MultiColorChart extends React.Component {
             legendData={legendData}
             legendPosition="bottom-left"
             height={225}
+            idPrefix="chart5"
             padding={{
               bottom: 75, // Adjusted to accomodate legend
               left: 50,

--- a/packages/react-charts/src/components/ChartStack/examples/ChartStack.md
+++ b/packages/react-charts/src/components/ChartStack/examples/ChartStack.md
@@ -50,7 +50,7 @@ import { Chart, ChartAxis, ChartBar, ChartStack, ChartVoronoiContainer } from '@
     legendOrientation="vertical"
     legendPosition="right"
     height={250}
-    idPrefix="chart1"
+    name="chart1"
     padding={{
       bottom: 50,
       left: 50,
@@ -85,7 +85,7 @@ import { Chart, ChartAxis, ChartBar, ChartStack, ChartThemeColor, ChartVoronoiCo
     legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
     legendPosition="bottom"
     height={275}
-    idPrefix="chart2"
+    name="chart2"
     padding={{
       bottom: 75, // Adjusted to accommodate legend
       left: 50,
@@ -123,7 +123,7 @@ import { Chart, ChartBar, ChartAxis, ChartStack, ChartThemeColor, ChartTooltip }
     legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
     legendPosition="bottom-left"
     height={275}
-    idPrefix="chart3"
+    name="chart3"
     padding={{
       bottom: 75, // Adjusted to accommodate legend
       left: 50,
@@ -271,7 +271,7 @@ class MonthlyResponsiveStack extends React.Component {
             legendData={[{ name: 'Sockets' }, { name: 'Cores' }, { name: 'Nodes' }]}
             legendPosition="bottom"
             height={225}
-            idPrefix="chart4"
+            name="chart4"
             padding={{
               bottom: 75, // Adjusted to accommodate legend
               left: 50,
@@ -353,7 +353,7 @@ class MultiColorChart extends React.Component {
             legendData={legendData}
             legendPosition="bottom-left"
             height={225}
-            idPrefix="chart5"
+            name="chart5"
             padding={{
               bottom: 75, // Adjusted to accomodate legend
               left: 50,

--- a/packages/react-charts/src/components/ChartTheme/examples/ChartTheme.md
+++ b/packages/react-charts/src/components/ChartTheme/examples/ChartTheme.md
@@ -48,6 +48,7 @@ import { Chart, ChartAxis, ChartGroup, ChartLine, ChartThemeColor, ChartVoronoiC
     legendData={[{ name: 'Cats' }, { name: 'Dogs', symbol: { type: 'dash' } }, { name: 'Birds' }, { name: 'Mice' }]}
     legendPosition="bottom"
     height={275}
+    idPrefix="chart1"
     maxDomain={{y: 10}}
     minDomain={{y: 0}}
     padding={{
@@ -118,6 +119,7 @@ import { ChartDonut, ChartThemeColor } from '@patternfly/react-charts';
     ariaTitle="Donut chart example"
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
+    idPrefix="chart2"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
@@ -150,6 +152,7 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartVoronoiContainer } from '
     ariaDesc="Average number of pets"
     ariaTitle="Area chart example"
     containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
+    idPrefix="chart3"
     legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }]}
     legendOrientation="vertical"
     legendPosition="right"
@@ -242,6 +245,7 @@ import chart_color_purple_300 from '@patternfly/react-tokens/dist/esm/chart_colo
     }
     legendPosition="bottom-left"
     height={275}
+    idPrefix="chart4"
     padding={{
       bottom: 75, // Adjusted to accommodate legend
       left: 50,
@@ -317,6 +321,7 @@ import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_
     ariaDesc="Average number of pets"
     ariaTitle="Line chart example"
     containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
+    idPrefix="chart5"
     legendData={[
       { name: 'Cats' },
       { name: 'Birds' },
@@ -451,6 +456,7 @@ class MultiColorChart extends React.Component {
           containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
           domain={{y: [0,9]}}
           domainPadding={{ x: [30, 25] }}
+          idPrefix="chart6"
           legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
           legendOrientation="vertical"
           legendPosition="right"

--- a/packages/react-charts/src/components/ChartTheme/examples/ChartTheme.md
+++ b/packages/react-charts/src/components/ChartTheme/examples/ChartTheme.md
@@ -48,9 +48,9 @@ import { Chart, ChartAxis, ChartGroup, ChartLine, ChartThemeColor, ChartVoronoiC
     legendData={[{ name: 'Cats' }, { name: 'Dogs', symbol: { type: 'dash' } }, { name: 'Birds' }, { name: 'Mice' }]}
     legendPosition="bottom"
     height={275}
-    idPrefix="chart1"
     maxDomain={{y: 10}}
     minDomain={{y: 0}}
+    name="chart1"
     padding={{
       bottom: 75, // Adjusted to accommodate legend
       left: 50,
@@ -119,11 +119,11 @@ import { ChartDonut, ChartThemeColor } from '@patternfly/react-charts';
     ariaTitle="Donut chart example"
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-    idPrefix="chart2"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
     legendPosition="right"
+    name="chart2"
     padding={{
       bottom: 20,
       left: 20,
@@ -152,12 +152,12 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartVoronoiContainer } from '
     ariaDesc="Average number of pets"
     ariaTitle="Area chart example"
     containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
-    idPrefix="chart3"
     legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }]}
     legendOrientation="vertical"
     legendPosition="right"
     height={200}
     maxDomain={{y: 9}}
+    name="chart3"
     padding={{
       bottom: 50,
       left: 50,
@@ -245,7 +245,7 @@ import chart_color_purple_300 from '@patternfly/react-tokens/dist/esm/chart_colo
     }
     legendPosition="bottom-left"
     height={275}
-    idPrefix="chart4"
+    name="chart4"
     padding={{
       bottom: 75, // Adjusted to accommodate legend
       left: 50,
@@ -321,7 +321,6 @@ import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_
     ariaDesc="Average number of pets"
     ariaTitle="Line chart example"
     containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
-    idPrefix="chart5"
     legendData={[
       { name: 'Cats' },
       { name: 'Birds' },
@@ -332,6 +331,7 @@ import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_
     height={275}
     maxDomain={{y: 10}}
     minDomain={{y: 0}}
+    name="chart5"
     padding={{
       bottom: 75, // Adjusted to accommodate legend
       left: 50,
@@ -456,11 +456,11 @@ class MultiColorChart extends React.Component {
           containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
           domain={{y: [0,9]}}
           domainPadding={{ x: [30, 25] }}
-          idPrefix="chart6"
           legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
           legendOrientation="vertical"
           legendPosition="right"
           height={250}
+          name="chart6"
           theme={this.myCustomTheme}
           width={600}
         >

--- a/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
+++ b/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
@@ -58,6 +58,7 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartVoronoiContainer } from '
     legendOrientation="vertical"
     legendPosition="right"
     height={200}
+    idPrefix="chart1"
     maxDomain={{y: 9}}
     padding={{
       bottom: 50,
@@ -134,6 +135,7 @@ class CombinedCursorVoronoiContainer extends React.Component {
           legendData={[{ name: 'Cats' }, { name: 'Dogs', symbol: { type: 'dash' } }, { name: 'Birds' }, { name: 'Mice' }]}
           legendPosition="bottom"
           height={275}
+          idPrefix="chart2"
           maxDomain={{y: 10}}
           minDomain={{y: 0}}
           padding={{
@@ -222,6 +224,7 @@ class EmbeddedLegend extends React.Component {
               voronoiPadding={50}
             />
           }
+          idPrefix="chart3"
           legendData={legendData}
           legendPosition="bottom"
           height={275}
@@ -367,6 +370,7 @@ class EmbeddedHtml extends React.Component {
               voronoiPadding={50}
             />
           }
+          idPrefix="chart4"
           legendData={legendData}
           legendPosition="bottom-left"
           height={225}
@@ -453,6 +457,7 @@ class EmbeddedLegendAlt extends React.Component {
               voronoiPadding={50}
             />
           }
+          idPrefix="chart5"
           legendData={legendData}
           legendPosition="bottom"
           height={275}
@@ -535,6 +540,7 @@ import { Chart, ChartAxis, ChartBar, ChartStack, ChartThemeColor, ChartTooltip }
     legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
     legendPosition="bottom-left"
     height={275}
+    idPrefix="chart6"
     padding={{
       bottom: 75, // Adjusted to accommodate legend
       left: 50,
@@ -626,6 +632,7 @@ class TooltipPieChart extends React.Component {
           constrainToVisibleArea
           data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
           height={275}
+          idPrefix="chart7"
           labels={({ datum }) => `${datum.x}: ${datum.y}`}
           legendComponent={this.getLegend([
             { name: 'Cats: 35' }, 
@@ -689,6 +696,7 @@ class TooltipThemeChart extends React.Component {
           legendOrientation="vertical"
           legendPosition="right"
           height={250}
+          idPrefix="chart8"
           maxDomain={{y: 10}}
           minDomain={{y: 0}}
           padding={{
@@ -763,6 +771,7 @@ import { ChartArea, ChartContainer, ChartGroup, ChartLabel, ChartThemeColor, Cha
       ariaTitle="CSS overflow example chart title"
       containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} />}
       height={100}
+      idPrefix="chart9"
       maxDomain={{y: 9}}
       padding={0}
       themeColor={ChartThemeColor.green}
@@ -816,6 +825,7 @@ class TooltipChart extends React.Component {
               ariaDesc="Storage capacity  - possibly more information to summarize the data in the chart."
               ariaTitle="Wrapped example chart title"
               data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
+              idPrefix="chart10"
               labels={() => null}
             >
               <ChartDonutUtilization

--- a/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
+++ b/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
@@ -58,8 +58,8 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartVoronoiContainer } from '
     legendOrientation="vertical"
     legendPosition="right"
     height={200}
-    idPrefix="chart1"
     maxDomain={{y: 9}}
+    name="chart1"
     padding={{
       bottom: 50,
       left: 50,
@@ -135,9 +135,9 @@ class CombinedCursorVoronoiContainer extends React.Component {
           legendData={[{ name: 'Cats' }, { name: 'Dogs', symbol: { type: 'dash' } }, { name: 'Birds' }, { name: 'Mice' }]}
           legendPosition="bottom"
           height={275}
-          idPrefix="chart2"
           maxDomain={{y: 10}}
           minDomain={{y: 0}}
+          name="chart2"
           padding={{
             bottom: 75, // Adjusted to accommodate legend
             left: 50,
@@ -224,12 +224,12 @@ class EmbeddedLegend extends React.Component {
               voronoiPadding={50}
             />
           }
-          idPrefix="chart3"
           legendData={legendData}
           legendPosition="bottom"
           height={275}
           maxDomain={{y: 10}}
           minDomain={{y: 0}}
+          name="chart3"
           padding={{
             bottom: 75, // Adjusted to accommodate legend
             left: 50,
@@ -370,10 +370,10 @@ class EmbeddedHtml extends React.Component {
               voronoiPadding={50}
             />
           }
-          idPrefix="chart4"
           legendData={legendData}
           legendPosition="bottom-left"
           height={225}
+          name="chart4"
           padding={{
             bottom: 75, // Adjusted to accommodate legend
             left: 50,
@@ -457,12 +457,12 @@ class EmbeddedLegendAlt extends React.Component {
               voronoiPadding={50}
             />
           }
-          idPrefix="chart5"
           legendData={legendData}
           legendPosition="bottom"
           height={275}
           maxDomain={{y: 10}}
           minDomain={{y: 0}}
+          name="chart5"
           padding={{
             bottom: 75, // Adjusted to accommodate legend
             left: 50,
@@ -540,7 +540,7 @@ import { Chart, ChartAxis, ChartBar, ChartStack, ChartThemeColor, ChartTooltip }
     legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
     legendPosition="bottom-left"
     height={275}
-    idPrefix="chart6"
+    name="chart6"
     padding={{
       bottom: 75, // Adjusted to accommodate legend
       left: 50,
@@ -632,7 +632,6 @@ class TooltipPieChart extends React.Component {
           constrainToVisibleArea
           data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
           height={275}
-          idPrefix="chart7"
           labels={({ datum }) => `${datum.x}: ${datum.y}`}
           legendComponent={this.getLegend([
             { name: 'Cats: 35' }, 
@@ -640,6 +639,7 @@ class TooltipPieChart extends React.Component {
             { name: 'Birds: 10' }
           ])}
           legendPosition="bottom"
+          name="chart7"
           padding={{
             bottom: 65,
             left: 20,
@@ -696,9 +696,9 @@ class TooltipThemeChart extends React.Component {
           legendOrientation="vertical"
           legendPosition="right"
           height={250}
-          idPrefix="chart8"
           maxDomain={{y: 10}}
           minDomain={{y: 0}}
+          name="chart8"
           padding={{
             bottom: 50,
             left: 50,
@@ -771,8 +771,8 @@ import { ChartArea, ChartContainer, ChartGroup, ChartLabel, ChartThemeColor, Cha
       ariaTitle="CSS overflow example chart title"
       containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} />}
       height={100}
-      idPrefix="chart9"
       maxDomain={{y: 9}}
+      name="chart9"
       padding={0}
       themeColor={ChartThemeColor.green}
       width={400}
@@ -825,8 +825,8 @@ class TooltipChart extends React.Component {
               ariaDesc="Storage capacity  - possibly more information to summarize the data in the chart."
               ariaTitle="Wrapped example chart title"
               data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
-              idPrefix="chart10"
               labels={() => null}
+              name="chart10"
             >
               <ChartDonutUtilization
                 allowTooltip={false}

--- a/packages/react-charts/src/components/Patterns/examples/patterms.md
+++ b/packages/react-charts/src/components/Patterns/examples/patterms.md
@@ -68,6 +68,7 @@ import { ChartPie } from '@patternfly/react-charts';
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     hasPatterns
     height={230}
+    idPrefix="chart1"
     labels={({ datum }) => `${datum.x}: ${datum.y}`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
@@ -98,6 +99,7 @@ import { Chart, ChartAxis, ChartBar, ChartGroup, ChartThemeColor, ChartVoronoiCo
     legendPosition="bottom"
     hasPatterns
     height={275}
+    idPrefix="chart2"
     padding={{
       bottom: 75, // Adjusted to accommodate legend
       left: 50,
@@ -135,6 +137,7 @@ import { Chart, ChartAxis, ChartBar, ChartStack, ChartThemeColor, ChartVoronoiCo
     legendPosition="right"
     hasPatterns
     height={250}
+    idPrefix="chart3"
     padding={{
       bottom: 50,
       left: 50,
@@ -168,6 +171,7 @@ import { ChartDonut, ChartThemeColor } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     hasPatterns
+    idPrefix="chart4"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
@@ -202,6 +206,7 @@ import { ChartDonutUtilization, ChartThemeColor } from '@patternfly/react-charts
     data={{ x: 'Storage capacity', y: 45 }}
     hasPatterns
     height={275}
+    idPrefix="chart5"
     labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
     legendData={[{ name: `Storage capacity: 45%` }, { name: 'Unused' }]}
     legendPosition="bottom"
@@ -236,6 +241,7 @@ import { ChartDonutThreshold, ChartDonutUtilization, ChartThemeColor } from '@pa
     data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
     hasPatterns
     height={275}
+    idPrefix="chart6"
     labels={({ datum }) => datum.x ? datum.x : null}
     padding={{
       bottom: 65, // Adjusted to accommodate legend
@@ -351,6 +357,7 @@ class InteractivePieLegendChart extends React.Component {
           events={this.getEvents()}
           hasPatterns
           height={275}
+          idPrefix="chart7"
           legendComponent={<ChartLegend name={'legend'} data={this.getLegendData()} />}
           legendPosition="bottom"
           padding={{
@@ -541,6 +548,7 @@ class InteractiveLegendChart extends React.Component {
             events={this.getEvents()}
             hasPatterns
             height={225}
+            idPrefix="chart8"
             legendComponent={<ChartLegend name={'legend'} data={this.getLegendData()} />}
             legendPosition="bottom-left"
             padding={{
@@ -603,6 +611,7 @@ import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
     data={[{ x: 'Cats', y: 15 }, { x: 'Dogs', y: 15 }, { x: 'Birds', y: 15 }, { x: 'Fish', y: 25 }, { x: 'Rabbits', y: 30 }]}
     hasPatterns={[ true, true, false, false, false ]}
     height={230}
+    idPrefix="chart9"
     labels={({ datum }) => `${datum.x}: ${datum.y}`}
     legendData={[{ name: 'Cats: 15' }, { name: 'Dogs: 15' }, { name: 'Birds: 15' }, { name: 'Fish: 25' }, { name: 'Rabbits: 30' }]}
     legendOrientation="vertical"
@@ -639,6 +648,7 @@ import chart_color_green_300 from '@patternfly/react-tokens/dist/esm/chart_color
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     hasPatterns={[ true, true, false ]}
     height={230}
+    idPrefix="chart10"
     labels={({ datum }) => `${datum.x}: ${datum.y}`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
@@ -681,6 +691,7 @@ import chart_color_green_300 from '@patternfly/react-tokens/dist/esm/chart_color
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={230}
+    idPrefix="chart11"
     labels={({ datum }) => `${datum.x}: ${datum.y}`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
@@ -727,6 +738,7 @@ import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
     ]}
     hasPatterns
     height={325}
+    idPrefix="chart12"
     labels={({ datum }) => `${datum.x}: ${datum.y}`}
     legendData={[
       { name: 'Cats: 6' },

--- a/packages/react-charts/src/components/Patterns/examples/patterms.md
+++ b/packages/react-charts/src/components/Patterns/examples/patterms.md
@@ -68,11 +68,11 @@ import { ChartPie } from '@patternfly/react-charts';
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     hasPatterns
     height={230}
-    idPrefix="chart1"
     labels={({ datum }) => `${datum.x}: ${datum.y}`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
     legendPosition="right"
+    name="chart1"
     padding={{
       bottom: 20,
       left: 20,
@@ -99,7 +99,7 @@ import { Chart, ChartAxis, ChartBar, ChartGroup, ChartThemeColor, ChartVoronoiCo
     legendPosition="bottom"
     hasPatterns
     height={275}
-    idPrefix="chart2"
+    name="chart2"
     padding={{
       bottom: 75, // Adjusted to accommodate legend
       left: 50,
@@ -137,7 +137,7 @@ import { Chart, ChartAxis, ChartBar, ChartStack, ChartThemeColor, ChartVoronoiCo
     legendPosition="right"
     hasPatterns
     height={250}
-    idPrefix="chart3"
+    name="chart3"
     padding={{
       bottom: 50,
       left: 50,
@@ -171,11 +171,11 @@ import { ChartDonut, ChartThemeColor } from '@patternfly/react-charts';
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     hasPatterns
-    idPrefix="chart4"
     labels={({ datum }) => `${datum.x}: ${datum.y}%`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
     legendPosition="right"
+    name="chart4"
     padding={{
       bottom: 20,
       left: 20,
@@ -206,10 +206,10 @@ import { ChartDonutUtilization, ChartThemeColor } from '@patternfly/react-charts
     data={{ x: 'Storage capacity', y: 45 }}
     hasPatterns
     height={275}
-    idPrefix="chart5"
     labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
     legendData={[{ name: `Storage capacity: 45%` }, { name: 'Unused' }]}
     legendPosition="bottom"
+    name="chart5"
     padding={{
       bottom: 65, // Adjusted to accommodate legend
       left: 20,
@@ -241,8 +241,8 @@ import { ChartDonutThreshold, ChartDonutUtilization, ChartThemeColor } from '@pa
     data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
     hasPatterns
     height={275}
-    idPrefix="chart6"
     labels={({ datum }) => datum.x ? datum.x : null}
+    name="chart6"
     padding={{
       bottom: 65, // Adjusted to accommodate legend
       left: 20,
@@ -311,7 +311,7 @@ class InteractivePieLegendChart extends React.Component {
     this.getEvents = () => getInteractiveLegendEvents({
       chartNames: this.getChartNames(),
       isHidden: this.isHidden,
-      legendName: 'legend',
+      legendName: 'chart7-ChartLegend',
       onLegendClick: this.handleLegendClick
     });
 
@@ -357,9 +357,9 @@ class InteractivePieLegendChart extends React.Component {
           events={this.getEvents()}
           hasPatterns
           height={275}
-          idPrefix="chart7"
-          legendComponent={<ChartLegend name={'legend'} data={this.getLegendData()} />}
+          legendComponent={<ChartLegend name={'chart7-ChartLegend'} data={this.getLegendData()} />}
           legendPosition="bottom"
+          name="chart7"
           padding={{
             bottom: 65,
             left: 20,
@@ -456,7 +456,7 @@ class InteractiveLegendChart extends React.Component {
     this.getEvents = () => getInteractiveLegendEvents({
       chartNames: this.getChartNames(),
       isHidden: this.isHidden,
-      legendName: 'legend',
+      legendName: 'chart8-ChartLegend',
       onLegendClick: this.handleLegendClick
     });
 
@@ -548,9 +548,9 @@ class InteractiveLegendChart extends React.Component {
             events={this.getEvents()}
             hasPatterns
             height={225}
-            idPrefix="chart8"
-            legendComponent={<ChartLegend name={'legend'} data={this.getLegendData()} />}
+            legendComponent={<ChartLegend name={'chart8-ChartLegend'} data={this.getLegendData()} />}
             legendPosition="bottom-left"
+            name="chart8"
             padding={{
               bottom: 75, // Adjusted to accommodate legend
               left: 50,
@@ -611,11 +611,11 @@ import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
     data={[{ x: 'Cats', y: 15 }, { x: 'Dogs', y: 15 }, { x: 'Birds', y: 15 }, { x: 'Fish', y: 25 }, { x: 'Rabbits', y: 30 }]}
     hasPatterns={[ true, true, false, false, false ]}
     height={230}
-    idPrefix="chart9"
     labels={({ datum }) => `${datum.x}: ${datum.y}`}
     legendData={[{ name: 'Cats: 15' }, { name: 'Dogs: 15' }, { name: 'Birds: 15' }, { name: 'Fish: 25' }, { name: 'Rabbits: 30' }]}
     legendOrientation="vertical"
     legendPosition="right"
+    name="chart9"
     padding={{
       bottom: 20,
       left: 20,
@@ -648,11 +648,11 @@ import chart_color_green_300 from '@patternfly/react-tokens/dist/esm/chart_color
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     hasPatterns={[ true, true, false ]}
     height={230}
-    idPrefix="chart10"
     labels={({ datum }) => `${datum.x}: ${datum.y}`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
     legendPosition="right"
+    name="chart10"
     padding={{
       bottom: 20,
       left: 20,
@@ -691,11 +691,11 @@ import chart_color_green_300 from '@patternfly/react-tokens/dist/esm/chart_color
     constrainToVisibleArea
     data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
     height={230}
-    idPrefix="chart11"
     labels={({ datum }) => `${datum.x}: ${datum.y}`}
     legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
     legendOrientation="vertical"
     legendPosition="right"
+    name="chart11"
     padding={{
       bottom: 20,
       left: 20,
@@ -738,7 +738,6 @@ import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
     ]}
     hasPatterns
     height={325}
-    idPrefix="chart12"
     labels={({ datum }) => `${datum.x}: ${datum.y}`}
     legendData={[
       { name: 'Cats: 6' },
@@ -759,6 +758,7 @@ import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
     ]}
     legendAllowWrap
     legendPosition="bottom"
+    name="chart12"
     padding={{
       bottom: 110,
       left: 20,

--- a/packages/react-charts/src/components/ResizeObserver/examples/resizeObserver.md
+++ b/packages/react-charts/src/components/ResizeObserver/examples/resizeObserver.md
@@ -91,11 +91,11 @@ class BulletChart extends React.Component {
           comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
           constrainToVisibleArea
           height={250}
-          idPrefix="chart1"
           labels={({ datum }) => `${datum.name}: ${datum.y}`}
           legendAllowWrap
           legendPosition="bottom-left"
           maxDomain={{y: 100}}
+          name="chart1"
           padding={{
             bottom: 50,
             left: 50,
@@ -177,7 +177,6 @@ class MultiColorChart extends React.Component {
                 constrainToVisibleArea
               />
             }
-            idPrefix="chart2"
             legendPosition="bottom-left"
             legendComponent={
               <ChartLegend
@@ -197,6 +196,7 @@ class MultiColorChart extends React.Component {
               />
             }
             height={250}
+            name="chart2"
             padding={{
               bottom: 100, // Adjusted to accomodate legend
               left: 50,
@@ -361,7 +361,7 @@ class MonthlyResponsiveStack extends React.Component {
             legendData={[{ name: 'Sockets' }, { name: 'Cores' }, { name: 'Nodes' }]}
             legendPosition="bottom"
             height={225}
-            idPrefix="chart3"
+            name="chart3"
             padding={{
               bottom: 75, // Adjusted to accommodate legend
               left: 50,

--- a/packages/react-charts/src/components/ResizeObserver/examples/resizeObserver.md
+++ b/packages/react-charts/src/components/ResizeObserver/examples/resizeObserver.md
@@ -91,6 +91,7 @@ class BulletChart extends React.Component {
           comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
           constrainToVisibleArea
           height={250}
+          idPrefix="chart1"
           labels={({ datum }) => `${datum.name}: ${datum.y}`}
           legendAllowWrap
           legendPosition="bottom-left"
@@ -176,6 +177,7 @@ class MultiColorChart extends React.Component {
                 constrainToVisibleArea
               />
             }
+            idPrefix="chart2"
             legendPosition="bottom-left"
             legendComponent={
               <ChartLegend
@@ -359,6 +361,7 @@ class MonthlyResponsiveStack extends React.Component {
             legendData={[{ name: 'Sockets' }, { name: 'Cores' }, { name: 'Nodes' }]}
             legendPosition="bottom"
             height={225}
+            idPrefix="chart3"
             padding={{
               bottom: 75, // Adjusted to accommodate legend
               left: 50,

--- a/packages/react-charts/src/components/Sparkline/examples/sparkline.md
+++ b/packages/react-charts/src/components/Sparkline/examples/sparkline.md
@@ -36,8 +36,8 @@ import { ChartArea, ChartContainer, ChartGroup, ChartLabel, ChartVoronoiContaine
       ariaTitle="Sparkline chart example"
       containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
       height={100}
-      idPrefix="chart1"
       maxDomain={{y: 9}}
+      name="chart1"
       padding={0}
       width={400}
     >
@@ -72,8 +72,8 @@ import { ChartArea, ChartContainer, ChartGroup, ChartLabel, ChartThemeColor, Cha
       ariaTitle="Sparkline chart example"
       containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} />}
       height={100}
-      idPrefix="chart2"
       maxDomain={{y: 9}}
+      name="chart2"
       padding={0}
       themeColor={ChartThemeColor.green}
       width={400}

--- a/packages/react-charts/src/components/Sparkline/examples/sparkline.md
+++ b/packages/react-charts/src/components/Sparkline/examples/sparkline.md
@@ -36,6 +36,7 @@ import { ChartArea, ChartContainer, ChartGroup, ChartLabel, ChartVoronoiContaine
       ariaTitle="Sparkline chart example"
       containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
       height={100}
+      idPrefix="chart1"
       maxDomain={{y: 9}}
       padding={0}
       width={400}
@@ -71,6 +72,7 @@ import { ChartArea, ChartContainer, ChartGroup, ChartLabel, ChartThemeColor, Cha
       ariaTitle="Sparkline chart example"
       containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} />}
       height={100}
+      idPrefix="chart2"
       maxDomain={{y: 9}}
       padding={0}
       themeColor={ChartThemeColor.green}

--- a/packages/react-docs/patternfly-a11y.config.js
+++ b/packages/react-docs/patternfly-a11y.config.js
@@ -21,6 +21,5 @@ module.exports = {
     'bypass',
     'nested-interactive'
   ].join(','),
-  ignoreIncomplete: true,
-  skip: /^\/charts\//
+  ignoreIncomplete: true
 };


### PR DESCRIPTION
This adds an `name` prop to `Chart` in order to resolve the docs a11y violations, related to duplicate IDs.

Victory uses the `name` prop as a prefix when creating child element IDs. This mimics that behavior so we don't need to create a new prop for `ChartAxis`, `ChartLegend`, etc.

https://github.com/patternfly/patternfly-react/issues/7675

Example:

When the top `Chart` component uses `name="chart1"`, axis tick label IDs are output as:
```
"chart1-ChartAxis-0-ChartLabel-0"
"chart1-ChartAxis-0-ChartLabel-1"
...
```

Dependent axis tick label IDs are output as:
```
"chart1-ChartAxis-1-ChartLabel-0"
"chart1-ChartAxis-1-ChartLabel-1"
...
```

And legend label IDs are output as:
```
"chart1-ChartLegend-ChartLabel-0"
"chart1-ChartLegend-ChartLabel-1"
...
```

This covers all the main `Chart` components:
```
Chart
ChartAxis
ChartBullet
ChartDonut
ChartDonutUtilization
ChartDonutThreshold
ChartLegend
ChartPie
```

Screenshot from browser inspector:
![Screen Shot 2022-08-09 at 10 58 38 AM](https://user-images.githubusercontent.com/17481322/183687532-2333763e-bcae-4d81-a6cf-d492d8d06bd4.png)


