### PR TITLE
docs(contributing guide): fixed broken links in contributing outline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,9 +22,9 @@
   - [Code Consistency](#code-consistency)
   - [Code Contribution Guidelines](#code-contribution-guidelines)
 - [Becoming a Maintainer](#becoming-a-maintainer)
-  - [How do I become a maintainer?](how-do-i-become-a-maintainer?)
-  - [How do I lose maintainers status?](how-do-i-lose-maintainers-status?)
-  - [Quick Tips for New Maintainers](quick-tips-for-new-maintainers)
+  - [How do I become a maintainer?](#how-do-i-become-a-maintainer)
+  - [How do I lose maintainers status?](#how-do-i-lose-maintainers-status)
+  - [Quick Tips for New Maintainers](#quick-tips-for-new-maintainers)
 
 ## Code of Conduct
 


### PR DESCRIPTION
**What**: These 3 links are not working in the [contribution guidelines](https://github.com/patternfly/patternfly-react/blob/main/CONTRIBUTING.md).
![screenshot](https://user-images.githubusercontent.com/53129852/191585983-c06824e1-7cb4-41f7-8f33-35faf713f1f6.png)

Closes: #8041
