### PR TITLE
Create workflow for extensions issues

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -1,0 +1,17 @@
+name: Add relevant issues to extensions project board
+
+on:
+  issues:
+    types:
+      - labeled
+
+jobs:
+  add-to-extensions:
+    if: github.event.label.name == 'extensions'
+    name: Add issue to extensions board
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.3.0
+        with:
+          project-url: https://github.com/orgs/patternfly/projects/12
+          github-token: ${{ secrets.PF_ISSUES_PROJECT_SECRET }}

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   add-to-extensions:
-    if: github.event.label.name == 'extensions'
+    if: github.event.label.name == 'extension'
     name: Add issue to extensions board
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Whenever a patternfly-react issue is tagged with the 'extensions' label, it will automatically get added to the 'PatternFly Extensions' project board
