### PR TITLE
[WIP] Form - allow group label required asterisk and help button to wrap together

### DIFF
--- a/packages/react-core/src/components/Form/FormGroup.tsx
+++ b/packages/react-core/src/components/Form/FormGroup.tsx
@@ -110,14 +110,14 @@ export const FormGroup: React.FunctionComponent<FormGroupProps> = ({
   const labelContent = (
     <React.Fragment>
       <LabelComponent className={css(styles.formLabel)} {...(!isGroupOrRadioGroup && { htmlFor: fieldId })}>
-        <span className={css(styles.formLabelText)}>{label}</span>
+        <span className={css(styles.formLabelText)}>{label}</span>&nbsp;
         {isRequired && (
           <span className={css(styles.formLabelRequired)} aria-hidden="true">
-            {' '}
             {ASTERISK}
           </span>
         )}
-      </LabelComponent>{' '}
+      </LabelComponent>
+      &nbsp;
       {React.isValidElement(labelIcon) && labelIcon}
     </React.Fragment>
   );

--- a/packages/react-core/src/components/Form/FormGroup.tsx
+++ b/packages/react-core/src/components/Form/FormGroup.tsx
@@ -109,11 +109,7 @@ export const FormGroup: React.FunctionComponent<FormGroupProps> = ({
 
   const labelContent = (
     <React.Fragment>
-      <LabelComponent
-        style={{ display: 'inline' }}
-        className={css(styles.formLabel)}
-        {...(!isGroupOrRadioGroup && { htmlFor: fieldId })}
-      >
+      <LabelComponent className={css(styles.formLabel)} {...(!isGroupOrRadioGroup && { htmlFor: fieldId })}>
         <span className={css(styles.formLabelText)}>{label}</span>
         &nbsp;
         {isRequired && (

--- a/packages/react-core/src/components/Form/FormGroup.tsx
+++ b/packages/react-core/src/components/Form/FormGroup.tsx
@@ -109,8 +109,13 @@ export const FormGroup: React.FunctionComponent<FormGroupProps> = ({
 
   const labelContent = (
     <React.Fragment>
-      <LabelComponent className={css(styles.formLabel)} {...(!isGroupOrRadioGroup && { htmlFor: fieldId })}>
-        <span className={css(styles.formLabelText)}>{label}</span>&nbsp;
+      <LabelComponent
+        style={{ display: 'inline' }}
+        className={css(styles.formLabel)}
+        {...(!isGroupOrRadioGroup && { htmlFor: fieldId })}
+      >
+        <span className={css(styles.formLabelText)}>{label}</span>
+        &nbsp;
         {isRequired && (
           <span className={css(styles.formLabelRequired)} aria-hidden="true">
             {ASTERISK}

--- a/packages/react-core/src/components/Form/__tests__/__snapshots__/FormGroup.test.tsx.snap
+++ b/packages/react-core/src/components/Form/__tests__/__snapshots__/FormGroup.test.tsx.snap
@@ -19,8 +19,9 @@ exports[`FormGroup should render correctly when label is not a string with Child
             label
           </div>
         </span>
+         
       </label>
-       
+       
     </div>
     <div
       class="pf-c-form__group-control"
@@ -54,8 +55,9 @@ exports[`FormGroup should render default form group variant 1`] = `
         >
           label
         </span>
+         
       </label>
-       
+       
     </div>
     <div
       class="pf-c-form__group-control"
@@ -92,8 +94,9 @@ exports[`FormGroup should render form group invalid variant 1`] = `
         >
           label
         </span>
+         
       </label>
-       
+       
     </div>
     <div
       class="pf-c-form__group-control"
@@ -130,8 +133,9 @@ exports[`FormGroup should render form group validated error variant 1`] = `
         >
           label
         </span>
+         
       </label>
-       
+       
     </div>
     <div
       class="pf-c-form__group-control"
@@ -162,8 +166,9 @@ exports[`FormGroup should render form group validated success variant 1`] = `
         >
           label
         </span>
+         
       </label>
-       
+       
     </div>
     <div
       class="pf-c-form__group-control"
@@ -201,8 +206,9 @@ exports[`FormGroup should render form group validated warning variant 1`] = `
         >
           label
         </span>
+         
       </label>
-       
+       
     </div>
     <div
       class="pf-c-form__group-control"
@@ -241,8 +247,9 @@ exports[`FormGroup should render form group variant with node label 1`] = `
             Header
           </h1>
         </span>
+         
       </label>
-       
+       
     </div>
     <div
       class="pf-c-form__group-control"
@@ -272,14 +279,15 @@ exports[`FormGroup should render form group variant with required label 1`] = `
         >
           label
         </span>
+         
         <span
           aria-hidden="true"
           class="pf-c-form__label-required"
         >
-           *
+          *
         </span>
       </label>
-       
+       
     </div>
     <div
       class="pf-c-form__group-control"
@@ -330,8 +338,9 @@ exports[`FormGroup should render form group with additonal label info 1`] = `
               Header
             </h1>
           </span>
+           
         </label>
-         
+         
       </div>
       <div
         class="pf-c-form__group-label-info"
@@ -371,8 +380,9 @@ exports[`FormGroup should render helper text above input 1`] = `
           >
             label
           </span>
+           
         </label>
-         
+         
       </div>
       <div
         class="pf-c-form__group-control"
@@ -414,8 +424,9 @@ exports[`FormGroup should render horizontal form group variant 1`] = `
           >
             label
           </span>
+           
         </label>
-         
+         
       </div>
       <div
         class="pf-c-form__group-control"
@@ -457,8 +468,9 @@ exports[`FormGroup should render stacked horizontal form group variant 1`] = `
           >
             label
           </span>
+           
         </label>
-         
+         
       </div>
       <div
         class="pf-c-form__group-control pf-m-stack"

--- a/packages/react-core/src/components/Form/examples/FormBasic.tsx
+++ b/packages/react-core/src/components/Form/examples/FormBasic.tsx
@@ -57,6 +57,7 @@ export const FormBasic: React.FunctionComponent = () => {
               onClick={e => e.preventDefault()}
               aria-describedby="simple-form-name-01"
               className="pf-c-form__group-label-help"
+              tabIndex={0}
             >
               <HelpIcon noVerticalAlign />
             </span>

--- a/packages/react-core/src/components/Form/examples/FormBasic.tsx
+++ b/packages/react-core/src/components/Form/examples/FormBasic.tsx
@@ -51,15 +51,15 @@ export const FormBasic: React.FunctionComponent = () => {
               </div>
             }
           >
-            <button
-              type="button"
+            <span
+              role="button"
               aria-label="More info for name field"
               onClick={e => e.preventDefault()}
               aria-describedby="simple-form-name-01"
               className="pf-c-form__group-label-help"
             >
               <HelpIcon noVerticalAlign />
-            </button>
+            </span>
           </Popover>
         }
         isRequired

--- a/packages/react-core/src/components/Form/examples/FormGroupLabelInfo.tsx
+++ b/packages/react-core/src/components/Form/examples/FormGroupLabelInfo.tsx
@@ -42,15 +42,15 @@ export const FormGroupLabelInfo: React.FunctionComponent = () => {
               </div>
             }
           >
-            <button
-              type="button"
+            <span
+              role="button"
               aria-label="More info for name field"
               onClick={e => e.preventDefault()}
               aria-describedby="form-group-label-info"
               className="pf-c-form__group-label-help"
             >
               <HelpIcon noVerticalAlign />
-            </button>
+            </span>
           </Popover>
         }
         isRequired

--- a/packages/react-core/src/components/Form/examples/FormGroupLabelInfo.tsx
+++ b/packages/react-core/src/components/Form/examples/FormGroupLabelInfo.tsx
@@ -48,6 +48,7 @@ export const FormGroupLabelInfo: React.FunctionComponent = () => {
               onClick={e => e.preventDefault()}
               aria-describedby="form-group-label-info"
               className="pf-c-form__group-label-help"
+              tabIndex={0}
             >
               <HelpIcon noVerticalAlign />
             </span>

--- a/packages/react-core/src/components/Form/examples/FormLimitWidth.tsx
+++ b/packages/react-core/src/components/Form/examples/FormLimitWidth.tsx
@@ -57,6 +57,7 @@ export const FormLimitWidth: React.FunctionComponent = () => {
               onClick={e => e.preventDefault()}
               aria-describedby="simple-form-name-02"
               className="pf-c-form__group-label-help"
+              tabIndex={0}
             >
               <HelpIcon noVerticalAlign />
             </span>

--- a/packages/react-core/src/components/Form/examples/FormLimitWidth.tsx
+++ b/packages/react-core/src/components/Form/examples/FormLimitWidth.tsx
@@ -51,15 +51,15 @@ export const FormLimitWidth: React.FunctionComponent = () => {
               </div>
             }
           >
-            <button
-              type="button"
+            <span
+              role="button"
               aria-label="More info for name field"
               onClick={e => e.preventDefault()}
               aria-describedby="simple-form-name-02"
               className="pf-c-form__group-label-help"
             >
               <HelpIcon noVerticalAlign />
-            </button>
+            </span>
           </Popover>
         }
         isRequired

--- a/packages/react-core/src/components/LoginPage/__tests__/__snapshots__/LoginForm.test.tsx.snap
+++ b/packages/react-core/src/components/LoginPage/__tests__/__snapshots__/LoginForm.test.tsx.snap
@@ -24,14 +24,15 @@ exports[`LoginForm LoginForm with rememberMeLabel 1`] = `
           >
             Username
           </span>
+           
           <span
             aria-hidden="true"
             class="pf-c-form__label-required"
           >
-             *
+            *
           </span>
         </label>
-         
+         
       </div>
       <div
         class="pf-c-form__group-control"
@@ -65,14 +66,15 @@ exports[`LoginForm LoginForm with rememberMeLabel 1`] = `
           >
             Password
           </span>
+           
           <span
             aria-hidden="true"
             class="pf-c-form__label-required"
           >
-             *
+            *
           </span>
         </label>
-         
+         
       </div>
       <div
         class="pf-c-form__group-control"
@@ -168,14 +170,15 @@ exports[`LoginForm LoginForm with show password 1`] = `
           >
             Username
           </span>
+           
           <span
             aria-hidden="true"
             class="pf-c-form__label-required"
           >
-             *
+            *
           </span>
         </label>
-         
+         
       </div>
       <div
         class="pf-c-form__group-control"
@@ -209,14 +212,15 @@ exports[`LoginForm LoginForm with show password 1`] = `
           >
             Password
           </span>
+           
           <span
             aria-hidden="true"
             class="pf-c-form__label-required"
           >
-             *
+            *
           </span>
         </label>
-         
+         
       </div>
       <div
         class="pf-c-form__group-control"
@@ -312,14 +316,15 @@ exports[`LoginForm should render Login form 1`] = `
           >
             Username
           </span>
+           
           <span
             aria-hidden="true"
             class="pf-c-form__label-required"
           >
-             *
+            *
           </span>
         </label>
-         
+         
       </div>
       <div
         class="pf-c-form__group-control"
@@ -353,14 +358,15 @@ exports[`LoginForm should render Login form 1`] = `
           >
             Password
           </span>
+           
           <span
             aria-hidden="true"
             class="pf-c-form__label-required"
           >
-             *
+            *
           </span>
         </label>
-         
+         
       </div>
       <div
         class="pf-c-form__group-control"

--- a/packages/react-core/src/components/Modal/examples/ModalWithForm.tsx
+++ b/packages/react-core/src/components/Modal/examples/ModalWithForm.tsx
@@ -80,6 +80,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
                   onClick={e => e.preventDefault()}
                   aria-describedby="modal-with-form-form-name"
                   className="pf-c-form__group-label-help"
+                  tabIndex={0}
                 >
                   <HelpIcon noVerticalAlign />
                 </span>
@@ -129,6 +130,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
                   onClick={e => e.preventDefault()}
                   aria-describedby="modal-with-form-form-email"
                   className="pf-c-form__group-label-help"
+                  tabIndex={0}
                 >
                   <HelpIcon noVerticalAlign />
                 </span>
@@ -177,6 +179,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
                   onClick={e => e.preventDefault()}
                   aria-describedby="modal-with-form-form-address"
                   className="pf-c-form__group-label-help"
+                  tabIndex={0}
                 >
                   <HelpIcon noVerticalAlign />
                 </span>

--- a/packages/react-core/src/components/Modal/examples/ModalWithForm.tsx
+++ b/packages/react-core/src/components/Modal/examples/ModalWithForm.tsx
@@ -74,15 +74,15 @@ export const ModalWithForm: React.FunctionComponent = () => {
                   </div>
                 }
               >
-                <button
-                  type="button"
+                <span
+                  role="button"
                   aria-label="More info for name field"
                   onClick={e => e.preventDefault()}
                   aria-describedby="modal-with-form-form-name"
                   className="pf-c-form__group-label-help"
                 >
                   <HelpIcon noVerticalAlign />
-                </button>
+                </span>
               </Popover>
             }
             isRequired
@@ -123,7 +123,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
                   </div>
                 }
               >
-                <button
+                <span
                   type="button"
                   aria-label="More info for e-mail field"
                   onClick={e => e.preventDefault()}
@@ -131,7 +131,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
                   className="pf-c-form__group-label-help"
                 >
                   <HelpIcon noVerticalAlign />
-                </button>
+                </span>
               </Popover>
             }
             isRequired
@@ -171,15 +171,14 @@ export const ModalWithForm: React.FunctionComponent = () => {
                   </div>
                 }
               >
-                <button
-                  type="button"
+                <span
                   aria-label="More info for address field"
                   onClick={e => e.preventDefault()}
                   aria-describedby="modal-with-form-form-address"
                   className="pf-c-form__group-label-help"
                 >
                   <HelpIcon noVerticalAlign />
-                </button>
+                </span>
               </Popover>
             }
             isRequired

--- a/packages/react-core/src/components/Modal/examples/ModalWithForm.tsx
+++ b/packages/react-core/src/components/Modal/examples/ModalWithForm.tsx
@@ -124,7 +124,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
                 }
               >
                 <span
-                  type="button"
+                  role="button"
                   aria-label="More info for e-mail field"
                   onClick={e => e.preventDefault()}
                   aria-describedby="modal-with-form-form-email"
@@ -172,6 +172,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
                 }
               >
                 <span
+                  role="button"
                   aria-label="More info for address field"
                   onClick={e => e.preventDefault()}
                   aria-describedby="modal-with-form-form-address"

--- a/packages/react-core/src/components/Popover/Popover.tsx
+++ b/packages/react-core/src/components/Popover/Popover.tsx
@@ -349,7 +349,13 @@ export const Popover: React.FunctionComponent<PopoverProps> = ({
   const hasCustomMinWidth = minWidth !== popoverMinWidth.value;
   const hasCustomMaxWidth = maxWidth !== popoverMaxWidth.value;
   const onDocumentKeyDown = (event: KeyboardEvent) => {
-    if (event.key === KeyTypes.Escape && visible) {
+    if (event.key === KeyTypes.Enter) {
+      if (visible) {
+        hide();
+      } else {
+        show(true);
+      }
+    } else if (event.key === KeyTypes.Escape && visible) {
       if (triggerManually) {
         shouldClose(null, hide, event);
       } else {

--- a/packages/react-core/src/components/SearchInput/__tests__/__snapshots__/SearchInput.test.tsx.snap
+++ b/packages/react-core/src/components/SearchInput/__tests__/__snapshots__/SearchInput.test.tsx.snap
@@ -276,8 +276,9 @@ exports[`SearchInput advanced search with custom attributes 1`] = `
                     >
                       Username
                     </span>
+                     
                   </label>
-                   
+                   
                 </div>
                 <div
                   class="pf-c-form__group-control"
@@ -309,8 +310,9 @@ exports[`SearchInput advanced search with custom attributes 1`] = `
                     >
                       First name
                     </span>
+                     
                   </label>
-                   
+                   
                 </div>
                 <div
                   class="pf-c-form__group-control"
@@ -342,8 +344,9 @@ exports[`SearchInput advanced search with custom attributes 1`] = `
                     >
                       Has words
                     </span>
+                     
                   </label>
-                   
+                   
                 </div>
                 <div
                   class="pf-c-form__group-control"

--- a/packages/react-integration/demo-app-ts/src/components/demos/FormDemo/FormDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/FormDemo/FormDemo.tsx
@@ -116,7 +116,7 @@ export class FormDemo extends Component<FormProps, FormState> {
                 headerContent={<div>The age of a person</div>}
                 bodyContent={<div>Age is typically measured in years.</div>}
               >
-                <button
+                <span
                   id="helper-text-target"
                   aria-label="More info for name field"
                   onClick={e => e.preventDefault()}
@@ -124,7 +124,7 @@ export class FormDemo extends Component<FormProps, FormState> {
                   className="pf-c-form__group-label-help"
                 >
                   <HelpIcon noVerticalAlign />
-                </button>
+                </span>
               </Popover>
             }
             type="number"

--- a/packages/react-integration/demo-app-ts/src/components/demos/FormDemo/FormDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/FormDemo/FormDemo.tsx
@@ -116,7 +116,7 @@ export class FormDemo extends Component<FormProps, FormState> {
                 headerContent={<div>The age of a person</div>}
                 bodyContent={<div>Age is typically measured in years.</div>}
               >
-                <span
+                <button
                   id="helper-text-target"
                   aria-label="More info for name field"
                   onClick={e => e.preventDefault()}
@@ -124,7 +124,7 @@ export class FormDemo extends Component<FormProps, FormState> {
                   className="pf-c-form__group-label-help"
                 >
                   <HelpIcon noVerticalAlign />
-                </span>
+                </button>
               </Popover>
             }
             type="number"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
### Do not merge; these updates behave differently in the react workspace vs in core, investigation underway with @mattnolting and @mcoker

**What**: Will close patternfly/patternfly#5168 once complete


I've modified the code to align with the core approach - @mattnolting 's recommendation as commented [here](https://github.com/patternfly/patternfly/pull/5118#issuecomment-1256365853). 

### How to test:

Copy this code into the ["Basic" react demo](https://patternfly-react-pr-8140.surge.sh/components/form#basic):
```
import React from 'react';
import { Form, FormGroup, TextInput, Checkbox, Popover, ActionGroup, Button, Radio } from '@patternfly/react-core';
import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';

export const FormBasic: React.FunctionComponent = () => {
  const [name, setName] = React.useState('');

  const handleNameChange = (name: string) => {
    setName(name);
  };

  return (
    <Form isHorizontal>
      <FormGroup
        label="This label is long and therefore it wraps"
        labelIcon={
          <Popover
            headerContent={
              <div>
                The{' '}
                <a href="https://schema.org/name" target="_blank" rel="noreferrer">
                  name
                </a>{' '}
                of a{' '}
                <a href="https://schema.org/Person" target="_blank" rel="noreferrer">
                  Person
                </a>
              </div>
            }
            bodyContent={
              <div>
                Often composed of{' '}
                <a href="https://schema.org/givenName" target="_blank" rel="noreferrer">
                  givenName
                </a>{' '}
                and{' '}
                <a href="https://schema.org/familyName" target="_blank" rel="noreferrer">
                  familyName
                </a>
                .
              </div>
            }
          >
            <span
              role="button"
              aria-label="More info for name field"
              onClick={e => e.preventDefault()}
              aria-describedby="simple-form-name-01"
              className="pf-c-form__group-label-help"
            >
              <HelpIcon noVerticalAlign />
            </span>
          </Popover>
        }
        isRequired
        fieldId="simple-form-name-01"
        helperText="Include your middle name if you have one."
      >
        <TextInput
          isRequired
          type="text"
          id="simple-form-name-01"
          name="simple-form-name-01"
          aria-describedby="simple-form-name-01-helper"
          value={name}
          onChange={handleNameChange}
        />
      </FormGroup>
      
      <ActionGroup>
        <Button variant="primary">Submit</Button>
        <Button variant="link">Cancel</Button>
      </ActionGroup>
    </Form>
  );
};
```

Then copy this code into the ["Basic" core demo](https://patternfly-pr-5118.surge.sh/components/form/html-demos/#basic):
```<form class="pf-c-form pf-m-horizontal" novalidate>
  <div class="pf-c-form__group">
    <div class="pf-c-form__group-label"><label class="pf-c-form__label" for="form-demo-basic-phone">
        <span class="pf-c-form__label-text">Phone number field that wraps because it is long</span>&nbsp;<span class="pf-c-form__label-required" aria-hidden="true">&#42;</span></label>&nbsp;<span
        class="pf-c-form__group-label-help"
        aria-label="More information for phone number field"
        aria-describedby="form-demo-basic-phone"
        role="button"
        type="button"
        tabindex="0"
      ><i class="pficon pf-icon-help" aria-hidden="true"></i></span>
    </div>
    <div class="pf-c-form__group-control">
      <input
        class="pf-c-form-control"
        required
        type="tel"
        placeholder="555-555-5555"
        id="form-demo-basic-phone"
        name="form-demo-basic-phone"
      />
    </div>
  </div>
  <div class="pf-c-form__group pf-m-action">
    <div class="pf-c-form__group-control">
      <div class="pf-c-form__actions">
        <button class="pf-c-button pf-m-primary" type="submit">Submit</button>
        <button class="pf-c-button pf-m-link" type="button">Cancel</button>
      </div>
    </div>
  </div>
</form>
```
