### PR TITLE
chore(pagination): fixed filter not applying in sticky example

### DIFF
--- a/packages/react-core/src/components/Pagination/examples/PaginationSticky.tsx
+++ b/packages/react-core/src/components/Pagination/examples/PaginationSticky.tsx
@@ -1,14 +1,5 @@
 import React from 'react';
-import {
-  Pagination,
-  PaginationVariant,
-  Gallery,
-  GalleryItem,
-  Card,
-  CardBody,
-  Page,
-  PageSection
-} from '@patternfly/react-core';
+import { Pagination, PaginationVariant, Gallery, GalleryItem, Card, CardBody } from '@patternfly/react-core';
 
 export const PaginationSticky: React.FunctionComponent = () => {
   const [page, setPage] = React.useState(1);
@@ -45,45 +36,38 @@ export const PaginationSticky: React.FunctionComponent = () => {
     ));
   };
 
-  return (
-    <Page>
-      <PageSection>
-        {isTopSticky && (
-          <React.Fragment>
-            <Pagination
-              perPageComponent="button"
-              itemCount={itemCount}
-              perPage={perPage}
-              page={page}
-              onSetPage={onSetPage}
-              widgetId="pagination-options-menu-top"
-              onPerPageSelect={onPerPageSelect}
-              isSticky
-            >
-              <button onClick={onToggleSticky}>Toggle to bottom position</button>
-            </Pagination>
-            <Gallery hasGutter>{buildCards()}</Gallery>
-          </React.Fragment>
-        )}
-        {!isTopSticky && (
-          <React.Fragment>
-            <Gallery hasGutter>{buildCards()}</Gallery>
-            <Pagination
-              perPageComponent="button"
-              itemCount={itemCount}
-              perPage={perPage}
-              page={page}
-              onSetPage={onSetPage}
-              widgetId="pagination-options-menu-top"
-              onPerPageSelect={onPerPageSelect}
-              isSticky
-              variant={PaginationVariant.bottom}
-            >
-              <button onClick={onToggleSticky}>Toggle to top position</button>
-            </Pagination>
-          </React.Fragment>
-        )}
-      </PageSection>
-    </Page>
+  return isTopSticky ? (
+    <React.Fragment>
+      <Pagination
+        perPageComponent="button"
+        itemCount={itemCount}
+        perPage={perPage}
+        page={page}
+        onSetPage={onSetPage}
+        widgetId="pagination-options-menu-top"
+        onPerPageSelect={onPerPageSelect}
+        isSticky
+      >
+        <button onClick={onToggleSticky}>Toggle to bottom position</button>
+      </Pagination>
+      <Gallery hasGutter>{buildCards()}</Gallery>
+    </React.Fragment>
+  ) : (
+    <React.Fragment>
+      <Gallery hasGutter>{buildCards()}</Gallery>
+      <Pagination
+        perPageComponent="button"
+        itemCount={itemCount}
+        perPage={perPage}
+        page={page}
+        onSetPage={onSetPage}
+        widgetId="pagination-options-menu-top"
+        onPerPageSelect={onPerPageSelect}
+        isSticky
+        variant={PaginationVariant.bottom}
+      >
+        <button onClick={onToggleSticky}>Toggle to top position</button>
+      </Pagination>
+    </React.Fragment>
   );
 };

