### PR TITLE
feat(Table): add tooltip for truncated Td, docs(Filter): add filter demos

### DIFF
--- a/packages/react-core/src/components/Menu/Menu.tsx
+++ b/packages/react-core/src/components/Menu/Menu.tsx
@@ -208,13 +208,19 @@ class MenuBase extends React.Component<MenuProps, MenuState> {
   createNavigableElements = () => {
     const isDrilldown = this.props.containsDrilldown;
 
-    return isDrilldown
-      ? Array.from(this.activeMenu.getElementsByTagName('UL')[0].children).filter(
-          el => !(el.classList.contains('pf-m-disabled') || el.classList.contains('pf-c-divider'))
-        )
-      : Array.from(this.menuRef.current.getElementsByTagName('LI')).filter(
-          el => !(el.classList.contains('pf-m-disabled') || el.classList.contains('pf-c-divider'))
-        );
+    if (isDrilldown) {
+      return this.activeMenu
+        ? Array.from(this.activeMenu.getElementsByTagName('UL')[0].children).filter(
+            el => !(el.classList.contains('pf-m-disabled') || el.classList.contains('pf-c-divider'))
+          )
+        : [];
+    } else {
+      return this.menuRef.current
+        ? Array.from(this.menuRef.current.getElementsByTagName('LI')).filter(
+            el => !(el.classList.contains('pf-m-disabled') || el.classList.contains('pf-c-divider'))
+          )
+        : [];
+    }
   };
 
   render() {

--- a/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
+++ b/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
@@ -136,6 +136,7 @@ export class MenuToggleBase extends React.Component<MenuToggleProps> {
     if (splitButtonOptions) {
       return (
         <div
+          ref={innerRef as React.Ref<HTMLDivElement>}
           className={css(
             commonStyles,
             styles.modifiers.splitButton,

--- a/packages/react-core/src/demos/Filters/FilterDemos.md
+++ b/packages/react-core/src/demos/Filters/FilterDemos.md
@@ -24,25 +24,47 @@ EmptyStateIcon,
 Title,
 EmptyStateBody,
 EmptyStatePrimary,
-Button
+Button,
+Bullseye,
+ToolbarToggleGroup
 } from '@patternfly/react-core';
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 
-## Demos
+## Filtering demos
 
-### Filtering with a search input
+### Search input
 
 ```ts file="./examples/FilterSearchInput.tsx"
 ```
 
-### Filtering with a single select
+### Single select
 
 ```ts file="./examples/FilterSingleSelect.tsx"
 ```
 
-### Filtering with a checkbox select
+### Checkbox select
 
 ```ts file="./examples/FilterCheckboxSelect.tsx"
+```
+
+### Attribute search
+
+```ts file="./examples/FilterAttributeSearch.tsx"
+```
+
+### Mixed select filter group
+
+```ts file="./examples/FilterMixedSelectGroup.tsx"
+```
+
+### Single select filter group
+
+```ts file="./examples/FilterSameSelectGroup.tsx"
+```
+
+### Faceted filter
+
+```ts file="./examples/FilterFaceted.tsx"
 ```

--- a/packages/react-core/src/demos/Filters/examples/FilterAttributeSearch.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterAttributeSearch.tsx
@@ -152,9 +152,9 @@ export const FilterAttributeSearch: React.FunctionComponent = () => {
   }, []);
 
   // Set up bulk selection menu
-  const bulkSelectMenuRef = React.createRef<HTMLDivElement>();
-  const bulkSelectToggleRef = React.createRef<any>();
-  const bulkSelectContainerRef = React.createRef<HTMLDivElement>();
+  const bulkSelectMenuRef = React.useRef<HTMLDivElement>(null);
+  const bulkSelectToggleRef = React.useRef<any>(null);
+  const bulkSelectContainerRef = React.useRef<HTMLDivElement>(null);
 
   const [isBulkSelectOpen, setIsBulkSelectOpen] = React.useState<boolean>(false);
 
@@ -174,7 +174,7 @@ export const FilterAttributeSearch: React.FunctionComponent = () => {
     ) {
       if (event.key === 'Escape' || event.key === 'Tab') {
         setIsBulkSelectOpen(!isBulkSelectOpen);
-        bulkSelectToggleRef.current?.focus();
+        bulkSelectToggleRef.current?.querySelector('button').focus();
       }
     }
   };
@@ -227,13 +227,13 @@ export const FilterAttributeSearch: React.FunctionComponent = () => {
   );
 
   const bulkSelectMenu = (
-    // eslint-disable-next-line no-console
     <Menu
       id="attribute-search-input-bulk-select"
       ref={bulkSelectMenuRef}
       onSelect={(_ev, itemId) => {
         selectAllRepos(itemId === 1 || itemId === 2);
         setIsBulkSelectOpen(!isBulkSelectOpen);
+        bulkSelectToggleRef.current?.querySelector('button').focus();
       }}
     >
       <MenuContent>

--- a/packages/react-core/src/demos/Filters/examples/FilterAttributeSearch.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterAttributeSearch.tsx
@@ -1,0 +1,701 @@
+import React from 'react';
+import {
+  SearchInput,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+  Menu,
+  MenuContent,
+  MenuList,
+  MenuItem,
+  MenuToggle,
+  MenuToggleCheckbox,
+  Popper,
+  Pagination,
+  EmptyState,
+  EmptyStateIcon,
+  Title,
+  EmptyStateBody,
+  EmptyStatePrimary,
+  Button,
+  Bullseye,
+  Badge,
+  ToolbarGroup,
+  ToolbarFilter,
+  ToolbarToggleGroup
+} from '@patternfly/react-core';
+import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
+import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
+
+interface Repository {
+  name: string;
+  threads: string;
+  apps: string;
+  workspaces: string;
+  status: string;
+  location: string;
+}
+
+// In real usage, this data would come from some external source like an API via props.
+const repositories: Repository[] = [
+  { name: 'US-Node 1', threads: '5', apps: '25', workspaces: '5', status: 'Stopped', location: 'Raleigh' },
+  { name: 'US-Node 2', threads: '5', apps: '30', workspaces: '2', status: 'Down', location: 'Westford' },
+  { name: 'US-Node 3', threads: '13', apps: '35', workspaces: '12', status: 'Degraded', location: 'Boston' },
+  { name: 'US-Node 4', threads: '2', apps: '5', workspaces: '18', status: 'Needs Maintenance', location: 'Raleigh' },
+  { name: 'US-Node 5', threads: '7', apps: '30', workspaces: '5', status: 'Running', location: 'Boston' },
+  { name: 'US-Node 6', threads: '5', apps: '20', workspaces: '15', status: 'Stopped', location: 'Raleigh' },
+  { name: 'CZ-Node 1', threads: '12', apps: '48', workspaces: '13', status: 'Down', location: 'Brno' },
+  { name: 'CZ-Node 2', threads: '3', apps: '8', workspaces: '20', status: 'Running', location: 'Brno' },
+  { name: 'CZ-Remote-Node 1', threads: '1', apps: '15', workspaces: '20', status: 'Down', location: 'Brno' },
+  { name: 'Bangalore-Node 1', threads: '1', apps: '20', workspaces: '20', status: 'Running', location: 'Bangalore' }
+];
+
+const columnNames = {
+  name: 'Servers',
+  threads: 'Threads',
+  apps: 'Applications',
+  workspaces: 'Workspaces',
+  status: 'Status',
+  location: 'Location'
+};
+
+/* eslint-disable patternfly-react/no-anonymous-functions */
+export const FilterAttributeSearch: React.FunctionComponent = () => {
+  // Set up repo filtering
+  const [searchValue, setSearchValue] = React.useState('');
+  const [locationSelections, setLocationSelections] = React.useState<string[]>([]);
+  const [statusSelection, setStatusSelection] = React.useState('');
+
+  const onSearchChange = (value: string) => {
+    setSearchValue(value);
+  };
+
+  const onFilter = (repo: Repository) => {
+    // Search name with search value
+    let searchValueInput: RegExp;
+    try {
+      searchValueInput = new RegExp(searchValue, 'i');
+    } catch (err) {
+      searchValueInput = new RegExp(searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+    }
+    const matchesSearchValue = repo.name.search(searchValueInput) >= 0;
+
+    // Search status with status selection
+    const matchesStatusValue = repo.status.toLowerCase() === statusSelection.toLowerCase();
+
+    // Search location with location selections
+    const matchesLocationValue = locationSelections.includes(repo.location);
+
+    return (
+      (searchValue === '' || matchesSearchValue) &&
+      (statusSelection === '' || matchesStatusValue) &&
+      (locationSelections.length === 0 || matchesLocationValue)
+    );
+  };
+  const filteredRepos = repositories.filter(onFilter);
+
+  // Set up table row selection
+  // In this example, selected rows are tracked by the repo names from each row. This could be any unique identifier.
+  // This is to prevent state from being based on row order index in case we later add sorting.
+  const isRepoSelectable = (repo: Repository) => repo.name !== 'a'; // Arbitrary logic for this example
+  const [selectedRepoNames, setSelectedRepoNames] = React.useState<string[]>([]);
+  const setRepoSelected = (repo: Repository, isSelecting = true) =>
+    setSelectedRepoNames(prevSelected => {
+      const otherSelectedRepoNames = prevSelected.filter(r => r !== repo.name);
+      return isSelecting && isRepoSelectable(repo) ? [...otherSelectedRepoNames, repo.name] : otherSelectedRepoNames;
+    });
+  const selectAllRepos = (isSelecting = true) =>
+    setSelectedRepoNames(isSelecting ? filteredRepos.map(r => r.name) : []); // Selecting all should only select all currently filtered rows
+  const areAllReposSelected = selectedRepoNames.length === filteredRepos.length && filteredRepos.length > 0;
+  const areSomeReposSelected = selectedRepoNames.length > 0;
+  const isRepoSelected = (repo: Repository) => selectedRepoNames.includes(repo.name);
+
+  // To allow shift+click to select/deselect multiple rows
+  const [recentSelectedRowIndex, setRecentSelectedRowIndex] = React.useState<number | null>(null);
+  const [shifting, setShifting] = React.useState(false);
+
+  const onSelectRepo = (repo: Repository, rowIndex: number, isSelecting: boolean) => {
+    // If the user is shift + selecting the checkboxes, then all intermediate checkboxes should be selected
+    if (shifting && recentSelectedRowIndex !== null) {
+      const numberSelected = rowIndex - recentSelectedRowIndex;
+      const intermediateIndexes =
+        numberSelected > 0
+          ? Array.from(new Array(numberSelected + 1), (_x, i) => i + recentSelectedRowIndex)
+          : Array.from(new Array(Math.abs(numberSelected) + 1), (_x, i) => i + rowIndex);
+      intermediateIndexes.forEach(index => setRepoSelected(repositories[index], isSelecting));
+    } else {
+      setRepoSelected(repo, isSelecting);
+    }
+    setRecentSelectedRowIndex(rowIndex);
+  };
+
+  React.useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') {
+        setShifting(true);
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') {
+        setShifting(false);
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    document.addEventListener('keyup', onKeyUp);
+
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('keyup', onKeyUp);
+    };
+  }, []);
+
+  // Set up bulk selection menu
+  const bulkSelectMenuRef = React.createRef<HTMLDivElement>();
+  const bulkSelectToggleRef = React.createRef<any>();
+  const bulkSelectContainerRef = React.createRef<HTMLDivElement>();
+
+  const [isBulkSelectOpen, setIsBulkSelectOpen] = React.useState<boolean>(false);
+
+  const handleBulkSelectClickOutside = (event: MouseEvent) => {
+    if (isBulkSelectOpen && !bulkSelectMenuRef.current?.contains(event.target as Node)) {
+      setIsBulkSelectOpen(false);
+    }
+  };
+
+  const handleBulkSelectMenuKeys = (event: KeyboardEvent) => {
+    if (!isBulkSelectOpen) {
+      return;
+    }
+    if (
+      bulkSelectMenuRef.current?.contains(event.target as Node) ||
+      bulkSelectToggleRef.current?.contains(event.target as Node)
+    ) {
+      if (event.key === 'Escape' || event.key === 'Tab') {
+        setIsBulkSelectOpen(!isBulkSelectOpen);
+        bulkSelectToggleRef.current?.focus();
+      }
+    }
+  };
+
+  React.useEffect(() => {
+    window.addEventListener('keydown', handleBulkSelectMenuKeys);
+    window.addEventListener('click', handleBulkSelectClickOutside);
+    return () => {
+      window.removeEventListener('keydown', handleBulkSelectMenuKeys);
+      window.removeEventListener('click', handleBulkSelectClickOutside);
+    };
+  }, [isBulkSelectOpen, bulkSelectMenuRef]);
+
+  const onBulkSelectToggleClick = (ev: React.MouseEvent) => {
+    ev.stopPropagation(); // Stop handleClickOutside from handling
+    setTimeout(() => {
+      if (bulkSelectMenuRef.current) {
+        const firstElement = bulkSelectMenuRef.current.querySelector('li > button:not(:disabled)');
+        firstElement && (firstElement as HTMLElement).focus();
+      }
+    }, 0);
+    setIsBulkSelectOpen(!isBulkSelectOpen);
+  };
+
+  let menuToggleCheckmark: boolean | null = false;
+  if (areAllReposSelected) {
+    menuToggleCheckmark = true;
+  } else if (areSomeReposSelected) {
+    menuToggleCheckmark = null;
+  }
+
+  const bulkSelectToggle = (
+    <MenuToggle
+      ref={bulkSelectToggleRef}
+      onClick={onBulkSelectToggleClick}
+      isExpanded={isBulkSelectOpen}
+      splitButtonOptions={{
+        items: [
+          <MenuToggleCheckbox
+            id="attribute-search-input-bulk-select"
+            key="attribute-search-input-bulk-select"
+            aria-label="Select all"
+            isChecked={menuToggleCheckmark}
+            onChange={(checked, _event) => selectAllRepos(checked)}
+          />
+        ]
+      }}
+      aria-label="Full table selection checkbox"
+    />
+  );
+
+  const bulkSelectMenu = (
+    // eslint-disable-next-line no-console
+    <Menu
+      id="attribute-search-input-bulk-select"
+      ref={bulkSelectMenuRef}
+      onSelect={(_ev, itemId) => {
+        selectAllRepos(itemId === 1 || itemId === 2);
+        setIsBulkSelectOpen(!isBulkSelectOpen);
+      }}
+    >
+      <MenuContent>
+        <MenuList>
+          <MenuItem itemId={0}>Select none (0 items)</MenuItem>
+          <MenuItem itemId={1}>Select page ({repositories.length} items)</MenuItem>
+          <MenuItem itemId={2}>Select all ({repositories.length} items)</MenuItem>
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+
+  const toolbarBulkSelect = (
+    <div ref={bulkSelectContainerRef}>
+      <Popper
+        trigger={bulkSelectToggle}
+        popper={bulkSelectMenu}
+        appendTo={bulkSelectContainerRef.current || undefined}
+        isVisible={isBulkSelectOpen}
+        popperMatchesTriggerWidth={false}
+      />
+    </div>
+  );
+
+  // Set up name search input
+  const searchInput = (
+    <SearchInput
+      placeholder="Filter by server name"
+      value={searchValue}
+      onChange={onSearchChange}
+      onClear={() => onSearchChange('')}
+    />
+  );
+
+  // Set up status single select
+  const [isStatusMenuOpen, setIsStatusMenuOpen] = React.useState<boolean>(false);
+  const statusToggleRef = React.useRef<HTMLButtonElement>(null);
+  const statusMenuRef = React.useRef<HTMLDivElement>(null);
+  const statusContainerRef = React.useRef<HTMLDivElement>(null);
+
+  const handleStatusMenuKeys = (event: KeyboardEvent) => {
+    if (isStatusMenuOpen && statusMenuRef.current?.contains(event.target as Node)) {
+      if (event.key === 'Escape' || event.key === 'Tab') {
+        setIsStatusMenuOpen(!isStatusMenuOpen);
+        statusToggleRef.current?.focus();
+      }
+    }
+  };
+
+  const handleStatusClickOutside = (event: MouseEvent) => {
+    if (isStatusMenuOpen && !statusMenuRef.current?.contains(event.target as Node)) {
+      setIsStatusMenuOpen(false);
+    }
+  };
+
+  React.useEffect(() => {
+    window.addEventListener('keydown', handleStatusMenuKeys);
+    window.addEventListener('click', handleStatusClickOutside);
+    return () => {
+      window.removeEventListener('keydown', handleStatusMenuKeys);
+      window.removeEventListener('click', handleStatusClickOutside);
+    };
+  }, [isStatusMenuOpen, statusMenuRef]);
+
+  const onStatusToggleClick = (ev: React.MouseEvent) => {
+    ev.stopPropagation(); // Stop handleClickOutside from handling
+    setTimeout(() => {
+      if (statusMenuRef.current) {
+        const firstElement = statusMenuRef.current.querySelector('li > button:not(:disabled)');
+        firstElement && (firstElement as HTMLElement).focus();
+      }
+    }, 0);
+    setIsStatusMenuOpen(!isStatusMenuOpen);
+  };
+
+  function onStatusSelect(event: React.MouseEvent | undefined, itemId: string | number | undefined) {
+    if (typeof itemId === 'undefined') {
+      return;
+    }
+
+    setStatusSelection(itemId.toString());
+    setIsStatusMenuOpen(!isStatusMenuOpen);
+  }
+
+  const statusToggle = (
+    <MenuToggle
+      ref={statusToggleRef}
+      onClick={onStatusToggleClick}
+      isExpanded={isStatusMenuOpen}
+      style={
+        {
+          width: '200px'
+        } as React.CSSProperties
+      }
+    >
+      Filter by status
+    </MenuToggle>
+  );
+
+  const statusMenu = (
+    <Menu ref={statusMenuRef} id="attribute-search-status-menu" onSelect={onStatusSelect} selected={statusSelection}>
+      <MenuContent>
+        <MenuList>
+          <MenuItem itemId="Degraded">Degraded</MenuItem>
+          <MenuItem itemId="Down">Down</MenuItem>
+          <MenuItem itemId="Needs maintenance">Needs maintenance</MenuItem>
+          <MenuItem itemId="Running">Running</MenuItem>
+          <MenuItem itemId="Stopped">Stopped</MenuItem>
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+
+  const statusSelect = (
+    <div ref={statusContainerRef}>
+      <Popper
+        trigger={statusToggle}
+        popper={statusMenu}
+        appendTo={statusContainerRef.current || undefined}
+        isVisible={isStatusMenuOpen}
+      />
+    </div>
+  );
+
+  // Set up location checkbox select
+  const [isLocationMenuOpen, setIsLocationMenuOpen] = React.useState<boolean>(false);
+  const locationToggleRef = React.useRef<HTMLButtonElement>(null);
+  const locationMenuRef = React.useRef<HTMLDivElement>(null);
+  const locationContainerRef = React.useRef<HTMLDivElement>(null);
+
+  const handleLocationMenuKeys = (event: KeyboardEvent) => {
+    if (isLocationMenuOpen && locationMenuRef.current?.contains(event.target as Node)) {
+      if (event.key === 'Escape' || event.key === 'Tab') {
+        setIsLocationMenuOpen(!isLocationMenuOpen);
+        locationToggleRef.current?.focus();
+      }
+    }
+  };
+
+  const handleLocationClickOutside = (event: MouseEvent) => {
+    if (isLocationMenuOpen && !locationMenuRef.current?.contains(event.target as Node)) {
+      setIsLocationMenuOpen(false);
+    }
+  };
+
+  React.useEffect(() => {
+    window.addEventListener('keydown', handleLocationMenuKeys);
+    window.addEventListener('click', handleLocationClickOutside);
+    return () => {
+      window.removeEventListener('keydown', handleLocationMenuKeys);
+      window.removeEventListener('click', handleLocationClickOutside);
+    };
+  }, [isLocationMenuOpen, locationMenuRef]);
+
+  const onLocationMenuToggleClick = (ev: React.MouseEvent) => {
+    ev.stopPropagation(); // Stop handleClickOutside from handling
+    setTimeout(() => {
+      if (locationMenuRef.current) {
+        const firstElement = locationMenuRef.current.querySelector('li > button:not(:disabled)');
+        firstElement && (firstElement as HTMLElement).focus();
+      }
+    }, 0);
+    setIsLocationMenuOpen(!isLocationMenuOpen);
+  };
+
+  function onLocationMenuSelect(event: React.MouseEvent | undefined, itemId: string | number | undefined) {
+    if (typeof itemId === 'undefined') {
+      return;
+    }
+
+    const itemStr = itemId.toString();
+
+    setLocationSelections(
+      locationSelections.includes(itemStr)
+        ? locationSelections.filter(selection => selection !== itemStr)
+        : [itemStr, ...locationSelections]
+    );
+  }
+
+  const locationToggle = (
+    <MenuToggle
+      ref={locationToggleRef}
+      onClick={onLocationMenuToggleClick}
+      isExpanded={isLocationMenuOpen}
+      {...(locationSelections.length > 0 && { badge: <Badge isRead>{locationSelections.length}</Badge> })}
+      style={
+        {
+          width: '200px'
+        } as React.CSSProperties
+      }
+    >
+      Filter by location
+    </MenuToggle>
+  );
+
+  const locationMenu = (
+    <Menu
+      ref={locationMenuRef}
+      id="attribute-search-location-menu"
+      onSelect={onLocationMenuSelect}
+      selected={locationSelections}
+    >
+      <MenuContent>
+        <MenuList>
+          <MenuItem hasCheck isSelected={locationSelections.includes('Bangalore')} itemId="Bangalore">
+            Bangalore
+          </MenuItem>
+          <MenuItem hasCheck isSelected={locationSelections.includes('Boston')} itemId="Boston">
+            Boston
+          </MenuItem>
+          <MenuItem hasCheck isSelected={locationSelections.includes('Brno')} itemId="Brno">
+            Brno
+          </MenuItem>
+          <MenuItem hasCheck isSelected={locationSelections.includes('Raleigh')} itemId="Raleigh">
+            Raleigh
+          </MenuItem>
+          <MenuItem hasCheck isSelected={locationSelections.includes('Westford')} itemId="Westford">
+            Westford
+          </MenuItem>
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+
+  const locationSelect = (
+    <div ref={locationContainerRef}>
+      <Popper
+        trigger={locationToggle}
+        popper={locationMenu}
+        appendTo={locationContainerRef.current || undefined}
+        isVisible={isLocationMenuOpen}
+      />
+    </div>
+  );
+
+  // Set up attribute selector
+  const [activeAttributeMenu, setActiveAttributeMenu] = React.useState<'Servers' | 'Status' | 'Location'>('Servers');
+  const [isAttributeMenuOpen, setIsAttributeMenuOpen] = React.useState(false);
+  const attributeToggleRef = React.useRef<HTMLButtonElement>(null);
+  const attributeMenuRef = React.useRef<HTMLDivElement>(null);
+  const attributeContainerRef = React.useRef<HTMLDivElement>(null);
+
+  const handleAttribueMenuKeys = (event: KeyboardEvent) => {
+    if (!isAttributeMenuOpen) {
+      return;
+    }
+    if (
+      attributeMenuRef.current?.contains(event.target as Node) ||
+      attributeToggleRef.current?.contains(event.target as Node)
+    ) {
+      if (event.key === 'Escape' || event.key === 'Tab') {
+        setIsAttributeMenuOpen(!isAttributeMenuOpen);
+        attributeToggleRef.current?.focus();
+      }
+    }
+  };
+
+  const handleAttributeClickOutside = (event: MouseEvent) => {
+    if (isAttributeMenuOpen && !attributeMenuRef.current?.contains(event.target as Node)) {
+      setIsAttributeMenuOpen(false);
+    }
+  };
+
+  React.useEffect(() => {
+    window.addEventListener('keydown', handleAttribueMenuKeys);
+    window.addEventListener('click', handleAttributeClickOutside);
+    return () => {
+      window.removeEventListener('keydown', handleAttribueMenuKeys);
+      window.removeEventListener('click', handleAttributeClickOutside);
+    };
+  }, [isAttributeMenuOpen, attributeMenuRef]);
+
+  const onAttributeToggleClick = (ev: React.MouseEvent) => {
+    ev.stopPropagation(); // Stop handleClickOutside from handling
+    setTimeout(() => {
+      if (attributeMenuRef.current) {
+        const firstElement = attributeMenuRef.current.querySelector('li > button:not(:disabled)');
+        firstElement && (firstElement as HTMLElement).focus();
+      }
+    }, 0);
+    setIsAttributeMenuOpen(!isAttributeMenuOpen);
+  };
+
+  const attributeToggle = (
+    <MenuToggle
+      ref={attributeToggleRef}
+      onClick={onAttributeToggleClick}
+      isExpanded={isAttributeMenuOpen}
+      icon={<FilterIcon />}
+    >
+      {activeAttributeMenu}
+    </MenuToggle>
+  );
+  const attributeMenu = (
+    // eslint-disable-next-line no-console
+    <Menu
+      ref={attributeMenuRef}
+      onSelect={(_ev, itemId) => {
+        setActiveAttributeMenu(itemId?.toString() as 'Servers' | 'Status' | 'Location');
+        setIsAttributeMenuOpen(!isAttributeMenuOpen);
+      }}
+    >
+      <MenuContent>
+        <MenuList>
+          <MenuItem itemId="Servers">Servers</MenuItem>
+          <MenuItem itemId="Status">Status</MenuItem>
+          <MenuItem itemId="Location">Location</MenuItem>
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+
+  const attributeDropdown = (
+    <div ref={attributeContainerRef}>
+      <Popper
+        trigger={attributeToggle}
+        popper={attributeMenu}
+        appendTo={attributeContainerRef.current || undefined}
+        isVisible={isAttributeMenuOpen}
+      />
+    </div>
+  );
+
+  // Set up pagination and toolbar
+  const toolbarPagination = (
+    <Pagination
+      titles={{ paginationTitle: 'Attribute search pagination' }}
+      perPageComponent="button"
+      itemCount={repositories.length}
+      perPage={10}
+      page={1}
+      widgetId="attribute-search-mock-pagination"
+      isCompact
+    />
+  );
+
+  const toolbar = (
+    <Toolbar
+      id="attribute-search-filter-toolbar"
+      clearAllFilters={() => {
+        setSearchValue('');
+        setStatusSelection('');
+        setLocationSelections([]);
+      }}
+    >
+      <ToolbarContent>
+        <ToolbarItem>{toolbarBulkSelect}</ToolbarItem>
+        <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl">
+          <ToolbarGroup variant="filter-group">
+            <ToolbarItem>{attributeDropdown}</ToolbarItem>
+            <ToolbarFilter
+              chips={searchValue !== '' ? [searchValue] : ([] as string[])}
+              deleteChip={() => setSearchValue('')}
+              deleteChipGroup={() => setSearchValue('')}
+              categoryName="Name"
+              showToolbarItem={activeAttributeMenu === 'Servers'}
+            >
+              {searchInput}
+            </ToolbarFilter>
+            <ToolbarFilter
+              chips={statusSelection !== '' ? [statusSelection] : ([] as string[])}
+              deleteChip={() => setStatusSelection('')}
+              deleteChipGroup={() => setStatusSelection('')}
+              categoryName="Status"
+              showToolbarItem={activeAttributeMenu === 'Status'}
+            >
+              {statusSelect}
+            </ToolbarFilter>
+            <ToolbarFilter
+              chips={locationSelections}
+              deleteChip={(category, chip) => onLocationMenuSelect(undefined, chip as string)}
+              deleteChipGroup={() => setLocationSelections([])}
+              categoryName="Location"
+              showToolbarItem={activeAttributeMenu === 'Location'}
+            >
+              {locationSelect}
+            </ToolbarFilter>
+          </ToolbarGroup>
+        </ToolbarToggleGroup>
+        <ToolbarItem variant="pagination">{toolbarPagination}</ToolbarItem>
+      </ToolbarContent>
+    </Toolbar>
+  );
+
+  const emptyState = (
+    <EmptyState>
+      <EmptyStateIcon icon={SearchIcon} />
+      <Title size="lg" headingLevel="h4">
+        No results found
+      </Title>
+      <EmptyStateBody>No results match the filter criteria. Clear all filters and try again.</EmptyStateBody>
+      <EmptyStatePrimary>
+        <Button
+          variant="link"
+          onClick={() => {
+            setSearchValue('');
+            setStatusSelection('');
+            setLocationSelections([]);
+          }}
+        >
+          Clear all filters
+        </Button>
+      </EmptyStatePrimary>
+    </EmptyState>
+  );
+
+  return (
+    <React.Fragment>
+      {toolbar}
+      <TableComposable aria-label="Selectable table">
+        <Thead>
+          <Tr>
+            <Th />
+            <Th width={20}>{columnNames.name}</Th>
+            <Th width={10}>{columnNames.threads}</Th>
+            <Th width={10}>{columnNames.apps}</Th>
+            <Th width={10}>{columnNames.workspaces}</Th>
+            <Th width={20}>{columnNames.status}</Th>
+            <Th width={20}>{columnNames.location}</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {filteredRepos.length > 0 &&
+            filteredRepos.map((repo, rowIndex) => (
+              <Tr key={repo.name}>
+                <Td
+                  select={{
+                    rowIndex,
+                    onSelect: (_event, isSelecting) => onSelectRepo(repo, rowIndex, isSelecting),
+                    isSelected: isRepoSelected(repo),
+                    disable: !isRepoSelectable(repo)
+                  }}
+                />
+                <Td dataLabel={columnNames.name} modifier="truncate">
+                  {repo.name}
+                </Td>
+                <Td dataLabel={columnNames.threads} modifier="truncate">
+                  {repo.threads}
+                </Td>
+                <Td dataLabel={columnNames.apps} modifier="truncate">
+                  {repo.apps}
+                </Td>
+                <Td dataLabel={columnNames.workspaces} modifier="truncate">
+                  {repo.workspaces}
+                </Td>
+                <Td dataLabel={columnNames.status} modifier="truncate">
+                  {repo.status}
+                </Td>
+                <Td dataLabel={columnNames.location} modifier="truncate">
+                  {repo.location}
+                </Td>
+              </Tr>
+            ))}
+          {filteredRepos.length === 0 && (
+            <Tr>
+              <Td colSpan={8}>
+                <Bullseye>{emptyState}</Bullseye>
+              </Td>
+            </Tr>
+          )}
+        </Tbody>
+      </TableComposable>
+    </React.Fragment>
+  );
+};

--- a/packages/react-core/src/demos/Filters/examples/FilterCheckboxSelect.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterCheckboxSelect.tsx
@@ -129,9 +129,9 @@ export const FilterCheckboxSelect: React.FunctionComponent = () => {
   }, []);
 
   // Set up bulk selection menu
-  const bulkSelectMenuRef = React.createRef<HTMLDivElement>();
-  const bulkSelectToggleRef = React.createRef<any>();
-  const bulkSelectcontainerRef = React.createRef<HTMLDivElement>();
+  const bulkSelectMenuRef = React.useRef<HTMLDivElement>(null);
+  const bulkSelectToggleRef = React.useRef<any>(null);
+  const bulkSelectContainerRef = React.useRef<HTMLDivElement>(null);
 
   const [isBulkSelectOpen, setIsBulkSelectOpen] = React.useState<boolean>(false);
 
@@ -151,7 +151,7 @@ export const FilterCheckboxSelect: React.FunctionComponent = () => {
     ) {
       if (event.key === 'Escape' || event.key === 'Tab') {
         setIsBulkSelectOpen(!isBulkSelectOpen);
-        bulkSelectToggleRef.current?.focus();
+        bulkSelectToggleRef.current?.querySelector('button').focus();
       }
     }
   };
@@ -204,12 +204,12 @@ export const FilterCheckboxSelect: React.FunctionComponent = () => {
   );
 
   const bulkSelectMenu = (
-    // eslint-disable-next-line no-console
     <Menu
       ref={bulkSelectMenuRef}
       onSelect={(_ev, itemId) => {
         selectAllRepos(itemId === 1 || itemId === 2);
         setIsBulkSelectOpen(!isBulkSelectOpen);
+        bulkSelectToggleRef.current?.querySelector('button').focus();
       }}
     >
       <MenuContent>
@@ -223,11 +223,11 @@ export const FilterCheckboxSelect: React.FunctionComponent = () => {
   );
 
   const toolbarBulkSelect = (
-    <div ref={bulkSelectcontainerRef}>
+    <div ref={bulkSelectContainerRef}>
       <Popper
         trigger={bulkSelectToggle}
         popper={bulkSelectMenu}
-        appendTo={bulkSelectcontainerRef.current || undefined}
+        appendTo={bulkSelectContainerRef.current || undefined}
         isVisible={isBulkSelectOpen}
         popperMatchesTriggerWidth={false}
       />

--- a/packages/react-core/src/demos/Filters/examples/FilterFaceted.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterFaceted.tsx
@@ -313,12 +313,14 @@ export const FilterFaceted: React.FunctionComponent = () => {
     }
   };
 
+  const areSelectionsPresent = locationSelections.length > 0 || statusSelections.length > 0;
+
   const toggle = (
     <MenuToggle
       ref={toggleRef}
       onClick={onToggleClick}
       isExpanded={isOpen}
-      {...((locationSelections.length > 0 || statusSelections.length > 0) && {
+      {...(areSelectionsPresent && {
         badge: <Badge isRead>{locationSelections.length + statusSelections.length}</Badge>
       })}
       icon={<FilterIcon />}

--- a/packages/react-core/src/demos/Filters/examples/FilterFaceted.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterFaceted.tsx
@@ -135,9 +135,9 @@ export const FilterFaceted: React.FunctionComponent = () => {
   }, []);
 
   // Set up bulk selection menu
-  const bulkSelectMenuRef = React.createRef<HTMLDivElement>();
-  const bulkSelectToggleRef = React.createRef<any>();
-  const bulkSelectContainerRef = React.createRef<HTMLDivElement>();
+  const bulkSelectMenuRef = React.useRef<HTMLDivElement>(null);
+  const bulkSelectToggleRef = React.useRef<any>(null);
+  const bulkSelectContainerRef = React.useRef<HTMLDivElement>(null);
 
   const [isBulkSelectOpen, setIsBulkSelectOpen] = React.useState<boolean>(false);
 
@@ -157,7 +157,7 @@ export const FilterFaceted: React.FunctionComponent = () => {
     ) {
       if (event.key === 'Escape' || event.key === 'Tab') {
         setIsBulkSelectOpen(!isBulkSelectOpen);
-        bulkSelectToggleRef.current?.focus();
+        bulkSelectToggleRef.current?.querySelector('button').focus();
       }
     }
   };
@@ -210,13 +210,13 @@ export const FilterFaceted: React.FunctionComponent = () => {
   );
 
   const bulkSelectMenu = (
-    // eslint-disable-next-line no-console
     <Menu
       id="filter-faceted-input-bulk-select"
       ref={bulkSelectMenuRef}
       onSelect={(_ev, itemId) => {
         selectAllRepos(itemId === 1 || itemId === 2);
         setIsBulkSelectOpen(!isBulkSelectOpen);
+        bulkSelectToggleRef.current?.querySelector('button').focus();
       }}
     >
       <MenuContent>

--- a/packages/react-core/src/demos/Filters/examples/FilterFaceted.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterFaceted.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import {
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
   Menu,
   MenuContent,
   MenuList,
@@ -7,15 +10,21 @@ import {
   MenuToggle,
   MenuToggleCheckbox,
   Popper,
-  Toolbar,
-  ToolbarContent,
-  ToolbarGroup,
-  ToolbarFilter,
-  ToolbarItem,
+  Pagination,
+  EmptyState,
+  EmptyStateIcon,
+  Title,
+  EmptyStateBody,
+  EmptyStatePrimary,
+  Button,
+  Bullseye,
   Badge,
-  Pagination
+  ToolbarFilter,
+  ToolbarToggleGroup,
+  MenuGroup
 } from '@patternfly/react-core';
 import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 
 interface Repository {
@@ -51,28 +60,25 @@ const columnNames = {
 };
 
 /* eslint-disable patternfly-react/no-anonymous-functions */
-export const FilterCheckboxSelect: React.FunctionComponent = () => {
+export const FilterFaceted: React.FunctionComponent = () => {
   // Set up repo filtering
-  const [selections, setSelections] = React.useState<string[]>([]);
+  const [locationSelections, setLocationSelections] = React.useState<string[]>([]);
+  const [statusSelections, setStatusSelections] = React.useState<string[]>([]);
+
   const onFilter = (repo: Repository) => {
-    if (selections.length === 0) {
-      return true;
-    }
+    // Search status with status selection
+    const matchesStatusValue = statusSelections.includes(repo.status);
 
-    return selections.some(searchValue => {
-      let input: RegExp;
-      try {
-        input = new RegExp(searchValue, 'i');
-      } catch (err) {
-        input = new RegExp(searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
-      }
-      return repo.location.search(input) >= 0;
-    });
+    // Search location with location selections
+    const matchesLocationValue = locationSelections.includes(repo.location);
+
+    return (
+      (statusSelections.length === 0 || matchesStatusValue) && (locationSelections.length === 0 || matchesLocationValue)
+    );
   };
-
   const filteredRepos = repositories.filter(onFilter);
 
-  // Set up table selection
+  // Set up table row selection
   // In this example, selected rows are tracked by the repo names from each row. This could be any unique identifier.
   // This is to prevent state from being based on row order index in case we later add sorting.
   const isRepoSelectable = (repo: Repository) => repo.name !== 'a'; // Arbitrary logic for this example
@@ -83,7 +89,7 @@ export const FilterCheckboxSelect: React.FunctionComponent = () => {
       return isSelecting && isRepoSelectable(repo) ? [...otherSelectedRepoNames, repo.name] : otherSelectedRepoNames;
     });
   const selectAllRepos = (isSelecting = true) =>
-    setSelectedRepoNames(isSelecting ? filteredRepos.map(r => r.name) : []);
+    setSelectedRepoNames(isSelecting ? filteredRepos.map(r => r.name) : []); // Selecting all should only select all currently filtered rows
   const areAllReposSelected = selectedRepoNames.length === filteredRepos.length && filteredRepos.length > 0;
   const areSomeReposSelected = selectedRepoNames.length > 0;
   const isRepoSelected = (repo: Repository) => selectedRepoNames.includes(repo.name);
@@ -131,7 +137,7 @@ export const FilterCheckboxSelect: React.FunctionComponent = () => {
   // Set up bulk selection menu
   const bulkSelectMenuRef = React.createRef<HTMLDivElement>();
   const bulkSelectToggleRef = React.createRef<any>();
-  const bulkSelectcontainerRef = React.createRef<HTMLDivElement>();
+  const bulkSelectContainerRef = React.createRef<HTMLDivElement>();
 
   const [isBulkSelectOpen, setIsBulkSelectOpen] = React.useState<boolean>(false);
 
@@ -191,8 +197,8 @@ export const FilterCheckboxSelect: React.FunctionComponent = () => {
       splitButtonOptions={{
         items: [
           <MenuToggleCheckbox
-            id="checkbox-bulk-select"
-            key="checkbox-bulk-select"
+            id="filter-faceted-input-bulk-select"
+            key="filter-faceted-input-bulk-select"
             aria-label="Select all"
             isChecked={menuToggleCheckmark}
             onChange={(checked, _event) => selectAllRepos(checked)}
@@ -206,6 +212,7 @@ export const FilterCheckboxSelect: React.FunctionComponent = () => {
   const bulkSelectMenu = (
     // eslint-disable-next-line no-console
     <Menu
+      id="filter-faceted-input-bulk-select"
       ref={bulkSelectMenuRef}
       onSelect={(_ev, itemId) => {
         selectAllRepos(itemId === 1 || itemId === 2);
@@ -223,24 +230,24 @@ export const FilterCheckboxSelect: React.FunctionComponent = () => {
   );
 
   const toolbarBulkSelect = (
-    <div ref={bulkSelectcontainerRef}>
+    <div ref={bulkSelectContainerRef}>
       <Popper
         trigger={bulkSelectToggle}
         popper={bulkSelectMenu}
-        appendTo={bulkSelectcontainerRef.current || undefined}
+        appendTo={bulkSelectContainerRef.current || undefined}
         isVisible={isBulkSelectOpen}
         popperMatchesTriggerWidth={false}
       />
     </div>
   );
 
-  // Set up checkbox select menu
+  // Set up location checkbox select
   const [isOpen, setIsOpen] = React.useState<boolean>(false);
   const toggleRef = React.useRef<HTMLButtonElement>(null);
   const menuRef = React.useRef<HTMLDivElement>(null);
   const containerRef = React.useRef<HTMLDivElement>(null);
 
-  const handleMenuKeys = (event: KeyboardEvent) => {
+  const handleKeys = (event: KeyboardEvent) => {
     if (isOpen && menuRef.current?.contains(event.target as Node)) {
       if (event.key === 'Escape' || event.key === 'Tab') {
         setIsOpen(!isOpen);
@@ -256,10 +263,10 @@ export const FilterCheckboxSelect: React.FunctionComponent = () => {
   };
 
   React.useEffect(() => {
-    window.addEventListener('keydown', handleMenuKeys);
+    window.addEventListener('keydown', handleKeys);
     window.addEventListener('click', handleClickOutside);
     return () => {
-      window.removeEventListener('keydown', handleMenuKeys);
+      window.removeEventListener('keydown', handleKeys);
       window.removeEventListener('click', handleClickOutside);
     };
   }, [isOpen, menuRef]);
@@ -275,53 +282,94 @@ export const FilterCheckboxSelect: React.FunctionComponent = () => {
     setIsOpen(!isOpen);
   };
 
-  function onSelect(event: React.MouseEvent | undefined, itemId: string | number | undefined) {
+  const onSelect = (event: React.MouseEvent | undefined, itemId: string | number | undefined) => {
     if (typeof itemId === 'undefined') {
       return;
     }
 
     const itemStr = itemId.toString();
-    setSelections(
-      selections.includes(itemStr) ? selections.filter(selection => selection !== itemStr) : [itemStr, ...selections]
-    );
-  }
+    const category = ['Raleigh', 'Boston', 'Brno', 'Westford', 'Bangalore'].includes(itemStr) ? 'location' : 'status';
+
+    if (category === 'status') {
+      setStatusSelections(
+        statusSelections.includes(itemStr)
+          ? statusSelections.filter(selection => selection !== itemStr)
+          : [itemStr, ...statusSelections]
+      );
+    } else {
+      setLocationSelections(
+        locationSelections.includes(itemStr)
+          ? locationSelections.filter(selection => selection !== itemStr)
+          : [itemStr, ...locationSelections]
+      );
+    }
+  };
+
+  const onChipDelete = (category: string, chip: string) => {
+    if (category === 'status') {
+      setStatusSelections(statusSelections.filter(selection => selection !== chip));
+    } else {
+      setLocationSelections(locationSelections.filter(selection => selection !== chip));
+    }
+  };
 
   const toggle = (
     <MenuToggle
       ref={toggleRef}
       onClick={onToggleClick}
       isExpanded={isOpen}
+      {...((locationSelections.length > 0 || statusSelections.length > 0) && {
+        badge: <Badge isRead>{locationSelections.length + statusSelections.length}</Badge>
+      })}
       icon={<FilterIcon />}
-      {...(selections.length > 0 && { badge: <Badge isRead>{selections.length}</Badge> })}
       style={
         {
           width: '200px'
         } as React.CSSProperties
       }
     >
-      Location
+      Filter
     </MenuToggle>
   );
 
   const menu = (
-    <Menu ref={menuRef} id="checkbox-select-menu" onSelect={onSelect} selected={selections}>
+    <Menu ref={menuRef} id="filter-faceted-location-menu" onSelect={onSelect} selected={locationSelections}>
       <MenuContent>
         <MenuList>
-          <MenuItem hasCheck isSelected={selections.includes('Bangalore')} itemId="Bangalore">
-            Bangalore
-          </MenuItem>
-          <MenuItem hasCheck isSelected={selections.includes('Boston')} itemId="Boston">
-            Boston
-          </MenuItem>
-          <MenuItem hasCheck isSelected={selections.includes('Brno')} itemId="Brno">
-            Brno
-          </MenuItem>
-          <MenuItem hasCheck isSelected={selections.includes('Raleigh')} itemId="Raleigh">
-            Raleigh
-          </MenuItem>
-          <MenuItem hasCheck isSelected={selections.includes('Westford')} itemId="Westford">
-            Westford
-          </MenuItem>
+          <MenuGroup label="Status">
+            <MenuItem hasCheck isSelected={statusSelections.includes('Degraded')} itemId="Degraded">
+              Degraded
+            </MenuItem>
+            <MenuItem hasCheck isSelected={statusSelections.includes('Down')} itemId="Down">
+              Down
+            </MenuItem>
+            <MenuItem hasCheck isSelected={statusSelections.includes('Needs Maintenance')} itemId="Needs Maintenance">
+              Needs Maintenance
+            </MenuItem>
+            <MenuItem hasCheck isSelected={statusSelections.includes('Running')} itemId="Running">
+              Running
+            </MenuItem>
+            <MenuItem hasCheck isSelected={statusSelections.includes('Stopped')} itemId="Stopped">
+              Stopped
+            </MenuItem>
+          </MenuGroup>
+          <MenuGroup label="Location">
+            <MenuItem hasCheck isSelected={locationSelections.includes('Bangalore')} itemId="Bangalore">
+              Bangalore
+            </MenuItem>
+            <MenuItem hasCheck isSelected={locationSelections.includes('Boston')} itemId="Boston">
+              Boston
+            </MenuItem>
+            <MenuItem hasCheck isSelected={locationSelections.includes('Brno')} itemId="Brno">
+              Brno
+            </MenuItem>
+            <MenuItem hasCheck isSelected={locationSelections.includes('Raleigh')} itemId="Raleigh">
+              Raleigh
+            </MenuItem>
+            <MenuItem hasCheck isSelected={locationSelections.includes('Westford')} itemId="Westford">
+              Westford
+            </MenuItem>
+          </MenuGroup>
         </MenuList>
       </MenuContent>
     </Menu>
@@ -333,36 +381,72 @@ export const FilterCheckboxSelect: React.FunctionComponent = () => {
     </div>
   );
 
-  // Set up pagination
+  // Set up pagination and toolbar
   const toolbarPagination = (
     <Pagination
-      titles={{ paginationTitle: 'Checkbox filter pagination' }}
+      titles={{ paginationTitle: 'Faceted filter group pagination' }}
       perPageComponent="button"
       itemCount={repositories.length}
       perPage={10}
       page={1}
-      widgetId="checkbox-select-mock-pagination"
+      widgetId="filter-faceted-mock-pagination"
       isCompact
     />
   );
 
   const toolbar = (
-    <Toolbar id="checkbox-filter-toolbar" clearAllFilters={() => setSelections([])}>
+    <Toolbar
+      id="filter-faceted-toolbar"
+      clearAllFilters={() => {
+        setStatusSelections([]);
+        setLocationSelections([]);
+      }}
+    >
       <ToolbarContent>
         <ToolbarItem>{toolbarBulkSelect}</ToolbarItem>
-        <ToolbarGroup variant="filter-group">
+        <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl">
           <ToolbarFilter
-            chips={selections}
-            deleteChip={(category, chip) => onSelect(undefined, chip as string)}
-            deleteChipGroup={() => setSelections([])}
+            chips={statusSelections}
+            deleteChip={(category, chip) => onChipDelete(category as string, chip as string)}
+            deleteChipGroup={() => setStatusSelections([])}
+            categoryName="Status"
+            showToolbarItem={false}
+          >
+            <div />
+          </ToolbarFilter>
+          <ToolbarFilter
+            chips={locationSelections}
+            deleteChip={(category, chip) => onChipDelete(category as string, chip as string)}
+            deleteChipGroup={() => setLocationSelections([])}
             categoryName="Location"
           >
             {select}
           </ToolbarFilter>
-        </ToolbarGroup>
+        </ToolbarToggleGroup>
         <ToolbarItem variant="pagination">{toolbarPagination}</ToolbarItem>
       </ToolbarContent>
     </Toolbar>
+  );
+
+  const emptyState = (
+    <EmptyState>
+      <EmptyStateIcon icon={SearchIcon} />
+      <Title size="lg" headingLevel="h4">
+        No results found
+      </Title>
+      <EmptyStateBody>No results match the filter criteria. Clear all filters and try again.</EmptyStateBody>
+      <EmptyStatePrimary>
+        <Button
+          variant="link"
+          onClick={() => {
+            setStatusSelections([]);
+            setLocationSelections([]);
+          }}
+        >
+          Clear all filters
+        </Button>
+      </EmptyStatePrimary>
+    </EmptyState>
   );
 
   return (
@@ -381,36 +465,44 @@ export const FilterCheckboxSelect: React.FunctionComponent = () => {
           </Tr>
         </Thead>
         <Tbody>
-          {filteredRepos.map((repo, rowIndex) => (
-            <Tr key={repo.name}>
-              <Td
-                select={{
-                  rowIndex,
-                  onSelect: (_event, isSelecting) => onSelectRepo(repo, rowIndex, isSelecting),
-                  isSelected: isRepoSelected(repo),
-                  disable: !isRepoSelectable(repo)
-                }}
-              />
-              <Td dataLabel={columnNames.name} modifier="truncate">
-                {repo.name}
-              </Td>
-              <Td dataLabel={columnNames.threads} modifier="truncate">
-                {repo.threads}
-              </Td>
-              <Td dataLabel={columnNames.apps} modifier="truncate">
-                {repo.apps}
-              </Td>
-              <Td dataLabel={columnNames.workspaces} modifier="truncate">
-                {repo.workspaces}
-              </Td>
-              <Td dataLabel={columnNames.status} modifier="truncate">
-                {repo.status}
-              </Td>
-              <Td dataLabel={columnNames.location} modifier="truncate">
-                {repo.location}
+          {filteredRepos.length > 0 &&
+            filteredRepos.map((repo, rowIndex) => (
+              <Tr key={repo.name}>
+                <Td
+                  select={{
+                    rowIndex,
+                    onSelect: (_event, isSelecting) => onSelectRepo(repo, rowIndex, isSelecting),
+                    isSelected: isRepoSelected(repo),
+                    disable: !isRepoSelectable(repo)
+                  }}
+                />
+                <Td dataLabel={columnNames.name} modifier="truncate">
+                  {repo.name}
+                </Td>
+                <Td dataLabel={columnNames.threads} modifier="truncate">
+                  {repo.threads}
+                </Td>
+                <Td dataLabel={columnNames.apps} modifier="truncate">
+                  {repo.apps}
+                </Td>
+                <Td dataLabel={columnNames.workspaces} modifier="truncate">
+                  {repo.workspaces}
+                </Td>
+                <Td dataLabel={columnNames.status} modifier="truncate">
+                  {repo.status}
+                </Td>
+                <Td dataLabel={columnNames.location} modifier="truncate">
+                  {repo.location}
+                </Td>
+              </Tr>
+            ))}
+          {filteredRepos.length === 0 && (
+            <Tr>
+              <Td colSpan={8}>
+                <Bullseye>{emptyState}</Bullseye>
               </Td>
             </Tr>
-          ))}
+          )}
         </Tbody>
       </TableComposable>
     </React.Fragment>

--- a/packages/react-core/src/demos/Filters/examples/FilterMixedSelectGroup.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterMixedSelectGroup.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {
-  SearchInput,
   Toolbar,
   ToolbarContent,
   ToolbarItem,
@@ -18,10 +17,14 @@ import {
   EmptyStateBody,
   EmptyStatePrimary,
   Button,
-  Bullseye
+  Bullseye,
+  Badge,
+  ToolbarFilter,
+  ToolbarToggleGroup
 } from '@patternfly/react-core';
 import { TableComposable, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
+import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 
 interface Repository {
   name: string;
@@ -56,26 +59,19 @@ const columnNames = {
 };
 
 /* eslint-disable patternfly-react/no-anonymous-functions */
-export const FilterSearchInput: React.FunctionComponent = () => {
+export const FilterMixedSelectGroup: React.FunctionComponent = () => {
   // Set up repo filtering
-  const [searchValue, setSearchValue] = React.useState('');
-
-  const onSearchChange = (value: string) => {
-    setSearchValue(value);
-  };
+  const [locationSelections, setLocationSelections] = React.useState<string[]>([]);
+  const [statusSelection, setStatusSelection] = React.useState('');
 
   const onFilter = (repo: Repository) => {
-    if (searchValue === '') {
-      return true;
-    }
+    // Search status with status selection
+    const matchesStatusValue = repo.status.toLowerCase() === statusSelection.toLowerCase();
 
-    let input: RegExp;
-    try {
-      input = new RegExp(searchValue, 'i');
-    } catch (err) {
-      input = new RegExp(searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
-    }
-    return repo.name.search(input) >= 0;
+    // Search location with location selections
+    const matchesLocationValue = locationSelections.includes(repo.location);
+
+    return (statusSelection === '' || matchesStatusValue) && (locationSelections.length === 0 || matchesLocationValue);
   };
   const filteredRepos = repositories.filter(onFilter);
 
@@ -138,7 +134,7 @@ export const FilterSearchInput: React.FunctionComponent = () => {
   // Set up bulk selection menu
   const bulkSelectMenuRef = React.createRef<HTMLDivElement>();
   const bulkSelectToggleRef = React.createRef<any>();
-  const containerRef = React.createRef<HTMLDivElement>();
+  const bulkSelectContainerRef = React.createRef<HTMLDivElement>();
 
   const [isBulkSelectOpen, setIsBulkSelectOpen] = React.useState<boolean>(false);
 
@@ -198,8 +194,8 @@ export const FilterSearchInput: React.FunctionComponent = () => {
       splitButtonOptions={{
         items: [
           <MenuToggleCheckbox
-            id="search-input-bulk-select"
-            key="search-input-bulk-select"
+            id="mixed-group-input-bulk-select"
+            key="mixed-group-input-bulk-select"
             aria-label="Select all"
             isChecked={menuToggleCheckmark}
             onChange={(checked, _event) => selectAllRepos(checked)}
@@ -213,7 +209,7 @@ export const FilterSearchInput: React.FunctionComponent = () => {
   const bulkSelectMenu = (
     // eslint-disable-next-line no-console
     <Menu
-      id="search-input-bulk-select"
+      id="mixed-group-input-bulk-select"
       ref={bulkSelectMenuRef}
       onSelect={(_ev, itemId) => {
         selectAllRepos(itemId === 1 || itemId === 2);
@@ -231,43 +227,261 @@ export const FilterSearchInput: React.FunctionComponent = () => {
   );
 
   const toolbarBulkSelect = (
-    <div ref={containerRef}>
+    <div ref={bulkSelectContainerRef}>
       <Popper
         trigger={bulkSelectToggle}
         popper={bulkSelectMenu}
-        appendTo={containerRef.current || undefined}
+        appendTo={bulkSelectContainerRef.current || undefined}
         isVisible={isBulkSelectOpen}
         popperMatchesTriggerWidth={false}
       />
     </div>
   );
 
-  const searchInput = (
-    <SearchInput
-      placeholder="Filter by server name"
-      value={searchValue}
-      onChange={onSearchChange}
-      onClear={() => onSearchChange('')}
-    />
+  // Set up status single select
+  const [isStatusMenuOpen, setIsStatusMenuOpen] = React.useState<boolean>(false);
+  const statusToggleRef = React.useRef<HTMLButtonElement>(null);
+  const statusMenuRef = React.useRef<HTMLDivElement>(null);
+  const statusContainerRef = React.useRef<HTMLDivElement>(null);
+
+  const handleStatusMenuKeys = (event: KeyboardEvent) => {
+    if (isStatusMenuOpen && statusMenuRef.current?.contains(event.target as Node)) {
+      if (event.key === 'Escape' || event.key === 'Tab') {
+        setIsStatusMenuOpen(!isStatusMenuOpen);
+        statusToggleRef.current?.focus();
+      }
+    }
+  };
+
+  const handleStatusClickOutside = (event: MouseEvent) => {
+    if (isStatusMenuOpen && !statusMenuRef.current?.contains(event.target as Node)) {
+      setIsStatusMenuOpen(false);
+    }
+  };
+
+  React.useEffect(() => {
+    window.addEventListener('keydown', handleStatusMenuKeys);
+    window.addEventListener('click', handleStatusClickOutside);
+    return () => {
+      window.removeEventListener('keydown', handleStatusMenuKeys);
+      window.removeEventListener('click', handleStatusClickOutside);
+    };
+  }, [isStatusMenuOpen, statusMenuRef]);
+
+  const onStatusToggleClick = (ev: React.MouseEvent) => {
+    ev.stopPropagation(); // Stop handleClickOutside from handling
+    setTimeout(() => {
+      if (statusMenuRef.current) {
+        const firstElement = statusMenuRef.current.querySelector('li > button:not(:disabled)');
+        firstElement && (firstElement as HTMLElement).focus();
+      }
+    }, 0);
+    setIsStatusMenuOpen(!isStatusMenuOpen);
+  };
+
+  function onStatusSelect(event: React.MouseEvent | undefined, itemId: string | number | undefined) {
+    if (typeof itemId === 'undefined') {
+      return;
+    }
+
+    setStatusSelection(itemId.toString());
+    setIsStatusMenuOpen(!isStatusMenuOpen);
+  }
+
+  const statusToggle = (
+    <MenuToggle
+      ref={statusToggleRef}
+      onClick={onStatusToggleClick}
+      isExpanded={isStatusMenuOpen}
+      icon={<FilterIcon />}
+      style={
+        {
+          width: '200px'
+        } as React.CSSProperties
+      }
+    >
+      Status
+    </MenuToggle>
   );
 
+  const statusMenu = (
+    <Menu ref={statusMenuRef} id="mixed-group-status-menu" onSelect={onStatusSelect} selected={statusSelection}>
+      <MenuContent>
+        <MenuList>
+          <MenuItem itemId="Degraded">Degraded</MenuItem>
+          <MenuItem itemId="Down">Down</MenuItem>
+          <MenuItem itemId="Needs maintenance">Needs maintenance</MenuItem>
+          <MenuItem itemId="Running">Running</MenuItem>
+          <MenuItem itemId="Stopped">Stopped</MenuItem>
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+
+  const statusSelect = (
+    <div ref={statusContainerRef}>
+      <Popper
+        trigger={statusToggle}
+        popper={statusMenu}
+        appendTo={statusContainerRef.current || undefined}
+        isVisible={isStatusMenuOpen}
+      />
+    </div>
+  );
+
+  // Set up location checkbox select
+  const [isLocationMenuOpen, setIsLocationMenuOpen] = React.useState<boolean>(false);
+  const locationToggleRef = React.useRef<HTMLButtonElement>(null);
+  const locationMenuRef = React.useRef<HTMLDivElement>(null);
+  const locationContainerRef = React.useRef<HTMLDivElement>(null);
+
+  const handleLocationMenuKeys = (event: KeyboardEvent) => {
+    if (isLocationMenuOpen && locationMenuRef.current?.contains(event.target as Node)) {
+      if (event.key === 'Escape' || event.key === 'Tab') {
+        setIsLocationMenuOpen(!isLocationMenuOpen);
+        locationToggleRef.current?.focus();
+      }
+    }
+  };
+
+  const handleLocationClickOutside = (event: MouseEvent) => {
+    if (isLocationMenuOpen && !locationMenuRef.current?.contains(event.target as Node)) {
+      setIsLocationMenuOpen(false);
+    }
+  };
+
+  React.useEffect(() => {
+    window.addEventListener('keydown', handleLocationMenuKeys);
+    window.addEventListener('click', handleLocationClickOutside);
+    return () => {
+      window.removeEventListener('keydown', handleLocationMenuKeys);
+      window.removeEventListener('click', handleLocationClickOutside);
+    };
+  }, [isLocationMenuOpen, locationMenuRef]);
+
+  const onLocationMenuToggleClick = (ev: React.MouseEvent) => {
+    ev.stopPropagation(); // Stop handleClickOutside from handling
+    setTimeout(() => {
+      if (locationMenuRef.current) {
+        const firstElement = locationMenuRef.current.querySelector('li > button:not(:disabled)');
+        firstElement && (firstElement as HTMLElement).focus();
+      }
+    }, 0);
+    setIsLocationMenuOpen(!isLocationMenuOpen);
+  };
+
+  function onLocationMenuSelect(event: React.MouseEvent | undefined, itemId: string | number | undefined) {
+    if (typeof itemId === 'undefined') {
+      return;
+    }
+
+    const itemStr = itemId.toString();
+
+    setLocationSelections(
+      locationSelections.includes(itemStr)
+        ? locationSelections.filter(selection => selection !== itemStr)
+        : [itemStr, ...locationSelections]
+    );
+  }
+
+  const locationToggle = (
+    <MenuToggle
+      ref={locationToggleRef}
+      onClick={onLocationMenuToggleClick}
+      isExpanded={isLocationMenuOpen}
+      {...(locationSelections.length > 0 && { badge: <Badge isRead>{locationSelections.length}</Badge> })}
+      icon={<FilterIcon />}
+      style={
+        {
+          width: '200px'
+        } as React.CSSProperties
+      }
+    >
+      Location
+    </MenuToggle>
+  );
+
+  const locationMenu = (
+    <Menu
+      ref={locationMenuRef}
+      id="mixed-group-location-menu"
+      onSelect={onLocationMenuSelect}
+      selected={locationSelections}
+    >
+      <MenuContent>
+        <MenuList>
+          <MenuItem hasCheck isSelected={locationSelections.includes('Bangalore')} itemId="Bangalore">
+            Bangalore
+          </MenuItem>
+          <MenuItem hasCheck isSelected={locationSelections.includes('Boston')} itemId="Boston">
+            Boston
+          </MenuItem>
+          <MenuItem hasCheck isSelected={locationSelections.includes('Brno')} itemId="Brno">
+            Brno
+          </MenuItem>
+          <MenuItem hasCheck isSelected={locationSelections.includes('Raleigh')} itemId="Raleigh">
+            Raleigh
+          </MenuItem>
+          <MenuItem hasCheck isSelected={locationSelections.includes('Westford')} itemId="Westford">
+            Westford
+          </MenuItem>
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+
+  const locationSelect = (
+    <div ref={locationContainerRef}>
+      <Popper
+        trigger={locationToggle}
+        popper={locationMenu}
+        appendTo={locationContainerRef.current || undefined}
+        isVisible={isLocationMenuOpen}
+      />
+    </div>
+  );
+
+  // Set up pagination and toolbar
   const toolbarPagination = (
     <Pagination
-      titles={{ paginationTitle: 'Search filter pagination' }}
+      titles={{ paginationTitle: 'Mixed filter group pagination' }}
       perPageComponent="button"
       itemCount={repositories.length}
       perPage={10}
       page={1}
-      widgetId="search-input-mock-pagination"
+      widgetId="mixed-group-mock-pagination"
       isCompact
     />
   );
 
   const toolbar = (
-    <Toolbar id="search-input-filter-toolbar">
+    <Toolbar
+      id="mixed-group-toolbar"
+      clearAllFilters={() => {
+        setStatusSelection('');
+        setLocationSelections([]);
+      }}
+    >
       <ToolbarContent>
         <ToolbarItem>{toolbarBulkSelect}</ToolbarItem>
-        <ToolbarItem variant="search-filter">{searchInput}</ToolbarItem>
+        <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl">
+          <ToolbarFilter
+            chips={statusSelection !== '' ? [statusSelection] : ([] as string[])}
+            deleteChip={() => setStatusSelection('')}
+            deleteChipGroup={() => setStatusSelection('')}
+            categoryName="Status"
+          >
+            {statusSelect}
+          </ToolbarFilter>
+          <ToolbarFilter
+            chips={locationSelections}
+            deleteChip={(category, chip) => onLocationMenuSelect(undefined, chip as string)}
+            deleteChipGroup={() => setLocationSelections([])}
+            categoryName="Location"
+          >
+            {locationSelect}
+          </ToolbarFilter>
+        </ToolbarToggleGroup>
         <ToolbarItem variant="pagination">{toolbarPagination}</ToolbarItem>
       </ToolbarContent>
     </Toolbar>
@@ -284,7 +498,8 @@ export const FilterSearchInput: React.FunctionComponent = () => {
         <Button
           variant="link"
           onClick={() => {
-            setSearchValue('');
+            setStatusSelection('');
+            setLocationSelections([]);
           }}
         >
           Clear all filters

--- a/packages/react-core/src/demos/Filters/examples/FilterMixedSelectGroup.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterMixedSelectGroup.tsx
@@ -132,9 +132,9 @@ export const FilterMixedSelectGroup: React.FunctionComponent = () => {
   }, []);
 
   // Set up bulk selection menu
-  const bulkSelectMenuRef = React.createRef<HTMLDivElement>();
-  const bulkSelectToggleRef = React.createRef<any>();
-  const bulkSelectContainerRef = React.createRef<HTMLDivElement>();
+  const bulkSelectMenuRef = React.useRef<HTMLDivElement>(null);
+  const bulkSelectToggleRef = React.useRef<any>(null);
+  const bulkSelectContainerRef = React.useRef<HTMLDivElement>(null);
 
   const [isBulkSelectOpen, setIsBulkSelectOpen] = React.useState<boolean>(false);
 
@@ -154,7 +154,7 @@ export const FilterMixedSelectGroup: React.FunctionComponent = () => {
     ) {
       if (event.key === 'Escape' || event.key === 'Tab') {
         setIsBulkSelectOpen(!isBulkSelectOpen);
-        bulkSelectToggleRef.current?.focus();
+        bulkSelectToggleRef.current?.querySelector('button').focus();
       }
     }
   };
@@ -207,13 +207,13 @@ export const FilterMixedSelectGroup: React.FunctionComponent = () => {
   );
 
   const bulkSelectMenu = (
-    // eslint-disable-next-line no-console
     <Menu
       id="mixed-group-input-bulk-select"
       ref={bulkSelectMenuRef}
       onSelect={(_ev, itemId) => {
         selectAllRepos(itemId === 1 || itemId === 2);
         setIsBulkSelectOpen(!isBulkSelectOpen);
+        bulkSelectToggleRef.current?.querySelector('button').focus();
       }}
     >
       <MenuContent>

--- a/packages/react-core/src/demos/Filters/examples/FilterSameSelectGroup.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterSameSelectGroup.tsx
@@ -133,9 +133,9 @@ export const FilterSameSelectGroup: React.FunctionComponent = () => {
   }, []);
 
   // Set up bulk selection menu
-  const bulkSelectMenuRef = React.createRef<HTMLDivElement>();
-  const bulkSelectToggleRef = React.createRef<any>();
-  const bulkSelectContainerRef = React.createRef<HTMLDivElement>();
+  const bulkSelectMenuRef = React.useRef<HTMLDivElement>(null);
+  const bulkSelectToggleRef = React.useRef<any>(null);
+  const bulkSelectContainerRef = React.useRef<HTMLDivElement>(null);
 
   const [isBulkSelectOpen, setIsBulkSelectOpen] = React.useState<boolean>(false);
 
@@ -155,7 +155,7 @@ export const FilterSameSelectGroup: React.FunctionComponent = () => {
     ) {
       if (event.key === 'Escape' || event.key === 'Tab') {
         setIsBulkSelectOpen(!isBulkSelectOpen);
-        bulkSelectToggleRef.current?.focus();
+        bulkSelectToggleRef.current?.querySelector('button').focus();
       }
     }
   };
@@ -208,13 +208,13 @@ export const FilterSameSelectGroup: React.FunctionComponent = () => {
   );
 
   const bulkSelectMenu = (
-    // eslint-disable-next-line no-console
     <Menu
       id="same-select-group-input-bulk-select"
       ref={bulkSelectMenuRef}
       onSelect={(_ev, itemId) => {
         selectAllRepos(itemId === 1 || itemId === 2);
         setIsBulkSelectOpen(!isBulkSelectOpen);
+        bulkSelectToggleRef.current?.querySelector('button').focus();
       }}
     >
       <MenuContent>

--- a/packages/react-core/src/demos/Filters/examples/FilterSearchInput.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterSearchInput.tsx
@@ -136,9 +136,9 @@ export const FilterSearchInput: React.FunctionComponent = () => {
   }, []);
 
   // Set up bulk selection menu
-  const bulkSelectMenuRef = React.createRef<HTMLDivElement>();
-  const bulkSelectToggleRef = React.createRef<any>();
-  const containerRef = React.createRef<HTMLDivElement>();
+  const bulkSelectMenuRef = React.useRef<HTMLDivElement>(null);
+  const bulkSelectToggleRef = React.useRef<any>(null);
+  const bulkSelectContainerRef = React.useRef<HTMLDivElement>(null);
 
   const [isBulkSelectOpen, setIsBulkSelectOpen] = React.useState<boolean>(false);
 
@@ -158,7 +158,7 @@ export const FilterSearchInput: React.FunctionComponent = () => {
     ) {
       if (event.key === 'Escape' || event.key === 'Tab') {
         setIsBulkSelectOpen(!isBulkSelectOpen);
-        bulkSelectToggleRef.current?.focus();
+        bulkSelectToggleRef.current?.querySelector('button').focus();
       }
     }
   };
@@ -211,13 +211,13 @@ export const FilterSearchInput: React.FunctionComponent = () => {
   );
 
   const bulkSelectMenu = (
-    // eslint-disable-next-line no-console
     <Menu
       id="search-input-bulk-select"
       ref={bulkSelectMenuRef}
       onSelect={(_ev, itemId) => {
         selectAllRepos(itemId === 1 || itemId === 2);
         setIsBulkSelectOpen(!isBulkSelectOpen);
+        bulkSelectToggleRef.current?.querySelector('button').focus();
       }}
     >
       <MenuContent>
@@ -231,11 +231,11 @@ export const FilterSearchInput: React.FunctionComponent = () => {
   );
 
   const toolbarBulkSelect = (
-    <div ref={containerRef}>
+    <div ref={bulkSelectContainerRef}>
       <Popper
         trigger={bulkSelectToggle}
         popper={bulkSelectMenu}
-        appendTo={containerRef.current || undefined}
+        appendTo={bulkSelectContainerRef.current || undefined}
         isVisible={isBulkSelectOpen}
         popperMatchesTriggerWidth={false}
       />

--- a/packages/react-core/src/demos/Filters/examples/FilterSingleSelect.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterSingleSelect.tsx
@@ -124,9 +124,9 @@ export const FilterSingleSelect: React.FunctionComponent = () => {
   }, []);
 
   // Set up bulk selection menu
-  const bulkSelectMenuRef = React.createRef<HTMLDivElement>();
-  const bulkSelectToggleRef = React.createRef<any>();
-  const bulkSelectcontainerRef = React.createRef<HTMLDivElement>();
+  const bulkSelectMenuRef = React.useRef<HTMLDivElement>(null);
+  const bulkSelectToggleRef = React.useRef<any>(null);
+  const bulkSelectContainerRef = React.useRef<HTMLDivElement>(null);
 
   const [isBulkSelectOpen, setIsBulkSelectOpen] = React.useState<boolean>(false);
 
@@ -146,7 +146,7 @@ export const FilterSingleSelect: React.FunctionComponent = () => {
     ) {
       if (event.key === 'Escape' || event.key === 'Tab') {
         setIsBulkSelectOpen(!isBulkSelectOpen);
-        bulkSelectToggleRef.current?.focus();
+        bulkSelectToggleRef.current?.querySelector('button').focus();
       }
     }
   };
@@ -199,12 +199,12 @@ export const FilterSingleSelect: React.FunctionComponent = () => {
   );
 
   const bulkSelectMenu = (
-    // eslint-disable-next-line no-console
     <Menu
       ref={bulkSelectMenuRef}
       onSelect={(_ev, itemId) => {
         selectAllRepos(itemId === 1 || itemId === 2);
         setIsBulkSelectOpen(!isBulkSelectOpen);
+        bulkSelectToggleRef.current?.querySelector('button').focus();
       }}
     >
       <MenuContent>
@@ -218,11 +218,11 @@ export const FilterSingleSelect: React.FunctionComponent = () => {
   );
 
   const toolbarBulkSelect = (
-    <div ref={bulkSelectcontainerRef}>
+    <div ref={bulkSelectContainerRef}>
       <Popper
         trigger={bulkSelectToggle}
         popper={bulkSelectMenu}
-        appendTo={bulkSelectcontainerRef.current || undefined}
+        appendTo={bulkSelectContainerRef.current || undefined}
         isVisible={isBulkSelectOpen}
         popperMatchesTriggerWidth={false}
       />

--- a/packages/react-core/src/demos/Filters/examples/FilterSingleSelect.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterSingleSelect.tsx
@@ -29,7 +29,7 @@ const repositories: Repository[] = [
   { name: 'US-Node 1', threads: '5', apps: '25', workspaces: '5', status: 'Stopped', location: 'Raleigh' },
   { name: 'US-Node 2', threads: '5', apps: '30', workspaces: '2', status: 'Down', location: 'Westford' },
   { name: 'US-Node 3', threads: '13', apps: '35', workspaces: '12', status: 'Degraded', location: 'Boston' },
-  { name: 'US-Node 4', threads: '2', apps: '5', workspaces: '18', status: 'Needs Maintainence', location: 'Raleigh' },
+  { name: 'US-Node 4', threads: '2', apps: '5', workspaces: '18', status: 'Needs Maintenance', location: 'Raleigh' },
   { name: 'US-Node 5', threads: '7', apps: '30', workspaces: '5', status: 'Running', location: 'Boston' },
   { name: 'US-Node 6', threads: '5', apps: '20', workspaces: '15', status: 'Stopped', location: 'Raleigh' },
   { name: 'CZ-Node 1', threads: '12', apps: '48', workspaces: '13', status: 'Down', location: 'Brno' },
@@ -49,12 +49,28 @@ const columnNames = {
 
 /* eslint-disable patternfly-react/no-anonymous-functions */
 export const FilterSingleSelect: React.FunctionComponent = () => {
-  // Set up table selection
-  const isRepoSelectable = (repo: Repository) => repo.name !== 'a'; // Arbitrary logic for this example
-  const selectableRepos = repositories.filter(isRepoSelectable);
+  // Set up repo filtering
+  const [searchValue, setSearchValue] = React.useState('');
+  const onFilter = (repo: Repository) => {
+    if (searchValue === 'all') {
+      return true;
+    }
 
+    let input: RegExp;
+    try {
+      input = new RegExp(searchValue, 'i');
+    } catch (err) {
+      input = new RegExp(searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+    }
+    return repo.status.search(input) >= 0;
+  };
+
+  const filteredRepos = repositories.filter(onFilter);
+
+  // Set up table selection
   // In this example, selected rows are tracked by the repo names from each row. This could be any unique identifier.
   // This is to prevent state from being based on row order index in case we later add sorting.
+  const isRepoSelectable = (repo: Repository) => repo.name !== 'a'; // Arbitrary logic for this example
   const [selectedRepoNames, setSelectedRepoNames] = React.useState<string[]>([]);
   const setRepoSelected = (repo: Repository, isSelecting = true) =>
     setSelectedRepoNames(prevSelected => {
@@ -62,8 +78,8 @@ export const FilterSingleSelect: React.FunctionComponent = () => {
       return isSelecting && isRepoSelectable(repo) ? [...otherSelectedRepoNames, repo.name] : otherSelectedRepoNames;
     });
   const selectAllRepos = (isSelecting = true) =>
-    setSelectedRepoNames(isSelecting ? selectableRepos.map(r => r.name) : []);
-  const areAllReposSelected = selectedRepoNames.length === selectableRepos.length;
+    setSelectedRepoNames(isSelecting ? filteredRepos.map(r => r.name) : []);
+  const areAllReposSelected = selectedRepoNames.length === filteredRepos.length && filteredRepos.length > 0;
   const areSomeReposSelected = selectedRepoNames.length > 0;
   const isRepoSelected = (repo: Repository) => selectedRepoNames.includes(repo.name);
 
@@ -114,15 +130,6 @@ export const FilterSingleSelect: React.FunctionComponent = () => {
 
   const [isBulkSelectOpen, setIsBulkSelectOpen] = React.useState<boolean>(false);
 
-  React.useEffect(() => {
-    window.addEventListener('keydown', handleBulkSelectMenuKeys);
-    window.addEventListener('click', handleBulkSelectClickOutside);
-    return () => {
-      window.removeEventListener('keydown', handleBulkSelectMenuKeys);
-      window.removeEventListener('click', handleBulkSelectClickOutside);
-    };
-  }, [isBulkSelectOpen, bulkSelectMenuRef]);
-
   const handleBulkSelectClickOutside = (event: MouseEvent) => {
     if (isBulkSelectOpen && !bulkSelectMenuRef.current?.contains(event.target as Node)) {
       setIsBulkSelectOpen(false);
@@ -143,6 +150,15 @@ export const FilterSingleSelect: React.FunctionComponent = () => {
       }
     }
   };
+
+  React.useEffect(() => {
+    window.addEventListener('keydown', handleBulkSelectMenuKeys);
+    window.addEventListener('click', handleBulkSelectClickOutside);
+    return () => {
+      window.removeEventListener('keydown', handleBulkSelectMenuKeys);
+      window.removeEventListener('click', handleBulkSelectClickOutside);
+    };
+  }, [isBulkSelectOpen, bulkSelectMenuRef]);
 
   const onBulkSelectToggleClick = (ev: React.MouseEvent) => {
     ev.stopPropagation(); // Stop handleClickOutside from handling
@@ -170,8 +186,8 @@ export const FilterSingleSelect: React.FunctionComponent = () => {
       splitButtonOptions={{
         items: [
           <MenuToggleCheckbox
-            id="select-checkbox"
-            key="select-checkbox"
+            id="single-bulk-select"
+            key="single-bulk-select"
             aria-label="Select all"
             isChecked={menuToggleCheckmark}
             onChange={(checked, _event) => selectAllRepos(checked)}
@@ -212,23 +228,6 @@ export const FilterSingleSelect: React.FunctionComponent = () => {
       />
     </div>
   );
-
-  // Set up table filtering
-  const [searchValue, setSearchValue] = React.useState('');
-
-  const onFilter = (repo: Repository) => {
-    if (searchValue === 'all') {
-      return true;
-    }
-
-    let input: RegExp;
-    try {
-      input = new RegExp(searchValue, 'i');
-    } catch (err) {
-      input = new RegExp(searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
-    }
-    return repo.status.search(input) >= 0;
-  };
 
   // Set up single select menu & state
   const [isOpen, setIsOpen] = React.useState<boolean>(false);
@@ -308,7 +307,7 @@ export const FilterSingleSelect: React.FunctionComponent = () => {
   );
 
   const menu = (
-    <Menu ref={menuRef} id="select-menu" onSelect={onSelect} selected={menuSelection}>
+    <Menu ref={menuRef} id="single-select-menu" onSelect={onSelect} selected={menuSelection}>
       <MenuContent>
         <MenuList>
           <MenuItem itemId="all">All statuses</MenuItem>
@@ -359,15 +358,15 @@ export const FilterSingleSelect: React.FunctionComponent = () => {
           <Tr>
             <Th />
             <Th width={20}>{columnNames.name}</Th>
-            <Th width={20}>{columnNames.threads}</Th>
-            <Th width={20}>{columnNames.apps}</Th>
-            <Th width={20}>{columnNames.workspaces}</Th>
+            <Th width={10}>{columnNames.threads}</Th>
+            <Th width={10}>{columnNames.apps}</Th>
+            <Th width={10}>{columnNames.workspaces}</Th>
             <Th width={20}>{columnNames.status}</Th>
             <Th width={20}>{columnNames.location}</Th>
           </Tr>
         </Thead>
         <Tbody>
-          {repositories.filter(onFilter).map((repo, rowIndex) => (
+          {filteredRepos.map((repo, rowIndex) => (
             <Tr key={repo.name}>
               <Td
                 select={{
@@ -377,12 +376,24 @@ export const FilterSingleSelect: React.FunctionComponent = () => {
                   disable: !isRepoSelectable(repo)
                 }}
               />
-              <Td dataLabel={columnNames.name}>{repo.name}</Td>
-              <Td dataLabel={columnNames.threads}>{repo.threads}</Td>
-              <Td dataLabel={columnNames.apps}>{repo.apps}</Td>
-              <Td dataLabel={columnNames.workspaces}>{repo.workspaces}</Td>
-              <Td dataLabel={columnNames.status}>{repo.status}</Td>
-              <Td dataLabel={columnNames.location}>{repo.location}</Td>
+              <Td dataLabel={columnNames.name} modifier="truncate">
+                {repo.name}
+              </Td>
+              <Td dataLabel={columnNames.threads} modifier="truncate">
+                {repo.threads}
+              </Td>
+              <Td dataLabel={columnNames.apps} modifier="truncate">
+                {repo.apps}
+              </Td>
+              <Td dataLabel={columnNames.workspaces} modifier="truncate">
+                {repo.workspaces}
+              </Td>
+              <Td dataLabel={columnNames.status} modifier="truncate">
+                {repo.status}
+              </Td>
+              <Td dataLabel={columnNames.location} modifier="truncate">
+                {repo.location}
+              </Td>
             </Tr>
           ))}
         </Tbody>

--- a/packages/react-table/src/components/TableComposable/Td.tsx
+++ b/packages/react-table/src/components/TableComposable/Td.tsx
@@ -251,8 +251,8 @@ const TdBase: React.FunctionComponent<TdProps> = ({
     </MergedComponent>
   );
 
-  const canDefault = tooltip === '' ? typeof children === 'string' : true;
-  return tooltip !== null && canDefault && showTooltip ? (
+  const canMakeDefaultTooltip = tooltip === '' ? typeof children === 'string' : true;
+  return tooltip !== null && canMakeDefaultTooltip && showTooltip ? (
     <Tooltip content={tooltip || (tooltip === '' && children)} isVisible>
       {cell}
     </Tooltip>

--- a/packages/react-table/src/components/TableComposable/Td.tsx
+++ b/packages/react-table/src/components/TableComposable/Td.tsx
@@ -49,10 +49,10 @@ export interface TdProps extends BaseCellProps, Omit<React.HTMLProps<HTMLTableDa
   /** Applies pf-c-table__action to td */
   isActionCell?: boolean;
   /**
-   * Tooltip to show on the body cell
-   * Note: If the body cell is truncated and has simple string content, it will already attempt to display the cell text
-   * If you want to show a tooltip that differs from the cell text, you can set it here
-   * To disable it completely you can set it to null
+   * Tooltip to show on the body cell.
+   * Note: If the body cell is truncated and has simple string content, it will already attempt to display the cell text.
+   * If you want to show a tooltip that differs from the cell text, you can set it here.
+   * To disable it completely you can set it to null.
    */
   tooltip?: React.ReactNode;
   /** Callback on mouse enter */

--- a/packages/react-table/src/components/TableComposable/Td.tsx
+++ b/packages/react-table/src/components/TableComposable/Td.tsx
@@ -13,6 +13,7 @@ import { draggable } from '../Table/utils/decorators/draggable';
 import { treeRow } from '../Table/utils/decorators/treeRow';
 import { mergeProps } from '../Table/base/merge-props';
 import { IVisibility } from '../Table/utils/decorators/classNames';
+import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip/Tooltip';
 import { IFormatterValueType, IExtra } from '../Table/TableTypes';
 import {
   TdActionsType,
@@ -47,6 +48,15 @@ export interface TdProps extends BaseCellProps, Omit<React.HTMLProps<HTMLTableDa
   noPadding?: boolean;
   /** Applies pf-c-table__action to td */
   isActionCell?: boolean;
+  /**
+   * Tooltip to show on the body cell
+   * Note: If the body cell is truncated and has simple string content, it will already attempt to display the cell text
+   * If you want to show a tooltip that differs from the cell text, you can set it here
+   * To disable it completely you can set it to null
+   */
+  tooltip?: React.ReactNode;
+  /** Callback on mouse enter */
+  onMouseEnter?: (event: any) => void;
 }
 
 const TdBase: React.FunctionComponent<TdProps> = ({
@@ -68,8 +78,20 @@ const TdBase: React.FunctionComponent<TdProps> = ({
   innerRef,
   favorites = null,
   draggableRow: draggableRowProp = null,
+  tooltip = '',
+  onMouseEnter: onMouseEnterProp = () => {},
   ...props
 }: TdProps) => {
+  const [showTooltip, setShowTooltip] = React.useState(false);
+  const onMouseEnter = (event: any) => {
+    if (event.target.offsetWidth < event.target.scrollWidth) {
+      !showTooltip && setShowTooltip(true);
+    } else {
+      showTooltip && setShowTooltip(false);
+    }
+    onMouseEnterProp(event);
+  };
+
   const selectParams = select
     ? selectable(children as IFormatterValueType, {
         rowIndex: select.rowIndex,
@@ -208,9 +230,10 @@ const TdBase: React.FunctionComponent<TdProps> = ({
     (className && className.includes('pf-c-table__tree-view-title-cell')) ||
     (mergedClassName && mergedClassName.includes('pf-c-table__tree-view-title-cell'));
 
-  return (
+  const cell = (
     <MergedComponent
       {...(!treeTableTitleCell && { 'data-label': dataLabel })}
+      onMouseEnter={tooltip !== null ? onMouseEnter : onMouseEnterProp}
       className={css(
         className,
         isActionCell && styles.tableAction,
@@ -226,6 +249,15 @@ const TdBase: React.FunctionComponent<TdProps> = ({
     >
       {mergedChildren || children}
     </MergedComponent>
+  );
+
+  const canDefault = tooltip === '' ? typeof children === 'string' : true;
+  return tooltip !== null && canDefault && showTooltip ? (
+    <Tooltip content={tooltip || (tooltip === '' && children)} isVisible>
+      {cell}
+    </Tooltip>
+  ) : (
+    cell
   );
 };
 

--- a/packages/react-table/src/components/TableComposable/Th.tsx
+++ b/packages/react-table/src/components/TableComposable/Th.tsx
@@ -30,10 +30,10 @@ export interface ThProps
   /** Formats the header so that its column will be sortable */
   sort?: ThSortType;
   /**
-   * Tooltip to show on the header cell
-   * Note: If the header cell is truncated and has simple string content, it will already attempt to display the header text
-   * If you want to show a tooltip that differs from the header text, you can set it here
-   * To disable it completely you can set it to null
+   * Tooltip to show on the header cell.
+   * Note: If the header cell is truncated and has simple string content, it will already attempt to display the header text.
+   * If you want to show a tooltip that differs from the header text, you can set it here.
+   * To disable it completely you can set it to null.
    */
   tooltip?: React.ReactNode;
   /** Callback on mouse enter */

--- a/packages/react-table/src/components/TableComposable/Th.tsx
+++ b/packages/react-table/src/components/TableComposable/Th.tsx
@@ -183,8 +183,8 @@ const ThBase: React.FunctionComponent<ThProps> = ({
     </MergedComponent>
   );
 
-  const canDefault = tooltip === '' ? typeof children === 'string' : true;
-  return tooltip !== null && canDefault && showTooltip ? (
+  const canMakeDefaultTooltip = tooltip === '' ? typeof children === 'string' : true;
+  return tooltip !== null && canMakeDefaultTooltip && showTooltip ? (
     <Tooltip content={tooltip || (tooltip === '' && children)} isVisible>
       {cell}
     </Tooltip>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7965

Adds remaining filter demos (attribute search, same select filter group, mixed select filter group, faceted filter).

Updates all filter demos to have the following:
- Bulk select respects filtered state
- Menu ids are unique between demos
- Checkbox column space is maintained when there is an empty state
- `Td`s are truncated to maintain column widths while filtering

While adding the last bullet I also noticed that no tooltip is added when Tds are truncated like Ths should I added that functionality as well.

Other updates in this PR:
- `Td`: Added `tooltip` prop, and when using the truncate modifier, `Td` will attempt to make a default tooltip like `Th`
- `Th`: Updated internal `canDefault` variable name to `canMakeDefaultTooltip` (matched in `Td` as well)
- `MenuToggle`: Added missing ref spread to split button variant of the `MenuToggle`
- `Menu`: added null check in `createNavigableItems` callback that can throw a console error if the menu closes due to the extraKeys handler
