### PR TITLE
Fixed dashboard wrapper codesandbox export error

### DIFF
--- a/packages/react-core/src/demos/BackToTop.md
+++ b/packages/react-core/src/demos/BackToTop.md
@@ -3,7 +3,7 @@ id: Back to top
 section: components
 ---
 
-import DashboardWrapper from './examples/DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 
 ## Demos
 

--- a/packages/react-core/src/demos/Banner.md
+++ b/packages/react-core/src/demos/Banner.md
@@ -3,7 +3,7 @@ id: Banner
 section: components
 ---
 
-import DashboardWrapper from './examples/DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 
 ## Demos
 
@@ -23,7 +23,7 @@ import {
   TextContent,
   Text
 } from '@patternfly/react-core';
-import DashboardWrapper from './examples/DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 
 class BannerDemo extends React.Component {
   render() {
@@ -87,7 +87,7 @@ import {
   TextContent,
   Text
 } from '@patternfly/react-core';
-import DashboardWrapper from '../examples/DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 
 class BannerDemo extends React.Component {
   render() {

--- a/packages/react-core/src/demos/Card/Card.md
+++ b/packages/react-core/src/demos/Card/Card.md
@@ -3,7 +3,7 @@ id: Card view
 section: demos
 ---
 
-import DashboardWrapper from '../examples/DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import TrashIcon from '@patternfly/react-icons/dist/esm/icons/trash-icon';
@@ -66,7 +66,7 @@ import {
   ToolbarFilter,
   ToolbarContent
 } from '@patternfly/react-core';
-import DashboardWrapper from '../examples/DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import TrashIcon from '@patternfly/react-icons/dist/esm/icons/trash-icon';

--- a/packages/react-core/src/demos/JumpLinks.md
+++ b/packages/react-core/src/demos/JumpLinks.md
@@ -3,7 +3,7 @@ id: Jump links
 section: components
 ---
 
-import DashboardWrapper from './examples/DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 
 ## Demos
 
@@ -33,7 +33,7 @@ import {
   TextContent,
   getResizeObserver
 } from '@patternfly/react-core';
-import DashboardWrapper from './examples/DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 
 ScrollspyH2 = () => {
   const headings = [1, 2, 3, 4, 5];

--- a/packages/react-core/src/demos/Nav.md
+++ b/packages/react-core/src/demos/Nav.md
@@ -3,8 +3,8 @@ id: Navigation
 section: components
 ---
 
-import { DashboardBreadcrumb } from './examples/DashboardWrapper';
-import DashboardHeader from './examples/DashboardHeader';
+import { DashboardBreadcrumb } from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
+import DashboardHeader from '@patternfly/react-core/src/demos/examples/DashboardHeader';
 import CogIcon from '@patternfly/react-icons/dist/esm/icons/cog-icon';
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 import QuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/question-circle-icon';
@@ -34,8 +34,8 @@ import {
   TextContent,
   Text
 } from '@patternfly/react-core';
-import { DashboardBreadcrumb } from './examples/DashboardWrapper';
-import DashboardHeader from './examples/DashboardHeader';
+import { DashboardBreadcrumb } from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
+import DashboardHeader from '@patternfly/react-core/src/demos/examples/DashboardHeader';
 
 class PageLayoutDefaultNav extends React.Component {
   constructor(props) {
@@ -133,7 +133,7 @@ import {
   TextContent,
   Text
 } from '@patternfly/react-core';
-import DashboardHeader from './examples/DashboardHeader';
+import DashboardHeader from '@patternfly/react-core/src/demos/examples/DashboardHeader';
 
 class PageLayoutGroupsNav extends React.Component {
   constructor(props) {
@@ -242,8 +242,8 @@ import {
   TextContent,
   Text
 } from '@patternfly/react-core';
-import { DashboardBreadcrumb } from './examples/DashboardWrapper';
-import DashboardHeader from './examples/DashboardHeader';
+import { DashboardBreadcrumb } from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
+import DashboardHeader from '@patternfly/react-core/src/demos/examples/DashboardHeader';
 
 class PageLayoutExpandableNav extends React.Component {
   constructor(props) {
@@ -380,7 +380,7 @@ import {
   PageHeaderToolsGroup,
   PageHeaderToolsItem
 } from '@patternfly/react-core';
-import { DashboardBreadcrumb } from './examples/DashboardWrapper';
+import { DashboardBreadcrumb } from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 import CogIcon from '@patternfly/react-icons/dist/esm/icons/cog-icon';
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 import QuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/question-circle-icon';
@@ -581,8 +581,8 @@ import {
   TextContent,
   Text
 } from '@patternfly/react-core';
-import { DashboardBreadcrumb } from './examples/DashboardWrapper';
-import DashboardHeader from './examples/DashboardHeader';
+import { DashboardBreadcrumb } from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
+import DashboardHeader from '@patternfly/react-core/src/demos/examples/DashboardHeader';
 
 class VerticalNavWithSubnav extends React.Component {
   constructor(props) {
@@ -737,7 +737,7 @@ import {
   PageHeaderToolsGroup,
   PageHeaderToolsItem
 } from '@patternfly/react-core';
-import { DashboardBreadcrumb } from './examples/DashboardWrapper';
+import { DashboardBreadcrumb } from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 import CogIcon from '@patternfly/react-icons/dist/esm/icons/cog-icon';
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 import QuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/question-circle-icon';
@@ -984,8 +984,8 @@ import {
   TextContent,
   Text
 } from '@patternfly/react-core';
-import { DashboardBreadcrumb } from './examples/DashboardWrapper';
-import DashboardHeader from './examples/DashboardHeader';
+import { DashboardBreadcrumb } from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
+import DashboardHeader from '@patternfly/react-core/src/demos/examples/DashboardHeader';
 
 class PageLayoutTertiaryNav extends React.Component {
   constructor(props) {
@@ -1087,7 +1087,7 @@ import {
   TextContent,
   Text
 } from '@patternfly/react-core';
-import DashboardHeader from './examples/DashboardHeader';
+import DashboardHeader from '@patternfly/react-core/src/demos/examples/DashboardHeader';
 
 class PageLayoutLightNav extends React.Component {
   constructor(props) {
@@ -1436,7 +1436,7 @@ import {
   MenuList,
   MenuItem
 } from '@patternfly/react-core';
-import DashboardHeader from './examples/DashboardHeader';
+import DashboardHeader from '@patternfly/react-core/src/demos/examples/DashboardHeader';
 
 class VerticalPage extends React.Component {
   constructor(props) {

--- a/packages/react-core/src/demos/PrimaryDetail.md
+++ b/packages/react-core/src/demos/PrimaryDetail.md
@@ -3,7 +3,7 @@ id: Primary-detail
 section: demos
 ---
 
-import DashboardWrapper from './examples/DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
 import TrashIcon from '@patternfly/react-icons/dist/esm/icons/trash-icon';
 import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
@@ -70,7 +70,7 @@ import {
   TextInput,
   Title
 } from '@patternfly/react-core';
-import DashboardWrapper from './examples/DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
 import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
@@ -530,7 +530,7 @@ import {
   TextInput,
   Title
 } from '@patternfly/react-core';
-import DashboardWrapper from './examples/DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
 import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
@@ -994,7 +994,7 @@ import {
   ToolbarContent,
   ToolbarFilter
 } from '@patternfly/react-core';
-import DashboardWrapper from './examples/DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 import TrashIcon from '@patternfly/react-icons/dist/esm/icons/trash-icon';
 import pfIcon from './pf-logo-small.svg';
 import activeMQIcon from './activemq-core_200x150.png';
@@ -1603,7 +1603,7 @@ import {
   TextInput,
   Title
 } from '@patternfly/react-core';
-import DashboardWrapper from './examples/DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 
 class PrimaryDetailSimpleListInCard extends React.Component {
   constructor(props) {
@@ -1764,7 +1764,7 @@ import {
   TextContent,
   Title
 } from '@patternfly/react-core';
-import DashboardWrapper from './examples/DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 import CaretDownIcon from '@patternfly/react-icons/dist/esm/icons/caret-down-icon';
 
 class PrimaryDetailDataListInCard extends React.Component {
@@ -2016,7 +2016,7 @@ import {
   TextInput,
   Title
 } from '@patternfly/react-core';
-import DashboardWrapper from './examples/DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
 import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';

--- a/packages/react-core/src/demos/Tabs.md
+++ b/packages/react-core/src/demos/Tabs.md
@@ -3,7 +3,7 @@ id: Tabs
 section: components
 ---
 
-import DashboardWrapper from './examples/DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
 import InfoCircleIcon from '@patternfly/react-icons/dist/js/icons/info-circle-icon';
 import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
@@ -39,7 +39,7 @@ import {
   Flex,
   FlexItem
 } from '@patternfly/react-core';
-import DashboardWrapper from './examples/DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
 import InfoCircleIcon from '@patternfly/react-icons/dist/js/icons/info-circle-icon';
 
@@ -229,7 +229,7 @@ import {
   Flex,
   FlexItem
 } from '@patternfly/react-core';
-import DashboardWrapper from './examples/DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
 import InfoCircleIcon from '@patternfly/react-icons/dist/js/icons/info-circle-icon';
 

--- a/packages/react-core/src/demos/Toolbar.md
+++ b/packages/react-core/src/demos/Toolbar.md
@@ -3,7 +3,7 @@ id: Toolbar
 section: components
 ---
 
-import DashboardWrapper from './examples/DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 
 import PauseIcon from '@patternfly/react-icons/dist/esm/icons/pause-icon';
 import PlayIcon from '@patternfly/react-icons/dist/esm/icons/play-icon';
@@ -40,7 +40,7 @@ import {
   PageSectionVariants,
   Tooltip
 } from '@patternfly/react-core';
-import DashboardWrapper from './examples/DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 
 import PauseIcon from '@patternfly/react-icons/dist/esm/icons/pause-icon';
 import PlayIcon from '@patternfly/react-icons/dist/esm/icons/play-icon';

--- a/packages/react-core/src/demos/Wizard/WizardDemo.md
+++ b/packages/react-core/src/demos/Wizard/WizardDemo.md
@@ -5,7 +5,7 @@ section: components
 
 import imgBrand from './imgBrand.svg';
 import BarsIcon from '@patternfly/react-icons/dist/js/icons/bars-icon';
-import DashboardWrapper from '../examples/DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 
 ## Demos
 
@@ -26,7 +26,7 @@ import {
   Modal,
   ModalVariant
 } from '@patternfly/react-core';
-import DashboardWrapper from '../examples/DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 
 class BasicWizardDemo extends React.Component {
   constructor(props) {
@@ -568,7 +568,7 @@ import {
 } from '@patternfly/react-core';
 import imgBrand from './imgBrand.svg';
 import BarsIcon from '@patternfly/react-icons/dist/js/icons/bars-icon';
-import DashboardWrapper from '../examples/DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 
 class FullPageWizard extends React.Component {
   constructor(props) {

--- a/packages/react-core/src/demos/examples/BackToTop/BackToTopNameDemo.tsx
+++ b/packages/react-core/src/demos/examples/BackToTop/BackToTopNameDemo.tsx
@@ -12,7 +12,7 @@ import {
   Page,
   Switch
 } from '@patternfly/react-core';
-import DashboardWrapper from '../DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 
 export const Name = () => {
   const [isAlwaysVisible, setIsAlwaysVisible] = React.useState(false);

--- a/packages/react-core/src/demos/examples/DashboardWrapper.js
+++ b/packages/react-core/src/demos/examples/DashboardWrapper.js
@@ -12,7 +12,7 @@ import {
   Text,
   TextContent
 } from '@patternfly/react-core';
-import DashboardHeader from './DashboardHeader';
+import DashboardHeader from '@patternfly/react-core/src/demos/examples/DashboardHeader';
 
 export const DashboardBreadcrumb = (
   <Breadcrumb>

--- a/packages/react-core/src/demos/examples/JumpLinks/JumpLinksWithDrawer.js
+++ b/packages/react-core/src/demos/examples/JumpLinks/JumpLinksWithDrawer.js
@@ -18,7 +18,7 @@ import {
   TextContent,
   getResizeObserver
 } from '@patternfly/react-core';
-import DashboardWrapper from '../DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 
 export const JumpLinksWithDrawer = () => {
   const headings = ['First', 'Second', 'Third', 'Fourth', 'Fifth'];

--- a/packages/react-core/src/demos/examples/Nav/NavDrilldown.tsx
+++ b/packages/react-core/src/demos/examples/Nav/NavDrilldown.tsx
@@ -12,7 +12,7 @@ import {
   PageSection
 } from '@patternfly/react-core';
 
-import DashboardHeader from '../DashboardHeader';
+import DashboardHeader from '@patternfly/react-core/src/demos/examples/DashboardHeader';
 
 interface MenuHeights {
   [menuId: string]: number;

--- a/packages/react-core/src/demos/examples/Tabs/GrayTabs.tsx
+++ b/packages/react-core/src/demos/examples/Tabs/GrayTabs.tsx
@@ -15,7 +15,7 @@ import {
   CardBody,
   CardHeader
 } from '@patternfly/react-core';
-import DashboardWrapper from '../DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 
 export const GrayTabsDemo: React.FunctionComponent = () => {
   const [activeTabKey, setActiveTabKey] = React.useState<string | number>(0);

--- a/packages/react-core/src/demos/examples/Tabs/ModalTabs.tsx
+++ b/packages/react-core/src/demos/examples/Tabs/ModalTabs.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import DashboardWrapper from '../DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 import {
   PageSection,
   TextContent,

--- a/packages/react-core/src/demos/examples/Tabs/NestedTabs.tsx
+++ b/packages/react-core/src/demos/examples/Tabs/NestedTabs.tsx
@@ -15,7 +15,7 @@ import {
   Flex,
   FlexItem
 } from '@patternfly/react-core';
-import DashboardWrapper from '../DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 
 export const NestedTabs: React.FunctionComponent = () => {
   const [activeTabKey, setActiveTabKey] = React.useState(0);

--- a/packages/react-core/src/demos/examples/Tabs/NestedUnindentedTabs.tsx
+++ b/packages/react-core/src/demos/examples/Tabs/NestedUnindentedTabs.tsx
@@ -16,7 +16,7 @@ import {
   TextContent,
   TitleSizes
 } from '@patternfly/react-core';
-import DashboardWrapper from '../DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 
 export const NestedUnindentedTabs: React.FunctionComponent = () => {
   const [activeTabKey, setActiveTabKey] = React.useState(1);

--- a/packages/react-core/src/demos/examples/Tabs/TabsAndTable.tsx
+++ b/packages/react-core/src/demos/examples/Tabs/TabsAndTable.tsx
@@ -54,7 +54,7 @@ import {
   ActionsColumn,
   CustomActionsToggleProps
 } from '@patternfly/react-table';
-import DashboardWrapper from '../DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
 import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';

--- a/packages/react-core/src/demos/examples/Tabs/TabsAndTablesAutoWidthTabs.tsx
+++ b/packages/react-core/src/demos/examples/Tabs/TabsAndTablesAutoWidthTabs.tsx
@@ -54,7 +54,7 @@ import {
   ActionsColumn,
   CustomActionsToggleProps
 } from '@patternfly/react-table';
-import DashboardWrapper from '../DashboardWrapper';
+import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';
 import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
 import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6596 

This PR changes all imports of `DashboardWrapper` and `DashboardHeader` from relative imports paths to absolute import paths, which allows Codesandbox to properly load the components.

Note: DashboardHeader image is not loading correctly in Codesandbox and will require separate investigation:
<img width="380" alt="Screen Shot 2022-09-08 at 5 03 38 PM" src="https://user-images.githubusercontent.com/8651509/189225474-8afd6519-6944-4ac7-b07b-99b2e80a2b49.png">


Note: a [different solution](https://github.com/patternfly/patternfly-org/pull/3122) was implemented for relative import paths for patternfly.org, but that did not translate to the problem here as that relies on the files being imported from an external package.  Updating the relative paths here will not conflict with that update as it will bypass the check for a relative import path implemented in that issue.