### PR TITLE
feat(log-viewer): add prop initialIndexWidth to support for custom line number col size

### DIFF
--- a/packages/react-log-viewer/src/LogViewer/examples/LogViewer.md
+++ b/packages/react-log-viewer/src/LogViewer/examples/LogViewer.md
@@ -38,6 +38,23 @@ BasicLogViewer = () => {
 };
 ```
 
+### With line number chars specified
+
+```js
+import React from 'react';
+import { data } from './realTestData.js';
+import { LogViewer } from '@patternfly/react-log-viewer';
+
+LineNumberCharsSpecifiedLogViewer = () => {
+  return (
+    <LogViewer
+      data={data.data}
+      initialIndexWidth={7}
+    />
+  );
+};
+```
+
 ### With search
 
 ```js

--- a/packages/react-log-viewer/src/react-window/createListComponent.ts
+++ b/packages/react-log-viewer/src/react-window/createListComponent.ts
@@ -249,6 +249,7 @@ export default function createListComponent({
         width,
         isTextWrapped,
         hasLineNumbers,
+        indexWidth,
         ansiUp
       } = this.props;
       const { isScrolling } = this.state;
@@ -301,7 +302,7 @@ export default function createListComponent({
             style: {
               height: estimatedTotalSize > height ? estimatedTotalSize : height,
               /* eslint-disable-next-line no-nested-ternary */
-              width: isTextWrapped ? (hasLineNumbers ? width - 65 : width) : 'auto',
+              width: isTextWrapped ? (hasLineNumbers ? width - indexWidth : width) : 'auto',
               pointerEvents: isScrolling ? 'none' : undefined
             }
           },


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7876 
Add a prop named `initialIndexWidth`. Users could specify the char numbers they want to show in the line numbers column. For example, if the user anticipates over 100,0000 lines of logs, they could set `initialIndexWidth={7}`, so the index width would expand enough to hold 7 chars.
Add an example to show the usage.
One thing that needs to be mentioned, the user cannot dynamically set this value if the log viewer is not re-rendered because the row height calculation will be inaccurate.
