### PR TITLE
Charts - fix broken tooltip examples for v5

### DIFF
--- a/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
+++ b/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
@@ -606,11 +606,16 @@ class TooltipPieChart extends React.Component {
   constructor(props) {
     super(props);
 
-    // Custom legend label compoenent
-    this.LegendLabel = ({datum, ...rest}) => (
-      <Tooltip content={datum.name} enableFlip>
-        <ChartLabel {...rest} />
-      </Tooltip>
+    // Custom legend label component
+    // Note: Tooltip outputs a div tag, so we wrap that using a foreignObject
+    this.LegendLabel = ({datum, x, y, ...rest}) => (
+      <g>
+        <foreignObject height="100%" width="100%" x={x - 10} y={y - 12}>
+          <Tooltip content={datum.name} enableFlip >
+            <ChartLabel {...rest} />
+          </Tooltip>
+        </foreignObject>
+      </g>
     );
 
     // Custom legend component

--- a/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
+++ b/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
@@ -297,7 +297,7 @@ This demonstrates how to embed HTML within a tooltip. Combining cursor and voron
 
 ```js
 import React from 'react';
-import { Chart, ChartArea, ChartAxis, ChartCursorFlyout, ChartCursorTooltip, ChartGroup, ChartPoint, ChartThemeColor } from '@patternfly/react-charts';
+import { Chart, ChartArea, ChartAxis, ChartCursorFlyout, ChartCursorTooltip, ChartGroup, ChartPoint, ChartThemeColor, createContainer } from '@patternfly/react-charts';
 // import '@patternfly/patternfly/patternfly-charts.css'; // Required for mix-blend-mode CSS property
 
 class EmbeddedHtml extends React.Component {
@@ -607,11 +607,16 @@ class TooltipPieChart extends React.Component {
   constructor(props) {
     super(props);
 
-    // Custom legend label compoenent
-    this.LegendLabel = ({datum, ...rest}) => (
-      <Tooltip content={datum.name} enableFlip>
-        <ChartLabel {...rest} />
-      </Tooltip>
+    // Custom legend label component
+    // Note: Tooltip outputs a div tag, so we wrap that using a foreignObject
+    this.LegendLabel = ({datum, x, y, ...rest}) => (
+      <g>
+        <foreignObject height="100%" width="100%" x={x - 10} y={y - 12}>
+          <Tooltip content={datum.name} enableFlip >
+            <ChartLabel {...rest} />
+          </Tooltip>
+        </foreignObject>
+      </g>
     );
 
     // Custom legend component


### PR DESCRIPTION
Need to fix two broken legend tooltip examples due to the Tooltip popper outputting a new div tag.

https://github.com/patternfly/patternfly-react/issues/8591
