### PR TITLE
feat(Table): update ActionsColumn to use Dropdown next

### DIFF
--- a/packages/react-core/src/components/Dropdown/DropdownToggleCheckbox.tsx
+++ b/packages/react-core/src/components/Dropdown/DropdownToggleCheckbox.tsx
@@ -91,7 +91,6 @@ export class DropdownToggleCheckbox extends React.Component<DropdownToggleCheckb
     const spinner = (
       <Spinner
         diameter="1em"
-        isSVG
         aria-valuetext={defaultProgressAriaValueText}
         aria-live="polite"
         aria-label={defaultProgressAriaLabel}

--- a/packages/react-core/src/next/components/Dropdown/Dropdown.tsx
+++ b/packages/react-core/src/next/components/Dropdown/Dropdown.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from '@patternfly/react-styles';
 import { Menu, MenuContent, MenuProps } from '../../../components/Menu';
-import { Popper } from '../../../helpers/Popper/Popper';
+import { Popper, PopperProps } from '../../../helpers/Popper/Popper';
 import { useOUIAProps, OUIAProps } from '../../../helpers';
 
 export interface DropdownProps extends MenuProps, OUIAProps {
@@ -32,6 +32,8 @@ export interface DropdownProps extends MenuProps, OUIAProps {
   ouiaSafe?: boolean;
   /** z-index of the dropdown menu */
   zIndex?: number;
+  /** Additional properties to pass to the Popper */
+  popperProps?: PopperProps;
 }
 
 const DropdownBase: React.FunctionComponent<DropdownProps> = ({
@@ -48,6 +50,7 @@ const DropdownBase: React.FunctionComponent<DropdownProps> = ({
   ouiaId,
   ouiaSafe = true,
   zIndex = 9999,
+  popperProps,
   ...props
 }: DropdownProps) => {
   const localMenuRef = React.useRef<HTMLDivElement>();
@@ -121,6 +124,7 @@ const DropdownBase: React.FunctionComponent<DropdownProps> = ({
         appendTo={containerRef.current || undefined}
         isVisible={isOpen}
         zIndex={zIndex}
+        {...popperProps}
       />
     </div>
   );

--- a/packages/react-core/src/next/components/Dropdown/Dropdown.tsx
+++ b/packages/react-core/src/next/components/Dropdown/Dropdown.tsx
@@ -103,7 +103,7 @@ const DropdownBase: React.FunctionComponent<DropdownProps> = ({
     <Menu
       className={css(className)}
       ref={menuRef}
-      onSelect={(event, itemId) => onSelect(event, itemId)}
+      onSelect={(event, itemId) => onSelect && onSelect(event, itemId)}
       isPlain={isPlain}
       isScrollable={isScrollable}
       {...(minWidth && {

--- a/packages/react-core/src/next/components/Select/Select.tsx
+++ b/packages/react-core/src/next/components/Select/Select.tsx
@@ -97,7 +97,7 @@ const SelectBase: React.FunctionComponent<SelectProps & OUIAProps> = ({
       role={role}
       className={css(className)}
       ref={menuRef}
-      onSelect={(event, itemId) => onSelect(event, itemId)}
+      onSelect={(event, itemId) => onSelect && onSelect(event, itemId)}
       isPlain={isPlain}
       selected={selected}
       {...(minWidth && {

--- a/packages/react-core/src/next/components/Wizard/WizardContext.tsx
+++ b/packages/react-core/src/next/components/Wizard/WizardContext.tsx
@@ -76,7 +76,7 @@ export const WizardContextProvider: React.FunctionComponent<WizardContextProvide
     [initialSteps, currentSteps]
   );
 
-  const activeStep =  React.useMemo(() => steps.find(step => step.index === activeStepIndex);
+  const activeStep = React.useMemo(() => steps.find(step => step.index === activeStepIndex), [activeStepIndex, steps]);
 
   const close = React.useCallback(() => onClose?.(null), [onClose]);
   const goToNextStep = React.useCallback(() => onNext(null, steps), [onNext, steps]);

--- a/packages/react-core/src/next/components/Wizard/WizardContext.tsx
+++ b/packages/react-core/src/next/components/Wizard/WizardContext.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { isCustomWizardFooter, isWizardSubStep, WizardStepType, WizardFooterType } from './types';
-import { getActiveStep } from './utils';
 import { WizardFooter, WizardFooterProps } from './WizardFooter';
 
 export interface WizardContextProps {
@@ -76,7 +75,8 @@ export const WizardContextProvider: React.FunctionComponent<WizardContextProvide
       })),
     [initialSteps, currentSteps]
   );
-  const activeStep = React.useMemo(() => getActiveStep(steps, activeStepIndex), [activeStepIndex, steps]);
+
+  const activeStep =  React.useMemo(() => steps.find(step => step.index === activeStepIndex);
 
   const close = React.useCallback(() => onClose?.(null), [onClose]);
   const goToNextStep = React.useCallback(() => onNext(null, steps), [onNext, steps]);

--- a/packages/react-core/src/next/components/Wizard/WizardToggle.tsx
+++ b/packages/react-core/src/next/components/Wizard/WizardToggle.tsx
@@ -6,8 +6,10 @@ import AngleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-right-i
 import CaretDownIcon from '@patternfly/react-icons/dist/esm/icons/caret-down-icon';
 
 import { KeyTypes } from '../../../helpers/constants';
-import { WizardNavProps, WizardBody, WizardStep, WizardStepProps } from '../Wizard';
 import { WizardStepType, isWizardSubStep } from './types';
+import { WizardNavProps } from './WizardNav';
+import { WizardStep, WizardStepProps } from './WizardStep';
+import { WizardBody } from './WizardBody';
 
 /**
  * Used to toggle between step content, including the body and footer. This is also where the navigation and its expandability is controlled.

--- a/packages/react-core/src/next/components/Wizard/utils.ts
+++ b/packages/react-core/src/next/components/Wizard/utils.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { WizardStepType } from './types';
+import { WizardControlStep, WizardNavStepData } from './types';
 import { WizardStep, WizardStepProps } from './WizardStep';
 
 /**
@@ -58,5 +58,8 @@ export const normalizeStepProps = ({
   ...controlStep
 }: WizardStepProps): Omit<WizardStepType, 'index'> => controlStep;
 
-export const getActiveStep = (steps: WizardStepType[], activeStepIndex: number) =>
-  steps.find(step => step.index === activeStepIndex);
+export const normalizeNavStep = (navStep: WizardControlStep): WizardNavStepData => ({
+  id: navStep.id,
+  index: navStep.index,
+  name: navStep.name.toString()
+});

--- a/packages/react-core/src/next/components/Wizard/utils.ts
+++ b/packages/react-core/src/next/components/Wizard/utils.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { WizardControlStep, WizardNavStepData } from './types';
+import { WizardStepType } from './types';
 import { WizardStep, WizardStepProps } from './WizardStep';
 
 /**
@@ -57,9 +57,3 @@ export const normalizeStepProps = ({
   steps: _steps,
   ...controlStep
 }: WizardStepProps): Omit<WizardStepType, 'index'> => controlStep;
-
-export const normalizeNavStep = (navStep: WizardControlStep): WizardNavStepData => ({
-  id: navStep.id,
-  index: navStep.index,
-  name: navStep.name.toString()
-});

--- a/packages/react-integration/cypress/integration/tablesimpleactions.spec.ts
+++ b/packages/react-integration/cypress/integration/tablesimpleactions.spec.ts
@@ -20,14 +20,14 @@ describe('Table Simple Actions Test', () => {
   });
 
   it('Verify dropdown toggle', () => {
-    cy.get('td .pf-c-dropdown__toggle')
+    cy.get('td .pf-c-menu-toggle')
       .first()
       .should('exist');
-    cy.get('td .pf-c-dropdown__toggle')
+    cy.get('td .pf-c-menu-toggle')
       .first()
       .click();
-    cy.get('.pf-c-dropdown__menu').should('exist');
-    cy.get('.pf-c-dropdown__menu-item')
+    cy.get('.pf-c-menu').should('exist');
+    cy.get('.pf-c-menu__item')
       .first()
       .click();
   });

--- a/packages/react-table/src/components/Table/ActionsColumn.tsx
+++ b/packages/react-table/src/components/Table/ActionsColumn.tsx
@@ -90,7 +90,14 @@ const ActionsColumnBase: React.FunctionComponent<ActionsColumnProps> = ({
           actionsToggle ? (
             actionsToggle({ onToggle, isOpen, isDisabled, toggleRef })
           ) : (
-            <MenuToggle ref={toggleRef} onClick={onToggle} isExpanded={isOpen} isDisabled={isDisabled} variant="plain">
+            <MenuToggle
+              aria-label="Kebab toggle"
+              ref={toggleRef}
+              onClick={onToggle}
+              isExpanded={isOpen}
+              isDisabled={isDisabled}
+              variant="plain"
+            >
               <EllipsisVIcon />
             </MenuToggle>
           )

--- a/packages/react-table/src/components/Table/ActionsColumn.tsx
+++ b/packages/react-table/src/components/Table/ActionsColumn.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Dropdown, DropdownItem, DropdownList } from '@patternfly/react-core/next';
+import { Dropdown, DropdownItem, DropdownList } from '@patternfly/react-core/dist/esm/next/components';
 import { Button } from '@patternfly/react-core/dist/esm/components/Button';
 import { Divider } from '@patternfly/react-core/dist/esm/components/Divider';
 import { MenuToggle } from '@patternfly/react-core/dist/esm/components/MenuToggle';

--- a/packages/react-table/src/components/Table/ActionsColumn.tsx
+++ b/packages/react-table/src/components/Table/ActionsColumn.tsx
@@ -1,71 +1,59 @@
 import * as React from 'react';
-import { Dropdown } from '@patternfly/react-core/dist/esm/components/Dropdown';
-import { KebabToggle } from '@patternfly/react-core/dist/esm/components/Dropdown/KebabToggle';
-import { DropdownItem } from '@patternfly/react-core/dist/esm/components/Dropdown/DropdownItem';
-import { DropdownSeparator } from '@patternfly/react-core/dist/esm/components/Dropdown/DropdownSeparator';
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
-
-import {
-  DropdownDirection,
-  DropdownPosition
-} from '@patternfly/react-core/dist/esm/components/Dropdown/dropdownConstants';
-
+import { Dropdown, DropdownItem, DropdownList } from '@patternfly/react-core/next';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import { Divider } from '@patternfly/react-core/dist/esm/components/Divider';
+import { MenuToggle } from '@patternfly/react-core/dist/esm/components/MenuToggle';
 import { IAction, IExtraData, IRowData } from './TableTypes';
+import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
 
 export interface CustomActionsToggleProps {
-  onToggle: (isOpen: boolean) => void;
+  onToggle: (evt: React.MouseEvent) => void;
   isOpen: boolean;
   isDisabled: boolean;
+  toggleRef: React.Ref<any>;
 }
-
-export interface ActionsColumnProps {
-  children?: React.ReactNode;
+export interface ActionsColumnProps extends Omit<React.HTMLProps<HTMLElement>, 'label'> {
+  /** Actions to be rendered within or without the action dropdown */
   items: IAction[];
+  /** Indicates whether the actions dropdown is disabled */
   isDisabled?: boolean;
-  menuAppendTo?: HTMLElement | (() => HTMLElement) | 'inline' | 'parent';
-  dropdownPosition?: DropdownPosition;
-  dropdownDirection?: DropdownDirection;
+  /** Data of the row the action dropdown is located */
   rowData?: IRowData;
+  /** Extra data of a row */
   extraData?: IExtraData;
+  /** Custom actions toggle for the actions dropdown */
   actionsToggle?: (props: CustomActionsToggleProps) => React.ReactNode;
+  /** Additional properties for the actions dropdown popper */
+  popperProps?: any;
+  /** @hide Forwarded ref */
+  innerRef?: React.Ref<any>;
 }
 
-export interface ActionsColumnState {
-  isOpen: boolean;
-}
+const ActionsColumnBase: React.FunctionComponent<ActionsColumnProps> = ({
+  items,
+  isDisabled,
+  rowData,
+  extraData,
+  actionsToggle,
+  popperProps = {
+    position: 'right',
+    direction: 'down',
+    popperMatchesTriggerWidth: false
+  },
+  ...props
+}: ActionsColumnProps) => {
+  const [isOpen, setIsOpen] = React.useState(false);
 
-export class ActionsColumn extends React.Component<ActionsColumnProps, ActionsColumnState> {
-  static displayName = 'ActionsColumn';
-  private toggleRef = React.createRef<HTMLButtonElement>();
-  static defaultProps = {
-    children: null as React.ReactNode,
-    items: [] as IAction[],
-    dropdownPosition: DropdownPosition.right,
-    dropdownDirection: DropdownDirection.down,
-    menuAppendTo: 'inline',
-    rowData: {} as IRowData,
-    extraData: {} as IExtraData
-  };
-  constructor(props: ActionsColumnProps) {
-    super(props);
-    this.state = {
-      isOpen: false
-    };
-  }
-
-  onToggle = (isOpen: boolean): void => {
-    this.setState({
-      isOpen
-    });
+  const onToggle = () => {
+    setIsOpen(!isOpen);
   };
 
-  onClick = (
+  const onActionClick = (
     event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent,
     onClick:
       | ((event: React.MouseEvent, rowIndex: number | undefined, rowData: IRowData, extraData: IExtraData) => void)
       | undefined
   ): void => {
-    const { rowData, extraData } = this.props;
     // Only prevent default if onClick is provided.  This allows href support.
     if (onClick) {
       event.preventDefault();
@@ -74,62 +62,54 @@ export class ActionsColumn extends React.Component<ActionsColumnProps, ActionsCo
     }
   };
 
-  render() {
-    const { isOpen } = this.state;
-    const {
-      items,
-      children,
-      dropdownPosition,
-      dropdownDirection,
-      menuAppendTo,
-      isDisabled,
-      rowData,
-      actionsToggle
-    } = this.props;
+  return (
+    <React.Fragment>
+      {items
+        .filter(item => item.isOutsideDropdown)
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        .map(({ title, itemKey, onClick, isOutsideDropdown, ...props }, key) =>
+          typeof title === 'string' ? (
+            <Button
+              onClick={event => onActionClick(event, onClick)}
+              {...(props as any)}
+              isDisabled={isDisabled}
+              key={itemKey || `outside_dropdown_${key}`}
+              data-key={itemKey || `outside_dropdown_${key}`}
+            >
+              {title}
+            </Button>
+          ) : (
+            React.cloneElement(title as React.ReactElement, { onClick, isDisabled, ...props })
+          )
+        )}
 
-    const actionsToggleClone = actionsToggle ? (
-      actionsToggle({ onToggle: this.onToggle, isOpen, isDisabled })
-    ) : (
-      <KebabToggle isDisabled={isDisabled} onToggle={this.onToggle} />
-    );
-
-    return (
-      <React.Fragment>
-        {items
-          .filter(item => item.isOutsideDropdown)
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          .map(({ title, itemKey, onClick, isOutsideDropdown, ...props }, key) =>
-            typeof title === 'string' ? (
-              <Button
-                onClick={event => this.onClick(event, onClick)}
-                {...(props as any)}
-                isDisabled={isDisabled}
-                key={itemKey || `outside_dropdown_${key}`}
-                data-key={itemKey || `outside_dropdown_${key}`}
-              >
-                {title}
-              </Button>
-            ) : (
-              React.cloneElement(title as React.ReactElement, { onClick, isDisabled, ...props })
-            )
-          )}
-        <Dropdown
-          toggle={actionsToggleClone}
-          position={dropdownPosition}
-          direction={dropdownDirection}
-          menuAppendTo={menuAppendTo}
-          isOpen={isOpen}
-          dropdownItems={items
+      <Dropdown
+        isOpen={isOpen}
+        onOpenChange={isOpen => setIsOpen(isOpen)}
+        toggle={toggleRef =>
+          actionsToggle ? (
+            actionsToggle({ onToggle, isOpen, isDisabled, toggleRef })
+          ) : (
+            <MenuToggle ref={toggleRef} onClick={onToggle} isExpanded={isOpen} isDisabled={isDisabled} variant="plain">
+              <EllipsisVIcon />
+            </MenuToggle>
+          )
+        }
+        {...(rowData && rowData.actionProps)}
+        {...props}
+        popperProps={popperProps}
+      >
+        <DropdownList>
+          {items
             .filter(item => !item.isOutsideDropdown)
             .map(({ title, itemKey, onClick, isSeparator, ...props }, key) =>
               isSeparator ? (
-                <DropdownSeparator {...props} key={itemKey || key} data-key={itemKey || key} />
+                <Divider key={itemKey || key} data-key={itemKey || key} />
               ) : (
                 <DropdownItem
-                  component="button"
                   onClick={event => {
-                    this.onClick(event, onClick);
-                    this.onToggle(!isOpen);
+                    onActionClick(event, onClick);
+                    onToggle();
                   }}
                   {...props}
                   key={itemKey || key}
@@ -139,11 +119,13 @@ export class ActionsColumn extends React.Component<ActionsColumnProps, ActionsCo
                 </DropdownItem>
               )
             )}
-          isPlain
-          {...(rowData && rowData.actionProps)}
-        />
-        {children}
-      </React.Fragment>
-    );
-  }
-}
+        </DropdownList>
+      </Dropdown>
+    </React.Fragment>
+  );
+};
+
+export const ActionsColumn = React.forwardRef((props: ActionsColumnProps, ref: React.Ref<HTMLElement>) => (
+  <ActionsColumnBase {...props} innerRef={ref} />
+));
+ActionsColumn.displayName = 'ActionsColumn';

--- a/packages/react-table/src/components/Table/TableTypes.tsx
+++ b/packages/react-table/src/components/Table/TableTypes.tsx
@@ -1,4 +1,4 @@
-import { DropdownItemProps } from '@patternfly/react-core/dist/esm/components/Dropdown/DropdownItem';
+import { DropdownItemProps } from '@patternfly/react-core/next';
 import { formatterValueType, ColumnType, RowType, RowKeyType, HeaderType } from './base';
 import { SortByDirection } from './SortColumn';
 import {
@@ -108,6 +108,7 @@ export interface IColumn {
     dropdownDirection?: DropdownDirection;
     menuAppendTo?: HTMLElement | (() => HTMLElement) | 'inline' | 'parent';
     actionsToggle?: (props: CustomActionsToggleProps) => React.ReactNode;
+    actionsPopperProps?: any;
     allRowsSelected?: boolean;
     allRowsExpanded?: boolean;
     isHeaderSelectDisabled?: boolean;

--- a/packages/react-table/src/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/packages/react-table/src/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -157,6 +157,7 @@ exports[`Table Actions table 1`] = `
             >
               <button
                 aria-expanded="false"
+                aria-label="Kebab toggle"
                 class="pf-c-menu-toggle pf-m-plain"
                 type="button"
               >
@@ -234,6 +235,7 @@ exports[`Table Actions table 1`] = `
             >
               <button
                 aria-expanded="false"
+                aria-label="Kebab toggle"
                 class="pf-c-menu-toggle pf-m-plain"
                 type="button"
               >
@@ -311,6 +313,7 @@ exports[`Table Actions table 1`] = `
             >
               <button
                 aria-expanded="false"
+                aria-label="Kebab toggle"
                 class="pf-c-menu-toggle pf-m-plain"
                 type="button"
               >
@@ -388,6 +391,7 @@ exports[`Table Actions table 1`] = `
             >
               <button
                 aria-expanded="false"
+                aria-label="Kebab toggle"
                 class="pf-c-menu-toggle pf-m-plain"
                 type="button"
               >
@@ -465,6 +469,7 @@ exports[`Table Actions table 1`] = `
             >
               <button
                 aria-expanded="false"
+                aria-label="Kebab toggle"
                 class="pf-c-menu-toggle pf-m-plain"
                 type="button"
               >
@@ -542,6 +547,7 @@ exports[`Table Actions table 1`] = `
             >
               <button
                 aria-expanded="false"
+                aria-label="Kebab toggle"
                 class="pf-c-menu-toggle pf-m-plain"
                 type="button"
               >
@@ -619,6 +625,7 @@ exports[`Table Actions table 1`] = `
             >
               <button
                 aria-expanded="false"
+                aria-label="Kebab toggle"
                 class="pf-c-menu-toggle pf-m-plain"
                 type="button"
               >
@@ -696,6 +703,7 @@ exports[`Table Actions table 1`] = `
             >
               <button
                 aria-expanded="false"
+                aria-label="Kebab toggle"
                 class="pf-c-menu-toggle pf-m-plain"
                 type="button"
               >
@@ -773,6 +781,7 @@ exports[`Table Actions table 1`] = `
             >
               <button
                 aria-expanded="false"
+                aria-label="Kebab toggle"
                 class="pf-c-menu-toggle pf-m-plain"
                 type="button"
               >
@@ -5383,6 +5392,7 @@ exports[`Table Simple Actions table 1`] = `
             >
               <button
                 aria-expanded="false"
+                aria-label="Kebab toggle"
                 class="pf-c-menu-toggle pf-m-plain"
                 type="button"
               >
@@ -5460,6 +5470,7 @@ exports[`Table Simple Actions table 1`] = `
             >
               <button
                 aria-expanded="false"
+                aria-label="Kebab toggle"
                 class="pf-c-menu-toggle pf-m-plain"
                 type="button"
               >
@@ -5537,6 +5548,7 @@ exports[`Table Simple Actions table 1`] = `
             >
               <button
                 aria-expanded="false"
+                aria-label="Kebab toggle"
                 class="pf-c-menu-toggle pf-m-plain"
                 type="button"
               >
@@ -5614,6 +5626,7 @@ exports[`Table Simple Actions table 1`] = `
             >
               <button
                 aria-expanded="false"
+                aria-label="Kebab toggle"
                 class="pf-c-menu-toggle pf-m-plain"
                 type="button"
               >
@@ -5691,6 +5704,7 @@ exports[`Table Simple Actions table 1`] = `
             >
               <button
                 aria-expanded="false"
+                aria-label="Kebab toggle"
                 class="pf-c-menu-toggle pf-m-plain"
                 type="button"
               >
@@ -5768,6 +5782,7 @@ exports[`Table Simple Actions table 1`] = `
             >
               <button
                 aria-expanded="false"
+                aria-label="Kebab toggle"
                 class="pf-c-menu-toggle pf-m-plain"
                 type="button"
               >
@@ -5845,6 +5860,7 @@ exports[`Table Simple Actions table 1`] = `
             >
               <button
                 aria-expanded="false"
+                aria-label="Kebab toggle"
                 class="pf-c-menu-toggle pf-m-plain"
                 type="button"
               >
@@ -5922,6 +5938,7 @@ exports[`Table Simple Actions table 1`] = `
             >
               <button
                 aria-expanded="false"
+                aria-label="Kebab toggle"
                 class="pf-c-menu-toggle pf-m-plain"
                 type="button"
               >
@@ -5999,6 +6016,7 @@ exports[`Table Simple Actions table 1`] = `
             >
               <button
                 aria-expanded="false"
+                aria-label="Kebab toggle"
                 class="pf-c-menu-toggle pf-m-plain"
                 type="button"
               >
@@ -6076,6 +6094,7 @@ exports[`Table Simple Actions table 1`] = `
             >
               <button
                 aria-expanded="false"
+                aria-label="Kebab toggle"
                 class="pf-c-menu-toggle pf-m-plain pf-m-disabled"
                 disabled=""
                 type="button"

--- a/packages/react-table/src/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/packages/react-table/src/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -148,33 +148,33 @@ exports[`Table Actions table 1`] = `
           style="padding-right: 0px;"
         >
           <div
-            class="pf-c-dropdown pf-m-align-right"
             data-ouia-component-id="OUIA-Generated-Dropdown-11"
             data-ouia-component-type="PF4/Dropdown"
             data-ouia-safe="true"
           >
-            <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Actions"
-              class="pf-c-dropdown__toggle pf-m-plain"
-              id="pf-dropdown-toggle-id-10"
-              type="button"
+            <div
+              style="display: contents;"
             >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 192 512"
-                width="1em"
+              <button
+                aria-expanded="false"
+                class="pf-c-menu-toggle pf-m-plain"
+                type="button"
               >
-                <path
-                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 192 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </td>
       </tr>
@@ -225,33 +225,33 @@ exports[`Table Actions table 1`] = `
           style="padding-right: 0px;"
         >
           <div
-            class="pf-c-dropdown pf-m-align-right"
             data-ouia-component-id="OUIA-Generated-Dropdown-12"
             data-ouia-component-type="PF4/Dropdown"
             data-ouia-safe="true"
           >
-            <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Actions"
-              class="pf-c-dropdown__toggle pf-m-plain"
-              id="pf-dropdown-toggle-id-11"
-              type="button"
+            <div
+              style="display: contents;"
             >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 192 512"
-                width="1em"
+              <button
+                aria-expanded="false"
+                class="pf-c-menu-toggle pf-m-plain"
+                type="button"
               >
-                <path
-                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 192 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </td>
       </tr>
@@ -302,33 +302,33 @@ exports[`Table Actions table 1`] = `
           style="padding-right: 0px;"
         >
           <div
-            class="pf-c-dropdown pf-m-align-right"
             data-ouia-component-id="OUIA-Generated-Dropdown-13"
             data-ouia-component-type="PF4/Dropdown"
             data-ouia-safe="true"
           >
-            <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Actions"
-              class="pf-c-dropdown__toggle pf-m-plain"
-              id="pf-dropdown-toggle-id-12"
-              type="button"
+            <div
+              style="display: contents;"
             >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 192 512"
-                width="1em"
+              <button
+                aria-expanded="false"
+                class="pf-c-menu-toggle pf-m-plain"
+                type="button"
               >
-                <path
-                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 192 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </td>
       </tr>
@@ -379,33 +379,33 @@ exports[`Table Actions table 1`] = `
           style="padding-right: 0px;"
         >
           <div
-            class="pf-c-dropdown pf-m-align-right"
             data-ouia-component-id="OUIA-Generated-Dropdown-14"
             data-ouia-component-type="PF4/Dropdown"
             data-ouia-safe="true"
           >
-            <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Actions"
-              class="pf-c-dropdown__toggle pf-m-plain"
-              id="pf-dropdown-toggle-id-13"
-              type="button"
+            <div
+              style="display: contents;"
             >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 192 512"
-                width="1em"
+              <button
+                aria-expanded="false"
+                class="pf-c-menu-toggle pf-m-plain"
+                type="button"
               >
-                <path
-                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 192 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </td>
       </tr>
@@ -456,33 +456,33 @@ exports[`Table Actions table 1`] = `
           style="padding-right: 0px;"
         >
           <div
-            class="pf-c-dropdown pf-m-align-right"
             data-ouia-component-id="OUIA-Generated-Dropdown-15"
             data-ouia-component-type="PF4/Dropdown"
             data-ouia-safe="true"
           >
-            <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Actions"
-              class="pf-c-dropdown__toggle pf-m-plain"
-              id="pf-dropdown-toggle-id-14"
-              type="button"
+            <div
+              style="display: contents;"
             >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 192 512"
-                width="1em"
+              <button
+                aria-expanded="false"
+                class="pf-c-menu-toggle pf-m-plain"
+                type="button"
               >
-                <path
-                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 192 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </td>
       </tr>
@@ -533,33 +533,33 @@ exports[`Table Actions table 1`] = `
           style="padding-right: 0px;"
         >
           <div
-            class="pf-c-dropdown pf-m-align-right"
             data-ouia-component-id="OUIA-Generated-Dropdown-16"
             data-ouia-component-type="PF4/Dropdown"
             data-ouia-safe="true"
           >
-            <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Actions"
-              class="pf-c-dropdown__toggle pf-m-plain"
-              id="pf-dropdown-toggle-id-15"
-              type="button"
+            <div
+              style="display: contents;"
             >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 192 512"
-                width="1em"
+              <button
+                aria-expanded="false"
+                class="pf-c-menu-toggle pf-m-plain"
+                type="button"
               >
-                <path
-                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 192 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </td>
       </tr>
@@ -610,33 +610,33 @@ exports[`Table Actions table 1`] = `
           style="padding-right: 0px;"
         >
           <div
-            class="pf-c-dropdown pf-m-align-right"
             data-ouia-component-id="OUIA-Generated-Dropdown-17"
             data-ouia-component-type="PF4/Dropdown"
             data-ouia-safe="true"
           >
-            <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Actions"
-              class="pf-c-dropdown__toggle pf-m-plain"
-              id="pf-dropdown-toggle-id-16"
-              type="button"
+            <div
+              style="display: contents;"
             >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 192 512"
-                width="1em"
+              <button
+                aria-expanded="false"
+                class="pf-c-menu-toggle pf-m-plain"
+                type="button"
               >
-                <path
-                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 192 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </td>
       </tr>
@@ -687,33 +687,33 @@ exports[`Table Actions table 1`] = `
           style="padding-right: 0px;"
         >
           <div
-            class="pf-c-dropdown pf-m-align-right"
             data-ouia-component-id="OUIA-Generated-Dropdown-18"
             data-ouia-component-type="PF4/Dropdown"
             data-ouia-safe="true"
           >
-            <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Actions"
-              class="pf-c-dropdown__toggle pf-m-plain"
-              id="pf-dropdown-toggle-id-17"
-              type="button"
+            <div
+              style="display: contents;"
             >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 192 512"
-                width="1em"
+              <button
+                aria-expanded="false"
+                class="pf-c-menu-toggle pf-m-plain"
+                type="button"
               >
-                <path
-                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 192 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </td>
       </tr>
@@ -764,33 +764,33 @@ exports[`Table Actions table 1`] = `
           style="padding-right: 0px;"
         >
           <div
-            class="pf-c-dropdown pf-m-align-right"
             data-ouia-component-id="OUIA-Generated-Dropdown-19"
             data-ouia-component-type="PF4/Dropdown"
             data-ouia-safe="true"
           >
-            <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Actions"
-              class="pf-c-dropdown__toggle pf-m-plain"
-              id="pf-dropdown-toggle-id-18"
-              type="button"
+            <div
+              style="display: contents;"
             >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 192 512"
-                width="1em"
+              <button
+                aria-expanded="false"
+                class="pf-c-menu-toggle pf-m-plain"
+                type="button"
               >
-                <path
-                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 192 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </td>
       </tr>
@@ -5374,33 +5374,33 @@ exports[`Table Simple Actions table 1`] = `
           style="padding-right: 0px;"
         >
           <div
-            class="pf-c-dropdown pf-m-align-right"
             data-ouia-component-id="OUIA-Generated-Dropdown-1"
             data-ouia-component-type="PF4/Dropdown"
             data-ouia-safe="true"
           >
-            <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Actions"
-              class="pf-c-dropdown__toggle pf-m-plain"
-              id="pf-dropdown-toggle-id-0"
-              type="button"
+            <div
+              style="display: contents;"
             >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 192 512"
-                width="1em"
+              <button
+                aria-expanded="false"
+                class="pf-c-menu-toggle pf-m-plain"
+                type="button"
               >
-                <path
-                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 192 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </td>
       </tr>
@@ -5451,33 +5451,33 @@ exports[`Table Simple Actions table 1`] = `
           style="padding-right: 0px;"
         >
           <div
-            class="pf-c-dropdown pf-m-align-right"
             data-ouia-component-id="OUIA-Generated-Dropdown-2"
             data-ouia-component-type="PF4/Dropdown"
             data-ouia-safe="true"
           >
-            <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Actions"
-              class="pf-c-dropdown__toggle pf-m-plain"
-              id="pf-dropdown-toggle-id-1"
-              type="button"
+            <div
+              style="display: contents;"
             >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 192 512"
-                width="1em"
+              <button
+                aria-expanded="false"
+                class="pf-c-menu-toggle pf-m-plain"
+                type="button"
               >
-                <path
-                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 192 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </td>
       </tr>
@@ -5528,33 +5528,33 @@ exports[`Table Simple Actions table 1`] = `
           style="padding-right: 0px;"
         >
           <div
-            class="pf-c-dropdown pf-m-align-right"
             data-ouia-component-id="OUIA-Generated-Dropdown-3"
             data-ouia-component-type="PF4/Dropdown"
             data-ouia-safe="true"
           >
-            <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Actions"
-              class="pf-c-dropdown__toggle pf-m-plain"
-              id="pf-dropdown-toggle-id-2"
-              type="button"
+            <div
+              style="display: contents;"
             >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 192 512"
-                width="1em"
+              <button
+                aria-expanded="false"
+                class="pf-c-menu-toggle pf-m-plain"
+                type="button"
               >
-                <path
-                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 192 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </td>
       </tr>
@@ -5605,33 +5605,33 @@ exports[`Table Simple Actions table 1`] = `
           style="padding-right: 0px;"
         >
           <div
-            class="pf-c-dropdown pf-m-align-right"
             data-ouia-component-id="OUIA-Generated-Dropdown-4"
             data-ouia-component-type="PF4/Dropdown"
             data-ouia-safe="true"
           >
-            <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Actions"
-              class="pf-c-dropdown__toggle pf-m-plain"
-              id="pf-dropdown-toggle-id-3"
-              type="button"
+            <div
+              style="display: contents;"
             >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 192 512"
-                width="1em"
+              <button
+                aria-expanded="false"
+                class="pf-c-menu-toggle pf-m-plain"
+                type="button"
               >
-                <path
-                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 192 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </td>
       </tr>
@@ -5682,33 +5682,33 @@ exports[`Table Simple Actions table 1`] = `
           style="padding-right: 0px;"
         >
           <div
-            class="pf-c-dropdown pf-m-align-right"
             data-ouia-component-id="OUIA-Generated-Dropdown-5"
             data-ouia-component-type="PF4/Dropdown"
             data-ouia-safe="true"
           >
-            <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Actions"
-              class="pf-c-dropdown__toggle pf-m-plain"
-              id="pf-dropdown-toggle-id-4"
-              type="button"
+            <div
+              style="display: contents;"
             >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 192 512"
-                width="1em"
+              <button
+                aria-expanded="false"
+                class="pf-c-menu-toggle pf-m-plain"
+                type="button"
               >
-                <path
-                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 192 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </td>
       </tr>
@@ -5759,33 +5759,33 @@ exports[`Table Simple Actions table 1`] = `
           style="padding-right: 0px;"
         >
           <div
-            class="pf-c-dropdown pf-m-align-right"
             data-ouia-component-id="OUIA-Generated-Dropdown-6"
             data-ouia-component-type="PF4/Dropdown"
             data-ouia-safe="true"
           >
-            <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Actions"
-              class="pf-c-dropdown__toggle pf-m-plain"
-              id="pf-dropdown-toggle-id-5"
-              type="button"
+            <div
+              style="display: contents;"
             >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 192 512"
-                width="1em"
+              <button
+                aria-expanded="false"
+                class="pf-c-menu-toggle pf-m-plain"
+                type="button"
               >
-                <path
-                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 192 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </td>
       </tr>
@@ -5836,33 +5836,33 @@ exports[`Table Simple Actions table 1`] = `
           style="padding-right: 0px;"
         >
           <div
-            class="pf-c-dropdown pf-m-align-right"
             data-ouia-component-id="OUIA-Generated-Dropdown-7"
             data-ouia-component-type="PF4/Dropdown"
             data-ouia-safe="true"
           >
-            <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Actions"
-              class="pf-c-dropdown__toggle pf-m-plain"
-              id="pf-dropdown-toggle-id-6"
-              type="button"
+            <div
+              style="display: contents;"
             >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 192 512"
-                width="1em"
+              <button
+                aria-expanded="false"
+                class="pf-c-menu-toggle pf-m-plain"
+                type="button"
               >
-                <path
-                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 192 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </td>
       </tr>
@@ -5913,33 +5913,33 @@ exports[`Table Simple Actions table 1`] = `
           style="padding-right: 0px;"
         >
           <div
-            class="pf-c-dropdown pf-m-align-right"
             data-ouia-component-id="OUIA-Generated-Dropdown-8"
             data-ouia-component-type="PF4/Dropdown"
             data-ouia-safe="true"
           >
-            <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Actions"
-              class="pf-c-dropdown__toggle pf-m-plain"
-              id="pf-dropdown-toggle-id-7"
-              type="button"
+            <div
+              style="display: contents;"
             >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 192 512"
-                width="1em"
+              <button
+                aria-expanded="false"
+                class="pf-c-menu-toggle pf-m-plain"
+                type="button"
               >
-                <path
-                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 192 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </td>
       </tr>
@@ -5990,33 +5990,33 @@ exports[`Table Simple Actions table 1`] = `
           style="padding-right: 0px;"
         >
           <div
-            class="pf-c-dropdown pf-m-align-right"
             data-ouia-component-id="OUIA-Generated-Dropdown-9"
             data-ouia-component-type="PF4/Dropdown"
             data-ouia-safe="true"
           >
-            <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Actions"
-              class="pf-c-dropdown__toggle pf-m-plain"
-              id="pf-dropdown-toggle-id-8"
-              type="button"
+            <div
+              style="display: contents;"
             >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 192 512"
-                width="1em"
+              <button
+                aria-expanded="false"
+                class="pf-c-menu-toggle pf-m-plain"
+                type="button"
               >
-                <path
-                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 192 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </td>
       </tr>
@@ -6067,34 +6067,34 @@ exports[`Table Simple Actions table 1`] = `
           style="padding-right: 0px;"
         >
           <div
-            class="pf-c-dropdown pf-m-align-right"
             data-ouia-component-id="OUIA-Generated-Dropdown-10"
             data-ouia-component-type="PF4/Dropdown"
             data-ouia-safe="true"
           >
-            <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="Actions"
-              class="pf-c-dropdown__toggle pf-m-plain"
-              disabled=""
-              id="pf-dropdown-toggle-id-9"
-              type="button"
+            <div
+              style="display: contents;"
             >
-              <svg
-                aria-hidden="true"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 192 512"
-                width="1em"
+              <button
+                aria-expanded="false"
+                class="pf-c-menu-toggle pf-m-plain pf-m-disabled"
+                disabled=""
+                type="button"
               >
-                <path
-                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                />
-              </svg>
-            </button>
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 192 512"
+                  width="1em"
+                >
+                  <path
+                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                  />
+                </svg>
+              </button>
+            </div>
           </div>
         </td>
       </tr>

--- a/packages/react-table/src/components/Table/examples/LegacyTableActions.tsx
+++ b/packages/react-table/src/components/Table/examples/LegacyTableActions.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {
   Button,
   Checkbox,
-  DropdownToggle,
+  MenuToggle,
   ToggleGroup,
   ToggleGroupItem,
   ToggleGroupItemProps,
@@ -62,9 +62,9 @@ export const LegacyTableActions: React.FunctionComponent = () => {
   const [useCustomToggle, setUseCustomToggle] = React.useState(false);
 
   const customActionsToggle = (props: CustomActionsToggleProps) => (
-    <DropdownToggle onToggle={props.onToggle} isDisabled={props.isDisabled}>
+    <MenuToggle ref={props.toggleRef} onClick={props.onToggle} isDisabled={props.isDisabled}>
       Actions
-    </DropdownToggle>
+    </MenuToggle>
   );
 
   const columns: TableProps['cells'] = [
@@ -77,7 +77,7 @@ export const LegacyTableActions: React.FunctionComponent = () => {
   ];
 
   const rows: TableProps['rows'] = repositories.map(repo => {
-    let singleActionButton = null;
+    let singleActionButton: React.ReactNode = null;
     if (repo.singleAction !== '') {
       singleActionButton = (
         <TableText>

--- a/packages/react-table/src/components/Table/utils/decorators/cellActions.tsx
+++ b/packages/react-table/src/components/Table/utils/decorators/cellActions.tsx
@@ -33,7 +33,7 @@ export const cellActions = (
     rowIndex,
     columnIndex,
     column: {
-      extraParams: { dropdownPosition, dropdownDirection, actionsToggle, menuAppendTo }
+      extraParams: { actionsToggle, actionsPopperProps }
     },
     property
   }: IExtra
@@ -58,13 +58,11 @@ export const cellActions = (
           children: (
             <ActionsColumn
               items={resolvedActions}
-              dropdownPosition={dropdownPosition}
-              dropdownDirection={dropdownDirection}
-              menuAppendTo={menuAppendTo}
               isDisabled={resolvedIsDisabled}
               rowData={rowData}
               extraData={extraData}
               actionsToggle={actionsToggle}
+              popperProps={actionsPopperProps}
             >
               {label as React.ReactNode}
             </ActionsColumn>

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTableActions.tsx
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTableActions.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import React from 'react';
-import { Button, DropdownToggle, ToggleGroup, ToggleGroupItem, ToggleGroupItemProps } from '@patternfly/react-core';
+import { Button, MenuToggle, ToggleGroup, ToggleGroupItem, ToggleGroupItemProps } from '@patternfly/react-core';
 import {
   TableComposable,
   TableText,
@@ -52,9 +52,9 @@ export const ComposableTableActions: React.FunctionComponent = () => {
   };
 
   const customActionsToggle = (props: CustomActionsToggleProps) => (
-    <DropdownToggle onToggle={props.onToggle} isDisabled={props.isDisabled}>
+    <MenuToggle ref={props.toggleRef} onClick={props.onToggle} isDisabled={props.isDisabled}>
       Actions
-    </DropdownToggle>
+    </MenuToggle>
   );
 
   const defaultActions = (repo: Repository): IAction[] => [
@@ -130,7 +130,7 @@ export const ComposableTableActions: React.FunctionComponent = () => {
             if (repo.name === '5') {
               rowActions = lastRowActions(repo);
             }
-            let singleActionButton = null;
+            let singleActionButton: React.ReactNode = null;
             if (repo.singleAction !== '') {
               singleActionButton = (
                 <TableText>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8390

- Updates `ActionsColumn` to use Dropdown-next components
- Adds `popperProps` to Dropdown-next to allow customization of Popper (including `direction`, `position`, `popperMatchesTriggerWidth` that is used by `ActionsColumn`). If this would be better as separately piped props let me know and I can update them. But for now this will allow the greatest flexibility.
- Updates examples to use `MenuToggle` for custom toggle
