### PR TITLE
fix(Select) - updated logic to focus first nondisabled option

### DIFF
--- a/packages/react-core/src/components/Menu/Menu.tsx
+++ b/packages/react-core/src/components/Menu/Menu.tsx
@@ -101,7 +101,9 @@ class MenuBase extends React.Component<MenuProps, MenuState> {
     // Allow tabbing to first menu item
     const current = this.menuRef.current;
     if (current) {
-      const first = current.querySelector('ul button, ul a') as HTMLButtonElement | HTMLAnchorElement;
+      const first = current.querySelector('ul button:not(:disabled), ul a:not(:disabled)') as
+        | HTMLButtonElement
+        | HTMLAnchorElement;
       if (first) {
         first.tabIndex = 0;
       }

--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -283,7 +283,13 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
 
     // Move focus to top of the menu if state.focusFirstOption was updated to true and the menu does not have custom content
     if (!prevState.focusFirstOption && this.state.focusFirstOption && !this.props.customContent) {
-      const firstRef = this.refCollection.find(ref => ref !== null);
+      const firstRef = this.refCollection.find(
+        ref =>
+          // If a select option is disabled then ref[0] will be undefined, so we want to return
+          // the first ref that both a) is not null and b) is not disabled.
+          ref !== null && ref[0]
+      );
+
       if (firstRef && firstRef[0]) {
         firstRef[0].focus();
       }

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableActionsMenu.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableActionsMenu.tsx
@@ -52,7 +52,7 @@ export const ComposableActionsMenu: React.FunctionComponent = () => {
     ev.stopPropagation(); // Stop handleClickOutside from handling
     setTimeout(() => {
       if (menuRef.current) {
-        const firstElement = menuRef.current.querySelector('li > button:not(:disabled)');
+        const firstElement = menuRef.current.querySelector('li > button:not(:disabled), li > a:not(:disabled)');
         firstElement && (firstElement as HTMLElement).focus();
       }
     }, 0);

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableApplicationLauncher.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableApplicationLauncher.tsx
@@ -47,7 +47,9 @@ export const ComposableApplicationLauncher: React.FunctionComponent = () => {
     ev.stopPropagation(); // Stop handleClickOutside from handling
     setTimeout(() => {
       if (menuRef.current) {
-        const firstElement = menuRef.current.querySelector('li > button,input:not(:disabled)');
+        const firstElement = menuRef.current.querySelector(
+          'li > button:not(:disabled), li > a:not(:disabled), input:not(:disabled)'
+        );
         firstElement && (firstElement as HTMLElement).focus();
         setRefFullOptions(Array.from(menuRef.current.querySelectorAll('li:not(li[role=separator])')));
       }

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableContextSelector.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableContextSelector.tsx
@@ -103,7 +103,9 @@ export const ComposableContextSelector: React.FunctionComponent = () => {
     ev.stopPropagation(); // Stop handleClickOutside from handling
     setTimeout(() => {
       if (menuRef.current) {
-        const firstElement = menuRef.current.querySelector('li > button,input:not(:disabled)');
+        const firstElement = menuRef.current.querySelector(
+          'li > button:not(:disabled), li > a:not(:disabled), input:not(:disabled)'
+        );
         firstElement && (firstElement as HTMLElement).focus();
       }
     }, 0);

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableDrilldownMenu.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableDrilldownMenu.tsx
@@ -56,7 +56,7 @@ export const ComposableDrilldownMenu: React.FunctionComponent = () => {
     ev.stopPropagation(); // Stop handleClickOutside from handling
     setTimeout(() => {
       if (menuRef.current) {
-        const firstElement = menuRef.current.querySelector('li > button:not(:disabled)');
+        const firstElement = menuRef.current.querySelector('li > button:not(:disabled), li > a:not(:disabled)');
         firstElement && (firstElement as HTMLElement).focus();
       }
     }, 0);

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableDropdwnVariants.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableDropdwnVariants.tsx
@@ -58,7 +58,9 @@ export const ComposableDropdwnVariants: React.FunctionComponent = () => {
     ev.stopPropagation(); // Stop handleClickOutside from handling
     setTimeout(() => {
       if (menuRef.current) {
-        const firstElement = menuRef.current.querySelector('li > button,input:not(:disabled),a');
+        const firstElement = menuRef.current.querySelector(
+          'li > button:not(:disabled), li > a:not(:disabled), input:not(:disabled)'
+        );
         firstElement && (firstElement as HTMLElement).focus();
       }
     }, 0);

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableFlyout.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableFlyout.tsx
@@ -72,7 +72,7 @@ export const ComposableFlyout: React.FunctionComponent = () => {
     ev.stopPropagation(); // Stop handleClickOutside from handling
     setTimeout(() => {
       if (menuRef.current) {
-        const firstElement = menuRef.current.querySelector('li > button:not(:disabled)');
+        const firstElement = menuRef.current.querySelector('li > button:not(:disabled), li > a:not(:disabled)');
         firstElement && (firstElement as HTMLElement).focus();
       }
     }, 0);

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableOptionsMenuVariants.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableOptionsMenuVariants.tsx
@@ -37,7 +37,9 @@ export const ComposableOptionsMenuVariants: React.FunctionComponent = () => {
     ev.stopPropagation(); // Stop handleClickOutside from handling
     setTimeout(() => {
       if (menuRef.current) {
-        const firstElement = menuRef.current.querySelector('li > button,input:not(:disabled)');
+        const firstElement = menuRef.current.querySelector(
+          'li > button:not(:disabled), li > a:not(:disabled), input:not(:disabled)'
+        );
         firstElement && (firstElement as HTMLElement).focus();
       }
     }, 0);

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleCheckboxSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleCheckboxSelect.tsx
@@ -43,7 +43,7 @@ export const ComposableSimpleCheckboxSelect: React.FunctionComponent = () => {
     ev.stopPropagation(); // Stop handleClickOutside from handling
     setTimeout(() => {
       if (menuRef.current) {
-        const firstElement = menuRef.current.querySelector('li input:not(:disabled)');
+        const firstElement = menuRef.current.querySelector('li > button:not(:disabled), li > a:not(:disabled)');
         firstElement && (firstElement as HTMLElement).focus();
       }
     }, 0);

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleDropdown.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleDropdown.tsx
@@ -38,7 +38,7 @@ export const ComposableSimpleDropdown: React.FunctionComponent = () => {
     ev.stopPropagation(); // Stop handleClickOutside from handling
     setTimeout(() => {
       if (menuRef.current) {
-        const firstElement = menuRef.current.querySelector('li > button:not(:disabled)');
+        const firstElement = menuRef.current.querySelector('li > button:not(:disabled), li > a:not(:disabled)');
         firstElement && (firstElement as HTMLElement).focus();
       }
     }, 0);

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleSelect.tsx
@@ -37,7 +37,7 @@ export const ComposableSimpleSelect: React.FunctionComponent = () => {
     ev.stopPropagation(); // Stop handleClickOutside from handling
     setTimeout(() => {
       if (menuRef.current) {
-        const firstElement = menuRef.current.querySelector('li > button:not(:disabled)');
+        const firstElement = menuRef.current.querySelector('li > button:not(:disabled), li > a:not(:disabled)');
         firstElement && (firstElement as HTMLElement).focus();
       }
     }, 0);

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableTreeViewMenu.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableTreeViewMenu.tsx
@@ -210,7 +210,7 @@ export const ComposableTreeViewMenu: React.FunctionComponent = () => {
     ev.stopPropagation(); // Stop handleClickOutside from handling
     setTimeout(() => {
       if (menuRef.current) {
-        const firstElement = menuRef.current.querySelector('li button:not(:disabled)');
+        const firstElement = menuRef.current.querySelector('li > button:not(:disabled), li > a:not(:disabled)');
         firstElement && (firstElement as HTMLElement).focus();
       }
     }, 0);

--- a/packages/react-integration/cypress/integration/select.spec.ts
+++ b/packages/react-integration/cypress/integration/select.spec.ts
@@ -287,4 +287,9 @@ describe('Select Test', () => {
       .contains('Miss')
       .should('exist');
   });
+
+  it('Verify focus is placed on first non-disabled option with keyboard', () => {
+    cy.get('#disabled-first-item-single-select').trigger('keydown', { key: 'Enter' });
+    cy.get('#first-item-disabled-select-opt-2 button').should('have.focus');
+  });
 });

--- a/packages/react-integration/demo-app-ts/src/components/demos/SelectDemo/SelectDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/SelectDemo/SelectDemo.tsx
@@ -62,6 +62,8 @@ export interface SelectDemoState {
   menuDocumentBodySelected: string[];
   lbltypeaheadSelected: string;
   lbltypeaheadisOpen: boolean;
+  disabledFirstItemIsOpen: boolean;
+  disabledFirstItemSelected: string;
 }
 
 export class SelectDemo extends Component<SelectDemoState> {
@@ -116,7 +118,9 @@ export class SelectDemo extends Component<SelectDemoState> {
     typeaheadInputValuePersisted: false,
     customContentisOpen: false,
     menuDocumentBodyisOpen: false,
-    menuDocumentBodySelected: ['']
+    menuDocumentBodySelected: [''],
+    disabledFirstItemIsOpen: false,
+    disabledFirstItemSelected: ''
   };
 
   singleOptions = [
@@ -159,6 +163,16 @@ export class SelectDemo extends Component<SelectDemoState> {
     <SelectOption key={9} value={new State('New Mexico', 'NM', 'Santa Fe', 1912)} />,
     <SelectOption key={10} value={new State('New York', 'NY', 'Albany', 1788)} />,
     <SelectOption key={11} value={new State('North Carolina', 'NC', 'Raleigh', 1789)} />
+  ];
+
+  disabledFirstItemOptions = [
+    { value: 'Choose', disabled: true, isPlaceholder: true, id: 'first-item-disabled-select-opt-1' },
+    { value: 'Mr', disabled: false, id: 'first-item-disabled-select-opt-2' },
+    { value: 'Miss', disabled: false, id: 'first-item-disabled-select-opt-3' },
+    { value: 'Mrs', disabled: false, id: 'first-item-disabled-select-opt-4' },
+    { value: 'Ms', disabled: false, id: 'first-item-disabled-select-opt-5' },
+    { value: 'Dr', disabled: false, id: 'first-item-disabled-select-opt-6' },
+    { value: 'Other', disabled: false, id: 'first-item-disabled-select-opt-7' }
   ];
 
   toggleDisabled = () => {
@@ -286,6 +300,12 @@ export class SelectDemo extends Component<SelectDemoState> {
   customContentOnToggle = (customContentisOpen: boolean) => {
     this.setState({
       customContentisOpen
+    });
+  };
+
+  disabledFirstItemOnToggle = (disabledFirstItemIsOpen: boolean) => {
+    this.setState({
+      disabledFirstItemIsOpen
     });
   };
 
@@ -549,6 +569,22 @@ export class SelectDemo extends Component<SelectDemoState> {
         }),
         () => console.log('selections: ', this.state.customTypeaheadMultiSelected)
       );
+    }
+  };
+
+  disabledFirstItemOnSelect = (
+    _event: React.MouseEvent | React.ChangeEvent,
+    selection: string | SelectOptionObject,
+    isPlaceholder?: boolean
+  ) => {
+    if (isPlaceholder) {
+      this.clearSelection();
+    } else {
+      this.setState({
+        disabledFirstItemSelected: selection,
+        disabledFirstItemIsOpen: false
+      });
+      console.log('selected:', selection.toString());
     }
   };
 
@@ -1293,6 +1329,43 @@ export class SelectDemo extends Component<SelectDemoState> {
     );
   }
 
+  renderDisabledFirstItemSelect() {
+    const { disabledFirstItemIsOpen, disabledFirstItemSelected } = this.state;
+    const titleId = 'disabled-first-item-title-id';
+    return (
+      <StackItem isFilled={false}>
+        <Title headingLevel="h2" size="2xl">
+          First Item Disabled Select
+        </Title>
+        <div>
+          <span id={titleId} hidden>
+            Title
+          </span>
+          <Select
+            toggleId="disabled-first-item-single-select"
+            variant={SelectVariant.single}
+            aria-label="Select Input"
+            onToggle={this.disabledFirstItemOnToggle}
+            onSelect={this.disabledFirstItemOnSelect}
+            selections={disabledFirstItemSelected}
+            isOpen={disabledFirstItemIsOpen}
+            aria-labelledby={titleId}
+          >
+            {this.disabledFirstItemOptions.map((option, index) => (
+              <SelectOption
+                id={option.id}
+                isDisabled={option.disabled}
+                key={index}
+                value={option.value}
+                isPlaceholder={option.isPlaceholder}
+              />
+            ))}
+          </Select>
+        </div>
+      </StackItem>
+    );
+  }
+
   render() {
     return (
       <Stack hasGutter>
@@ -1313,6 +1386,7 @@ export class SelectDemo extends Component<SelectDemoState> {
         {this.renderSelectWithDivider()}
         {this.renderLabelTypeaheadSelect()}
         {this.renderSingleSelectMenuAppendTo()}
+        {this.renderDisabledFirstItemSelect()}
       </Stack>
     );
   }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8095

[menu examples](https://patternfly-react-pr-8111.surge.sh/components/menu/)
[select examples](https://patternfly-react-pr-8111.surge.sh/components/select)
[composable menu demos](https://patternfly-react-pr-8111.surge.sh/demos/composable-menu)

To test, just add `isDisabled` to the first menu option in an example, and focus should still be placed on the first, non-disabled option either after opening the menu toggle or pressing Tab (for the menu examples that don't have a toggle)

Also fixed the same issue that was occurring in the Menu component, as well as updating logic in several of the composable menu demos.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
