### PR TITLE
feat(ExpandableSection): add truncated variant

### DIFF
--- a/packages/react-core/src/components/ExpandableSection/ExpandableSection.tsx
+++ b/packages/react-core/src/components/ExpandableSection/ExpandableSection.tsx
@@ -39,9 +39,10 @@ export interface ExpandableSectionProps extends React.HTMLProps<HTMLDivElement> 
   isWidthLimited?: boolean;
   /** Flag to indicate if the content is indented */
   isIndented?: boolean;
-  /** Determines the variant of the expandable section. */
+  /** @beta Determines the variant of the expandable section. */
   variant?: 'default' | 'truncate';
-  /** @beta Truncates the expandable content to the specified number of lines. */
+  /** @beta Truncates the expandable content to the specified number of lines when using the
+   * "truncate" variant. */
   truncateMaxLines?: number;
 }
 
@@ -81,7 +82,8 @@ export class ExpandableSection extends React.Component<ExpandableSectionProps, E
     isWidthLimited: false,
     isIndented: false,
     contentId: '',
-    variant: 'default'
+    variant: 'default',
+    truncateMaxLines: 3
   };
 
   private calculateToggleText(
@@ -134,6 +136,8 @@ export class ExpandableSection extends React.Component<ExpandableSectionProps, E
       isIndented,
       contentId,
       variant,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      truncateMaxLines,
       ...props
     } = this.props;
     let onToggle = onToggleProp;
@@ -159,7 +163,6 @@ export class ExpandableSection extends React.Component<ExpandableSectionProps, E
         className={css(styles.expandableSectionToggle)}
         type="button"
         aria-expanded={propOrStateIsExpanded}
