### PR TITLE
feat(ProgressStepper): updating description prop to ReactNode

### DIFF
--- a/packages/react-core/src/components/ProgressStepper/ProgressStep.tsx
+++ b/packages/react-core/src/components/ProgressStepper/ProgressStep.tsx
@@ -19,7 +19,7 @@ export interface ProgressStepProps
   /** Custom icon of a progress step. Will override default icons provided by the variant. */
   icon?: React.ReactNode;
   /** Description text of a progress step. */
-  description?: string;
+  description?: React.ReactNode;
   /** ID of the title of the progress step. */
   titleId?: string;
   /** Accessible label for the progress step. Should communicate all information being communicated by the progress

--- a/packages/react-core/src/components/ProgressStepper/__tests__/ProgressStepper.test.tsx
+++ b/packages/react-core/src/components/ProgressStepper/__tests__/ProgressStepper.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { ProgressStepper } from '../ProgressStepper';
 import { ProgressStep } from '../ProgressStep';
 import InProgressIcon from '@patternfly/react-icons/dist/esm/icons/in-progress-icon';
@@ -109,4 +109,35 @@ describe('ProgressStep', () => {
     const { asFragment } = render(<ProgressStep description="This is a description">Title</ProgressStep>);
     expect(asFragment()).toMatchSnapshot();
   });
+});
+
+test('renders description class and text', () => {
+  render(
+    <ProgressStep
+      description="Test description"
+    >
+      Title
+    </ProgressStep>
+  );
+
+  expect(screen.getByText('Test description')).toBeVisible();
+  expect(screen.getByText('Test description')).toHaveClass('pf-c-progress-stepper__step-description');
+});
+
+test('renders description line break', () => {
+  render(
+    <ProgressStep
+      description={
+        <>
+          Testing description
+          <br />
+          Line break
+        </>
+      }
+      >
+        Title
+      </ProgressStep>
+  );
+
+  expect(screen.getByText("Testing descriptionLine break")).toBeVisible();
 });

--- a/packages/react-core/src/components/ProgressStepper/examples/ProgressStepperBasicWithDescription.tsx
+++ b/packages/react-core/src/components/ProgressStepper/examples/ProgressStepperBasicWithDescription.tsx
@@ -15,7 +15,13 @@ export const ProgressStepperBasicWithDescription: React.FunctionComponent = () =
     <ProgressStep
       variant="info"
       isCurrent
-      description="This is the second thing to happen"
+      description={
+        <>
+          This is the second thing to happen
+          <br />
+          In progress
+        </>
+      }
       id="basic-desc-step2"
       titleId="basic-desc-step2-title"
       aria-label="step with info"

--- a/packages/react-core/src/components/ProgressStepper/examples/ProgressStepperBasicWithDescription.tsx
+++ b/packages/react-core/src/components/ProgressStepper/examples/ProgressStepperBasicWithDescription.tsx
@@ -15,13 +15,7 @@ export const ProgressStepperBasicWithDescription: React.FunctionComponent = () =
     <ProgressStep
       variant="info"
       isCurrent
-      description={
-        <>
-          This is the second thing to happen
-          <br />
-          In progress
-        </>
-      }
+      description="This is the second thing to happen"
       id="basic-desc-step2"
       titleId="basic-desc-step2-title"
       aria-label="step with info"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7801 . Updated the `description` prop in `ProgressStep.tsx` to allow for the use of line breaks. This was demonstrated in the updated example of `ProgressStepperWithBasicDescription.tsx` in the second step.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
