### PR TITLE
fix(MenuToggle): Typeahead variant styles

### DIFF
--- a/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
+++ b/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
@@ -124,7 +124,13 @@ export class MenuToggleBase extends React.Component<MenuToggleProps> {
     };
 
     if (isTypeahead) {
-      return <div ref={innerRef as React.Ref<HTMLDivElement>} className={css(commonStyles)} {...componentProps} />;
+      return (
+        <div
+          ref={innerRef as React.Ref<HTMLDivElement>}
+          className={css(commonStyles, styles.modifiers.typeahead)}
+          {...componentProps}
+        />
+      );
     }
 
     if (splitButtonOptions) {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/96431149/187457772-441b165c-24eb-44d1-80c3-7218fec52dc2.png)

After:
![image](https://user-images.githubusercontent.com/96431149/187457714-4655c1c1-eb61-44fd-bdb1-23439bd1453c.png)
