### PR TITLE
fix(Menu): removed li wrapper from breadcrumb example

### DIFF
--- a/packages/react-core/src/components/Menu/examples/MenuWithDrilldownBreadcrumbs.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuWithDrilldownBreadcrumbs.tsx
@@ -247,7 +247,7 @@ export const MenuWithDrilldownBreadcrumbs: React.FunctionComponent = () => {
         {breadcrumb && (
           <>
             <MenuBreadcrumb>{breadcrumb}</MenuBreadcrumb>
-            <Divider component="li" />
+            <Divider />
           </>
         )}
         <MenuContent menuHeight={`${menuHeights[activeMenu]}px`} maxMenuHeight={withMaxMenuHeight ? '100px' : 'auto'}>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #7756 

The above issue was mainly fixed by https://github.com/patternfly/patternfly/pull/5271, this PR simply removes an unnecessary li wrapper from an example based on the last comment in the issue

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
