### PR TITLE
feat(MultipleFileUpload): added support for helper text

### DIFF
--- a/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadStatusItem.tsx
+++ b/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadStatusItem.tsx
@@ -3,7 +3,6 @@ import styles from '@patternfly/react-styles/css/components/MultipleFileUpload/m
 import { css } from '@patternfly/react-styles';
 import { Progress } from '../Progress';
 import { Button } from '../Button';
-import { HelperText, HelperTextItem } from '../HelperText';
 import FileIcon from '@patternfly/react-icons/dist/esm/icons/file-icon';
 import TimesCircleIcon from '@patternfly/react-icons/dist/esm/icons/times-circle-icon';
 
@@ -55,7 +54,7 @@ export interface MultipleFileUploadStatusItemProps extends React.HTMLProps<HTMLL
   progressAriaLiveMessage?: string | ((loadPercentage: number) => string);
   /** Unique identifier for progress. Generated if not specified. */
   progressId?: string;
-  /** @beta Additional content related to the status item, intended to be dynamically rendered content such as status messages. */
+  /** @beta Additional content related to the status item. */
   progressHelperText?: React.ReactNode;
 }
 
@@ -145,14 +144,6 @@ export const MultipleFileUploadStatusItem: React.FunctionComponent<MultipleFileU
     </span>
   );
 
