### PR TITLE
feat(Select): add toggle ref

### DIFF
--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -95,6 +95,8 @@ export interface SelectProps
   isCheckboxSelectionBadgeHidden?: boolean;
   /** Id for select toggle element */
   toggleId?: string;
+  /** Ref for the select toggle element */
+  toggleRef?: React.Ref<HTMLButtonElement> | React.Ref<HTMLDivElement>;
   /** Adds accessible text to Select */
   'aria-label'?: string;
   /** Id of label for the Select aria-labelledby */
@@ -983,6 +985,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
       onClear,
       onBlur,
       toggleId,
+      toggleRef,
       isOpen,
       isGrouped,
       isPlain,
@@ -1325,6 +1328,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
           id={selectToggleId}
           parentRef={this.parentRef}
           menuRef={this.menuComponentRef}
+          ref={toggleRef}
           {...(footer && { footerRef: this.footerRef })}
           isOpen={isOpen}
           isPlain={isPlain}

--- a/packages/react-core/src/components/Select/SelectToggle.tsx
+++ b/packages/react-core/src/components/Select/SelectToggle.tsx
@@ -8,7 +8,7 @@ import { PickOptional } from '../../helpers/typeUtils';
 import { findTabbableElements } from '../../helpers/util';
 import { KeyTypes } from '../../helpers/constants';
 
-export interface SelectToggleProps extends React.HTMLProps<HTMLElement> {
+export interface SelectToggleProps extends Omit<React.HTMLProps<HTMLElement>, 'ref'> {
   /** HTML ID of dropdown toggle */
   id: string;
   /** Anything which can be rendered as dropdown toggle */
@@ -59,9 +59,11 @@ export interface SelectToggleProps extends React.HTMLProps<HTMLElement> {
   hasFooter?: boolean;
   /** @hide Internal callback for handling focus when typeahead toggle button clicked. */
   onClickTypeaheadToggleButton?: () => void;
+  /** @hide Internal ref for the select toggle */
+  innerRef?: React.Ref<any>;
 }
 
-export class SelectToggle extends React.Component<SelectToggleProps> {
+class SelectToggleBase extends React.Component<SelectToggleProps> {
   static displayName = 'SelectToggle';
   private toggle: React.RefObject<HTMLDivElement> | React.RefObject<HTMLButtonElement>;
 
@@ -88,7 +90,11 @@ export class SelectToggle extends React.Component<SelectToggleProps> {
     super(props);
     const { variant } = props;
     const isTypeahead = variant === SelectVariant.typeahead || variant === SelectVariant.typeaheadMulti;
-    this.toggle = isTypeahead ? React.createRef<HTMLDivElement>() : React.createRef<HTMLButtonElement>();
+    if (this.props.innerRef) {
+      this.toggle = this.props.innerRef as React.RefObject<HTMLButtonElement> | React.RefObject<HTMLDivElement>;
+    } else {
+      this.toggle = isTypeahead ? React.createRef<HTMLDivElement>() : React.createRef<HTMLButtonElement>();
+    }
   }
 
   componentDidMount() {
@@ -265,6 +271,7 @@ export class SelectToggle extends React.Component<SelectToggleProps> {
       hasFooter,
       footerRef,
       toggleIndicator,
+      innerRef,
       ...props
     } = this.props;
     /* eslint-enable @typescript-eslint/no-unused-vars */
@@ -363,3 +370,7 @@ export class SelectToggle extends React.Component<SelectToggleProps> {
     );
   }
 }
+
+export const SelectToggle = React.forwardRef((props: SelectToggleProps, ref: React.Ref<any>) => (
+  <SelectToggleBase innerRef={ref} {...props} />
+));

--- a/packages/react-core/src/components/Select/examples/Select.md
+++ b/packages/react-core/src/components/Select/examples/Select.md
@@ -31,6 +31,8 @@ class SingleSelectInput extends React.Component {
       <SelectOption key={7} value="Other" />
     ];
 
+    this.toggleRef = React.createRef();
+
     this.state = {
       isToggleIcon: false,
       isOpen: false,
@@ -53,6 +55,7 @@ class SingleSelectInput extends React.Component {
           isOpen: false
         });
         console.log('selected:', selection);
+        this.toggleRef.current.focus();
       }
     };
 
@@ -97,6 +100,7 @@ class SingleSelectInput extends React.Component {
           Title
         </span>
         <Select
+          toggleRef={this.toggleRef}
           toggleIcon={isToggleIcon && <CubeIcon />}
           variant={SelectVariant.single}
           aria-label="Select Input"
@@ -158,6 +162,8 @@ class SingleSelectDescription extends React.Component {
       { value: 'Other', disabled: false }
     ];
 
+    this.toggleRef = React.createRef();
+
     this.state = {
       isOpen: false,
       selected: null,
@@ -178,6 +184,7 @@ class SingleSelectDescription extends React.Component {
           isOpen: false
         });
         console.log('selected:', selection);
+        this.toggleRef.current.focus();
       }
     };
 
