### PR TITLE
feat(OverflowMenu): allow breakpoint on container width

### DIFF
--- a/packages/react-core/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/packages/react-core/src/components/OverflowMenu/OverflowMenu.tsx
@@ -28,7 +28,7 @@ export class OverflowMenu extends React.Component<OverflowMenuProps, OverflowMen
     super(props);
     this.state = {
       isBelowBreakpoint: false,
-      breakpointRef: null
+      breakpointRef: undefined
     };
   }
 
@@ -36,17 +36,16 @@ export class OverflowMenu extends React.Component<OverflowMenuProps, OverflowMen
 
   getBreakpointRef() {
     const { breakpointReference } = this.props;
-    if (breakpointReference) {
-      if ((breakpointReference as React.RefObject<any>).current) {
-        return (breakpointReference as React.RefObject<any>).current;
-      } else if (typeof breakpointReference === 'function') {
-        return breakpointReference();
-      }
+
+    if ((breakpointReference as React.RefObject<any>).current) {
+      return (breakpointReference as React.RefObject<any>).current;
+    } else if (typeof breakpointReference === 'function') {
+      return breakpointReference();
     }
   }
 
   componentDidMount() {
-    const reference = this.getBreakpointRef();
+    const reference = this.props.breakpointReference ? this.getBreakpointRef() : undefined;
 
     this.setState({ breakpointRef: reference });
     this.observer = getResizeObserver(reference, this.handleResizeWithDelay);
@@ -54,7 +53,7 @@ export class OverflowMenu extends React.Component<OverflowMenuProps, OverflowMen
   }
 
   componentDidUpdate(prevProps: Readonly<OverflowMenuProps>, prevState: Readonly<OverflowMenuState>): void {
-    const reference = this.getBreakpointRef();
+    const reference = this.props.breakpointReference ? this.getBreakpointRef() : undefined;
 
     if (prevState.breakpointRef !== reference) {
       // To remove any previous observer/event listener from componentDidMount before adding a new one

--- a/packages/react-core/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/packages/react-core/src/components/OverflowMenu/OverflowMenu.tsx
@@ -2,18 +2,9 @@ import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/OverflowMenu/overflow-menu';
 import { css } from '@patternfly/react-styles';
 import { OverflowMenuContext } from './OverflowMenuContext';
-import mdBreakpoint from '@patternfly/react-tokens/dist/esm/global_breakpoint_md';
-import lgBreakpoint from '@patternfly/react-tokens/dist/esm/global_breakpoint_lg';
-import xlBreakpoint from '@patternfly/react-tokens/dist/esm/global_breakpoint_xl';
-import xl2Breakpoint from '@patternfly/react-tokens/dist/esm/global_breakpoint_2xl';
-import { debounce, canUseDOM } from '../../helpers/util';
-
-const breakpoints = {
-  md: mdBreakpoint,
-  lg: lgBreakpoint,
-  xl: xlBreakpoint,
-  '2xl': xl2Breakpoint
-};
+import { debounce } from '../../helpers/util';
+import { globalWidthBreakpoints } from '../../helpers/constants';
+import { getResizeObserver } from '../../helpers/resizeObserver';
 
 export interface OverflowMenuProps extends React.HTMLProps<HTMLDivElement> {
   /** Any elements that can be rendered in the menu */
@@ -21,7 +12,11 @@ export interface OverflowMenuProps extends React.HTMLProps<HTMLDivElement> {
   /** Additional classes added to the OverflowMenu. */
   className?: string;
   /** Indicates breakpoint at which to switch between horizontal menu and vertical dropdown */
-  breakpoint: 'md' | 'lg' | 'xl' | '2xl';
+  breakpoint: 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+  /** Flag to indicate that the specified breakpoint should be relative to the overflow menu
+   * container width instead of the viewport width.
+   */
+  hasBreakpointOnContainer?: boolean;
 }
 
 export interface OverflowMenuState extends React.HTMLProps<HTMLDivElement> {
@@ -37,39 +32,44 @@ export class OverflowMenu extends React.Component<OverflowMenuProps, OverflowMen
     };
   }
 
+  overflowMenuRef = React.createRef<HTMLDivElement>();
+  observer: any = () => {};
+
   componentDidMount() {
     this.handleResize();
-    if (canUseDOM) {
-      window.addEventListener('resize', this.handleResizeWithDelay);
-    }
+
+    const containerToObserve = this.props.hasBreakpointOnContainer && this.overflowMenuRef.current;
+    this.observer = getResizeObserver(containerToObserve, this.handleResizeWithDelay);
   }
 
   componentWillUnmount() {
-    if (canUseDOM) {
-      window.removeEventListener('resize', this.handleResizeWithDelay);
-    }
+    this.observer();
   }
 
   handleResize = () => {
-    const breakpointPx = breakpoints[this.props.breakpoint];
-    if (!breakpointPx) {
+    const { hasBreakpointOnContainer } = this.props;
+    const breakpointWidth = globalWidthBreakpoints[this.props.breakpoint];
+    if (!breakpointWidth) {
       // eslint-disable-next-line no-console
       console.error('OverflowMenu will not be visible without a valid breakpoint.');
       return;
     }
-    const breakpointWidth = Number(breakpointPx.value.replace('px', ''));
-    const isBelowBreakpoint = window.innerWidth < breakpointWidth;
-    this.setState({ isBelowBreakpoint });
+
+    const relativeWidth = hasBreakpointOnContainer ? this.overflowMenuRef.current.clientWidth : window.innerWidth;
+    const isBelowBreakpoint = relativeWidth < breakpointWidth;
+    if (this.state.isBelowBreakpoint !== isBelowBreakpoint) {
+      this.setState({ isBelowBreakpoint });
+    }
   };
 
   handleResizeWithDelay = debounce(this.handleResize, 250);
 
   render() {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { className, breakpoint, children, ...props } = this.props;
+    const { className, breakpoint, children, hasBreakpointOnContainer, ...props } = this.props;
 
     return (
-      <div {...props} className={css(styles.overflowMenu, className)}>
+      <div {...props} className={css(styles.overflowMenu, className)} ref={this.overflowMenuRef}>
         <OverflowMenuContext.Provider value={{ isBelowBreakpoint: this.state.isBelowBreakpoint }}>
           {children}
         </OverflowMenuContext.Provider>

--- a/packages/react-core/src/components/OverflowMenu/__tests__/OverflowMenu.test.tsx
+++ b/packages/react-core/src/components/OverflowMenu/__tests__/OverflowMenu.test.tsx
@@ -4,6 +4,7 @@ import { render, screen } from '@testing-library/react';
 
 import styles from '@patternfly/react-styles/css/components/OverflowMenu/overflow-menu';
 import { OverflowMenu } from '../OverflowMenu';
+import * as getResizeObserver from '../../../helpers/resizeObserver';
 
 describe('OverflowMenu', () => {
   test('md', () => {
@@ -41,5 +42,42 @@ describe('OverflowMenu', () => {
     );
 
     expect(myMock).toHaveBeenCalled();
+  });
+
+  test('should call resizeObserver on undefined containerRefElement', () => {
+    const resizeObserver = jest.spyOn(getResizeObserver, 'getResizeObserver');
+
+    render(<OverflowMenu breakpoint={'md'} />);
+
+    expect(resizeObserver.mock.calls[1][0]).toEqual(undefined);
+  });
+
+  test('should call resizeObserver on selector ref containerRefElement', () => {
+    const resizeObserver = jest.spyOn(getResizeObserver, 'getResizeObserver');
+
+    render(
+      <div id="selector-ref-test">
+        <OverflowMenu breakpointReference={() => document.getElementById('selector-ref-test')} breakpoint={'md'}>
+          <div>Selector ref test</div>
+        </OverflowMenu>
+      </div>
+    );
+
+    const containerRef = screen.getByText('Selector ref test').parentElement?.parentElement;
+
+    expect(resizeObserver.mock.calls[1][0]).toEqual(containerRef);
+  });
+
+  test('should call resizeObserver on React ref containerRefElement', () => {
+    const resizeObserver = jest.spyOn(getResizeObserver, 'getResizeObserver');
+    const containerRef = React.createRef<HTMLDivElement>();
+
+    render(
+      <div ref={containerRef}>
+        <OverflowMenu breakpointReference={containerRef} breakpoint={'md'} />
+      </div>
+    );
+
+    expect(resizeObserver.mock.calls[1][0]).toEqual(containerRef.current);
   });
 });

--- a/packages/react-core/src/components/OverflowMenu/__tests__/OverflowMenu.test.tsx
+++ b/packages/react-core/src/components/OverflowMenu/__tests__/OverflowMenu.test.tsx
@@ -49,7 +49,7 @@ describe('OverflowMenu', () => {
 
     render(<OverflowMenu breakpoint={'md'} />);
 
-    expect(resizeObserver.mock.calls[1]).toEqual(undefined);
+    expect(resizeObserver).toHaveBeenCalledWith(undefined, expect.any(Function));
   });
 
   test('should call resizeObserver on selector ref containerRefElement', () => {
@@ -65,7 +65,7 @@ describe('OverflowMenu', () => {
 
     const containerRef = screen.getByText('Selector ref test').parentElement?.parentElement;
 
-    expect(resizeObserver.mock.calls[1][0]).toEqual(containerRef);
+    expect(resizeObserver).toHaveBeenCalledWith(containerRef, expect.any(Function));
   });
 
   test('should call resizeObserver on React ref containerRefElement', () => {
@@ -78,6 +78,6 @@ describe('OverflowMenu', () => {
       </div>
     );
 
-    expect(resizeObserver.mock.calls[1][0]).toEqual(containerRef.current);
+    expect(resizeObserver).toHaveBeenCalledWith(containerRef.current, expect.any(Function));
   });
 });

--- a/packages/react-core/src/components/OverflowMenu/__tests__/OverflowMenu.test.tsx
+++ b/packages/react-core/src/components/OverflowMenu/__tests__/OverflowMenu.test.tsx
@@ -49,7 +49,7 @@ describe('OverflowMenu', () => {
 
     render(<OverflowMenu breakpoint={'md'} />);
 
-    expect(resizeObserver.mock.calls[1][0]).toEqual(undefined);
+    expect(resizeObserver.mock.calls[1]).toEqual(undefined);
   });
 
   test('should call resizeObserver on selector ref containerRefElement', () => {

--- a/packages/react-core/src/components/OverflowMenu/examples/OverflowMenu.md
+++ b/packages/react-core/src/components/OverflowMenu/examples/OverflowMenu.md
@@ -2,7 +2,15 @@
 id: Overflow menu
 section: components
 cssPrefix: pf-c-overflow-menu
-propComponents: ['OverflowMenu', 'OverflowMenuContent', 'OverflowMenuControl', 'OverflowMenuDropdownItem', 'OverflowMenuGroup', 'OverflowMenuItem']
+propComponents:
+  [
+    'OverflowMenu',
+    'OverflowMenuContent',
+    'OverflowMenuControl',
+    'OverflowMenuDropdownItem',
+    'OverflowMenuGroup',
+    'OverflowMenuItem',
+  ]
 ---
 
 import AlignLeftIcon from '@patternfly/react-icons/dist/esm/icons/align-left-icon';
@@ -10,10 +18,19 @@ import AlignCenterIcon from '@patternfly/react-icons/dist/esm/icons/align-center
 import AlignRightIcon from '@patternfly/react-icons/dist/esm/icons/align-right-icon';
 
 ## Examples
+
 ### Simple (responsive)
+
 ```js
 import React from 'react';
-import { OverflowMenu, OverflowMenuControl, OverflowMenuContent, OverflowMenuGroup, OverflowMenuItem, OverflowMenuDropdownItem } from '@patternfly/react-core';
+import {
+  OverflowMenu,
+  OverflowMenuControl,
+  OverflowMenuContent,
+  OverflowMenuGroup,
+  OverflowMenuItem,
+  OverflowMenuDropdownItem
+} from '@patternfly/react-core';
 import { Dropdown, KebabToggle } from '@patternfly/react-core';
 
 class SimpleOverflowMenu extends React.Component {
@@ -37,12 +54,22 @@ class SimpleOverflowMenu extends React.Component {
   render() {
     const { isOpen } = this.state;
     const dropdownItems = [
-      <OverflowMenuDropdownItem key="item1" isShared>Item 1</OverflowMenuDropdownItem>,
-      <OverflowMenuDropdownItem key="item2" isShared>Item 2</OverflowMenuDropdownItem>,
-      <OverflowMenuDropdownItem key="item3" isShared>Item 3</OverflowMenuDropdownItem>,
-      <OverflowMenuDropdownItem key="item4" isShared>Item 4</OverflowMenuDropdownItem>,
-      <OverflowMenuDropdownItem key="item5" isShared>Item 5</OverflowMenuDropdownItem>
-    ]
+      <OverflowMenuDropdownItem key="item1" isShared>
+        Item 1
+      </OverflowMenuDropdownItem>,
+      <OverflowMenuDropdownItem key="item2" isShared>
+        Item 2
+      </OverflowMenuDropdownItem>,
+      <OverflowMenuDropdownItem key="item3" isShared>
+        Item 3
+      </OverflowMenuDropdownItem>,
+      <OverflowMenuDropdownItem key="item4" isShared>
+        Item 4
+      </OverflowMenuDropdownItem>,
+      <OverflowMenuDropdownItem key="item5" isShared>
+        Item 5
+      </OverflowMenuDropdownItem>
+    ];
     return (
       <OverflowMenu breakpoint="lg">
         <OverflowMenuContent>
@@ -66,15 +93,23 @@ class SimpleOverflowMenu extends React.Component {
           />
         </OverflowMenuControl>
       </OverflowMenu>
-    )
+    );
   }
 }
 ```
 
 ### Group types
+
 ```js
 import React from 'react';
-import { OverflowMenu, OverflowMenuControl, OverflowMenuContent, OverflowMenuGroup, OverflowMenuItem, OverflowMenuDropdownItem } from '@patternfly/react-core';
+import {
+  OverflowMenu,
+  OverflowMenuControl,
+  OverflowMenuContent,
+  OverflowMenuGroup,
+  OverflowMenuItem,
+  OverflowMenuDropdownItem
+} from '@patternfly/react-core';
 import { Dropdown, KebabToggle, Button, ButtonVariant } from '@patternfly/react-core';
 import AlignLeftIcon from '@patternfly/react-icons/dist/esm/icons/align-left-icon';
 import AlignCenterIcon from '@patternfly/react-icons/dist/esm/icons/align-center-icon';
@@ -101,15 +136,33 @@ class OverflowMenuGroupTypes extends React.Component {
   render() {
     const { isOpen } = this.state;
     const dropdownItems = [
-      <OverflowMenuDropdownItem key="item1" isShared>Item 1</OverflowMenuDropdownItem>,
-      <OverflowMenuDropdownItem key="item2" isShared>Item 2</OverflowMenuDropdownItem>,
-      <OverflowMenuDropdownItem key="item3" isShared>Item 3</OverflowMenuDropdownItem>,
-      <OverflowMenuDropdownItem key="primary" isShared>Primary</OverflowMenuDropdownItem>,
-      <OverflowMenuDropdownItem key="secondary" isShared>Secondary</OverflowMenuDropdownItem>,
-      <OverflowMenuDropdownItem key="tertiary" isShared>Tertiary</OverflowMenuDropdownItem>,
-      <OverflowMenuDropdownItem key="action1" isShared>Action 1</OverflowMenuDropdownItem>,
-      <OverflowMenuDropdownItem key="action2" isShared>Action 2</OverflowMenuDropdownItem>,
-      <OverflowMenuDropdownItem key="action3" isShared>Action 3</OverflowMenuDropdownItem>,
+      <OverflowMenuDropdownItem key="item1" isShared>
+        Item 1
+      </OverflowMenuDropdownItem>,
+      <OverflowMenuDropdownItem key="item2" isShared>
+        Item 2
+      </OverflowMenuDropdownItem>,
+      <OverflowMenuDropdownItem key="item3" isShared>
+        Item 3
+      </OverflowMenuDropdownItem>,
+      <OverflowMenuDropdownItem key="primary" isShared>
+        Primary
+      </OverflowMenuDropdownItem>,
+      <OverflowMenuDropdownItem key="secondary" isShared>
+        Secondary
+      </OverflowMenuDropdownItem>,
+      <OverflowMenuDropdownItem key="tertiary" isShared>
+        Tertiary
+      </OverflowMenuDropdownItem>,
+      <OverflowMenuDropdownItem key="action1" isShared>
+        Action 1
+      </OverflowMenuDropdownItem>,
+      <OverflowMenuDropdownItem key="action2" isShared>
+        Action 2
+      </OverflowMenuDropdownItem>,
+      <OverflowMenuDropdownItem key="action3" isShared>
+        Action 3
+      </OverflowMenuDropdownItem>
     ];
     return (
       <OverflowMenu breakpoint="lg">
@@ -160,16 +213,23 @@ class OverflowMenuGroupTypes extends React.Component {
           />
         </OverflowMenuControl>
       </OverflowMenu>
-    )
+    );
   }
 }
 ```
 
-
 ### Multiple groups
+
 ```js
 import React from 'react';
-import { OverflowMenu, OverflowMenuControl, OverflowMenuContent, OverflowMenuGroup, OverflowMenuItem, OverflowMenuDropdownItem } from '@patternfly/react-core';
+import {
+  OverflowMenu,
+  OverflowMenuControl,
+  OverflowMenuContent,
+  OverflowMenuGroup,
+  OverflowMenuItem,
+  OverflowMenuDropdownItem
+} from '@patternfly/react-core';
 import { Dropdown, KebabToggle, Button, ButtonVariant } from '@patternfly/react-core';
 import AlignLeftIcon from '@patternfly/react-icons/dist/esm/icons/align-left-icon';
 import AlignCenterIcon from '@patternfly/react-icons/dist/esm/icons/align-center-icon';
@@ -196,13 +256,25 @@ class OverflowMenuAdditionalOptions extends React.Component {
   render() {
     const { isOpen } = this.state;
     const dropdownItems = [
-      <OverflowMenuDropdownItem key="1" isShared>Primary</OverflowMenuDropdownItem>,
-      <OverflowMenuDropdownItem key="2" isShared>Secondary</OverflowMenuDropdownItem>,
-      <OverflowMenuDropdownItem key="3" isShared>Tertiary</OverflowMenuDropdownItem>,
-      <OverflowMenuDropdownItem key="4" isShared>Action 4</OverflowMenuDropdownItem>,
-      <OverflowMenuDropdownItem key="5" isShared>Action 5</OverflowMenuDropdownItem>,
-      <OverflowMenuDropdownItem key="6" isShared>Action 6</OverflowMenuDropdownItem>,
-      <OverflowMenuDropdownItem key="7">Action 7</OverflowMenuDropdownItem>,
+      <OverflowMenuDropdownItem key="1" isShared>
+        Primary
+      </OverflowMenuDropdownItem>,
+      <OverflowMenuDropdownItem key="2" isShared>
+        Secondary
+      </OverflowMenuDropdownItem>,
+      <OverflowMenuDropdownItem key="3" isShared>
+        Tertiary
+      </OverflowMenuDropdownItem>,
+      <OverflowMenuDropdownItem key="4" isShared>
+        Action 4
+      </OverflowMenuDropdownItem>,
+      <OverflowMenuDropdownItem key="5" isShared>
+        Action 5
+      </OverflowMenuDropdownItem>,
+      <OverflowMenuDropdownItem key="6" isShared>
+        Action 6
+      </OverflowMenuDropdownItem>,
+      <OverflowMenuDropdownItem key="7">Action 7</OverflowMenuDropdownItem>
     ];
     return (
       <OverflowMenu breakpoint="lg">
@@ -248,16 +320,23 @@ class OverflowMenuAdditionalOptions extends React.Component {
           />
         </OverflowMenuControl>
       </OverflowMenu>
-    )
+    );
   }
 }
 ```
 
-
 ### Persistent
+
 ```js
 import React from 'react';
-import { OverflowMenu, OverflowMenuControl, OverflowMenuContent, OverflowMenuGroup, OverflowMenuItem, OverflowMenuDropdownItem } from '@patternfly/react-core';
+import {
+  OverflowMenu,
+  OverflowMenuControl,
+  OverflowMenuContent,
+  OverflowMenuGroup,
+  OverflowMenuItem,
+  OverflowMenuDropdownItem
+} from '@patternfly/react-core';
 import { Dropdown, KebabToggle, Button, ButtonVariant } from '@patternfly/react-core';
 
 class OverflowMenuPersist extends React.Component {
@@ -281,8 +360,12 @@ class OverflowMenuPersist extends React.Component {
   render() {
     const { isOpen } = this.state;
     const dropdownItems = [
-      <OverflowMenuDropdownItem key="secondary" isShared>Secondary</OverflowMenuDropdownItem>,
-      <OverflowMenuDropdownItem key="tertiary" isShared>Tertiary</OverflowMenuDropdownItem>,
+      <OverflowMenuDropdownItem key="secondary" isShared>
+        Secondary
+      </OverflowMenuDropdownItem>,
+      <OverflowMenuDropdownItem key="tertiary" isShared>
+        Tertiary
+      </OverflowMenuDropdownItem>,
       <OverflowMenuDropdownItem key="action">Action 4</OverflowMenuDropdownItem>
     ];
     return (
@@ -312,7 +395,16 @@ class OverflowMenuPersist extends React.Component {
           />
         </OverflowMenuControl>
       </OverflowMenu>
-    )
+    );
   }
 }
+```
+
+### Breakpoint on container
+
+By passing in the `hasBreakpointOnContainer` property, the overflow menu's breakpoint will be relative to its own container width rather than the viewport width.
+
+You can change the container width in this example by adjusting the slider. As the container width changes, the overflow menu will change between a horizontal menu and a vertical dropdown despite the viewport width not changing.
+
+```ts file="./OverflowMenuBreakpointOnContainer.tsx"
 ```

--- a/packages/react-core/src/components/OverflowMenu/examples/OverflowMenu.md
+++ b/packages/react-core/src/components/OverflowMenu/examples/OverflowMenu.md
@@ -402,7 +402,7 @@ class OverflowMenuPersist extends React.Component {
 
 ### Breakpoint on container
 
-By passing in the `hasBreakpointOnContainer` property, the overflow menu's breakpoint will be relative to its own container width rather than the viewport width.
+By passing in the `breakpointReference` property, the overflow menu's breakpoint will be relative to the width of the reference container rather than the viewport width.
 
 You can change the container width in this example by adjusting the slider. As the container width changes, the overflow menu will change between a horizontal menu and a vertical dropdown despite the viewport width not changing.
 

--- a/packages/react-core/src/components/OverflowMenu/examples/OverflowMenuBreakpointOnContainer.tsx
+++ b/packages/react-core/src/components/OverflowMenu/examples/OverflowMenuBreakpointOnContainer.tsx
@@ -13,7 +13,7 @@ import {
 
 export const OverflowMenuBreakpointOnContainer: React.FunctionComponent = () => {
   const [isOpen, setIsOpen] = React.useState(false);
-  const [width, setWidth] = React.useState(100);
+  const [containerWidth, setContainerWidth] = React.useState(100);
   const containerRef = React.useRef<HTMLDivElement>(null);
 
   const onToggle = (isOpen: boolean) => {
@@ -25,7 +25,14 @@ export const OverflowMenuBreakpointOnContainer: React.FunctionComponent = () => 
   };
 
   const onChange = (value: number) => {
-    setWidth(value);
+    setContainerWidth(value);
+  };
+
+  const containerStyles = {
+    width: `${containerWidth}%`,
+    padding: '1rem',
+    borderWidth: '2px',
+    borderStyle: 'dashed'
   };
 
   const dropdownItems = [
@@ -50,10 +57,11 @@ export const OverflowMenuBreakpointOnContainer: React.FunctionComponent = () => 
     <>
       <div style={{ width: '100%', maxWidth: '400px' }}>
         <div>
-          <span id="overflowMenu-hasBreakpointOnContainer-slider-label">Current container width</span>: {width}%
+          <span id="overflowMenu-hasBreakpointOnContainer-slider-label">Current container width</span>: {containerWidth}
+          %
         </div>
         <Slider
-          value={width}
+          value={containerWidth}
           onChange={onChange}
           max={100}
           min={20}
@@ -63,11 +71,7 @@ export const OverflowMenuBreakpointOnContainer: React.FunctionComponent = () => 
           aria-labelledby="overflowMenu-hasBreakpointOnContainer-slider-label"
         />
       </div>
-      <div
-        ref={containerRef}
-        id="breakpoint-reference-container"
-        style={{ width: `${width}%`, border: '1px solid black' }}
-      >
+      <div ref={containerRef} id="breakpoint-reference-container" style={containerStyles}>
         <OverflowMenu breakpointReference={containerRef} breakpoint="sm">
           <OverflowMenuContent>
             <OverflowMenuItem>Item 1</OverflowMenuItem>

--- a/packages/react-core/src/components/OverflowMenu/examples/OverflowMenuBreakpointOnContainer.tsx
+++ b/packages/react-core/src/components/OverflowMenu/examples/OverflowMenuBreakpointOnContainer.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import {
+  OverflowMenu,
+  OverflowMenuControl,
+  OverflowMenuContent,
+  OverflowMenuGroup,
+  OverflowMenuItem,
+  OverflowMenuDropdownItem,
+  Dropdown,
+  KebabToggle,
+  Slider
+} from '@patternfly/react-core';
+
+export const OverflowMenuBreakpointOnContainer: React.FunctionComponent = () => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [width, setWidth] = React.useState(100);
+
+  const onToggle = (isOpen: boolean) => {
+    setIsOpen(isOpen);
+  };
+
+  const onSelect = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const onChange = (value: number) => {
+    setWidth(value);
+  };
+
+  const dropdownItems = [
+    <OverflowMenuDropdownItem key="item1" isShared>
+      Item 1
+    </OverflowMenuDropdownItem>,
+    <OverflowMenuDropdownItem key="item2" isShared>
+      Item 2
+    </OverflowMenuDropdownItem>,
+    <OverflowMenuDropdownItem key="item3" isShared>
+      Item 3
+    </OverflowMenuDropdownItem>,
+    <OverflowMenuDropdownItem key="item4" isShared>
+      Item 4
+    </OverflowMenuDropdownItem>,
+    <OverflowMenuDropdownItem key="item5" isShared>
+      Item 5
+    </OverflowMenuDropdownItem>
+  ];
+
+  return (
+    <>
+      <div style={{ width: '100%', maxWidth: '400px' }}>
+        <div>
+          <span id="overflowMenu-hasBreakpointOnContainer-slider-label">Current container width</span>: {width}%
+        </div>
+        <Slider
+          value={width}
+          onChange={onChange}
+          max={100}
+          min={20}
+          step={20}
+          showTicks
+          showBoundaries={false}
+          aria-labelledby="overflowMenu-hasBreakpointOnContainer-slider-label"
+        />
+      </div>
+      <OverflowMenu style={{ width: `${width}%`, border: '1px solid black' }} hasBreakpointOnContainer breakpoint="sm">
+        <OverflowMenuContent>
+          <OverflowMenuItem>Item 1</OverflowMenuItem>
+          <OverflowMenuItem>Item 2</OverflowMenuItem>
+          <OverflowMenuGroup>
+            <OverflowMenuItem>Item 3</OverflowMenuItem>
+            <OverflowMenuItem>Item 4</OverflowMenuItem>
+            <OverflowMenuItem>Item 5</OverflowMenuItem>
+          </OverflowMenuGroup>
+        </OverflowMenuContent>
+        <OverflowMenuControl>
+          <Dropdown
+            onSelect={onSelect}
+            toggle={<KebabToggle onToggle={onToggle} />}
+            isOpen={isOpen}
+            isPlain
+            dropdownItems={dropdownItems}
+            isFlipEnabled
+            menuAppendTo="parent"
+          />
+        </OverflowMenuControl>
+      </OverflowMenu>
+    </>
+  );
+};

--- a/packages/react-core/src/components/OverflowMenu/examples/OverflowMenuBreakpointOnContainer.tsx
+++ b/packages/react-core/src/components/OverflowMenu/examples/OverflowMenuBreakpointOnContainer.tsx
@@ -14,6 +14,7 @@ import {
 export const OverflowMenuBreakpointOnContainer: React.FunctionComponent = () => {
   const [isOpen, setIsOpen] = React.useState(false);
   const [width, setWidth] = React.useState(100);
+  const containerRef = React.useRef<HTMLDivElement>(null);
 
   const onToggle = (isOpen: boolean) => {
     setIsOpen(isOpen);
@@ -62,28 +63,34 @@ export const OverflowMenuBreakpointOnContainer: React.FunctionComponent = () => 
           aria-labelledby="overflowMenu-hasBreakpointOnContainer-slider-label"
         />
       </div>
-      <OverflowMenu style={{ width: `${width}%`, border: '1px solid black' }} hasBreakpointOnContainer breakpoint="sm">
-        <OverflowMenuContent>
-          <OverflowMenuItem>Item 1</OverflowMenuItem>
-          <OverflowMenuItem>Item 2</OverflowMenuItem>
-          <OverflowMenuGroup>
-            <OverflowMenuItem>Item 3</OverflowMenuItem>
-            <OverflowMenuItem>Item 4</OverflowMenuItem>
-            <OverflowMenuItem>Item 5</OverflowMenuItem>
-          </OverflowMenuGroup>
-        </OverflowMenuContent>
-        <OverflowMenuControl>
-          <Dropdown
-            onSelect={onSelect}
-            toggle={<KebabToggle onToggle={onToggle} />}
-            isOpen={isOpen}
-            isPlain
-            dropdownItems={dropdownItems}
-            isFlipEnabled
-            menuAppendTo="parent"
-          />
-        </OverflowMenuControl>
-      </OverflowMenu>
+      <div
+        ref={containerRef}
+        id="breakpoint-reference-container"
+        style={{ width: `${width}%`, border: '1px solid black' }}
+      >
+        <OverflowMenu breakpointReference={containerRef} breakpoint="sm">
+          <OverflowMenuContent>
+            <OverflowMenuItem>Item 1</OverflowMenuItem>
+            <OverflowMenuItem>Item 2</OverflowMenuItem>
+            <OverflowMenuGroup>
+              <OverflowMenuItem>Item 3</OverflowMenuItem>
+              <OverflowMenuItem>Item 4</OverflowMenuItem>
+              <OverflowMenuItem>Item 5</OverflowMenuItem>
+            </OverflowMenuGroup>
+          </OverflowMenuContent>
+          <OverflowMenuControl>
+            <Dropdown
+              onSelect={onSelect}
+              toggle={<KebabToggle onToggle={onToggle} />}
+              isOpen={isOpen}
+              isPlain
+              dropdownItems={dropdownItems}
+              isFlipEnabled
+              menuAppendTo="parent"
+            />
+          </OverflowMenuControl>
+        </OverflowMenu>
+      </div>
     </>
   );
 };

--- a/packages/react-integration/cypress/integration/overflowmenu.spec.ts
+++ b/packages/react-integration/cypress/integration/overflowmenu.spec.ts
@@ -116,4 +116,43 @@ describe('OverflowMenu Demo Test', () => {
       });
     });
   });
+
+  describe('Container Breakpoint OverflowMenu Small', () => {
+    context('List view', () => {
+      beforeEach(() => {
+        cy.viewport(1200, 800);
+      });
+
+      it('displays OverflowMenuContent', () => {
+        cy.get('#container-breakpoint-overflow-menu .pf-c-overflow-menu__content').should('exist');
+        cy.get('#container-breakpoint-overflow-menu .pf-c-overflow-menu__control').should('not.exist');
+      });
+    });
+
+    context('Dropdown view', () => {
+      beforeEach(() => {
+        cy.viewport(1151, 800);
+      });
+
+      it('displays OverflowMenuControl', () => {
+        cy.get('#container-breakpoint-overflow-menu .pf-c-overflow-menu__control').should('exist');
+        cy.get('#container-breakpoint-overflow-menu .pf-c-overflow-menu__content').should('not.exist');
+      });
+
+      it('Verify toggle dropdown', () => {
+        cy.get('#container-breakpoint-overflow-menu button').should('have.class', 'pf-c-dropdown__toggle');
+      });
+
+      it('Verify dropdown menu expanded', () => {
+        cy.get('#container-breakpoint-overflow-menu button')
+          .last()
+          .click({ force: true });
+        cy.get('#container-breakpoint-overflow-menu .pf-c-dropdown').should('have.class', 'pf-m-expanded');
+        // close overflow menu again
+        cy.get('#container-breakpoint-overflow-menu button')
+          .last()
+          .click({ force: true });
+      });
+    });
+  });
 });

--- a/packages/react-integration/cypress/integration/overflowmenu.spec.ts
+++ b/packages/react-integration/cypress/integration/overflowmenu.spec.ts
@@ -131,7 +131,8 @@ describe('OverflowMenu Demo Test', () => {
 
     context('Dropdown view', () => {
       beforeEach(() => {
-        cy.viewport(1151, 800);
+        cy.viewport(1200, 800);
+        cy.get('#container-breakpoint-container').invoke('attr', 'style', 'width: 575px');
       });
 
       it('displays OverflowMenuControl', () => {

--- a/packages/react-integration/demo-app-ts/src/components/demos/OverflowMenuDemo/OverflowMenuDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/OverflowMenuDemo/OverflowMenuDemo.tsx
@@ -18,8 +18,11 @@ export class OverflowMenuDemo extends React.Component {
   state = {
     isSimpleOpen: false,
     isAdditionalOptionsOpen: false,
-    isPersistOpen: false
+    isPersistOpen: false,
+    isContainerBreakpointOpen: false
   };
+
+  breakpointContainerRef = React.createRef<HTMLDivElement>();
 
   style = {
     display: 'flex',
@@ -225,12 +228,79 @@ export class OverflowMenuDemo extends React.Component {
     );
   }
 
+  onContainerBreakpointToggle = (isContainerBreakpointOpen: boolean) => {
+    this.setState({
+      isContainerBreakpointOpen
+    });
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  onContainerBreakpointSelect = (_event?: React.SyntheticEvent<HTMLDivElement>) => {
+    this.setState({
+      isContainerBreakpointOpen: !this.state.isContainerBreakpointOpen
+    });
+  };
+
+  renderContainerBreakpointOverflowMenu() {
+    const { isContainerBreakpointOpen } = this.state;
+    const dropdownItems = [
+      <OverflowMenuDropdownItem key="action">Action</OverflowMenuDropdownItem>,
+      <OverflowMenuDropdownItem key="item1" isShared>
+        Item 1
+      </OverflowMenuDropdownItem>,
+      <OverflowMenuDropdownItem key="item2" isShared>
+        Item 2
+      </OverflowMenuDropdownItem>,
+      <OverflowMenuDropdownItem key="item3" isShared>
+        Item 3
+      </OverflowMenuDropdownItem>,
+      <OverflowMenuDropdownItem key="item4" isShared>
+        Item 4
+      </OverflowMenuDropdownItem>,
+      <OverflowMenuDropdownItem key="item5" isShared>
+        Item 5
+      </OverflowMenuDropdownItem>
+    ];
+    return (
+      <div ref={this.breakpointContainerRef} style={{ width: '50%' }}>
+        <OverflowMenu
+          breakpointReference={this.breakpointContainerRef}
+          breakpoint="sm"
+          id="container-breakpoint-overflow-menu"
+          style={this.style}
+        >
+          <OverflowMenuContent>
+            <OverflowMenuItem>Item</OverflowMenuItem>
+            <OverflowMenuItem>Item</OverflowMenuItem>
+            <OverflowMenuGroup>
+              <OverflowMenuItem>Item</OverflowMenuItem>
+              <OverflowMenuItem>Item</OverflowMenuItem>
+              <OverflowMenuItem>Item</OverflowMenuItem>
+            </OverflowMenuGroup>
+          </OverflowMenuContent>
+          <OverflowMenuControl>
+            <Dropdown
+              onSelect={this.onContainerBreakpointSelect}
+              toggle={<KebabToggle onToggle={this.onContainerBreakpointToggle} />}
+              isOpen={isContainerBreakpointOpen}
+              isPlain
+              dropdownItems={dropdownItems}
+              isFlipEnabled
+              menuAppendTo="parent"
+            />
+          </OverflowMenuControl>
+        </OverflowMenu>
+      </div>
+    );
+  }
+
   render() {
     return (
       <React.Fragment>
         {this.renderSimpleOverflowMenu()}
         {this.renderOverflowMenuAdditionalOptions()}
         {this.renderOverflowMenuPersist()}
+        {this.renderContainerBreakpointOverflowMenu()}
       </React.Fragment>
     );
   }

--- a/packages/react-integration/demo-app-ts/src/components/demos/OverflowMenuDemo/OverflowMenuDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/OverflowMenuDemo/OverflowMenuDemo.tsx
@@ -262,7 +262,7 @@ export class OverflowMenuDemo extends React.Component {
       </OverflowMenuDropdownItem>
     ];
     return (
-      <div ref={this.breakpointContainerRef} style={{ width: '50%' }}>
+      <div id="container-breakpoint-container" ref={this.breakpointContainerRef} style={{ width: '600px' }}>
         <OverflowMenu
           breakpointReference={this.breakpointContainerRef}
           breakpoint="sm"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7376

[Breakpoint on container example](https://patternfly-react-pr-7913.surge.sh/components/overflow-menu#breakpoint-on-container)

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
