### PR TITLE
fix(CodeEditor): use codeEditorControls and clean up overall

### DIFF
--- a/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
@@ -25,6 +25,7 @@ import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 import Dropzone from 'react-dropzone';
 import { CodeEditorContext } from './CodeEditorUtils';
+import { CodeEditorControl } from './CodeEditorControl';
 
 export interface Shortcut {
   description: string;
@@ -444,8 +445,7 @@ export class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState
       window.clearTimeout(this.timer);
       this.setState({ copied: false });
     }
-    this.editor?.focus();
-    document.execCommand('copy');
+    navigator.clipboard.writeText(this.state.value);
     this.setState({ copied: true }, () => {
       this.timer = window.setTimeout(() => {
         this.setState({ copied: false });
@@ -486,7 +486,7 @@ export class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState
       downloadButtonAriaLabel,
       downloadButtonToolTipText,
       toolTipDelay,
-      toolTipCopyExitDelay,
+      toolTipCopyExitDelay: tooltipCopyExitDelay,
       toolTipMaxWidth,
       toolTipPosition,
       isLineNumbersVisible,
@@ -555,55 +555,50 @@ export class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState
               </EmptyState>
             ));
 
+          const tooltipProps = {
+            position: toolTipPosition,
+            exitDelay: toolTipDelay,
+            entryDelay: toolTipDelay,
+            maxWidth: toolTipMaxWidth,
+            trigger: 'mouseenter focus'
+          };
+
           const editorHeader = (
             <div className={css(styles.codeEditorHeader)}>
               {
                 <div className={css(styles.codeEditorControls)}>
-                  {isCopyEnabled && (!showEmptyState || !!value) && (
-                    <Tooltip
-                      trigger="mouseenter"
-                      content={<div>{copied ? copyButtonSuccessTooltipText : copyButtonToolTipText}</div>}
-                      exitDelay={copied ? toolTipCopyExitDelay : toolTipDelay}
-                      entryDelay={toolTipDelay}
-                      maxWidth={toolTipMaxWidth}
-                      position={toolTipPosition}
-                    >
-                      <Button onClick={this.copyCode} variant="control" aria-label={copyButtonAriaLabel}>
-                        <CopyIcon />
-                      </Button>
-                    </Tooltip>
-                  )}
-                  {isUploadEnabled && (
-                    <Tooltip
-                      trigger="mouseenter focus click"
-                      content={<div>{uploadButtonToolTipText}</div>}
-                      entryDelay={toolTipDelay}
-                      exitDelay={toolTipDelay}
-                      maxWidth={toolTipMaxWidth}
-                      position={toolTipPosition}
-                    >
-                      <Button onClick={open} variant="control" aria-label={uploadButtonAriaLabel}>
-                        <UploadIcon />
-                      </Button>
-                    </Tooltip>
-                  )}
-                  {isDownloadEnabled && (!showEmptyState || !!value) && (
-                    <Tooltip
-                      trigger="mouseenter focus click"
-                      content={<div>{downloadButtonToolTipText}</div>}
-                      entryDelay={toolTipDelay}
-                      exitDelay={toolTipDelay}
-                      maxWidth={toolTipMaxWidth}
-                      position={toolTipPosition}
-                    >
-                      <Button onClick={this.download} variant="control" aria-label={downloadButtonAriaLabel}>
-                        <DownloadIcon />
-                      </Button>
-                    </Tooltip>
-                  )}
-                  {customControls && (
-                    <CodeEditorContext.Provider value={{ code: value }}>{customControls}</CodeEditorContext.Provider>
-                  )}
+                  <CodeEditorContext.Provider value={{ code: value }}>
+                    {isCopyEnabled && (!showEmptyState || !!value) && (
+                      <CodeEditorControl
+                        icon={<CopyIcon />}
+                        aria-label={copyButtonAriaLabel}
+                        tooltipProps={{
+                          ...tooltipProps,
+                          'aria-live': 'polite',
+                          content: <div>{copied ? copyButtonSuccessTooltipText : copyButtonToolTipText}</div>,
+                          exitDelay: copied ? tooltipCopyExitDelay : toolTipDelay
+                        }}
+                        onClick={this.copyCode}
+                      />
+                    )}
+                    {isUploadEnabled && (
+                      <CodeEditorControl
+                        icon={<UploadIcon />}
+                        aria-label={uploadButtonAriaLabel}
+                        tooltipProps={{content: <div>{uploadButtonToolTipText}</div>, ...tooltipProps}}
+                        onClick={open}
+                      />
+                    )}
+                    {isDownloadEnabled && (!showEmptyState || !!value) && (
+                      <CodeEditorControl
+                        icon={<DownloadIcon />}
+                        aria-label={downloadButtonAriaLabel}
+                        tooltipProps={{content: <div>{downloadButtonToolTipText}</div>, ...tooltipProps}}
+                        onClick={this.download}
+                      />
+                    )}
+                    {customControls && customControls}
+                  </CodeEditorContext.Provider>
                 </div>
               }
               {<div className={css(styles.codeEditorHeaderMain)}>{headerMainContent}</div>}

--- a/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
@@ -550,7 +550,7 @@ export class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState
             exitDelay: toolTipDelay,
             entryDelay: toolTipDelay,
             maxWidth: toolTipMaxWidth,
-            trigger: 'mouseenter focus',
+            trigger: 'mouseenter focus'
           };
 
           const editorHeader = (
@@ -567,7 +567,7 @@ export class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState
                           'aria-live': 'polite',
                           content: <div>{copied ? copyButtonSuccessTooltipText : copyButtonToolTipText}</div>,
                           exitDelay: copied ? toolTipCopyExitDelay : toolTipDelay,
-                          onTooltipHidden: () => this.setState({copied:false})
+                          onTooltipHidden: () => this.setState({ copied: false })
                         }}
                         onClick={this.copyCode}
                       />

--- a/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
@@ -440,17 +440,8 @@ export class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState
   };
 
   copyCode = () => {
-    if (this.timer) {
-      window.clearTimeout(this.timer);
-      this.setState({ copied: false });
-    }
     navigator.clipboard.writeText(this.state.value);
-    this.setState({ copied: true }, () => {
-      this.timer = window.setTimeout(() => {
-        this.setState({ copied: false });
-        this.timer = null;
-      }, 2500);
-    });
+    this.setState({ copied: true });
   };
 
   download = () => {
@@ -559,7 +550,7 @@ export class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState
             exitDelay: toolTipDelay,
             entryDelay: toolTipDelay,
             maxWidth: toolTipMaxWidth,
-            trigger: 'mouseenter focus'
+            trigger: 'mouseenter focus',
           };
 
           const editorHeader = (
@@ -575,7 +566,8 @@ export class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState
                           ...tooltipProps,
                           'aria-live': 'polite',
                           content: <div>{copied ? copyButtonSuccessTooltipText : copyButtonToolTipText}</div>,
-                          exitDelay: copied ? toolTipCopyExitDelay : toolTipDelay
+                          exitDelay: copied ? toolTipCopyExitDelay : toolTipDelay,
+                          onTooltipHidden: () => this.setState({copied:false})
                         }}
                         onClick={this.copyCode}
                       />

