### PR TITLE
feat(Masthead, PageHeader): update component logic

### DIFF
--- a/packages/react-core/src/components/Dropdown/DropdownToggleCheckbox.tsx
+++ b/packages/react-core/src/components/Dropdown/DropdownToggleCheckbox.tsx
@@ -91,7 +91,6 @@ export class DropdownToggleCheckbox extends React.Component<DropdownToggleCheckb
     const spinner = (
       <Spinner
         diameter="1em"
-        isSVG
         aria-valuetext={defaultProgressAriaValueText}
         aria-live="polite"
         aria-label={defaultProgressAriaLabel}

--- a/packages/react-core/src/components/Masthead/MastheadBrand.tsx
+++ b/packages/react-core/src/components/Masthead/MastheadBrand.tsx
@@ -22,14 +22,12 @@ export const MastheadBrand: React.FunctionComponent<MastheadBrandProps> = ({
   if (!component) {
     if (props?.href !== undefined) {
       Component = 'a';
-    } else if (props?.onClick !== undefined) {
-      Component = 'button';
     } else {
       Component = 'span';
     }
   }
   return (
-    <Component className={css(styles.mastheadBrand, className)} tabIndex={0} {...props}>
+    <Component className={css(styles.mastheadBrand, className)} {...(Component === 'a' && { tabIndex: 0 })} {...props}>
       {children}
     </Component>
   );

--- a/packages/react-core/src/components/Masthead/MastheadBrand.tsx
+++ b/packages/react-core/src/components/Masthead/MastheadBrand.tsx
@@ -15,10 +15,19 @@ export interface MastheadBrandProps
 export const MastheadBrand: React.FunctionComponent<MastheadBrandProps> = ({
   children,
   className,
-  component = 'a',
+  component,
   ...props
 }: MastheadBrandProps) => {
-  const Component = component as any;
+  let Component = component as any;
+  if (!component) {
+    if (props?.href !== undefined) {
+      Component = 'a';
+    } else if (props?.onClick !== undefined) {
+      Component = 'button';
+    } else {
+      Component = 'span';
+    }
+  }
   return (
     <Component className={css(styles.mastheadBrand, className)} tabIndex={0} {...props}>
       {children}

--- a/packages/react-core/src/components/Masthead/__tests__/Masthead.test.tsx
+++ b/packages/react-core/src/components/Masthead/__tests__/Masthead.test.tsx
@@ -102,12 +102,6 @@ describe('MastheadBrand', () => {
 
     expect(asFragment()).toMatchSnapshot();
   });
-
-  test('verify button component with onClick', () => {
-    const { asFragment } = render(<MastheadBrand onClick={() => {}}>test</MastheadBrand>);
-
-    expect(asFragment()).toMatchSnapshot();
-  });
 });
 
 describe('MastheadContent', () => {

--- a/packages/react-core/src/components/Masthead/__tests__/Masthead.test.tsx
+++ b/packages/react-core/src/components/Masthead/__tests__/Masthead.test.tsx
@@ -85,8 +85,26 @@ describe('MastheadBrand', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
+  test('verify default component', () => {
+    const { asFragment } = render(<MastheadBrand>test</MastheadBrand>);
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
   test('verify custom component', () => {
     const { asFragment } = render(<MastheadBrand component="div">test</MastheadBrand>);
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  test('verify anchor component with href', () => {
+    const { asFragment } = render(<MastheadBrand href="#">test</MastheadBrand>);
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  test('verify button component with onClick', () => {
+    const { asFragment } = render(<MastheadBrand onClick={() => {}}>test</MastheadBrand>);
 
     expect(asFragment()).toMatchSnapshot();
   });

--- a/packages/react-core/src/components/Masthead/__tests__/__snapshots__/Masthead.test.tsx.snap
+++ b/packages/react-core/src/components/Masthead/__tests__/__snapshots__/Masthead.test.tsx.snap
@@ -33,12 +33,12 @@ exports[`Masthead verify full structure 1`] = `
     <div
       class="pf-c-masthead__main"
     >
-      <a
+      <span
         class="pf-c-masthead__brand"
         tabindex="0"
       >
         Logo
-      </a>
+      </span>
     </div>
     <div
       class="pf-c-masthead__content"
@@ -151,10 +151,11 @@ exports[`Masthead verify stack display breakpoints 1`] = `
 </DocumentFragment>
 `;
 
-exports[`MastheadBrand verify basic 1`] = `
+exports[`MastheadBrand verify anchor component with href 1`] = `
 <DocumentFragment>
   <a
     class="pf-c-masthead__brand"
+    href="#"
     tabindex="0"
   >
     test
@@ -162,14 +163,36 @@ exports[`MastheadBrand verify basic 1`] = `
 </DocumentFragment>
 `;
 
+exports[`MastheadBrand verify basic 1`] = `
+<DocumentFragment>
+  <span
+    class="pf-c-masthead__brand"
+    tabindex="0"
+  >
+    test
+  </span>
+</DocumentFragment>
+`;
+
+exports[`MastheadBrand verify button component with onClick 1`] = `
+<DocumentFragment>
+  <button
+    class="pf-c-masthead__brand"
+    tabindex="0"
+  >
+    test
+  </button>
+</DocumentFragment>
+`;
+
 exports[`MastheadBrand verify custom class 1`] = `
 <DocumentFragment>
-  <a
+  <span
     class="pf-c-masthead__brand custom-css"
     tabindex="0"
   >
     test
-  </a>
+  </span>
 </DocumentFragment>
 `;
 
@@ -181,6 +204,17 @@ exports[`MastheadBrand verify custom component 1`] = `
   >
     test
   </div>
+</DocumentFragment>
+`;
+
+exports[`MastheadBrand verify default component 1`] = `
+<DocumentFragment>
+  <span
+    class="pf-c-masthead__brand"
+    tabindex="0"
+  >
+    test
+  </span>
 </DocumentFragment>
 `;
 

--- a/packages/react-core/src/components/Masthead/__tests__/__snapshots__/Masthead.test.tsx.snap
+++ b/packages/react-core/src/components/Masthead/__tests__/__snapshots__/Masthead.test.tsx.snap
@@ -35,7 +35,6 @@ exports[`Masthead verify full structure 1`] = `
     >
       <span
         class="pf-c-masthead__brand"
-        tabindex="0"
       >
         Logo
       </span>
@@ -167,21 +166,9 @@ exports[`MastheadBrand verify basic 1`] = `
 <DocumentFragment>
   <span
     class="pf-c-masthead__brand"
-    tabindex="0"
   >
     test
   </span>
-</DocumentFragment>
-`;
-
-exports[`MastheadBrand verify button component with onClick 1`] = `
-<DocumentFragment>
-  <button
-    class="pf-c-masthead__brand"
-    tabindex="0"
-  >
-    test
-  </button>
 </DocumentFragment>
 `;
 
@@ -189,7 +176,6 @@ exports[`MastheadBrand verify custom class 1`] = `
 <DocumentFragment>
   <span
     class="pf-c-masthead__brand custom-css"
-    tabindex="0"
   >
     test
   </span>
@@ -200,7 +186,6 @@ exports[`MastheadBrand verify custom component 1`] = `
 <DocumentFragment>
   <div
     class="pf-c-masthead__brand"
-    tabindex="0"
   >
     test
   </div>
@@ -211,7 +196,6 @@ exports[`MastheadBrand verify default component 1`] = `
 <DocumentFragment>
   <span
     class="pf-c-masthead__brand"
-    tabindex="0"
   >
     test
   </span>

--- a/packages/react-core/src/components/Page/PageHeader.tsx
+++ b/packages/react-core/src/components/Page/PageHeader.tsx
@@ -12,7 +12,7 @@ export interface PageHeaderProps extends React.HTMLProps<HTMLDivElement> {
   /** Component to render the logo/brand, use <Brand /> */
   logo?: React.ReactNode;
   /** Additional props passed to the logo anchor container */
-  logoProps?: object;
+  logoProps?: any;
   /** Component to use to wrap the passed <logo> */
   logoComponent?: React.ReactNode;
   /** Component to render the header tools, use <PageHeaderTools />  */
@@ -36,8 +36,8 @@ export interface PageHeaderProps extends React.HTMLProps<HTMLDivElement> {
 export const PageHeader: React.FunctionComponent<PageHeaderProps> = ({
   className = '',
   logo = null as React.ReactNode,
-  logoProps = null as object,
-  logoComponent = 'a',
+  logoProps = null as any,
+  logoComponent,
   headerTools = null as React.ReactNode,
   topNav = null as React.ReactNode,
   isNavOpen = true,
@@ -49,7 +49,16 @@ export const PageHeader: React.FunctionComponent<PageHeaderProps> = ({
   'aria-controls': ariaControls = null,
   ...props
 }: PageHeaderProps) => {
-  const LogoComponent = logoComponent as any;
+  let LogoComponent = logoComponent as any;
+  if (!logoComponent) {
+    if (logoProps?.href !== undefined) {
+      LogoComponent = 'a';
+    } else if (logoProps?.onClick !== undefined) {
+      LogoComponent = 'button';
+    } else {
+      LogoComponent = 'span';
+    }
+  }
   return (
     <PageContextConsumer>
       {({ isManagedSidebar, onNavToggle: managedOnNavToggle, isNavOpen: managedIsNavOpen }: PageContextProps) => {

--- a/packages/react-core/src/components/Page/PageHeader.tsx
+++ b/packages/react-core/src/components/Page/PageHeader.tsx
@@ -53,8 +53,6 @@ export const PageHeader: React.FunctionComponent<PageHeaderProps> = ({
   if (!logoComponent) {
     if (logoProps?.href !== undefined) {
       LogoComponent = 'a';
-    } else if (logoProps?.onClick !== undefined) {
-      LogoComponent = 'button';
     } else {
       LogoComponent = 'span';
     }

--- a/packages/react-core/src/components/Page/__tests__/PageHeader.test.tsx
+++ b/packages/react-core/src/components/Page/__tests__/PageHeader.test.tsx
@@ -30,16 +30,3 @@ test('Test that logoComponent with href is an anchor', () => {
   const { asFragment } = render(Header);
   expect(asFragment()).toMatchSnapshot();
 });
-
-test('Test that logoComponent with onClick is a button', () => {
-  const Header = (
-    <PageHeader
-      logo="Logo"
-      logoProps={{ onClick: () => {} }}
-      headerTools="PageHeaderTools | Avatar"
-      onNavToggle={() => undefined}
-    />
-  );
-  const { asFragment } = render(Header);
-  expect(asFragment()).toMatchSnapshot();
-});

--- a/packages/react-core/src/components/Page/__tests__/PageHeader.test.tsx
+++ b/packages/react-core/src/components/Page/__tests__/PageHeader.test.tsx
@@ -9,3 +9,37 @@ test('Check page vertical layout example against snapshot', () => {
   const { asFragment } = render(Header);
   expect(asFragment()).toMatchSnapshot();
 });
+
+test('Test that passed logoComponent overrides default', () => {
+  const Header = (
+    <PageHeader logo="Logo" logoComponent="div" headerTools="PageHeaderTools | Avatar" onNavToggle={() => undefined} />
+  );
+  const { asFragment } = render(Header);
+  expect(asFragment()).toMatchSnapshot();
+});
+
+test('Test that logoComponent with href is an anchor', () => {
+  const Header = (
+    <PageHeader
+      logo="Logo"
+      logoProps={{ href: '#' }}
+      headerTools="PageHeaderTools | Avatar"
+      onNavToggle={() => undefined}
+    />
+  );
+  const { asFragment } = render(Header);
+  expect(asFragment()).toMatchSnapshot();
+});
+
+test('Test that logoComponent with onClick is a button', () => {
+  const Header = (
+    <PageHeader
+      logo="Logo"
+      logoProps={{ onClick: () => {} }}
+      headerTools="PageHeaderTools | Avatar"
+      onNavToggle={() => undefined}
+    />
+  );
+  const { asFragment } = render(Header);
+  expect(asFragment()).toMatchSnapshot();
+});

--- a/packages/react-core/src/components/Page/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/packages/react-core/src/components/Page/__tests__/__snapshots__/Page.test.tsx.snap
@@ -13,11 +13,11 @@ exports[`Page Check dark page against snapshot 1`] = `
       <div
         class="pf-c-page__header-brand"
       >
-        <a
+        <span
           class="pf-c-page__header-brand-link"
         >
           Logo
-        </a>
+        </span>
       </div>
       PageHeaderTools | Avatar
     </header>
@@ -74,11 +74,11 @@ exports[`Page Check page horizontal layout example against snapshot 1`] = `
       <div
         class="pf-c-page__header-brand"
       >
-        <a
+        <span
           class="pf-c-page__header-brand-link"
         >
           Logo
-        </a>
+        </span>
       </div>
       <div
         class="pf-c-page__header-nav"
@@ -138,11 +138,11 @@ exports[`Page Check page to verify breadcrumb is created - PageBreadcrumb syntax
       <div
         class="pf-c-page__header-brand"
       >
-        <a
+        <span
           class="pf-c-page__header-brand-link"
         >
           Logo
-        </a>
+        </span>
       </div>
       <div
         class="pf-c-page__header-nav"
@@ -305,11 +305,11 @@ exports[`Page Check page to verify breadcrumb is created 1`] = `
       <div
         class="pf-c-page__header-brand"
       >
-        <a
+        <span
           class="pf-c-page__header-brand-link"
         >
           Logo
-        </a>
+        </span>
       </div>
       <div
         class="pf-c-page__header-nav"
@@ -472,11 +472,11 @@ exports[`Page Check page to verify grouped nav and breadcrumb - new components s
       <div
         class="pf-c-page__header-brand"
       >
-        <a
+        <span
           class="pf-c-page__header-brand-link"
         >
           Logo
-        </a>
+        </span>
       </div>
       <div
         class="pf-c-page__header-nav"
@@ -758,11 +758,11 @@ exports[`Page Check page to verify grouped nav and breadcrumb - old / props synt
       <div
         class="pf-c-page__header-brand"
       >
-        <a
+        <span
           class="pf-c-page__header-brand-link"
         >
           Logo
-        </a>
+        </span>
       </div>
       <div
         class="pf-c-page__header-nav"
@@ -1049,11 +1049,11 @@ exports[`Page Check page to verify nav is created - PageNavigation syntax 1`] = 
       <div
         class="pf-c-page__header-brand"
       >
-        <a
+        <span
           class="pf-c-page__header-brand-link"
         >
           Logo
-        </a>
+        </span>
       </div>
       <div
         class="pf-c-page__header-nav"
@@ -1235,11 +1235,11 @@ exports[`Page Check page to verify skip to content points to main content region
       <div
         class="pf-c-page__header-brand"
       >
-        <a
+        <span
           class="pf-c-page__header-brand-link"
         >
           Logo
-        </a>
+        </span>
       </div>
       <div
         class="pf-c-page__header-nav"
@@ -1403,11 +1403,11 @@ exports[`Page Check page vertical layout example against snapshot 1`] = `
       <div
         class="pf-c-page__header-brand"
       >
-        <a
+        <span
           class="pf-c-page__header-brand-link"
         >
           Logo
-        </a>
+        </span>
       </div>
       PageHeaderTools | Avatar
     </header>
@@ -1464,11 +1464,11 @@ exports[`Page Sticky bottom breadcrumb on all height breakpoints - PageBreadcrum
       <div
         class="pf-c-page__header-brand"
       >
-        <a
+        <span
           class="pf-c-page__header-brand-link"
         >
           Logo
-        </a>
+        </span>
       </div>
       <div
         class="pf-c-page__header-nav"
@@ -1631,11 +1631,11 @@ exports[`Page Verify sticky bottom breadcrumb on all height breakpoints 1`] = `
       <div
         class="pf-c-page__header-brand"
       >
-        <a
+        <span
           class="pf-c-page__header-brand-link"
         >
           Logo
-        </a>
+        </span>
       </div>
       <div
         class="pf-c-page__header-nav"
@@ -1798,11 +1798,11 @@ exports[`Page Verify sticky top breadcrumb on all height breakpoints - PageBread
       <div
         class="pf-c-page__header-brand"
       >
-        <a
+        <span
           class="pf-c-page__header-brand-link"
         >
           Logo
-        </a>
+        </span>
       </div>
       <div
         class="pf-c-page__header-nav"
@@ -1965,11 +1965,11 @@ exports[`Page Verify sticky top breadcrumb on all height breakpoints 1`] = `
       <div
         class="pf-c-page__header-brand"
       >
-        <a
+        <span
           class="pf-c-page__header-brand-link"
         >
           Logo
-        </a>
+        </span>
       </div>
       <div
         class="pf-c-page__header-nav"

--- a/packages/react-core/src/components/Page/__tests__/__snapshots__/PageHeader.test.tsx.snap
+++ b/packages/react-core/src/components/Page/__tests__/__snapshots__/PageHeader.test.tsx.snap
@@ -39,25 +39,6 @@ exports[`Test that logoComponent with href is an anchor 1`] = `
 </DocumentFragment>
 `;
 
-exports[`Test that logoComponent with onClick is a button 1`] = `
-<DocumentFragment>
-  <header
-    class="pf-c-page__header"
-  >
-    <div
-      class="pf-c-page__header-brand"
-    >
-      <button
-        class="pf-c-page__header-brand-link"
-      >
-        Logo
-      </button>
-    </div>
-    PageHeaderTools | Avatar
-  </header>
-</DocumentFragment>
-`;
-
 exports[`Test that passed logoComponent overrides default 1`] = `
 <DocumentFragment>
   <header

--- a/packages/react-core/src/components/Page/__tests__/__snapshots__/PageHeader.test.tsx.snap
+++ b/packages/react-core/src/components/Page/__tests__/__snapshots__/PageHeader.test.tsx.snap
@@ -8,11 +8,69 @@ exports[`Check page vertical layout example against snapshot 1`] = `
     <div
       class="pf-c-page__header-brand"
     >
-      <a
+      <span
         class="pf-c-page__header-brand-link"
       >
         Logo
+      </span>
+    </div>
+    PageHeaderTools | Avatar
+  </header>
+</DocumentFragment>
+`;
+
+exports[`Test that logoComponent with href is an anchor 1`] = `
+<DocumentFragment>
+  <header
+    class="pf-c-page__header"
+  >
+    <div
+      class="pf-c-page__header-brand"
+    >
+      <a
+        class="pf-c-page__header-brand-link"
+        href="#"
+      >
+        Logo
       </a>
+    </div>
+    PageHeaderTools | Avatar
+  </header>
+</DocumentFragment>
+`;
+
+exports[`Test that logoComponent with onClick is a button 1`] = `
+<DocumentFragment>
+  <header
+    class="pf-c-page__header"
+  >
+    <div
+      class="pf-c-page__header-brand"
+    >
+      <button
+        class="pf-c-page__header-brand-link"
+      >
+        Logo
+      </button>
+    </div>
+    PageHeaderTools | Avatar
+  </header>
+</DocumentFragment>
+`;
+
+exports[`Test that passed logoComponent overrides default 1`] = `
+<DocumentFragment>
+  <header
+    class="pf-c-page__header"
+  >
+    <div
+      class="pf-c-page__header-brand"
+    >
+      <div
+        class="pf-c-page__header-brand-link"
+      >
+        Logo
+      </div>
     </div>
     PageHeaderTools | Avatar
   </header>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4665

Adds logic to component type of Masthead and PageHeader. If an `href` is passed, the component type will be an anchor. If an `onClick` is passed, the type will be a button. Otherwise the type will be a span. 
