### PR TITLE
feat(Tabs): add TabAction, update core ver

### DIFF
--- a/packages/react-catalog-view-extension/package.json
+++ b/packages/react-catalog-view-extension/package.json
@@ -35,7 +35,7 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
-    "@patternfly/patternfly": "4.219.2",
+    "@patternfly/patternfly": "4.220.0",
     "@patternfly/react-core": "^4.263.0",
     "@patternfly/react-styles": "^4.91.10"
   },

--- a/packages/react-console/package.json
+++ b/packages/react-console/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@novnc/novnc": "^1.2.0",
-    "@patternfly/patternfly": "4.219.2",
+    "@patternfly/patternfly": "4.220.0",
     "@patternfly/react-core": "^4.263.0",
     "@spice-project/spice-html5": "^0.2.1",
     "@types/file-saver": "^2.0.1",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -53,7 +53,7 @@
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "4.219.2",
+    "@patternfly/patternfly": "4.220.0",
     "@rollup/plugin-commonjs": "^21.0.0",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@rollup/plugin-replace": "^3.0.0",

--- a/packages/react-core/src/components/Tabs/Tab.tsx
+++ b/packages/react-core/src/components/Tabs/Tab.tsx
@@ -42,7 +42,7 @@ export interface TabProps
   /** @beta Flag indicating the close button should be disabled */
   isCloseDisabled?: boolean;
   /** @beta Actions rendered beside the tab content */
-  action?: React.ReactNode;
+  actions?: React.ReactNode;
   /** Value to set the data-ouia-component-id for the tab button.*/
   ouiaId?: number | string;
 }