--- a/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
@@ -13,7 +13,6 @@ import {
   Popover,
   PopoverProps,
   Title,
-  Tooltip,
   TooltipPosition
 } from '@patternfly/react-core';
 import MonacoEditor, { ChangeHandler, EditorDidMount } from 'react-monaco-editor';
@@ -585,7 +584,7 @@ export class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState
                       <CodeEditorControl
                         icon={<UploadIcon />}
                         aria-label={uploadButtonAriaLabel}
-                        tooltipProps={{content: <div>{uploadButtonToolTipText}</div>, ...tooltipProps}}
+                        tooltipProps={{ content: <div>{uploadButtonToolTipText}</div>, ...tooltipProps }}
                         onClick={open}
                       />
                     )}
@@ -593,7 +592,7 @@ export class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState
                       <CodeEditorControl
                         icon={<DownloadIcon />}
                         aria-label={downloadButtonAriaLabel}
-                        tooltipProps={{content: <div>{downloadButtonToolTipText}</div>, ...tooltipProps}}
+                        tooltipProps={{ content: <div>{downloadButtonToolTipText}</div>, ...tooltipProps }}
                         onClick={this.download}
                       />
                     )}

--- a/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
@@ -485,7 +485,7 @@ export class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState
       downloadButtonAriaLabel,
       downloadButtonToolTipText,
       toolTipDelay,
-      toolTipCopyExitDelay: tooltipCopyExitDelay,
+      toolTipCopyExitDelay,
       toolTipMaxWidth,
       toolTipPosition,
       isLineNumbersVisible,
@@ -575,7 +575,7 @@ export class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState
                           ...tooltipProps,
                           'aria-live': 'polite',
                           content: <div>{copied ? copyButtonSuccessTooltipText : copyButtonToolTipText}</div>,
-                          exitDelay: copied ? tooltipCopyExitDelay : toolTipDelay
+                          exitDelay: copied ? toolTipCopyExitDelay : toolTipDelay
                         }}
                         onClick={this.copyCode}
                       />

--- a/packages/react-code-editor/src/components/CodeEditor/CodeEditorControl.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/CodeEditorControl.tsx
@@ -65,7 +65,7 @@ export const CodeEditorControl: React.FunctionComponent<CodeEditorControlProps> 
     // eslint-disable-next-line no-console
     console.warn(
       'The CodeEditorControl entryDelay prop has been deprecated. ' +
-      'Pass the entryDelay via the tooltipProps prop instead.'
+        'Pass the entryDelay via the tooltipProps prop instead.'
     );
   }
 
