### PR TITLE
fix(charts): Interactive legend highlighting not working as expected

### DIFF
--- a/packages/react-charts/src/components/ChartUtils/chart-interactive-legend.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-interactive-legend.ts
@@ -188,14 +188,14 @@ const getInteractiveLegendTargetEvents = ({
           },
           {
             // Restore all legend item symbols associated with this event
-            childName: 'legend',
+            childName: legendName,
             target: 'data',
             eventKey: legendItems,
             mutation: () => null as any
           },
           {
             // Restore all legend item labels associated with this event
-            childName: 'legend',
+            childName: legendName,
             target: 'labels',
             eventKey: legendItems,
             mutation: () => null as any


### PR DESCRIPTION
The chart's interactive legend highlighting doesn't work as expected when the `name` property is changed to something other than 'legend'. Some legend items remain greyed out while hovering the cursor over legend items.

https://github.com/patternfly/patternfly-react/issues/8034

