### PR TITLE
fix(Treeview): ignore folder selection in basic example

### DIFF
--- a/packages/react-core/src/components/TreeView/examples/TreeView.md
+++ b/packages/react-core/src/components/TreeView/examples/TreeView.md
@@ -291,9 +291,12 @@ class SearchTreeView extends React.Component {
     this.state = { activeItems: {}, filteredItems: this.options, isFiltered: null };
 
     this.onSelect = (evt, treeViewItem) => {
-      this.setState({
-        activeItems: [treeViewItem]
-      });
+      // Ignore folders for selection
+      if (treeViewItem && !treeViewItem.children) {
+        this.setState({
+          activeItems: [treeViewItem]
+        });
+      }
     };
 
     this.onSearch = evt => {
@@ -578,9 +581,12 @@ class IconTreeView extends React.Component {
     this.state = { activeItems: {} };
 
     this.onSelect = (evt, treeViewItem) => {
-      this.setState({
-        activeItems: [treeViewItem]
-      });
+      // Ignore folders for selection
+      if (treeViewItem && !treeViewItem.children) {
+        this.setState({
+          activeItems: [treeViewItem]
+        });
+      }
     };
   }
 
@@ -671,9 +677,12 @@ class BadgesTreeView extends React.Component {
     this.state = { activeItems: {} };
 
     this.onSelect = (evt, treeViewItem) => {
-      this.setState({
-        activeItems: [treeViewItem]
-      });
+      // Ignore folders for selection
+      if (treeViewItem && !treeViewItem.children) {
+        this.setState({
+          activeItems: [treeViewItem]
+        });
+      }
     };
   }
 
@@ -756,9 +765,12 @@ class CustomBadgesTreeView extends React.Component {
     this.state = { activeItems: {} };
 
     this.onSelect = (evt, treeViewItem) => {
-      this.setState({
-        activeItems: [treeViewItem]
-      });
+      // Ignore folders for selection
+      if (treeViewItem && !treeViewItem.children) {
+        this.setState({
+          activeItems: [treeViewItem]
+        });
+      }
     };
   }
 
@@ -856,9 +868,12 @@ class IconTreeView extends React.Component {
     this.state = { activeItems: {}, isOpen: false };
 
     this.onSelect = (evt, treeViewItem) => {
-      this.setState({
-        activeItems: [treeViewItem]
-      });
+      // Ignore folders for selection
+      if (treeViewItem && !treeViewItem.children) {
+        this.setState({
+          activeItems: [treeViewItem]
+        });
+      }
     };
 
     this.onToggle = isOpen => {

--- a/packages/react-core/src/components/TreeView/examples/TreeView.md
+++ b/packages/react-core/src/components/TreeView/examples/TreeView.md
@@ -20,12 +20,15 @@ class DefaultTreeView extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = { activeItems: {}, allExpanded: null };
+    this.state = { activeItems: [], allExpanded: null };
 
     this.onSelect = (evt, treeViewItem) => {
-      this.setState({
-        activeItems: [treeViewItem]
-      });
+      // Ignore folders for selection
+      if (treeViewItem && !treeViewItem.children) {
+        this.setState({
+          activeItems: [treeViewItem]
+        });
+      }
     };
 
     this.onToggle = evt => {


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7785

Folder selection looked like it wasn't being persisted because the parent folder was technically getting selected (but this doesn't have visual styling by default).