### PR TITLE
Change pipeline node visuals as scale, show icons for status

### DIFF
--- a/packages/react-integration/demo-app-ts/src/Demos.ts
+++ b/packages/react-integration/demo-app-ts/src/Demos.ts
@@ -515,8 +515,7 @@ export const Demos: DemoInterface[] = [
   {
     id: 'topology-pipelines-demo',
     name: 'Topology Pipelines Demo',
-    componentType: Examples.TopologyPipelineDemo,
-    isDefault: true
+    componentType: Examples.TopologyPipelineDemo
   },
   {
     id: 'treeview-demo',

--- a/packages/react-integration/demo-app-ts/src/Demos.ts
+++ b/packages/react-integration/demo-app-ts/src/Demos.ts
@@ -515,7 +515,8 @@ export const Demos: DemoInterface[] = [
   {
     id: 'topology-pipelines-demo',
     name: 'Topology Pipelines Demo',
-    componentType: Examples.TopologyPipelineDemo
+    componentType: Examples.TopologyPipelineDemo,
+    isDefault: true
   },
   {
     id: 'treeview-demo',

--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/PipelineLayout.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/PipelineLayout.tsx
@@ -55,7 +55,7 @@ const getModel = (layout: string): Model => {
     type: 'finally-group',
     children: finallyNodes.map(n => n.id),
     group: true,
-    style: { padding: 17 }
+    style: { padding: [35, 17] }
   };
 
   const spacerNodes = getSpacerNodes([...tasks, ...finallyNodes]);
@@ -75,7 +75,7 @@ const getModel = (layout: string): Model => {
 };
 
 export const PipelineLayout = withTopologySetup(() => {
-  useLayoutFactory((type: string, graph: Graph): Layout | undefined => new PipelineDagreLayout(graph));
+  useLayoutFactory((type: string, graph: Graph): Layout | undefined => new PipelineDagreLayout(graph, { nodesep: 95 }));
   useComponentFactory(pipelineComponentFactory);
   // support pan zoom and drag
   useComponentFactory(

--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/PipelineTasks.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/PipelineTasks.tsx
@@ -33,7 +33,7 @@ export const PipelineTasks: React.FC = () => {
       type: 'finally-group',
       children: finallyNodes.map(n => n.id),
       group: true,
-      style: { padding: 17 }
+      style: { padding: 30 }
     };
     const model = {
       graph: {

--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/components/DemoFinallyNode.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/components/DemoFinallyNode.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { observer } from 'mobx-react';
+import {
+  DEFAULT_LAYER,
+  FinallyNode,
+  Layer,
+  Node,
+  ScaleDetailsLevel,
+  TOP_LAYER,
+  useDetailsLevel,
+  useHover,
+  WithContextMenuProps,
+  WithSelectionProps
+} from '@patternfly/react-topology';
+
+type DemoFinallyNodeProps = {
+  element: Node;
+} & WithContextMenuProps &
+  WithSelectionProps;
+
+const DemoFinallyNode: React.FunctionComponent<DemoFinallyNodeProps> = ({ ...props }) => {
+  const [hover, hoverRef] = useHover();
+  const detailsLevel = useDetailsLevel();
+
+  return (
+    <Layer id={detailsLevel !== ScaleDetailsLevel.high && hover ? TOP_LAYER : DEFAULT_LAYER}>
+      <g ref={hoverRef}>
+        <FinallyNode scaleNode={hover && detailsLevel !== ScaleDetailsLevel.high} hideDetailsAtMedium {...props} />
+      </g>
+    </Layer>
+  );
+};
+
+export default observer(DemoFinallyNode);

--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/components/DemoTaskNode.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/components/DemoTaskNode.tsx
@@ -1,9 +1,15 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
 import {
+  DEFAULT_LAYER,
   DEFAULT_WHEN_OFFSET,
+  Layer,
   Node,
+  ScaleDetailsLevel,
   TaskNode,
+  TOP_LAYER,
+  useDetailsLevel,
+  useHover,
   WhenDecorator,
   WithContextMenuProps,
   WithSelectionProps
@@ -22,6 +28,8 @@ const DemoTaskNode: React.FunctionComponent<DemoTaskNodeProps> = ({
   ...rest
 }) => {
   const data = element.getData();
+  const [hover, hoverRef] = useHover();
+  const detailsLevel = useDetailsLevel();
 
   const passedData = React.useMemo(() => {
     const newData = { ...data };
@@ -49,16 +57,22 @@ const DemoTaskNode: React.FunctionComponent<DemoTaskNodeProps> = ({
     footerContent: 'Popover footer'
   };
   return (
-    <TaskNode
-      element={element}
-      onContextMenu={data.showContextMenu ? onContextMenu : undefined}
-      contextMenuOpen={contextMenuOpen}
-      {...passedData}
-      {...rest}
-      badgePopoverParams={badgePopoverParams}
-    >
-      {whenDecorator}
-    </TaskNode>
+    <Layer id={detailsLevel !== ScaleDetailsLevel.high && hover ? TOP_LAYER : DEFAULT_LAYER}>
+      <g ref={hoverRef}>
+        <TaskNode
+          element={element}
+          onContextMenu={data.showContextMenu ? onContextMenu : undefined}
+          contextMenuOpen={contextMenuOpen}
+          scaleNode={(hover || contextMenuOpen) && detailsLevel !== ScaleDetailsLevel.high}
+          hideDetailsAtMedium
+          {...passedData}
+          {...rest}
+          badgePopoverParams={badgePopoverParams}
+        >
+          {whenDecorator}
+        </TaskNode>
+      </g>
+    </Layer>
   );
 };
 

--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/components/pipelineComponentFactory.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/components/pipelineComponentFactory.tsx
@@ -10,7 +10,6 @@ import {
   DEFAULT_SPACER_NODE_TYPE,
   DEFAULT_EDGE_TYPE,
   DEFAULT_FINALLY_NODE_TYPE,
-  FinallyNode,
   ContextMenuSeparator,
   ContextMenuItem,
   withContextMenu,
@@ -20,6 +19,7 @@ import {
 } from '@patternfly/react-topology';
 import DemoTaskNode from './DemoTaskNode';
 import * as React from 'react';
+import DemoFinallyNode from './DemoFinallyNode';
 
 const contextMenuItem = (label: string, i: number): React.ReactElement => {
   if (label === '-') {
@@ -48,7 +48,7 @@ const pipelineComponentFactory: ComponentFactory = (
     case DEFAULT_TASK_NODE_TYPE:
       return withContextMenu(() => defaultMenu)(withSelection()(DemoTaskNode));
     case DEFAULT_FINALLY_NODE_TYPE:
-      return withContextMenu(() => defaultMenu)(withSelection()(FinallyNode));
+      return withContextMenu(() => defaultMenu)(withSelection()(DemoFinallyNode));
     case 'finally-group':
       return DefaultTaskGroup;
     case DEFAULT_SPACER_NODE_TYPE:

--- a/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/utils/pipelineUtils.ts
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TopologyDemo/utils/pipelineUtils.ts
@@ -9,7 +9,7 @@ import {
 } from '@patternfly/react-topology';
 import { logos } from './logos';
 
-export const ROW_HEIGHT = 80;
+export const ROW_HEIGHT = 100;
 export const COLUMN_WIDTH = 250;
 
 export const DEFAULT_TASK_WIDTH = 170;

--- a/packages/react-styles/src/css/components/Topology/topology-pipelines.css
+++ b/packages/react-styles/src/css/components/Topology/topology-pipelines.css
@@ -209,7 +209,7 @@
 }
 
 .pf-topology-pipelines__pill.pf-m-selected.pf-m-skipped .pf-topology-pipelines__pill-background {
-  --pf-topology-pipelines__pill-background--Fill: var(--pf-topology-pipelines__pill-background--m-skipped--Fill);
+  --pf-topology-pipelines__pill-background--Fill: var(--pf-topology-pipelines__pill-background--m-selected--m-skipped--Fill);
   --pf-topology-pipelines__pill-background--Stroke: var(--pf-topology-pipelines__pill-background--m-skipped--Stroke);
 }
 

--- a/packages/react-styles/src/css/components/Topology/topology-pipelines.css
+++ b/packages/react-styles/src/css/components/Topology/topology-pipelines.css
@@ -12,6 +12,7 @@
   --pf-topology-pipelines__pill-background--m-danger--Fill: var(--pf-global--danger-color--100);
   --pf-topology-pipelines__pill-background--m-success--Fill: var(--pf-global--success-color--100);
   --pf-topology-pipelines__pill-background--m-warning--Fill: var(--pf-global--warning-color--100);
+  --pf-topology-pipelines__pill-background--m-skipped--Fill: var(--pf-global--secondary-color--100);
   --pf-topology-pipelines__pill-background--m-in-progress--Fill: var(--pf-global--info-color--100);
   --pf-topology-pipelines__pill-background--m-pending--Fill: var(--pf-global--BackgroundColor--100);
   --pf-topology-pipelines__pill-background--m-running--Fill: var(--pf-global--BackgroundColor--100);
@@ -20,6 +21,7 @@
   --pf-topology-pipelines__pill-background--m-danger--Stroke: var(--pf-global--danger-color--100);
   --pf-topology-pipelines__pill-background--m-success--Stroke: var(--pf-global--success-color--100);
   --pf-topology-pipelines__pill-background--m-warning--Stroke: var(--pf-global--warning-color--100);
+  --pf-topology-pipelines__pill-background--m-skipped--Stroke: var(--pf-global--BorderColor--100);
   --pf-topology-pipelines__pill-background--m-in-progress--Stroke: var(--pf-global--info-color--100);
   --pf-topology-pipelines__pill-background--m-pending--Stroke: var(--pf-global--BorderColor--100);
   --pf-topology-pipelines__pill-background--m-running--Stroke: var(--pf-global--BorderColor--100);
@@ -34,10 +36,11 @@
   --pf-topology-pipelines__pill-background--m-selected--m-danger--Fill: var(--pf-global--Color--light-100);
   --pf-topology-pipelines__pill-background--m-selected--m-success--Fill: var(--pf-global--Color--light-100);
   --pf-topology-pipelines__pill-background--m-selected--m-warning--Fill: var(--pf-global--Color--100);
+  --pf-topology-pipelines__pill-background--m-selected--m-skipped--Fill: var(--pf-global--secondary-color--100);
   --pf-topology-pipelines__pill-background--m-selected--m-in-progress--Fill: var(--pf-global--Color--light-100);
-  --pf-topology-pipelines__pill-background--m-selected--m-pending--Fill: var(--pf-global--active-color--100);
-  --pf-topology-pipelines__pill-background--m-selected--m-running--Fill: var(--pf-global--active-color--100);
-  --pf-topology-pipelines__pill-background--m-selected--m-idle--Fill: var(--pf-global--active-color--100);
+  --pf-topology-pipelines__pill-background--m-selected--m-pending--Fill: var(--pf-global--BorderColor--100);
+  --pf-topology-pipelines__pill-background--m-selected--m-running--Fill: var(--pf-global--BorderColor--100);
+  --pf-topology-pipelines__pill-background--m-selected--m-idle--Fill: var(--pf-global--BorderColor--100);
 
   --pf-topology-pipelines__pill-text--Color: var(--pf-topology-pipelines__pill--Color);
 
@@ -45,16 +48,18 @@
   --pf-topology-pipelines__pill-text--m-selected--m-danger--Color: var(--pf-global--Color--light-100);
   --pf-topology-pipelines__pill-text--m-selected--m-success--Color: var(--pf-global--Color--light-100);
   --pf-topology-pipelines__pill-text--m-selected--m-warning--Color: var(--pf-global--Color--100);
+  --pf-topology-pipelines__pill-text--m-selected--m-skipped--Color: var(--pf-global--Color--light-100);
   --pf-topology-pipelines__pill-text--m-selected--m-in-progress--Color: var(--pf-global--Color--light-100);
-  --pf-topology-pipelines__pill-text--m-selected--m-pending--Color: var(--pf-global--Color--light-100);
-  --pf-topology-pipelines__pill-text--m-selected--m-running--Color: var(--pf-global--Color--light-100);
-  --pf-topology-pipelines__pill-text--m-selected--m-idle--Color: var(--pf-global--Color--light-100);
+  --pf-topology-pipelines__pill-text--m-selected--m-pending--Color: var(--pf-global--palette--black-1000);
+  --pf-topology-pipelines__pill-text--m-selected--m-running--Color: var(--pf-global--palette--black-1000);
+  --pf-topology-pipelines__pill-text--m-selected--m-idle--Color: var(--pf-global--palette--black-1000);
 
   /* pill status icon */
   --pf-topology-pipelines__pill-status--color: var(--pf-global--BorderColor--100);
   --pf-topology-pipelines__pill-status--m-danger--color: var(--pf-global--danger-color--100);
   --pf-topology-pipelines__pill-status--m-success--color: var(--pf-global--success-color--100);
   --pf-topology-pipelines__pill-status--m-warning--color: var(--pf-global--warning-color--100);
+  --pf-topology-pipelines__pill-status--m-skipped--color: var(--pf-global--secondary-color--100);
   --pf-topology-pipelines__pill-status--m-in-progress--color: var(--pf-global--info-color--100);
   --pf-topology-pipelines__pill-status--m-pending--color: var(--pf-global--Color--100);
   --pf-topology-pipelines__pill-status--m-running--color: var(--pf-global--Color--100);
@@ -65,13 +70,37 @@
   --pf-topology-pipelines__pill-status--m-selected--m-danger--color: var(--pf-global--Color--light-100);
   --pf-topology-pipelines__pill-status--m-selected--m-success--color: var(--pf-global--Color--light-100);
   --pf-topology-pipelines__pill-status--m-selected--m-warning--color: var(--pf-global--Color--light-100);
+  --pf-topology-pipelines__pill-status--m-selected--m-skipped--color: var(--pf-global--Color--light-100);
   --pf-topology-pipelines__pill-status--m-selected--m-in-progress--color: var(--pf-global--Color--light-100);
-  --pf-topology-pipelines__pill-status--m-selected--m-pending--color: var(--pf-global--Color--light-100);
-  --pf-topology-pipelines__pill-status--m-selected--m-running--color: var(--pf-global--Color--light-100);
-  --pf-topology-pipelines__pill-status--m-selected--m-idle--color: var(--pf-global--Color--light-100);
+  --pf-topology-pipelines__pill-status--m-selected--m-pending--color: var(--pf-global--palette--black-1000);
+  --pf-topology-pipelines__pill-status--m-selected--m-running--color: var(--pf-global--palette--black-1000);
+  --pf-topology-pipelines__pill-status--m-selected--m-idle--color: var(--pf-global--palette--black-1000);
 
   --pf-topology-pipelines__pill-badge--fill: var(--pf-global--palette--black-200);
   --pf-topology-pipelines__pill-badge--text--fill: var(--pf-global--palette--black-1000);
+
+  /* status icon, (hidden details) */
+  --pf-topology-pipelines__status-icon--color: var(--pf-global--BorderColor--100);
+  --pf-topology-pipelines__status-icon--fill: var(--pf-global--Color--light-100);
+  --pf-topology-pipelines__status-icon--m-danger--color: var(--pf-global--danger-color--100);
+  --pf-topology-pipelines__status-icon--m-success--color: var(--pf-global--success-color--100);
+  --pf-topology-pipelines__status-icon--m-warning--color: var(--pf-global--warning-color--100);
+  --pf-topology-pipelines__status-icon--m-skipped--color: var(--pf-global--secondary-color--100);
+  --pf-topology-pipelines__status-icon--m-in-progress--color: var(--pf-global--info-color--100);
+  --pf-topology-pipelines__status-icon--m-pending--color: var(--pf-global--Color--100);
+  --pf-topology-pipelines__status-icon--m-running--color: var(--pf-global--Color--100);
+  --pf-topology-pipelines__status-icon--m-idle--color: var(--pf-global--Color--100);
+
+  --pf-topology-pipelines__status-icon--m-selected--color: var(--pf-global--active-color--100);
+  --pf-topology-pipelines__status-icon--m-selected--m-danger--color: var(--pf-global--Color--light-100);
+  --pf-topology-pipelines__status-icon--m-selected--m-success--color: var(--pf-global--Color--light-100);
+  --pf-topology-pipelines__status-icon--m-selected--m-warning--color: var(--pf-global--Color--light-100);
+  --pf-topology-pipelines__status-icon--m-selected--m-skipped--color: var(--pf-global--Color--light-100);
+  --pf-topology-pipelines__status-icon--m-selected--m-in-progress--color: var(--pf-global--Color--light-100);
+  --pf-topology-pipelines__status-icon--m-selected--m-pending--color: var(--pf-global--Color--light-100);
+  --pf-topology-pipelines__status-icon--m-selected--m-running--color: var(--pf-global--Color--light-100);
+  --pf-topology-pipelines__status-icon--m-selected--m-idle--color: var(--pf-global--Color--light-100);
+
 
   /* when expression */
   --pf-topology-pipelines__when-expression-background--Stroke: var(--pf-global--BorderColor--200);
@@ -82,6 +111,7 @@
   --pf-topology-pipelines__when-expression--m-danger--color: var(--pf-global--danger-color--100);
   --pf-topology-pipelines__when-expression--m-success--color: var(--pf-global--success-color--100);
   --pf-topology-pipelines__when-expression--m-warning--color: var(--pf-global--BorderColor--200);
+  --pf-topology-pipelines__when-expression--m-skipped--color: var(--pf-global--secondary-color--100);
   --pf-topology-pipelines__when-expression--m-in-progress--color: var(--pf-global--info-color--100);
 
   /* selected when expression */
@@ -105,6 +135,7 @@
   --pf-topology-pipelines__pill-text--m-selected--m-danger--Color: var(--pf-global--palette--black-900);
   --pf-topology-pipelines__pill-text--m-selected--m-success--Color: var(--pf-global--palette--black-900);
   --pf-topology-pipelines__pill-text--m-selected--m-warning--Color: var(--pf-global--palette--black-900);
+  --pf-topology-pipelines__pill-text--m-selected--m-skipped--Color: var(--pf-global--BackgroundColor--150);
   --pf-topology-pipelines__pill-text--m-selected--m-in-progress--Color: var(--pf-global--palette--black-900);
   --pf-topology-pipelines__pill-text--m-selected--m-pending--Color: var(--pf-global--Color--100);
   --pf-topology-pipelines__pill-text--m-selected--m-running--Color: var(--pf-global--Color--100);
@@ -135,6 +166,10 @@
 
 .pf-topology-pipelines__pill.pf-m-warning .pf-topology-pipelines__pill-background {
   --pf-topology-pipelines__pill-background--Stroke: var(--pf-topology-pipelines__pill-background--m-warning--Fill);
+}
+
+.pf-topology-pipelines__pill.pf-m-skipped .pf-topology-pipelines__pill-background {
+  --pf-topology-pipelines__pill-background--Stroke: var(--pf-topology-pipelines__pill-background--m-skipped--Fill);
 }
 
 .pf-topology-pipelines__pill.pf-m-in-progress .pf-topology-pipelines__pill-background {
@@ -173,6 +208,11 @@
   --pf-topology-pipelines__pill-background--Stroke: var(--pf-topology-pipelines__pill-background--m-warning--Stroke);
 }
 
+.pf-topology-pipelines__pill.pf-m-selected.pf-m-skipped .pf-topology-pipelines__pill-background {
+  --pf-topology-pipelines__pill-background--Fill: var(--pf-topology-pipelines__pill-background--m-skipped--Fill);
+  --pf-topology-pipelines__pill-background--Stroke: var(--pf-topology-pipelines__pill-background--m-skipped--Stroke);
+}
+
 .pf-topology-pipelines__pill.pf-m-selected.pf-m-in-progress .pf-topology-pipelines__pill-background {
   --pf-topology-pipelines__pill-background--Fill: var(--pf-topology-pipelines__pill-background--m-in-progress--Fill);
   --pf-topology-pipelines__pill-background--Stroke: var(--pf-topology-pipelines__pill-background--m-in-progress--Stroke);
@@ -202,6 +242,10 @@
 .pf-topology-pipelines__pill.pf-m-hover.pf-m-warning .pf-topology-pipelines__pill-background {
   --pf-topology-pipelines__pill-background--StrokeWidth: var(--pf-global--BorderWidth--md);
 }
+.pf-topology-pipelines__pill.pf-m-hover.pf-m-skipped .pf-topology-pipelines__pill-background {
+  --pf-topology-pipelines__pill-background--StrokeWidth: var(--pf-global--BorderWidth--md);
+}
+
 .pf-topology-pipelines__pill.pf-m-hover.pf-m-in-progress .pf-topology-pipelines__pill-background {
   --pf-topology-pipelines__pill-background--StrokeWidth: var(--pf-global--BorderWidth--md);
 }
@@ -227,6 +271,10 @@
 
 .pf-topology-pipelines__pill.pf-m-selected.pf-m-warning .pf-topology-pipelines__pill-text {
   --pf-topology-pipelines__pill-text--Color: var(--pf-topology-pipelines__pill-text--m-selected--m-warning--Color);
+}
+
+.pf-topology-pipelines__pill.pf-m-selected.pf-m-skipped .pf-topology-pipelines__pill-text {
+  --pf-topology-pipelines__pill-text--Color: var(--pf-topology-pipelines__pill-text--m-selected--m-skipped--Color);
 }
 
 .pf-topology-pipelines__pill.pf-m-selected.pf-m-in-progress .pf-topology-pipelines__pill-text {
@@ -263,6 +311,9 @@
 .pf-topology-pipelines__pill-status.pf-m-warning {
   --pf-topology-pipelines__pill-status--color: var(--pf-topology-pipelines__pill-status--m-warning--color);
 }
+.pf-topology-pipelines__pill-status.pf-m-skipped {
+  --pf-topology-pipelines__pill-status--color: var(--pf-topology-pipelines__pill-status--m-skipped--color);
+}
 .pf-topology-pipelines__pill-status.pf-m-in-progress {
   --pf-topology-pipelines__pill-status--color: var(--pf-topology-pipelines__pill-status--m-in-progress--color);
 }
@@ -284,6 +335,9 @@
 }
 .pf-topology-pipelines__pill-status.pf-m-selected.pf-m-warning {
   --pf-topology-pipelines__pill-status--color: var(--pf-topology-pipelines__pill-status--m-selected--m-warning--color);
+}
+.pf-topology-pipelines__pill-status.pf-m-selected.pf-m-skipped {
+  --pf-topology-pipelines__pill-status--color: var(--pf-topology-pipelines__pill-status--m-selected--m-skipped--color);
 }
 .pf-topology-pipelines__pill-status.pf-m-selected.pf-m-in-progress {
   --pf-topology-pipelines__pill-status--color: var(--pf-topology-pipelines__pill-status--m-selected--m-in-progress--color);
@@ -338,6 +392,9 @@
 .pf-topology-pipelines__pill.pf-m-selected.pf-m-warning .pf-topology__node__action-icon__icon {
   --pf-topology__node__action-icon__icon--Color: var(--pf-topology-pipelines__pill-text--m-selected--m-warning--Color);
 }
+.pf-topology-pipelines__pill.pf-m-selected.pf-m-skipped .pf-topology__node__action-icon__icon {
+  --pf-topology__node__action-icon__icon--Color: var(--pf-topology-pipelines__pill-text--m-selected--m-skipped--Color);
+}
 .pf-topology-pipelines__pill.pf-m-selected.pf-m-in-progress .pf-topology__node__action-icon__icon {
   --pf-topology__node__action-icon__icon--Color: var(--pf-topology-pipelines__pill-text--m-selected--m-in-progress--Color);
 }
@@ -366,6 +423,10 @@
   --pf-topology-pipelines__when-expression-background--Stroke: var(--pf-topology-pipelines__when-expression--m-warning--color);
   --pf-topology-pipelines__when-expression-background--Fill: var(--pf-topology-pipelines__when-expression--m-warning--color);
  }
+.pf-topology-pipelines__when-expression-background.pf-m-skipped {
+  --pf-topology-pipelines__when-expression-background--Stroke: var(--pf-topology-pipelines__when-expression--m-skipped--color);
+  --pf-topology-pipelines__when-expression-background--Fill: var(--pf-topology-pipelines__when-expression--m-skipped--color);
+}
 .pf-topology-pipelines__when-expression-background.pf-m-in-progress {
   --pf-topology-pipelines__when-expression-background--Stroke: var(--pf-topology-pipelines__when-expression--m-in-progress--color);
   --pf-topology-pipelines__when-expression-background--Fill: var(--pf-topology-pipelines__when-expression--m-in-progress--color);
@@ -373,4 +434,121 @@
 
 .pf-topology-pipelines__pill.pf-m-selected .pf-topology-pipelines__when-expression-edge {
   stroke: var(--pf-topology-pipelines__when-expression--m-selected--color);
+}
+
+.pf-topology-pipelines__status-icon {
+  color: var(--pf-topology-pipelines__status-icon--color);
+}
+.pf-topology-pipelines__status-icon.pf-m-selected {
+  fill: var(--pf-topology-pipelines__status-icon--fill);
+}
+.pf-topology-pipelines__status-icon.pf-m-selected {
+  --pf-topology-pipelines__status-icon--color: var(--pf-topology-pipelines__status-icon--m-selected--color);
+}
+.pf-topology-pipelines__status-icon.pf-m-danger {
+  --pf-topology-pipelines__status-icon--color: var(--pf-topology-pipelines__status-icon--m-danger--color);
+}
+.pf-topology-pipelines__status-icon.pf-m-success {
+  --pf-topology-pipelines__status-icon--color: var(--pf-topology-pipelines__status-icon--m-success--color);
+}
+.pf-topology-pipelines__status-icon.pf-m-warning {
+  --pf-topology-pipelines__status-icon--color: var(--pf-topology-pipelines__status-icon--m-warning--color);
+}
+.pf-topology-pipelines__status-icon.pf-m-skipped {
+  --pf-topology-pipelines__status-icon--color: var(--pf-topology-pipelines__status-icon--m-skipped--color);
+}
+.pf-topology-pipelines__status-icon.pf-m-in-progress {
+  --pf-topology-pipelines__status-icon--color: var(--pf-topology-pipelines__status-icon--m-in-progress--color);
+}
+.pf-topology-pipelines__status-icon.pf-m-pending {
+  --pf-topology-pipelines__status-icon--color: var(--pf-topology-pipelines__status-icon--m-pending--color);
+}
+.pf-topology-pipelines__status-icon.pf-m-running {
+  --pf-topology-pipelines__status-icon--color: var(--pf-topology-pipelines__status-icon--m-running--color);
+}
+.pf-topology-pipelines__status-icon.pf-m-idle {
+  --pf-topology-pipelines__status-icon--color: var(--pf-topology-pipelines__status-icon--m-idle--color);
+}
+
+.pf-topology-pipelines__status-icon.pf-m-selected.pf-m-danger {
+  --pf-topology-pipelines__status-icon--color: var(--pf-topology-pipelines__status-icon--m-selected--m-danger--color);
+}
+.pf-topology-pipelines__status-icon.pf-m-selected.pf-m-success {
+  --pf-topology-pipelines__status-icon--color: var(--pf-topology-pipelines__status-icon--m-selected--m-success--color);
+}
+.pf-topology-pipelines__status-icon.pf-m-selected.pf-m-warning {
+  --pf-topology-pipelines__status-icon--color: var(--pf-topology-pipelines__status-icon--m-selected--m-warning--color);
+}
+.pf-topology-pipelines__status-icon.pf-m-selected.pf-m-skipped {
+  --pf-topology-pipelines__status-icon--color: var(--pf-topology-pipelines__status-icon--m-selected--m-skipped--color);
+}
+.pf-topology-pipelines__status-icon.pf-m-selected.pf-m-in-progress {
+  --pf-topology-pipelines__status-icon--color: var(--pf-topology-pipelines__status-icon--m-selected--m-in-progress--color);
+}
+.pf-topology-pipelines__status-icon.pf-m-selected.pf-m-pending {
+  --pf-topology-pipelines__status-icon--color: var(--pf-topology-pipelines__status-icon--m-selected--m-pending--color);
+}
+.pf-topology-pipelines__status-icon.pf-m-selected.pf-m-running {
+  --pf-topology-pipelines__status-icon--color: var(--pf-topology-pipelines__status-icon--m-selected--m-running--color);
+}
+.pf-topology-pipelines__status-icon.pf-m-selected.pf-m-idle {
+  --pf-topology-pipelines__status-icon--color: var(--pf-topology-pipelines__status-icon--m-selected--m-idle--color);
+}
+
+.pf-topology-pipelines__status-icon-background {
+  fill: var(--pf-topology-pipelines__pill-background--Fill);
+  stroke: var(--pf-topology-pipelines__pill-background--Stroke);
+}
+
+.pf-topology-pipelines__status-icon-background.pf-m-danger {
+  --pf-topology-pipelines__pill-background--Stroke: var(--pf-topology-pipelines__pill-background--m-danger--Stroke);
+}
+.pf-topology-pipelines__status-icon-background.pf-m-success {
+  --pf-topology-pipelines__pill-background--Stroke: var(--pf-topology-pipelines__pill-background--m-success--Stroke);
+}
+.pf-topology-pipelines__status-icon-background.pf-m-warning {
+  --pf-topology-pipelines__pill-background--Stroke: var(--pf-topology-pipelines__pill-background--m-warning--Stroke);
+}
+.pf-topology-pipelines__status-icon-background.pf-m-skipped {
+  --pf-topology-pipelines__pill-background--Stroke: var(--pf-topology-pipelines__pill-background--m-skipped--Stroke);
+}
+.pf-topology-pipelines__status-icon-background.pf-m-in-progress {
+  --pf-topology-pipelines__pill-background--Stroke: var(--pf-topology-pipelines__pill-background--m-in-progress--Stroke);
+}
+.pf-topology-pipelines__status-icon-background.pf-m-pending {
+  --pf-topology-pipelines__pill-background--Stroke: var(--pf-topology-pipelines__pill-background--m-pending--Stroke);
+}
+.pf-topology-pipelines__status-icon-background.pf-m-running {
+  --pf-topology-pipelines__pill-background--Stroke: var(--pf-topology-pipelines__pill-background--m-running--Stroke);
+}
+.pf-topology-pipelines__status-icon-background.pf-m-idle {
+  --pf-topology-pipelines__pill-background--Stroke: var(--pf-topology-pipelines__pill-background--m-idle--Stroke);
+}
+
+.pf-topology-pipelines__status-icon-background.pf-m-selected {
+  --pf-topology-pipelines__pill-background--Fill: var(--pf-topology-pipelines__status-icon--m-selected--color);
+}
+.pf-topology-pipelines__status-icon-background.pf-m-danger.pf-m-selected {
+  --pf-topology-pipelines__pill-background--Fill: var(--pf-topology-pipelines__pill-background--m-danger--Stroke);
+}
+.pf-topology-pipelines__status-icon-background.pf-m-success.pf-m-selected {
+  --pf-topology-pipelines__pill-background--Fill: var(--pf-topology-pipelines__pill-background--m-success--Stroke);
+}
+.pf-topology-pipelines__status-icon-background.pf-m-warning.pf-m-selected {
+  --pf-topology-pipelines__pill-background--Fill: var(--pf-topology-pipelines__pill-background--m-warning--Stroke);
+}
+.pf-topology-pipelines__status-icon-background.pf-m-skipped.pf-m-selected {
+  --pf-topology-pipelines__pill-background--Fill: var(--pf-topology-pipelines__pill-background--m-skipped--Stroke);
+}
+.pf-topology-pipelines__status-icon-background.pf-m-in-progress.pf-m-selected {
+  --pf-topology-pipelines__pill-background--Fill: var(--pf-topology-pipelines__pill-background--m-in-progress--Stroke);
+}
+.pf-topology-pipelines__status-icon-background.pf-m-pending.pf-m-selected {
+  --pf-topology-pipelines__pill-background--Fill: var(--pf-topology-pipelines__pill-background--m-pending--Stroke);
+}
+.pf-topology-pipelines__status-icon-background.pf-m-running.pf-m-selected {
+  --pf-topology-pipelines__pill-background--Fill: var(--pf-topology-pipelines__pill-background--m-running--Stroke);
+}
+.pf-topology-pipelines__status-icon-background.pf-m-idle.pf-m-selected {
+  --pf-topology-pipelines__pill-background--Fill: var(--pf-topology-pipelines__pill-background--m-idle--Stroke);
 }

--- a/packages/react-topology/src/hooks/index.ts
+++ b/packages/react-topology/src/hooks/index.ts
@@ -5,3 +5,5 @@ export { default as useLayoutFactory } from './useLayoutFactory';
 export { default as useModel } from './useModel';
 export { default as useVisualizationController } from './useVisualizationController';
 export { default as useVisualizationState } from './useVisualizationState';
+export { default as useDetailsLevel } from './useDetailsLevel';
+export { default as useScaleNode } from './useScaleNode';

--- a/packages/react-topology/src/hooks/useScaleNode.tsx
+++ b/packages/react-topology/src/hooks/useScaleNode.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+
+const useScaleNode = (scaleNode: boolean, scale: number, scaleUpTime: number = 200): number => {
+  const [nodeScale, setNodeScale] = React.useState<number>(1);
+  const animationRef = React.useRef<number>();
+  const scaleGoal = React.useRef<number>(1);
+  const nodeScaled = React.useRef<boolean>(false);
+
+  React.useEffect(() => {
+    if (!scaleNode || scale >= 1) {
+      setNodeScale(1);
+      nodeScaled.current = false;
+      if (animationRef.current) {
+        window.cancelAnimationFrame(animationRef.current);
+        animationRef.current = 0;
+      }
+    } else {
+      scaleGoal.current = 1 / scale;
+      const scaleDelta = scaleGoal.current - scale;
+      const initTime = performance.now();
+
+      const bumpScale = (bumpTime: number) => {
+        const scalePercent = (bumpTime - initTime) / scaleUpTime;
+        const nextScale = Math.min(scale + scaleDelta * scalePercent, scaleGoal.current);
+        setNodeScale(nextScale);
+        if (nextScale < scaleGoal.current) {
+          animationRef.current = window.requestAnimationFrame(bumpScale);
+        } else {
+          nodeScaled.current = true;
+          animationRef.current = 0;
+        }
+      };
+
+      if (nodeScaled.current) {
+        setNodeScale(scaleGoal.current);
+      } else if (!animationRef.current) {
+        animationRef.current = window.requestAnimationFrame(bumpScale);
+      }
+    }
+    return () => {
+      if (animationRef.current) {
+        window.cancelAnimationFrame(animationRef.current);
+        animationRef.current = 0;
+      }
+    };
+  }, [scale, scaleNode, scaleUpTime]);
+
+  return nodeScale;
+};
+export default useScaleNode;

--- a/packages/react-topology/src/pipelines/components/anchors/TaskNodeSourceAnchor.ts
+++ b/packages/react-topology/src/pipelines/components/anchors/TaskNodeSourceAnchor.ts
@@ -1,13 +1,27 @@
 import { Point } from '../../../geom';
 import { AbstractAnchor } from '../../../anchors';
+import { Node, ScaleDetailsLevel } from '../../../types';
 
-export default class TaskNodeSourceAnchor extends AbstractAnchor {
+export default class TaskNodeSourceAnchor<E extends Node = Node> extends AbstractAnchor {
+  private detailsLevel: ScaleDetailsLevel;
+  private lowDetailsStatusIconWidth = 0;
+
+  constructor(owner: E, detailsLevel: ScaleDetailsLevel, lowDetailsStatusIconWidth: number) {
+    super(owner);
+    this.detailsLevel = detailsLevel;
+    this.lowDetailsStatusIconWidth = lowDetailsStatusIconWidth;
+  }
+
   getLocation(): Point {
     return this.getReferencePoint();
   }
 
   getReferencePoint(): Point {
     const bounds = this.owner.getBounds();
+    if (this.detailsLevel !== ScaleDetailsLevel.high) {
+      const scale = this.owner.getGraph().getScale();
+      return new Point(bounds.x + this.lowDetailsStatusIconWidth * (1 / scale), bounds.y + bounds.height / 2);
+    }
     return new Point(bounds.right(), bounds.y + bounds.height / 2);
   }
 }

--- a/packages/react-topology/src/pipelines/components/nodes/TaskNode.tsx
+++ b/packages/react-topology/src/pipelines/components/nodes/TaskNode.tsx
@@ -281,6 +281,7 @@ const TaskNode: React.FC<TaskNodeProps> = ({
           <circle
             className={css(
               styles.topologyPipelinesStatusIconBackground,
+              styles.topologyPipelinesPillStatus,
               runStatusModifier,
               selected && 'pf-m-selected'
             )}

--- a/packages/react-topology/src/pipelines/components/nodes/TaskNode.tsx
+++ b/packages/react-topology/src/pipelines/components/nodes/TaskNode.tsx
@@ -4,11 +4,11 @@ import styles from '@patternfly/react-styles/css/components/Topology/topology-pi
 import topologyStyles from '@patternfly/react-styles/css/components/Topology/topology-components';
 import { Popover, PopoverProps, Tooltip } from '@patternfly/react-core';
 import { observer } from '../../../mobx-exports';
-import { AnchorEnd, Node } from '../../../types';
+import { AnchorEnd, Node, ScaleDetailsLevel } from '../../../types';
 import { RunStatus } from '../../types';
 import { useAnchor, WithContextMenuProps, WithSelectionProps } from '../../../behavior';
 import { truncateMiddle } from '../../../utils/truncate-middle';
-import { createSvgIdUrl, useHover, useSize } from '../../../utils';
+import { createSvgIdUrl, getNodeScaleTranslation, useHover, useSize } from '../../../utils';
 import { getRunStatusModifier, nonShadowModifiers } from '../../utils';
 import StatusIcon from '../../utils/StatusIcon';
 import { TaskNodeSourceAnchor, TaskNodeTargetAnchor } from '../anchors';
@@ -21,8 +21,11 @@ import NodeShadows, {
 } from '../../../components/nodes/NodeShadows';
 import LabelBadge from '../../../components/nodes/labels/LabelBadge';
 import LabelIcon from '../../../components/nodes/labels/LabelIcon';
+import useDetailsLevel from '../../../hooks/useDetailsLevel';
+import { useScaleNode } from '../../../hooks';
 
 const STATUS_ICON_SIZE = 16;
+const SCALE_UP_TIME = 200;
 
 export type TaskNodeProps = {
   children?: React.ReactNode;
@@ -34,6 +37,9 @@ export type TaskNodeProps = {
   status?: RunStatus;
   statusIconSize?: number;
   showStatusState?: boolean;
+  scaleNode?: boolean; // Whether or not to scale the node, best on hover when details are hidden
+  hideDetailsAtMedium?: boolean; // Whether or not to hide details at medium scale
+  hiddenDetailsShownStatuses?: RunStatus[]; // Statuses to show at when details are hidden
   badge?: string;
   badgeColor?: string;
   badgeTextColor?: string;
@@ -66,6 +72,9 @@ const TaskNode: React.FC<TaskNodeProps> = ({
   status,
   statusIconSize = STATUS_ICON_SIZE,
   showStatusState = true,
+  scaleNode,
+  hideDetailsAtMedium,
+  hiddenDetailsShownStatuses = [RunStatus.Failed, RunStatus.FailedToStart, RunStatus.Cancelled],
   badge,
   badgeColor,
   badgeTextColor,
@@ -101,17 +110,25 @@ const TaskNode: React.FC<TaskNodeProps> = ({
   const [badgeSize, badgeRef] = useSize([badge]);
   const [actionSize, actionRef] = useSize([actionIcon, paddingX]);
   const [contextSize, contextRef] = useSize([onContextMenu, paddingX]);
+  const detailsLevel = useDetailsLevel();
 
   const textWidth = textSize?.width ?? 0;
   const textHeight = textSize?.height ?? 0;
-
-  useAnchor(TaskNodeSourceAnchor, AnchorEnd.source);
+  useAnchor(
+    React.useCallback((node: Node) => new TaskNodeSourceAnchor(node, detailsLevel, statusIconSize + 4), [
+      detailsLevel,
+      statusIconSize,
+      scaleNode
+    ]),
+    AnchorEnd.source
+  );
   useAnchor(
     React.useCallback((node: Node) => new TaskNodeTargetAnchor(node, hasWhenExpression ? 0 : whenSize + whenOffset), [
       hasWhenExpression,
       whenSize,
       whenOffset
-    ])
+    ]),
+    AnchorEnd.target
   );
 
   const {
@@ -197,9 +214,13 @@ const TaskNode: React.FC<TaskNodeProps> = ({
     const sourceEdges = element.getSourceEdges();
     sourceEdges.forEach(edge => {
       const data = edge.getData();
-      edge.setData({ ...(data || {}), indent: width - pillWidth });
+      edge.setData({ ...(data || {}), indent: detailsLevel === ScaleDetailsLevel.high ? width - pillWidth : 0 });
     });
-  }, [element, pillWidth, width]);
+  }, [detailsLevel, element, pillWidth, width]);
+
+  const scale = element.getGraph().getScale();
+  const nodeScale = useScaleNode(scaleNode, scale, SCALE_UP_TIME);
+  const { translateX, translateY } = getNodeScaleTranslation(element, nodeScale, scaleNode);
 
   const nameLabel = (
     <text ref={textRef} className={css(styles.topologyPipelinesPillText)} dominantBaseline="middle">
@@ -217,7 +238,7 @@ const TaskNode: React.FC<TaskNodeProps> = ({
     onSelect && styles.modifiers.selectable
   );
 
-  let filter;
+  let filter: string;
   if (runStatusModifier === styles.modifiers.danger) {
     filter = createSvgIdUrl(NODE_SHADOW_FILTER_ID_DANGER);
   } else if (isHover && !nonShadowModifiers.includes(runStatusModifier)) {
@@ -249,114 +270,152 @@ const TaskNode: React.FC<TaskNodeProps> = ({
     />
   );
 
-  const taskPill = (
-    <g
-      className={pillClasses}
-      transform={`translate(${whenOffset + whenSize}, 0)`}
-      ref={hoverRef}
-      onClick={onSelect}
-      onContextMenu={onContextMenu}
-    >
-      <NodeShadows />
-      <rect
-        x={0}
-        y={0}
-        width={pillWidth}
-        height={height}
-        rx={height / 2}
-        className={css(styles.topologyPipelinesPillBackground)}
-        filter={filter}
-      />
-      <g transform={`translate(${textStartX}, ${paddingY + textHeight / 2 + 1})`}>
-        {element.getLabel() !== label && !disableTooltip ? (
-          <Tooltip content={element.getLabel()}>
-            <g>{nameLabel}</g>
-          </Tooltip>
-        ) : (
-          nameLabel
-        )}
-      </g>
-      {status && showStatusState && (
-        <g transform={`translate(${statusStartX + paddingX / 2}, ${(height - statusIconSize) / 2})`} ref={statusRef}>
-          <g
-            className={css(
-              styles.topologyPipelinesPillStatus,
-              runStatusModifier,
-              selected && 'pf-m-selected',
-              (status === RunStatus.Running || status === RunStatus.InProgress) && styles.modifiers.spin
-            )}
-          >
-            <StatusIcon status={status} />
-          </g>
-        </g>
-      )}
-      {taskIconComponent &&
-        (taskIconTooltip ? <Tooltip content={taskIconTooltip}>{taskIconComponent}</Tooltip> : taskIconComponent)}
-      {badgeComponent &&
-        (badgePopoverParams ? (
-          <g onClick={e => e.stopPropagation()}>
-            <Popover {...badgePopoverParams}>{badgeComponent}</Popover>
-          </g>
-        ) : (
-          badgeComponent
-        ))}
-      {actionIcon && (
-        <>
-          <line
-            className={css(topologyStyles.topologyNodeSeparator)}
-            x1={actionStartX}
-            y1={0}
-            x2={actionStartX}
-            y2={height}
-            shapeRendering="crispEdges"
-          />
-          <LabelActionIcon
-            ref={actionRef}
-            x={actionStartX}
-            y={0}
-            height={height}
-            paddingX={paddingX}
-            paddingY={0}
-            icon={actionIcon}
-            className={actionIconClassName}
-            onClick={onActionIconClick}
-          />
-        </>
-      )}
-      {textSize && onContextMenu && (
-        <>
-          <line
-            className={css(topologyStyles.topologyNodeSeparator)}
-            x1={contextStartX}
-            y1={0}
-            x2={contextStartX}
-            y2={height}
-            shapeRendering="crispEdges"
-          />
-          <LabelContextMenu
-            ref={contextRef}
-            x={contextStartX}
-            y={0}
-            height={height}
-            paddingX={paddingX}
-            paddingY={0}
-            onContextMenu={onContextMenu}
-            contextMenuOpen={contextMenuOpen}
-          />
-        </>
-      )}
+  const renderTask = () => {
+    if (showStatusState && !scaleNode && hideDetailsAtMedium && detailsLevel !== ScaleDetailsLevel.high) {
+      const statusBackgroundRadius = statusIconSize / 2 + 4;
+      const height = element.getBounds().height;
+      const upScale = 1 / scale;
 
-      {children}
-    </g>
-  );
+      return (
+        <g transform={`translate(0, ${(height - statusBackgroundRadius * 2 * upScale) / 2}) scale(${upScale})`}>
+          <circle
+            className={css(
+              styles.topologyPipelinesStatusIconBackground,
+              runStatusModifier,
+              selected && 'pf-m-selected'
+            )}
+            cx={statusBackgroundRadius}
+            cy={statusBackgroundRadius}
+            r={statusBackgroundRadius}
+          />
+          {status && (!hiddenDetailsShownStatuses || hiddenDetailsShownStatuses.includes(status)) ? (
+            <g transform={`translate(4, 4)`}>
+              <g
+                className={css(
+                  styles.topologyPipelinesStatusIcon,
+                  runStatusModifier,
+                  selected && 'pf-m-selected',
+                  (status === RunStatus.Running || status === RunStatus.InProgress) && styles.modifiers.spin
+                )}
+              >
+                <StatusIcon status={status} />
+              </g>
+            </g>
+          ) : null}
+        </g>
+      );
+    }
+    return (
+      <g
+        className={pillClasses}
+        transform={`translate(${whenOffset + whenSize}, 0)`}
+        ref={hoverRef}
+        onClick={onSelect}
+        onContextMenu={onContextMenu}
+      >
+        <NodeShadows />
+        <rect
+          x={0}
+          y={0}
+          width={pillWidth}
+          height={height}
+          rx={height / 2}
+          className={css(styles.topologyPipelinesPillBackground)}
+          filter={filter}
+        />
+        <g transform={`translate(${textStartX}, ${paddingY + textHeight / 2 + 1})`}>
+          {element.getLabel() !== label && !disableTooltip ? (
+            <Tooltip content={element.getLabel()}>
+              <g>{nameLabel}</g>
+            </Tooltip>
+          ) : (
+            nameLabel
+          )}
+        </g>
+        {status && showStatusState && (
+          <g transform={`translate(${statusStartX + paddingX / 2}, ${(height - statusIconSize) / 2})`} ref={statusRef}>
+            <g
+              className={css(
+                styles.topologyPipelinesPillStatus,
+                runStatusModifier,
+                selected && 'pf-m-selected',
+                (status === RunStatus.Running || status === RunStatus.InProgress) && styles.modifiers.spin
+              )}
+            >
+              <StatusIcon status={status} />
+            </g>
+          </g>
+        )}
+        {taskIconComponent &&
+          (taskIconTooltip ? <Tooltip content={taskIconTooltip}>{taskIconComponent}</Tooltip> : taskIconComponent)}
+        {badgeComponent &&
+          (badgePopoverParams ? (
+            <g onClick={e => e.stopPropagation()}>
+              <Popover {...badgePopoverParams}>{badgeComponent}</Popover>
+            </g>
+          ) : (
+            badgeComponent
+          ))}
+        {actionIcon && (
+          <>
+            <line
+              className={css(topologyStyles.topologyNodeSeparator)}
+              x1={actionStartX}
+              y1={0}
+              x2={actionStartX}
+              y2={height}
+              shapeRendering="crispEdges"
+            />
+            <LabelActionIcon
+              ref={actionRef}
+              x={actionStartX}
+              y={0}
+              height={height}
+              paddingX={paddingX}
+              paddingY={0}
+              icon={actionIcon}
+              className={actionIconClassName}
+              onClick={onActionIconClick}
+            />
+          </>
+        )}
+        {textSize && onContextMenu && (
+          <>
+            <line
+              className={css(topologyStyles.topologyNodeSeparator)}
+              x1={contextStartX}
+              y1={0}
+              x2={contextStartX}
+              y2={height}
+              shapeRendering="crispEdges"
+            />
+            <LabelContextMenu
+              ref={contextRef}
+              x={contextStartX}
+              y={0}
+              height={height}
+              paddingX={paddingX}
+              paddingY={0}
+              onContextMenu={onContextMenu}
+              contextMenuOpen={contextMenuOpen}
+            />
+          </>
+        )}
+        {children}
+      </g>
+    );
+  };
 
   return (
-    <g className={css('pf-topology__pipelines__task-node', className)}>
+    <g
+      className={css('pf-topology__pipelines__task-node', className)}
+      transform={`${scaleNode ? `translate(${translateX}, ${translateY})` : ''} scale(${nodeScale})`}
+    >
       {!toolTip || disableTooltip ? (
-        taskPill
+        renderTask()
       ) : (
         <Tooltip position="bottom" enableFlip={false} content={toolTip}>
-          {taskPill}
+          {renderTask()}
         </Tooltip>
       )}
     </g>

--- a/packages/react-topology/src/pipelines/utils/utils.ts
+++ b/packages/react-topology/src/pipelines/utils/utils.ts
@@ -7,6 +7,7 @@ export const nonShadowModifiers: string[] = [
   styles.modifiers.danger,
   styles.modifiers.warning,
   styles.modifiers.success,
+  styles.modifiers.skipped,
   styles.modifiers.inProgress
 ];
 
@@ -18,8 +19,9 @@ export const getRunStatusModifier = (status: RunStatus): string => {
     case RunStatus.Succeeded:
       return styles.modifiers.success;
     case RunStatus.Cancelled:
-    case RunStatus.Skipped:
       return styles.modifiers.warning;
+    case RunStatus.Skipped:
+      return styles.modifiers.skipped;
     case RunStatus.Running:
       return styles.modifiers.running;
     case RunStatus.InProgress:

--- a/packages/react-topology/src/utils/getNodeScaleTranslation.ts
+++ b/packages/react-topology/src/utils/getNodeScaleTranslation.ts
@@ -1,0 +1,16 @@
+import { Node } from '../types';
+
+export const getNodeScaleTranslation = (
+  element: Node,
+  nodeScale: number,
+  scaleNode: boolean
+): { translateX: number; translateY: number } => {
+  if (!scaleNode) {
+    return { translateX: 0, translateY: 0 };
+  }
+  const bounds = element.getBounds();
+  const translateX = bounds.width / 2 - (bounds.width / 2) * nodeScale;
+  const translateY = bounds.height / 2 - (bounds.height / 2) * nodeScale;
+
+  return { translateX, translateY };
+};

--- a/packages/react-topology/src/utils/index.ts
+++ b/packages/react-topology/src/utils/index.ts
@@ -5,6 +5,7 @@ export * from './element-utils';
 export * from './geom-utils';
 export * from './svg-utils';
 export * from './style-utils';
+export * from './getNodeScaleTranslation';
 export { default as useCallbackRef } from './useCallbackRef';
 export { default as useCombineRefs } from './useCombineRefs';
 export { default as useHover } from './useHover';


### PR DESCRIPTION
**What**:
Closes #7900 

**Screen Shots**:

![TopologyScaleIcons](https://user-images.githubusercontent.com/11633780/187982703-443a6a6a-7117-4bc9-9500-49535f0eb6bb.gif)

/cc @andrew-ronaldson @mceledonia @serenamarie125 @karthikjeeyar
