### PR TITLE
fix(composable typeahead select): updated accessibility

### DIFF
--- a/packages/react-core/src/components/Menu/MenuItem.tsx
+++ b/packages/react-core/src/components/Menu/MenuItem.tsx
@@ -68,6 +68,7 @@ export interface MenuItemProps extends Omit<React.HTMLProps<HTMLLIElement>, 'onC
   'aria-label'?: string;
   /** @hide Forwarded ref */
   innerRef?: React.Ref<HTMLAnchorElement | HTMLButtonElement>;
+  /** Sets the id attribute on the menu item component. */
   id?: string;
 }
 

--- a/packages/react-core/src/components/Menu/MenuItem.tsx
+++ b/packages/react-core/src/components/Menu/MenuItem.tsx
@@ -68,6 +68,7 @@ export interface MenuItemProps extends Omit<React.HTMLProps<HTMLLIElement>, 'onC
   'aria-label'?: string;
   /** @hide Forwarded ref */
   innerRef?: React.Ref<HTMLAnchorElement | HTMLButtonElement>;
+  id?: string;
 }
 
 const FlyoutContext = React.createContext({
@@ -100,6 +101,7 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
   drilldownMenu,
   isOnPath,
   innerRef,
+  id,
   ...props
 }: MenuItemProps) => {
   const {
@@ -314,6 +316,7 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
       <GenerateId>
         {randomId => (
           <Component
+            id={id}
             tabIndex={-1}
             className={css(styles.menuItem, getIsSelected() && !hasCheckbox && styles.modifiers.selected, className)}
             aria-current={getAriaCurrent()}

--- a/packages/react-core/src/components/TextInputGroup/TextInputGroupMain.tsx
+++ b/packages/react-core/src/components/TextInputGroup/TextInputGroupMain.tsx
@@ -41,6 +41,10 @@ export interface TextInputGroupMainProps extends Omit<React.HTMLProps<HTMLDivEle
   innerRef?: React.RefObject<any>;
   /** Name for the input */
   name?: string;
+  'aria-activedescendant'?: string;
+  role?: string;
+  isExpanded?: boolean;
+  'aria-controls'?: string;
 }
 
 export const TextInputGroupMain: React.FunctionComponent<TextInputGroupMainProps> = ({
@@ -57,6 +61,10 @@ export const TextInputGroupMain: React.FunctionComponent<TextInputGroupMainProps
   placeholder: inputPlaceHolder,
   innerRef,
   name,
+  'aria-activedescendant': ariaActivedescendant,
+  role,
+  isExpanded,
+  'aria-controls': ariaControls,
   ...props
 }: TextInputGroupMainProps) => {
   const { isDisabled } = React.useContext(TextInputGroupContext);
@@ -93,6 +101,10 @@ export const TextInputGroupMain: React.FunctionComponent<TextInputGroupMainProps
           value={inputValue || ''}
           placeholder={inputPlaceHolder}
           name={name}
+          aria-activedescendant={ariaActivedescendant}
+          {...(role && { role })}
+          {...(isExpanded !== undefined && { 'aria-expanded': isExpanded })}
+          {...(ariaControls && { 'aria-controls': ariaControls })}
         />
       </span>
     </div>

--- a/packages/react-core/src/components/TextInputGroup/TextInputGroupMain.tsx
+++ b/packages/react-core/src/components/TextInputGroup/TextInputGroupMain.tsx
@@ -41,9 +41,17 @@ export interface TextInputGroupMainProps extends Omit<React.HTMLProps<HTMLDivEle
   innerRef?: React.RefObject<any>;
   /** Name for the input */
   name?: string;
+  /** @beta The id of the active element. Required if role has a value of "combobox", and focus
+   * should remain on the input.
+   */
   'aria-activedescendant'?: string;
+  /** @beta Determines the accessible role of the input. */
   role?: string;
+  /** @beta Flag for whether an associated element controlled by the input is visible. Required if
+   * role has a value of "combobox".
+   */
   isExpanded?: boolean;
+  /** @beta The id of the element(s) controlled by the input. Required if role has a value of "combobox". */
   'aria-controls'?: string;
 }
 

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableMultipleTypeaheadSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableMultipleTypeaheadSelect.tsx
@@ -50,6 +50,11 @@ export const ComposableMultipleTypeaheadSelect: React.FunctionComponent = () => 
       if (!newMenuItems.length) {
         newMenuItems = [{ isDisabled: false, children: `No results found for "${inputValue}"`, itemId: 'no results' }];
       }
+
+      // Open the menu when the input value changes and the new value is not empty
+      if (!isMenuOpen) {
+        setIsMenuOpen(true);
+      }
     }
 
     setMenuItems(newMenuItems);
@@ -112,8 +117,6 @@ export const ComposableMultipleTypeaheadSelect: React.FunctionComponent = () => 
         event.preventDefault();
         handleMenuArrowKeys(event.key);
         break;
-      default:
-        !isMenuOpen && setIsMenuOpen(true);
     }
   };
 

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableMultipleTypeaheadSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableMultipleTypeaheadSelect.tsx
@@ -222,9 +222,10 @@ export const ComposableMultipleTypeaheadSelect: React.FunctionComponent = () => 
       id="multiple-typeahead-select-menu"
       onSelect={(_ev, itemId) => onMenuSelect(itemId?.toString() as string)}
       selected={selected}
