### PR TITLE
fix(LabelGroup): show the correct count of overflow labels

### DIFF
--- a/packages/react-core/src/components/LabelGroup/LabelGroup.tsx
+++ b/packages/react-core/src/components/LabelGroup/LabelGroup.tsx
@@ -156,15 +156,14 @@ export class LabelGroup extends React.Component<LabelGroupProps, LabelGroupState
       ...rest
     } = this.props;
     const { isOpen } = this.state;
-    const numChildren = React.Children.count(children);
+    const renderedChildren = React.Children.toArray(children);
+    const numChildren = renderedChildren.length;
     const collapsedTextResult = fillTemplate(collapsedText as string, {
-      remaining: React.Children.count(children) - numLabels
+      remaining: numChildren - numLabels
     });
 
     const renderLabelGroup = (id: string) => {
-      const labelArray = !isOpen
-        ? React.Children.toArray(children).slice(0, numLabels)
-        : React.Children.toArray(children);
+      const labelArray = !isOpen ? renderedChildren.slice(0, numLabels) : renderedChildren;
 
       const content = (
         <React.Fragment>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8495 
Use `React.Children.toArray(children).length` to calculate the label count. So when the label is conditionally rendered it can show the correct count number.
