### PR TITLE
feat(react-styles): parse & update relative imports in css files

### DIFF
--- a/packages/react-styles/scripts/writeClassMaps.js
+++ b/packages/react-styles/scripts/writeClassMaps.js
@@ -54,7 +54,7 @@ function writeClassMaps(classMaps) {
     while ((relImportMatch = relImportRegex.exec(code))) {
       const relImportPath = relImportMatch[1];
       const absImportPath = /(\/node_modules\/.*)/gm.exec(resolve(dirname(file), relImportPath))[1];
-      code = code.replaceAll(relImportPath, absImportPath);
+      code = code.replace(relImportPath, absImportPath);
     }
     writeFileSync(join(outDir, outPath), code);
   });


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
Towards #7825 

This PR parses CSS files being copied into `react-styles` and replaces relative asset paths with absolute paths.