@@ -63,7 +63,7 @@ const TabBase: React.FunctionComponent<TabProps> = ({
   tooltip,
   closeButtonAriaLabel,
   isCloseDisabled = false,
-  action,
+  actions,
   ...props
 }: TabProps) => {
   const preventedEvents = inoperableEvents.reduce(
@@ -122,14 +122,14 @@ const TabBase: React.FunctionComponent<TabProps> = ({
       className={css(
         styles.tabsItem,
         eventKey === localActiveKey && styles.modifiers.current,
-        (handleTabClose || action) && styles.modifiers.action,
+        (handleTabClose || actions) && styles.modifiers.action,
         (isDisabled || isAriaDisabled) && styles.modifiers.disabled,
         childClassName
       )}
       role="presentation"
     >
       {tooltip ? <Tooltip {...tooltip.props}>{tabButton}</Tooltip> : tabButton}
-      {handleTabClose !== undefined && !action && (
+      {handleTabClose !== undefined && !actions && (
         <span className={css(styles.tabsItemAction)}>
           <Button
             variant="plain"
@@ -143,7 +143,7 @@ const TabBase: React.FunctionComponent<TabProps> = ({
           </Button>
         </span>
       )}
-      {action && action}
+      {actions && actions}
     </li>
   );
 };

--- a/packages/react-core/src/components/Tabs/Tab.tsx
+++ b/packages/react-core/src/components/Tabs/Tab.tsx
@@ -8,7 +8,9 @@ import { Tooltip } from '../Tooltip';
 import { Button } from '../Button';
 import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
 
-export interface TabProps extends Omit<React.HTMLProps<HTMLAnchorElement | HTMLButtonElement>, 'title'>, OUIAProps {
+export interface TabProps
+  extends Omit<React.HTMLProps<HTMLAnchorElement | HTMLButtonElement>, 'title' | 'action'>,
+    OUIAProps {
   /** content rendered inside the Tab content area. */
   children?: React.ReactNode;
   /** additional classes added to the Tab */
@@ -39,6 +41,8 @@ export interface TabProps extends Omit<React.HTMLProps<HTMLAnchorElement | HTMLB
   closeButtonAriaLabel?: string;
   /** @beta Flag indicating the close button should be disabled */
   isCloseDisabled?: boolean;
+  /** @beta Actions rendered beside the tab content */
+  action?: React.ReactNode;
   /** Value to set the data-ouia-component-id for the tab button.*/
   ouiaId?: number | string;
 }
@@ -59,6 +63,7 @@ const TabBase: React.FunctionComponent<TabProps> = ({
   tooltip,
   closeButtonAriaLabel,
   isCloseDisabled = false,
+  action,
   ...props
 }: TabProps) => {
   const preventedEvents = inoperableEvents.reduce(
@@ -117,27 +122,28 @@ const TabBase: React.FunctionComponent<TabProps> = ({
       className={css(
         styles.tabsItem,
         eventKey === localActiveKey && styles.modifiers.current,
-        handleTabClose && styles.modifiers.action,
-        handleTabClose && (isDisabled || isAriaDisabled) && styles.modifiers.disabled,
+        (handleTabClose || action) && styles.modifiers.action,
+        (isDisabled || isAriaDisabled) && styles.modifiers.disabled,
         childClassName
       )}
       role="presentation"
     >
       {tooltip ? <Tooltip {...tooltip.props}>{tabButton}</Tooltip> : tabButton}
-      {handleTabClose !== undefined && (
-        <span className={css(styles.tabsItemClose)}>
+      {handleTabClose !== undefined && !action && (
+        <span className={css(styles.tabsItemAction)}>
           <Button
             variant="plain"
             aria-label={closeButtonAriaLabel || 'Close tab'}
             onClick={(event: any) => handleTabClose(event, eventKey, tabContentRef)}
             isDisabled={isCloseDisabled}
           >
-            <span className={css(styles.tabsItemCloseIcon)}>
+            <span className={css(styles.tabsItemActionIcon)}>
               <TimesIcon />
             </span>
           </Button>
         </span>
       )}
+      {action && action}
     </li>
   );
 };

--- a/packages/react-core/src/components/Tabs/Tab.tsx
+++ b/packages/react-core/src/components/Tabs/Tab.tsx
@@ -5,8 +5,8 @@ import { TabButton } from './TabButton';
 import { TabsContext } from './TabsContext';
 import { css } from '@patternfly/react-styles';
 import { Tooltip } from '../Tooltip';
-import { Button } from '../Button';
 import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+import { TabAction } from './TabAction';
 
 export interface TabProps
   extends Omit<React.HTMLProps<HTMLAnchorElement | HTMLButtonElement>, 'title' | 'action'>,
@@ -129,21 +129,16 @@ const TabBase: React.FunctionComponent<TabProps> = ({
       role="presentation"
     >
       {tooltip ? <Tooltip {...tooltip.props}>{tabButton}</Tooltip> : tabButton}
-      {handleTabClose !== undefined && !actions && (
-        <span className={css(styles.tabsItemAction)}>
-          <Button
-            variant="plain"
-            aria-label={closeButtonAriaLabel || 'Close tab'}
-            onClick={(event: any) => handleTabClose(event, eventKey, tabContentRef)}
-            isDisabled={isCloseDisabled}
-          >
-            <span className={css(styles.tabsItemActionIcon)}>
-              <TimesIcon />
-            </span>
-          </Button>
-        </span>
-      )}
       {actions && actions}
+      {handleTabClose !== undefined && (
+        <TabAction
+          aria-label={closeButtonAriaLabel || 'Close tab'}
+          onClick={(event: any) => handleTabClose(event, eventKey, tabContentRef)}
+          isDisabled={isCloseDisabled}
+        >
+          <TimesIcon />
+        </TabAction>
+      )}
     </li>
   );
 };

--- a/packages/react-core/src/components/Tabs/TabAction.tsx
+++ b/packages/react-core/src/components/Tabs/TabAction.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { css } from '@patternfly/react-styles';
+import styles from '@patternfly/react-styles/css/components/Tabs/tabs';
+import { Button } from '../Button';
+import { getOUIAProps, OUIAProps } from '../../helpers';
+
+export interface TabActionProps extends Omit<React.HTMLProps<HTMLButtonElement>, 'ref' | 'type'>, OUIAProps {
+  /** Content rendered in the tab action */
+  children?: React.ReactNode;
+  /** Additional classes added to the tab action span */
+  className?: string;
+  /** Click callback for tab action button */
+  onClick?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
+  /** Flag indicating if the tab action is a help action */
+  isHelpAction?: boolean;
+  /** Flag indicating if the tab action is disabled */
+  isDisabled?: boolean;
+  /** Tab action aria-label */
+  'aria-label'?: string;
+  /** @hide Callback for the section ref */
+  innerRef?: React.Ref<any>;
+}
+
+const TabActionBase: React.FunctionComponent<TabActionProps> = ({
+  children,
+  onClick,
+  isHelpAction,
+  isDisabled,
+  'aria-label': ariaLabel = 'Tab action',
+  innerRef,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  ouiaId,
+  ouiaSafe,
+  ...props
+}: TabActionProps) => (
+  <span className={css(styles.tabsItemAction, isHelpAction && styles.modifiers.help)}>
+    <Button
+      ref={innerRef}
+      type="button"
+      variant="plain"
+      aria-label={ariaLabel}
+      onClick={onClick}
+      isDisabled={isDisabled}
+      {...getOUIAProps(TabAction.displayName, ouiaId, ouiaSafe)}
+      {...props}
+    >
+      <span className={css(styles.tabsItemActionIcon)}>{children}</span>
+    </Button>
+  </span>
+);
+
+export const TabAction = React.forwardRef((props: TabActionProps, ref: React.Ref<HTMLElement>) => (
+  <TabActionBase {...props} innerRef={ref} />
+));
+
+TabAction.displayName = 'TabAction';

--- a/packages/react-core/src/components/Tabs/TabAction.tsx
+++ b/packages/react-core/src/components/Tabs/TabAction.tsx
@@ -15,7 +15,7 @@ export interface TabActionProps extends Omit<React.HTMLProps<HTMLButtonElement>,
   isHelpAction?: boolean;
   /** Flag indicating if the tab action is disabled */
   isDisabled?: boolean;
-  /** Tab action aria-label */
+  /** Accessible label for the tab action */
   'aria-label'?: string;
   /** @hide Callback for the section ref */
   innerRef?: React.Ref<any>;

--- a/packages/react-core/src/components/Tabs/TabAction.tsx
+++ b/packages/react-core/src/components/Tabs/TabAction.tsx
@@ -23,6 +23,7 @@ export interface TabActionProps extends Omit<React.HTMLProps<HTMLButtonElement>,
 
 const TabActionBase: React.FunctionComponent<TabActionProps> = ({
   children,
+  className,
   onClick,
   isHelpAction,
   isDisabled,
@@ -33,7 +34,7 @@ const TabActionBase: React.FunctionComponent<TabActionProps> = ({
   ouiaSafe,
   ...props
 }: TabActionProps) => (
-  <span className={css(styles.tabsItemAction, isHelpAction && styles.modifiers.help)}>
+  <span className={css(styles.tabsItemAction, isHelpAction && styles.modifiers.help, className)}>
     <Button
       ref={innerRef}
       type="button"

--- a/packages/react-core/src/components/Tabs/Tabs.tsx
+++ b/packages/react-core/src/components/Tabs/Tabs.tsx
@@ -42,7 +42,7 @@ export interface TabsProps extends Omit<React.HTMLProps<HTMLElement | HTMLDivEle
   defaultActiveKey?: number | string;
   /** Callback to handle tab selection */
   onSelect?: (event: React.MouseEvent<HTMLElement, MouseEvent>, eventKey: number | string) => void;
-  /** @beta Callback to handle tab closing and adds a basic close button to all tabs. This is overridden by the Tab actions property. */
+  /** @beta Callback to handle tab closing and adds a basic close button to all tabs. This is overridden by the tab actions property. */
   onClose?: (event: React.MouseEvent<HTMLElement, MouseEvent>, eventKey: number | string) => void;
   /** @beta Callback for the add button. Passing this property inserts the add button */
   onAdd?: () => void;

--- a/packages/react-core/src/components/Tabs/Tabs.tsx
+++ b/packages/react-core/src/components/Tabs/Tabs.tsx
@@ -42,7 +42,7 @@ export interface TabsProps extends Omit<React.HTMLProps<HTMLElement | HTMLDivEle
   defaultActiveKey?: number | string;
   /** Callback to handle tab selection */
   onSelect?: (event: React.MouseEvent<HTMLElement, MouseEvent>, eventKey: number | string) => void;
-  /** @beta Callback to handle tab closing */
+  /** @beta Callback to handle tab closing and adds a basic close button to all tabs. This is overridden by the Tab actions property. */
   onClose?: (event: React.MouseEvent<HTMLElement, MouseEvent>, eventKey: number | string) => void;
   /** @beta Callback for the add button. Passing this property inserts the add button */
   onAdd?: () => void;

--- a/packages/react-core/src/components/Tabs/__tests__/Tab.test.tsx
+++ b/packages/react-core/src/components/Tabs/__tests__/Tab.test.tsx
@@ -1,12 +1,22 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { Tab } from '../Tab';
+import { TabAction } from '../TabAction';
 import { TabTitleText } from '../TabTitleText';
 
 test('should not render anything', () => {
   const { asFragment } = render(
     <Tab eventKey={0} title={<TabTitleText>"Tab item 1"</TabTitleText>}>
       Tab 1 section
+    </Tab>
+  );
+  expect(asFragment()).toMatchSnapshot();
+});
+
+test('renders tab action', () => {
+  const { asFragment } = render(
+    <Tab eventKey={1} title={<TabTitleText>"Tab item 2"</TabTitleText>} action={<TabAction>test</TabAction>}>
+      Tab 2 section
     </Tab>
   );
   expect(asFragment()).toMatchSnapshot();

--- a/packages/react-core/src/components/Tabs/__tests__/Tab.test.tsx
+++ b/packages/react-core/src/components/Tabs/__tests__/Tab.test.tsx
@@ -15,7 +15,7 @@ test('should not render anything', () => {
 
 test('renders tab action', () => {
   const { asFragment } = render(
-    <Tab eventKey={1} title={<TabTitleText>"Tab item 2"</TabTitleText>} action={<TabAction>test</TabAction>}>
+    <Tab eventKey={1} title={<TabTitleText>"Tab item 2"</TabTitleText>} actions={<TabAction>test</TabAction>}>
       Tab 2 section
     </Tab>
   );

--- a/packages/react-core/src/components/Tabs/__tests__/__snapshots__/Tab.test.tsx.snap
+++ b/packages/react-core/src/components/Tabs/__tests__/__snapshots__/Tab.test.tsx.snap
@@ -1,5 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`renders tab action 1`] = `
+<DocumentFragment>
+  <li
+    class="pf-c-tabs__item pf-m-action"
+    role="presentation"
+  >
+    <button
+      aria-controls="pf-tab-section-1-"
+      aria-selected="false"
+      class="pf-c-tabs__link"
+      data-ouia-component-type="PF4/TabButton"
+      data-ouia-safe="true"
+      id="pf-tab-1-"
+      role="tab"
+      type="button"
+    >
+      <span
+        class="pf-c-tabs__item-text"
+      >
+        "Tab item 2"
+      </span>
+    </button>
+    <span
+      class="pf-c-tabs__item-action"
+    >
+      <button
+        aria-disabled="false"
+        aria-label="Tab action"
+        class="pf-c-button pf-m-plain"
+        data-ouia-component-id="OUIA-Generated-Button-plain-1"
+        data-ouia-component-type="PF4/Button"
+        data-ouia-safe="true"
+        type="button"
+      >
+        <span
+          class="pf-c-tabs__item-action-icon"
+        >
+          test
+        </span>
+      </button>
+    </span>
+  </li>
+</DocumentFragment>
+`;
+
 exports[`should not render anything 1`] = `
 <DocumentFragment>
   <li

--- a/packages/react-core/src/components/Tabs/examples/Tabs.md
+++ b/packages/react-core/src/components/Tabs/examples/Tabs.md
@@ -12,6 +12,8 @@ import DatabaseIcon from '@patternfly/react-icons/dist/esm/icons/database-icon';
 import ServerIcon from '@patternfly/react-icons/dist/esm/icons/server-icon';
 import LaptopIcon from '@patternfly/react-icons/dist/esm/icons/laptop-icon';
 import ProjectDiagramIcon from '@patternfly/react-icons/dist/esm/icons/project-diagram-icon';
+import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
+import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
 
 Most tab variations are available as open (default) or box style tabs. Select the 'isBox' checkbox to preview an example with box styled tabs.
 The Tabs items background can be also toggled with 'Tab light variation' checkbox.
@@ -458,7 +460,15 @@ class VerticalTabs extends React.Component {
           aria-label="Tabs in the vertical example"
           role="region"
         >
-          <Tab eventKey={0} title={<TabTitleText aria-label="vertical" role="region">Users</TabTitleText>} aria-label="Vertical example content users">
+          <Tab
+            eventKey={0}
+            title={
+              <TabTitleText aria-label="vertical" role="region">
+                Users
+              </TabTitleText>
+            }
+            aria-label="Vertical example content users"
+          >
             Users
           </Tab>
           <Tab eventKey={1} title={<TabTitleText>Containers</TabTitleText>}>
@@ -591,7 +601,11 @@ class VerticalExpandableUncontrolledTabs extends React.Component {
         aria-label="Tabs in the vertical expandable uncontrolled example"
         role="region"
       >
-        <Tab eventKey={0} title={<TabTitleText>Users</TabTitleText>} aria-label="Vertical expandable uncontrolled content users">
+        <Tab
+          eventKey={0}
+          title={<TabTitleText>Users</TabTitleText>}
+          aria-label="Vertical expandable uncontrolled content users"
+        >
           Users
         </Tab>
         <Tab eventKey={1} title={<TabTitleText>Containers</TabTitleText>}>
@@ -1206,7 +1220,12 @@ class TabsNav extends React.Component {
         component={TabsComponent.nav}
         aria-label="Tabs in the nav element example"
       >
-        <Tab eventKey={0} title={<TabTitleText>Users</TabTitleText>} href="#users"  aria-label="Nav element content users">
+        <Tab
+          eventKey={0}
+          title={<TabTitleText>Users</TabTitleText>}
+          href="#users"
+          aria-label="Nav element content users"
+        >
           Users
         </Tab>
         <Tab eventKey={1} title={<TabTitleText>Containers</TabTitleText>} href="#containers">
@@ -1267,7 +1286,12 @@ class SecondaryTabsNav extends React.Component {
         component={TabsComponent.nav}
         aria-label="Tabs in the sub tabs with nav element example"
       >
-        <Tab eventKey={0} title={<TabTitleText>Users</TabTitleText>} href="#" aria-label="Subtabs with nav content users">
+        <Tab
+          eventKey={0}
+          title={<TabTitleText>Users</TabTitleText>}
+          href="#"
+          aria-label="Subtabs with nav content users"
+        >
           <Tabs
             activeKey={this.state.activeTabKey2}
             isSecondary
@@ -1423,7 +1447,12 @@ const TabContentWithBody = () => {
 
   return (
     <React.Fragment>
-      <Tabs activeKey={activeTabKey} onSelect={handleTabClick} aria-label="Tabs in the body and padding example" role="region">
+      <Tabs
+        activeKey={activeTabKey}
+        onSelect={handleTabClick}
+        aria-label="Tabs in the body and padding example"
+        role="region"
+      >
         <Tab
           eventKey={0}
           title={<TabTitleText>Tab item 1</TabTitleText>}
@@ -1447,20 +1476,10 @@ const TabContentWithBody = () => {
         <TabContent eventKey={0} id="tab1SectionBodyPadding" ref={contentRef1}>
           <TabContentBody hasPadding> Tab 1 section with body and padding </TabContentBody>
         </TabContent>
-        <TabContent
-          eventKey={1}
-          id="tab2SectionBodyPadding"
-          ref={contentRef2}
-          hidden
-        >
+        <TabContent eventKey={1} id="tab2SectionBodyPadding" ref={contentRef2} hidden>
           <TabContentBody hasPadding> Tab 2 section with body and padding </TabContentBody>
         </TabContent>
-        <TabContent
-          eventKey={2}
-          id="tab3SectionBodyPadding"
-          ref={contentRef3}
-          hidden
-        >
+        <TabContent eventKey={2} id="tab3SectionBodyPadding" ref={contentRef3} hidden>
           <TabContentBody hasPadding> Tab 3 section with body and padding </TabContentBody>
         </TabContent>
       </div>
@@ -1597,11 +1616,26 @@ class ToggledSeparateContent extends React.Component {
           aria-label="Tabs in the toggled separate content example"
           role="region"
         >
-          <Tab eventKey={0} title="Tab item 1" tabContentId="tab1SectionSeparateContent" tabContentRef={this.contentRef1} />
+          <Tab
+            eventKey={0}
+            title="Tab item 1"
+            tabContentId="tab1SectionSeparateContent"
+            tabContentRef={this.contentRef1}
+          />
           {!isTab2Hidden && (
-            <Tab eventKey={1} title="Tab item 2" tabContentId="tab2SectionSeparateContent" tabContentRef={this.contentRef2} />
+            <Tab
+              eventKey={1}
+              title="Tab item 2"
+              tabContentId="tab2SectionSeparateContent"
+              tabContentRef={this.contentRef2}
+            />
           )}
-          <Tab eventKey={2} title="Tab item 3" tabContentId="tab3SectionSeparateContent" tabContentRef={this.contentRef3} />
+          <Tab
+            eventKey={2}
+            title="Tab item 3"
+            tabContentId="tab3SectionSeparateContent"
+            tabContentRef={this.contentRef3}
+          />
         </Tabs>
         <div>
           <TabContent
@@ -1644,4 +1678,14 @@ class ToggledSeparateContent extends React.Component {
 To enable closeable tabs, pass the `onClose` property to `Tabs`, and to enable the add button, pass the `onAdd` property to `Tabs`. Aria labels may be controlled manually by passing `closeButtonAriaLabel` to `Tab` and `addButtonAriaLabel` to `Tabs`.
 
 ```ts file="./TabsDynamic.tsx" isBeta
+```
+
+### Help action
+
+```ts file="./TabsHelp.tsx" isBeta
+```
+
+### Help and close actions
+
+```ts file="./TabsHelpAndClose.tsx" isBeta
 ```

--- a/packages/react-core/src/components/Tabs/examples/TabsHelp.tsx
+++ b/packages/react-core/src/components/Tabs/examples/TabsHelp.tsx
@@ -4,24 +4,11 @@ import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 
 export const TabsHelp: React.FunctionComponent = () => {
   const [activeTabKey, setActiveTabKey] = React.useState<number>(0);
-  const tabComponentRef = React.useRef<any>();
-  const firstMount = React.useRef(true);
 
   const tabs = ['Users', 'Containers', 'Database', 'Disabled', 'ARIA disabled', 'Help disabled'];
 
-  React.useEffect(() => {
-    if (firstMount.current) {
-      firstMount.current = false;
-      return;
-    } else {
-      const first = tabComponentRef.current.tabList.current.childNodes[activeTabKey];
-      first && first.firstChild.focus();
-    }
-  }, [tabs]);
-
   const helpPopover = (header: string, popoverRef: React.RefObject<any>) => (
     <Popover
-      aria-label="Popover with react reference example"
       headerContent={<div>{header}</div>}
       bodyContent={
         <div>
@@ -37,10 +24,8 @@ export const TabsHelp: React.FunctionComponent = () => {
     <Tabs
       activeKey={activeTabKey}
       onSelect={(event: any, tabIndex: string | number) => setActiveTabKey(tabIndex as number)}
-      aria-label="Tabs in the addable/closeable example"
-      addButtonAriaLabel="Add new tab"
+      aria-label="Tabs in the help action example"
       role="region"
-      ref={tabComponentRef}
     >
       {tabs.map((tab, index) => {
         const ref = React.createRef<HTMLElement>();
@@ -49,11 +34,11 @@ export const TabsHelp: React.FunctionComponent = () => {
           <Tab
             key={index}
             eventKey={index}
-            aria-label={`Dynamic ${tab}`}
+            aria-label={`Help action content - ${tab}`}
             title={<TabTitleText>{tab}</TabTitleText>}
             {...(tab === 'Disabled' && { isDisabled: true })}
             {...(tab === 'ARIA disabled' && { isAriaDisabled: true })}
-            action={
+            actions={
               <>
                 <TabAction
                   aria-label={`Help action for ${tab}`}

--- a/packages/react-core/src/components/Tabs/examples/TabsHelp.tsx
+++ b/packages/react-core/src/components/Tabs/examples/TabsHelp.tsx
@@ -41,6 +41,7 @@ export const TabsHelp: React.FunctionComponent = () => {
             actions={
               <>
                 <TabAction
+                  isHelpAction
                   aria-label={`Help action for ${tab}`}
                   ref={ref}
                   {...(tab === 'Help disabled' && { isDisabled: true })}

--- a/packages/react-core/src/components/Tabs/examples/TabsHelp.tsx
+++ b/packages/react-core/src/components/Tabs/examples/TabsHelp.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { Tabs, Tab, TabTitleText, TabAction, Popover } from '@patternfly/react-core';
+import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
+
+export const TabsHelp: React.FunctionComponent = () => {
+  const [activeTabKey, setActiveTabKey] = React.useState<number>(0);
+  const tabComponentRef = React.useRef<any>();
+  const firstMount = React.useRef(true);
+
+  const tabs = ['Users', 'Containers', 'Database', 'Disabled', 'ARIA disabled', 'Help disabled'];
+
+  React.useEffect(() => {
+    if (firstMount.current) {
+      firstMount.current = false;
+      return;
+    } else {
+      const first = tabComponentRef.current.tabList.current.childNodes[activeTabKey];
+      first && first.firstChild.focus();
+    }
+  }, [tabs]);
+
+  const helpPopover = (header: string, popoverRef: React.RefObject<any>) => (
+    <Popover
+      aria-label="Popover with react reference example"
+      headerContent={<div>{header}</div>}
+      bodyContent={
+        <div>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
+        </div>
+      }
+      footerContent="Popover footer"
+      reference={popoverRef}
+    />
+  );
+
+  return (
+    <Tabs
+      activeKey={activeTabKey}
+      onSelect={(event: any, tabIndex: string | number) => setActiveTabKey(tabIndex as number)}
+      aria-label="Tabs in the addable/closeable example"
+      addButtonAriaLabel="Add new tab"
+      role="region"
+      ref={tabComponentRef}
+    >
+      {tabs.map((tab, index) => {
+        const ref = React.createRef<HTMLElement>();
+
+        return (
+          <Tab
+            key={index}
+            eventKey={index}
+            aria-label={`Dynamic ${tab}`}
+            title={<TabTitleText>{tab}</TabTitleText>}
+            {...(tab === 'Disabled' && { isDisabled: true })}
+            {...(tab === 'ARIA disabled' && { isAriaDisabled: true })}
+            action={
+              <>
+                <TabAction
+                  aria-label={`Help action for ${tab}`}
+                  ref={ref}
+                  {...(tab === 'Help disabled' && { isDisabled: true })}
+                >
+                  <HelpIcon />
+                </TabAction>
+                {helpPopover(`Help popover for ${tab}`, ref)}
+              </>
+            }
+          >
+            {tab}
+          </Tab>
+        );
+      })}
+    </Tabs>
+  );
+};

--- a/packages/react-core/src/components/Tabs/examples/TabsHelpAndClose.tsx
+++ b/packages/react-core/src/components/Tabs/examples/TabsHelpAndClose.tsx
@@ -25,7 +25,6 @@ export const TabsHelpAndClose: React.FunctionComponent = () => {
 
   const helpPopover = (header: string, popoverRef: React.RefObject<any>) => (
     <Popover
-      aria-label="Popover with react reference example"
       headerContent={<div>{header}</div>}
       bodyContent={
         <div>
@@ -62,9 +61,9 @@ export const TabsHelpAndClose: React.FunctionComponent = () => {
           <Tab
             key={index}
             eventKey={index}
-            aria-label={`Dynamic ${tab}`}
+            aria-label={`Help action and closable content - ${tab}`}
             title={<TabTitleText>{tab}</TabTitleText>}
-            action={
+            actions={
               <>
                 <TabAction isHelpAction aria-label={`Help for ${tab}`} ref={ref}>
                   <HelpIcon />

--- a/packages/react-core/src/components/Tabs/examples/TabsHelpAndClose.tsx
+++ b/packages/react-core/src/components/Tabs/examples/TabsHelpAndClose.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { Tabs, Tab, TabTitleText, Popover, TabAction } from '@patternfly/react-core';
+import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
+import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+
+export const TabsHelpAndClose: React.FunctionComponent = () => {
+  const [activeTabKey, setActiveTabKey] = React.useState<number>(0);
+  const [tabs, setTabs] = React.useState<string[]>(['Terminal 1', 'Terminal 2', 'Terminal 3']);
+  const tabComponentRef = React.useRef<any>();
+  const firstMount = React.useRef(true);
+
+  const onClose = (event: any, tabIndex: string | number) => {
+    const tabIndexNum = tabIndex as number;
+    let nextTabIndex = activeTabKey;
+    if (tabIndexNum < activeTabKey) {
+      // if a preceding tab is closing, keep focus on the new index of the current tab
+      nextTabIndex = activeTabKey - 1 > 0 ? activeTabKey - 1 : 0;
+    } else if (activeTabKey === tabs.length - 1) {
+      // if the closing tab is the last tab, focus the preceding tab
+      nextTabIndex = tabs.length - 2 > 0 ? tabs.length - 2 : 0;
+    }
+    setActiveTabKey(nextTabIndex);
+    setTabs(tabs.filter((tab, index) => index !== tabIndex));
+  };
+
+  const helpPopover = (header: string, popoverRef: React.RefObject<any>) => (
+    <Popover
+      aria-label="Popover with react reference example"
+      headerContent={<div>{header}</div>}
+      bodyContent={
+        <div>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
+        </div>
+      }
+      footerContent="Popover footer"
+      reference={popoverRef}
+    />
+  );
+
+  React.useEffect(() => {
+    if (firstMount.current) {
+      firstMount.current = false;
+      return;
+    } else {
+      const first = tabComponentRef.current.tabList.current.childNodes[activeTabKey];
+      first && first.firstChild.focus();
+    }
+  }, [tabs]);
+
+  return (
+    <Tabs
+      activeKey={activeTabKey}
+      onSelect={(event: any, tabIndex: string | number) => setActiveTabKey(tabIndex as number)}
+      aria-label="Tabs in the help enabled and closeable example"
+      role="region"
+      ref={tabComponentRef}
+    >
+      {tabs.map((tab, index) => {
+        const ref = React.createRef<HTMLElement>();
+
+        return (
+          <Tab
+            key={index}
+            eventKey={index}
+            aria-label={`Dynamic ${tab}`}
+            title={<TabTitleText>{tab}</TabTitleText>}
+            action={
+              <>
+                <TabAction isHelpAction aria-label={`Help for ${tab}`} ref={ref}>
+                  <HelpIcon />
+                </TabAction>
+                <TabAction aria-label={`Close ${tab}`} onClick={e => onClose(e, index)} isDisabled={tabs.length === 1}>
+                  <TimesIcon />
+                </TabAction>
+                {helpPopover(`Help popover for ${tab}`, ref)}
+              </>
+            }
+          >
+            {tab}
+          </Tab>
+        );
+      })}
+    </Tabs>
+  );
+};

--- a/packages/react-core/src/components/Tabs/index.ts
+++ b/packages/react-core/src/components/Tabs/index.ts
@@ -1,4 +1,5 @@
 export * from './Tab';
+export * from './TabAction';
 export * from './Tabs';
 export * from './TabContent';
 export * from './TabContentBody';

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -22,7 +22,7 @@
     "test:a11y": "patternfly-a11y --config patternfly-a11y.config"
   },
   "dependencies": {
-    "@patternfly/patternfly": "4.219.2",
+    "@patternfly/patternfly": "4.220.0",
     "@patternfly/react-catalog-view-extension": "^4.92.66",
     "@patternfly/react-charts": "^6.94.11",
     "@patternfly/react-code-editor": "^4.82.66",

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -32,7 +32,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.14.0",
     "@fortawesome/free-regular-svg-icons": "^5.14.0",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
-    "@patternfly/patternfly": "4.219.2",
+    "@patternfly/patternfly": "4.220.0",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",
     "rimraf": "^2.6.2",

--- a/packages/react-styles/package.json
+++ b/packages/react-styles/package.json
@@ -19,7 +19,7 @@
     "clean": "rimraf dist css"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "4.219.2",
+    "@patternfly/patternfly": "4.220.0",
     "camel-case": "^3.0.0",
     "css": "^2.2.3",
     "fs-extra": "^6.0.1",

--- a/packages/react-tokens/package.json
+++ b/packages/react-tokens/package.json
@@ -29,7 +29,7 @@
     "clean": "rimraf dist"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "4.219.2",
+    "@patternfly/patternfly": "4.220.0",
     "css": "^2.2.3",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3612,10 +3612,10 @@
     puppeteer-cluster "^0.23.0"
     xmldoc "^1.1.2"
 
-"@patternfly/patternfly@4.219.2":
-  version "4.219.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.219.2.tgz#c26160620e827f0412fb51fb71ef625043f1b617"
-  integrity sha512-SZ+9ig6DVygwM6fpldYhRjoyr9KMJTit/ZMyWCUE7DfpTqEr69wQnOaGxfvNlH1UV6G7Z+ALZXeck3Dy1nb9Vw==
+"@patternfly/patternfly@4.220.0":
+  version "4.220.0"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.220.0.tgz#2ebbeea0718afe988aeef2ff19822695ab3b1ac5"
+  integrity sha512-Ax2VjWdCQzc+ltRAIPiQoB5c1GbmtE9JOMCpT46MHDWpluq9VzWe8NvXr7l74aaNM65d+olTye+I5A2btJjwYQ==
 
 "@reach/router@1.3.4":
   version "1.3.4"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8236

Adds `TabAction` component.
Adds `action` prop to `Tab` - inserts content inside the Tab `li` but not as part of the Tab `button`. Accepts a ReactNode, and multiple `TabAction` components (and other things like Popover) can be passed in with an empty tag wrapping them.
Adds example for help popovers and help + close buttons.

Keeps the `Tabs` `onClose` prop currently, but this could be removed if it's too confusing to have both (as passing `action` to Tab will overwrite the content generated from `onClose`). I can just see this prop being useful as a bit of a shortcut if a user wants only the close button for all tabs.