+      role="listbox"
     >
       <MenuContent>
-        <MenuList id="composable-multi-typeahead-listbox">
+        <MenuList id="composable-multi-typeahead-listbox" isAriaMultiselectable>
           {menuItems.map((itemProps, index) => (
             <MenuItem
               id={`composable-multi-typeahead-${itemProps.itemId.replace(' ', '-')}`}

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableMultipleTypeaheadSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableMultipleTypeaheadSelect.tsx
@@ -57,6 +57,8 @@ export const ComposableMultipleTypeaheadSelect: React.FunctionComponent = () => 
     setFocusedItemIndex(null);
   }, [inputValue]);
 
+  const focusOnInput = () => textInputRef.current?.focus();
+
   const handleMenuArrowKeys = (key: string) => {
     let indexToFocus;
 
@@ -126,9 +128,21 @@ export const ComposableMultipleTypeaheadSelect: React.FunctionComponent = () => 
     }
   };
 
+  // Close the menu when focus is on a menu item and Escape or Tab is pressed
+  const onDocumentKeydown = (event: KeyboardEvent | undefined) => {
+    if (isMenuOpen && menuRef?.current?.contains(event?.target as HTMLElement)) {
+      if (event?.key === 'Escape') {
+        setIsMenuOpen(false);
+        focusOnInput();
+      } else if (event?.key === 'Tab') {
+        setIsMenuOpen(false);
+      }
+    }
+  };
+
   const toggleMenuOpen = () => {
     setIsMenuOpen(!isMenuOpen);
-    textInputRef.current?.focus();
+    focusOnInput();
   };
 
   const onTextInputChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => {
@@ -143,7 +157,7 @@ export const ComposableMultipleTypeaheadSelect: React.FunctionComponent = () => 
       );
     }
 
-    textInputRef.current?.focus();
+    focusOnInput();
   };
 
   const toggle = (
@@ -230,6 +244,7 @@ export const ComposableMultipleTypeaheadSelect: React.FunctionComponent = () => 
         appendTo={containerRef.current}
         isVisible={isMenuOpen}
         onDocumentClick={onDocumentClick}
+        onDocumentKeyDown={onDocumentKeydown}
       />
     </div>
   );

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableTypeaheadSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableTypeaheadSelect.tsx
@@ -57,7 +57,7 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
     setFocusedItemIndex(null);
   }, [inputValue]);
 
