### PR TITLE
chore(Table): added menuAppendTo props to actions tables

### DIFF
--- a/packages/react-table/src/components/Table/ActionsColumn.tsx
+++ b/packages/react-table/src/components/Table/ActionsColumn.tsx
@@ -22,6 +22,7 @@ export interface ActionsColumnProps {
   children?: React.ReactNode;
   items: IAction[];
   isDisabled?: boolean;
+  menuAppendTo?: HTMLElement | (() => HTMLElement) | 'inline' | 'parent';
   dropdownPosition?: DropdownPosition;
   dropdownDirection?: DropdownDirection;
   rowData?: IRowData;
@@ -41,6 +42,7 @@ export class ActionsColumn extends React.Component<ActionsColumnProps, ActionsCo
     items: [] as IAction[],
     dropdownPosition: DropdownPosition.right,
     dropdownDirection: DropdownDirection.down,
+    menuAppendTo: 'inline',
     rowData: {} as IRowData,
     extraData: {} as IExtraData
   };
@@ -74,7 +76,7 @@ export class ActionsColumn extends React.Component<ActionsColumnProps, ActionsCo
 
   render() {
     const { isOpen } = this.state;
-    const { items, children, dropdownPosition, dropdownDirection, isDisabled, rowData, actionsToggle } = this.props;
+    const { items, children, dropdownPosition, dropdownDirection, menuAppendTo, isDisabled, rowData, actionsToggle } = this.props;
 
     const actionsToggleClone = actionsToggle ? (
       actionsToggle({ onToggle: this.onToggle, isOpen, isDisabled })
@@ -106,6 +108,7 @@ export class ActionsColumn extends React.Component<ActionsColumnProps, ActionsCo
           toggle={actionsToggleClone}
           position={dropdownPosition}
           direction={dropdownDirection}
+          menuAppendTo={menuAppendTo}
           isOpen={isOpen}
           dropdownItems={items
             .filter(item => !item.isOutsideDropdown)

--- a/packages/react-table/src/components/Table/ActionsColumn.tsx
+++ b/packages/react-table/src/components/Table/ActionsColumn.tsx
@@ -76,7 +76,16 @@ export class ActionsColumn extends React.Component<ActionsColumnProps, ActionsCo
 
   render() {
     const { isOpen } = this.state;
-    const { items, children, dropdownPosition, dropdownDirection, menuAppendTo, isDisabled, rowData, actionsToggle } = this.props;
+    const {
+      items,
+      children,
+      dropdownPosition,
+      dropdownDirection,
+      menuAppendTo,
+      isDisabled,
+      rowData,
+      actionsToggle
+    } = this.props;
 
     const actionsToggleClone = actionsToggle ? (
       actionsToggle({ onToggle: this.onToggle, isOpen, isDisabled })

--- a/packages/react-table/src/components/Table/Table.tsx
+++ b/packages/react-table/src/components/Table/Table.tsx
@@ -93,6 +93,14 @@ export interface TableProps extends OUIAProps {
   dropdownPosition?: 'right' | 'left';
   /** The desired direction to show the dropdown when clicking on the actions Kebab. Can only be used together with `actions` property */
   dropdownDirection?: 'up' | 'down';
+  /** The container to append the dropdown menu to. Defaults to 'inline'.
+   * If your menu is being cut off you can append it to an element higher up the DOM tree.
+   * Some examples:
+   * actionsMenuAppendTo="parent"
+   * actionsMenuAppendTo={() => document.body}
+   * actionsMenuAppendTo={document.getElementById('target')}
+   */
+  actionsMenuAppendTo?: HTMLElement | (() => HTMLElement) | 'inline' | 'parent';
   /** The toggle of the actions menu dropdown. A KebabToggle or DropdownToggle component */
   actionsToggle?: (props: CustomActionsToggleProps) => React.ReactNode;
   /** Row data */
@@ -141,6 +149,7 @@ export class Table extends React.Component<TableProps, {}> {
     contentId: 'expanded-content',
     dropdownPosition: DropdownPosition.right,
     dropdownDirection: DropdownDirection.down,
+    actionsMenuAppendTo: 'inline',
     header: undefined as React.ReactNode,
     caption: undefined as React.ReactNode,
     'aria-label': undefined as string,
@@ -202,6 +211,7 @@ export class Table extends React.Component<TableProps, {}> {
       rowLabeledBy,
       dropdownPosition,
       dropdownDirection,
+      actionsMenuAppendTo: menuAppendTo,
       actionsToggle,
       contentId,
       expandId,
@@ -244,6 +254,7 @@ export class Table extends React.Component<TableProps, {}> {
       contentId,
       dropdownPosition,
       dropdownDirection,
+      menuAppendTo,
       actionsToggle,
       onFavorite,
       canSortFavorites,

--- a/packages/react-table/src/components/Table/TableTypes.tsx
+++ b/packages/react-table/src/components/Table/TableTypes.tsx
@@ -106,6 +106,7 @@ export interface IColumn {
     contentId?: string;
     dropdownPosition?: DropdownPosition;
     dropdownDirection?: DropdownDirection;
+    menuAppendTo?: HTMLElement | (() => HTMLElement) | 'inline' | 'parent';
     actionsToggle?: (props: CustomActionsToggleProps) => React.ReactNode;
     allRowsSelected?: boolean;
     allRowsExpanded?: boolean;

--- a/packages/react-table/src/components/Table/base/types.tsx
+++ b/packages/react-table/src/components/Table/base/types.tsx
@@ -68,6 +68,14 @@ export interface TdActionsType {
   dropdownPosition?: DropdownPosition;
   /** Actions dropdown direction */
   dropdownDirection?: DropdownDirection;
+  /** The container to append the dropdown menu to. Defaults to 'inline'.
+   * If your menu is being cut off you can append it to an element higher up the DOM tree.
+   * Some examples:
+   * menuAppendTo="parent"
+   * menuAppendTo={() => document.body}
+   * menuAppendTo={document.getElementById('target')}
+   */
+  menuAppendTo?: HTMLElement | (() => HTMLElement) | 'inline' | 'parent';
   /** Custom toggle for the actions menu */
   actionsToggle?: (props: CustomActionsToggleProps) => React.ReactNode;
 }

--- a/packages/react-table/src/components/Table/examples/Table.md
+++ b/packages/react-table/src/components/Table/examples/Table.md
@@ -214,6 +214,8 @@ This selectable rows feature is intended for use when a table is used to present
 
 To use actions you can either specify an array of actions and pass that into the `Table`'s `actions` prop, or for more control you can use the `actionResolver` callback prop to add actions conditionally.
 
+If actions menus are getting clipped by other items on the page, such as sticky columns or rows, the `Table` can be passed a `actionsMenuAppendTo` prop to adjust where the actions menu is appended.
+
 ```ts file="LegacyTableActions.tsx"
 ```
 

--- a/packages/react-table/src/components/Table/utils/decorators/cellActions.tsx
+++ b/packages/react-table/src/components/Table/utils/decorators/cellActions.tsx
@@ -33,7 +33,7 @@ export const cellActions = (
     rowIndex,
     columnIndex,
     column: {
-      extraParams: { dropdownPosition, dropdownDirection, actionsToggle }
+      extraParams: { dropdownPosition, dropdownDirection, actionsToggle, menuAppendTo }
     },
     property
   }: IExtra
@@ -60,6 +60,7 @@ export const cellActions = (
               items={resolvedActions}
               dropdownPosition={dropdownPosition}
               dropdownDirection={dropdownDirection}
+              menuAppendTo={menuAppendTo}
               isDisabled={resolvedIsDisabled}
               rowData={rowData}
               extraData={extraData}

--- a/packages/react-table/src/components/TableComposable/Td.tsx
+++ b/packages/react-table/src/components/TableComposable/Td.tsx
@@ -33,7 +33,7 @@ export interface TdProps extends BaseCellProps, Omit<React.HTMLProps<HTMLTableDa
   dataLabel?: string;
   /** Renders a checkbox or radio select */
   select?: TdSelectType;
-  /** Turns the cell into an actions cell */
+  /** Turns the cell into an actions cell. Recommended to use an ActionsColumn component as a child of the Td rather than this prop. */
   actions?: TdActionsType;
   /** Turns the cell into an expansion toggle and determines if the corresponding expansion row is open */
   expand?: TdExpandType;

--- a/packages/react-table/src/components/TableComposable/Td.tsx
+++ b/packages/react-table/src/components/TableComposable/Td.tsx
@@ -154,6 +154,7 @@ const TdBase: React.FunctionComponent<TdProps> = ({
           extraParams: {
             dropdownPosition: actions?.dropdownPosition,
             dropdownDirection: actions?.dropdownDirection,
+            menuAppendTo: actions?.menuAppendTo,
             actionsToggle: actions?.actionsToggle
           }
         }

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
@@ -16,6 +16,7 @@ propComponents:
     'TdSelectType',
     'ThSelectType',
     'TdTreeRowType',
+    'ActionsColumn',
     'IActions',
     'TdCompoundExpandType',
     'TdFavoritesType',
@@ -163,6 +164,8 @@ This selectable rows feature is intended for use when a table is used to present
 This example demonstrates adding actions as the last column. The header's last cell is an empty cell, and each body row's last cell is an action cell.
 
 To make a cell an action cell, render an `ActionsColumn` component inside a row's last `Td` and pass an array of `IAction` objects via the `items` prop of `ActionsColumn`.
+
+If actions menus are getting clipped by other items on the page, such as sticky columns or rows, the `ActionsColumn` can be passed a `menuAppendTo` prop to adjust where the actions menu is appended.
 
 ```ts file="ComposableTableActions.tsx"
 ```


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8475

added `actionsMenuAppendTo` to the Table component
added `menuAppendTo` to the TdActionsType for usage in TableComposable
