### PR TITLE
fix(label): fix hrefs in compact example

### DIFF
--- a/packages/react-core/src/components/Label/examples/LabelCompact.tsx
+++ b/packages/react-core/src/components/Label/examples/LabelCompact.tsx
@@ -14,10 +14,10 @@ export const LabelCompact: React.FunctionComponent = () => (
     <Label isCompact icon={<InfoCircleIcon />} onClose={() => Function.prototype}>
       Compact icon removable
     </Label>{' '}
-    <Label isCompact href="#outline">
+    <Label isCompact href="#compact">
       Compact link
     </Label>{' '}
-    <Label isCompact href="#outline" onClose={() => Function.prototype}>
+    <Label isCompact href="#compact" onClose={() => Function.prototype}>
       Compact link removable
     </Label>
     <Label isCompact icon={<InfoCircleIcon />} onClose={() => Function.prototype} isTruncated>


### PR DESCRIPTION
 Bug - Label - hrefs in compact example have wrong anchor tag #8311

<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
