### PR TITLE
chore(Dropdown): remove deprecated props

### DIFF
--- a/packages/react-core/src/components/Dropdown/DropdownItem.tsx
+++ b/packages/react-core/src/components/Dropdown/DropdownItem.tsx
@@ -27,8 +27,6 @@ export interface DropdownItemProps extends Omit<InternalDropdownItemProps, 'tabI
   isAriaDisabled?: boolean;
   /** Render dropdown item as non-interactive item */
   isPlainText?: boolean;
-  /** @deprecated Forces display of the hover state of the element */
-  isHovered?: boolean;
   /** Default hyperlink location */
   href?: string;
   /** Tooltip to display when hovered over the item */

--- a/packages/react-core/src/components/Dropdown/DropdownMenu.tsx
+++ b/packages/react-core/src/components/Dropdown/DropdownMenu.tsx
@@ -12,8 +12,6 @@ export interface DropdownMenuProps {
   className?: string;
   /** Flag to indicate if menu is opened */
   isOpen?: boolean;
-  /** @deprecated - no longer used */
-  openedOnEnter?: boolean;
   /** Flag to indicate if the first dropdown item should gain initial focus, set false when adding
    * a specific auto-focus item (like a current selection) otherwise leave as true
    */
@@ -51,7 +49,6 @@ export class DropdownMenu extends React.Component<DropdownMenuProps> {
   static defaultProps: DropdownMenuProps = {
     className: '',
     isOpen: true,
-    openedOnEnter: false,
     autoFocus: true,
     position: DropdownPosition.left,
     component: 'ul',
@@ -180,7 +177,6 @@ export class DropdownMenu extends React.Component<DropdownMenuProps> {
       isGrouped,
       setMenuComponentRef,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      openedOnEnter,
       alignments,
       ...props
     } = this.props;

--- a/packages/react-core/src/components/Dropdown/DropdownMenu.tsx
+++ b/packages/react-core/src/components/Dropdown/DropdownMenu.tsx
@@ -176,7 +176,6 @@ export class DropdownMenu extends React.Component<DropdownMenuProps> {
       component,
       isGrouped,
       setMenuComponentRef,
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       alignments,
       ...props
     } = this.props;

--- a/packages/react-core/src/components/Dropdown/DropdownToggle.tsx
+++ b/packages/react-core/src/components/Dropdown/DropdownToggle.tsx
@@ -29,8 +29,6 @@ export interface DropdownToggleProps extends React.HTMLProps<HTMLButtonElement>,
   isText?: boolean;
   /** Whether or not the <div> has a disabled state */
   isDisabled?: boolean;
-  /** @deprecated Use `toggleVariant` instead. Whether or not the dropdown toggle button should have primary button styling */
-  isPrimary?: boolean;
   /** Alternate styles for the dropdown toggle button */
   toggleVariant?: 'primary' | 'secondary' | 'default';
   /** An image to display within the dropdown toggle, appearing before any component children */
@@ -65,7 +63,6 @@ export const DropdownToggle: React.FunctionComponent<DropdownToggleProps> = ({
   isDisabled = false,
   isPlain = false,
   isText = false,
-  isPrimary = false,
   toggleVariant = 'default',
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   isActive = false,
@@ -97,7 +94,6 @@ export const DropdownToggle: React.FunctionComponent<DropdownToggleProps> = ({
           isDisabled={isDisabled}
           isPlain={isPlain}
           isText={isText}
-          isPrimary={isPrimary}
           toggleVariant={toggleVariant}
           onToggle={onToggle}
           aria-haspopup={ariaHasPopup}
@@ -123,7 +119,7 @@ export const DropdownToggle: React.FunctionComponent<DropdownToggleProps> = ({
           styles.dropdownToggle,
           styles.modifiers.splitButton,
           splitButtonVariant === 'action' && styles.modifiers.action,
-          (toggleVariant === 'primary' || isPrimary) && splitButtonVariant === 'action' && styles.modifiers.primary,
+          toggleVariant === 'primary' && splitButtonVariant === 'action' && styles.modifiers.primary,
           toggleVariant === 'secondary' && splitButtonVariant === 'action' && styles.modifiers.secondary,
           isDisabled && styles.modifiers.disabled
         )}

--- a/packages/react-core/src/components/Dropdown/Toggle.tsx
+++ b/packages/react-core/src/components/Dropdown/Toggle.tsx
@@ -35,8 +35,6 @@ export interface ToggleProps {
   isPlain?: boolean;
   /** Display the toggle in text only mode */
   isText?: boolean;
-  /** @deprecated Use `toggleVariant` instead. Display the toggle with a primary button style */
-  isPrimary?: boolean;
   /** Style the toggle as a child of a split button */
   isSplitButton?: boolean;
   /** Alternate styles for the dropdown toggle button */
@@ -64,7 +62,6 @@ export class Toggle extends React.Component<ToggleProps> {
     isDisabled: false,
     isPlain: false,
     isText: false,
-    isPrimary: false,
     isSplitButton: false,
     onToggle: () => {},
     onEnter: () => {},
@@ -138,7 +135,6 @@ export class Toggle extends React.Component<ToggleProps> {
       isDisabled,
       isPlain,
       isText,
-      isPrimary,
       isSplitButton,
       toggleVariant,
       onToggle,
@@ -166,7 +162,6 @@ export class Toggle extends React.Component<ToggleProps> {
               isActive && styles.modifiers.active,
               isPlain && styles.modifiers.plain,
               isText && styles.modifiers.text,
-              isPrimary && styles.modifiers.primary,
               toggleVariant && buttonVariantStyles[toggleVariant],
               className
             )}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8088 .

Removed all instances of:
- DropdownItem: `isHovered`
- DropdownMenu: `openedOnEnter`
- DropdownToggle: `isPrimary`
- Toggle: `isPrimary`

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