@@ -73,7 +73,7 @@ export const CodeEditorControl: React.FunctionComponent<CodeEditorControlProps> 
     // eslint-disable-next-line no-console
     console.warn(
       'The CodeEditorControl exitDelay prop has been deprecated. ' +
-      'Pass the exitDelay via the tooltipProps prop instead.'
+        'Pass the exitDelay via the tooltipProps prop instead.'
     );
   }
 
@@ -81,7 +81,7 @@ export const CodeEditorControl: React.FunctionComponent<CodeEditorControlProps> 
     // eslint-disable-next-line no-console
     console.warn(
       'The CodeEditorControl maxWidth prop has been deprecated. ' +
-      'Pass the maxWidth via the tooltipProps prop instead.'
+        'Pass the maxWidth via the tooltipProps prop instead.'
     );
   }
 
@@ -89,7 +89,7 @@ export const CodeEditorControl: React.FunctionComponent<CodeEditorControlProps> 
     // eslint-disable-next-line no-console
     console.warn(
       'The CodeEditorControl position prop has been deprecated. ' +
-      'Pass the position via the tooltipProps prop instead.'
+        'Pass the position via the tooltipProps prop instead.'
     );
   }
 
@@ -97,7 +97,7 @@ export const CodeEditorControl: React.FunctionComponent<CodeEditorControlProps> 
     // eslint-disable-next-line no-console
     console.warn(
       'The CodeEditorControl toolTipText prop has been deprecated. ' +
-      'Pass the toolTipText by setting the content field in tooltipProps prop instead.'
+        'Pass the toolTipText by setting the content field in tooltipProps prop instead.'
     );
   }
 

--- a/packages/react-code-editor/src/components/CodeEditor/CodeEditorControl.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/CodeEditorControl.tsx
@@ -64,7 +64,7 @@ export const CodeEditorControl: React.FunctionComponent<CodeEditorControlProps> 
   if (entryDelay !== undefined) {
     // eslint-disable-next-line no-console
     console.warn(
-      'The CodeEditorControl entryDelay prop has been deprecated. ' +
+      'CodeEditorControl: entryDelay prop has been deprecated. ' +
         'Pass the entryDelay via the tooltipProps prop instead.'
     );
   }
@@ -72,7 +72,7 @@ export const CodeEditorControl: React.FunctionComponent<CodeEditorControlProps> 
   if (exitDelay !== undefined) {
     // eslint-disable-next-line no-console
     console.warn(
-      'The CodeEditorControl exitDelay prop has been deprecated. ' +
+      'CodeEditorControl: exitDelay prop has been deprecated. ' +
         'Pass the exitDelay via the tooltipProps prop instead.'
     );
   }
@@ -80,7 +80,7 @@ export const CodeEditorControl: React.FunctionComponent<CodeEditorControlProps> 
   if (maxWidth !== undefined) {
     // eslint-disable-next-line no-console
     console.warn(
-      'The CodeEditorControl maxWidth prop has been deprecated. ' +
+      'CodeEditorControl: maxWidth prop has been deprecated. ' +
         'Pass the maxWidth via the tooltipProps prop instead.'
     );
   }
@@ -88,7 +88,7 @@ export const CodeEditorControl: React.FunctionComponent<CodeEditorControlProps> 
   if (position !== undefined) {
     // eslint-disable-next-line no-console
     console.warn(
-      'The CodeEditorControl position prop has been deprecated. ' +
+      'CodeEditorControl: position prop has been deprecated. ' +
         'Pass the position via the tooltipProps prop instead.'
     );
   }
@@ -96,7 +96,7 @@ export const CodeEditorControl: React.FunctionComponent<CodeEditorControlProps> 
   if (toolTipText !== undefined) {
     // eslint-disable-next-line no-console
     console.warn(
-      'The CodeEditorControl toolTipText prop has been deprecated. ' +
+      'CodeEditorControl: toolTipText prop has been deprecated. ' +
         'Pass the toolTipText by setting the content field in tooltipProps prop instead.'
     );
   }

--- a/packages/react-code-editor/src/components/CodeEditor/CodeEditorControl.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/CodeEditorControl.tsx
@@ -80,16 +80,14 @@ export const CodeEditorControl: React.FunctionComponent<CodeEditorControlProps> 
   if (maxWidth !== undefined) {
     // eslint-disable-next-line no-console
     console.warn(
-      'CodeEditorControl: maxWidth prop has been deprecated. ' +
-        'Pass the maxWidth via the tooltipProps prop instead.'
+      'CodeEditorControl: maxWidth prop has been deprecated. ' + 'Pass the maxWidth via the tooltipProps prop instead.'
     );
   }
 
   if (position !== undefined) {
     // eslint-disable-next-line no-console
     console.warn(
-      'CodeEditorControl: position prop has been deprecated. ' +
-        'Pass the position via the tooltipProps prop instead.'
+      'CodeEditorControl: position prop has been deprecated. ' + 'Pass the position via the tooltipProps prop instead.'
     );
   }
 

