### PR TITLE
fix(Popper): add display contents to wrapping divs

### DIFF
--- a/packages/react-core/src/components/Popover/__tests__/__snapshots__/Popover.test.tsx.snap
+++ b/packages/react-core/src/components/Popover/__tests__/__snapshots__/Popover.test.tsx.snap
@@ -36,7 +36,9 @@ exports[`popover renders close-button, header and body 1`] = `
 
 exports[`popover renders in strict mode 1`] = `
 <DocumentFragment>
-  <div>
+  <div
+    style="display: contents;"
+  >
     <div>
       Toggle Popover
     </div>

--- a/packages/react-core/src/components/SearchInput/__tests__/__snapshots__/SearchInput.test.tsx.snap
+++ b/packages/react-core/src/components/SearchInput/__tests__/__snapshots__/SearchInput.test.tsx.snap
@@ -441,7 +441,9 @@ exports[`SearchInput renders search input in strict mode 1`] = `
   <div
     class=""
   >
-    <div>
+    <div
+      style="display: contents;"
+    >
       <div
         class="pf-c-input-group"
       >

--- a/packages/react-core/src/components/Tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/react-core/src/components/Tooltip/__tests__/__snapshots__/Tooltip.test.tsx.snap
@@ -10,7 +10,9 @@ exports[`tooltip renders 1`] = `
 
 exports[`tooltip renders in strict mode 1`] = `
 <DocumentFragment>
-  <div>
+  <div
+    style="display: contents;"
+  >
     <div>
       Toggle tooltip
     </div>

--- a/packages/react-core/src/helpers/Popper/Popper.tsx
+++ b/packages/react-core/src/helpers/Popper/Popper.tsx
@@ -383,7 +383,11 @@ export const Popper: React.FunctionComponent<PopperProps> = ({
   let popperPortal;
   if (removeFindDomNode) {
     // If removeFindDomNode is passed, use the removeFindDomNode method of wrapping divs
-    popperPortal = <div ref={node => setPopperElement(node?.firstElementChild as HTMLElement)}>{menuWithPopper}</div>;
+    popperPortal = (
+      <div style={{ display: 'contents' }} ref={node => setPopperElement(node?.firstElementChild as HTMLElement)}>
+        {menuWithPopper}
+      </div>
+    );
   } else if (popperRef) {
     // If removeFindDomNode is not passed and popperRef is passed, use the popperRef method
     popperPortal = menuWithPopper;
@@ -400,7 +404,9 @@ export const Popper: React.FunctionComponent<PopperProps> = ({
         <FindRefWrapper onFoundRef={(foundRef: any) => setTriggerElement(foundRef)}>{trigger}</FindRefWrapper>
       )}
       {!reference && trigger && React.isValidElement(trigger) && removeFindDomNode && (
-        <div ref={node => setTriggerElement(node?.firstElementChild as HTMLElement)}>{trigger}</div>
+        <div style={{ display: 'contents' }} ref={node => setTriggerElement(node?.firstElementChild as HTMLElement)}>
+          {trigger}
+        </div>
       )}
       {ready && isVisible && ReactDOM.createPortal(popperPortal, getTarget())}
     </>

--- a/packages/react-core/src/helpers/Popper/Popper.tsx
+++ b/packages/react-core/src/helpers/Popper/Popper.tsx
@@ -311,7 +311,7 @@ export const Popper: React.FunctionComponent<PopperProps> = ({
     [popperMatchesTriggerWidth]
   );
 
-  const { styles: popperStyles, attributes, update } = usePopper(refOrTrigger, popperElement, {
+  const { styles: popperStyles, attributes, update, forceUpdate } = usePopper(refOrTrigger, popperElement, {
     placement: getPlacementMemo,
     modifiers: [
       {
@@ -339,6 +339,10 @@ export const Popper: React.FunctionComponent<PopperProps> = ({
       sameWidthMod
     ]
   });
+
+  React.useEffect(() => {
+    forceUpdate && forceUpdate();
+  }, [popper]);
 
   // Returns the CSS modifier class in order to place the Popper's arrow properly
   // Depends on the position of the Popper relative to the reference element


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8277

This should resolve the layout issues that can occur due to the new `div`.
