### PR TITLE
fix: react-core should export all contents of dist directory

### DIFF
--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -5,12 +5,6 @@
   "main": "dist/js/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
-  "exports": {
-    ".": "./dist/esm/index.js",
-    "./next": "./dist/esm/next/index.js",
-    "./deprecated": "./dist/esm/deprecated/index.js",
-    "./package.json": "./package.json"
-  },
   "typesVersions": {
     "*": {
       "next": [
@@ -45,7 +39,7 @@
   },
   "homepage": "https://github.com/patternfly/patternfly-react#readme",
   "scripts": {
-    "build:umd": "rollup -c && rollup -c --environment IS_PRODUCTION",
+    "build:umd": "rollup -c --environment IS_PRODUCTION",
     "clean": "rimraf dist",
     "generate": "node scripts/copyStyles.js"
   },


### PR DESCRIPTION
Tested this fix in koku-ui locally. Whether this addresses the reported issue with Keycloak is to be determined.
