### PR TITLE
docs: add filter demos

### DIFF
--- a/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
+++ b/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
@@ -149,6 +149,7 @@ export class MenuToggleBase extends React.Component<MenuToggleProps> {
             aria-expanded={isExpanded}
             aria-label={ariaLabel}
             disabled={isDisabled}
+            onClick={onClick}
             {...otherProps}
           >
             {toggleControls}

--- a/packages/react-core/src/demos/Filters/FilterDemos.md
+++ b/packages/react-core/src/demos/Filters/FilterDemos.md
@@ -13,7 +13,10 @@ Menu,
 MenuContent,
 MenuList,
 MenuItem,
-MenuToggle
+MenuToggle,
+ToolbarGroup,
+ToolbarFilter,
+Badge
 } from '@patternfly/react-core';
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
@@ -26,4 +29,9 @@ import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-tab
 ### Filtering with a single select
 
 ```ts file="./examples/FilterSingleSelect.tsx"
+```
+
+### Filtering with a checkbox select
+
+```ts file="./examples/FilterCheckboxSelect.tsx"
 ```

--- a/packages/react-core/src/demos/Filters/FilterDemos.md
+++ b/packages/react-core/src/demos/Filters/FilterDemos.md
@@ -14,9 +14,11 @@ MenuContent,
 MenuList,
 MenuItem,
 MenuToggle,
+MenuToggleCheckbox,
 ToolbarGroup,
 ToolbarFilter,
-Badge
+Badge,
+Pagination
 } from '@patternfly/react-core';
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';

--- a/packages/react-core/src/demos/Filters/FilterDemos.md
+++ b/packages/react-core/src/demos/Filters/FilterDemos.md
@@ -18,9 +18,16 @@ MenuToggleCheckbox,
 ToolbarGroup,
 ToolbarFilter,
 Badge,
-Pagination
+Pagination,
+EmptyState,
+EmptyStateIcon,
+Title,
+EmptyStateBody,
+EmptyStatePrimary,
+Button
 } from '@patternfly/react-core';
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
+import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 
 ## Demos

