### PR TITLE
fix(DualListSelector): Add/remove button didn't work if search is used

### DIFF
--- a/packages/react-core/src/components/DualListSelector/DualListSelector.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelector.tsx
@@ -279,7 +279,9 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
 
       return {
         chosenOptions: newChosen,
+        chosenFilteredOptions: newChosen,
         availableOptions: newAvailable,
+        availableFilteredOptions: newAvailable,
         chosenOptionsSelected: [],
         availableOptionsSelected: []
       };
@@ -339,7 +341,9 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
         chosenOptionsSelected: [],
         availableOptionsSelected: [],
         chosenOptions: newChosen,
-        availableOptions: newAvailable
+        chosenFilteredOptions: newChosen,
+        availableOptions: newAvailable,
+        availableFilteredOptions: newAvailable
       };
     });
   };
@@ -393,7 +397,9 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
 
       return {
         chosenOptions: newChosen,
+        chosenFilteredOptions: newChosen,
         availableOptions: newAvailable,
+        availableFilteredOptions: newAvailable,
         chosenOptionsSelected: [],
         availableOptionsSelected: []
       };
@@ -449,7 +455,9 @@ export class DualListSelector extends React.Component<DualListSelectorProps, Dua
         chosenOptionsSelected: [],
         availableOptionsSelected: [],
         chosenOptions: newChosen,
-        availableOptions: newAvailable
+        chosenFilteredOptions: newChosen,
+        availableOptions: newAvailable,
+        availableFilteredOptions: newAvailable
       };
     });
   };


### PR DESCRIPTION
**What**: Closes #8268

**Additional issues**: Reported in a code review by @sanketpathak https://github.com/openshift/console/pull/12159#issuecomment-1282122767

**Analysis / Root cause**: 
`addAllVisible` and `removeAllVisible` uses `prevState.availableFilteredOptions || prevState.availableOptions` and `prevState.chosenFilteredOptions || prevState.chosenOptions` to take a look into filtered or all options.

`availableFilteredOptions` and `chosenFilteredOptions` was only calculated before when the filter is changed.

But it should be also recalculated when values are moved from the left to the right side and vice versa.

**Solution Description**: 
Calculate `availableFilteredOptions` and `chosenFilteredOptions` also when moving options in `addAllVisible`, `removeAllVisible`, `addSelected` or `removeSelected`.

Steps to reproduce the issue:
1. Start with all 4 options on the left side, both search fields are empty.
2. Enter "option" (or "option 1") into the right search field (chosen option)
3. Press "Add all" (») to move all elements to the right side
    1. alternative: select one or more option and press "Add" (›) to move just these options to the right side
4. Press "Remove all" («) to move all options to the left side again. :bug: But nothing happens.

https://patternfly-react-main.surge.sh/components/dual-list-selector/react/basic-with-search/
https://patternfly-react-pr-8269.surge.sh/components/dual-list-selector/react/basic-with-search/

**Screenrecording**:

Before (main branch):

https://user-images.githubusercontent.com/139310/196555861-32a76e17-66ee-407a-95a8-2d022c913861.mp4

With this PR:

https://user-images.githubusercontent.com/139310/196555711-bdc7e5c2-914c-4f55-8011-0f6d332e921e.mp4