-        {...(variant === ExpandableSectionVariant.truncate && { 'aria-hidden': true })}
         onClick={() => onToggle(!propOrStateIsExpanded)}
       >
         {variant !== ExpandableSectionVariant.truncate && (
@@ -190,7 +193,7 @@ export class ExpandableSection extends React.Component<ExpandableSectionProps, E
         <div
           ref={this.expandableContentRef}
           className={css(styles.expandableSectionContent)}
-          hidden={!propOrStateIsExpanded}
+          hidden={variant !== ExpandableSectionVariant.truncate && !propOrStateIsExpanded}
           id={contentId}
         >
           {children}

--- a/packages/react-core/src/components/ExpandableSection/ExpandableSection.tsx
+++ b/packages/react-core/src/components/ExpandableSection/ExpandableSection.tsx
@@ -39,7 +39,9 @@ export interface ExpandableSectionProps extends React.HTMLProps<HTMLDivElement> 
   isWidthLimited?: boolean;
   /** Flag to indicate if the content is indented */
   isIndented?: boolean;
-  /** @beta Determines the variant of the expandable section. */
+  /** @beta Determines the variant of the expandable section. When passing in "truncate" as the
+   * variant, the expandable content will be truncated after 3 lines by default.
+   */
   variant?: 'default' | 'truncate';
   /** @beta Truncates the expandable content to the specified number of lines when using the
    * "truncate" variant. */
@@ -82,8 +84,7 @@ export class ExpandableSection extends React.Component<ExpandableSectionProps, E
     isWidthLimited: false,
     isIndented: false,
     contentId: '',
-    variant: 'default',
-    truncateMaxLines: 3
+    variant: 'default'
   };
 
   private calculateToggleText(
@@ -102,7 +103,7 @@ export class ExpandableSection extends React.Component<ExpandableSectionProps, E
   }
 
   componentDidMount() {
-    if (this.props.variant === ExpandableSectionVariant.truncate) {
+    if (this.props.variant === ExpandableSectionVariant.truncate && this.props.truncateMaxLines) {
       const expandableContent = this.expandableContentRef.current;
       setLineClamp(this.props.truncateMaxLines, expandableContent);
     }

--- a/packages/react-core/src/components/ExpandableSection/ExpandableSection.tsx
+++ b/packages/react-core/src/components/ExpandableSection/ExpandableSection.tsx
@@ -5,6 +5,11 @@ import lineClamp from '@patternfly/react-tokens/dist/esm/c_expandable_section_m_
 import AngleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-right-icon';
 import { PickOptional } from '../../helpers/typeUtils';
 
+export enum ExpandableSectionVariant {
+  default = 'default',
+  truncate = 'truncate'
+}
+
 export interface ExpandableSectionProps extends React.HTMLProps<HTMLDivElement> {
   /** Content rendered inside the expandable section. */
   children?: React.ReactNode;
@@ -34,8 +39,10 @@ export interface ExpandableSectionProps extends React.HTMLProps<HTMLDivElement> 
   isWidthLimited?: boolean;
   /** Flag to indicate if the content is indented */
   isIndented?: boolean;
-  /** Truncates the expandable content to the specified number of lines. */
-  truncateContent?: number;
+  /** Determines the variant of the expandable section. */
+  variant?: 'default' | 'truncate';
+  /** @beta Truncates the expandable content to the specified number of lines. */
+  truncateMaxLines?: number;
 }
 
 interface ExpandableSectionState {
@@ -74,7 +81,7 @@ export class ExpandableSection extends React.Component<ExpandableSectionProps, E
     isWidthLimited: false,
     isIndented: false,
     contentId: '',
-    truncateContent: 0
+    variant: 'default'
   };
 
   private calculateToggleText(
@@ -93,14 +100,19 @@ export class ExpandableSection extends React.Component<ExpandableSectionProps, E
   }
 
   componentDidMount() {
-    const expandableContent = this.expandableContentRef.current;
-    setLineClamp(this.props.truncateContent, expandableContent);
+    if (this.props.variant === ExpandableSectionVariant.truncate) {
+      const expandableContent = this.expandableContentRef.current;
+      setLineClamp(this.props.truncateMaxLines, expandableContent);
+    }
   }
 
   componentDidUpdate(prevProps: ExpandableSectionProps) {
-    if (prevProps.truncateContent !== this.props.truncateContent) {
+    if (
+      this.props.variant === ExpandableSectionVariant.truncate &&
+      prevProps.truncateMaxLines !== this.props.truncateMaxLines
+    ) {
       const expandableContent = this.expandableContentRef.current;
-      setLineClamp(this.props.truncateContent, expandableContent);
+      setLineClamp(this.props.truncateMaxLines, expandableContent);
     }
   }
 
@@ -121,7 +133,7 @@ export class ExpandableSection extends React.Component<ExpandableSectionProps, E
       isWidthLimited,
       isIndented,
       contentId,
-      truncateContent,
+      variant,
       ...props
     } = this.props;
     let onToggle = onToggleProp;
@@ -147,9 +159,10 @@ export class ExpandableSection extends React.Component<ExpandableSectionProps, E
         className={css(styles.expandableSectionToggle)}
         type="button"
         aria-expanded={propOrStateIsExpanded}
+        {...(variant === ExpandableSectionVariant.truncate && { 'aria-hidden': true })}
         onClick={() => onToggle(!propOrStateIsExpanded)}
       >
-        {!truncateContent && (
+        {variant !== ExpandableSectionVariant.truncate && (
           <span className={css(styles.expandableSectionToggleIcon)}>
             <AngleRightIcon aria-hidden />
           </span>
@@ -168,12 +181,12 @@ export class ExpandableSection extends React.Component<ExpandableSectionProps, E
           displaySize === 'large' && styles.modifiers.displayLg,
           isWidthLimited && styles.modifiers.limitWidth,
           isIndented && styles.modifiers.indented,
-          truncateContent && styles.modifiers.truncate,
+          variant === ExpandableSectionVariant.truncate && styles.modifiers.truncate,
           className
         )}
         {...props}
       >
-        {!truncateContent && expandableToggle}
+        {variant === ExpandableSectionVariant.default && expandableToggle}
         <div
           ref={this.expandableContentRef}
           className={css(styles.expandableSectionContent)}
@@ -182,7 +195,7 @@ export class ExpandableSection extends React.Component<ExpandableSectionProps, E
         >
           {children}
         </div>
-        {truncateContent > 0 && expandableToggle}
+        {variant === ExpandableSectionVariant.truncate && expandableToggle}
       </div>
     );
   }

--- a/packages/react-core/src/components/ExpandableSection/ExpandableSection.tsx
+++ b/packages/react-core/src/components/ExpandableSection/ExpandableSection.tsx
@@ -5,9 +5,9 @@ import AngleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-right-i
 import { PickOptional } from '../../helpers/typeUtils';
 
 export interface ExpandableSectionProps extends React.HTMLProps<HTMLDivElement> {
-  /** Content rendered inside the Expandable Component */
+  /** Content rendered inside the expandable section. */
   children?: React.ReactNode;
-  /** Additional classes added to the Expandable Component */
+  /** Additional classes added to the expandable section. */
   className?: string;
   /** Flag to indicate if the content is expanded */
   isExpanded?: boolean;
@@ -19,7 +19,7 @@ export interface ExpandableSectionProps extends React.HTMLProps<HTMLDivElement> 
   toggleTextCollapsed?: string;
   /** React node that appears in the attached toggle in place of toggle text */
   toggleContent?: React.ReactNode;
-  /** Callback function to toggle the expandable content. Detached expandable sections should use the onToggle property of ExpandableSectionToggle. */
+  /** Callback function to toggle the expandable section. Detached expandable sections should use the onToggle property of the expandable section toggle sub-component. */
   onToggle?: (isExpanded: boolean) => void;
   /** Forces active state */
   isActive?: boolean;
@@ -33,6 +33,8 @@ export interface ExpandableSectionProps extends React.HTMLProps<HTMLDivElement> 
   isWidthLimited?: boolean;
   /** Flag to indicate if the content is indented */
   isIndented?: boolean;
+  /** Flag to indicate if the expandable content is truncated. */
+  isTruncated?: boolean;
 }
 
 interface ExpandableSectionState {
@@ -61,7 +63,8 @@ export class ExpandableSection extends React.Component<ExpandableSectionProps, E
     displaySize: 'default',
     isWidthLimited: false,
     isIndented: false,
-    contentId: ''
+    contentId: '',
+    isTruncated: false
   };
 
   private calculateToggleText(
@@ -96,6 +99,7 @@ export class ExpandableSection extends React.Component<ExpandableSectionProps, E
       isWidthLimited,
       isIndented,
       contentId,
+      isTruncated,
       ...props
     } = this.props;
     let onToggle = onToggleProp;
@@ -116,9 +120,24 @@ export class ExpandableSection extends React.Component<ExpandableSectionProps, E
       propOrStateIsExpanded
     );
 
+    const expandableToggle = !isDetached && (
+      <button
+        className={css(styles.expandableSectionToggle)}
+        type="button"
+        aria-expanded={propOrStateIsExpanded}
+        onClick={() => onToggle(!propOrStateIsExpanded)}
+      >
+        {!isTruncated && (
+          <span className={css(styles.expandableSectionToggleIcon)}>
+            <AngleRightIcon aria-hidden />
+          </span>
+        )}
+        <span className={css(styles.expandableSectionToggleText)}>{toggleContent || computedToggleText}</span>
+      </button>
+    );
+
     return (
       <div
-        {...props}
         className={css(
           styles.expandableSection,
           propOrStateIsExpanded && styles.modifiers.expanded,
@@ -127,25 +146,16 @@ export class ExpandableSection extends React.Component<ExpandableSectionProps, E
           displaySize === 'large' && styles.modifiers.displayLg,
           isWidthLimited && styles.modifiers.limitWidth,
           isIndented && styles.modifiers.indented,
+          // isTruncated && styles.modifiers.truncate,
           className
         )}
+        {...props}
       >
-        {!isDetached && (
-          <button
-            className={css(styles.expandableSectionToggle)}
-            type="button"
-            aria-expanded={propOrStateIsExpanded}
-            onClick={() => onToggle(!propOrStateIsExpanded)}
-          >
-            <span className={css(styles.expandableSectionToggleIcon)}>
-              <AngleRightIcon aria-hidden />
-            </span>
-            <span className={css(styles.expandableSectionToggleText)}>{toggleContent || computedToggleText}</span>
-          </button>
-        )}
+        {!isTruncated && expandableToggle}
         <div className={css(styles.expandableSectionContent)} hidden={!propOrStateIsExpanded} id={contentId}>
           {children}
         </div>
+        {isTruncated && expandableToggle}
       </div>
     );
   }

--- a/packages/react-core/src/components/ExpandableSection/ExpandableSectionToggle.tsx
+++ b/packages/react-core/src/components/ExpandableSection/ExpandableSectionToggle.tsx
@@ -45,7 +45,6 @@ export const ExpandableSectionToggle: React.FunctionComponent<ExpandableSectionT
       type="button"
       aria-expanded={isExpanded}
       aria-controls={contentId}
-      {...(hasTruncatedContent && { 'aria-hidden': true })}
       onClick={() => onToggle(!isExpanded)}
     >
       {!hasTruncatedContent && (

--- a/packages/react-core/src/components/ExpandableSection/ExpandableSectionToggle.tsx
+++ b/packages/react-core/src/components/ExpandableSection/ExpandableSectionToggle.tsx
@@ -16,6 +16,8 @@ export interface ExpandableSectionToggleProps extends React.HTMLProps<HTMLDivEle
   contentId?: string;
   /** Direction the toggle arrow should point when the expandable section is expanded. */
   direction?: 'up' | 'down';
+  /** Flag to determine toggle styling when the expandable content is truncated. */
+  hasTruncatedContent?: boolean;
 }
 
 export const ExpandableSectionToggle: React.FunctionComponent<ExpandableSectionToggleProps> = ({
@@ -25,6 +27,7 @@ export const ExpandableSectionToggle: React.FunctionComponent<ExpandableSectionT
   onToggle,
   contentId,
   direction = 'down',
+  hasTruncatedContent = false,
   ...props
 }: ExpandableSectionToggleProps) => (
   <div
@@ -43,14 +46,16 @@ export const ExpandableSectionToggle: React.FunctionComponent<ExpandableSectionT
       aria-controls={contentId}
       onClick={() => onToggle(!isExpanded)}
     >
-      <span
-        className={css(
-          styles.expandableSectionToggleIcon,
-          isExpanded && direction === 'up' && styles.modifiers.expandTop
-        )}
-      >
-        <AngleRightIcon aria-hidden />
-      </span>
+      {!hasTruncatedContent && (
+        <span
+          className={css(
+            styles.expandableSectionToggleIcon,
+            isExpanded && direction === 'up' && styles.modifiers.expandTop
+          )}
+        >
+          <AngleRightIcon aria-hidden />
+        </span>
+      )}
       <span className={css(styles.expandableSectionToggleText)}>{children}</span>
     </button>
   </div>

--- a/packages/react-core/src/components/ExpandableSection/ExpandableSectionToggle.tsx
+++ b/packages/react-core/src/components/ExpandableSection/ExpandableSectionToggle.tsx
@@ -16,7 +16,7 @@ export interface ExpandableSectionToggleProps extends React.HTMLProps<HTMLDivEle
   contentId?: string;
   /** Direction the toggle arrow should point when the expandable section is expanded. */
   direction?: 'up' | 'down';
-  /** Flag to determine toggle styling when the expandable content is truncated. */
+  /** @beta Flag to determine toggle styling when the expandable content is truncated. */
   hasTruncatedContent?: boolean;
 }
 

--- a/packages/react-core/src/components/ExpandableSection/ExpandableSectionToggle.tsx
+++ b/packages/react-core/src/components/ExpandableSection/ExpandableSectionToggle.tsx
@@ -31,19 +31,21 @@ export const ExpandableSectionToggle: React.FunctionComponent<ExpandableSectionT
   ...props
 }: ExpandableSectionToggleProps) => (
   <div
-    {...props}
     className={css(
       styles.expandableSection,
       isExpanded && styles.modifiers.expanded,
       styles.modifiers.detached,
+      hasTruncatedContent && styles.modifiers.truncate,
       className
     )}
+    {...props}
   >
     <button
       className={css(styles.expandableSectionToggle)}
       type="button"
       aria-expanded={isExpanded}
       aria-controls={contentId}
+      {...(hasTruncatedContent && { 'aria-hidden': true })}
       onClick={() => onToggle(!isExpanded)}
     >
       {!hasTruncatedContent && (

--- a/packages/react-core/src/components/ExpandableSection/__tests__/ExpandableSection.test.tsx
+++ b/packages/react-core/src/components/ExpandableSection/__tests__/ExpandableSection.test.tsx
@@ -83,7 +83,7 @@ test('Does not render with pf-m-truncate class when variant is not truncate', ()
 
 test('Renders with pf-m-truncate class when variant is truncate', () => {
   render(
-    <ExpandableSection variant={ExpandableSectionVariant.truncate} truncateMaxLines={1} {...props}>
+    <ExpandableSection variant={ExpandableSectionVariant.truncate} {...props}>
       test
     </ExpandableSection>
   );

--- a/packages/react-core/src/components/ExpandableSection/__tests__/ExpandableSection.test.tsx
+++ b/packages/react-core/src/components/ExpandableSection/__tests__/ExpandableSection.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { ExpandableSection } from '../ExpandableSection';
+import { ExpandableSection, ExpandableSectionVariant } from '../ExpandableSection';
 import { ExpandableSectionToggle } from '../ExpandableSectionToggle';
 
 const props = {};
@@ -65,15 +65,15 @@ test('Renders ExpandableSection indented', () => {
   expect(asFragment()).toMatchSnapshot();
 });
 
-test('Does not render with pf-m-truncate class when truncateContent is not passed', () => {
+test('Does not render with pf-m-truncate class when variant is not passed', () => {
   render(<ExpandableSection {...props}>test</ExpandableSection>);
 
   expect(screen.getByText('test').parentElement).not.toHaveClass('pf-m-truncate');
 });
 
-test('Does not render with pf-m-truncate class when truncateContent is 0', () => {
+test('Does not render with pf-m-truncate class when variant is not truncate', () => {
   render(
-    <ExpandableSection truncateContent={0} {...props}>
+    <ExpandableSection variant={ExpandableSectionVariant.default} {...props}>
       test
     </ExpandableSection>
   );
@@ -81,9 +81,9 @@ test('Does not render with pf-m-truncate class when truncateContent is 0', () =>
   expect(screen.getByText('test').parentElement).not.toHaveClass('pf-m-truncate');
 });
 
-test('Renders with pf-m-truncate class when truncateContent is greater than 0', () => {
+test('Renders with pf-m-truncate class when variant is truncate', () => {
   render(
-    <ExpandableSection truncateContent={3} {...props}>
+    <ExpandableSection variant={ExpandableSectionVariant.truncate} truncateMaxLines={1} {...props}>
       test
     </ExpandableSection>
   );

--- a/packages/react-core/src/components/ExpandableSection/__tests__/ExpandableSection.test.tsx
+++ b/packages/react-core/src/components/ExpandableSection/__tests__/ExpandableSection.test.tsx
@@ -64,3 +64,29 @@ test('Renders ExpandableSection indented', () => {
   );
   expect(asFragment()).toMatchSnapshot();
 });
+
+test('Does not render with pf-m-truncate class when truncateContent is not passed', () => {
+  render(<ExpandableSection {...props}>test</ExpandableSection>);
+
+  expect(screen.getByText('test').parentElement).not.toHaveClass('pf-m-truncate');
+});
+
+test('Does not render with pf-m-truncate class when truncateContent is 0', () => {
+  render(
+    <ExpandableSection truncateContent={0} {...props}>
+      test
+    </ExpandableSection>
+  );
+
+  expect(screen.getByText('test').parentElement).not.toHaveClass('pf-m-truncate');
+});
+
+test('Renders with pf-m-truncate class when truncateContent is greater than 0', () => {
+  render(
+    <ExpandableSection truncateContent={3} {...props}>
+      test
+    </ExpandableSection>
+  );
+
+  expect(screen.getByText('test').parentElement).toHaveClass('pf-m-truncate');
+});

--- a/packages/react-core/src/components/ExpandableSection/examples/ExpandableSection.md
+++ b/packages/react-core/src/components/ExpandableSection/examples/ExpandableSection.md
@@ -45,3 +45,8 @@ By using the `toggleContent` prop, you can pass in content other than a simple s
 
 ```ts file="ExpandableSectionCustomToggle.tsx"
 ```
+
+### Truncate expansion
+
+```ts file="ExpandableSectionTruncateExpansion.tsx"
+```

--- a/packages/react-core/src/components/ExpandableSection/examples/ExpandableSection.md
+++ b/packages/react-core/src/components/ExpandableSection/examples/ExpandableSection.md
@@ -48,5 +48,7 @@ By using the `toggleContent` prop, you can pass in content other than a simple s
 
 ### Truncate expansion
 
-```ts file="ExpandableSectionTruncateExpansion.tsx"
+By passing in `variant="truncate"`, the expandable content will be visible up to a maximum number of lines before being truncated, with the toggle revealing or hiding the truncated content. By default the expandable content will truncate after 3 lines, and this can be customized by also passing in the `truncateMaxLines` prop.
+
+```ts file="ExpandableSectionTruncateExpansion.tsx" isBeta
 ```

--- a/packages/react-core/src/components/ExpandableSection/examples/ExpandableSectionTruncateExpansion.tsx
+++ b/packages/react-core/src/components/ExpandableSection/examples/ExpandableSectionTruncateExpansion.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { ExpandableSection } from '@patternfly/react-core';
+
+export const ExpandableSectionTruncateExpansion: React.FunctionComponent = () => {
+  const [isExpanded, setIsExpanded] = React.useState(false);
+
+  const onToggle = (isExpanded: boolean) => {
+    setIsExpanded(isExpanded);
+  };
+
+  return (
+    <ExpandableSection
+      isTruncated
+      toggleText={isExpanded ? 'Show less' : 'Show more'}
+      onToggle={onToggle}
+      isExpanded={isExpanded}
+    >
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque nec dignissim turpis, et tristique purus.
+      Phasellus efficitur ante quis dolor viverra imperdiet. Orci varius natoque penatibus et magnis dis parturient
+      montes, nascetur ridiculus mus. Pellentesque laoreet, sem ac elementum semper, lectus mauris vestibulum nulla,
+      eget volutpat massa neque vel turpis. Donec finibus enim eu leo accumsan consectetur. Praesent massa diam,
+      tincidunt eu dui ac, ullamcorper elementum est. Phasellus metus felis, venenatis vitae semper nec, porta a metus.
+      Vestibulum justo nisi, imperdiet id eleifend at, varius nec lorem. Fusce porttitor mollis nibh, ut elementum ante
+      commodo tincidunt. Integer tincidunt at ipsum non aliquet.
+    </ExpandableSection>
+  );
+};

--- a/packages/react-core/src/components/ExpandableSection/examples/ExpandableSectionTruncateExpansion.tsx
+++ b/packages/react-core/src/components/ExpandableSection/examples/ExpandableSectionTruncateExpansion.tsx
@@ -11,7 +11,6 @@ export const ExpandableSectionTruncateExpansion: React.FunctionComponent = () =>
   return (
     <ExpandableSection
       variant={ExpandableSectionVariant.truncate}
-      truncateMaxLines={3}
       toggleText={isExpanded ? 'Show less' : 'Show more'}
       onToggle={onToggle}
       isExpanded={isExpanded}

--- a/packages/react-core/src/components/ExpandableSection/examples/ExpandableSectionTruncateExpansion.tsx
+++ b/packages/react-core/src/components/ExpandableSection/examples/ExpandableSectionTruncateExpansion.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ExpandableSection } from '@patternfly/react-core';
+import { ExpandableSection, ExpandableSectionVariant } from '@patternfly/react-core';
 
 export const ExpandableSectionTruncateExpansion: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = React.useState(false);
@@ -10,7 +10,8 @@ export const ExpandableSectionTruncateExpansion: React.FunctionComponent = () =>
 
   return (
     <ExpandableSection
-      truncateContent={3}
+      variant={ExpandableSectionVariant.truncate}
+      truncateMaxLines={3}
       toggleText={isExpanded ? 'Show less' : 'Show more'}
       onToggle={onToggle}
       isExpanded={isExpanded}

--- a/packages/react-core/src/components/ExpandableSection/examples/ExpandableSectionTruncateExpansion.tsx
+++ b/packages/react-core/src/components/ExpandableSection/examples/ExpandableSectionTruncateExpansion.tsx
@@ -10,7 +10,7 @@ export const ExpandableSectionTruncateExpansion: React.FunctionComponent = () =>
 
   return (
     <ExpandableSection
-      isTruncated
+      truncateContent={3}
       toggleText={isExpanded ? 'Show less' : 'Show more'}
       onToggle={onToggle}
       isExpanded={isExpanded}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7780 

[Expandable section truncate example](https://patternfly-react-pr-7852.surge.sh/components/expandable-section#truncate-expansion)

Also made slight edits to some prop descriptions.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