-  const focusOnInput = () => menuToggleRef.current?.querySelector('input')?.focus();
+  const focusOnInput = () => textInputRef.current?.focus();
 
   const onMenuSelect = (_event: React.MouseEvent | undefined, itemId: string | number | undefined) => {
     // Only allow selection if the item is a valid, selectable option
@@ -146,6 +146,18 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
     }
   };
 
+  // Close the menu when focus is on a menu item and Escape or Tab is pressed
+  const onDocumentKeydown = (event: KeyboardEvent | undefined) => {
+    if (isMenuOpen && menuRef?.current?.contains(event?.target as HTMLElement)) {
+      if (event?.key === 'Escape') {
+        setIsMenuOpen(false);
+        focusOnInput();
+      } else if (event?.key === 'Tab') {
+        setIsMenuOpen(false);
+      }
+    }
+  };
+
   const toggleMenuOpen = () => {
     setIsMenuOpen(prevIsOpen => !prevIsOpen);
     textInputRef.current?.focus();
@@ -213,6 +225,7 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
       }
       isVisible={isMenuOpen}
       onDocumentClick={onDocumentClick}
+      onDocumentKeyDown={onDocumentKeydown}
       appendTo={() => document.getElementById('temp-toggle-id')}
     />
   );

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableTypeaheadSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableTypeaheadSelect.tsx
@@ -28,10 +28,12 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
   const [inputValue, setInputValue] = React.useState<string>('');
   const [menuItems, setMenuItems] = React.useState<MenuItemProps[]>(intitalMenuItems);
   const [focusedItemIndex, setFocusedItemIndex] = React.useState<number | null>(null);
+  const [activeItem, setActiveItem] = React.useState<string | null>(null);
   const [isSelected, setIsSelected] = React.useState(false);
 
   const menuToggleRef = React.useRef<MenuToggleElement>({} as MenuToggleElement);
   const textInputRef = React.useRef<HTMLInputElement>();
+  const menuRef = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
     let newMenuItems: MenuItemProps[] = intitalMenuItems;
@@ -46,7 +48,7 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
 
       // When no options are found after filtering, display 'No results found'
       if (!newMenuItems.length) {
-        newMenuItems = [{ isDisabled: true, children: 'No results found' }];
+        newMenuItems = [{ isDisabled: false, children: `No results found for "${inputValue}"`, itemId: 'no results' }];
       }
     }
 
@@ -55,14 +57,16 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
 
   const focusOnInput = () => menuToggleRef.current?.querySelector('input')?.focus();
 
-  const onMenuSelect = (event: React.MouseEvent | undefined, itemId: string | number | undefined) => {
-    if (itemId) {
+  const onMenuSelect = (_event: React.MouseEvent | undefined, itemId: string | number | undefined) => {
+    // Only allow selection if the item is a valid, selectable option
+    if (itemId && itemId !== 'no results') {
       setInputValue(itemId.toString());
       setIsSelected(true);
     }
 
     setIsMenuOpen(false);
     setFocusedItemIndex(null);
+    setActiveItem(null);
     focusOnInput();
   };
 
@@ -89,6 +93,9 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
       }
 
       setFocusedItemIndex(indexToFocus);
+      setActiveItem(
+        `composable-typeahead-${menuItems.filter(item => !item.isDisabled)[indexToFocus].itemId.replace(' ', '-')}`
+      );
     }
   };
 
@@ -100,19 +107,22 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
     switch (event.key) {
       // Select the first available option
       case 'Enter':
-        if (isMenuOpen) {
+        // Only allow selection if the first item is a valid, selectable option
+        if (isMenuOpen && focusedItem.itemId !== 'no results') {
           setInputValue(String(focusedItem.children));
           setIsSelected(true);
         }
 
         setIsMenuOpen(prevIsOpen => !prevIsOpen);
         setFocusedItemIndex(null);
+        setActiveItem(null);
         focusOnInput();
 
         break;
       case 'Tab':
       case 'Escape':
         setIsMenuOpen(false);
+        setActiveItem(null);
         break;
       case 'ArrowUp':
       case 'ArrowDown':
@@ -123,10 +133,14 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
     }
   };
 
