### PR TITLE
fix(Table): fix tooltips not appearing

### DIFF
--- a/packages/react-table/src/components/TableComposable/Td.tsx
+++ b/packages/react-table/src/components/TableComposable/Td.tsx
@@ -96,7 +96,7 @@ const TdBase: React.FunctionComponent<TdProps> = ({
   ...props
 }: TdProps) => {
   const [showTooltip, setShowTooltip] = React.useState(false);
-  const cellRef = innerRef || React.createRef();
+  const cellRef = innerRef ? innerRef : React.createRef();
   const onMouseEnter = (event: any) => {
     if (event.target.offsetWidth < event.target.scrollWidth) {
       !showTooltip && setShowTooltip(true);

--- a/packages/react-table/src/components/TableComposable/Td.tsx
+++ b/packages/react-table/src/components/TableComposable/Td.tsx
@@ -96,8 +96,7 @@ const TdBase: React.FunctionComponent<TdProps> = ({
   ...props
 }: TdProps) => {
   const [showTooltip, setShowTooltip] = React.useState(false);
-  const cellRef = innerRef ? innerRef : React.createRef();
-
+  const cellRef = innerRef || React.createRef();
   const onMouseEnter = (event: any) => {
     if (event.target.offsetWidth < event.target.scrollWidth) {
       !showTooltip && setShowTooltip(true);

--- a/packages/react-table/src/components/TableComposable/Th.tsx
+++ b/packages/react-table/src/components/TableComposable/Th.tsx
@@ -79,7 +79,7 @@ const ThBase: React.FunctionComponent<ThProps> = ({
   ...props
 }: ThProps) => {
   const [showTooltip, setShowTooltip] = React.useState(false);
-  const cellRef = innerRef ? innerRef : React.createRef();
+  const cellRef = innerRef || React.createRef();
   const onMouseEnter = (event: any) => {
     if (event.target.offsetWidth < event.target.scrollWidth) {
       !showTooltip && setShowTooltip(true);

--- a/packages/react-table/src/components/TableComposable/Th.tsx
+++ b/packages/react-table/src/components/TableComposable/Th.tsx
@@ -79,7 +79,7 @@ const ThBase: React.FunctionComponent<ThProps> = ({
   ...props
 }: ThProps) => {
   const [showTooltip, setShowTooltip] = React.useState(false);
-  const cellRef = innerRef || React.createRef();
+  const cellRef = innerRef ? innerRef : React.createRef();
   const onMouseEnter = (event: any) => {
     if (event.target.offsetWidth < event.target.scrollWidth) {
       !showTooltip && setShowTooltip(true);


### PR DESCRIPTION
Tooltips were not appearing for `Th` and `Td` because of the trigger wrapping div.