--- a/packages/react-code-editor/src/components/CodeEditor/CodeEditorControl.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/CodeEditorControl.tsx
@@ -7,19 +7,19 @@ import { CodeEditorContext } from './CodeEditorUtils';
  */
 
 export interface CodeEditorControlProps extends Omit<ButtonProps, 'onClick'> {
-  /** Accessible label for the code editor control. */
+  /** Accessible label for the code editor control */
   'aria-label'?: string;
   /** Additional classes added to the code editor control. */
   className?: string;
-  /** Delay in ms before the tooltip appears. */
+  /** @deprecated  Delay in ms before the tooltip appears. */
   entryDelay?: number;
-  /** Delay in ms before the tooltip disappears. */
+  /** @deprecated  Delay in ms before the tooltip disappears. */
   exitDelay?: number;
   /** Icon rendered inside the code editor control. */
   icon: React.ReactNode;
-  /** Maximum width of the tooltip (default 150px). */
+  /** @deprecated Maximum width of the tooltip (default 150px). */
   maxWidth?: string;
-  /** Copy button popover position. */
+  /** @deprecated Copy button popover position. */
   position?:
     | PopoverPosition
     | 'auto'
@@ -35,12 +35,14 @@ export interface CodeEditorControlProps extends Omit<ButtonProps, 'onClick'> {
     | 'left-end'
     | 'right-start'
     | 'right-end';
-  /** Text to display in the tooltip. */
-  toolTipText: React.ReactNode;
-  /** Event handler for the click of the button. */
+  /** @deprecated Text to display in the tooltip*/
+  toolTipText?: React.ReactNode;
+  /** Event handler for the click of the button */
   onClick: (code: string, event?: any) => void;
   /** Flag indicating that the button is visible above the code editor. */
   isVisible?: boolean;
+  /** Additional tooltip props forwarded to the Tooltip component */
+  tooltipProps?: any;
 }
 
 export const CodeEditorControl: React.FunctionComponent<CodeEditorControlProps> = ({
@@ -48,12 +50,13 @@ export const CodeEditorControl: React.FunctionComponent<CodeEditorControlProps> 
   className,
   'aria-label': ariaLabel,
   toolTipText,
-  exitDelay = 0,
-  entryDelay = 300,
-  maxWidth = '100px',
-  position = 'top',
+  exitDelay,
+  entryDelay,
+  maxWidth,
+  position,
   onClick = () => {},
   isVisible = true,
+  tooltipProps = {},
   ...props
 }: CodeEditorControlProps) => {
   const context = React.useContext(CodeEditorContext);
@@ -64,12 +67,12 @@ export const CodeEditorControl: React.FunctionComponent<CodeEditorControlProps> 
 
   return isVisible ? (
     <Tooltip
-      trigger="mouseenter focus click"
       exitDelay={exitDelay}
       entryDelay={entryDelay}
       maxWidth={maxWidth}
       position={position}
       content={<div>{toolTipText}</div>}
+      {...tooltipProps}
     >
       <Button className={className} onClick={onCustomClick} variant="control" aria-label={ariaLabel} {...props}>
         {icon}

--- a/packages/react-code-editor/src/components/CodeEditor/CodeEditorControl.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/CodeEditorControl.tsx
@@ -61,6 +61,46 @@ export const CodeEditorControl: React.FunctionComponent<CodeEditorControlProps> 
 }: CodeEditorControlProps) => {
   const context = React.useContext(CodeEditorContext);
 
+  if (entryDelay !== undefined) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'The CodeEditorControl entryDelay prop has been deprecated. ' +
+      'Pass the entryDelay via the tooltipProps prop instead.'
+    );
+  }
+
+  if (exitDelay !== undefined) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'The CodeEditorControl exitDelay prop has been deprecated. ' +
+      'Pass the exitDelay via the tooltipProps prop instead.'
+    );
+  }
+
+  if (maxWidth !== undefined) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'The CodeEditorControl maxWidth prop has been deprecated. ' +
+      'Pass the maxWidth via the tooltipProps prop instead.'
+    );
+  }
+
+  if (position !== undefined) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'The CodeEditorControl position prop has been deprecated. ' +
+      'Pass the position via the tooltipProps prop instead.'
+    );
+  }
+
+  if (toolTipText !== undefined) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'The CodeEditorControl toolTipText prop has been deprecated. ' +
+      'Pass the toolTipText by setting the content field in tooltipProps prop instead.'
+    );
+  }
+
   const onCustomClick = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     onClick(context.code, event);
   };

