### PR TITLE
feat(PageSection): add ability to specify HTML element via prop

### DIFF
--- a/packages/react-core/src/components/Page/PageSection.tsx
+++ b/packages/react-core/src/components/Page/PageSection.tsx
@@ -65,6 +65,8 @@ export interface PageSectionProps extends React.HTMLProps<HTMLDivElement> {
    * This prop should also be passed in if a heading is not being used to describe the content of the page section.
    */
   'aria-label'?: string;
+  /** Sets the base component to render. Defaults to section */
+  component?: keyof JSX.IntrinsicElements;
 }
 
 const variantType = {
@@ -98,6 +100,7 @@ export const PageSection: React.FunctionComponent<PageSectionProps> = ({
   hasShadowBottom = false,
   hasOverflowScroll = false,
   'aria-label': ariaLabel,
+  component = 'section',
   ...props
 }: PageSectionProps) => {
   const { height, getVerticalBreakpoint } = React.useContext(PageContext);
@@ -109,8 +112,10 @@ export const PageSection: React.FunctionComponent<PageSectionProps> = ({
     }
   }, [hasOverflowScroll, ariaLabel]);
 
+  const Component = component as any;
+
   return (
-    <section
+    <Component
       {...props}
       className={css(
         variantType[type],
@@ -133,7 +138,7 @@ export const PageSection: React.FunctionComponent<PageSectionProps> = ({
     >
       {isWidthLimited && <div className={css(styles.pageMainBody)}>{children}</div>}
       {!isWidthLimited && children}
-    </section>
+    </Component>
   );
 };
 PageSection.displayName = 'PageSection';

--- a/packages/react-core/src/components/Page/__tests__/PageSection.test.tsx
+++ b/packages/react-core/src/components/Page/__tests__/PageSection.test.tsx
@@ -128,3 +128,15 @@ test('Logs a warning in the console when an aria-label is not included with hasO
 
   expect(consoleWarning).toHaveBeenCalled();
 });
+
+test('Renders as a section by default', () => {
+  render(<PageSection>test</PageSection>);
+
+  expect(screen.getByText('test')).toHaveProperty('nodeName', 'SECTION');
+});
+
+test('Renders as other elements when a different element type is passed using the component prop', () => {
+  render(<PageSection component="main">test</PageSection>);
+
+  expect(screen.getByRole('main')).toHaveTextContent('test');
+});


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7419

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:

Convenience link to the Page component: https://patternfly-react-pr-7891.surge.sh/components/page