-  // Close the menu when a click occurs outside of the menu toggle content
+  // Close the menu when a click occurs outside of the menu, toggle, or input
   const onDocumentClick = (event: MouseEvent | undefined) => {
-    if (!menuToggleRef.current?.contains(event?.target as HTMLElement)) {
+    const isValidClick = [menuRef, menuToggleRef, textInputRef].some(ref =>
+      ref?.current?.contains(event?.target as HTMLElement)
+    );
+    if (isMenuOpen && !isValidClick) {
       setIsMenuOpen(false);
+      setActiveItem(null);
     }
   };
 
@@ -144,6 +158,8 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
     <Popper
       trigger={
         <MenuToggle
+          // Needed to append the menu closer to the toggle in DOM
+          id="temp-toggle-id"
           variant="typeahead"
           onClick={toggleMenuOpen}
           innerRef={menuToggleRef}
@@ -159,6 +175,10 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
               id="typeahead-select-input"
               autoComplete="off"
               innerRef={textInputRef}
+              {...(activeItem && { 'aria-activedescendant': activeItem })}
+              role="combobox"
+              isExpanded={isMenuOpen}
+              aria-controls="composable-typeahead-listbox"
             />
 
             <TextInputGroupUtilities>
@@ -172,15 +192,15 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
         </MenuToggle>
       }
       popper={
-        <Menu id="select-menu" onSelect={onMenuSelect} selected={isSelected && inputValue}>
+        <Menu ref={menuRef} id="select-menu" onSelect={onMenuSelect} selected={isSelected && inputValue}>
           <MenuContent>
-            <MenuList>
+            <MenuList id="composable-typeahead-listbox">
               {menuItems.map((itemProps, index) => (
                 <MenuItem
+                  id={`composable-typeahead-${itemProps.itemId.replace(' ', '-')}`}
                   key={itemProps.itemId || itemProps.children}
                   isFocused={focusedItemIndex === index}
                   className={itemProps.className}
-                  onClick={() => setIsSelected(true)}
                   {...itemProps}
                   ref={null}
                 />
@@ -191,6 +211,7 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
       }
       isVisible={isMenuOpen}
       onDocumentClick={onDocumentClick}
+      appendTo={() => document.getElementById('temp-toggle-id')}
     />
   );
 };

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableTypeaheadSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableTypeaheadSelect.tsx
@@ -209,7 +209,7 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
         </MenuToggle>
       }
       popper={
-        <Menu ref={menuRef} id="select-menu" onSelect={onMenuSelect} selected={isSelected && inputValue}>
+        <Menu role="listbox" ref={menuRef} id="select-menu" onSelect={onMenuSelect} selected={isSelected && inputValue}>
           <MenuContent>
             <MenuList id="composable-typeahead-listbox">
               {menuItems.map((itemProps, index) => (

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableTypeaheadSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableTypeaheadSelect.tsx
@@ -50,6 +50,11 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
       if (!newMenuItems.length) {
         newMenuItems = [{ isDisabled: false, children: `No results found for "${inputValue}"`, itemId: 'no results' }];
       }
+
+      // Open the menu when the input value changes and the new value is not empty
+      if (!isMenuOpen) {
+        setIsMenuOpen(true);
+      }
     }
 
     setMenuItems(newMenuItems);
@@ -130,8 +135,6 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
         event.preventDefault();
         handleMenuArrowKeys(event.key);
         break;
-      default:
-        !isMenuOpen && setIsMenuOpen(true);
     }
   };
 

--- a/packages/react-core/src/demos/ComposableMenu/examples/ComposableTypeaheadSelect.tsx
+++ b/packages/react-core/src/demos/ComposableMenu/examples/ComposableTypeaheadSelect.tsx
@@ -53,6 +53,8 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
     }
 
     setMenuItems(newMenuItems);
+    setActiveItem(null);
+    setFocusedItemIndex(null);
   }, [inputValue]);
 
   const focusOnInput = () => menuToggleRef.current?.querySelector('input')?.focus();