--- a/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditorCustomControl.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditorCustomControl.tsx
@@ -18,7 +18,7 @@ export const CodeEditorCustomControl: React.FunctionComponent = () => {
     <CodeEditorControl
       icon={<PlayIcon />}
       aria-label="Execute code"
-      toolTipText="Execute code"
+      tooltipProps={{content:"Execute code"}}
       onClick={onExecuteCode}
       isVisible={code !== ''}
     />

--- a/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditorCustomControl.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditorCustomControl.tsx
@@ -18,7 +18,7 @@ export const CodeEditorCustomControl: React.FunctionComponent = () => {
     <CodeEditorControl
       icon={<PlayIcon />}
       aria-label="Execute code"
-      tooltipProps={{content:"Execute code"}}
+      tooltipProps={{ content: 'Execute code' }}
       onClick={onExecuteCode}
       isVisible={code !== ''}
     />

--- a/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditorShortcutMainHeader.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditorShortcutMainHeader.tsx
@@ -37,20 +37,20 @@ export const CodeEditorShortcutMainHeader: React.FunctionComponent = () => {
   const shortcutsPopoverProps = {
     bodyContent: (
       <Grid span={6} hasGutter key="grid">
-        {shortcuts.map((s, i) => (
-          <React.Fragment key={i}>
+        {shortcuts.map((shortcut, index) => (
+          <React.Fragment key={index}>
             <GridItem style={{ textAlign: 'right', marginRight: '1em' }}>
-              {s.keys
-                .map(k => (
-                  <Chip key={k} isReadOnly>
-                    {k}
+              {shortcut.keys
+                .map(key => (
+                  <Chip key={key} isReadOnly>
+                    {key}
                   </Chip>
                 ))
                 .reduce((prev, curr) => (
                   <>{[prev, ' + ', curr]}</>
                 ))}
             </GridItem>
-            <GridItem>{s.description}</GridItem>
+            <GridItem>{shortcut.description}</GridItem>
           </React.Fragment>
         ))}
       </Grid>

--- a/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditorShortcutMainHeader.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditorShortcutMainHeader.tsx
@@ -36,7 +36,7 @@ export const CodeEditorShortcutMainHeader: React.FunctionComponent = () => {
   ];
   const shortcutsPopoverProps = {
     bodyContent: (
-      <Grid span={6} hasGutter key='grid'>
+      <Grid span={6} hasGutter key="grid">
         {shortcuts.map((s, i) => (
           <React.Fragment key={i}>
             <GridItem style={{ textAlign: 'right', marginRight: '1em' }}>
@@ -50,7 +50,7 @@ export const CodeEditorShortcutMainHeader: React.FunctionComponent = () => {
                   <>{[prev, ' + ', curr]}</>
                 ))}
             </GridItem>
-            <GridItem >{s.description}</GridItem>
+            <GridItem>{s.description}</GridItem>
           </React.Fragment>
         ))}
       </Grid>

--- a/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditorShortcutMainHeader.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditorShortcutMainHeader.tsx
@@ -36,9 +36,9 @@ export const CodeEditorShortcutMainHeader: React.FunctionComponent = () => {
   ];
   const shortcutsPopoverProps = {
     bodyContent: (
-      <Grid span={6} hasGutter>
-        {shortcuts.map(s => (
-          <>
+      <Grid span={6} hasGutter key='grid'>
+        {shortcuts.map((s, i) => (
+          <React.Fragment key={i}>
             <GridItem style={{ textAlign: 'right', marginRight: '1em' }}>
               {s.keys
                 .map(k => (
@@ -50,8 +50,8 @@ export const CodeEditorShortcutMainHeader: React.FunctionComponent = () => {
                   <>{[prev, ' + ', curr]}</>
                 ))}
             </GridItem>
-            <GridItem>{s.description}</GridItem>
-          </>
+            <GridItem >{s.description}</GridItem>
+          </React.Fragment>
         ))}
       </Grid>
     ),
@@ -60,7 +60,6 @@ export const CodeEditorShortcutMainHeader: React.FunctionComponent = () => {
 
   return (
     <CodeEditor
-      headerMainContent="Shortcut Example"
       shortcutsPopoverProps={shortcutsPopoverProps}
       isLanguageLabelVisible
       code="Some example content"

--- a/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
+++ b/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
@@ -105,7 +105,7 @@ export class ClipboardCopy extends React.Component<ClipboardCopyProps, Clipboard
     variant: 'inline',
     position: PopoverPosition.top,
     maxWidth: '150px',
-    exitDelay: 1600,
+    exitDelay: 1500,
     entryDelay: 300,
     switchDelay: 2000,
     onCopy: clipboardCopyFunc,

--- a/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
+++ b/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
@@ -98,7 +98,7 @@ export class ClipboardCopy extends React.Component<ClipboardCopyProps, Clipboard
     if (this.props.switchDelay !== undefined) {
       // eslint-disable-next-line no-console
       console.warn(
-        'The ClipboardCopy switchDelay prop has been deprecated. ' +
+        'ClipboardCopy: switchDelay prop has been deprecated. ' +
           'The tooltip message will switch back to the hover tip as soon as the tooltip is hidden.'
       );
     }

--- a/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
+++ b/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
@@ -11,13 +11,7 @@ import { ClipboardCopyToggle } from './ClipboardCopyToggle';
 import { ClipboardCopyExpanded } from './ClipboardCopyExpanded';
 
 export const clipboardCopyFunc = (event: React.ClipboardEvent<HTMLDivElement>, text?: React.ReactNode) => {
-  const clipboard = event.currentTarget.parentElement;
-  const el = document.createElement('textarea');
-  el.value = text.toString();
-  clipboard.appendChild(el);
-  el.select();
-  document.execCommand('copy');
-  clipboard.removeChild(el);
+  navigator.clipboard.writeText(text.toString());
 };
 
 export enum ClipboardCopyVariant {

--- a/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
+++ b/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
@@ -99,7 +99,7 @@ export class ClipboardCopy extends React.Component<ClipboardCopyProps, Clipboard
       // eslint-disable-next-line no-console
       console.warn(
         'The ClipboardCopy switchDelay prop has been deprecated. ' +
-        'The tooltip message will switch back to the hover tip as soon as the tooltip is hidden.'
+          'The tooltip message will switch back to the hover tip as soon as the tooltip is hidden.'
       );
     }
   }

--- a/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
+++ b/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
@@ -145,6 +145,7 @@ export class ClipboardCopy extends React.Component<ClipboardCopyProps, Clipboard
       /* eslint-disable @typescript-eslint/no-unused-vars */
       isExpanded,
       onChange, // Don't pass to <div>
+      switchDelay,
       /* eslint-enable @typescript-eslint/no-unused-vars */
       isReadOnly,
       isCode,
@@ -152,7 +153,6 @@ export class ClipboardCopy extends React.Component<ClipboardCopyProps, Clipboard
       exitDelay,
       maxWidth,
       entryDelay,
-      switchDelay,
       onCopy,
       hoverTip,
       clickTip,
@@ -207,7 +207,7 @@ export class ClipboardCopy extends React.Component<ClipboardCopyProps, Clipboard
                         onCopy(event, this.state.text);
                         this.setState({ copied: true });
                       }}
-                      onTooltipHidden={() => this.setState({copied: false})}
+                      onTooltipHidden={() => this.setState({ copied: false })}
                     >
                       {this.state.copied ? clickTip : hoverTip}
                     </ClipboardCopyButton>
@@ -252,7 +252,7 @@ export class ClipboardCopy extends React.Component<ClipboardCopyProps, Clipboard
                       onCopy(event, this.state.text);
                       this.setState({ copied: true });
                     }}
-                    onTooltipHidden={() => this.setState({copied: false})}
+                    onTooltipHidden={() => this.setState({ copied: false })}
                   >
                     {this.state.copied ? clickTip : hoverTip}
                   </ClipboardCopyButton>

--- a/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
+++ b/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
@@ -94,6 +94,14 @@ export class ClipboardCopy extends React.Component<ClipboardCopyProps, Clipboard
       expanded: this.props.isExpanded,
       copied: false
     };
+
+    if (this.props.switchDelay !== undefined) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'The ClipboardCopy switchDelay prop has been deprecated. ' +
+        'The tooltip message will switch back to the hover tip as soon as the tooltip is hidden.'
+      );
+    }
   }
 
   static defaultProps: PickOptional<ClipboardCopyProps> = {
@@ -107,7 +115,6 @@ export class ClipboardCopy extends React.Component<ClipboardCopyProps, Clipboard
     maxWidth: '150px',
     exitDelay: 1500,
     entryDelay: 300,
-    switchDelay: 2000,
     onCopy: clipboardCopyFunc,
     onChange: (): any => undefined,
     textAriaLabel: 'Copyable input',

--- a/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
+++ b/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
@@ -70,7 +70,7 @@ export interface ClipboardCopyProps extends Omit<React.HTMLProps<HTMLDivElement>
   exitDelay?: number;
   /** Delay in ms before the tooltip appears. */
   entryDelay?: number;
-  /** Delay in ms before the tooltip message switch to hover tip. */
+  /** @deprecated Delay in ms before the tooltip message switch to hover tip. */
   switchDelay?: number;
   /** A function that is triggered on clicking the copy button. */
   onCopy?: (event: React.ClipboardEvent<HTMLDivElement>, text?: React.ReactNode) => void;
@@ -204,18 +204,10 @@ export class ClipboardCopy extends React.Component<ClipboardCopyProps, Clipboard
                       textId={`text-input-${id}`}
                       aria-label={hoverTip}
                       onClick={(event: any) => {
-                        if (this.timer) {
-                          window.clearTimeout(this.timer);
-                          this.setState({ copied: false });
-                        }
                         onCopy(event, this.state.text);
-                        this.setState({ copied: true }, () => {
-                          this.timer = window.setTimeout(() => {
-                            this.setState({ copied: false });
-                            this.timer = null;
-                          }, switchDelay);
-                        });
+                        this.setState({ copied: true });
                       }}
+                      onTooltipHidden={() => this.setState({copied: false})}
                     >
                       {this.state.copied ? clickTip : hoverTip}
                     </ClipboardCopyButton>
@@ -257,18 +249,10 @@ export class ClipboardCopy extends React.Component<ClipboardCopyProps, Clipboard
                     textId={`text-input-${id}`}
                     aria-label={hoverTip}
                     onClick={(event: any) => {
-                      if (this.timer) {
-                        window.clearTimeout(this.timer);
-                        this.setState({ copied: false });
-                      }
                       onCopy(event, this.state.text);
-                      this.setState({ copied: true }, () => {
-                        this.timer = window.setTimeout(() => {
-                          this.setState({ copied: false });
-                          this.timer = null;
-                        }, switchDelay);
-                      });
+                      this.setState({ copied: true });
                     }}
+                    onTooltipHidden={() => this.setState({copied: false})}
                   >
                     {this.state.copied ? clickTip : hoverTip}
                   </ClipboardCopyButton>

--- a/packages/react-core/src/components/ClipboardCopy/ClipboardCopyButton.tsx
+++ b/packages/react-core/src/components/ClipboardCopy/ClipboardCopyButton.tsx
@@ -43,6 +43,8 @@ export interface ClipboardCopyButtonProps
   'aria-label'?: string;
   /** Variant of the copy button */
   variant?: 'control' | 'plain';
+  /** Callback when tooltip's hide transition has finished executing */
+  onTooltipHidden?: () => void;
 }
 
 export const ClipboardCopyButton: React.FunctionComponent<ClipboardCopyButtonProps> = ({
@@ -56,6 +58,7 @@ export const ClipboardCopyButton: React.FunctionComponent<ClipboardCopyButtonPro
   textId,
   children,
   variant = 'control',
+  onTooltipHidden = () => {},
   ...props
 }: ClipboardCopyButtonProps) => (
   <Tooltip
@@ -67,6 +70,7 @@ export const ClipboardCopyButton: React.FunctionComponent<ClipboardCopyButtonPro
     aria-live="polite"
     aria="none"
     content={<div>{children}</div>}
+    onTooltipHidden={onTooltipHidden}
   >
     <Button
       type="button"

--- a/packages/react-core/src/components/CodeBlock/examples/CodeBlockBasic.tsx
+++ b/packages/react-core/src/components/CodeBlock/examples/CodeBlockBasic.tsx
@@ -6,13 +6,7 @@ export const BasicCodeBlock: React.FunctionComponent = () => {
   const [copied, setCopied] = React.useState(false);
 
   const clipboardCopyFunc = (event, text) => {
-    const clipboard = event.currentTarget.parentElement;
-    const el = document.createElement('textarea');
-    el.value = text.toString();
-    clipboard.appendChild(el);
-    el.select();
-    document.execCommand('copy');
-    clipboard.removeChild(el);
+    navigator.clipboard.writeText(text.toString());
   };
 
   const onClick = (event, text) => {

--- a/packages/react-core/src/components/CodeBlock/examples/CodeBlockBasic.tsx
+++ b/packages/react-core/src/components/CodeBlock/examples/CodeBlockBasic.tsx
@@ -30,9 +30,10 @@ url: https://raw.githubusercontent.com/Azure-Samples/helm-charts/master/docs`;
           textId="code-content"
           aria-label="Copy to clipboard"
           onClick={e => onClick(e, code)}
-          exitDelay={600}
+          exitDelay={copied ? 1500 : 600}
           maxWidth="110px"
           variant="plain"
+          onTooltipHidden={() => setCopied(false)}
         >
           {copied ? 'Successfully copied to clipboard!' : 'Copy to clipboard'}
         </ClipboardCopyButton>

--- a/packages/react-core/src/components/CodeBlock/examples/CodeBlockExpandable.tsx
+++ b/packages/react-core/src/components/CodeBlock/examples/CodeBlockExpandable.tsx
@@ -19,13 +19,7 @@ export const ExpandableCodeBlock: React.FunctionComponent = () => {
   };
 
   const clipboardCopyFunc = (event, text) => {
-    const clipboard = event.currentTarget.parentElement;
-    const el = document.createElement('textarea');
-    el.value = text.toString();
-    clipboard.appendChild(el);
-    el.select();
-    document.execCommand('copy');
-    clipboard.removeChild(el);
+    navigator.clipboard.writeText(text.toString());
   };
 
   const onClick = (event, text) => {

--- a/packages/react-core/src/components/CodeBlock/examples/CodeBlockExpandable.tsx
+++ b/packages/react-core/src/components/CodeBlock/examples/CodeBlockExpandable.tsx
@@ -51,9 +51,10 @@ url: https://raw.githubusercontent.com/Azure-Samples/helm-charts/master/docs`;
           textId="code-content"
           aria-label="Copy to clipboard"
           onClick={e => onClick(e, copyBlock)}
-          exitDelay={600}
+          exitDelay={copied ? 1500 : 600}
           maxWidth="110px"
           variant="plain"
+          onTooltipHidden={() => setCopied(false)}
         >
           {copied ? 'Successfully copied to clipboard!' : 'Copy to clipboard'}
         </ClipboardCopyButton>

--- a/packages/react-core/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-core/src/components/Tooltip/Tooltip.tsx
@@ -247,13 +247,13 @@ export const Tooltip: React.FunctionComponent<TooltipProps> = ({
       setOpacity(1);
     }, entryDelay);
   };
-  const hide = () => {
+  const hide = React.useCallback(() => {
     clearTimeouts([showTimerRef, transitionTimerRef, hideTimerRef]);
     hideTimerRef.current = setTimeout(() => {
       setOpacity(0);
       transitionTimerRef.current = setTimeout(() => setVisible(false), animationDuration);
     }, exitDelay);
-  };
+  }, [exitDelay]);
   const positionModifiers = {
     top: styles.modifiers.top,
     bottom: styles.modifiers.bottom,

--- a/packages/react-core/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-core/src/components/Tooltip/Tooltip.tsx
@@ -233,6 +233,13 @@ export const Tooltip: React.FunctionComponent<TooltipProps> = ({
       hide();
     }
   }, [isVisible]);
+  React.useEffect(() => {
+    clearTimeouts([transitionTimerRef, hideTimerRef]);
+    hideTimerRef.current = setTimeout(() => {
+      setOpacity(0);
+      transitionTimerRef.current = setTimeout(() => setVisible(false), animationDuration);
+    }, exitDelay);
+  }, [exitDelay]);
   const show = () => {
     clearTimeouts([transitionTimerRef, hideTimerRef]);
     showTimerRef.current = setTimeout(() => {
@@ -240,13 +247,13 @@ export const Tooltip: React.FunctionComponent<TooltipProps> = ({
       setOpacity(1);
     }, entryDelay);
   };
-  const hide = () => {
-    clearTimeouts([showTimerRef]);
+  const hide = React.useCallback(() => {
+    clearTimeouts([showTimerRef, transitionTimerRef, hideTimerRef]);
     hideTimerRef.current = setTimeout(() => {
       setOpacity(0);
       transitionTimerRef.current = setTimeout(() => setVisible(false), animationDuration);
     }, exitDelay);
-  };
+  }, [exitDelay]);
   const positionModifiers = {
     top: styles.modifiers.top,
     bottom: styles.modifiers.bottom,

--- a/packages/react-core/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-core/src/components/Tooltip/Tooltip.tsx
@@ -247,13 +247,13 @@ export const Tooltip: React.FunctionComponent<TooltipProps> = ({
       setOpacity(1);
     }, entryDelay);
   };
-  const hide = React.useCallback(() => {
+  const hide = () => {
     clearTimeouts([showTimerRef, transitionTimerRef, hideTimerRef]);
     hideTimerRef.current = setTimeout(() => {
       setOpacity(0);
       transitionTimerRef.current = setTimeout(() => setVisible(false), animationDuration);
     }, exitDelay);
-  }, [exitDelay]);
+  };
   const positionModifiers = {
     top: styles.modifiers.top,
     bottom: styles.modifiers.bottom,

--- a/packages/react-core/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-core/src/components/Tooltip/Tooltip.tsx
@@ -234,7 +234,7 @@ export const Tooltip: React.FunctionComponent<TooltipProps> = ({
     }
   }, [isVisible]);
   React.useEffect(() => {
-    clearTimeouts([transitionTimerRef, hideTimerRef]);
+    clearTimeouts([hideTimerRef]);
     hideTimerRef.current = setTimeout(() => {
       setOpacity(0);
       transitionTimerRef.current = setTimeout(() => setVisible(false), animationDuration);
@@ -248,7 +248,7 @@ export const Tooltip: React.FunctionComponent<TooltipProps> = ({
     }, entryDelay);
   };
   const hide = React.useCallback(() => {
-    clearTimeouts([showTimerRef, transitionTimerRef, hideTimerRef]);
+    clearTimeouts([showTimerRef]);
     hideTimerRef.current = setTimeout(() => {
       setOpacity(0);
       transitionTimerRef.current = setTimeout(() => setVisible(false), animationDuration);


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7884 

- we now use `<CodeEditorControl>` for all dynamically built controls in CodeEditor.tsx.
- we now pass tooltipProps to `<CodeEditorControl>` that gets passed along to `<Tooltip>`.
- Code editor now uses tooltip's default prop values unless consumer overrides them with tooltipProps
- Deprecated the previous prop that were passed to the tooltip (they still work)
- Copy to clipboard button in the code editor now triggers with keyboard focus
- created a callback so that the 'copied to clipboard' success text can be reverted back only after the tooltip closes (prevents timings from getting out of sync and the text reverting back right before the tooltip closes)
- Updated copy functions to use `navigator.clipboard()` (keeps broswer focus on the copy button once clicked)
- adds similar features to the code block examples so the 'copied to clipboard!' text reverts back after the tooltip closes