### PR TITLE
Update dist.yml to avoid cache hit when subpaths change

### DIFF
--- a/.github/workflows-src/partials/dist.yml
+++ b/.github/workflows-src/partials/dist.yml
@@ -4,7 +4,12 @@
   with:
     path: |
       packages/*/dist
+      packages/*/next
+      packages/*/deprecated
+      packages/*/components
       packages/react-styles/css
+      packages/react-core/layouts
+      packages/react-core/helpers
     key: ${{ runner.os }}-dist-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/*/*', '!packages/*/dist', '!packages/*/node_modules') }}
 - name: Build dist
   run: yarn build && yarn build:umd

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -35,7 +35,12 @@ jobs:
         with:
           path: |
             packages/*/dist
+            packages/*/next
+            packages/*/deprecated
+            packages/*/components
             packages/react-styles/css
+            packages/react-core/layouts
+            packages/react-core/helpers
           key: ${{ runner.os }}-dist-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/*/*', '!packages/*/dist', '!packages/*/node_modules') }}
       - name: Build dist
         run: yarn build && yarn build:umd
@@ -114,7 +119,12 @@ jobs:
         with:
           path: |
             packages/*/dist
+            packages/*/next
+            packages/*/deprecated
+            packages/*/components
             packages/react-styles/css
+            packages/react-core/layouts
+            packages/react-core/helpers
           key: ${{ runner.os }}-dist-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/*/*', '!packages/*/dist', '!packages/*/node_modules') }}
       - name: Build dist
         run: yarn build && yarn build:umd
@@ -158,7 +168,12 @@ jobs:
         with:
           path: |
             packages/*/dist
+            packages/*/next
+            packages/*/deprecated
+            packages/*/components
             packages/react-styles/css
+            packages/react-core/layouts
+            packages/react-core/helpers
           key: ${{ runner.os }}-dist-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/*/*', '!packages/*/dist', '!packages/*/node_modules') }}
       - name: Build dist
         run: yarn build && yarn build:umd
@@ -213,7 +228,12 @@ jobs:
         with:
           path: |
             packages/*/dist
+            packages/*/next
+            packages/*/deprecated
+            packages/*/components
             packages/react-styles/css
+            packages/react-core/layouts
+            packages/react-core/helpers
           key: ${{ runner.os }}-dist-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/*/*', '!packages/*/dist', '!packages/*/node_modules') }}
       - name: Build dist
         run: yarn build && yarn build:umd
@@ -264,7 +284,12 @@ jobs:
         with:
           path: |
             packages/*/dist
+            packages/*/next
+            packages/*/deprecated
+            packages/*/components
             packages/react-styles/css
+            packages/react-core/layouts
+            packages/react-core/helpers
           key: ${{ runner.os }}-dist-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/*/*', '!packages/*/dist', '!packages/*/node_modules') }}
       - name: Build dist
         run: yarn build && yarn build:umd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,12 @@ jobs:
         with:
           path: |
             packages/*/dist
+            packages/*/next
+            packages/*/deprecated
+            packages/*/components
             packages/react-styles/css
+            packages/react-core/layouts
+            packages/react-core/helpers
           key: ${{ runner.os }}-dist-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/*/*', '!packages/*/dist', '!packages/*/node_modules') }}
       - name: Build dist
         run: yarn build && yarn build:umd
@@ -117,7 +122,12 @@ jobs:
         with:
           path: |
             packages/*/dist
+            packages/*/next
+            packages/*/deprecated
+            packages/*/components
             packages/react-styles/css
+            packages/react-core/layouts
+            packages/react-core/helpers
           key: ${{ runner.os }}-dist-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/*/*', '!packages/*/dist', '!packages/*/node_modules') }}
       - name: Build dist
         run: yarn build && yarn build:umd
@@ -161,7 +171,12 @@ jobs:
         with:
           path: |
             packages/*/dist
+            packages/*/next
+            packages/*/deprecated
+            packages/*/components
             packages/react-styles/css
+            packages/react-core/layouts
+            packages/react-core/helpers
           key: ${{ runner.os }}-dist-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/*/*', '!packages/*/dist', '!packages/*/node_modules') }}
       - name: Build dist
         run: yarn build && yarn build:umd
@@ -216,7 +231,12 @@ jobs:
         with:
           path: |
             packages/*/dist
+            packages/*/next
+            packages/*/deprecated
+            packages/*/components
             packages/react-styles/css
+            packages/react-core/layouts
+            packages/react-core/helpers
           key: ${{ runner.os }}-dist-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/*/*', '!packages/*/dist', '!packages/*/node_modules') }}
       - name: Build dist
         run: yarn build && yarn build:umd
@@ -267,7 +287,12 @@ jobs:
         with:
           path: |
             packages/*/dist
+            packages/*/next
+            packages/*/deprecated
+            packages/*/components
             packages/react-styles/css
+            packages/react-core/layouts
+            packages/react-core/helpers
           key: ${{ runner.os }}-dist-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/*/*', '!packages/*/dist', '!packages/*/node_modules') }}
       - name: Build dist
         run: yarn build && yarn build:umd
@@ -316,7 +341,12 @@ jobs:
         with:
           path: |
             packages/*/dist
+            packages/*/next
+            packages/*/deprecated
+            packages/*/components
             packages/react-styles/css
+            packages/react-core/layouts
+            packages/react-core/helpers
           key: ${{ runner.os }}-dist-14-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock', 'package.json', 'packages/*/*', '!packages/*/dist', '!packages/*/node_modules') }}
       - name: Build dist
         run: yarn build && yarn build:umd


### PR DESCRIPTION
**Relates to**: #8438

This change should theoretically lead to the `release/deploy` `Build dist` build step not being skipped due to a cache hit (can see the step was skipped here; https://github.com/patternfly/patternfly-react/actions/runs/3678915968/jobs/6223122730). This will therefore lead to the generation of subpaths anticipated in the referenced, already merged PR.

Changes were made by updating the paths checked in `dist.yml` to determine if there is a cache hit and running `node .github/generate-workflows.js`
