### PR TITLE
Fix type definition for `ContextSelectorItemProps`

### DIFF
--- a/packages/react-core/src/components/ContextSelector/ContextSelectorItem.tsx
+++ b/packages/react-core/src/components/ContextSelector/ContextSelectorItem.tsx
@@ -11,11 +11,11 @@ export interface ContextSelectorItemProps {
   /** Render Context  Selector item as disabled */
   isDisabled?: boolean;
   /** Callback for click event */
-  onClick: (event: React.MouseEvent) => void;
+  onClick?: (event: React.MouseEvent) => void;
   /** @hide internal index of the item */
-  index: number;
+  index?: number;
   /** Internal callback for ref tracking */
-  sendRef: (index: number, current: any) => void;
+  sendRef?: (index: number, current: any) => void;
   /** Link href, indicates item should render as anchor tag */
   href?: string;
 }


### PR DESCRIPTION
Changes the type definition of `ContextSelectorItemProps` so that the `onClick`, `index` and `sendRef` props are no longer required. Default values are [already provided ](https://github.com/jonkoops/patternfly-react/blob/280682c003d1292656d95f9d97744eed6bc596aa/packages/react-core/src/components/ContextSelector/ContextSelectorItem.tsx#L29-L31)for these props, so this type was simply wrong.