### PR TITLE
fix(Table): fix ThExpandType label type

### DIFF
--- a/packages/react-table/src/components/Table/base/types.tsx
+++ b/packages/react-table/src/components/Table/base/types.tsx
@@ -183,7 +183,7 @@ export interface ThExpandType {
   /** Whether all are expanded */
   areAllExpanded: boolean;
   /** Alternative aria label */
-  collapseAllAriaLabel: '';
+  collapseAllAriaLabel: string;
 }
 
 // Rows Types


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8330

Changes the `collapseAllAriaLabel` type to `string`. It still defaults to `''` where it is actually used.

If we want to include renaming the `collapseAllAriaLabel` and `areAllExpanded` mentioned in the issue I can add that in to this PR as well, but I'm unsure what to rename them to at the moment.
