### PR TITLE
fix(Alert): prevent error being thrown when using invalid variant

### DIFF
--- a/packages/react-core/src/components/Alert/AlertIcon.tsx
+++ b/packages/react-core/src/components/Alert/AlertIcon.tsx
@@ -26,9 +26,9 @@ export interface AlertIconProps extends React.HTMLProps<HTMLDivElement> {
 
 export const AlertIcon = ({ variant, customIcon, className = '', ...props }: AlertIconProps) => {
   const Icon = variantIcons[variant];
-  return (
+  return Icon ? (
     <div {...props} className={css(styles.alertIcon, className)}>
       {customIcon || <Icon />}
     </div>
-  );
+  ) : null;
 };


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8015

To reproduce, change the variant in an alert [on this page](https://www.patternfly.org/v4/components/alert) to 'error' (which is not a valid variant) and see the error message on the screen.

in my preview build, change the variant in an alert to error and see it just fall back to the default style for alert rather than crashing the component.