--- a/packages/react-core/src/demos/Filters/FilterDemos.md
+++ b/packages/react-core/src/demos/Filters/FilterDemos.md
@@ -23,6 +23,8 @@ Pagination
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 
+## Demos
+
 ### Filtering with a search input
 
 ```ts file="./examples/FilterSearchInput.tsx"

--- a/packages/react-core/src/demos/Filters/FilterDemos.md
+++ b/packages/react-core/src/demos/Filters/FilterDemos.md
@@ -1,0 +1,29 @@
+---
+id: Filters
+section: demos
+---
+
+import {
+Popper,
+SearchInput,
+Toolbar,
+ToolbarContent,
+ToolbarItem,
+Menu,
+MenuContent,
+MenuList,
+MenuItem,
+MenuToggle
+} from '@patternfly/react-core';
+import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
+import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+
+### Filtering with a search input
+
+```ts file="./examples/FilterSearchInput.tsx"
+```
+
+### Filtering with a single select
+
+```ts file="./examples/FilterSingleSelect.tsx"
+```

--- a/packages/react-core/src/demos/Filters/examples/FilterCheckboxSelect.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterCheckboxSelect.tsx
@@ -1,0 +1,285 @@
+import React from 'react';
+import {
+  Menu,
+  MenuContent,
+  MenuList,
+  MenuItem,
+  MenuToggle,
+  Popper,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarFilter,
+  Badge
+} from '@patternfly/react-core';
+import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
+
+interface Repository {
+  name: string;
+  threads: string;
+  apps: string;
+  workspaces: string;
+  status: string;
+  location: string;
+}
+
+// In real usage, this data would come from some external source like an API via props.
+const repositories: Repository[] = [
+  { name: 'US-Node 1', threads: '5', apps: '25', workspaces: '5', status: 'Stopped', location: 'Raleigh' },
+  { name: 'US-Node 2', threads: '5', apps: '30', workspaces: '2', status: 'Down', location: 'Westford' },
+  { name: 'US-Node 3', threads: '13', apps: '35', workspaces: '12', status: 'Degraded', location: 'Boston' },
+  { name: 'US-Node 4', threads: '2', apps: '5', workspaces: '18', status: 'Needs Maintainence', location: 'Raleigh' },
+  { name: 'US-Node 5', threads: '7', apps: '30', workspaces: '5', status: 'Running', location: 'Boston' },
+  { name: 'US-Node 6', threads: '5', apps: '20', workspaces: '15', status: 'Stopped', location: 'Raleigh' },
+  { name: 'CZ-Node 1', threads: '12', apps: '48', workspaces: '13', status: 'Down', location: 'Brno' },
+  { name: 'CZ-Node 2', threads: '3', apps: '8', workspaces: '20', status: 'Running', location: 'Brno' },
+  { name: 'CZ-Remote-Node 1', threads: '1', apps: '15', workspaces: '20', status: 'Down', location: 'Brno' },
+  { name: 'Bangalore-Node 1', threads: '1', apps: '20', workspaces: '20', status: 'Running', location: 'Bangalore' }
+];
+
+const columnNames = {
+  name: 'Servers',
+  threads: 'Threads',
+  apps: 'Applications',
+  workspaces: 'Workspaces',
+  status: 'Status',
+  location: 'Location'
+};
+
+/* eslint-disable patternfly-react/no-anonymous-functions */
+export const FilterCheckboxSelect: React.FunctionComponent = () => {
+  // Set up table selection
+  const isRepoSelectable = (repo: Repository) => repo.name !== 'a'; // Arbitrary logic for this example
+  const selectableRepos = repositories.filter(isRepoSelectable);
+
+  // In this example, selected rows are tracked by the repo names from each row. This could be any unique identifier.
+  // This is to prevent state from being based on row order index in case we later add sorting.
+  const [selectedRepoNames, setSelectedRepoNames] = React.useState<string[]>([]);
+  const setRepoSelected = (repo: Repository, isSelecting = true) =>
+    setSelectedRepoNames(prevSelected => {
+      const otherSelectedRepoNames = prevSelected.filter(r => r !== repo.name);
+      return isSelecting && isRepoSelectable(repo) ? [...otherSelectedRepoNames, repo.name] : otherSelectedRepoNames;
+    });
+  const selectAllRepos = (isSelecting = true) =>
+    setSelectedRepoNames(isSelecting ? selectableRepos.map(r => r.name) : []);
+  const areAllReposSelected = selectedRepoNames.length === selectableRepos.length;
+  const isRepoSelected = (repo: Repository) => selectedRepoNames.includes(repo.name);
+
+  // To allow shift+click to select/deselect multiple rows
+  const [recentSelectedRowIndex, setRecentSelectedRowIndex] = React.useState<number | null>(null);
+  const [shifting, setShifting] = React.useState(false);
+
+  const onSelectRepo = (repo: Repository, rowIndex: number, isSelecting: boolean) => {
+    // If the user is shift + selecting the checkboxes, then all intermediate checkboxes should be selected
+    if (shifting && recentSelectedRowIndex !== null) {
+      const numberSelected = rowIndex - recentSelectedRowIndex;
+      const intermediateIndexes =
+        numberSelected > 0
+          ? Array.from(new Array(numberSelected + 1), (_x, i) => i + recentSelectedRowIndex)
+          : Array.from(new Array(Math.abs(numberSelected) + 1), (_x, i) => i + rowIndex);
+      intermediateIndexes.forEach(index => setRepoSelected(repositories[index], isSelecting));
+    } else {
+      setRepoSelected(repo, isSelecting);
+    }
+    setRecentSelectedRowIndex(rowIndex);
+  };
+
+  React.useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') {
+        setShifting(true);
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') {
+        setShifting(false);
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    document.addEventListener('keyup', onKeyUp);
+
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('keyup', onKeyUp);
+    };
+  }, []);
+
+  // Set up single select menu & state
+  const [isOpen, setIsOpen] = React.useState<boolean>(false);
+  const [selections, setSelections] = React.useState<string[]>([]);
+  const toggleRef = React.useRef<HTMLButtonElement>(null);
+  const menuRef = React.useRef<HTMLDivElement>(null);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
+  const onFilter = (repo: Repository) => {
+    if (selections.length === 0) {
+      return true;
+    }
+
+    return selections.some(searchValue => {
+      let input: RegExp;
+      try {
+        input = new RegExp(searchValue, 'i');
+      } catch (err) {
+        input = new RegExp(searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+      }
+      return repo.location.search(input) >= 0;
+    });
+  };
+
+  const handleMenuKeys = (event: KeyboardEvent) => {
+    if (isOpen && menuRef.current?.contains(event.target as Node)) {
+      if (event.key === 'Escape' || event.key === 'Tab') {
+        setIsOpen(!isOpen);
+        toggleRef.current?.focus();
+      }
+    }
+  };
+
+  const handleClickOutside = (event: MouseEvent) => {
+    if (isOpen && !menuRef.current?.contains(event.target as Node)) {
+      setIsOpen(false);
+    }
+  };
+
+  React.useEffect(() => {
+    window.addEventListener('keydown', handleMenuKeys);
+    window.addEventListener('click', handleClickOutside);
+    return () => {
+      window.removeEventListener('keydown', handleMenuKeys);
+      window.removeEventListener('click', handleClickOutside);
+    };
+  }, [isOpen, menuRef]);
+
+  const onToggleClick = (ev: React.MouseEvent) => {
+    ev.stopPropagation(); // Stop handleClickOutside from handling
+    setTimeout(() => {
+      if (menuRef.current) {
+        const firstElement = menuRef.current.querySelector('li > button:not(:disabled)');
+        firstElement && (firstElement as HTMLElement).focus();
+      }
+    }, 0);
+    setIsOpen(!isOpen);
+  };
+
+  function onSelect(event: React.MouseEvent | undefined, itemId: string | number | undefined) {
+    if (typeof itemId === 'undefined') {
+      return;
+    }
+
+    const itemStr = itemId.toString();
+    setSelections(
+      selections.includes(itemStr) ? selections.filter(selection => selection !== itemStr) : [itemStr, ...selections]
+    );
+  }
+
+  const toggle = (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={onToggleClick}
+      isExpanded={isOpen}
+      icon={<FilterIcon />}
+      {...(selections.length > 0 && { badge: <Badge isRead>{selections.length}</Badge> })}
+      style={
+        {
+          width: '200px'
+        } as React.CSSProperties
+      }
+    >
+      Location
+    </MenuToggle>
+  );
+
+  const menu = (
+    <Menu ref={menuRef} id="select-menu" onSelect={onSelect} selected={selections}>
+      <MenuContent>
+        <MenuList>
+          <MenuItem hasCheck isSelected={selections.includes('Bangalore')} itemId="Bangalore">
+            Bangalore
+          </MenuItem>
+          <MenuItem hasCheck isSelected={selections.includes('Boston')} itemId="Boston">
+            Boston
+          </MenuItem>
+          <MenuItem hasCheck isSelected={selections.includes('Brno')} itemId="Brno">
+            Brno
+          </MenuItem>
+          <MenuItem hasCheck isSelected={selections.includes('Raleigh')} itemId="Raleigh">
+            Raleigh
+          </MenuItem>
+          <MenuItem hasCheck isSelected={selections.includes('Westford')} itemId="Westford">
+            Westford
+          </MenuItem>
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+
+  const select = (
+    <div ref={containerRef}>
+      <Popper trigger={toggle} popper={menu} appendTo={containerRef.current || undefined} isVisible={isOpen} />
+    </div>
+  );
+
+  const toolbar = (
+    <Toolbar id="toolbar-items" clearAllFilters={() => setSelections([])}>
+      <ToolbarContent>
+        <ToolbarGroup variant="filter-group">
+          <ToolbarFilter
+            chips={selections}
+            deleteChip={(category, chip) => onSelect(undefined, chip as string)}
+            deleteChipGroup={() => setSelections([])}
+            categoryName="Location"
+          >
+            {select}
+          </ToolbarFilter>
+        </ToolbarGroup>
+      </ToolbarContent>
+    </Toolbar>
+  );
+
+  return (
+    <React.Fragment>
+      {toolbar}
+      <TableComposable aria-label="Selectable table">
+        <Thead>
+          <Tr>
+            <Th
+              select={{
+                onSelect: (_event, isSelecting) => selectAllRepos(isSelecting),
+                isSelected: areAllReposSelected
+              }}
+            />
+            <Th>{columnNames.name}</Th>
+            <Th>{columnNames.threads}</Th>
+            <Th>{columnNames.apps}</Th>
+            <Th>{columnNames.workspaces}</Th>
+            <Th>{columnNames.status}</Th>
+            <Th>{columnNames.location}</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {repositories.filter(onFilter).map((repo, rowIndex) => (
+            <Tr key={repo.name}>
+              <Td
+                select={{
+                  rowIndex,
+                  onSelect: (_event, isSelecting) => onSelectRepo(repo, rowIndex, isSelecting),
+                  isSelected: isRepoSelected(repo),
+                  disable: !isRepoSelectable(repo)
+                }}
+              />
+              <Td dataLabel={columnNames.name}>{repo.name}</Td>
+              <Td dataLabel={columnNames.threads}>{repo.threads}</Td>
+              <Td dataLabel={columnNames.apps}>{repo.apps}</Td>
+              <Td dataLabel={columnNames.workspaces}>{repo.workspaces}</Td>
+              <Td dataLabel={columnNames.status}>{repo.status}</Td>
+              <Td dataLabel={columnNames.location}>{repo.location}</Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </TableComposable>
+    </React.Fragment>
+  );
+};

--- a/packages/react-core/src/demos/Filters/examples/FilterCheckboxSelect.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterCheckboxSelect.tsx
@@ -371,12 +371,12 @@ export const FilterCheckboxSelect: React.FunctionComponent = () => {
         <Thead>
           <Tr>
             <Th />
-            <Th>{columnNames.name}</Th>
-            <Th>{columnNames.threads}</Th>
-            <Th>{columnNames.apps}</Th>
-            <Th>{columnNames.workspaces}</Th>
-            <Th>{columnNames.status}</Th>
-            <Th>{columnNames.location}</Th>
+            <Th width={20}>{columnNames.name}</Th>
+            <Th width={20}>{columnNames.threads}</Th>
+            <Th width={20}>{columnNames.apps}</Th>
+            <Th width={20}>{columnNames.workspaces}</Th>
+            <Th width={20}>{columnNames.status}</Th>
+            <Th width={20}>{columnNames.location}</Th>
           </Tr>
         </Thead>
         <Tbody>

--- a/packages/react-core/src/demos/Filters/examples/FilterCheckboxSelect.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterCheckboxSelect.tsx
@@ -5,12 +5,15 @@ import {
   MenuList,
   MenuItem,
   MenuToggle,
+  MenuToggleCheckbox,
   Popper,
   Toolbar,
   ToolbarContent,
   ToolbarGroup,
   ToolbarFilter,
-  Badge
+  ToolbarItem,
+  Badge,
+  Pagination
 } from '@patternfly/react-core';
 import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
@@ -105,6 +108,104 @@ export const FilterCheckboxSelect: React.FunctionComponent = () => {
       document.removeEventListener('keyup', onKeyUp);
     };
   }, []);
+
+  // Set up bulk selection menu
+  const bulkSelectMenuRef = React.createRef<HTMLDivElement>();
+  const bulkSelectToggleRef = React.createRef<any>();
+  const bulkSelectcontainerRef = React.createRef<HTMLDivElement>();
+
+  const [isBulkSelectOpen, setIsBulkSelectOpen] = React.useState<boolean>(false);
+
+  React.useEffect(() => {
+    window.addEventListener('keydown', handleBulkSelectMenuKeys);
+    window.addEventListener('click', handleBulkSelectClickOutside);
+    return () => {
+      window.removeEventListener('keydown', handleBulkSelectMenuKeys);
+      window.removeEventListener('click', handleBulkSelectClickOutside);
+    };
+  }, [isBulkSelectOpen, bulkSelectMenuRef]);
+
+  const handleBulkSelectClickOutside = (event: MouseEvent) => {
+    if (isBulkSelectOpen && !bulkSelectMenuRef.current?.contains(event.target as Node)) {
+      setIsBulkSelectOpen(false);
+    }
+  };
+
+  const handleBulkSelectMenuKeys = (event: KeyboardEvent) => {
+    if (!isBulkSelectOpen) {
+      return;
+    }
+    if (
+      bulkSelectMenuRef.current?.contains(event.target as Node) ||
+      bulkSelectToggleRef.current?.contains(event.target as Node)
+    ) {
+      if (event.key === 'Escape' || event.key === 'Tab') {
+        setIsBulkSelectOpen(!isBulkSelectOpen);
+        bulkSelectToggleRef.current?.focus();
+      }
+    }
+  };
+
+  const onBulkSelectToggleClick = (ev: React.MouseEvent) => {
+    ev.stopPropagation(); // Stop handleClickOutside from handling
+    setTimeout(() => {
+      if (bulkSelectMenuRef.current) {
+        const firstElement = bulkSelectMenuRef.current.querySelector('li > button:not(:disabled)');
+        firstElement && (firstElement as HTMLElement).focus();
+      }
+    }, 0);
+    setIsBulkSelectOpen(!isBulkSelectOpen);
+  };
+
+  const bulkSelectToggle = (
+    <MenuToggle
+      ref={bulkSelectToggleRef}
+      onClick={onBulkSelectToggleClick}
+      isExpanded={isBulkSelectOpen}
+      splitButtonOptions={{
+        items: [
+          <MenuToggleCheckbox
+            id="select-checkbox"
+            key="select-checkbox"
+            aria-label="Select all"
+            isChecked={areAllReposSelected}
+            onChange={(checked, _event) => selectAllRepos(checked)}
+          />
+        ]
+      }}
+      aria-label="Full table selection checkbox"
+    />
+  );
+
+  const bulkSelectMenu = (
+    // eslint-disable-next-line no-console
+    <Menu
+      ref={bulkSelectMenuRef}
+      onSelect={(_ev, itemId) => {
+        selectAllRepos(itemId === 0);
+        setIsBulkSelectOpen(!isBulkSelectOpen);
+      }}
+    >
+      <MenuContent>
+        <MenuList>
+          <MenuItem itemId={0}>Select all</MenuItem>
+          <MenuItem itemId={1}>Deselect all</MenuItem>
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+
+  const toolbarBulkSelect = (
+    <div ref={bulkSelectcontainerRef}>
+      <Popper
+        trigger={bulkSelectToggle}
+        popper={bulkSelectMenu}
+        appendTo={bulkSelectcontainerRef.current || undefined}
+        isVisible={isBulkSelectOpen}
+        popperMatchesTriggerWidth={false}
+      />
+    </div>
+  );
 
   // Set up single select menu & state
   const [isOpen, setIsOpen] = React.useState<boolean>(false);
@@ -222,9 +323,21 @@ export const FilterCheckboxSelect: React.FunctionComponent = () => {
     </div>
   );
 
+  // Set up pagination
+  const toolbarPagination = (
+    <Pagination
+      perPageComponent="button"
+      itemCount={repositories.length}
+      perPage={50}
+      page={1}
+      widgetId="table-mock-pagination"
+    />
+  );
+
   const toolbar = (
     <Toolbar id="toolbar-items" clearAllFilters={() => setSelections([])}>
       <ToolbarContent>
+        <ToolbarItem>{toolbarBulkSelect}</ToolbarItem>
         <ToolbarGroup variant="filter-group">
           <ToolbarFilter
             chips={selections}
@@ -235,6 +348,7 @@ export const FilterCheckboxSelect: React.FunctionComponent = () => {
             {select}
           </ToolbarFilter>
         </ToolbarGroup>
+        <ToolbarItem variant="pagination">{toolbarPagination}</ToolbarItem>
       </ToolbarContent>
     </Toolbar>
   );
@@ -245,12 +359,7 @@ export const FilterCheckboxSelect: React.FunctionComponent = () => {
       <TableComposable aria-label="Selectable table">
         <Thead>
           <Tr>
-            <Th
-              select={{
-                onSelect: (_event, isSelecting) => selectAllRepos(isSelecting),
-                isSelected: areAllReposSelected
-              }}
-            />
+            <Th />
             <Th>{columnNames.name}</Th>
             <Th>{columnNames.threads}</Th>
             <Th>{columnNames.apps}</Th>

--- a/packages/react-core/src/demos/Filters/examples/FilterCheckboxSelect.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterCheckboxSelect.tsx
@@ -67,6 +67,7 @@ export const FilterCheckboxSelect: React.FunctionComponent = () => {
   const selectAllRepos = (isSelecting = true) =>
     setSelectedRepoNames(isSelecting ? selectableRepos.map(r => r.name) : []);
   const areAllReposSelected = selectedRepoNames.length === selectableRepos.length;
+  const areSomeReposSelected = selectedRepoNames.length > 0;
   const isRepoSelected = (repo: Repository) => selectedRepoNames.includes(repo.name);
 
   // To allow shift+click to select/deselect multiple rows
@@ -157,6 +158,13 @@ export const FilterCheckboxSelect: React.FunctionComponent = () => {
     setIsBulkSelectOpen(!isBulkSelectOpen);
   };
 
+  let menuToggleCheckmark: boolean | null = false;
+  if (areAllReposSelected) {
+    menuToggleCheckmark = true;
+  } else if (areSomeReposSelected) {
+    menuToggleCheckmark = null;
+  }
+
   const bulkSelectToggle = (
     <MenuToggle
       ref={bulkSelectToggleRef}
@@ -168,7 +176,7 @@ export const FilterCheckboxSelect: React.FunctionComponent = () => {
             id="select-checkbox"
             key="select-checkbox"
             aria-label="Select all"
-            isChecked={areAllReposSelected}
+            isChecked={menuToggleCheckmark}
             onChange={(checked, _event) => selectAllRepos(checked)}
           />
         ]
@@ -182,14 +190,15 @@ export const FilterCheckboxSelect: React.FunctionComponent = () => {
     <Menu
       ref={bulkSelectMenuRef}
       onSelect={(_ev, itemId) => {
-        selectAllRepos(itemId === 0);
+        selectAllRepos(itemId === 1 || itemId === 2);
         setIsBulkSelectOpen(!isBulkSelectOpen);
       }}
     >
       <MenuContent>
         <MenuList>
-          <MenuItem itemId={0}>Select all</MenuItem>
-          <MenuItem itemId={1}>Deselect all</MenuItem>
+          <MenuItem itemId={0}>Select none (0 items)</MenuItem>
+          <MenuItem itemId={1}>Select page ({repositories.length} items)</MenuItem>
+          <MenuItem itemId={2}>Select all ({repositories.length} items)</MenuItem>
         </MenuList>
       </MenuContent>
     </Menu>
@@ -329,9 +338,10 @@ export const FilterCheckboxSelect: React.FunctionComponent = () => {
       titles={{ paginationTitle: 'Checkbox filter pagination' }}
       perPageComponent="button"
       itemCount={repositories.length}
-      perPage={50}
+      perPage={10}
       page={1}
-      widgetId="table-mock-pagination"
+      widgetId="checkbox-select-mock-pagination"
+      isCompact
     />
   );
 

--- a/packages/react-core/src/demos/Filters/examples/FilterCheckboxSelect.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterCheckboxSelect.tsx
@@ -326,6 +326,7 @@ export const FilterCheckboxSelect: React.FunctionComponent = () => {
   // Set up pagination
   const toolbarPagination = (
     <Pagination
+      titles={{ paginationTitle: 'Checkbox filter pagination' }}
       perPageComponent="button"
       itemCount={repositories.length}
       perPage={50}
@@ -335,7 +336,7 @@ export const FilterCheckboxSelect: React.FunctionComponent = () => {
   );
 
   const toolbar = (
-    <Toolbar id="toolbar-items" clearAllFilters={() => setSelections([])}>
+    <Toolbar id="checkbox-filter-toolbar" clearAllFilters={() => setSelections([])}>
       <ToolbarContent>
         <ToolbarItem>{toolbarBulkSelect}</ToolbarItem>
         <ToolbarGroup variant="filter-group">

--- a/packages/react-core/src/demos/Filters/examples/FilterSearchInput.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterSearchInput.tsx
@@ -1,0 +1,175 @@
+import React from 'react';
+import { SearchInput, Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
+import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+
+interface Repository {
+  name: string;
+  threads: string;
+  apps: string;
+  workspaces: string;
+  status: string;
+  location: string;
+}
+
+// In real usage, this data would come from some external source like an API via props.
+const repositories: Repository[] = [
+  { name: 'US-Node 1', threads: '5', apps: '25', workspaces: '5', status: 'Stopped', location: 'Raleigh' },
+  { name: 'US-Node 2', threads: '5', apps: '30', workspaces: '2', status: 'Down', location: 'Westford' },
+  { name: 'US-Node 3', threads: '13', apps: '35', workspaces: '12', status: 'Degraded', location: 'Boston' },
+  { name: 'US-Node 4', threads: '2', apps: '5', workspaces: '18', status: 'Needs Maintainence', location: 'Raleigh' },
+  { name: 'US-Node 5', threads: '7', apps: '30', workspaces: '5', status: 'Running', location: 'Boston' },
+  { name: 'US-Node 6', threads: '5', apps: '20', workspaces: '15', status: 'Stopped', location: 'Raleigh' },
+  { name: 'CZ-Node 1', threads: '12', apps: '48', workspaces: '13', status: 'Down', location: 'Brno' },
+  { name: 'CZ-Node 2', threads: '3', apps: '8', workspaces: '20', status: 'Running', location: 'Brno' },
+  { name: 'CZ-Remote-Node 1', threads: '1', apps: '15', workspaces: '20', status: 'Down', location: 'Brno' },
+  { name: 'Bangalore-Node 1', threads: '1', apps: '20', workspaces: '20', status: 'Running', location: 'Bangalore' }
+];
+
+const columnNames = {
+  name: 'Servers',
+  threads: 'Threads',
+  apps: 'Applications',
+  workspaces: 'Workspaces',
+  status: 'Status',
+  location: 'Location'
+};
+
+/* eslint-disable patternfly-react/no-anonymous-functions */
+export const FilterSearchInput: React.FunctionComponent = () => {
+  const isRepoSelectable = (repo: Repository) => repo.name !== 'a'; // Arbitrary logic for this example
+  const selectableRepos = repositories.filter(isRepoSelectable);
+
+  // In this example, selected rows are tracked by the repo names from each row. This could be any unique identifier.
+  // This is to prevent state from being based on row order index in case we later add sorting.
+  const [selectedRepoNames, setSelectedRepoNames] = React.useState<string[]>([]);
+  const setRepoSelected = (repo: Repository, isSelecting = true) =>
+    setSelectedRepoNames(prevSelected => {
+      const otherSelectedRepoNames = prevSelected.filter(r => r !== repo.name);
+      return isSelecting && isRepoSelectable(repo) ? [...otherSelectedRepoNames, repo.name] : otherSelectedRepoNames;
+    });
+  const selectAllRepos = (isSelecting = true) =>
+    setSelectedRepoNames(isSelecting ? selectableRepos.map(r => r.name) : []);
+  const areAllReposSelected = selectedRepoNames.length === selectableRepos.length;
+  const isRepoSelected = (repo: Repository) => selectedRepoNames.includes(repo.name);
+
+  // To allow shift+click to select/deselect multiple rows
+  const [recentSelectedRowIndex, setRecentSelectedRowIndex] = React.useState<number | null>(null);
+  const [shifting, setShifting] = React.useState(false);
+
+  const onSelectRepo = (repo: Repository, rowIndex: number, isSelecting: boolean) => {
+    // If the user is shift + selecting the checkboxes, then all intermediate checkboxes should be selected
+    if (shifting && recentSelectedRowIndex !== null) {
+      const numberSelected = rowIndex - recentSelectedRowIndex;
+      const intermediateIndexes =
+        numberSelected > 0
+          ? Array.from(new Array(numberSelected + 1), (_x, i) => i + recentSelectedRowIndex)
+          : Array.from(new Array(Math.abs(numberSelected) + 1), (_x, i) => i + rowIndex);
+      intermediateIndexes.forEach(index => setRepoSelected(repositories[index], isSelecting));
+    } else {
+      setRepoSelected(repo, isSelecting);
+    }
+    setRecentSelectedRowIndex(rowIndex);
+  };
+
+  React.useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') {
+        setShifting(true);
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') {
+        setShifting(false);
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    document.addEventListener('keyup', onKeyUp);
+
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('keyup', onKeyUp);
+    };
+  }, []);
+
+  const [searchValue, setSearchValue] = React.useState('');
+
+  const onSearchChange = (value: string) => {
+    setSearchValue(value);
+  };
+
+  const onFilter = (repo: Repository) => {
+    if (searchValue === '') {
+      return true;
+    }
+
+    let input: RegExp;
+    try {
+      input = new RegExp(searchValue, 'i');
+    } catch (err) {
+      input = new RegExp(searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+    }
+    return repo.name.search(input) >= 0;
+  };
+
+  const searchInput = (
+    <SearchInput
+      placeholder="Filter by server name"
+      value={searchValue}
+      onChange={onSearchChange}
+      onClear={() => onSearchChange('')}
+    />
+  );
+
+  const toolbar = (
+    <Toolbar id="toolbar-items">
+      <ToolbarContent>
+        <ToolbarItem variant="search-filter">{searchInput}</ToolbarItem>
+      </ToolbarContent>
+    </Toolbar>
+  );
+
+  return (
+    <React.Fragment>
+      {toolbar}
+      <TableComposable aria-label="Selectable table">
+        <Thead>
+          <Tr>
+            <Th
+              select={{
+                onSelect: (_event, isSelecting) => selectAllRepos(isSelecting),
+                isSelected: areAllReposSelected
+              }}
+            />
+            <Th>{columnNames.name}</Th>
+            <Th>{columnNames.threads}</Th>
+            <Th>{columnNames.apps}</Th>
+            <Th>{columnNames.workspaces}</Th>
+            <Th>{columnNames.status}</Th>
+            <Th>{columnNames.location}</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {repositories.filter(onFilter).map((repo, rowIndex) => (
+            <Tr key={repo.name}>
+              <Td
+                select={{
+                  rowIndex,
+                  onSelect: (_event, isSelecting) => onSelectRepo(repo, rowIndex, isSelecting),
+                  isSelected: isRepoSelected(repo),
+                  disable: !isRepoSelectable(repo)
+                }}
+              />
+              <Td dataLabel={columnNames.name}>{repo.name}</Td>
+              <Td dataLabel={columnNames.threads}>{repo.threads}</Td>
+              <Td dataLabel={columnNames.apps}>{repo.apps}</Td>
+              <Td dataLabel={columnNames.workspaces}>{repo.workspaces}</Td>
+              <Td dataLabel={columnNames.status}>{repo.status}</Td>
+              <Td dataLabel={columnNames.location}>{repo.location}</Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </TableComposable>
+    </React.Fragment>
+  );
+};

--- a/packages/react-core/src/demos/Filters/examples/FilterSearchInput.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterSearchInput.tsx
@@ -233,6 +233,7 @@ export const FilterSearchInput: React.FunctionComponent = () => {
 
   const toolbarPagination = (
     <Pagination
+      titles={{ paginationTitle: 'Search filter pagination' }}
       perPageComponent="button"
       itemCount={repositories.length}
       perPage={50}
@@ -242,7 +243,7 @@ export const FilterSearchInput: React.FunctionComponent = () => {
   );
 
   const toolbar = (
-    <Toolbar id="toolbar-items">
+    <Toolbar id="search-input-filter-toolbar">
       <ToolbarContent>
         <ToolbarItem>{toolbarBulkSelect}</ToolbarItem>
         <ToolbarItem variant="search-filter">{searchInput}</ToolbarItem>

--- a/packages/react-core/src/demos/Filters/examples/FilterSearchInput.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterSearchInput.tsx
@@ -315,12 +315,12 @@ export const FilterSearchInput: React.FunctionComponent = () => {
         <Thead>
           <Tr>
             <Th />
-            <Th>{columnNames.name}</Th>
-            <Th>{columnNames.threads}</Th>
-            <Th>{columnNames.apps}</Th>
-            <Th>{columnNames.workspaces}</Th>
-            <Th>{columnNames.status}</Th>
-            <Th>{columnNames.location}</Th>
+            <Th width={20}>{columnNames.name}</Th>
+            <Th width={20}>{columnNames.threads}</Th>
+            <Th width={20}>{columnNames.apps}</Th>
+            <Th width={20}>{columnNames.workspaces}</Th>
+            <Th width={20}>{columnNames.status}</Th>
+            <Th width={20}>{columnNames.location}</Th>
           </Tr>
         </Thead>
         <Tbody>{filteredRepos.length > 0 && filteredRepos}</Tbody>

--- a/packages/react-core/src/demos/Filters/examples/FilterSingleSelect.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterSingleSelect.tsx
@@ -358,12 +358,12 @@ export const FilterSingleSelect: React.FunctionComponent = () => {
         <Thead>
           <Tr>
             <Th />
-            <Th>{columnNames.name}</Th>
-            <Th>{columnNames.threads}</Th>
-            <Th>{columnNames.apps}</Th>
-            <Th>{columnNames.workspaces}</Th>
-            <Th>{columnNames.status}</Th>
-            <Th>{columnNames.location}</Th>
+            <Th width={20}>{columnNames.name}</Th>
+            <Th width={20}>{columnNames.threads}</Th>
+            <Th width={20}>{columnNames.apps}</Th>
+            <Th width={20}>{columnNames.workspaces}</Th>
+            <Th width={20}>{columnNames.status}</Th>
+            <Th width={20}>{columnNames.location}</Th>
           </Tr>
         </Thead>
         <Tbody>

--- a/packages/react-core/src/demos/Filters/examples/FilterSingleSelect.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterSingleSelect.tsx
@@ -322,6 +322,7 @@ export const FilterSingleSelect: React.FunctionComponent = () => {
   // Set up pagination
   const toolbarPagination = (
     <Pagination
+      titles={{ paginationTitle: 'Single select filter pagination' }}
       perPageComponent="button"
       itemCount={repositories.length}
       perPage={50}
@@ -331,7 +332,7 @@ export const FilterSingleSelect: React.FunctionComponent = () => {
   );
 
   const toolbar = (
-    <Toolbar id="toolbar-items">
+    <Toolbar id="single-select-filter-toolbar">
       <ToolbarContent>
         <ToolbarItem>{toolbarBulkSelect}</ToolbarItem>
         <ToolbarItem>{select}</ToolbarItem>

--- a/packages/react-core/src/demos/Filters/examples/FilterSingleSelect.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterSingleSelect.tsx
@@ -5,10 +5,12 @@ import {
   MenuList,
   MenuItem,
   MenuToggle,
+  MenuToggleCheckbox,
   Popper,
   Toolbar,
   ToolbarContent,
-  ToolbarItem
+  ToolbarItem,
+  Pagination
 } from '@patternfly/react-core';
 import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
@@ -103,6 +105,104 @@ export const FilterSingleSelect: React.FunctionComponent = () => {
       document.removeEventListener('keyup', onKeyUp);
     };
   }, []);
+
+  // Set up bulk selection menu
+  const bulkSelectMenuRef = React.createRef<HTMLDivElement>();
+  const bulkSelectToggleRef = React.createRef<any>();
+  const bulkSelectcontainerRef = React.createRef<HTMLDivElement>();
+
+  const [isBulkSelectOpen, setIsBulkSelectOpen] = React.useState<boolean>(false);
+
+  React.useEffect(() => {
+    window.addEventListener('keydown', handleBulkSelectMenuKeys);
+    window.addEventListener('click', handleBulkSelectClickOutside);
+    return () => {
+      window.removeEventListener('keydown', handleBulkSelectMenuKeys);
+      window.removeEventListener('click', handleBulkSelectClickOutside);
+    };
+  }, [isBulkSelectOpen, bulkSelectMenuRef]);
+
+  const handleBulkSelectClickOutside = (event: MouseEvent) => {
+    if (isBulkSelectOpen && !bulkSelectMenuRef.current?.contains(event.target as Node)) {
+      setIsBulkSelectOpen(false);
+    }
+  };
+
+  const handleBulkSelectMenuKeys = (event: KeyboardEvent) => {
+    if (!isBulkSelectOpen) {
+      return;
+    }
+    if (
+      bulkSelectMenuRef.current?.contains(event.target as Node) ||
+      bulkSelectToggleRef.current?.contains(event.target as Node)
+    ) {
+      if (event.key === 'Escape' || event.key === 'Tab') {
+        setIsBulkSelectOpen(!isBulkSelectOpen);
+        bulkSelectToggleRef.current?.focus();
+      }
+    }
+  };
+
+  const onBulkSelectToggleClick = (ev: React.MouseEvent) => {
+    ev.stopPropagation(); // Stop handleClickOutside from handling
+    setTimeout(() => {
+      if (bulkSelectMenuRef.current) {
+        const firstElement = bulkSelectMenuRef.current.querySelector('li > button:not(:disabled)');
+        firstElement && (firstElement as HTMLElement).focus();
+      }
+    }, 0);
+    setIsBulkSelectOpen(!isBulkSelectOpen);
+  };
+
+  const bulkSelectToggle = (
+    <MenuToggle
+      ref={bulkSelectToggleRef}
+      onClick={onBulkSelectToggleClick}
+      isExpanded={isBulkSelectOpen}
+      splitButtonOptions={{
+        items: [
+          <MenuToggleCheckbox
+            id="select-checkbox"
+            key="select-checkbox"
+            aria-label="Select all"
+            isChecked={areAllReposSelected}
+            onChange={(checked, _event) => selectAllRepos(checked)}
+          />
+        ]
+      }}
+      aria-label="Full table selection checkbox"
+    />
+  );
+
+  const bulkSelectMenu = (
+    // eslint-disable-next-line no-console
+    <Menu
+      ref={bulkSelectMenuRef}
+      onSelect={(_ev, itemId) => {
+        selectAllRepos(itemId === 0);
+        setIsBulkSelectOpen(!isBulkSelectOpen);
+      }}
+    >
+      <MenuContent>
+        <MenuList>
+          <MenuItem itemId={0}>Select all</MenuItem>
+          <MenuItem itemId={1}>Deselect all</MenuItem>
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+
+  const toolbarBulkSelect = (
+    <div ref={bulkSelectcontainerRef}>
+      <Popper
+        trigger={bulkSelectToggle}
+        popper={bulkSelectMenu}
+        appendTo={bulkSelectcontainerRef.current || undefined}
+        isVisible={isBulkSelectOpen}
+        popperMatchesTriggerWidth={false}
+      />
+    </div>
+  );
 
   // Set up table filtering
   const [searchValue, setSearchValue] = React.useState('');
@@ -219,10 +319,23 @@ export const FilterSingleSelect: React.FunctionComponent = () => {
     </div>
   );
 
+  // Set up pagination
+  const toolbarPagination = (
+    <Pagination
+      perPageComponent="button"
+      itemCount={repositories.length}
+      perPage={50}
+      page={1}
+      widgetId="table-mock-pagination"
+    />
+  );
+
   const toolbar = (
     <Toolbar id="toolbar-items">
       <ToolbarContent>
+        <ToolbarItem>{toolbarBulkSelect}</ToolbarItem>
         <ToolbarItem>{select}</ToolbarItem>
+        <ToolbarItem variant="pagination">{toolbarPagination}</ToolbarItem>
       </ToolbarContent>
     </Toolbar>
   );
@@ -233,12 +346,7 @@ export const FilterSingleSelect: React.FunctionComponent = () => {
       <TableComposable aria-label="Selectable table">
         <Thead>
           <Tr>
-            <Th
-              select={{
-                onSelect: (_event, isSelecting) => selectAllRepos(isSelecting),
-                isSelected: areAllReposSelected
-              }}
-            />
+            <Th />
             <Th>{columnNames.name}</Th>
             <Th>{columnNames.threads}</Th>
             <Th>{columnNames.apps}</Th>

--- a/packages/react-core/src/demos/Filters/examples/FilterSingleSelect.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterSingleSelect.tsx
@@ -64,6 +64,7 @@ export const FilterSingleSelect: React.FunctionComponent = () => {
   const selectAllRepos = (isSelecting = true) =>
     setSelectedRepoNames(isSelecting ? selectableRepos.map(r => r.name) : []);
   const areAllReposSelected = selectedRepoNames.length === selectableRepos.length;
+  const areSomeReposSelected = selectedRepoNames.length > 0;
   const isRepoSelected = (repo: Repository) => selectedRepoNames.includes(repo.name);
 
   // To allow shift+click to select/deselect multiple rows
@@ -154,6 +155,13 @@ export const FilterSingleSelect: React.FunctionComponent = () => {
     setIsBulkSelectOpen(!isBulkSelectOpen);
   };
 
+  let menuToggleCheckmark: boolean | null = false;
+  if (areAllReposSelected) {
+    menuToggleCheckmark = true;
+  } else if (areSomeReposSelected) {
+    menuToggleCheckmark = null;
+  }
+
   const bulkSelectToggle = (
     <MenuToggle
       ref={bulkSelectToggleRef}
@@ -165,7 +173,7 @@ export const FilterSingleSelect: React.FunctionComponent = () => {
             id="select-checkbox"
             key="select-checkbox"
             aria-label="Select all"
-            isChecked={areAllReposSelected}
+            isChecked={menuToggleCheckmark}
             onChange={(checked, _event) => selectAllRepos(checked)}
           />
         ]
@@ -179,14 +187,15 @@ export const FilterSingleSelect: React.FunctionComponent = () => {
     <Menu
       ref={bulkSelectMenuRef}
       onSelect={(_ev, itemId) => {
-        selectAllRepos(itemId === 0);
+        selectAllRepos(itemId === 1 || itemId === 2);
         setIsBulkSelectOpen(!isBulkSelectOpen);
       }}
     >
       <MenuContent>
         <MenuList>
-          <MenuItem itemId={0}>Select all</MenuItem>
-          <MenuItem itemId={1}>Deselect all</MenuItem>
+          <MenuItem itemId={0}>Select none (0 items)</MenuItem>
+          <MenuItem itemId={1}>Select page ({repositories.length} items)</MenuItem>
+          <MenuItem itemId={2}>Select all ({repositories.length} items)</MenuItem>
         </MenuList>
       </MenuContent>
     </Menu>
@@ -325,9 +334,10 @@ export const FilterSingleSelect: React.FunctionComponent = () => {
       titles={{ paginationTitle: 'Single select filter pagination' }}
       perPageComponent="button"
       itemCount={repositories.length}
-      perPage={50}
+      perPage={10}
       page={1}
-      widgetId="table-mock-pagination"
+      widgetId="single-select-mock-pagination"
+      isCompact
     />
   );
 

--- a/packages/react-core/src/demos/Filters/examples/FilterSingleSelect.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterSingleSelect.tsx
@@ -1,0 +1,273 @@
+import React from 'react';
+import {
+  Menu,
+  MenuContent,
+  MenuList,
+  MenuItem,
+  MenuToggle,
+  Popper,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem
+} from '@patternfly/react-core';
+import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
+
+interface Repository {
+  name: string;
+  threads: string;
+  apps: string;
+  workspaces: string;
+  status: string;
+  location: string;
+}
+
+// In real usage, this data would come from some external source like an API via props.
+const repositories: Repository[] = [
+  { name: 'US-Node 1', threads: '5', apps: '25', workspaces: '5', status: 'Stopped', location: 'Raleigh' },
+  { name: 'US-Node 2', threads: '5', apps: '30', workspaces: '2', status: 'Down', location: 'Westford' },
+  { name: 'US-Node 3', threads: '13', apps: '35', workspaces: '12', status: 'Degraded', location: 'Boston' },
+  { name: 'US-Node 4', threads: '2', apps: '5', workspaces: '18', status: 'Needs Maintainence', location: 'Raleigh' },
+  { name: 'US-Node 5', threads: '7', apps: '30', workspaces: '5', status: 'Running', location: 'Boston' },
+  { name: 'US-Node 6', threads: '5', apps: '20', workspaces: '15', status: 'Stopped', location: 'Raleigh' },
+  { name: 'CZ-Node 1', threads: '12', apps: '48', workspaces: '13', status: 'Down', location: 'Brno' },
+  { name: 'CZ-Node 2', threads: '3', apps: '8', workspaces: '20', status: 'Running', location: 'Brno' },
+  { name: 'CZ-Remote-Node 1', threads: '1', apps: '15', workspaces: '20', status: 'Down', location: 'Brno' },
+  { name: 'Bangalore-Node 1', threads: '1', apps: '20', workspaces: '20', status: 'Running', location: 'Bangalore' }
+];
+
+const columnNames = {
+  name: 'Servers',
+  threads: 'Threads',
+  apps: 'Applications',
+  workspaces: 'Workspaces',
+  status: 'Status',
+  location: 'Location'
+};
+
+/* eslint-disable patternfly-react/no-anonymous-functions */
+export const FilterSingleSelect: React.FunctionComponent = () => {
+  // Set up table selection
+  const isRepoSelectable = (repo: Repository) => repo.name !== 'a'; // Arbitrary logic for this example
+  const selectableRepos = repositories.filter(isRepoSelectable);
+
+  // In this example, selected rows are tracked by the repo names from each row. This could be any unique identifier.
+  // This is to prevent state from being based on row order index in case we later add sorting.
+  const [selectedRepoNames, setSelectedRepoNames] = React.useState<string[]>([]);
+  const setRepoSelected = (repo: Repository, isSelecting = true) =>
+    setSelectedRepoNames(prevSelected => {
+      const otherSelectedRepoNames = prevSelected.filter(r => r !== repo.name);
+      return isSelecting && isRepoSelectable(repo) ? [...otherSelectedRepoNames, repo.name] : otherSelectedRepoNames;
+    });
+  const selectAllRepos = (isSelecting = true) =>
+    setSelectedRepoNames(isSelecting ? selectableRepos.map(r => r.name) : []);
+  const areAllReposSelected = selectedRepoNames.length === selectableRepos.length;
+  const isRepoSelected = (repo: Repository) => selectedRepoNames.includes(repo.name);
+
+  // To allow shift+click to select/deselect multiple rows
+  const [recentSelectedRowIndex, setRecentSelectedRowIndex] = React.useState<number | null>(null);
+  const [shifting, setShifting] = React.useState(false);
+
+  const onSelectRepo = (repo: Repository, rowIndex: number, isSelecting: boolean) => {
+    // If the user is shift + selecting the checkboxes, then all intermediate checkboxes should be selected
+    if (shifting && recentSelectedRowIndex !== null) {
+      const numberSelected = rowIndex - recentSelectedRowIndex;
+      const intermediateIndexes =
+        numberSelected > 0
+          ? Array.from(new Array(numberSelected + 1), (_x, i) => i + recentSelectedRowIndex)
+          : Array.from(new Array(Math.abs(numberSelected) + 1), (_x, i) => i + rowIndex);
+      intermediateIndexes.forEach(index => setRepoSelected(repositories[index], isSelecting));
+    } else {
+      setRepoSelected(repo, isSelecting);
+    }
+    setRecentSelectedRowIndex(rowIndex);
+  };
+
+  React.useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') {
+        setShifting(true);
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') {
+        setShifting(false);
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    document.addEventListener('keyup', onKeyUp);
+
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('keyup', onKeyUp);
+    };
+  }, []);
+
+  // Set up table filtering
+  const [searchValue, setSearchValue] = React.useState('');
+
+  const onFilter = (repo: Repository) => {
+    if (searchValue === 'all') {
+      return true;
+    }
+
+    let input: RegExp;
+    try {
+      input = new RegExp(searchValue, 'i');
+    } catch (err) {
+      input = new RegExp(searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+    }
+    return repo.status.search(input) >= 0;
+  };
+
+  // Set up single select menu & state
+  const [isOpen, setIsOpen] = React.useState<boolean>(false);
+  const [menuSelection, setMenuSelection] = React.useState<string>('all');
+  const toggleRef = React.useRef<HTMLButtonElement>(null);
+  const menuRef = React.useRef<HTMLDivElement>(null);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
+  const handleMenuKeys = (event: KeyboardEvent) => {
+    if (isOpen && menuRef.current?.contains(event.target as Node)) {
+      if (event.key === 'Escape' || event.key === 'Tab') {
+        setIsOpen(!isOpen);
+        toggleRef.current?.focus();
+      }
+    }
+  };
+
+  const handleClickOutside = (event: MouseEvent) => {
+    if (isOpen && !menuRef.current?.contains(event.target as Node)) {
+      setIsOpen(false);
+    }
+  };
+
+  React.useEffect(() => {
+    window.addEventListener('keydown', handleMenuKeys);
+    window.addEventListener('click', handleClickOutside);
+    return () => {
+      window.removeEventListener('keydown', handleMenuKeys);
+      window.removeEventListener('click', handleClickOutside);
+    };
+  }, [isOpen, menuRef]);
+
+  const onToggleClick = (ev: React.MouseEvent) => {
+    ev.stopPropagation(); // Stop handleClickOutside from handling
+    setTimeout(() => {
+      if (menuRef.current) {
+        const firstElement = menuRef.current.querySelector('li > button:not(:disabled)');
+        firstElement && (firstElement as HTMLElement).focus();
+      }
+    }, 0);
+    setIsOpen(!isOpen);
+  };
+
+  function onSelect(event: React.MouseEvent | undefined, itemId: string | number | undefined) {
+    if (typeof itemId === 'undefined') {
+      return;
+    }
+
+    setMenuSelection(itemId.toString());
+    setSearchValue(itemId.toString());
+    setIsOpen(!isOpen);
+  }
+
+  const menuToggleDisplay = {
+    all: 'All statuses',
+    down: 'Down',
+    stopped: 'Stopped',
+    degraded: 'Degraded',
+    running: 'Running',
+    maint: 'Needs maintenance'
+  };
+
+  const toggle = (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={onToggleClick}
+      isExpanded={isOpen}
+      icon={<FilterIcon />}
+      style={
+        {
+          width: '200px'
+        } as React.CSSProperties
+      }
+    >
+      {menuToggleDisplay[menuSelection]}
+    </MenuToggle>
+  );
+
+  const menu = (
+    <Menu ref={menuRef} id="select-menu" onSelect={onSelect} selected={menuSelection}>
+      <MenuContent>
+        <MenuList>
+          <MenuItem itemId="all">All statuses</MenuItem>
+          <MenuItem itemId="stopped">Stopped</MenuItem>
+          <MenuItem itemId="down">Down</MenuItem>
+          <MenuItem itemId="degraded">Degraded</MenuItem>
+          <MenuItem itemId="running">Running</MenuItem>
+          <MenuItem itemId="maint">Needs maintenance</MenuItem>
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+
+  const select = (
+    <div ref={containerRef}>
+      <Popper trigger={toggle} popper={menu} appendTo={containerRef.current || undefined} isVisible={isOpen} />
+    </div>
+  );
+
+  const toolbar = (
+    <Toolbar id="toolbar-items">
+      <ToolbarContent>
+        <ToolbarItem>{select}</ToolbarItem>
+      </ToolbarContent>
+    </Toolbar>
+  );
+
+  return (
+    <React.Fragment>
+      {toolbar}
+      <TableComposable aria-label="Selectable table">
+        <Thead>
+          <Tr>
+            <Th
+              select={{
+                onSelect: (_event, isSelecting) => selectAllRepos(isSelecting),
+                isSelected: areAllReposSelected
+              }}
+            />
+            <Th>{columnNames.name}</Th>
+            <Th>{columnNames.threads}</Th>
+            <Th>{columnNames.apps}</Th>
+            <Th>{columnNames.workspaces}</Th>
+            <Th>{columnNames.status}</Th>
+            <Th>{columnNames.location}</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {repositories.filter(onFilter).map((repo, rowIndex) => (
+            <Tr key={repo.name}>
+              <Td
+                select={{
+                  rowIndex,
+                  onSelect: (_event, isSelecting) => onSelectRepo(repo, rowIndex, isSelecting),
+                  isSelected: isRepoSelected(repo),
+                  disable: !isRepoSelectable(repo)
+                }}
+              />
+              <Td dataLabel={columnNames.name}>{repo.name}</Td>
+              <Td dataLabel={columnNames.threads}>{repo.threads}</Td>
+              <Td dataLabel={columnNames.apps}>{repo.apps}</Td>
+              <Td dataLabel={columnNames.workspaces}>{repo.workspaces}</Td>
+              <Td dataLabel={columnNames.status}>{repo.status}</Td>
+              <Td dataLabel={columnNames.location}>{repo.location}</Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </TableComposable>
+    </React.Fragment>
+  );
+};


### PR DESCRIPTION
Tied to #6710 but will not fully close the issue (more demos are requested). Since the groundwork of updating older demos to use the newer composable components and putting the demo into TSX/functional form was a bulk of the work and is now done the rest should be quicker to finish, I'm just not positive I'll get them all out in this PR.

Working off the design here: https://marvelapp.com/prototype/7i0dj2d/screen/75593646

- [x] Search input
- [x] Single select
- [x] Checkbox select
- [ ] Attribute filter
- [ ] Filter group
- [ ] Faceted filter

Demos are under the Demos section in the "Filters" page. Let me know if they should be moved elsewhere or called something else.