### PR TITLE
fix: syntax errors on surge

### DIFF
--- a/packages/react-core/src/components/DualListSelector/examples/DualListSelectorComposableDragDrop.tsx
+++ b/packages/react-core/src/components/DualListSelector/examples/DualListSelectorComposableDragDrop.tsx
@@ -81,7 +81,7 @@ export const DualListSelectorComposableDragDrop: React.FunctionComponent = () =>
     }
   };
 
-  const onDrop = (source: DraggableItemPosition, dest?: DraggableItemPosition) => {
+  const onDrop = (source: DraggableItemPosition, dest: DraggableItemPosition | undefined) => {
     if (dest) {
       const newList = [...chosenOptions];
       const [removed] = newList.splice(source.index, 1);

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableActionsMenu.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableActionsMenu.tsx
@@ -36,7 +36,7 @@ export const ComposableActionsMenu: React.FunctionComponent = () => {
     };
   }, [isOpen, menuRef]);
 
-  const onSelect = (event?: React.MouseEvent, itemId?: string | number) => {
+  const onSelect = (event: React.MouseEvent | undefined, itemId: string | number | undefined) => {
     if (typeof itemId === 'string' || typeof itemId === 'undefined') {
       return;
     }

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableFlyout.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableFlyout.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { MenuToggle, Menu, MenuContent, MenuList, MenuItem, Popper } from '@patternfly/react-core';
 
-// eslint-disable-next-line no-console
-const onSelect = (event?: React.MouseEvent, itemId?: string | number) => console.log('selected', itemId);
-
+/* eslint-disable no-console */
+const onSelect = (event: React.MouseEvent | undefined, itemId: string | number | undefined) =>
+  console.log('selected', itemId);
+/* eslint-enable no-console */
 interface FlyoutMenuProps {
   children?: React.ReactElement;
   depth: number;

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleCheckboxSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleCheckboxSelect.tsx
@@ -50,7 +50,7 @@ export const ComposableSimpleCheckboxSelect: React.FunctionComponent = () => {
     setIsOpen(!isOpen);
   };
 
-  const onSelect = (event?: React.MouseEvent, itemId?: string | number) => {
+  const onSelect = (event: React.MouseEvent | undefined, itemId: string | number | undefined) => {
     if (typeof itemId === 'string' || typeof itemId === 'undefined') {
       return;
     }

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleSelect.tsx
@@ -59,7 +59,7 @@ export const ComposableSimpleSelect: React.FunctionComponent = () => {
     </MenuToggle>
   );
 
-  function onSelect(event?: React.MouseEvent, itemId?: string | number) {
+  function onSelect(event: React.MouseEvent | undefined, itemId: string | number | undefined) {
     if (typeof itemId === 'undefined') {
       return;
     }

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableTypeaheadSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableTypeaheadSelect.tsx
@@ -55,7 +55,7 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
 
   const focusOnInput = () => menuToggleRef.current?.querySelector('input')?.focus();
 
-  const onMenuSelect = (event?: React.MouseEvent, itemId?: string | number) => {
+  const onMenuSelect = (event: React.MouseEvent | undefined, itemId: string | number | undefined) => {
     if (itemId) {
       setInputValue(itemId.toString());
       setIsSelected(true);
@@ -124,7 +124,7 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
   };
 
   // Close the menu when a click occurs outside of the menu toggle content
-  const onDocumentClick = (event?: MouseEvent) => {
+  const onDocumentClick = (event: MouseEvent | undefined) => {
     if (!menuToggleRef.current?.contains(event?.target as HTMLElement)) {
       setIsMenuOpen(false);
     }


### PR DESCRIPTION
Fixes the various syntax errors on the site (one DualListSelector demo and several composable menu demos). Updated the optional function parameters to instead account for undefined in their types (the `?` was registering as a syntax error).