-  const helperTextVariant = variant === 'danger' ? 'error' : variant;
-
-  const statusItemHelperText = progressHelperText && (
-    <HelperText isLiveRegion>
-      <HelperTextItem variant={helperTextVariant}>{progressHelperText}</HelperTextItem>
-    </HelperText>
-  );
-
   return (
     <li className={css(styles.multipleFileUploadStatusItem, className)} {...props}>
       <div className={styles.multipleFileUploadStatusItemIcon}>{fileIcon || <FileIcon />}</div>
@@ -171,7 +162,7 @@ export const MultipleFileUploadStatusItem: React.FunctionComponent<MultipleFileU
           aria-label={progressAriaLabel}
           aria-labelledby={progressAriaLabelledBy}
           id={progressId}
-          helperText={statusItemHelperText}
+          helperText={progressHelperText}
         />
       </div>
       <div className={styles.multipleFileUploadStatusItemClose}>

--- a/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadStatusItem.tsx
+++ b/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadStatusItem.tsx
@@ -56,7 +56,7 @@ export interface MultipleFileUploadStatusItemProps extends React.HTMLProps<HTMLL
   /** Unique identifier for progress. Generated if not specified. */
   progressId?: string;
   /** @beta Additional content related to the status item, intended to be dynamically rendered content such as status messages. */
-  helperText?: React.ReactNode;
+  progressHelperText?: React.ReactNode;
 }
 
 export const MultipleFileUploadStatusItem: React.FunctionComponent<MultipleFileUploadStatusItemProps> = ({
@@ -78,7 +78,7 @@ export const MultipleFileUploadStatusItem: React.FunctionComponent<MultipleFileU
   progressId,
   progressAriaLiveMessage,
   buttonAriaLabel = 'Remove from list',
-  helperText,
+  progressHelperText,
   ...props
 }: MultipleFileUploadStatusItemProps) => {
   const [loadPercentage, setLoadPercentage] = React.useState(0);
@@ -147,9 +147,9 @@ export const MultipleFileUploadStatusItem: React.FunctionComponent<MultipleFileU
 
   const helperTextVariant = variant === 'danger' ? 'error' : variant;
 
-  const statusItemHelperText = helperText && (
+  const statusItemHelperText = progressHelperText && (
     <HelperText isLiveRegion>
-      <HelperTextItem variant={helperTextVariant}>{helperText}</HelperTextItem>
+      <HelperTextItem variant={helperTextVariant}>{progressHelperText}</HelperTextItem>
     </HelperText>
   );
 

--- a/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadStatusItem.tsx
+++ b/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadStatusItem.tsx
@@ -3,6 +3,7 @@ import styles from '@patternfly/react-styles/css/components/MultipleFileUpload/m
 import { css } from '@patternfly/react-styles';
 import { Progress } from '../Progress';
 import { Button } from '../Button';
+import { HelperText, HelperTextItem } from '../HelperText';
 import FileIcon from '@patternfly/react-icons/dist/esm/icons/file-icon';
 import TimesCircleIcon from '@patternfly/react-icons/dist/esm/icons/times-circle-icon';
 
@@ -54,6 +55,8 @@ export interface MultipleFileUploadStatusItemProps extends React.HTMLProps<HTMLL
   progressAriaLiveMessage?: string | ((loadPercentage: number) => string);
   /** Unique identifier for progress. Generated if not specified. */
   progressId?: string;
+  /** @beta Additional content related to the status item, intended to be dynamically rendered content such as status messages. */
+  helperText?: React.ReactNode;
 }
 
 export const MultipleFileUploadStatusItem: React.FunctionComponent<MultipleFileUploadStatusItemProps> = ({
@@ -75,6 +78,7 @@ export const MultipleFileUploadStatusItem: React.FunctionComponent<MultipleFileU
   progressId,
   progressAriaLiveMessage,
   buttonAriaLabel = 'Remove from list',
+  helperText,
   ...props
 }: MultipleFileUploadStatusItemProps) => {
   const [loadPercentage, setLoadPercentage] = React.useState(0);
@@ -129,6 +133,9 @@ export const MultipleFileUploadStatusItem: React.FunctionComponent<MultipleFileU
     return `${Math.round(size)}${prefixes[prefixUnit]}B`;
   };
 
+  const value = progressValue || loadPercentage;
+  const variant = progressVariant || loadResult;
+
   const title = (
     <span className={styles.multipleFileUploadStatusItemProgress}>
       <span className={styles.multipleFileUploadStatusItemProgressText}>{fileName || file?.name || ''}</span>
@@ -136,6 +143,14 @@ export const MultipleFileUploadStatusItem: React.FunctionComponent<MultipleFileU
         {fileSize || getHumanReadableFileSize(file?.size || 0)}
       </span>
     </span>
+  );
+
+  const helperTextVariant = variant === 'danger' ? 'error' : variant;
+
+  const statusItemHelperText = helperText && (
+    <HelperText isLiveRegion>
+      <HelperTextItem variant={helperTextVariant}>{helperText}</HelperTextItem>
+    </HelperText>
   );
 
   return (
@@ -151,11 +166,12 @@ export const MultipleFileUploadStatusItem: React.FunctionComponent<MultipleFileU
         </div>
         <Progress
           title={title}
-          value={progressValue || loadPercentage}
-          variant={progressVariant || loadResult}
+          value={value}
+          variant={variant}
           aria-label={progressAriaLabel}
           aria-labelledby={progressAriaLabelledBy}
           id={progressId}
+          helperText={statusItemHelperText}
         />
       </div>
       <div className={styles.multipleFileUploadStatusItemClose}>

--- a/packages/react-core/src/components/MultipleFileUpload/__tests__/MultipleFileUploadStatusItem.test.tsx
+++ b/packages/react-core/src/components/MultipleFileUpload/__tests__/MultipleFileUploadStatusItem.test.tsx
@@ -5,8 +5,6 @@ import { render, screen } from '@testing-library/react';
 import { MultipleFileUploadStatusItem } from '../MultipleFileUploadStatusItem';
 import FileImageIcon from '@patternfly/react-icons/dist/esm/icons/file-image-icon';
 
-jest.mock('../../HelperText');
-
 describe('MultipleFileUploadStatusItem', () => {
   test('renders with expected class names', () => {
     const { asFragment } = render(<MultipleFileUploadStatusItem progressId="test-progress-id" />);
@@ -135,108 +133,4 @@ test('renders helper text', () => {
   const helperText = screen.getByText('Test helper text');
 
   expect(helperText).toBeVisible();
-});
-
-test('renders the helper text inside of a HelperTextItem and HelperText component', () => {
-  const testFile = new File(['foo'], 'testFile.txt');
-  render(
-    <MultipleFileUploadStatusItem
-      file={testFile}
-      buttonAriaLabel="buttonAriaLabel"
-      progressAriaLabel="progressAriaLabel"
-      progressAriaLabelledBy="progressAriaLabelledBy"
-      progressId="test-progress-id"
-      progressHelperText="Test helper text"
-    />
-  );
-
-  const helperText = screen.getByText('Test helper text');
-  const helperTextItemContainer = screen.getByTestId('helper-text-item-children-container');
-  const helperTextContainer = screen.getByTestId('helper-text-children-container');
-
-  expect(helperTextContainer).toContainElement(helperTextItemContainer);
-  expect(helperTextItemContainer).toContainElement(helperText);
-});
-
-test('renders the helper text with a variant of undefined when the progress variant is undefined', () => {
-  const testFile = new File(['foo'], 'testFile.txt');
-  render(
-    <MultipleFileUploadStatusItem
-      file={testFile}
-      buttonAriaLabel="buttonAriaLabel"
-      progressAriaLabel="progressAriaLabel"
-      progressAriaLabelledBy="progressAriaLabelledBy"
-      progressId="test-progress-id"
-      progressHelperText="Test helper text"
-    />
-  );
-
-  expect(screen.getByText('variant: undefined')).toBeVisible();
-});
-
-test('renders the helper text with a variant of success when the progress variant is success', () => {
-  const testFile = new File(['foo'], 'testFile.txt');
-  render(
-    <MultipleFileUploadStatusItem
-      file={testFile}
-      buttonAriaLabel="buttonAriaLabel"
-      progressAriaLabel="progressAriaLabel"
-      progressAriaLabelledBy="progressAriaLabelledBy"
-      progressId="test-progress-id"
-      progressVariant="success"
-      progressHelperText="Test helper text"
-    />
-  );
-
-  expect(screen.getByText('variant: success')).toBeVisible();
-});
-
-test('renders the helper text with a variant of warning when the progress variant is warning', () => {
-  const testFile = new File(['foo'], 'testFile.txt');
-  render(
-    <MultipleFileUploadStatusItem
-      file={testFile}
-      buttonAriaLabel="buttonAriaLabel"
-      progressAriaLabel="progressAriaLabel"
-      progressAriaLabelledBy="progressAriaLabelledBy"
-      progressId="test-progress-id"
-      progressVariant="warning"
-      progressHelperText="Test helper text"
-    />
-  );
-
-  expect(screen.getByText('variant: warning')).toBeVisible();
-});
-
-test('renders the helper text with a variant of error when the progress variant is danger', () => {
-  const testFile = new File(['foo'], 'testFile.txt');
-  render(
-    <MultipleFileUploadStatusItem
-      file={testFile}
-      buttonAriaLabel="buttonAriaLabel"
-      progressAriaLabel="progressAriaLabel"
-      progressAriaLabelledBy="progressAriaLabelledBy"
-      progressId="test-progress-id"
-      progressVariant="danger"
-      progressHelperText="Test helper text"
-    />
-  );
-
-  expect(screen.getByText('variant: error')).toBeVisible();
-});
-
-test('renders the helper text as a live region', () => {
-  const testFile = new File(['foo'], 'testFile.txt');
-  render(
-    <MultipleFileUploadStatusItem
-      file={testFile}
-      buttonAriaLabel="buttonAriaLabel"
-      progressAriaLabel="progressAriaLabel"
-      progressAriaLabelledBy="progressAriaLabelledBy"
-      progressId="test-progress-id"
-      progressHelperText="Test helper text"
-    />
-  );
-
-  expect(screen.getByText('isLiveRegion: true')).toBeVisible();
 });

--- a/packages/react-core/src/components/MultipleFileUpload/__tests__/MultipleFileUploadStatusItem.test.tsx
+++ b/packages/react-core/src/components/MultipleFileUpload/__tests__/MultipleFileUploadStatusItem.test.tsx
@@ -5,6 +5,8 @@ import { render, screen } from '@testing-library/react';
 import { MultipleFileUploadStatusItem } from '../MultipleFileUploadStatusItem';
 import FileImageIcon from '@patternfly/react-icons/dist/esm/icons/file-image-icon';
 
+jest.mock('../../HelperText');
+
 describe('MultipleFileUploadStatusItem', () => {
   test('renders with expected class names', () => {
     const { asFragment } = render(<MultipleFileUploadStatusItem progressId="test-progress-id" />);
@@ -98,4 +100,143 @@ describe('MultipleFileUploadStatusItem', () => {
 
     expect(asFragment()).toMatchSnapshot();
   });
+});
+
+test('does not render helper text by default', () => {
+  const testFile = new File(['foo'], 'testFile.txt');
+  render(
+    <MultipleFileUploadStatusItem
+      file={testFile}
+      buttonAriaLabel="buttonAriaLabel"
+      progressAriaLabel="progressAriaLabel"
+      progressAriaLabelledBy="progressAriaLabelledBy"
+      progressId="test-progress-id"
+    />
+  );
+
+  const helperText = screen.queryByText('Test helper text');
+
+  expect(helperText).not.toBeInTheDocument();
+});
+
+test('renders helper text', () => {
+  const testFile = new File(['foo'], 'testFile.txt');
+  render(
+    <MultipleFileUploadStatusItem
+      file={testFile}
+      buttonAriaLabel="buttonAriaLabel"
+      progressAriaLabel="progressAriaLabel"
+      progressAriaLabelledBy="progressAriaLabelledBy"
+      progressId="test-progress-id"
+      helperText="Test helper text"
+    />
+  );
+
+  const helperText = screen.getByText('Test helper text');
+
+  expect(helperText).toBeVisible();
+});
+
+test('renders the helper text inside of a HelperTextItem and HelperText component', () => {
+  const testFile = new File(['foo'], 'testFile.txt');
+  render(
+    <MultipleFileUploadStatusItem
+      file={testFile}
+      buttonAriaLabel="buttonAriaLabel"
+      progressAriaLabel="progressAriaLabel"
+      progressAriaLabelledBy="progressAriaLabelledBy"
+      progressId="test-progress-id"
+      helperText="Test helper text"
+    />
+  );
+
+  const helperText = screen.getByText('Test helper text');
+  const helperTextItemContainer = screen.getByTestId('helper-text-item-children-container');
+  const helperTextContainer = screen.getByTestId('helper-text-children-container');
+
+  expect(helperTextContainer).toContainElement(helperTextItemContainer);
+  expect(helperTextItemContainer).toContainElement(helperText);
+});
+
+test('renders the helper text with a variant of undefined when the progress variant is undefined', () => {
+  const testFile = new File(['foo'], 'testFile.txt');
+  render(
+    <MultipleFileUploadStatusItem
+      file={testFile}
+      buttonAriaLabel="buttonAriaLabel"
+      progressAriaLabel="progressAriaLabel"
+      progressAriaLabelledBy="progressAriaLabelledBy"
+      progressId="test-progress-id"
+      helperText="Test helper text"
+    />
+  );
+
+  expect(screen.getByText('variant: undefined')).toBeVisible();
+});
+
+test('renders the helper text with a variant of success when the progress variant is success', () => {
+  const testFile = new File(['foo'], 'testFile.txt');
+  render(
+    <MultipleFileUploadStatusItem
+      file={testFile}
+      buttonAriaLabel="buttonAriaLabel"
+      progressAriaLabel="progressAriaLabel"
+      progressAriaLabelledBy="progressAriaLabelledBy"
+      progressId="test-progress-id"
+      progressVariant="success"
+      helperText="Test helper text"
+    />
+  );
+
+  expect(screen.getByText('variant: success')).toBeVisible();
+});
+
+test('renders the helper text with a variant of warning when the progress variant is warning', () => {
+  const testFile = new File(['foo'], 'testFile.txt');
+  render(
+    <MultipleFileUploadStatusItem
+      file={testFile}
+      buttonAriaLabel="buttonAriaLabel"
+      progressAriaLabel="progressAriaLabel"
+      progressAriaLabelledBy="progressAriaLabelledBy"
+      progressId="test-progress-id"
+      progressVariant="warning"
+      helperText="Test helper text"
+    />
+  );
+
+  expect(screen.getByText('variant: warning')).toBeVisible();
+});
+
+test('renders the helper text with a variant of error when the progress variant is danger', () => {
+  const testFile = new File(['foo'], 'testFile.txt');
+  render(
+    <MultipleFileUploadStatusItem
+      file={testFile}
+      buttonAriaLabel="buttonAriaLabel"
+      progressAriaLabel="progressAriaLabel"
+      progressAriaLabelledBy="progressAriaLabelledBy"
+      progressId="test-progress-id"
+      progressVariant="danger"
+      helperText="Test helper text"
+    />
+  );
+
+  expect(screen.getByText('variant: error')).toBeVisible();
+});
+
+test('renders the helper text as a live region', () => {
+  const testFile = new File(['foo'], 'testFile.txt');
+  render(
+    <MultipleFileUploadStatusItem
+      file={testFile}
+      buttonAriaLabel="buttonAriaLabel"
+      progressAriaLabel="progressAriaLabel"
+      progressAriaLabelledBy="progressAriaLabelledBy"
+      progressId="test-progress-id"
+      helperText="Test helper text"
+    />
+  );
+
+  expect(screen.getByText('isLiveRegion: true')).toBeVisible();
 });

--- a/packages/react-core/src/components/MultipleFileUpload/__tests__/MultipleFileUploadStatusItem.test.tsx
+++ b/packages/react-core/src/components/MultipleFileUpload/__tests__/MultipleFileUploadStatusItem.test.tsx
@@ -128,7 +128,7 @@ test('renders helper text', () => {
       progressAriaLabel="progressAriaLabel"
       progressAriaLabelledBy="progressAriaLabelledBy"
       progressId="test-progress-id"
-      helperText="Test helper text"
+      progressHelperText="Test helper text"
     />
   );
 
@@ -146,7 +146,7 @@ test('renders the helper text inside of a HelperTextItem and HelperText componen
       progressAriaLabel="progressAriaLabel"
       progressAriaLabelledBy="progressAriaLabelledBy"
       progressId="test-progress-id"
-      helperText="Test helper text"
+      progressHelperText="Test helper text"
     />
   );
 
@@ -167,7 +167,7 @@ test('renders the helper text with a variant of undefined when the progress vari
       progressAriaLabel="progressAriaLabel"
       progressAriaLabelledBy="progressAriaLabelledBy"
       progressId="test-progress-id"
-      helperText="Test helper text"
+      progressHelperText="Test helper text"
     />
   );
 
@@ -184,7 +184,7 @@ test('renders the helper text with a variant of success when the progress varian
       progressAriaLabelledBy="progressAriaLabelledBy"
       progressId="test-progress-id"
       progressVariant="success"
-      helperText="Test helper text"
+      progressHelperText="Test helper text"
     />
   );
 
@@ -201,7 +201,7 @@ test('renders the helper text with a variant of warning when the progress varian
       progressAriaLabelledBy="progressAriaLabelledBy"
       progressId="test-progress-id"
       progressVariant="warning"
-      helperText="Test helper text"
+      progressHelperText="Test helper text"
     />
   );
 
@@ -218,7 +218,7 @@ test('renders the helper text with a variant of error when the progress variant 
       progressAriaLabelledBy="progressAriaLabelledBy"
       progressId="test-progress-id"
       progressVariant="danger"
-      helperText="Test helper text"
+      progressHelperText="Test helper text"
     />
   );
 
@@ -234,7 +234,7 @@ test('renders the helper text as a live region', () => {
       progressAriaLabel="progressAriaLabel"
       progressAriaLabelledBy="progressAriaLabelledBy"
       progressId="test-progress-id"
-      helperText="Test helper text"
+      progressHelperText="Test helper text"
     />
   );
 

--- a/packages/react-core/src/components/MultipleFileUpload/examples/MultipleFileUpload.md
+++ b/packages/react-core/src/components/MultipleFileUpload/examples/MultipleFileUpload.md
@@ -46,7 +46,7 @@ The below example demonstrates a typical application of file upload - multiple, 
 
 The "Show as horizontal" checkbox can be used to easily toggle the `isHorizontal` prop, showing our available styling variations.
 
-The "Demonstrate error state with helper text" checkbox shows how our `helperText` prop can be used to provide status messages to users, such as when a file fails to upload. While this checkbox is checked it will cause any file uploaded to automatically fail the file reading process, and helper text will be dynamically rendered which informs the user of that error.
+The "Demonstrate error state with helper text" checkbox shows how our `progressHelperText` prop can be used to provide status messages to users, such as when a file fails to upload. While this checkbox is checked it will cause any file uploaded to automatically fail the file reading process, and helper text will be dynamically rendered which informs the user of that error.
 
 ```ts file="./MultipleFileUploadBasic.tsx"
 ```

--- a/packages/react-core/src/components/MultipleFileUpload/examples/MultipleFileUpload.md
+++ b/packages/react-core/src/components/MultipleFileUpload/examples/MultipleFileUpload.md
@@ -46,7 +46,7 @@ The below example demonstrates a typical application of file upload - multiple, 
 
 The "Show as horizontal" checkbox can be used to easily toggle the `isHorizontal` prop, showing our available styling variations.
 
-The "Demonstrate error state with helper text" checkbox shows how our `progressHelperText` prop can be used to provide status messages to users, such as when a file fails to upload. While this checkbox is checked it will cause any file uploaded to automatically fail the file reading process, and helper text will be dynamically rendered which informs the user of that error.
+The "Demonstrate error reporting by forcing uploads to fail" checkbox shows how our `progressHelperText` prop can be used to provide status messages to users, such as when a file fails to upload. While this checkbox is checked it will cause any file uploaded to automatically fail the file reading process, and helper text will be dynamically rendered which informs the user of that error.
 
 ```ts file="./MultipleFileUploadBasic.tsx"
 ```

--- a/packages/react-core/src/components/MultipleFileUpload/examples/MultipleFileUpload.md
+++ b/packages/react-core/src/components/MultipleFileUpload/examples/MultipleFileUpload.md
@@ -42,5 +42,11 @@ File upload - multiple is designed in a composable manner to make customization 
 
 ### Basic
 
+The below example demonstrates a typical application of file upload - multiple, with a few tweaks from that typical application to enhance the convenience of the example.
+
+The "Show as horizontal" checkbox can be used to easily toggle the `isHorizontal` prop, showing our available styling variations.
+
+The "Demonstrate error state with helper text" checkbox shows how our `helperText` prop can be used to provide status messages to users, such as when a file fails to upload. While this checkbox is checked it will cause any file uploaded to automatically fail the file reading process, and helper text will be dynamically rendered which informs the user of that error.
+
 ```ts file="./MultipleFileUploadBasic.tsx"
 ```

--- a/packages/react-core/src/components/MultipleFileUpload/examples/MultipleFileUploadBasic.tsx
+++ b/packages/react-core/src/components/MultipleFileUpload/examples/MultipleFileUploadBasic.tsx
@@ -142,7 +142,7 @@ export const MultipleFileUploadBasic: React.FunctionComponent = () => {
       />
       <Checkbox
         id="upload-should-fail-checkbox"
-        label="Demonstrate error state with helper text"
+        label="Demonstrate error reporting by forcing uploads to fail"
         isChecked={fileUploadShouldFail}
         onChange={() => setFileUploadShouldFail(!fileUploadShouldFail)}
       />

--- a/packages/react-core/src/components/MultipleFileUpload/examples/MultipleFileUploadBasic.tsx
+++ b/packages/react-core/src/components/MultipleFileUpload/examples/MultipleFileUploadBasic.tsx
@@ -56,7 +56,7 @@ export const MultipleFileUploadBasic: React.FunctionComponent = () => {
     setReadFileData(newReadFiles);
   };
 
-  /** this function forces uploaded files to become corrupted if "Demonstrate error state with helper text" is selected in the example,
+  /** Forces uploaded files to become corrupted if "Demonstrate error reporting by forcing uploads to fail" is selected in the example,
    * only used in this example for demonstration purposes */
   const updateCurrentFiles = (files: File[]) => {
     if (fileUploadShouldFail) {

--- a/packages/react-core/src/components/MultipleFileUpload/examples/MultipleFileUploadBasic.tsx
+++ b/packages/react-core/src/components/MultipleFileUpload/examples/MultipleFileUploadBasic.tsx
@@ -54,7 +54,7 @@ export const MultipleFileUploadBasic: React.FunctionComponent = () => {
     setReadFileData(newReadFiles);
   };
 
-  /** this function causes uploaded files to become corrupted if the corresponding option is selected in the example,
+  /** this function forces uploaded files to become corrupted if "Demonstrate error state with helper text" is selected in the example,
    * only used in this example for demonstration purposes */
   const updateCurrentFiles = (files: File[]) => {
     if (fileUploadShouldFail) {
@@ -142,7 +142,7 @@ export const MultipleFileUploadBasic: React.FunctionComponent = () => {
       />
       <Checkbox
         id="upload-should-fail-checkbox"
-        label="Force uploads to fail"
+        label="Demonstrate error state with helper text"
         isChecked={fileUploadShouldFail}
         onChange={() => setFileUploadShouldFail(!fileUploadShouldFail)}
       />

--- a/packages/react-core/src/components/MultipleFileUpload/examples/MultipleFileUploadBasic.tsx
+++ b/packages/react-core/src/components/MultipleFileUpload/examples/MultipleFileUploadBasic.tsx
@@ -128,7 +128,7 @@ export const MultipleFileUploadBasic: React.FunctionComponent = () => {
                 onClearClick={() => removeFiles([file.name])}
                 onReadSuccess={handleReadSuccess}
                 onReadFail={handleReadFail}
-                helperText={createHelperText(file)}
+                progressHelperText={createHelperText(file)}
               />
             ))}
           </MultipleFileUploadStatus>

--- a/packages/react-core/src/components/MultipleFileUpload/examples/MultipleFileUploadBasic.tsx
+++ b/packages/react-core/src/components/MultipleFileUpload/examples/MultipleFileUploadBasic.tsx
@@ -4,7 +4,9 @@ import {
   MultipleFileUploadMain,
   MultipleFileUploadStatus,
   MultipleFileUploadStatusItem,
-  Checkbox
+  Checkbox,
+  HelperText,
+  HelperTextItem
 } from '@patternfly/react-core';
 import UploadIcon from '@patternfly/react-icons/dist/esm/icons/upload-icon';
 
@@ -95,7 +97,11 @@ export const MultipleFileUploadBasic: React.FunctionComponent = () => {
   const createHelperText = (file: File) => {
     const fileResult = readFileData.find(readFile => readFile.fileName === file.name);
     if (fileResult?.loadError) {
-      return fileResult.loadError.toString();
+      return (
+        <HelperText isLiveRegion>
+          <HelperTextItem variant={'error'}>{fileResult.loadError.toString()}</HelperTextItem>
+        </HelperText>
+      );
     }
   };
 


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8238 

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:

Convenience link: https://patternfly-react-pr-8344.surge.sh/components/file-upload---multiple#basic

Check the "Force uploads to fail" checkbox to see the helper text in action!