@@ -93,9 +95,8 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
       }
 
       setFocusedItemIndex(indexToFocus);
-      setActiveItem(
-        `composable-typeahead-${menuItems.filter(item => !item.isDisabled)[indexToFocus].itemId.replace(' ', '-')}`
-      );
+      const focusedItem = menuItems.filter(item => !item.isDisabled)[indexToFocus];
+      setActiveItem(`composable-typeahead-${focusedItem.itemId.replace(' ', '-')}`);
     }
   };
 
@@ -126,6 +127,7 @@ export const ComposableTypeaheadSelect: React.FunctionComponent = () => {
         break;
       case 'ArrowUp':
       case 'ArrowDown':
+        event.preventDefault();
         handleMenuArrowKeys(event.key);
         break;
       default:

--- a/packages/react-core/src/next/components/Select/examples/SelectMultiTypeahead.tsx
+++ b/packages/react-core/src/next/components/Select/examples/SelectMultiTypeahead.tsx
@@ -27,6 +27,7 @@ export const SelectMultiTypeahead: React.FunctionComponent = () => {
   const [selected, setSelected] = React.useState<string[]>([]);
   const [selectOptions, setSelectOptions] = React.useState<SelectOptionProps[]>(initialSelectOptions);
   const [focusedItemIndex, setFocusedItemIndex] = React.useState<number | null>(null);
+  const [activeItem, setActiveItem] = React.useState<string | null>(null);
 
   const menuRef = React.useRef<HTMLDivElement>(null);
   const textInputRef = React.useRef<HTMLInputElement>();
@@ -44,12 +45,15 @@ export const SelectMultiTypeahead: React.FunctionComponent = () => {
 
       // When no options are found after filtering, display 'No results found'
       if (!newSelectOptions.length) {
-        newSelectOptions = [{ isDisabled: true, children: 'No results found' }];
+        newSelectOptions = [
+          { isDisabled: false, children: `No results found for "${inputValue}"`, itemId: 'no results' }
+        ];
       }
     }
 
     setSelectOptions(newSelectOptions);
-    setFocusedItemIndex(0);
+    setFocusedItemIndex(null);
+    setActiveItem(null);
   }, [inputValue]);
 
   const handleMenuArrowKeys = (key: string) => {
@@ -75,6 +79,8 @@ export const SelectMultiTypeahead: React.FunctionComponent = () => {
       }
 
       setFocusedItemIndex(indexToFocus);
+      const focusedItem = selectOptions.filter(option => !option.isDisabled)[indexToFocus];
+      setActiveItem(`select-multi-typeahead-${focusedItem.itemId.replace(' ', '-')}`);
     }
   };
 
