### PR TITLE
feat(react-icons): added support for SVG symbols

### DIFF
--- a/packages/react-icons/src/createIcon.tsx
+++ b/packages/react-icons/src/createIcon.tsx
@@ -36,6 +36,8 @@ export interface SVGIconProps extends Omit<React.HTMLProps<SVGElement>, 'size' |
   size?: IconSize | keyof typeof IconSize;
   title?: string;
   noVerticalAlign?: boolean;
+  isSymbol?: boolean;
+  isSymbolRef?: boolean;
 }
 
 let currentId = 0;
@@ -56,35 +58,69 @@ export function createIcon({
     static defaultProps = {
       color: 'currentColor',
       size: IconSize.sm,
-      noVerticalAlign: false
+      noVerticalAlign: false,
+      isSymbol: false,
+      isSymbolRef: false
     };
 
     id = `icon-title-${currentId++}`;
 
     render() {
-      const { size, color, title, noVerticalAlign, ...props } = this.props;
+      const { size, color, title, noVerticalAlign, isSymbol, isSymbolRef, ...props } = this.props;
 
       const hasTitle = Boolean(title);
       const heightWidth = getSize(size);
       const baseAlign = -0.125 * Number.parseFloat(heightWidth);
       const style = noVerticalAlign ? null : { verticalAlign: `${baseAlign}em` };
       const viewBox = [xOffset, yOffset, width, height].join(' ');
+      const symbolID = 'ReactIcon' + name;
 
       return (
-        <svg
-          style={style}
-          fill={color}
-          height={heightWidth}
-          width={heightWidth}
-          viewBox={viewBox}
-          aria-labelledby={hasTitle ? this.id : null}
-          aria-hidden={hasTitle ? null : true}
-          role="img"
-          {...(props as Omit<React.SVGProps<SVGElement>, 'ref'>)} // Lie.
-        >
-          {hasTitle && <title id={this.id}>{title}</title>}
-          <path d={svgPath} />
-        </svg>
+        <>
+          {isSymbol && (
+            <>
+              <svg style={{ display: 'none' }}>
+                <symbol id={symbolID}>
+                  <path d={svgPath} />
+                </symbol>
+              </svg>
+            </>
+          )}
+          {isSymbolRef && (
+            <>
+              <svg
+                height={heightWidth}
+                width={heightWidth}
+                style={style}
+                fill={color}
+                viewBox={viewBox}
+                aria-labelledby={hasTitle ? this.id : null}
+                aria-hidden={hasTitle ? null : true}
+                role="img"
+                {...(props as Omit<React.SVGProps<SVGElement>, 'ref'>)} // Lie.
+              >
+                {hasTitle && <title id={this.id}>{title}</title>}
+                <use xlinkHref={'#' + symbolID}></use>
+              </svg>
+            </>
+          )}
+          {!isSymbol && !isSymbolRef && (
+            <svg
+              style={style}
+              fill={color}
+              height={heightWidth}
+              width={heightWidth}
+              viewBox={viewBox}
+              aria-labelledby={hasTitle ? this.id : null}
+              aria-hidden={hasTitle ? null : true}
+              role="img"
+              {...(props as Omit<React.SVGProps<SVGElement>, 'ref'>)} // Lie.
+            >
+              {hasTitle && <title id={this.id}>{title}</title>}
+              <path d={svgPath} />
+            </svg>
+          )}
+        </>
       );
     }
   };


### PR DESCRIPTION
fixes #8031

This adds support for an SVG `<symbol>` that can be defined once, then referred to throughout the rest of the document.  How does it work?

* `@import` the icon as you currently would
* Define the symbol somewhere in the rendered code by passing the `isSymbol` prop. eg, `<EllipsisVIcon isSymbol />`. This can be anywhere on the page. That creates the SVG code for the icon and hides it visually and will serve as a reference for places you want to use that icon.
* Use the symbol for the icon anywhere you want the SVG to render by passing the `isSymbolRef` prop. eg, `<EllipsisVIcon isSymbolRef />`.

Why would you want to do this?
If a page has 100 kebab icons (dashboard card actions, table row actions, etc), currently there will be 100 SVG's that are exactly the same repeated code everywhere the icon is used. That's a bunch of kilobits-n-bobs. Using symbols, a dev can instead define the SVG code once by adding `<EllipsisVIcon isSymbol />` somewhere on the page, which will render the SVG code once, then using `<EllipsisVIcon isSymbolRef />` where they want to render the icon.

This is just a day of learning thing as I was learning about icons, then react and react-icons 🤗 If it's a good idea, maybe we can iterate and improve this and I can DRY this out some and make sure everything works with the existing props.

We may also see if it makes sense to pass multiple icons to build an SVG sprite.