### PR TITLE
fix(TimePicker): fixed bugs when updating time/minTime/maxTime props

### DIFF
--- a/packages/react-core/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react-core/src/components/TimePicker/TimePicker.tsx
@@ -143,6 +143,8 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
     document.addEventListener('mousedown', this.onDocClick);
     document.addEventListener('touchstart', this.onDocClick);
     document.addEventListener('keydown', this.handleGlobalKeys);
+
+    this.setState({ isInvalid: !this.isValid(this.state.timeState) });
   }
 
   componentWillUnmount() {
@@ -212,8 +214,11 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
       });
     }
     if (time !== '' && time !== prevProps.time) {
+      const parsedTime = parseTime(time, timeRegex, delimiter, !is24Hour, includeSeconds);
+
       this.setState({
-        timeState: parseTime(time, timeRegex, delimiter, !is24Hour, includeSeconds)
+        timeState: parsedTime,
+        isInvalid: !this.isValid(parsedTime)
       });
     }
   }

--- a/packages/react-core/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react-core/src/components/TimePicker/TimePicker.tsx
@@ -200,7 +200,7 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
 
   componentDidUpdate(prevProps: TimePickerProps, prevState: TimePickerState) {
     const { timeState, isTimeOptionsOpen, isInvalid, timeRegex } = this.state;
-    const { time, is24Hour, delimiter, includeSeconds, isOpen } = this.props;
+    const { time, is24Hour, delimiter, includeSeconds, isOpen, minTime, maxTime } = this.props;
     if (prevProps.isOpen !== isOpen) {
       this.onToggle(isOpen);
     }
@@ -219,6 +219,17 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
       this.setState({
         timeState: parsedTime,
         isInvalid: !this.isValid(parsedTime)
+      });
+    }
+    if (minTime !== '' && minTime !== prevProps.minTime) {
+      this.setState({
+        minTimeState: parseTime(minTime, timeRegex, delimiter, !is24Hour, includeSeconds)
+      });
+    }
+
+    if (maxTime !== '' && maxTime !== prevProps.maxTime) {
+      this.setState({
+        maxTimeState: parseTime(maxTime, timeRegex, delimiter, !is24Hour, includeSeconds)
       });
     }
   }

--- a/packages/react-core/src/components/TimePicker/__tests__/TimePicker.test.tsx
+++ b/packages/react-core/src/components/TimePicker/__tests__/TimePicker.test.tsx
@@ -107,22 +107,25 @@ describe('TimePicker', () => {
     });
 
     test('should be invalid after onBlur', async () => {
-      const validateTime = (_time: string) => {
-        return false;
-      };
       const user = userEvent.setup();
 
       render(
         <>
           <div>Other element</div>
-          <TimePicker value={'00:00'} validateTime={validateTime} aria-label="time picker" />
+          <TimePicker value={'00:00'} aria-label="time picker" />
         </>
       );
 
-      await user.type(screen.getByLabelText('time picker'), '01:00');
+      await user.type(screen.getByLabelText('time picker'), '14:00');
       expect(screen.queryByText('Invalid time format')).toBeNull();
 
       await user.click(screen.getByText('Other element'));
+      expect(screen.getByText('Invalid time format')).toBeInTheDocument();
+    });
+
+    test('should be invalid when invalid time prop is passed', () => {
+      render(<TimePicker time="00:00" aria-label="time picker" />);
+
       expect(screen.getByText('Invalid time format')).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7953 , closes #7993

[Timepicker on live site](https://www.patternfly.org/v4/components/time-picker)
[Timepicker preview build](https://patternfly-react-pr-8267.surge.sh/components/time-picker)

To test the `minTime`/`maxTime` issue, copy+paste the following code and click the buttons to notice how the timepicker menu updates with the new min/max times in the preview build (but not on the live site):

```
import React from 'react';
import { TimePicker } from '@patternfly/react-core';

const MinimummaximumTimes = () => {
    const [minTime, setMinTime] = React.useState("9:30")
    const [maxTime, setMaxTime] = React.useState("17:15")

    return (
        <>
            <button onClick={() => setMinTime("8:30")}>Update minTime</button>
            <button onClick={() => setMaxTime("18:15")}>Update maxTime</button>
            <TimePicker is24Hour minTime={minTime} maxTime={maxTime} placeholder="14:00" />
        </>)
};
```

To test the `time` prop issue, copy+paste the following code, and first click the button to update the time, then manually pass in `time="3:35 abc"`, to notice that the invalid error renders in both scenarios on the preview build (but not the live site):

```
import React from 'react';
import { TimePicker } from '@patternfly/react-core';

SimpleTimePicker = () => {
  const [time, setTime] = React.useState("3:35 AM")

  return (
    <>
      <button onClick={() => setTime("4:00 AMC")}>Update time</button>
      <TimePicker time={time} />
    </>);
};
```

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
