### PR TITLE
feat(Table): update ActionsColumn to use Dropdown next

### DIFF
--- a/packages/react-core/src/next/components/Dropdown/Dropdown.tsx
+++ b/packages/react-core/src/next/components/Dropdown/Dropdown.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from '@patternfly/react-styles';
 import { Menu, MenuContent, MenuProps } from '../../../components/Menu';
-import { Popper } from '../../../helpers/Popper/Popper';
+import { Popper, PopperProps } from '../../../helpers/Popper/Popper';
 import { useOUIAProps, OUIAProps } from '../../../helpers';
 
 export interface DropdownProps extends MenuProps, OUIAProps {
@@ -32,6 +32,8 @@ export interface DropdownProps extends MenuProps, OUIAProps {
   ouiaSafe?: boolean;
   /** z-index of the dropdown menu */
   zIndex?: number;
+  /** Additional properties to pass to the Popper */
+  popperProps?: PopperProps;
 }
 
 const DropdownBase: React.FunctionComponent<DropdownProps> = ({
@@ -48,6 +50,7 @@ const DropdownBase: React.FunctionComponent<DropdownProps> = ({
   ouiaId,
   ouiaSafe = true,
   zIndex = 9999,
+  popperProps,
   ...props
 }: DropdownProps) => {
   const localMenuRef = React.useRef<HTMLDivElement>();
@@ -122,6 +125,7 @@ const DropdownBase: React.FunctionComponent<DropdownProps> = ({
         appendTo={containerRef.current || undefined}
         isVisible={isOpen}
         zIndex={zIndex}
+        {...popperProps}
       />
     </div>
   );

--- a/packages/react-table/src/components/Table/ActionsColumn.tsx
+++ b/packages/react-table/src/components/Table/ActionsColumn.tsx
@@ -1,71 +1,59 @@
 import * as React from 'react';
-import { Dropdown } from '@patternfly/react-core/dist/esm/components/Dropdown';
-import { KebabToggle } from '@patternfly/react-core/dist/esm/components/Dropdown/KebabToggle';
-import { DropdownItem } from '@patternfly/react-core/dist/esm/components/Dropdown/DropdownItem';
-import { DropdownSeparator } from '@patternfly/react-core/dist/esm/components/Dropdown/DropdownSeparator';
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
-
-import {
-  DropdownDirection,
-  DropdownPosition
-} from '@patternfly/react-core/dist/esm/components/Dropdown/dropdownConstants';
-
+import { Dropdown, DropdownItem, DropdownList } from '@patternfly/react-core/next';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import { Divider } from '@patternfly/react-core/dist/esm/components/Divider';
+import { MenuToggle } from '@patternfly/react-core/dist/esm/components/MenuToggle';
 import { IAction, IExtraData, IRowData } from './TableTypes';
+import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
 
 export interface CustomActionsToggleProps {
-  onToggle: (isOpen: boolean) => void;
+  onToggle: (evt: React.MouseEvent) => void;
   isOpen: boolean;
   isDisabled: boolean;
+  toggleRef: React.Ref<any>;
 }
-
-export interface ActionsColumnProps {
-  children?: React.ReactNode;
+export interface ActionsColumnProps extends Omit<React.HTMLProps<HTMLElement>, 'label'> {
+  /** Actions to be rendered within or without the action dropdown */
   items: IAction[];
+  /** Indicates whether the actions dropdown is disabled */
   isDisabled?: boolean;
-  menuAppendTo?: HTMLElement | (() => HTMLElement) | 'inline' | 'parent';
-  dropdownPosition?: DropdownPosition;
-  dropdownDirection?: DropdownDirection;
+  /** Data of the row the action dropdown is located */
   rowData?: IRowData;
+  /** Extra data of a row */
   extraData?: IExtraData;
+  /** Custom actions toggle for the actions dropdown */
   actionsToggle?: (props: CustomActionsToggleProps) => React.ReactNode;
+  /** Additional properties for the actions dropdown popper */
+  popperProps?: any;
+  /** @hide Forwarded ref */
+  innerRef?: React.Ref<any>;
 }
 
-export interface ActionsColumnState {
-  isOpen: boolean;
-}
+const ActionsColumnBase: React.FunctionComponent<ActionsColumnProps> = ({
+  items,
+  isDisabled,
+  rowData,
+  extraData,
+  actionsToggle,
+  popperProps = {
+    position: 'right',
+    direction: 'down',
+    popperMatchesTriggerWidth: false
+  },
+  ...props
+}: ActionsColumnProps) => {
+  const [isOpen, setIsOpen] = React.useState(false);
 
-export class ActionsColumn extends React.Component<ActionsColumnProps, ActionsColumnState> {
-  static displayName = 'ActionsColumn';
-  private toggleRef = React.createRef<HTMLButtonElement>();
-  static defaultProps = {
-    children: null as React.ReactNode,
-    items: [] as IAction[],
-    dropdownPosition: DropdownPosition.right,
-    dropdownDirection: DropdownDirection.down,
-    menuAppendTo: 'inline',
-    rowData: {} as IRowData,
-    extraData: {} as IExtraData
-  };
-  constructor(props: ActionsColumnProps) {
-    super(props);
-    this.state = {
-      isOpen: false
-    };
-  }
-
-  onToggle = (isOpen: boolean): void => {
-    this.setState({
-      isOpen
-    });
+  const onToggle = () => {
+    setIsOpen(!isOpen);
   };
 
-  onClick = (
+  const onActionClick = (
     event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent,
     onClick:
       | ((event: React.MouseEvent, rowIndex: number | undefined, rowData: IRowData, extraData: IExtraData) => void)
       | undefined
   ): void => {
-    const { rowData, extraData } = this.props;
     // Only prevent default if onClick is provided.  This allows href support.
     if (onClick) {
       event.preventDefault();
@@ -74,62 +62,54 @@ export class ActionsColumn extends React.Component<ActionsColumnProps, ActionsCo
     }
   };
 
-  render() {
-    const { isOpen } = this.state;
-    const {
-      items,
-      children,
-      dropdownPosition,
-      dropdownDirection,
-      menuAppendTo,
-      isDisabled,
-      rowData,
-      actionsToggle
-    } = this.props;
+  return (
+    <React.Fragment>
+      {items
+        .filter(item => item.isOutsideDropdown)
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        .map(({ title, itemKey, onClick, isOutsideDropdown, ...props }, key) =>
+          typeof title === 'string' ? (
+            <Button
+              onClick={event => onActionClick(event, onClick)}
+              {...(props as any)}
+              isDisabled={isDisabled}
+              key={itemKey || `outside_dropdown_${key}`}
+              data-key={itemKey || `outside_dropdown_${key}`}
+            >
+              {title}
+            </Button>
+          ) : (
+            React.cloneElement(title as React.ReactElement, { onClick, isDisabled, ...props })
+          )
+        )}
 
-    const actionsToggleClone = actionsToggle ? (
-      actionsToggle({ onToggle: this.onToggle, isOpen, isDisabled })
-    ) : (
-      <KebabToggle isDisabled={isDisabled} onToggle={this.onToggle} />
-    );
-
-    return (
-      <React.Fragment>
-        {items
-          .filter(item => item.isOutsideDropdown)
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          .map(({ title, itemKey, onClick, isOutsideDropdown, ...props }, key) =>
-            typeof title === 'string' ? (
-              <Button
-                onClick={event => this.onClick(event, onClick)}
-                {...(props as any)}
-                isDisabled={isDisabled}
-                key={itemKey || `outside_dropdown_${key}`}
-                data-key={itemKey || `outside_dropdown_${key}`}
-              >
-                {title}
-              </Button>
-            ) : (
-              React.cloneElement(title as React.ReactElement, { onClick, isDisabled, ...props })
-            )
-          )}
-        <Dropdown
-          toggle={actionsToggleClone}
-          position={dropdownPosition}
-          direction={dropdownDirection}
-          menuAppendTo={menuAppendTo}
-          isOpen={isOpen}
-          dropdownItems={items
+      <Dropdown
+        isOpen={isOpen}
+        onOpenChange={isOpen => setIsOpen(isOpen)}
+        toggle={toggleRef =>
+          actionsToggle ? (
+            actionsToggle({ onToggle, isOpen, isDisabled, toggleRef })
+          ) : (
+            <MenuToggle ref={toggleRef} onClick={onToggle} isExpanded={isOpen} isDisabled={isDisabled} variant="plain">
+              <EllipsisVIcon />
+            </MenuToggle>
+          )
+        }
+        {...(rowData && rowData.actionProps)}
+        {...props}
+        popperProps={popperProps}
+      >
+        <DropdownList>
+          {items
             .filter(item => !item.isOutsideDropdown)
             .map(({ title, itemKey, onClick, isSeparator, ...props }, key) =>
               isSeparator ? (
-                <DropdownSeparator {...props} key={itemKey || key} data-key={itemKey || key} />
+                <Divider key={itemKey || key} data-key={itemKey || key} />
               ) : (
                 <DropdownItem
-                  component="button"
                   onClick={event => {
-                    this.onClick(event, onClick);
-                    this.onToggle(!isOpen);
+                    onActionClick(event, onClick);
+                    onToggle();
                   }}
                   {...props}
                   key={itemKey || key}
@@ -139,11 +119,13 @@ export class ActionsColumn extends React.Component<ActionsColumnProps, ActionsCo
                 </DropdownItem>
               )
             )}
-          isPlain
-          {...(rowData && rowData.actionProps)}
-        />
-        {children}
-      </React.Fragment>
-    );
-  }
-}
+        </DropdownList>
+      </Dropdown>
+    </React.Fragment>
+  );
+};
+
+export const ActionsColumn = React.forwardRef((props: ActionsColumnProps, ref: React.Ref<HTMLElement>) => (
+  <ActionsColumnBase {...props} innerRef={ref} />
+));
+ActionsColumn.displayName = 'ActionsColumn';

--- a/packages/react-table/src/components/Table/TableTypes.tsx
+++ b/packages/react-table/src/components/Table/TableTypes.tsx
@@ -1,4 +1,4 @@
-import { DropdownItemProps } from '@patternfly/react-core/dist/esm/components/Dropdown/DropdownItem';
+import { DropdownItemProps } from '@patternfly/react-core/next';
 import { formatterValueType, ColumnType, RowType, RowKeyType, HeaderType } from './base';
 import { SortByDirection } from './SortColumn';
 import {
@@ -108,6 +108,7 @@ export interface IColumn {
     dropdownDirection?: DropdownDirection;
     menuAppendTo?: HTMLElement | (() => HTMLElement) | 'inline' | 'parent';
     actionsToggle?: (props: CustomActionsToggleProps) => React.ReactNode;
+    actionsPopperProps?: any;
     allRowsSelected?: boolean;
     allRowsExpanded?: boolean;
     isHeaderSelectDisabled?: boolean;

--- a/packages/react-table/src/components/Table/examples/LegacyTableActions.tsx
+++ b/packages/react-table/src/components/Table/examples/LegacyTableActions.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {
   Button,
   Checkbox,
-  DropdownToggle,
+  MenuToggle,
   ToggleGroup,
   ToggleGroupItem,
   ToggleGroupItemProps,
@@ -62,9 +62,9 @@ export const LegacyTableActions: React.FunctionComponent = () => {
   const [useCustomToggle, setUseCustomToggle] = React.useState(false);
 
   const customActionsToggle = (props: CustomActionsToggleProps) => (
-    <DropdownToggle onToggle={props.onToggle} isDisabled={props.isDisabled}>
+    <MenuToggle ref={props.toggleRef} onClick={props.onToggle} isDisabled={props.isDisabled}>
       Actions
-    </DropdownToggle>
+    </MenuToggle>
   );
 
   const columns: TableProps['cells'] = [
@@ -77,7 +77,7 @@ export const LegacyTableActions: React.FunctionComponent = () => {
   ];
 
   const rows: TableProps['rows'] = repositories.map(repo => {
-    let singleActionButton = null;
+    let singleActionButton: React.ReactNode = null;
     if (repo.singleAction !== '') {
       singleActionButton = (
         <TableText>

--- a/packages/react-table/src/components/Table/utils/decorators/cellActions.tsx
+++ b/packages/react-table/src/components/Table/utils/decorators/cellActions.tsx
@@ -33,7 +33,7 @@ export const cellActions = (
     rowIndex,
     columnIndex,
     column: {
-      extraParams: { dropdownPosition, dropdownDirection, actionsToggle, menuAppendTo }
+      extraParams: { actionsToggle, actionsPopperProps }
     },
     property
   }: IExtra
@@ -58,13 +58,11 @@ export const cellActions = (
           children: (
             <ActionsColumn
               items={resolvedActions}
-              dropdownPosition={dropdownPosition}
-              dropdownDirection={dropdownDirection}
-              menuAppendTo={menuAppendTo}
               isDisabled={resolvedIsDisabled}
               rowData={rowData}
               extraData={extraData}
               actionsToggle={actionsToggle}
+              popperProps={actionsPopperProps}
             >
               {label as React.ReactNode}
             </ActionsColumn>

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTableActions.tsx
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTableActions.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import React from 'react';
-import { Button, DropdownToggle, ToggleGroup, ToggleGroupItem, ToggleGroupItemProps } from '@patternfly/react-core';
+import { Button, MenuToggle, ToggleGroup, ToggleGroupItem, ToggleGroupItemProps } from '@patternfly/react-core';
 import {
   TableComposable,
   TableText,
@@ -52,9 +52,9 @@ export const ComposableTableActions: React.FunctionComponent = () => {
   };
 
   const customActionsToggle = (props: CustomActionsToggleProps) => (
-    <DropdownToggle onToggle={props.onToggle} isDisabled={props.isDisabled}>
+    <MenuToggle ref={props.toggleRef} onClick={props.onToggle} isDisabled={props.isDisabled}>
       Actions
-    </DropdownToggle>
+    </MenuToggle>
   );
 
   const defaultActions = (repo: Repository): IAction[] => [
@@ -130,7 +130,7 @@ export const ComposableTableActions: React.FunctionComponent = () => {
             if (repo.name === '5') {
               rowActions = lastRowActions(repo);
             }
-            let singleActionButton = null;
+            let singleActionButton: React.ReactNode = null;
             if (repo.singleAction !== '') {
               singleActionButton = (
                 <TableText>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8390

- Updates `ActionsColumn` to use Dropdown-next components
- Adds `popperProps` to Dropdown-next to allow customization of Popper (including `direction`, `position`, `popperMatchesTriggerWidth` that is used by `ActionsColumn`). If this would be better as separately piped props let me know and I can update them. But for now this will allow the greatest flexibility.
- Updates examples to use `MenuToggle` for custom toggle