--- a/packages/react-core/src/components/Pagination/examples/PaginationSticky.tsx
+++ b/packages/react-core/src/components/Pagination/examples/PaginationSticky.tsx
@@ -5,6 +5,7 @@ export const PaginationSticky: React.FunctionComponent = () => {
   const [page, setPage] = React.useState(1);
   const [perPage, setPerPage] = React.useState(20);
   const [isTopSticky, setIsTopSticky] = React.useState(true);
+  const itemCount = 523;
 
   const onToggleSticky = () => {
     setIsTopSticky(prev => !prev);
@@ -23,13 +24,25 @@ export const PaginationSticky: React.FunctionComponent = () => {
     setPage(newPage);
   };
 
+  const buildCards = () => {
+    const numberOfCards = (page - 1) * perPage + perPage - 1 >= itemCount ? itemCount - (page - 1) * perPage : perPage;
+
+    return Array.apply(0, Array(numberOfCards)).map((x, i) => (
+      <GalleryItem key={i}>
+        <Card>
+          <CardBody>This is a card</CardBody>
+        </Card>
+      </GalleryItem>
+    ));
+  };
+
   return (
     <div>
       {isTopSticky && (
         <React.Fragment>
           <Pagination
             perPageComponent="button"
-            itemCount={523}
+            itemCount={itemCount}
             perPage={perPage}
             page={page}
             onSetPage={onSetPage}
@@ -39,31 +52,15 @@ export const PaginationSticky: React.FunctionComponent = () => {
           >
             <button onClick={onToggleSticky}>Toggle to bottom position</button>
           </Pagination>
-          <Gallery hasGutter>
-            {Array.apply(0, Array(40)).map((x, i) => (
-              <GalleryItem key={i}>
-                <Card>
-                  <CardBody>This is a card</CardBody>
-                </Card>
-              </GalleryItem>
-            ))}
-          </Gallery>
+          <Gallery hasGutter>{buildCards()}</Gallery>
         </React.Fragment>
       )}
       {!isTopSticky && (
         <React.Fragment>
-          <Gallery hasGutter>
-            {Array.apply(0, Array(40)).map((x, i) => (
-              <GalleryItem key={i}>
-                <Card>
-                  <CardBody>This is a card</CardBody>
-                </Card>
-              </GalleryItem>
-            ))}
-          </Gallery>
+          <Gallery hasGutter>{buildCards()}</Gallery>
           <Pagination
             perPageComponent="button"
-            itemCount={523}
+            itemCount={itemCount}
             perPage={perPage}
             page={page}
             onSetPage={onSetPage}

--- a/packages/react-core/src/components/Pagination/examples/PaginationSticky.tsx
+++ b/packages/react-core/src/components/Pagination/examples/PaginationSticky.tsx
@@ -1,9 +1,18 @@
 import React from 'react';
-import { Pagination, PaginationVariant, Gallery, GalleryItem, Card, CardBody } from '@patternfly/react-core';
+import {
+  Pagination,
+  PaginationVariant,
+  Gallery,
+  GalleryItem,
+  Card,
+  CardBody,
+  Page,
+  PageSection
+} from '@patternfly/react-core';
 
 export const PaginationSticky: React.FunctionComponent = () => {
   const [page, setPage] = React.useState(1);
-  const [perPage, setPerPage] = React.useState(20);
+  const [perPage, setPerPage] = React.useState(100);
   const [isTopSticky, setIsTopSticky] = React.useState(true);
   const itemCount = 523;
 
@@ -37,42 +46,44 @@ export const PaginationSticky: React.FunctionComponent = () => {
   };
 
   return (
-    <div>
-      {isTopSticky && (
-        <React.Fragment>
-          <Pagination
-            perPageComponent="button"
-            itemCount={itemCount}
-            perPage={perPage}
-            page={page}
-            onSetPage={onSetPage}
-            widgetId="sticky-example"
-            onPerPageSelect={onPerPageSelect}
-            isSticky
-          >
-            <button onClick={onToggleSticky}>Toggle to bottom position</button>
-          </Pagination>
-          <Gallery hasGutter>{buildCards()}</Gallery>
-        </React.Fragment>
-      )}
-      {!isTopSticky && (
-        <React.Fragment>
-          <Gallery hasGutter>{buildCards()}</Gallery>
-          <Pagination
-            perPageComponent="button"
-            itemCount={itemCount}
-            perPage={perPage}
-            page={page}
-            onSetPage={onSetPage}
-            widgetId="pagination-options-menu-top"
-            onPerPageSelect={onPerPageSelect}
-            isSticky
-            variant={PaginationVariant.bottom}
-          >
-            <button onClick={onToggleSticky}>Toggle to top position</button>
-          </Pagination>
-        </React.Fragment>
-      )}
-    </div>
+    <Page>
+      <PageSection>
+        {isTopSticky && (
+          <React.Fragment>
+            <Pagination
+              perPageComponent="button"
+              itemCount={itemCount}
+              perPage={perPage}
+              page={page}
+              onSetPage={onSetPage}
+              widgetId="pagination-options-menu-top"
+              onPerPageSelect={onPerPageSelect}
+              isSticky
+            >
+              <button onClick={onToggleSticky}>Toggle to bottom position</button>
+            </Pagination>
+            <Gallery hasGutter>{buildCards()}</Gallery>
+          </React.Fragment>
+        )}
+        {!isTopSticky && (
+          <React.Fragment>
+            <Gallery hasGutter>{buildCards()}</Gallery>
+            <Pagination
+              perPageComponent="button"
+              itemCount={itemCount}
+              perPage={perPage}
+              page={page}
+              onSetPage={onSetPage}
+              widgetId="pagination-options-menu-top"
+              onPerPageSelect={onPerPageSelect}
+              isSticky
+              variant={PaginationVariant.bottom}
+            >
+              <button onClick={onToggleSticky}>Toggle to top position</button>
+            </Pagination>
+          </React.Fragment>
+        )}
+      </PageSection>
+    </Page>
   );
 };


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7652

To keep the code DRY, I've refactored the build cards functionality.

Also, I've added a logic for when there are less cards in the page than the `perPage` prop.
