### PR TITLE
fix(SkipToContent): Updated markup

### DIFF
--- a/packages/react-core/src/components/Page/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/packages/react-core/src/components/Page/__tests__/__snapshots__/Page.test.tsx.snap
@@ -1229,7 +1229,11 @@ exports[`Page Check page to verify skip to content points to main content region
       class="pf-c-skip-to-content"
     >
       <a
+        aria-disabled="false"
         class="pf-c-button pf-m-primary"
+        data-ouia-component-id="OUIA-Generated-Button-primary-1"
+        data-ouia-component-type="PF4/Button"
+        data-ouia-safe="true"
         href="#main-content-page-layout-test-nav"
       >
         Skip to Content

--- a/packages/react-core/src/components/Page/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/packages/react-core/src/components/Page/__tests__/__snapshots__/Page.test.tsx.snap
@@ -1225,12 +1225,16 @@ exports[`Page Check page to verify skip to content points to main content region
     data-testid="page-test-id"
     id="PageId"
   >
-    <a
-      class="pf-c-button pf-m-primary pf-c-skip-to-content"
-      href="#main-content-page-layout-test-nav"
+    <div
+      class="pf-c-skip-to-content"
     >
-      Skip to Content
-    </a>
+      <a
+        class="pf-c-button pf-m-primary"
+        href="#main-content-page-layout-test-nav"
+      >
+        Skip to Content
+      </a>
+    </div>
     <header
       class="pf-c-page__header"
     >

--- a/packages/react-core/src/components/SkipToContent/SkipToContent.tsx
+++ b/packages/react-core/src/components/SkipToContent/SkipToContent.tsx
@@ -32,14 +32,16 @@ export class SkipToContent extends React.Component<SkipToContentProps> {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { children, className, href, show, type, ...rest } = this.props;
     return (
-      <a
-        {...rest}
-        className={css(buttonStyles.button, buttonStyles.modifiers.primary, styles.skipToContent, className)}
-        ref={this.componentRef}
-        href={href}
-      >
-        {children}
-      </a>
+      <div className={css(styles.skipToContent, className)}>
+        <a
+          {...rest}
+          className={css(buttonStyles.button, buttonStyles.modifiers.primary)}
+          ref={this.componentRef}
+          href={href}
+        >
+          {children}
+        </a>
+      </div>
     );
   }
 }

--- a/packages/react-core/src/components/SkipToContent/SkipToContent.tsx
+++ b/packages/react-core/src/components/SkipToContent/SkipToContent.tsx
@@ -1,47 +1,28 @@
 import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/SkipToContent/skip-to-content';
-import buttonStyles from '@patternfly/react-styles/css/components/Button/button';
 import { css } from '@patternfly/react-styles';
-import { PickOptional } from '../../helpers/typeUtils';
+import { Button, ButtonVariant } from '../Button';
 
