### PR TITLE
VncConsole: Introduce RFB clipViewport and dragViewport options

### DIFF
--- a/packages/react-console/src/components/VncConsole/VncConsole.tsx
+++ b/packages/react-console/src/components/VncConsole/VncConsole.tsx
@@ -28,6 +28,10 @@ export interface VncConsoleProps extends React.HTMLProps<HTMLDivElement> {
   encrypt?: boolean;
   /** Is a boolean indicating if a request to resize the remote session should be sent whenever the container changes dimensions */
   resizeSession?: boolean;
+  /** Is a boolean indicating if the remote session should be clipped to its container */
+  clipViewport?: boolean;
+  /** Is a boolean indicating if mouse events should control the relative position of a clipped remote session.*/
+  dragViewport?: boolean;
   /** Is a boolean indicating if the remote session should be scaled locally so it fits its container */
   scaleViewport?: boolean;
   /** Is a boolean indicating if any events (e.g. key presses or mouse movement) should be prevented from being sent to the server */
@@ -73,6 +77,8 @@ export const VncConsole: React.FunctionComponent<VncConsoleProps> = ({
   path = '',
   encrypt = false,
   resizeSession = true,
+  clipViewport = false,
+  dragViewport = false,
   scaleViewport = false,
   viewOnly = false,
   shared = false,
@@ -150,6 +156,8 @@ export const VncConsole: React.FunctionComponent<VncConsoleProps> = ({
     rfb.current = new RFB(novncElem.current, url, options);
     addEventListeners();
     rfb.current.viewOnly = viewOnly;
+    rfb.current.clipViewport = clipViewport;
+    rfb.current.dragViewport = dragViewport;
     rfb.current.scaleViewport = scaleViewport;
     rfb.current.resizeSession = resizeSession;
   }, [
@@ -158,6 +166,8 @@ export const VncConsole: React.FunctionComponent<VncConsoleProps> = ({
     path,
     port,
     resizeSession,
+    clipViewport,
+    dragViewport,
     scaleViewport,
     viewOnly,
     encrypt,


### PR DESCRIPTION
In Cockpit machines, we use VNC to show a view of virtual machine.

There is however an issue where if you set Virtual machine system's resolution to something way larger than VNC console shown in the browser, the view will be scaled down, but there will be an offset for mouse:

[false.webm](https://user-images.githubusercontent.com/42733240/209137592-a6bc77ac-d0ea-4f2b-a817-5a962c329fda.webm)

Using dragViewport + clipViewport will allow us to fix this:

[true-(2).webm](https://user-images.githubusercontent.com/42733240/209137676-8a70725e-f81c-4092-88b2-64653485d67d.webm)


**Additional issues**:
https://github.com/cockpit-project/cockpit-machines/issues/29
https://bugzilla.redhat.com/show_bug.cgi?id=2030836
https://bugzilla.redhat.com/show_bug.cgi?id=1913548