@@ -202,6 +209,7 @@ class SingleSelectDescription extends React.Component {
           placeholderText="Select an option"
           aria-label="Select Input with descriptions"
           onToggle={this.onToggle}
+          toggleRef={this.toggleRef}
           onSelect={this.onSelect}
           selections={selected}
           isOpen={isOpen}
@@ -238,6 +246,8 @@ class GroupedSingleSelectInput extends React.Component {
       selected: null
     };
 
+    this.toggleRef = React.createRef();
+
     this.onToggle = isOpen => {
       this.setState({
         isOpen
@@ -249,6 +259,7 @@ class GroupedSingleSelectInput extends React.Component {
         selected: selection,
         isOpen: false
       });
+      this.toggleRef.current.focus();
     };
 
     this.clearSelection = () => {
@@ -284,6 +295,7 @@ class GroupedSingleSelectInput extends React.Component {
         </span>
         <Select
           variant={SelectVariant.single}
+          toggleRef={this.toggleRef}
           onToggle={this.onToggle}
           onSelect={this.onSelect}
           selections={selected}
@@ -319,6 +331,8 @@ class ValidatedSelect extends React.Component {
       <SelectOption key={6} value="Other" />
     ];
 
+    this.toggleRef = React.createRef();
+
     this.state = {
       isOpen: false,
       selected: null,
@@ -352,6 +366,7 @@ class ValidatedSelect extends React.Component {
       this.setState({
         validated: validatedState
       });
+      this.toggleRef.current.focus();
     };
 
     this.clearSelection = () => {
@@ -372,6 +387,7 @@ class ValidatedSelect extends React.Component {
         </span>
         <Select
           variant={SelectVariant.single}
+          toggleRef={this.toggleRef}
           placeholderText="Select an option"
           aria-label="Select Input with validation"
           onToggle={this.onToggle}
@@ -728,6 +744,8 @@ class FilteringSingleSelectInput extends React.Component {
       isInputFilterPersisted: false
     };
 
+    this.toggleRef = React.createRef();
+
     this.options = [
       <SelectGroup label="Status" key="group1">
         <SelectOption key={0} value="Running" />
@@ -749,6 +767,7 @@ class FilteringSingleSelectInput extends React.Component {
 
     this.onSelect = (event, selection) => {
       this.setState({ selected: selection, isOpen: false }), console.log('selected: ', selection);
+      this.toggleRef.current.focus();
     };
 
     this.onFilter = (_, textInput) => {
@@ -805,6 +824,7 @@ class FilteringSingleSelectInput extends React.Component {
         </span>
         <Select
           variant={SelectVariant.single}
+          toggleRef={this.toggleRef}
           onToggle={this.onToggle}
           onSelect={this.onSelect}
           selections={selected}
@@ -2460,6 +2480,8 @@ class SelectWithFooter extends React.Component {
       <SelectOption key={7} value="Other" />
     ];
 
+    this.toggleRef = React.createRef();
+
     this.state = {
       isToggleIcon: false,
       isOpen: false,
@@ -2482,6 +2504,7 @@ class SelectWithFooter extends React.Component {
           isOpen: false
         });
         console.log('selected:', selection);
+        this.toggleRef.current.focus();
       }
     };
 
@@ -2503,6 +2526,7 @@ class SelectWithFooter extends React.Component {
         </span>
         <Select
           toggleIcon={isToggleIcon && <CubeIcon />}
+          toggleRef={this.toggleRef}
           variant={SelectVariant.single}
           aria-label="Select Input"
           onToggle={this.onToggle}
@@ -2630,6 +2654,8 @@ class SelectViewMore extends React.Component {
       <SelectOption key={6} value="Other" />
     ];
 
+    this.toggleRef = React.createRef();
+
     this.state = {
       isOpen: false,
       selected: null,
@@ -2651,6 +2677,7 @@ class SelectViewMore extends React.Component {
           isOpen: false
         });
         console.log('selected:', selection);
+        this.toggleRef.current.focus();
       }
     };
 
@@ -2686,6 +2713,7 @@ class SelectViewMore extends React.Component {
         </span>
         <Select
           variant={SelectVariant.single}
+          toggleRef={this.toggleRef}
           aria-label="Select Input"
           onToggle={this.onToggle}
           onSelect={this.onSelect}

--- a/packages/react-integration/cypress/integration/select.spec.ts
+++ b/packages/react-integration/cypress/integration/select.spec.ts
@@ -42,6 +42,20 @@ describe('Select Test', () => {
       .should('exist');
   });
 
+  it('Verify Single Select closes on escape with internal ref', () => {
+    cy.get('#single-select')
+      .click()
+      .type('{esc}');
+    cy.focused().should('have.id', 'single-select');
+  });
+
+  it('Verify Single Select closes on escape with passed ref', () => {
+    cy.get('#single-ref-select')
+      .click()
+      .type('{esc}');
+    cy.focused().should('have.id', 'single-ref-select');
+  });
+
   it('Verify Description Select', () => {
     cy.get('#single-select-with-descriptions').click();
     cy.get('.pf-c-select__menu-footer').should('exist');

--- a/packages/react-integration/demo-app-ts/src/components/demos/SelectDemo/SelectDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/SelectDemo/SelectDemo.tsx
@@ -27,6 +27,8 @@ export interface SelectDemoState {
   optionisDisabled?: boolean;
   singleisOpen: boolean;
   singleSelected: string;
+  singleRefisOpen: boolean;
+  singleRefSelected: string;
   singleAppendisOpen: boolean;
   singleAppendSelected: boolean;
   singleDescisOpen: boolean;
@@ -71,6 +73,8 @@ export class SelectDemo extends Component<SelectDemoState> {
     optionisDisabled: false,
     singleisOpen: false,
     singleSelected: '',
+    singleRefisOpen: false,
+    singleRefSelected: '',
     singleAppendisOpen: false,
     singleAppendSelected: '',
     singleDescisOpen: false,
@@ -215,6 +219,12 @@ export class SelectDemo extends Component<SelectDemoState> {
     });
   };
 
+  singleRefOnToggle = (singleRefisOpen: boolean) => {
+    this.setState({
+      singleRefisOpen
+    });
+  };
+
   singleAppendOnToggle = (singleAppendisOpen: boolean) => {
     this.setState({
       singleAppendisOpen
@@ -320,6 +330,22 @@ export class SelectDemo extends Component<SelectDemoState> {
       this.setState({
         singleSelected: selection,
         singleisOpen: false
+      });
+      console.log('selected:', selection.toString());
+    }
+  };
+
+  singleRefOnSelect = (
+    event: React.MouseEvent | React.ChangeEvent,
+    selection: string | SelectOptionObject,
+    isPlaceholder?: boolean
+  ) => {
+    if (isPlaceholder) {
+      this.clearSelection();
+    } else {
+      this.setState({
+        singleRefSelected: selection,
+        singleRefisOpen: false
       });
       console.log('selected:', selection.toString());
     }
@@ -665,6 +691,47 @@ export class SelectDemo extends Component<SelectDemoState> {
           id="toggle-direction"
           name="toggle-direction"
         />
+      </StackItem>
+    );
+  }
+
+  renderCustomRefSingleSelect() {
+    const { singleRefisOpen, singleRefSelected } = this.state;
+    const titleId = 'title-id';
+    return (
+      <StackItem isFilled={false}>
+        <Title headingLevel="h2" size="2xl">
+          Single Custom Ref Select
+        </Title>
+        <div>
+          <span id={titleId} hidden>
+            Title
+          </span>
+          <Select
+            id="single-ref-select-component"
+            toggleId="single-ref-select"
+            toggleRef={React.createRef() as React.RefObject<HTMLButtonElement>}
+            variant={SelectVariant.single}
+            aria-label="Select Input"
+            onToggle={this.singleRefOnToggle}
+            onSelect={this.singleRefOnSelect}
+            selections={singleRefSelected}
+            isOpen={singleRefisOpen}
+            aria-labelledby={titleId}
+            direction={this.state.direction}
+            maxHeight={200}
+          >
+            {this.singleOptions.map((option, index) => (
+              <SelectOption
+                id={option.value}
+                isDisabled={option.disabled}
+                key={index}
+                value={option.value}
+                isPlaceholder={option.isPlaceholder}
+              />
+            ))}
+          </Select>
+        </div>
       </StackItem>
     );
   }
@@ -1370,6 +1437,7 @@ export class SelectDemo extends Component<SelectDemoState> {
     return (
       <Stack hasGutter>
         {this.renderSingleSelect()}
+        {this.renderCustomRefSingleSelect()}
         {this.renderCustomSingleSelect()}
         {this.renderDisabledSingleSelect()}
         {this.renderCheckboxSelect()}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8478

It looks like the single select variant didn't have support for re-focusing the toggle upon selection. I added the ability to pass in a toggle reference so a user can control when the toggle is focused (typically in the onSelect handler) & updated the related examples. 

Adding the refocus to the Toggle internally is also probably an option but it would be trickier to ensure it fired only the in the right circumstances (currently the toggle handles Tab/Escape because that always closes the menu but with selection, some selects should stay open and not refocus). I can take a crack at making the handling internal if we would rather have that than the external ref though.