### PR TITLE
fix(Popover): updated appendTo to inline by default

### DIFF
--- a/packages/react-core/src/components/Popover/Popover.tsx
+++ b/packages/react-core/src/components/Popover/Popover.tsx
@@ -277,7 +277,6 @@ export const Popover: React.FunctionComponent<PopoverProps> = ({
   const transitionTimerRef = React.useRef(null);
   const showTimerRef = React.useRef(null);
   const hideTimerRef = React.useRef(null);
-  const containerRef = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
     onMount();
@@ -455,41 +454,25 @@ export const Popover: React.FunctionComponent<PopoverProps> = ({
     </FocusTrap>
   );
 
-  const getInlineReference = () => {
-    if (reference) {
-      if ((reference as React.RefObject<any>)?.current) {
-        return (reference as React.RefObject<any>)?.current.parentElement;
-      } else if (typeof reference === 'function') {
-        return reference()?.parentElement;
-      }
-    }
-
-    return containerRef?.current;
-  };
-
-  const popoverPopper = (
-    <Popper
-      trigger={children}
-      reference={reference}
-      popper={content}
-      popperMatchesTriggerWidth={false}
-      appendTo={appendTo === 'inline' ? getInlineReference || undefined : appendTo}
-      isVisible={visible}
-      positionModifiers={positionModifiers}
-      distance={distance}
-      placement={position}
-      onTriggerClick={onTriggerClick}
-      onDocumentClick={onDocumentClick}
-      onDocumentKeyDown={onDocumentKeyDown}
-      enableFlip={enableFlip}
-      zIndex={zIndex}
-      flipBehavior={flipBehavior}
-    />
-  );
-
   return (
     <PopoverContext.Provider value={{ headerComponent }}>
-      {appendTo === 'inline' && children ? <div ref={containerRef}>{popoverPopper}</div> : popoverPopper}
+      <Popper
+        trigger={children}
+        reference={reference}
+        popper={content}
+        popperMatchesTriggerWidth={false}
+        appendTo={appendTo}
+        isVisible={visible}
+        positionModifiers={positionModifiers}
+        distance={distance}
+        placement={position}
+        onTriggerClick={onTriggerClick}
+        onDocumentClick={onDocumentClick}
+        onDocumentKeyDown={onDocumentKeyDown}
+        enableFlip={enableFlip}
+        zIndex={zIndex}
+        flipBehavior={flipBehavior}
+      />
     </PopoverContext.Provider>
   );
 };

--- a/packages/react-core/src/components/Popover/Popover.tsx
+++ b/packages/react-core/src/components/Popover/Popover.tsx
@@ -455,13 +455,25 @@ export const Popover: React.FunctionComponent<PopoverProps> = ({
     </FocusTrap>
   );
 
+  const getInlineReference = () => {
+    if (reference) {
+      if ((reference as React.RefObject<any>)?.current) {
+        return (reference as React.RefObject<any>)?.current.parentElement;
+      } else if (typeof reference === 'function') {
+        return reference()?.parentElement;
+      }
+    }
+
+    return containerRef?.current;
+  };
+
   const popoverPopper = (
     <Popper
       trigger={children}
       reference={reference}
       popper={content}
       popperMatchesTriggerWidth={false}
-      appendTo={appendTo === 'inline' ? containerRef.current || undefined : appendTo}
+      appendTo={appendTo === 'inline' ? getInlineReference() || undefined : appendTo}
       isVisible={visible}
       positionModifiers={positionModifiers}
       distance={distance}
@@ -477,7 +489,7 @@ export const Popover: React.FunctionComponent<PopoverProps> = ({
 
   return (
     <PopoverContext.Provider value={{ headerComponent }}>
-      {appendTo === 'inline' ? <div ref={containerRef}>{popoverPopper}</div> : popoverPopper}
+      {appendTo === 'inline' && children ? <div ref={containerRef}>{popoverPopper}</div> : popoverPopper}
     </PopoverContext.Provider>
   );
 };

--- a/packages/react-core/src/components/Popover/Popover.tsx
+++ b/packages/react-core/src/components/Popover/Popover.tsx
@@ -49,7 +49,7 @@ export interface PopoverProps {
   /** The duration of the CSS fade transition animation. */
   animationDuration?: number;
   /** The element to append the popover to. Defaults to "document.body". */
-  appendTo?: HTMLElement | ((ref?: HTMLElement) => HTMLElement);
+  appendTo?: HTMLElement | ((ref?: HTMLElement) => HTMLElement) | 'inline';
   /** Accessible label for the popover, required when header is not present. */
   'aria-label'?: string;
   /**
@@ -232,7 +232,7 @@ export const Popover: React.FunctionComponent<PopoverProps> = ({
   alertSeverityVariant,
   alertSeverityScreenReaderText,
   footerContent = null,
-  appendTo = () => document.body,
+  appendTo = 'inline',
   hideOnOutsideClick = true,
   onHide = (): void => null,
   onHidden = (): void => null,
@@ -277,6 +277,7 @@ export const Popover: React.FunctionComponent<PopoverProps> = ({
   const transitionTimerRef = React.useRef(null);
   const showTimerRef = React.useRef(null);
   const hideTimerRef = React.useRef(null);
+  const containerRef = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
     onMount();
@@ -454,25 +455,29 @@ export const Popover: React.FunctionComponent<PopoverProps> = ({
     </FocusTrap>
   );
 
+  const popoverPopper = (
+    <Popper
+      trigger={children}
+      reference={reference}
+      popper={content}
+      popperMatchesTriggerWidth={false}
+      appendTo={appendTo === 'inline' ? containerRef.current || undefined : appendTo}
+      isVisible={visible}
+      positionModifiers={positionModifiers}
+      distance={distance}
+      placement={position}
+      onTriggerClick={onTriggerClick}
+      onDocumentClick={onDocumentClick}
+      onDocumentKeyDown={onDocumentKeyDown}
+      enableFlip={enableFlip}
+      zIndex={zIndex}
+      flipBehavior={flipBehavior}
+    />
+  );
+
   return (
     <PopoverContext.Provider value={{ headerComponent }}>
-      <Popper
-        trigger={children}
-        reference={reference}
-        popper={content}
-        popperMatchesTriggerWidth={false}
-        appendTo={appendTo}
-        isVisible={visible}
-        positionModifiers={positionModifiers}
-        distance={distance}
-        placement={position}
-        onTriggerClick={onTriggerClick}
-        onDocumentClick={onDocumentClick}
-        onDocumentKeyDown={onDocumentKeyDown}
-        enableFlip={enableFlip}
-        zIndex={zIndex}
-        flipBehavior={flipBehavior}
-      />
+      {appendTo === 'inline' ? <div ref={containerRef}>{popoverPopper}</div> : popoverPopper}
     </PopoverContext.Provider>
   );
 };

--- a/packages/react-core/src/components/Popover/Popover.tsx
+++ b/packages/react-core/src/components/Popover/Popover.tsx
@@ -473,7 +473,7 @@ export const Popover: React.FunctionComponent<PopoverProps> = ({
       reference={reference}
       popper={content}
       popperMatchesTriggerWidth={false}
-      appendTo={appendTo === 'inline' ? getInlineReference() || undefined : appendTo}
+      appendTo={appendTo === 'inline' ? getInlineReference || undefined : appendTo}
       isVisible={visible}
       positionModifiers={positionModifiers}
       distance={distance}

--- a/packages/react-core/src/components/Popover/Popover.tsx
+++ b/packages/react-core/src/components/Popover/Popover.tsx
@@ -48,7 +48,7 @@ export interface PopoverProps {
   alertSeverityVariant?: 'default' | 'info' | 'warning' | 'success' | 'danger';
   /** The duration of the CSS fade transition animation. */
   animationDuration?: number;
-  /** The element to append the popover to. Defaults to "document.body". */
+  /** The element to append the popover to. Defaults to "inline". */
   appendTo?: HTMLElement | ((ref?: HTMLElement) => HTMLElement) | 'inline';
   /** Accessible label for the popover, required when header is not present. */
   'aria-label'?: string;

--- a/packages/react-core/src/components/Popover/__tests__/__snapshots__/Popover.test.tsx.snap
+++ b/packages/react-core/src/components/Popover/__tests__/__snapshots__/Popover.test.tsx.snap
@@ -2,25 +2,29 @@
 
 exports[`popover can close from content (uncontrolled) 1`] = `
 <DocumentFragment>
-  <div
-    style="display: contents;"
-  >
-    <button
-      id="uncontrolled-toggle"
+  <div>
+    <div
+      style="display: contents;"
     >
-      Toggle Popover
-    </button>
+      <button
+        id="uncontrolled-toggle"
+      >
+        Toggle Popover
+      </button>
+    </div>
   </div>
 </DocumentFragment>
 `;
 
 exports[`popover can have a custom minimum width 1`] = `
 <DocumentFragment>
-  <div
-    style="display: contents;"
-  >
-    <div>
-      Toggle Popover
+  <div>
+    <div
+      style="display: contents;"
+    >
+      <div>
+        Toggle Popover
+      </div>
     </div>
   </div>
 </DocumentFragment>
@@ -28,11 +32,13 @@ exports[`popover can have a custom minimum width 1`] = `
 
 exports[`popover can specify position as object value 1`] = `
 <DocumentFragment>
-  <div
-    style="display: contents;"
-  >
-    <div>
-      Toggle Popover
+  <div>
+    <div
+      style="display: contents;"
+    >
+      <div>
+        Toggle Popover
+      </div>
     </div>
   </div>
 </DocumentFragment>
@@ -40,11 +46,13 @@ exports[`popover can specify position as object value 1`] = `
 
 exports[`popover renders close-button, header and body 1`] = `
 <DocumentFragment>
-  <div
-    style="display: contents;"
-  >
-    <div>
-      Toggle Popover
+  <div>
+    <div
+      style="display: contents;"
+    >
+      <div>
+        Toggle Popover
+      </div>
     </div>
   </div>
 </DocumentFragment>
@@ -52,11 +60,13 @@ exports[`popover renders close-button, header and body 1`] = `
 
 exports[`popover renders in strict mode 1`] = `
 <DocumentFragment>
-  <div
-    style="display: contents;"
-  >
-    <div>
-      Toggle Popover
+  <div>
+    <div
+      style="display: contents;"
+    >
+      <div>
+        Toggle Popover
+      </div>
     </div>
   </div>
 </DocumentFragment>

--- a/packages/react-core/src/components/Popover/__tests__/__snapshots__/Popover.test.tsx.snap
+++ b/packages/react-core/src/components/Popover/__tests__/__snapshots__/Popover.test.tsx.snap
@@ -2,29 +2,25 @@
 
 exports[`popover can close from content (uncontrolled) 1`] = `
 <DocumentFragment>
-  <div>
-    <div
-      style="display: contents;"
+  <div
+    style="display: contents;"
+  >
+    <button
+      id="uncontrolled-toggle"
     >
-      <button
-        id="uncontrolled-toggle"
-      >
-        Toggle Popover
-      </button>
-    </div>
+      Toggle Popover
+    </button>
   </div>
 </DocumentFragment>
 `;
 
 exports[`popover can have a custom minimum width 1`] = `
 <DocumentFragment>
-  <div>
-    <div
-      style="display: contents;"
-    >
-      <div>
-        Toggle Popover
-      </div>
+  <div
+    style="display: contents;"
+  >
+    <div>
+      Toggle Popover
     </div>
   </div>
 </DocumentFragment>
@@ -32,13 +28,11 @@ exports[`popover can have a custom minimum width 1`] = `
 
 exports[`popover can specify position as object value 1`] = `
 <DocumentFragment>
-  <div>
-    <div
-      style="display: contents;"
-    >
-      <div>
-        Toggle Popover
-      </div>
+  <div
+    style="display: contents;"
+  >
+    <div>
+      Toggle Popover
     </div>
   </div>
 </DocumentFragment>
@@ -46,13 +40,11 @@ exports[`popover can specify position as object value 1`] = `
 
 exports[`popover renders close-button, header and body 1`] = `
 <DocumentFragment>
-  <div>
-    <div
-      style="display: contents;"
-    >
-      <div>
-        Toggle Popover
-      </div>
+  <div
+    style="display: contents;"
+  >
+    <div>
+      Toggle Popover
     </div>
   </div>
 </DocumentFragment>
@@ -60,13 +52,11 @@ exports[`popover renders close-button, header and body 1`] = `
 
 exports[`popover renders in strict mode 1`] = `
 <DocumentFragment>
-  <div>
-    <div
-      style="display: contents;"
-    >
-      <div>
-        Toggle Popover
-      </div>
+  <div
+    style="display: contents;"
+  >
+    <div>
+      Toggle Popover
     </div>
   </div>
 </DocumentFragment>

--- a/packages/react-integration/cypress/integration/popover.spec.ts
+++ b/packages/react-integration/cypress/integration/popover.spec.ts
@@ -21,7 +21,7 @@ describe('Popover Demo Test', () => {
   });
 
   it('Popover header has correct default size', () => {
-    cy.get('div[id="popoverTarget"]').then((popoverLink: JQuery<HTMLDivElement>) => {
+    cy.get('button[id="popoverTarget"]').then((popoverLink: JQuery<HTMLDivElement>) => {
       cy.wrap(popoverLink).click();
       cy.get('.pf-c-popover').should('exist');
       cy.get('h6').should('have.class', 'pf-m-md');

--- a/packages/react-integration/demo-app-ts/src/components/demos/FormDemo/FormDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/FormDemo/FormDemo.tsx
@@ -114,7 +114,12 @@ export class FormDemo extends Component<FormProps, FormState> {
             labelIcon={
               <Popover
                 headerContent={<div>The age of a person</div>}
-                bodyContent={<div>Age is typically measured in years.</div>}
+                bodyContent={
+                  <div>
+                    Age is typically measured in years. It is also common to measure age in months for newborns, e.g. 18
+                    months.
+                  </div>
+                }
               >
                 <button
                   id="helper-text-target"

--- a/packages/react-integration/demo-app-ts/src/components/demos/PopoverDemo/PopoverDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/PopoverDemo/PopoverDemo.tsx
@@ -6,8 +6,7 @@ export class PopoverDemo extends Component {
   myPopoverProps = {
     headerContent: <div>Popover Header</div>,
     bodyContent: <div>Popover Body</div>,
-    footerContent: 'Popover Footer',
-    children: <div id="popoverTarget">Hello</div>
+    footerContent: 'Popover Footer'
   };
 
   constructor(props: any) {
@@ -20,21 +19,18 @@ export class PopoverDemo extends Component {
   }
 
   render() {
+    const { headerContent, bodyContent, footerContent } = this.myPopoverProps;
     return (
       <>
-        <Popover
-          headerContent={this.myPopoverProps.headerContent}
-          bodyContent={this.myPopoverProps.bodyContent}
-          footerContent={this.myPopoverProps.footerContent}
-        >
-          {this.myPopoverProps.children}
+        <Popover headerContent={headerContent} bodyContent={bodyContent} footerContent={footerContent}>
+          <button id="popoverTarget">Popover attached to children</button>
         </Popover>
         <div>
           <button id="popover-selector">Popover attached via selector ref</button>
           <Popover
-            headerContent={this.myPopoverProps.headerContent}
-            bodyContent={this.myPopoverProps.bodyContent}
-            footerContent={this.myPopoverProps.footerContent}
+            headerContent={headerContent}
+            bodyContent={bodyContent}
+            footerContent={footerContent}
             reference={() => document.getElementById('popover-selector')}
           />
         </div>
@@ -43,9 +39,10 @@ export class PopoverDemo extends Component {
             Popover attached via react ref
           </button>
           <Popover
-            headerContent={this.myPopoverProps.headerContent}
-            bodyContent={this.myPopoverProps.bodyContent}
-            footerContent={this.myPopoverProps.footerContent}
+            position="right-start"
+            headerContent={headerContent}
+            bodyContent={bodyContent}
+            footerContent={footerContent}
             reference={this.popoverRef}
           />
         </div>
@@ -53,6 +50,7 @@ export class PopoverDemo extends Component {
           id="popover-content-close"
           aria-label="Popover with button in the body that can close it"
           headerContent={<div>Popover header</div>}
+          position="right-start"
           bodyContent={hide => (
             <div>
               <div>
@@ -95,3 +93,5 @@ export class PopoverDemo extends Component {
     );
   }
 }
+
+export default PopoverDemo;

--- a/packages/react-integration/demo-app-ts/src/components/demos/PopoverDemo/PopoverDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/PopoverDemo/PopoverDemo.tsx
@@ -86,6 +86,7 @@ export class PopoverDemo extends Component {
           bodyContent="I have a custom heading level."
           footerContent="Popover footer"
           headerComponent="h1"
+          position="auto"
         >
           <button id="popover-heading-level-toggle">Toggle Popover</button>
         </Popover>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8599

[Popover examples](https://patternfly-react-pr-8621.surge.sh/components/popover)

This results in markup similar to Timepicker (wrapping the Popper in a div internally and appending to that wrapper div). 

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
