### PR TITLE
feat(NotificationBadge): added expanded state

### DIFF
--- a/packages/react-core/src/components/NotificationBadge/NotificationBadge.tsx
+++ b/packages/react-core/src/components/NotificationBadge/NotificationBadge.tsx
@@ -12,22 +12,24 @@ export enum NotificationBadgeVariant {
 }
 
 export interface NotificationBadgeProps extends Omit<ButtonProps, 'variant'> {
-  /** @deprecated Use the variant prop instead - Adds styling to the notification badge to indicate it has been read */
-  isRead?: boolean;
-  /** Determines the variant of the notification badge */
-  variant?: NotificationBadgeVariant | 'read' | 'unread' | 'attention';
-  /** A number displayed in the badge alongside the icon */
-  count?: number;
-  /** content rendered inside the notification badge */
-  children?: React.ReactNode;
-  /** additional classes added to the notification badge */
-  className?: string;
-  /** Adds accessible text to the notification badge. */
+  /** Adds an accessible label to the notification badge. */
   'aria-label'?: string;
-  /** Icon to display for attention variant */
+  /** Icon to display for attention variant. */
   attentionIcon?: React.ReactNode;
-  /** Icon do display in notification badge */
+  /** Content rendered inside the notification badge. */
+  children?: React.ReactNode;
+  /** Additional classes added to the notification badge. */
+  className?: string;
+  /** A number displayed in the badge alongside the icon. */
+  count?: number;
+  /** Icon to display in the notification badge. */
   icon?: React.ReactNode;
+  /** Flag for indicating whether the notification badge is expanded. */
+  isExpanded?: boolean;
+  /** @deprecated Use the variant prop instead - Adds styling to the notification badge to indicate it has been read. */
+  isRead?: boolean;
+  /** Determines the variant of the notification badge. */
+  variant?: NotificationBadgeVariant | 'read' | 'unread' | 'attention';
 }
 
 export const NotificationBadge: React.FunctionComponent<NotificationBadgeProps> = ({
@@ -38,6 +40,7 @@ export const NotificationBadge: React.FunctionComponent<NotificationBadgeProps> 
   attentionIcon = <AttentionBellIcon />,
   icon = <BellIcon />,
   className,
+  isExpanded = false,
   ...props
 }: NotificationBadgeProps) => {
   let notificationChild = icon;
@@ -47,8 +50,10 @@ export const NotificationBadge: React.FunctionComponent<NotificationBadgeProps> 
     notificationChild = attentionIcon;
   }
   return (
-    <Button variant={ButtonVariant.plain} className={className} {...props}>
-      <span className={css(styles.notificationBadge, styles.modifiers[variant])}>
+    <Button variant={ButtonVariant.plain} className={className} aria-expanded={isExpanded} {...props}>
+      <span
+        className={css(styles.notificationBadge, styles.modifiers[variant], isExpanded && styles.modifiers.expanded)}
+      >
         {notificationChild}
         {count > 0 && <span className={css(styles.notificationBadgeCount)}>{count}</span>}
       </span>

--- a/packages/react-core/src/components/NotificationBadge/NotificationBadge.tsx
+++ b/packages/react-core/src/components/NotificationBadge/NotificationBadge.tsx
@@ -24,7 +24,9 @@ export interface NotificationBadgeProps extends Omit<ButtonProps, 'variant'> {
   count?: number;
   /** Icon to display in the notification badge. */
   icon?: React.ReactNode;
-  /** Flag for indicating whether the notification badge is expanded. */
+  /** Flag for applying expanded styling and setting the aria-expanded attribute on the
+   * notification badge.
+   */
   isExpanded?: boolean;
   /** @deprecated Use the variant prop instead - Adds styling to the notification badge to indicate it has been read. */
   isRead?: boolean;

--- a/packages/react-core/src/components/NotificationBadge/__tests__/NotificationBadge.test.tsx
+++ b/packages/react-core/src/components/NotificationBadge/__tests__/NotificationBadge.test.tsx
@@ -1,6 +1,6 @@
 import { NotificationBadge } from '../NotificationBadge';
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 Object.values([true, false]).forEach(isRead => {
   test(`${isRead} NotificationBadge`, () => {
@@ -23,4 +23,28 @@ Object.values([true, false]).forEach(attentionVariant => {
 test(`NotificationBadge count`, () => {
   const { asFragment } = render(<NotificationBadge variant="read" count={3} />);
   expect(asFragment()).toMatchSnapshot();
+});
+
+test('Renders with aria-expanded="false" when isExpanded is not passed in.', () => {
+  render(<NotificationBadge />);
+
+  expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'false');
+});
+
+test('Renders with aria-expanded="true" when isExpanded is passed in.', () => {
+  render(<NotificationBadge isExpanded />);
+
+  expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'true');
+});
+
+test('Does not render with .pf-m-expanded when isExpanded is not passed in.', () => {
+  render(<NotificationBadge />);
+
+  expect(screen.getByRole('button').firstChild).not.toHaveClass('pf-m-expanded');
+});
+
+test('Renders with .pf-m-expanded when isExpanded is passed in.', () => {
+  render(<NotificationBadge isExpanded />);
+
+  expect(screen.getByRole('button').firstChild).toHaveClass('pf-m-expanded');
 });

--- a/packages/react-core/src/components/NotificationBadge/__tests__/__snapshots__/NotificationBadge.test.tsx.snap
+++ b/packages/react-core/src/components/NotificationBadge/__tests__/__snapshots__/NotificationBadge.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`NotificationBadge count 1`] = `
 <DocumentFragment>
   <button
     aria-disabled="false"
+    aria-expanded="false"
     class="pf-c-button pf-m-plain"
     data-ouia-component-id="OUIA-Generated-Button-plain-5"
     data-ouia-component-type="PF4/Button"
@@ -40,6 +41,7 @@ exports[`false NotificationBadge 1`] = `
 <DocumentFragment>
   <button
     aria-disabled="false"
+    aria-expanded="false"
     class="pf-c-button pf-m-plain"
     data-ouia-component-id="OUIA-Generated-Button-plain-2"
     data-ouia-component-type="PF4/Button"
@@ -71,6 +73,7 @@ exports[`false NotificationBadge needs attention 1`] = `
 <DocumentFragment>
   <button
     aria-disabled="false"
+    aria-expanded="false"
     class="pf-c-button pf-m-plain"
     data-ouia-component-id="OUIA-Generated-Button-plain-4"
     data-ouia-component-type="PF4/Button"
@@ -90,6 +93,7 @@ exports[`true NotificationBadge 1`] = `
 <DocumentFragment>
   <button
     aria-disabled="false"
+    aria-expanded="false"
     class="pf-c-button pf-m-plain"
     data-ouia-component-id="OUIA-Generated-Button-plain-1"
     data-ouia-component-type="PF4/Button"
@@ -121,6 +125,7 @@ exports[`true NotificationBadge needs attention 1`] = `
 <DocumentFragment>
   <button
     aria-disabled="false"
+    aria-expanded="false"
     class="pf-c-button pf-m-plain"
     data-ouia-component-id="OUIA-Generated-Button-plain-3"
     data-ouia-component-type="PF4/Button"

--- a/packages/react-core/src/components/NotificationBadge/examples/NotificationBadge.md
+++ b/packages/react-core/src/components/NotificationBadge/examples/NotificationBadge.md
@@ -4,15 +4,18 @@ section: components
 cssPrefix: pf-c-notification-badge
 propComponents: ['NotificationBadge']
 ---
+
 import BellIcon from '@patternfly/react-icons/dist/esm/icons/bell-icon';
 import './notificationBadge.css';
 
 ## Examples
 
 ### Basic
-```ts file='./NotificationBadgeBasic.tsx' 
+
+```ts file='./NotificationBadgeBasic.tsx'
 ```
 
 ### With count
-```ts file='./NotificationBadgeWithCount.tsx' 
+
+```ts file='./NotificationBadgeWithCount.tsx'
 ```

--- a/packages/react-core/src/components/NotificationBadge/examples/NotificationBadge.md
+++ b/packages/react-core/src/components/NotificationBadge/examples/NotificationBadge.md
@@ -14,7 +14,11 @@ import './notificationBadge.css';
 
 The following example demonstrates the three variants of notification badge that are available: "read", "unread", and "attention".
 
-The `isExpanded` property is also passed in to indicate that the badge is expanded, for use-cases as seen in our [notification drawer react demos](/components/notification-drawer/react-demos).
+The `isExpanded` property is also passed in to:
+
+- set the `aria-expanded` attribute on the notification badge,
+- apply visual styling on the notification badge, and
+- to indiciate that a notification drawer is expanded, for use-cases as seen in our [notification drawer react demos](/components/notification-drawer/react-demos).
 
 ```ts file='./NotificationBadgeBasic.tsx'
 ```

--- a/packages/react-core/src/components/NotificationBadge/examples/NotificationBadge.md
+++ b/packages/react-core/src/components/NotificationBadge/examples/NotificationBadge.md
@@ -12,10 +12,16 @@ import './notificationBadge.css';
 
 ### Basic
 
+The following example demonstrates the three variants of notification badge that are available: "read", "unread", and "attention".
+
+The `isExpanded` property is also passed in to indicate that the badge is expanded, for use-cases as seen in our [notification drawer react demos](/components/notification-drawer/react-demos).
+
 ```ts file='./NotificationBadgeBasic.tsx'
 ```
 
 ### With count
+
+You can display a number within the notification badge by passing in the `count` property, to indicate how many read, unread, or attention notifications there are. The `isExpanded` property is also passed in, similar to the [notification badge basic example](/components/notification-badge#basic).
 
 ```ts file='./NotificationBadgeWithCount.tsx'
 ```

--- a/packages/react-core/src/components/NotificationBadge/examples/NotificationBadgeBasic.tsx
+++ b/packages/react-core/src/components/NotificationBadge/examples/NotificationBadgeBasic.tsx
@@ -1,29 +1,42 @@
 import React from 'react';
 import { NotificationBadge, NotificationBadgeVariant } from '@patternfly/react-core';
 
-export const SimpleNotificationBadge: React.FunctionComponent = () => {
-  const [unreadVariant, setUnreadVariant] = React.useState(NotificationBadgeVariant.unread);
-  const [attentionVariant, setAttentionVariant] = React.useState(NotificationBadgeVariant.attention);
+export const NotificationBadgeBasic: React.FunctionComponent = () => {
+  const [readExpanded, setReadExpanded] = React.useState(false);
+  const [unreadExpanded, setUnreadExpanded] = React.useState(false);
+  const [attentionExpanded, setAttentionExpanded] = React.useState(false);
 
-  const onFirstClick = (value: NotificationBadgeVariant) => {
-    setUnreadVariant(value);
+  const onReadClick = () => {
+    setReadExpanded(!readExpanded);
   };
 
-  const onSecondClick = (value: NotificationBadgeVariant) => {
-    setAttentionVariant(value);
+  const onUnreadClick = () => {
+    setUnreadExpanded(!unreadExpanded);
+  };
+
+  const onAttentionClick = () => {
+    setAttentionExpanded(!attentionExpanded);
   };
 
   return (
     <div className="pf-t-dark">
       <NotificationBadge
-        variant={unreadVariant}
-        onClick={() => onFirstClick(NotificationBadgeVariant.read)}
-        aria-label="First notifications"
+        variant={NotificationBadgeVariant.read}
+        onClick={onReadClick}
+        aria-label="Basic notification badge with read variant"
+        isExpanded={readExpanded}
       />
       <NotificationBadge
-        variant={attentionVariant}
-        onClick={() => onSecondClick(NotificationBadgeVariant.read)}
-        aria-label="Second notifications"
+        variant={NotificationBadgeVariant.unread}
+        onClick={onUnreadClick}
+        aria-label="Basic notification badge with unread variant"
+        isExpanded={unreadExpanded}
+      />
+      <NotificationBadge
+        variant={NotificationBadgeVariant.attention}
+        onClick={onAttentionClick}
+        aria-label="Basic notification badge with attention variant"
+        isExpanded={attentionExpanded}
       />
     </div>
   );

--- a/packages/react-core/src/components/NotificationBadge/examples/NotificationBadgeWithCount.tsx
+++ b/packages/react-core/src/components/NotificationBadge/examples/NotificationBadgeWithCount.tsx
@@ -2,34 +2,44 @@ import React from 'react';
 import { NotificationBadge, NotificationBadgeVariant } from '@patternfly/react-core';
 
 export const NotificationBadgeWithCount: React.FunctionComponent = () => {
-  const [firstVariant, setFirstVariant] = React.useState(NotificationBadgeVariant.unread);
-  const [firstVariantCount, setFirstVariantCount] = React.useState(30);
-  const [secondVariant, setSecondVariant] = React.useState(NotificationBadgeVariant.attention);
-  const [secondVariantCount, setSecondVariantCount] = React.useState(30);
+  const [readExpanded, setReadExpanded] = React.useState(false);
+  const [unreadExpanded, setUnreadExpanded] = React.useState(false);
+  const [attentionExpanded, setAttentionExpanded] = React.useState(false);
 
-  const onFirstClick = (value: NotificationBadgeVariant) => {
-    setFirstVariant(value);
-    setFirstVariantCount(10);
+  const onReadClick = () => {
+    setReadExpanded(!readExpanded);
   };
 
-  const onSecondClick = (value: NotificationBadgeVariant) => {
-    setSecondVariant(value);
-    setSecondVariantCount(10);
+  const onUnreadClick = () => {
+    setUnreadExpanded(!unreadExpanded);
+  };
+
+  const onAttentionClick = () => {
+    setAttentionExpanded(!attentionExpanded);
   };
 
   return (
     <div className="pf-t-dark">
       <NotificationBadge
-        variant={firstVariant}
-        onClick={() => onFirstClick(NotificationBadgeVariant.read)}
-        aria-label="First notifications"
-        count={firstVariantCount}
+        variant={NotificationBadgeVariant.read}
+        onClick={onReadClick}
+        aria-label="Notification badge with count and read variant"
+        isExpanded={readExpanded}
+        count={10}
       />
       <NotificationBadge
-        variant={secondVariant}
-        onClick={() => onSecondClick(NotificationBadgeVariant.read)}
-        aria-label="Second notifications"
-        count={secondVariantCount}
+        variant={NotificationBadgeVariant.unread}
+        onClick={onUnreadClick}
+        aria-label="Notification badge with count and unread variant"
+        isExpanded={unreadExpanded}
+        count={10}
+      />
+      <NotificationBadge
+        variant={NotificationBadgeVariant.attention}
+        onClick={onAttentionClick}
+        aria-label="Notification badge with count and attention variant"
+        isExpanded={attentionExpanded}
+        count={10}
       />
     </div>
   );

--- a/packages/react-core/src/demos/NotificationDrawer/NotificationDrawer.md
+++ b/packages/react-core/src/demos/NotificationDrawer/NotificationDrawer.md
@@ -246,6 +246,7 @@ class BasicNotificationDrawer extends React.Component {
                   variant={this.getNumberUnread() === 0 ? 'read' : 'unread'}
                   onClick={this.onCloseNotificationDrawer}
                   aria-label="Notifications"
+                  isExpanded={isDrawerExpanded}
                 >
                   <BellIcon />
                 </NotificationBadge>
@@ -812,6 +813,7 @@ class GroupedNotificationDrawer extends React.Component {
                   variant={this.getNumberUnread() === 0 ? 'read' : 'unread'}
                   onClick={this.onCloseNotificationDrawer}
                   aria-label="Notifications"
+                  isExpanded={isDrawerExpanded}
                 >
                   <BellIcon />
                 </NotificationBadge>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7379, closes #6142 

[Notification badge examples](https://patternfly-react-pr-8010.surge.sh/components/notification-badge)
[Notification drawer demos](https://patternfly-react-pr-8010.surge.sh/components/notification-drawer/react-demos)

- Added an `isExpanded` prop to the Notification Badge component
- Updated the examples so that they match Core (showing read, unread, and attention variants)
- Updated the examples so that the onClick handler updates the expanded state, rather than the variant
- Updated Notification Drawer demos to use this new expanded state 
- Reordered the props alphabetically

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
N/A