### PR TITLE
fix(MenuGroup): do not set id when titleId prop isn't passed

### DIFF
--- a/packages/react-core/src/components/Menu/MenuGroup.tsx
+++ b/packages/react-core/src/components/Menu/MenuGroup.tsx
@@ -21,7 +21,7 @@ const MenuGroupBase: React.FunctionComponent<MenuGroupProps> = ({
   children,
   className = '',
   label = '',
-  titleId = '',
+  titleId,
   innerRef,
   labelHeadingLevel: HeadingLevel = 'h1',
   ...props

--- a/packages/react-integration/demo-app-ts/package.json
+++ b/packages/react-integration/demo-app-ts/package.json
@@ -9,7 +9,7 @@
     "serve:demo-app": "node scripts/serve"
   },
   "dependencies": {
-    "@patternfly/react-core": "^5.0.0-alpha.10",
+    "@patternfly/react-core": "^5.0.0-alpha.11",
     "react": "^18",
     "react-dom": "^18",
     "react-router": "^5.3.3",


### PR DESCRIPTION
remove default titleId prop value, so id is not being set everytime

closes #8162
BREAKING CHANGE

https://github.com/patternfly/patternfly-react/issues/8162

https://www.patternfly.org/v4/components/menu#titled-groups-of-items
