### PR TITLE
feat(Menu): add drilldown filter demo, add flag to support demo & fix some keyboard interaction

### DIFF
--- a/packages/react-core/src/components/Menu/examples/Menu.md
+++ b/packages/react-core/src/components/Menu/examples/Menu.md
@@ -105,6 +105,11 @@ To render an initially drilled in menu, the `menuDrilledIn`, `drilldownPath`, an
 ```ts file="MenuWithDrilldownBreadcrumbs.tsx" isBeta
 ```
 
+### With drilldown and inline filter
+
+```ts file="MenuFilterDrilldown.tsx"
+```
+
 ### Scrollable
 
 ```ts file="MenuScrollable.tsx"

--- a/packages/react-core/src/components/Menu/examples/MenuFilterDrilldown.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuFilterDrilldown.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import {
+  Menu,
+  MenuContent,
+  MenuList,
+  MenuItem,
+  Divider,
+  DrilldownMenu,
+  MenuInput,
+  SearchInput
+} from '@patternfly/react-core';
+
+export const MenuWithDrilldown: React.FunctionComponent = () => {
+  const [menuDrilledIn, setMenuDrilledIn] = React.useState<string[]>([]);
+  const [drilldownPath, setDrilldownPath] = React.useState<string[]>([]);
+  const [menuHeights, setMenuHeights] = React.useState<any>({});
+  const [activeMenu, setActiveMenu] = React.useState<string>('filter_drilldown-rootMenu');
+
+  const drillIn = (fromMenuId: string, toMenuId: string, pathId: string) => {
+    setMenuDrilledIn([...menuDrilledIn, fromMenuId]);
+    setDrilldownPath([...drilldownPath, pathId]);
+    setActiveMenu(toMenuId);
+  };
+
+  const drillOut = (toMenuId: string) => {
+    const menuDrilledInSansLast = menuDrilledIn.slice(0, menuDrilledIn.length - 1);
+    const pathSansLast = drilldownPath.slice(0, drilldownPath.length - 1);
+    setMenuDrilledIn(menuDrilledInSansLast);
+    setDrilldownPath(pathSansLast);
+    setActiveMenu(toMenuId);
+  };
+
+  const setHeight = (menuId: string, height: number) => {
+    if (
+      menuHeights[menuId] === undefined ||
+      (menuId !== 'filter_drilldown-rootMenu' && menuHeights[menuId] !== height)
+    ) {
+      setMenuHeights({ ...menuHeights, [menuId]: height });
+    }
+  };
+
+  const searchRef = React.createRef<HTMLInputElement>();
+  const [startInput, setStartInput] = React.useState('');
+  const [shouldFocusOnDrillIn, setDrillFocusToggle] = React.useState<boolean>(true);
+
+  const handleStartTextInputChange = (value: string) => {
+    setStartInput(value);
+    searchRef?.current?.focus();
+    setDrillFocusToggle(false);
+  };
+
+  const onBlur = () => {
+    setDrillFocusToggle(true);
+  };
+
+  const startDrillItems = [
+    {
+      item: 'Application grouping',
+      rest: { description: 'Description text' }
+    },
+    { item: 'Labels' },
+    { item: 'Annotations' },
+    { item: 'Count' },
+    { item: 'Count 2' },
+    { item: 'Count 3' },
+    { item: 'Other' }
+  ];
+
+  const mapped = startDrillItems
+    .filter(opt => !startInput || opt.item.toLowerCase().includes(startInput.toString().toLowerCase()))
+    .map((opt, index) => (
+      <MenuItem key={opt.item} itemId={index} {...opt.rest}>
+        {opt.item}
+      </MenuItem>
+    ));
+  if (startInput && mapped.length === 0) {
+    mapped.push(
+      <MenuItem isDisabled key="no result">
+        No results found
+      </MenuItem>
+    );
+  }
+
+  return (
+    <Menu
+      id="filter_drilldown-rootMenu"
+      containsDrilldown
+      drilldownItemPath={drilldownPath}
+      drilledInMenus={menuDrilledIn}
+      activeMenu={activeMenu}
+      onDrillIn={drillIn}
+      onDrillOut={drillOut}
+      onGetMenuHeight={setHeight}
+      shouldFocusOnDrillIn={shouldFocusOnDrillIn}
+    >
+      <MenuContent menuHeight={`${menuHeights[activeMenu]}px`}>
+        <MenuList>
+          <MenuItem
+            itemId="filter_group:start_rollout"
+            direction="down"
+            drilldownMenu={
+              <DrilldownMenu id="filter_drilldown-drilldownMenuStart">
+                <MenuItem itemId="filter_group:start_rollout_breadcrumb" direction="up">
+                  Start rollout
+                </MenuItem>
+                <Divider component="li" />
+                <MenuInput>
+                  <SearchInput
+                    ref={searchRef}
+                    value={startInput}
+                    aria-label="Filter menu items"
+                    type="search"
+                    onChange={value => handleStartTextInputChange(value)}
+                    onBlur={onBlur}
+                  />
+                </MenuInput>
+                <Divider component="li" />
+                {mapped}
+              </DrilldownMenu>
+            }
+          >
+            Start rollout
+          </MenuItem>
+          <MenuItem itemId="item-a">Item B</MenuItem>
+          <MenuItem itemId="item-b">Item C</MenuItem>
+          <MenuItem itemId="item-c">Item D</MenuItem>
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+};

--- a/packages/react-core/src/components/Menu/examples/MenuFilterDrilldown.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuFilterDrilldown.tsx
@@ -41,16 +41,10 @@ export const MenuWithDrilldown: React.FunctionComponent = () => {
 
   const searchRef = React.createRef<HTMLInputElement>();
   const [startInput, setStartInput] = React.useState('');
-  const [shouldFocusOnDrillIn, setDrillFocusToggle] = React.useState<boolean>(true);
 
   const handleStartTextInputChange = (value: string) => {
     setStartInput(value);
     searchRef?.current?.focus();
-    setDrillFocusToggle(false);
-  };
-
-  const onBlur = () => {
-    setDrillFocusToggle(true);
   };
 
   const startDrillItems = [
@@ -91,7 +85,6 @@ export const MenuWithDrilldown: React.FunctionComponent = () => {
       onDrillIn={drillIn}
       onDrillOut={drillOut}
       onGetMenuHeight={setHeight}
-      shouldFocusOnDrillIn={shouldFocusOnDrillIn}
     >
       <MenuContent menuHeight={`${menuHeights[activeMenu]}px`}>
         <MenuList>
@@ -111,7 +104,6 @@ export const MenuWithDrilldown: React.FunctionComponent = () => {
                     aria-label="Filter menu items"
                     type="search"
                     onChange={value => handleStartTextInputChange(value)}
-                    onBlur={onBlur}
                   />
                 </MenuInput>
                 <Divider component="li" />


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #6965

Adds a new `shouldFocusOnDrillIn` property to control whether the menu will focus the first option in the list when a drilldown transition happens. This property is used in the demo to prevent re-focusing the first item in the current menu when the list contents change based on the filter state.

Also adds some robustness to the internal keyboard handler props to account for MenuInput (and maintain general menu items and checkbox menu items).

LMK if the demo should remain on the docs page or if this is better off as a codesandbox only demo.


