### PR TITLE
docs: Remove incorrect terminology in alert group example output

### DIFF
--- a/packages/react-core/src/components/AlertGroup/examples/AlertGroupSingularDynamic.tsx
+++ b/packages/react-core/src/components/AlertGroup/examples/AlertGroupSingularDynamic.tsx
@@ -24,15 +24,15 @@ export const AlertGroupSingularDynamic: React.FunctionComponent = () => {
   const getUniqueId = () => new Date().getTime();
 
   const addSuccessAlert = () => {
-    addAlert('Toast success alert', 'success', getUniqueId());
+    addAlert('Success alert', 'success', getUniqueId());
   };
 
   const addDangerAlert = () => {
-    addAlert('Toast danger alert', 'danger', getUniqueId());
+    addAlert('Danger alert', 'danger', getUniqueId());
   };
 
   const addInfoAlert = () => {
-    addAlert('Toast info alert', 'info', getUniqueId());
+    addAlert('Info alert', 'info', getUniqueId());
   };
 
   return (

--- a/packages/react-core/src/components/AlertGroup/examples/AlertGroupSingularDynamicOverflow.tsx
+++ b/packages/react-core/src/components/AlertGroup/examples/AlertGroupSingularDynamicOverflow.tsx
@@ -38,15 +38,15 @@ export const AlertGroupSingularDynamicOverflow: React.FunctionComponent = () => 
   const getUniqueId = () => new Date().getTime();
 
   const addSuccessAlert = () => {
-    addAlert('Toast success alert', 'success', getUniqueId());
+    addAlert('Success alert', 'success', getUniqueId());
   };
 
   const addDangerAlert = () => {
-    addAlert('Toast danger alert', 'danger', getUniqueId());
+    addAlert('Danger alert', 'danger', getUniqueId());
   };
 
   const addInfoAlert = () => {
-    addAlert('Toast info alert', 'info', getUniqueId());
+    addAlert('Info alert', 'info', getUniqueId());
   };
 
   const onOverflowClick = () => {


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: 
The examples "Singular dynamic alert group" and "Singular dynamic alert group with overflow message" in the [alert group React examples](https://www.patternfly.org/v4/components/alert-group) output messages that say "Toast" even though these are not toast alert examples. "Toast" is removed from all success, danger, and info alert simulation messages in these examples.
Closes #7799

