### PR TITLE
fix(TimePicker): scroll dropdown to typed value in safari

### DIFF
--- a/packages/react-core/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react-core/src/components/TimePicker/TimePicker.tsx
@@ -282,7 +282,7 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
     ) {
       time = `${time}${new Date().getHours() > 11 ? pmSuffix : amSuffix}`;
     }
-    let scrollIndex = this.getOptions().findIndex(option => option.innerText === time);
+    let scrollIndex = this.getOptions().findIndex(option => option.textContent === time);
 
     // if we found an exact match, scroll to match and return index of match for focus
     if (scrollIndex !== -1) {
@@ -299,7 +299,7 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
         }
       }
       time = `${splitTime[0]}${delimiter}00${amPm}`;
-      scrollIndex = this.getOptions().findIndex(option => option.innerText === time);
+      scrollIndex = this.getOptions().findIndex(option => option.textContent === time);
       if (scrollIndex !== -1) {
         this.scrollToIndex(scrollIndex);
       }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7747 

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:

I would like to be able to add a test for this bug, but since it's something that only presented in Safari I'm not sure how I would go about that. If anyone has any ideas for that please let me know!

Convenience link: https://patternfly-react-pr-7888.surge.sh/components/time-picker/