-export interface SkipToContentProps extends React.HTMLProps<HTMLAnchorElement> {
+export interface SkipToContentProps extends React.HTMLProps<HTMLDivElement> {
   /** The skip to content link. */
   href: string;
   /** Content to display within the skip to content component, typically a string. */
   children?: React.ReactNode;
   /** Additional styles to apply to the skip to content component. */
   className?: string;
-  /** Forces the skip to content to display. This is primarily for demonstration purposes and would not normally be used. */
-  show?: boolean;
 }
 
-export class SkipToContent extends React.Component<SkipToContentProps> {
-  static displayName = 'SkipToContent';
-  static defaultProps: PickOptional<SkipToContentProps> = {
-    show: false
-  };
-  componentRef = React.createRef<HTMLAnchorElement>();
+export const SkipToContent: React.FunctionComponent<SkipToContentProps> = ({
+  children = null,
+  className = '',
+  href,
+  ...props
+}: SkipToContentProps) => (
+  <div className={css(styles.skipToContent, className)} {...props}>
+    <Button variant={ButtonVariant.primary} component='a' href={href}>
+      {children}
+    </Button>
+  </div>
+);
 
-  componentDidMount() {
-    if (this.props.show && this.componentRef.current) {
-      this.componentRef.current.focus();
-    }
-  }
-
-  render() {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { children, className, href, show, type, ...rest } = this.props;
-    return (
-      <div className={css(styles.skipToContent, className)}>
-        <a
-          {...rest}
-          className={css(buttonStyles.button, buttonStyles.modifiers.primary)}
-          ref={this.componentRef}
-          href={href}
-        >
-          {children}
-        </a>
-      </div>
-    );
-  }
-}
+SkipToContent.displayName = 'SkipToContent';

--- a/packages/react-core/src/components/SkipToContent/SkipToContent.tsx
+++ b/packages/react-core/src/components/SkipToContent/SkipToContent.tsx
@@ -19,7 +19,7 @@ export const SkipToContent: React.FunctionComponent<SkipToContentProps> = ({
   ...props
 }: SkipToContentProps) => (
   <div className={css(styles.skipToContent, className)} {...props}>
-    <Button variant={ButtonVariant.primary} component='a' href={href}>
+    <Button variant={ButtonVariant.primary} component="a" href={href}>
       {children}
     </Button>
   </div>

--- a/packages/react-core/src/components/SkipToContent/__tests__/SkipToContent.test.tsx
+++ b/packages/react-core/src/components/SkipToContent/__tests__/SkipToContent.test.tsx
@@ -10,8 +10,3 @@ test('Verify Skip To Content', () => {
   expect(asFragment()).toMatchSnapshot();
 });
 
-test('Verify Skip To Content if forced to display', () => {
-  const { asFragment } = render(<SkipToContent href="#main-content" {...props} show />);
-  // Add a useful assertion here.
-  expect(asFragment()).toMatchSnapshot();
-});

--- a/packages/react-core/src/components/SkipToContent/__tests__/__snapshots__/SkipToContent.test.tsx.snap
+++ b/packages/react-core/src/components/SkipToContent/__tests__/__snapshots__/SkipToContent.test.tsx.snap
@@ -6,20 +6,11 @@ exports[`Verify Skip To Content 1`] = `
     class="pf-c-skip-to-content"
   >
     <a
+      aria-disabled="false"
       class="pf-c-button pf-m-primary"
-      href="#main-content"
-    />
-  </div>
-</DocumentFragment>
-`;
-
-exports[`Verify Skip To Content if forced to display 1`] = `
-<DocumentFragment>
-  <div
-    class="pf-c-skip-to-content"
-  >
-    <a
-      class="pf-c-button pf-m-primary"
+      data-ouia-component-id="OUIA-Generated-Button-primary-1"
+      data-ouia-component-type="PF4/Button"
+      data-ouia-safe="true"
       href="#main-content"
     />
   </div>

--- a/packages/react-core/src/components/SkipToContent/__tests__/__snapshots__/SkipToContent.test.tsx.snap
+++ b/packages/react-core/src/components/SkipToContent/__tests__/__snapshots__/SkipToContent.test.tsx.snap
@@ -2,18 +2,26 @@
 
 exports[`Verify Skip To Content 1`] = `
 <DocumentFragment>
-  <a
-    class="pf-c-button pf-m-primary pf-c-skip-to-content"
-    href="#main-content"
-  />
+  <div
+    class="pf-c-skip-to-content"
+  >
+    <a
+      class="pf-c-button pf-m-primary"
+      href="#main-content"
+    />
+  </div>
 </DocumentFragment>
 `;
 
 exports[`Verify Skip To Content if forced to display 1`] = `
 <DocumentFragment>
-  <a
-    class="pf-c-button pf-m-primary pf-c-skip-to-content"
-    href="#main-content"
-  />
+  <div
+    class="pf-c-skip-to-content"
+  >
+    <a
+      class="pf-c-button pf-m-primary"
+      href="#main-content"
+    />
+  </div>
 </DocumentFragment>
 `;

--- a/packages/react-integration/demo-app-ts/package.json
+++ b/packages/react-integration/demo-app-ts/package.json
@@ -9,7 +9,7 @@
     "serve:demo-app": "node scripts/serve"
   },
   "dependencies": {
-    "@patternfly/react-core": "^5.0.0-alpha.15",
+    "@patternfly/react-core": "^5.0.0-alpha.16",
     "react": "^18",
     "react-dom": "^18",
     "react-router": "^5.3.3",


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8260

Moves the `pf-c-skip-to-content` class off of the `Button` and onto a div wrapping the `Button`.