### PR TITLE
chore(composable menu demos): updated appendTo

### DIFF
--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableActionsMenu.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableActionsMenu.tsx
@@ -60,9 +60,11 @@ export const ComposableActionsMenu: React.FunctionComponent = () => {
   };
 
   const toggle = (
-    <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
-      {isOpen ? 'Expanded' : 'Collapsed'}
-    </MenuToggle>
+    <div ref={containerRef}>
+      <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
+        {isOpen ? 'Expanded' : 'Collapsed'}
+      </MenuToggle>
+    </div>
   );
   const menu = (
     <Menu
@@ -124,14 +126,12 @@ export const ComposableActionsMenu: React.FunctionComponent = () => {
   );
 
   return (
-    <div ref={containerRef}>
-      <Popper
-        trigger={toggle}
-        popper={menu}
-        isVisible={isOpen}
-        appendTo={containerRef.current || undefined}
-        popperMatchesTriggerWidth={false}
-      />
-    </div>
+    <Popper
+      trigger={toggle}
+      popper={menu}
+      isVisible={isOpen}
+      appendTo={containerRef.current || undefined}
+      popperMatchesTriggerWidth={false}
+    />
   );
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableActionsMenu.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableActionsMenu.tsx
@@ -10,7 +10,6 @@ export const ComposableActionsMenu: React.FunctionComponent = () => {
   const [selectedItems, setSelectedItems] = React.useState<number[]>([]);
   const toggleRef = React.useRef<HTMLButtonElement>(null);
   const menuRef = React.useRef<HTMLDivElement>(null);
-  const containerRef = React.useRef<HTMLDivElement>(null);
 
   const handleMenuKeys = (event: KeyboardEvent) => {
     if (isOpen && menuRef.current?.contains(event.target as Node)) {
@@ -60,11 +59,9 @@ export const ComposableActionsMenu: React.FunctionComponent = () => {
   };
 
   const toggle = (
-    <div ref={containerRef}>
-      <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
-        {isOpen ? 'Expanded' : 'Collapsed'}
-      </MenuToggle>
-    </div>
+    <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
+      {isOpen ? 'Expanded' : 'Collapsed'}
+    </MenuToggle>
   );
   const menu = (
     <Menu
@@ -125,13 +122,5 @@ export const ComposableActionsMenu: React.FunctionComponent = () => {
     </Menu>
   );
 
-  return (
-    <Popper
-      trigger={toggle}
-      popper={menu}
-      isVisible={isOpen}
-      appendTo={containerRef.current || undefined}
-      popperMatchesTriggerWidth={false}
-    />
-  );
+  return <Popper trigger={toggle} popper={menu} isVisible={isOpen} popperMatchesTriggerWidth={false} />;
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableApplicationLauncher.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableApplicationLauncher.tsx
@@ -68,16 +68,18 @@ export const ComposableApplicationLauncher: React.FunctionComponent = () => {
   }, [isOpen, menuRef]);
 
   const toggle = (
-    <MenuToggle
-      aria-label="Toggle"
-      ref={toggleRef}
-      variant="plain"
-      onClick={onToggleClick}
-      isExpanded={isOpen}
-      style={{ width: 'auto' }}
-    >
-      <ThIcon />
-    </MenuToggle>
+    <div ref={containerRef}>
+      <MenuToggle
+        aria-label="Toggle"
+        ref={toggleRef}
+        variant="plain"
+        onClick={onToggleClick}
+        isExpanded={isOpen}
+        style={{ width: 'auto' }}
+      >
+        <ThIcon />
+      </MenuToggle>
+    </div>
   );
 
   const menuItems = [
@@ -267,14 +269,12 @@ export const ComposableApplicationLauncher: React.FunctionComponent = () => {
     </Menu>
   );
   return (
-    <div ref={containerRef}>
-      <Popper
-        trigger={toggle}
-        popper={menu}
-        isVisible={isOpen}
-        popperMatchesTriggerWidth={false}
-        appendTo={containerRef.current || undefined}
-      />
-    </div>
+    <Popper
+      trigger={toggle}
+      popper={menu}
+      isVisible={isOpen}
+      popperMatchesTriggerWidth={false}
+      appendTo={containerRef.current || undefined}
+    />
   );
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableApplicationLauncher.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableApplicationLauncher.tsx
@@ -23,7 +23,6 @@ export const ComposableApplicationLauncher: React.FunctionComponent = () => {
   const [filteredIds, setFilteredIds] = React.useState<string[]>(['*']);
   const menuRef = React.useRef<HTMLDivElement>(null);
   const toggleRef = React.useRef<HTMLButtonElement>(null);
-  const containerRef = React.useRef<HTMLDivElement>(null);
 
   const handleMenuKeys = (event: KeyboardEvent) => {
     if (!isOpen) {
@@ -68,18 +67,16 @@ export const ComposableApplicationLauncher: React.FunctionComponent = () => {
   }, [isOpen, menuRef]);
 
   const toggle = (
-    <div ref={containerRef}>
-      <MenuToggle
-        aria-label="Toggle"
-        ref={toggleRef}
-        variant="plain"
-        onClick={onToggleClick}
-        isExpanded={isOpen}
-        style={{ width: 'auto' }}
-      >
-        <ThIcon />
-      </MenuToggle>
-    </div>
+    <MenuToggle
+      aria-label="Toggle"
+      ref={toggleRef}
+      variant="plain"
+      onClick={onToggleClick}
+      isExpanded={isOpen}
+      style={{ width: 'auto' }}
+    >
+      <ThIcon />
+    </MenuToggle>
   );
 
   const menuItems = [
@@ -268,13 +265,5 @@ export const ComposableApplicationLauncher: React.FunctionComponent = () => {
       </MenuContent>
     </Menu>
   );
-  return (
-    <Popper
-      trigger={toggle}
-      popper={menu}
-      isVisible={isOpen}
-      popperMatchesTriggerWidth={false}
-      appendTo={containerRef.current || undefined}
-    />
-  );
+  return <Popper trigger={toggle} popper={menu} isVisible={isOpen} popperMatchesTriggerWidth={false} />;
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableContextSelector.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableContextSelector.tsx
@@ -113,9 +113,11 @@ export const ComposableContextSelector: React.FunctionComponent = () => {
   };
 
   const toggle = (
-    <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
-      {selected}
-    </MenuToggle>
+    <div ref={containerRef}>
+      <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
+        {selected}
+      </MenuToggle>
+    </div>
   );
 
   const onSelect = (ev: React.MouseEvent<Element, MouseEvent>, itemId: string) => {
@@ -200,14 +202,12 @@ export const ComposableContextSelector: React.FunctionComponent = () => {
     </Menu>
   );
   return (
-    <div ref={containerRef}>
-      <Popper
-        trigger={toggle}
-        popper={menu}
-        appendTo={containerRef.current}
-        isVisible={isOpen}
-        popperMatchesTriggerWidth={false}
-      />
-    </div>
+    <Popper
+      trigger={toggle}
+      popper={menu}
+      appendTo={containerRef.current}
+      isVisible={isOpen}
+      popperMatchesTriggerWidth={false}
+    />
   );
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableContextSelector.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableContextSelector.tsx
@@ -60,7 +60,6 @@ export const ComposableContextSelector: React.FunctionComponent = () => {
   const menuRef = React.useRef<HTMLDivElement>(null);
   const toggleRef = React.useRef<HTMLButtonElement>(null);
   const menuFooterBtnRef = React.useRef<HTMLButtonElement>(null);
-  const containerRef = React.useRef<HTMLDivElement>(null);
 
   const handleMenuKeys = (event: KeyboardEvent) => {
     if (!isOpen) {
@@ -113,11 +112,9 @@ export const ComposableContextSelector: React.FunctionComponent = () => {
   };
 
   const toggle = (
-    <div ref={containerRef}>
-      <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
-        {selected}
-      </MenuToggle>
-    </div>
+    <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
+      {selected}
+    </MenuToggle>
   );
 
   const onSelect = (ev: React.MouseEvent<Element, MouseEvent>, itemId: string) => {
@@ -201,13 +198,5 @@ export const ComposableContextSelector: React.FunctionComponent = () => {
       </MenuFooter>
     </Menu>
   );
-  return (
-    <Popper
-      trigger={toggle}
-      popper={menu}
-      appendTo={containerRef.current}
-      isVisible={isOpen}
-      popperMatchesTriggerWidth={false}
-    />
-  );
+  return <Popper trigger={toggle} popper={menu} isVisible={isOpen} popperMatchesTriggerWidth={false} />;
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableDateSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableDateSelect.tsx
@@ -6,22 +6,21 @@ export const ComposableSimpleDropdown: React.FunctionComponent = () => {
   const [selected, setSelected] = React.useState<number>(0);
   const toggleRef = React.useRef<HTMLButtonElement>();
   const menuRef = React.useRef<HTMLDivElement>();
-  const containerRef = React.useRef<HTMLDivElement>();
 
   const handleMenuKeys = (event: KeyboardEvent) => {
     if (!isOpen) {
       return;
     }
-    if (menuRef.current.contains(event.target as Node) || toggleRef.current.contains(event.target as Node)) {
+    if (menuRef?.current?.contains(event.target as Node) || toggleRef?.current?.contains(event.target as Node)) {
       if (event.key === 'Escape' || event.key === 'Tab') {
         setIsOpen(!isOpen);
-        toggleRef.current.focus();
+        toggleRef?.current?.focus();
       }
     }
   };
 
   const handleClickOutside = (event: MouseEvent) => {
-    if (isOpen && !menuRef.current.contains(event.target as Node)) {
+    if (isOpen && !menuRef?.current?.contains(event.target as Node)) {
       setIsOpen(false);
     }
   };
@@ -92,12 +91,10 @@ export const ComposableSimpleDropdown: React.FunctionComponent = () => {
   };
 
   const toggle = (
-    <div ref={containerRef}>
-      <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen} style={{ minWidth: '250px' }}>
-        <span style={{ verticalAlign: 'middle', marginRight: '8px' }}>{toggleText[selected]}</span>
-        {dateText[selected]}
-      </MenuToggle>
-    </div>
+    <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen} style={{ minWidth: '250px' }}>
+      <span style={{ verticalAlign: 'middle', marginRight: '8px' }}>{toggleText[selected]}</span>
+      {dateText[selected]}
+    </MenuToggle>
   );
   const menu = (
     // eslint-disable-next-line no-console
@@ -112,13 +109,5 @@ export const ComposableSimpleDropdown: React.FunctionComponent = () => {
       </MenuContent>
     </Menu>
   );
-  return (
-    <Popper
-      trigger={toggle}
-      popper={menu}
-      appendTo={containerRef.current}
-      isVisible={isOpen}
-      popperMatchesTriggerWidth={false}
-    />
-  );
+  return <Popper trigger={toggle} popper={menu} isVisible={isOpen} popperMatchesTriggerWidth={false} />;
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableDateSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableDateSelect.tsx
@@ -92,10 +92,12 @@ export const ComposableSimpleDropdown: React.FunctionComponent = () => {
   };
 
   const toggle = (
-    <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen} style={{ minWidth: '250px' }}>
-      <span style={{ verticalAlign: 'middle', marginRight: '8px' }}>{toggleText[selected]}</span>
-      {dateText[selected]}
-    </MenuToggle>
+    <div ref={containerRef}>
+      <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen} style={{ minWidth: '250px' }}>
+        <span style={{ verticalAlign: 'middle', marginRight: '8px' }}>{toggleText[selected]}</span>
+        {dateText[selected]}
+      </MenuToggle>
+    </div>
   );
   const menu = (
     // eslint-disable-next-line no-console
@@ -111,14 +113,12 @@ export const ComposableSimpleDropdown: React.FunctionComponent = () => {
     </Menu>
   );
   return (
-    <div ref={containerRef}>
-      <Popper
-        trigger={toggle}
-        popper={menu}
-        appendTo={containerRef.current}
-        isVisible={isOpen}
-        popperMatchesTriggerWidth={false}
-      />
-    </div>
+    <Popper
+      trigger={toggle}
+      popper={menu}
+      appendTo={containerRef.current}
+      isVisible={isOpen}
+      popperMatchesTriggerWidth={false}
+    />
   );
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableDrilldownMenu.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableDrilldownMenu.tsx
@@ -93,9 +93,11 @@ export const ComposableDrilldownMenu: React.FunctionComponent = () => {
   };
 
   const toggle = (
-    <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
-      {isOpen ? 'Expanded' : 'Collapsed'}
-    </MenuToggle>
+    <div ref={containerRef}>
+      <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
+        {isOpen ? 'Expanded' : 'Collapsed'}
+      </MenuToggle>
+    </div>
   );
   const menu = (
     <Menu
@@ -249,14 +251,12 @@ export const ComposableDrilldownMenu: React.FunctionComponent = () => {
     </Menu>
   );
   return (
-    <div ref={containerRef}>
-      <Popper
-        trigger={toggle}
-        popper={menu}
-        appendTo={containerRef.current || undefined}
-        isVisible={isOpen}
-        popperMatchesTriggerWidth={false}
-      />
-    </div>
+    <Popper
+      trigger={toggle}
+      popper={menu}
+      appendTo={containerRef.current || undefined}
+      isVisible={isOpen}
+      popperMatchesTriggerWidth={false}
+    />
   );
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableDrilldownMenu.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableDrilldownMenu.tsx
@@ -26,7 +26,6 @@ export const ComposableDrilldownMenu: React.FunctionComponent = () => {
   const [menuHeights, setMenuHeights] = React.useState<MenuHeightsType>({});
   const toggleRef = React.useRef<HTMLButtonElement>(null);
   const menuRef = React.useRef<HTMLDivElement>(null);
-  const containerRef = React.useRef<HTMLDivElement>(null);
 
   const handleMenuKeys = (event: KeyboardEvent) => {
     if (isOpen && menuRef.current?.contains(event.target as Node)) {
@@ -93,11 +92,9 @@ export const ComposableDrilldownMenu: React.FunctionComponent = () => {
   };
 
   const toggle = (
-    <div ref={containerRef}>
-      <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
-        {isOpen ? 'Expanded' : 'Collapsed'}
-      </MenuToggle>
-    </div>
+    <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
+      {isOpen ? 'Expanded' : 'Collapsed'}
+    </MenuToggle>
   );
   const menu = (
     <Menu
@@ -250,13 +247,5 @@ export const ComposableDrilldownMenu: React.FunctionComponent = () => {
       </MenuContent>
     </Menu>
   );
-  return (
-    <Popper
-      trigger={toggle}
-      popper={menu}
-      appendTo={containerRef.current || undefined}
-      isVisible={isOpen}
-      popperMatchesTriggerWidth={false}
-    />
-  );
+  return <Popper trigger={toggle} popper={menu} isVisible={isOpen} popperMatchesTriggerWidth={false} />;
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableDropdwnVariants.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableDropdwnVariants.tsx
@@ -23,7 +23,6 @@ export const ComposableDropdwnVariants: React.FunctionComponent = () => {
   const [toggleSelected, setToggleSelected] = React.useState<string>('basic');
   const menuRef = React.useRef<HTMLDivElement>();
   const toggleRef = React.useRef<HTMLButtonElement>();
-  const containerRef = React.useRef<HTMLDivElement>();
 
   const handleToggleSwitch = (selected: boolean, e: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent) => {
     setToggleSelected(e.currentTarget.id);
@@ -33,7 +32,7 @@ export const ComposableDropdwnVariants: React.FunctionComponent = () => {
     if (isOpen && menuRef && menuRef.current && menuRef.current.contains(event.target as Node)) {
       if (event.key === 'Escape' || event.key === 'Tab') {
         setIsOpen(!isOpen);
-        toggleRef.current.focus();
+        toggleRef?.current?.focus();
       }
     }
   };
@@ -228,9 +227,8 @@ export const ComposableDropdwnVariants: React.FunctionComponent = () => {
       </ToggleGroup>
       <br />
       <Popper
-        trigger={<div ref={containerRef}>{buildToggle()}</div>}
+        trigger={buildToggle()}
         popper={menu}
-        appendTo={containerRef.current}
         isVisible={isOpen}
         popperMatchesTriggerWidth={['image', 'checkbox'].includes(toggleSelected)}
       />

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableDropdwnVariants.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableDropdwnVariants.tsx
@@ -227,15 +227,13 @@ export const ComposableDropdwnVariants: React.FunctionComponent = () => {
         />
       </ToggleGroup>
       <br />
-      <div ref={containerRef}>
-        <Popper
-          trigger={buildToggle()}
-          popper={menu}
-          appendTo={containerRef.current}
-          isVisible={isOpen}
-          popperMatchesTriggerWidth={['image', 'checkbox'].includes(toggleSelected)}
-        />
-      </div>
+      <Popper
+        trigger={<div ref={containerRef}>{buildToggle()}</div>}
+        popper={menu}
+        appendTo={containerRef.current}
+        isVisible={isOpen}
+        popperMatchesTriggerWidth={['image', 'checkbox'].includes(toggleSelected)}
+      />
     </React.Fragment>
   );
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableFlyout.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableFlyout.tsx
@@ -34,7 +34,6 @@ export const ComposableFlyout: React.FunctionComponent = () => {
   const [isOpen, setIsOpen] = React.useState<boolean>(false);
   const menuRef = React.useRef<HTMLDivElement>(null);
   const toggleRef = React.useRef<HTMLButtonElement>(null);
-  const containerRef = React.useRef<HTMLDivElement>(null);
 
   const handleMenuKeys = (event: KeyboardEvent) => {
     if (!isOpen) {
@@ -80,11 +79,9 @@ export const ComposableFlyout: React.FunctionComponent = () => {
   };
 
   const toggle = (
-    <div ref={containerRef}>
-      <MenuToggle onClick={onToggleClick} isExpanded={isOpen}>
-        {isOpen ? 'Expanded' : 'Collapsed'}
-      </MenuToggle>
-    </div>
+    <MenuToggle onClick={onToggleClick} isExpanded={isOpen}>
+      {isOpen ? 'Expanded' : 'Collapsed'}
+    </MenuToggle>
   );
 
   const menu = (
@@ -103,13 +100,5 @@ export const ComposableFlyout: React.FunctionComponent = () => {
     </Menu>
   );
 
-  return (
-    <Popper
-      trigger={toggle}
-      popper={menu}
-      appendTo={containerRef.current || undefined}
-      isVisible={isOpen}
-      popperMatchesTriggerWidth={false}
-    />
-  );
+  return <Popper trigger={toggle} popper={menu} isVisible={isOpen} popperMatchesTriggerWidth={false} />;
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableFlyout.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableFlyout.tsx
@@ -80,9 +80,11 @@ export const ComposableFlyout: React.FunctionComponent = () => {
   };
 
   const toggle = (
-    <MenuToggle onClick={onToggleClick} isExpanded={isOpen}>
-      {isOpen ? 'Expanded' : 'Collapsed'}
-    </MenuToggle>
+    <div ref={containerRef}>
+      <MenuToggle onClick={onToggleClick} isExpanded={isOpen}>
+        {isOpen ? 'Expanded' : 'Collapsed'}
+      </MenuToggle>
+    </div>
   );
 
   const menu = (
@@ -102,14 +104,12 @@ export const ComposableFlyout: React.FunctionComponent = () => {
   );
 
   return (
-    <div ref={containerRef}>
-      <Popper
-        trigger={toggle}
-        popper={menu}
-        appendTo={containerRef.current || undefined}
-        isVisible={isOpen}
-        popperMatchesTriggerWidth={false}
-      />
-    </div>
+    <Popper
+      trigger={toggle}
+      popper={menu}
+      appendTo={containerRef.current || undefined}
+      isVisible={isOpen}
+      popperMatchesTriggerWidth={false}
+    />
   );
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableMultipleTypeaheadSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableMultipleTypeaheadSelect.tsx
@@ -30,7 +30,6 @@ export const ComposableMultipleTypeaheadSelect: React.FunctionComponent = () => 
   const [focusedItemIndex, setFocusedItemIndex] = React.useState<number | null>(null);
   const [activeItem, setActiveItem] = React.useState<string | null>(null);
   const [selected, setSelected] = React.useState<string[]>([]);
-  const containerRef = React.useRef<HTMLDivElement>();
   const menuToggleRef = React.useRef<MenuToggleElement>({} as MenuToggleElement);
   const textInputRef = React.useRef<HTMLInputElement>();
   const menuRef = React.useRef<HTMLDivElement>();
@@ -241,15 +240,12 @@ export const ComposableMultipleTypeaheadSelect: React.FunctionComponent = () => 
     </Menu>
   );
   return (
-    <div ref={containerRef as React.Ref<HTMLDivElement>}>
-      <Popper
-        trigger={toggle}
-        popper={menu}
-        appendTo={containerRef.current}
-        isVisible={isMenuOpen}
-        onDocumentClick={onDocumentClick}
-        onDocumentKeyDown={onDocumentKeydown}
-      />
-    </div>
+    <Popper
+      trigger={toggle}
+      popper={menu}
+      isVisible={isMenuOpen}
+      onDocumentClick={onDocumentClick}
+      onDocumentKeyDown={onDocumentKeydown}
+    />
   );
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableOptionsMenuVariants.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableOptionsMenuVariants.tsx
@@ -47,9 +47,11 @@ export const ComposableOptionsMenuVariants: React.FunctionComponent = () => {
   };
 
   const toggle = (
-    <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
-      Options menu
-    </MenuToggle>
+    <div ref={containerRef}>
+      <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
+        Options menu
+      </MenuToggle>
+    </div>
   );
 
   const menu = (
@@ -93,9 +95,5 @@ export const ComposableOptionsMenuVariants: React.FunctionComponent = () => {
       </MenuContent>
     </Menu>
   );
-  return (
-    <div ref={containerRef}>
-      <Popper trigger={toggle} popper={menu} appendTo={containerRef.current} isVisible={isOpen} />
-    </div>
-  );
+  return <Popper trigger={toggle} popper={menu} appendTo={containerRef.current} isVisible={isOpen} />;
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableOptionsMenuVariants.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableOptionsMenuVariants.tsx
@@ -6,19 +6,18 @@ export const ComposableOptionsMenuVariants: React.FunctionComponent = () => {
   const [selected, setSelected] = React.useState<string>('');
   const menuRef = React.useRef<HTMLDivElement>();
   const toggleRef = React.useRef<HTMLButtonElement>();
-  const containerRef = React.useRef<HTMLDivElement>();
 
   const handleMenuKeys = (event: KeyboardEvent) => {
-    if (isOpen && menuRef.current.contains(event.target as Node)) {
+    if (isOpen && menuRef?.current?.contains(event.target as Node)) {
       if (event.key === 'Escape' || event.key === 'Tab') {
         setIsOpen(!isOpen);
-        toggleRef.current.focus();
+        toggleRef?.current?.focus();
       }
     }
   };
 
   const handleClickOutside = (event: MouseEvent) => {
-    if (isOpen && !menuRef.current.contains(event.target as Node)) {
+    if (isOpen && !menuRef?.current?.contains(event.target as Node)) {
       setIsOpen(false);
     }
   };
@@ -47,11 +46,9 @@ export const ComposableOptionsMenuVariants: React.FunctionComponent = () => {
   };
 
   const toggle = (
-    <div ref={containerRef}>
-      <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
-        Options menu
-      </MenuToggle>
-    </div>
+    <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
+      Options menu
+    </MenuToggle>
   );
 
   const menu = (
@@ -95,5 +92,5 @@ export const ComposableOptionsMenuVariants: React.FunctionComponent = () => {
       </MenuContent>
     </Menu>
   );
-  return <Popper trigger={toggle} popper={menu} appendTo={containerRef.current} isVisible={isOpen} />;
+  return <Popper trigger={toggle} popper={menu} isVisible={isOpen} />;
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleCheckboxSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleCheckboxSelect.tsx
@@ -6,6 +6,7 @@ export const ComposableSimpleCheckboxSelect: React.FunctionComponent = () => {
   const [selectedItems, setSelectedItems] = React.useState<number[]>([]);
   const toggleRef = React.useRef<HTMLButtonElement>(null);
   const menuRef = React.useRef<HTMLDivElement>(null);
+  const containerRef = React.useRef<HTMLDivElement>(null);
 
   const handleMenuKeys = React.useCallback(
     event => {
@@ -63,19 +64,21 @@ export const ComposableSimpleCheckboxSelect: React.FunctionComponent = () => {
   };
 
   const toggle = (
-    <MenuToggle
-      ref={toggleRef}
-      {...(selectedItems.length > 0 && { badge: <Badge isRead>{selectedItems.length}</Badge> })}
-      onClick={onToggleClick}
-      isExpanded={isOpen}
-      style={
-        {
-          width: '220px'
-        } as React.CSSProperties
-      }
-    >
-      Filter by status
-    </MenuToggle>
+    <div ref={containerRef}>
+      <MenuToggle
+        ref={toggleRef}
+        {...(selectedItems.length > 0 && { badge: <Badge isRead>{selectedItems.length}</Badge> })}
+        onClick={onToggleClick}
+        isExpanded={isOpen}
+        style={
+          {
+            width: '220px'
+          } as React.CSSProperties
+        }
+      >
+        Filter by status
+      </MenuToggle>
+    </div>
   );
   const menu = (
     <Menu ref={menuRef} id="select-menu" onSelect={onSelect} selected={selectedItems}>
@@ -97,5 +100,5 @@ export const ComposableSimpleCheckboxSelect: React.FunctionComponent = () => {
       </MenuContent>
     </Menu>
   );
-  return <Popper appendTo={toggleRef.current || undefined} trigger={toggle} popper={menu} isVisible={isOpen} />;
+  return <Popper appendTo={containerRef.current || undefined} trigger={toggle} popper={menu} isVisible={isOpen} />;
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleCheckboxSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleCheckboxSelect.tsx
@@ -6,7 +6,6 @@ export const ComposableSimpleCheckboxSelect: React.FunctionComponent = () => {
   const [selectedItems, setSelectedItems] = React.useState<number[]>([]);
   const toggleRef = React.useRef<HTMLButtonElement>(null);
   const menuRef = React.useRef<HTMLDivElement>(null);
-  const containerRef = React.useRef<HTMLDivElement>(null);
 
   const handleMenuKeys = React.useCallback(
     event => {
@@ -64,21 +63,19 @@ export const ComposableSimpleCheckboxSelect: React.FunctionComponent = () => {
   };
 
   const toggle = (
-    <div ref={containerRef}>
-      <MenuToggle
-        ref={toggleRef}
-        {...(selectedItems.length > 0 && { badge: <Badge isRead>{selectedItems.length}</Badge> })}
-        onClick={onToggleClick}
-        isExpanded={isOpen}
-        style={
-          {
-            width: '220px'
-          } as React.CSSProperties
-        }
-      >
-        Filter by status
-      </MenuToggle>
-    </div>
+    <MenuToggle
+      ref={toggleRef}
+      {...(selectedItems.length > 0 && { badge: <Badge isRead>{selectedItems.length}</Badge> })}
+      onClick={onToggleClick}
+      isExpanded={isOpen}
+      style={
+        {
+          width: '220px'
+        } as React.CSSProperties
+      }
+    >
+      Filter by status
+    </MenuToggle>
   );
   const menu = (
     <Menu ref={menuRef} id="select-menu" onSelect={onSelect} selected={selectedItems}>
@@ -100,5 +97,5 @@ export const ComposableSimpleCheckboxSelect: React.FunctionComponent = () => {
       </MenuContent>
     </Menu>
   );
-  return <Popper appendTo={containerRef.current || undefined} trigger={toggle} popper={menu} isVisible={isOpen} />;
+  return <Popper trigger={toggle} popper={menu} isVisible={isOpen} />;
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleDropdown.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleDropdown.tsx
@@ -46,9 +46,11 @@ export const ComposableSimpleDropdown: React.FunctionComponent = () => {
   };
 
   const toggle = (
-    <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
-      {isOpen ? 'Expanded' : 'Collapsed'}
-    </MenuToggle>
+    <div ref={containerRef}>
+      <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
+        {isOpen ? 'Expanded' : 'Collapsed'}
+      </MenuToggle>
+    </div>
   );
   const menu = (
     // eslint-disable-next-line no-console
@@ -67,9 +69,5 @@ export const ComposableSimpleDropdown: React.FunctionComponent = () => {
       </MenuContent>
     </Menu>
   );
-  return (
-    <div ref={containerRef}>
-      <Popper trigger={toggle} popper={menu} appendTo={containerRef.current || undefined} isVisible={isOpen} />
-    </div>
-  );
+  return <Popper trigger={toggle} popper={menu} appendTo={containerRef.current || undefined} isVisible={isOpen} />;
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleDropdown.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleDropdown.tsx
@@ -5,7 +5,6 @@ export const ComposableSimpleDropdown: React.FunctionComponent = () => {
   const [isOpen, setIsOpen] = React.useState(false);
   const toggleRef = React.useRef<HTMLButtonElement>(null);
   const menuRef = React.useRef<HTMLDivElement>(null);
-  const containerRef = React.useRef<HTMLDivElement>(null);
 
   const handleMenuKeys = (event: KeyboardEvent) => {
     if (!isOpen) {
@@ -46,11 +45,9 @@ export const ComposableSimpleDropdown: React.FunctionComponent = () => {
   };
 
   const toggle = (
-    <div ref={containerRef}>
-      <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
-        {isOpen ? 'Expanded' : 'Collapsed'}
-      </MenuToggle>
-    </div>
+    <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
+      {isOpen ? 'Expanded' : 'Collapsed'}
+    </MenuToggle>
   );
   const menu = (
     // eslint-disable-next-line no-console
@@ -69,5 +66,5 @@ export const ComposableSimpleDropdown: React.FunctionComponent = () => {
       </MenuContent>
     </Menu>
   );
-  return <Popper trigger={toggle} popper={menu} appendTo={containerRef.current || undefined} isVisible={isOpen} />;
+  return <Popper trigger={toggle} popper={menu} isVisible={isOpen} />;
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleSelect.tsx
@@ -7,7 +7,6 @@ export const ComposableSimpleSelect: React.FunctionComponent = () => {
   const [selected, setSelected] = React.useState<string>('Select a value');
   const toggleRef = React.useRef<HTMLButtonElement>(null);
   const menuRef = React.useRef<HTMLDivElement>(null);
-  const containerRef = React.useRef<HTMLDivElement>(null);
 
   const handleMenuKeys = (event: KeyboardEvent) => {
     if (isOpen && menuRef.current?.contains(event.target as Node)) {
@@ -45,20 +44,18 @@ export const ComposableSimpleSelect: React.FunctionComponent = () => {
   };
 
   const toggle = (
-    <div ref={containerRef}>
-      <MenuToggle
-        ref={toggleRef}
-        onClick={onToggleClick}
-        isExpanded={isOpen}
-        style={
-          {
-            width: '200px'
-          } as React.CSSProperties
-        }
-      >
-        {selected}
-      </MenuToggle>
-    </div>
+    <MenuToggle
+      ref={toggleRef}
+      onClick={onToggleClick}
+      isExpanded={isOpen}
+      style={
+        {
+          width: '200px'
+        } as React.CSSProperties
+      }
+    >
+      {selected}
+    </MenuToggle>
   );
 
   function onSelect(event: React.MouseEvent | undefined, itemId: string | number | undefined) {
@@ -82,5 +79,5 @@ export const ComposableSimpleSelect: React.FunctionComponent = () => {
       </MenuContent>
     </Menu>
   );
-  return <Popper trigger={toggle} popper={menu} appendTo={containerRef.current || undefined} isVisible={isOpen} />;
+  return <Popper trigger={toggle} popper={menu} isVisible={isOpen} />;
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableSimpleSelect.tsx
@@ -45,18 +45,20 @@ export const ComposableSimpleSelect: React.FunctionComponent = () => {
   };
 
   const toggle = (
-    <MenuToggle
-      ref={toggleRef}
-      onClick={onToggleClick}
-      isExpanded={isOpen}
-      style={
-        {
-          width: '200px'
-        } as React.CSSProperties
-      }
-    >
-      {selected}
-    </MenuToggle>
+    <div ref={containerRef}>
+      <MenuToggle
+        ref={toggleRef}
+        onClick={onToggleClick}
+        isExpanded={isOpen}
+        style={
+          {
+            width: '200px'
+          } as React.CSSProperties
+        }
+      >
+        {selected}
+      </MenuToggle>
+    </div>
   );
 
   function onSelect(event: React.MouseEvent | undefined, itemId: string | number | undefined) {
@@ -80,9 +82,5 @@ export const ComposableSimpleSelect: React.FunctionComponent = () => {
       </MenuContent>
     </Menu>
   );
-  return (
-    <div ref={containerRef}>
-      <Popper trigger={toggle} popper={menu} appendTo={containerRef.current || undefined} isVisible={isOpen} />
-    </div>
-  );
+  return <Popper trigger={toggle} popper={menu} appendTo={containerRef.current || undefined} isVisible={isOpen} />;
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableTreeViewMenu.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableTreeViewMenu.tsx
@@ -14,7 +14,6 @@ export const ComposableTreeViewMenu: React.FunctionComponent = () => {
   const [isOpen, setIsOpen] = React.useState<boolean>(false);
   const [checkedItems, setCheckedItems] = React.useState<TreeViewDataItem[]>([]);
   const toggleRef = React.useRef<HTMLButtonElement>(null);
-  const containerRef = React.useRef<HTMLDivElement>(null);
   const menuRef = React.useRef<HTMLDivElement>();
 
   const statusOptions: TreeViewDataItem[] = [
@@ -218,11 +217,9 @@ export const ComposableTreeViewMenu: React.FunctionComponent = () => {
   };
 
   const toggle = (
-    <div ref={containerRef}>
-      <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
-        {isOpen ? 'Expanded' : 'Collapsed'}
-      </MenuToggle>
-    </div>
+    <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
+      {isOpen ? 'Expanded' : 'Collapsed'}
+    </MenuToggle>
   );
   const statusMapped = statusOptions.map(mapTree);
   const roleMapped = roleOptions.map(mapTree);
@@ -268,13 +265,5 @@ export const ComposableTreeViewMenu: React.FunctionComponent = () => {
       </PanelMain>
     </Panel>
   );
-  return (
-    <Popper
-      trigger={toggle}
-      popper={menu}
-      isVisible={isOpen}
-      appendTo={containerRef.current || undefined}
-      popperMatchesTriggerWidth={false}
-    />
-  );
+  return <Popper trigger={toggle} popper={menu} isVisible={isOpen} popperMatchesTriggerWidth={false} />;
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableTreeViewMenu.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableTreeViewMenu.tsx
@@ -218,9 +218,11 @@ export const ComposableTreeViewMenu: React.FunctionComponent = () => {
   };
 
   const toggle = (
-    <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
-      {isOpen ? 'Expanded' : 'Collapsed'}
-    </MenuToggle>
+    <div ref={containerRef}>
+      <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
+        {isOpen ? 'Expanded' : 'Collapsed'}
+      </MenuToggle>
+    </div>
   );
   const statusMapped = statusOptions.map(mapTree);
   const roleMapped = roleOptions.map(mapTree);
@@ -267,14 +269,12 @@ export const ComposableTreeViewMenu: React.FunctionComponent = () => {
     </Panel>
   );
   return (
-    <div ref={containerRef}>
-      <Popper
-        trigger={toggle}
-        popper={menu}
-        isVisible={isOpen}
-        appendTo={containerRef.current || undefined}
-        popperMatchesTriggerWidth={false}
-      />
-    </div>
+    <Popper
+      trigger={toggle}
+      popper={menu}
+      isVisible={isOpen}
+      appendTo={containerRef.current || undefined}
+      popperMatchesTriggerWidth={false}
+    />
   );
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableTypeaheadSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableTypeaheadSelect.tsx
@@ -175,8 +175,6 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
     <Popper
       trigger={
         <MenuToggle
-          // Needed to append the menu closer to the toggle in DOM
-          id="temp-toggle-id"
           variant="typeahead"
           onClick={toggleMenuOpen}
           innerRef={menuToggleRef}
@@ -229,7 +227,6 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
       isVisible={isMenuOpen}
       onDocumentClick={onDocumentClick}
       onDocumentKeyDown={onDocumentKeydown}
-      appendTo={() => document.getElementById('temp-toggle-id')}
     />
   );
 };


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8600 

[Composable menu demos](https://patternfly-react-pr-8623.surge.sh/demos/composable-menu)

Moved the `<div ref={containerRef}>` wrapper to the toggle, which is similar to the proposed solution for the "Editable labels with add dropdown" demo in the epic.

Alternatively since all of these demos are setup the same way, we *could* append to `toggleRef.current.parent`, which should always be the wrapper div provided by Popper with `style="display: contents"`:

![Menu composable dropdown markup](https://user-images.githubusercontent.com/70952936/215539147-7699460f-f0e4-4032-967f-44509e722999.png)


<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