@@ -88,16 +94,18 @@ export const SelectMultiTypeahead: React.FunctionComponent = () => {
       case 'Enter':
         if (!isOpen) {
           setIsOpen(prevIsOpen => !prevIsOpen);
-        } else {
+        } else if (isOpen && focusedItem.itemId !== 'no results') {
           onSelect(focusedItem.itemId as string);
         }
         break;
       case 'Tab':
       case 'Escape':
         setIsOpen(false);
+        setActiveItem(null);
         break;
       case 'ArrowUp':
       case 'ArrowDown':
+        event.preventDefault();
         handleMenuArrowKeys(event.key);
         break;
       default:
@@ -117,11 +125,13 @@ export const SelectMultiTypeahead: React.FunctionComponent = () => {
     // eslint-disable-next-line no-console
     console.log('selected', itemId);
 
-    if (itemId) {
+    if (itemId && itemId !== 'no results') {
       setSelected(
         selected.includes(itemId) ? selected.filter(selection => selection !== itemId) : [...selected, itemId]
       );
     }
+
+    textInputRef.current?.focus();
   };
 
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
@@ -136,8 +146,12 @@ export const SelectMultiTypeahead: React.FunctionComponent = () => {
           autoComplete="off"
           innerRef={textInputRef}
           placeholder="Select a state"
+          {...(activeItem && { 'aria-activedescendant': activeItem })}
+          role="combobox"
+          isExpanded={isOpen}
+          aria-controls="select-multi-typeahead-listbox"
         >
-          <ChipGroup>
+          <ChipGroup aria-label="Current selections">
             {selected.map((selection, index) => (
               <Chip
                 key={index}
@@ -158,6 +172,7 @@ export const SelectMultiTypeahead: React.FunctionComponent = () => {
               onClick={() => {
                 setInputValue('');
                 setSelected([]);
+                textInputRef?.current?.focus();
               }}
               aria-label="Clear input value"
             >
@@ -179,12 +194,13 @@ export const SelectMultiTypeahead: React.FunctionComponent = () => {
       onOpenChange={() => setIsOpen(false)}
       toggle={toggle}
     >
-      <SelectList isAriaMultiselectable>
+      <SelectList isAriaMultiselectable id="select-multi-typeahead-listbox">
         {selectOptions.map((option, index) => (
           <SelectOption
             key={option.itemId || option.children}
             isFocused={focusedItemIndex === index}
             className={option.className}
+            id={`select-multi-typeahead-${option.itemId.replace(' ', '-')}`}
             {...option}
             ref={null}
           />

--- a/packages/react-core/src/next/components/Select/examples/SelectMultiTypeahead.tsx
+++ b/packages/react-core/src/next/components/Select/examples/SelectMultiTypeahead.tsx
@@ -49,6 +49,11 @@ export const SelectMultiTypeahead: React.FunctionComponent = () => {
           { isDisabled: false, children: `No results found for "${inputValue}"`, itemId: 'no results' }
         ];
       }
+
+      // Open the menu when the input value changes and the new value is not empty
+      if (!isOpen) {
+        setIsOpen(true);
+      }
     }
 
     setSelectOptions(newSelectOptions);
@@ -108,8 +113,6 @@ export const SelectMultiTypeahead: React.FunctionComponent = () => {
         event.preventDefault();
         handleMenuArrowKeys(event.key);
         break;
-      default:
-        !isOpen && setIsOpen(true);
     }
   };
 

--- a/packages/react-core/src/next/components/Select/examples/SelectTypeahead.tsx
+++ b/packages/react-core/src/next/components/Select/examples/SelectTypeahead.tsx
@@ -48,6 +48,11 @@ export const SelectBasic: React.FunctionComponent = () => {
           { isDisabled: false, children: `No results found for "${filterValue}"`, itemId: 'no results' }
         ];
       }
+
+      // Open the menu when the input value changes and the new value is not empty
+      if (!isOpen) {
+        setIsOpen(true);
+      }
     }
 
     setSelectOptions(newSelectOptions);
@@ -134,8 +139,6 @@ export const SelectBasic: React.FunctionComponent = () => {
         event.preventDefault();
         handleMenuArrowKeys(event.key);
         break;
-      default:
-        !isOpen && setIsOpen(true);
     }
   };
 

--- a/packages/react-core/src/next/components/Select/examples/SelectTypeahead.tsx
+++ b/packages/react-core/src/next/components/Select/examples/SelectTypeahead.tsx
@@ -23,7 +23,6 @@ export const SelectBasic: React.FunctionComponent = () => {
   const [isOpen, setIsOpen] = React.useState(false);
   const [selected, setSelected] = React.useState<string>('');
   const [inputValue, setInputValue] = React.useState<string>('');
-  const [filterValue, setFilterValue] = React.useState<string>('');
   const [selectOptions, setSelectOptions] = React.useState<SelectOptionProps[]>(initialSelectOptions);
   const [focusedItemIndex, setFocusedItemIndex] = React.useState<number | null>(null);
   const [activeItem, setActiveItem] = React.useState<string | null>(null);
@@ -35,17 +34,17 @@ export const SelectBasic: React.FunctionComponent = () => {
     let newSelectOptions: SelectOptionProps[] = initialSelectOptions;
 
     // Filter menu items based on the text input value when one exists
-    if (filterValue) {
+    if (inputValue) {
       newSelectOptions = initialSelectOptions.filter(menuItem =>
         String(menuItem.children)
           .toLowerCase()
-          .includes(filterValue.toLowerCase())
+          .includes(inputValue.toLowerCase())
       );
 
       // When no options are found after filtering, display 'No results found'
       if (!newSelectOptions.length) {
         newSelectOptions = [
-          { isDisabled: false, children: `No results found for "${filterValue}"`, itemId: 'no results' }
+          { isDisabled: false, children: `No results found for "${inputValue}"`, itemId: 'no results' }
         ];
       }
 
@@ -58,7 +57,7 @@ export const SelectBasic: React.FunctionComponent = () => {
     setSelectOptions(newSelectOptions);
     setActiveItem(null);
     setFocusedItemIndex(null);
-  }, [filterValue]);
+  }, [inputValue]);
 
   const onToggleClick = () => {
     setIsOpen(!isOpen);
@@ -70,7 +69,6 @@ export const SelectBasic: React.FunctionComponent = () => {
 
     if (itemId && itemId !== 'no results') {
       setInputValue(itemId as string);
-      setFilterValue(itemId as string);
       setSelected(itemId as string);
     }
     setIsOpen(false);
@@ -80,7 +78,6 @@ export const SelectBasic: React.FunctionComponent = () => {
 
   const onTextInputChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => {
     setInputValue(value);
-    setFilterValue(value);
   };
 
   const handleMenuArrowKeys = (key: string) => {
@@ -167,7 +164,6 @@ export const SelectBasic: React.FunctionComponent = () => {
               onClick={() => {
                 setSelected('');
                 setInputValue('');
-                setFilterValue('');
                 textInputRef?.current?.focus();
               }}
               aria-label="Clear input value"
@@ -189,7 +185,6 @@ export const SelectBasic: React.FunctionComponent = () => {
       onSelect={onSelect}
       onOpenChange={() => {
         setIsOpen(false);
-        setFilterValue('');
       }}
       toggle={toggle}
     >

--- a/packages/react-integration/cypress/integration/menu.spec.ts
+++ b/packages/react-integration/cypress/integration/menu.spec.ts
@@ -29,7 +29,7 @@ describe('Menu Test', () => {
   it('Verify Flyout Menu', () => {
     cy.get('.pf-c-menu.pf-m-flyout').should('exist');
 
-    cy.get('#edit.pf-c-menu__list-item > button').click();
+    cy.get('#edit').click();
   });
 
   it('Verify Filterable Menu', () => {
@@ -39,18 +39,18 @@ describe('Menu Test', () => {
 
     cy.get('.pf-c-text-input-group__text-input').type('Action 1');
 
-    cy.get('#filtered-items.pf-c-menu__list-item')
+    cy.get('#filtered-items-0')
       .last()
       .should('contain', 'Action 1');
-    cy.get('#filtered-items.pf-c-menu__list-item')
+    cy.get('#filtered-items-0')
       .children()
       .should('not.contain', 'Action 2');
   });
 
   it('Verify Menu with Links', () => {
-    cy.get('#links-menu-link-1.pf-c-menu__list-item > a').should('have.attr', 'href', '#default-link1');
-    cy.get('#links-menu-link-2.pf-c-menu__list-item > a').should('have.attr', 'href', '#default-link2');
-    cy.get('#links-menu-link-3.pf-c-menu__list-item > a').should('have.attr', 'href', '#default-link3');
+    cy.get('#links-menu-link-1').should('have.attr', 'href', '#default-link1');
+    cy.get('#links-menu-link-2').should('have.attr', 'href', '#default-link2');
+    cy.get('#links-menu-link-3').should('have.attr', 'href', '#default-link3');
   });
 
   it('Verify Menu with Separator', () => {
@@ -67,7 +67,7 @@ describe('Menu Test', () => {
   });
 
   it('Verify Menu with Description', () => {
-    cy.get('#description-item-1 > .pf-c-menu__item')
+    cy.get('#description-item-1')
       .last()
       .should('contain', 'Description');
   });
@@ -91,25 +91,25 @@ describe('Menu Test', () => {
   it('Verify Single Select Menu', () => {
     cy.get('#single-select-menu.pf-c-menu').should('exist');
 
-    cy.get('#single-select-item-2.pf-c-menu__list-item > button').click();
+    cy.get('#single-select-item-2').click();
 
-    cy.get('#single-select-item-3.pf-c-menu__list-item > button')
+    cy.get('#single-select-item-3')
       .click()
       .should('have.class', 'pf-m-selected');
 
-    cy.get('#single-select-item-1.pf-c-menu__list-item > button').should('not.have.class', 'pf-m-selected');
+    cy.get('#single-select-item-1').should('not.have.class', 'pf-m-selected');
   });
 
   it('Verify Multi Select Menu', () => {
     cy.get('#multi-select-menu.pf-c-menu').should('exist');
 
-    cy.get('#multi-select-item-1.pf-c-menu__list-item > button').should('have.class', 'pf-m-selected');
+    cy.get('#multi-select-item-1').should('have.class', 'pf-m-selected');
 
-    cy.get('#multi-select-item-2.pf-c-menu__list-item > button')
+    cy.get('#multi-select-item-2')
       .click()
       .should('have.class', 'pf-m-selected');
 
-    cy.get('#multi-select-item-3.pf-c-menu__list-item > button').should('have.class', 'pf-m-selected');
+    cy.get('#multi-select-item-3').should('have.class', 'pf-m-selected');
   });
 
   it('Verify Footer Menu', () => {

--- a/packages/react-integration/demo-app-ts/src/components/demos/MenuDemo/MenuDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/MenuDemo/MenuDemo.tsx
@@ -239,7 +239,7 @@ export class MenuDemo extends Component {
     const menuListItems = menuListItemsText
       .filter(item => !input || item.toLowerCase().includes(input.toLowerCase()))
       .map((currentValue, index) => (
-        <MenuItem id="filtered-items" key={currentValue} itemId={index}>
+        <MenuItem id={`filtered-items-${index}`} key={currentValue} itemId={index}>
           {currentValue}
         </MenuItem>
       ));


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8125 

[Composable typeahead select demo](https://patternfly-react-pr-8633.surge.sh/demos/composable-menu#composable-typeahead-select)

Parts of the linked issue should be resolved by https://github.com/patternfly/patternfly-react/pull/8496 (adding functionality for select menus in Menu components) getting merged into v5 from main, and https://github.com/patternfly/patternfly-react/pull/8623 (placing the menu closer to the toggle in the DOM).

@nicolethoen regarding having options announced, I think one potential caveat of that - either as they type or when the input receives focus - is that it could possibly lead to a very verbose output. In the composable typeahead examples it isn't too bad since they only show a few options, but if the typeahead has dozens of possible options, all of them getting announced each time a thing occurs (input focus or typing), it might be a lot to sit through/constantly have to stop the announcement manually. The same would most likely apply to the multi typeahead examples with the ChipGroup. This can be tested by passing `aria-live` and `aria-atomic="true"` to the MenuList (composable examples) or ChipGroup (Select Next examples).

Another possible issue I noticed is that the "No results found" item can't be navigated to in order to tell that there are no results found. It looks like that may be the expected (or at least common?) behavior if there is no menu rendered ([ARIA authoring practices editable combobox](https://www.w3.org/WAI/ARIA/apg/example-index/combobox/combobox-autocomplete-both.html) for an example), but since we opt to include a "No result found" in the menu I updated some logic to show an alternative approach (not make it disabled, but prevent it being selected).

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
