### PR TITLE
Topology - DefaultNode - Set status decorators to be opaque

### DIFF
--- a/packages/react-topology/src/components/nodes/DefaultNode.tsx
+++ b/packages/react-topology/src/components/nodes/DefaultNode.tsx
@@ -151,7 +151,7 @@ const DefaultNode: React.FunctionComponent<DefaultNodeProps> = ({
         x={x}
         y={y}
         radius={DEFAULT_DECORATOR_RADIUS}
-        showBackground={false}
+        showBackground
         onClick={e => onStatusDecoratorClick(e, element)}
         icon={<g className={css(styles.topologyNodeDecoratorStatus)}>{icon}</g>}
       />


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #
Closes #8334 

Before:
![Screen Shot 2022-11-04 at 9 21 23 AM](https://user-images.githubusercontent.com/2293210/200045298-86868643-f306-4b96-82b9-32b49e8003a1.png)
After:
<img width="111" alt="Screen Shot 2022-11-04 at 11 05 25 AM" src="https://user-images.githubusercontent.com/2293210/200045303-fbf94283-1285-40c7-92e9-d4f45d9229d6.png">
