### PR TITLE
fix(Table): fix verbiage/formatting in example documentation

### DIFF
--- a/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
@@ -305,7 +305,7 @@ To make a row draggable:
 1. The table needs a draggable column.
 2. Each draggable `Tr` needs to be passed `draggable`, `onDrop`, `onDragEnd`, and `onDragStart` props.
 3. The `Tbody` needs `onDragOver`, `onDrop`, and `onDragLeave` props.
-4. While the user is dragging a row, the `` class needs to be applied to `TableComposable`.
+4. While the user is dragging a row, the `pf-m-drag-over` class needs to be applied to `TableComposable`.
 5. The draggable `Td` in each row needs a `TdDraggableType` object passed to its `draggable` prop.
 
 ```ts isBeta file="ComposableTableDraggable.tsx"


### PR DESCRIPTION
**What**: fixes this
![image](https://user-images.githubusercontent.com/5322142/213056138-47a0b402-b414-4886-aeef-c8a05e316607.png)

to show..

![image](https://user-images.githubusercontent.com/5322142/213056523-88e92d60-2765-4c11-9e7d-8d040b1c9f14.png)
