### PR TITLE
fix(lists): added role to list elements within components

### DIFF
--- a/packages/react-core/src/components/AlertGroup/AlertGroup.tsx
+++ b/packages/react-core/src/components/AlertGroup/AlertGroup.tsx
@@ -18,6 +18,8 @@ export interface AlertGroupProps extends Omit<React.HTMLProps<HTMLUListElement>,
   onOverflowClick?: () => void;
   /** Custom text to show for the overflow message */
   overflowMessage?: string;
+  /** Adds an accessible label to the alert group. */
+  'aria-label'?: string;
 }
 
 interface AlertGroupState {
@@ -53,7 +55,16 @@ export class AlertGroup extends React.Component<AlertGroupProps, AlertGroupState
   }
 
   render() {
-    const { className, children, isToast, isLiveRegion, onOverflowClick, overflowMessage, ...props } = this.props;
+    const {
+      className,
+      children,
+      isToast,
+      isLiveRegion,
+      onOverflowClick,
+      overflowMessage,
+      'aria-label': ariaLabel,
+      ...props
+    } = this.props;
     const alertGroup = (
       <AlertGroupInline
         onOverflowClick={onOverflowClick}
@@ -61,6 +72,7 @@ export class AlertGroup extends React.Component<AlertGroupProps, AlertGroupState
         isToast={isToast}
         isLiveRegion={isLiveRegion}
         overflowMessage={overflowMessage}
+        aria-label={ariaLabel}
         {...props}
       >
         {children}

--- a/packages/react-core/src/components/AlertGroup/AlertGroupInline.tsx
+++ b/packages/react-core/src/components/AlertGroup/AlertGroupInline.tsx
@@ -14,6 +14,7 @@ export const AlertGroupInline: React.FunctionComponent<AlertGroupProps> = ({
   ...rest
 }: AlertGroupProps) => (
   <ul
+    role="list"
     aria-live={isLiveRegion ? 'polite' : null}
     aria-atomic={isLiveRegion ? false : null}
     className={css(styles.alertGroup, className, isToast ? styles.modifiers.toast : '')}

--- a/packages/react-core/src/components/AlertGroup/__tests__/Generated/__snapshots__/AlertGroupInline.test.tsx.snap
+++ b/packages/react-core/src/components/AlertGroup/__tests__/Generated/__snapshots__/AlertGroupInline.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`AlertGroupInline should match snapshot (auto-generated) 1`] = `
 <DocumentFragment>
   <ul
     class="pf-c-alert-group"
+    role="list"
   />
 </DocumentFragment>
 `;

--- a/packages/react-core/src/components/AlertGroup/__tests__/__snapshots__/AlertGroup.test.tsx.snap
+++ b/packages/react-core/src/components/AlertGroup/__tests__/__snapshots__/AlertGroup.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`AlertGroup Alert Group renders without children 1`] = `
 <DocumentFragment>
   <ul
     class="pf-c-alert-group"
+    role="list"
   />
 </DocumentFragment>
 `;

--- a/packages/react-core/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/react-core/src/components/Breadcrumb/Breadcrumb.tsx
@@ -27,7 +27,7 @@ export const Breadcrumb: React.FunctionComponent<BreadcrumbProps> = ({
   const ouiaProps = useOUIAProps(Breadcrumb.displayName, ouiaId, ouiaSafe);
   return (
     <nav {...props} aria-label={ariaLabel} className={css(styles.breadcrumb, className)} {...ouiaProps}>
-      <ol className={styles.breadcrumbList}>
+      <ol className={styles.breadcrumbList} role="list">
         {React.Children.map(children, (child, index) => {
           const showDivider = index > 0;
           if (React.isValidElement(child)) {

--- a/packages/react-core/src/components/Breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/react-core/src/components/Breadcrumb/__tests__/__snapshots__/Breadcrumb.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`Breadcrumb component should render breadcrumb with aria-label 1`] = `
   >
     <ol
       class="pf-c-breadcrumb__list"
+      role="list"
     />
   </nav>
 </DocumentFragment>
@@ -27,6 +28,7 @@ exports[`Breadcrumb component should render breadcrumb with children 1`] = `
   >
     <ol
       class="pf-c-breadcrumb__list"
+      role="list"
     >
       <li
         class="pf-c-breadcrumb__item"
@@ -82,6 +84,7 @@ exports[`Breadcrumb component should render breadcrumb with className 1`] = `
   >
     <ol
       class="pf-c-breadcrumb__list"
+      role="list"
     />
   </nav>
 </DocumentFragment>
@@ -98,6 +101,7 @@ exports[`Breadcrumb component should render default breadcrumb 1`] = `
   >
     <ol
       class="pf-c-breadcrumb__list"
+      role="list"
     />
   </nav>
 </DocumentFragment>

--- a/packages/react-core/src/components/ContextSelector/ContextSelector.tsx
+++ b/packages/react-core/src/components/ContextSelector/ContextSelector.tsx
@@ -67,6 +67,8 @@ export interface ContextSelectorProps extends OUIAProps {
   ouiaId?: number | string;
   /** Set the value of data-ouia-safe. Only set to true when the component is in a static state, i.e. no animations are occurring. At all other times, this value must be false. */
   ouiaSafe?: boolean;
+  /** Adds an accessible label to the context selector menu. */
+  menuAriaLabel?: string;
 }
 
 export class ContextSelector extends React.Component<ContextSelectorProps, { ouiaStateId: string }> {
@@ -128,6 +130,7 @@ export class ContextSelector extends React.Component<ContextSelectorProps, { oui
       isFlipEnabled,
       id,
       zIndex,
+      menuAriaLabel,
       ...props
     } = this.props;
 
@@ -156,7 +159,9 @@ export class ContextSelector extends React.Component<ContextSelectorProps, { oui
               />
             </div>
             <ContextSelectorContext.Provider value={{ onSelect }}>
-              <ContextSelectorMenuList isOpen={isOpen}>{children}</ContextSelectorMenuList>
+              <ContextSelectorMenuList isOpen={isOpen} aria-label={menuAriaLabel}>
+                {children}
+              </ContextSelectorMenuList>
             </ContextSelectorContext.Provider>
             {footer}
           </FocusTrap>

--- a/packages/react-core/src/components/ContextSelector/ContextSelectorMenuList.tsx
+++ b/packages/react-core/src/components/ContextSelector/ContextSelectorMenuList.tsx
@@ -3,12 +3,14 @@ import styles from '@patternfly/react-styles/css/components/ContextSelector/cont
 import { css } from '@patternfly/react-styles';
 
 export interface ContextSelectorMenuListProps {
-  /** Content rendered inside the Context Selector Menu */
+  /** Content rendered inside the context selector menu */
   children?: React.ReactNode;
-  /** Classess applied to root element of Context Selector menu */
+  /** Classess applied to root element of context selector menu */
   className?: string;
-  /** Flag to indicate if Context Selector menu is opened */
+  /** Flag to indicate if context selector menu is opened */
   isOpen?: boolean;
+  /** Adds an accessible label to the context selector menu. */
+  'aria-label'?: string;
 }
 
 export class ContextSelectorMenuList extends React.Component<ContextSelectorMenuListProps> {

--- a/packages/react-core/src/components/DataList/DataList.tsx
+++ b/packages/react-core/src/components/DataList/DataList.tsx
@@ -111,6 +111,7 @@ export class DataList extends React.Component<DataListProps> {
             className
           )}
           style={props.style}
+          role="list"
           {...props}
           ref={this.ref}
         >

--- a/packages/react-core/src/components/DataList/__tests__/__snapshots__/DataList.test.tsx.snap
+++ b/packages/react-core/src/components/DataList/__tests__/__snapshots__/DataList.test.tsx.snap
@@ -36,6 +36,7 @@ exports[`DataList DataList variants Breakpoint - 2xl 1`] = `
   <ul
     aria-label="this is a simple list"
     class="pf-c-data-list pf-m-grid-2xl"
+    role="list"
   />
 </DocumentFragment>
 `;
@@ -45,6 +46,7 @@ exports[`DataList DataList variants Breakpoint - always 1`] = `
   <ul
     aria-label="this is a simple list"
     class="pf-c-data-list pf-m-grid"
+    role="list"
   />
 </DocumentFragment>
 `;
@@ -54,6 +56,7 @@ exports[`DataList DataList variants Breakpoint - lg 1`] = `
   <ul
     aria-label="this is a simple list"
     class="pf-c-data-list pf-m-grid-lg"
+    role="list"
   />
 </DocumentFragment>
 `;
@@ -63,6 +66,7 @@ exports[`DataList DataList variants Breakpoint - md 1`] = `
   <ul
     aria-label="this is a simple list"
     class="pf-c-data-list pf-m-grid-md"
+    role="list"
   />
 </DocumentFragment>
 `;
@@ -72,6 +76,7 @@ exports[`DataList DataList variants Breakpoint - none 1`] = `
   <ul
     aria-label="this is a simple list"
     class="pf-c-data-list pf-m-grid-none"
+    role="list"
   />
 </DocumentFragment>
 `;
@@ -81,6 +86,7 @@ exports[`DataList DataList variants Breakpoint - sm 1`] = `
   <ul
     aria-label="this is a simple list"
     class="pf-c-data-list pf-m-grid-sm"
+    role="list"
   />
 </DocumentFragment>
 `;
@@ -90,6 +96,7 @@ exports[`DataList DataList variants Breakpoint - xl 1`] = `
   <ul
     aria-label="this is a simple list"
     class="pf-c-data-list pf-m-grid-xl"
+    role="list"
   />
 </DocumentFragment>
 `;
@@ -214,6 +221,7 @@ exports[`DataList List 1`] = `
   <ul
     aria-label="this is a simple list"
     class="pf-c-data-list pf-m-grid-md data-list-custom"
+    role="list"
   />
 </DocumentFragment>
 `;
@@ -223,6 +231,7 @@ exports[`DataList List compact 1`] = `
   <ul
     aria-label="this is a simple list"
     class="pf-c-data-list pf-m-compact pf-m-grid-md"
+    role="list"
   />
 </DocumentFragment>
 `;
@@ -232,6 +241,7 @@ exports[`DataList List default 1`] = `
   <ul
     aria-label="this is a simple list"
     class="pf-c-data-list pf-m-grid-md"
+    role="list"
   />
 </DocumentFragment>
 `;
@@ -241,6 +251,7 @@ exports[`DataList List draggable 1`] = `
   <ul
     aria-label="this is a simple list"
     class="pf-c-data-list pf-m-compact pf-m-grid-md"
+    role="list"
   />
 </DocumentFragment>
 `;

--- a/packages/react-core/src/components/Divider/examples/DividerUsingLi.tsx
+++ b/packages/react-core/src/components/Divider/examples/DividerUsingLi.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Divider } from '@patternfly/react-core';
 
 export const DividerUsingLi: React.FunctionComponent = () => (
-  <ul>
+  <ul role="list">
     <li>List item one</li>
     <Divider component="li" />
     <li>List item two</li>

--- a/packages/react-core/src/components/HelperText/HelperText.tsx
+++ b/packages/react-core/src/components/HelperText/HelperText.tsx
@@ -18,6 +18,8 @@ export interface HelperTextProps extends React.HTMLProps<HTMLDivElement | HTMLUL
    * expect or intend for any helper text items within the container to be dynamically updated.
    */
   isLiveRegion?: boolean;
+  /** Adds an accessible label to the helper text when component is a "ul". */
+  'aria-label'?: string;
 }
 
 export const HelperText: React.FunctionComponent<HelperTextProps> = ({
@@ -26,6 +28,7 @@ export const HelperText: React.FunctionComponent<HelperTextProps> = ({
   component = 'div',
   id,
   isLiveRegion = false,
+  'aria-label': ariaLabel,
   ...props
 }: HelperTextProps) => {
   const Component = component as any;
@@ -34,6 +37,7 @@ export const HelperText: React.FunctionComponent<HelperTextProps> = ({
       id={id}
       className={css(styles.helperText, className)}
       {...(isLiveRegion && { 'aria-live': 'polite' })}
+      {...(component === 'ul' && { role: 'list', 'aria-label': ariaLabel })}
       {...props}
     >
       {children}

--- a/packages/react-core/src/components/HelperText/__tests__/__snapshots__/HelperText.test.tsx.snap
+++ b/packages/react-core/src/components/HelperText/__tests__/__snapshots__/HelperText.test.tsx.snap
@@ -191,6 +191,7 @@ exports[`HelperText variant comonent helper text renders properly 1`] = `
 <DocumentFragment>
   <ul
     class="pf-c-helper-text"
+    role="list"
   >
     <li
       class="pf-c-helper-text__item"

--- a/packages/react-core/src/components/JumpLinks/JumpLinks.tsx
+++ b/packages/react-core/src/components/JumpLinks/JumpLinks.tsx
@@ -19,7 +19,7 @@ export interface JumpLinksProps extends Omit<React.HTMLProps<HTMLElement>, 'labe
   label?: React.ReactNode;
   /** Flag to always show the label when using `expandable` */
   alwaysShowLabel?: boolean;
-  /** Aria-label to add to nav element. Defaults to label. */
+  /** Adds an accessible label to the internal nav element. Defaults to the value of the label prop. */
   'aria-label'?: string;
   /** Selector for the scrollable element to spy on. Not passing a selector disables spying. */
   scrollableSelector?: string;

--- a/packages/react-core/src/components/JumpLinks/JumpLinks.tsx
+++ b/packages/react-core/src/components/JumpLinks/JumpLinks.tsx
@@ -72,12 +72,7 @@ const getScrollItems = (children: React.ReactNode, res: HTMLElement[]) => {
 
 function isResponsive(jumpLinks: HTMLElement) {
   // https://github.com/patternfly/patternfly/blob/main/src/patternfly/components/JumpLinks/jump-links.scss#L103
-  return (
-    jumpLinks &&
-    getComputedStyle(jumpLinks)
-      .getPropertyValue(cssToggleDisplayVar.name)
-      .includes('block')
-  );
+  return jumpLinks && getComputedStyle(jumpLinks).getPropertyValue(cssToggleDisplayVar.name).includes('block');
 }
 
 export const JumpLinks: React.FunctionComponent<JumpLinksProps> = ({
@@ -245,7 +240,9 @@ export const JumpLinks: React.FunctionComponent<JumpLinksProps> = ({
           )}
           {label && alwaysShowLabel && <div className={css(styles.jumpLinksLabel)}>{label}</div>}
         </div>
-        <ul className={styles.jumpLinksList}>{cloneChildren(children)}</ul>
+        <ul className={styles.jumpLinksList} role="list">
+          {cloneChildren(children)}
+        </ul>
       </div>
     </nav>
   );

--- a/packages/react-core/src/components/JumpLinks/JumpLinksList.tsx
+++ b/packages/react-core/src/components/JumpLinks/JumpLinksList.tsx
@@ -14,7 +14,7 @@ export const JumpLinksList: React.FunctionComponent<JumpLinksListProps> = ({
   className,
   ...props
 }: JumpLinksListProps) => (
-  <ul className={css(styles.jumpLinksList, className)} {...props}>
+  <ul className={css(styles.jumpLinksList, className)} role="list" {...props}>
     {children}
   </ul>
 );

--- a/packages/react-core/src/components/JumpLinks/__tests__/__snapshots__/JumpLinks.test.tsx.snap
+++ b/packages/react-core/src/components/JumpLinks/__tests__/__snapshots__/JumpLinks.test.tsx.snap
@@ -57,6 +57,7 @@ exports[`expandable vertical with subsection 1`] = `
       </div>
       <ul
         class="pf-c-jump-links__list"
+        role="list"
       >
         <li
           class="pf-c-jump-links__item"
@@ -85,6 +86,7 @@ exports[`expandable vertical with subsection 1`] = `
           </a>
           <ul
             class="pf-c-jump-links__list"
+            role="list"
           >
             <li
               aria-current="location"
@@ -173,6 +175,7 @@ exports[`jumplinks centered 1`] = `
       />
       <ul
         class="pf-c-jump-links__list"
+        role="list"
       >
         <li
           class="pf-c-jump-links__item"
@@ -240,6 +243,7 @@ exports[`jumplinks with label 1`] = `
       </div>
       <ul
         class="pf-c-jump-links__list"
+        role="list"
       >
         <li
           class="pf-c-jump-links__item"
@@ -300,6 +304,7 @@ exports[`simple jumplinks 1`] = `
       />
       <ul
         class="pf-c-jump-links__list"
+        role="list"
       >
         <li
           class="pf-c-jump-links__item"
@@ -367,6 +372,7 @@ exports[`vertical with label 1`] = `
       </div>
       <ul
         class="pf-c-jump-links__list"
+        role="list"
       >
         <li
           class="pf-c-jump-links__item"

--- a/packages/react-core/src/components/List/List.tsx
+++ b/packages/react-core/src/components/List/List.tsx
@@ -32,9 +32,12 @@ export interface ListProps extends Omit<React.HTMLProps<HTMLUListElement | HTMLO
   isPlain?: boolean;
   /** Modifies the size of the icons in the list */
   iconSize?: 'default' | 'large';
-  /** Sets the way items are numbered if variant is set to ordered */
+  /** Sets the way items are numbered if component is set to "ol". */
   type?: OrderType;
+  /** Sets the type of the list component. */
   component?: 'ol' | 'ul';
+  /** Adds an accessible label to the list. */
+  'aria-label'?: string;
 }
 
 export const List: React.FunctionComponent<ListProps> = ({
@@ -47,12 +50,15 @@ export const List: React.FunctionComponent<ListProps> = ({
   type = OrderType.number,
   ref = null,
   component = ListComponent.ul,
+  'aria-label': ariaLabel,
   ...props
 }: ListProps) =>
   component === ListComponent.ol ? (
     <ol
       ref={ref as React.LegacyRef<HTMLOListElement>}
       type={type}
+      {...(isPlain && { role: 'list' })}
+      aria-label={ariaLabel}
       {...props}
       className={css(
         styles.list,
@@ -68,6 +74,8 @@ export const List: React.FunctionComponent<ListProps> = ({
   ) : (
     <ul
       ref={ref as React.LegacyRef<HTMLUListElement>}
+      {...(isPlain && { role: 'list' })}
+      {...(ariaLabel && { 'aria-label': ariaLabel })}
       {...props}
       className={css(
         styles.list,

--- a/packages/react-core/src/components/List/List.tsx
+++ b/packages/react-core/src/components/List/List.tsx
@@ -50,7 +50,6 @@ export const List: React.FunctionComponent<ListProps> = ({
   type = OrderType.number,
   ref = null,
   component = ListComponent.ul,
-  'aria-label': ariaLabel,
   ...props
 }: ListProps) =>
   component === ListComponent.ol ? (
@@ -58,7 +57,6 @@ export const List: React.FunctionComponent<ListProps> = ({
       ref={ref as React.LegacyRef<HTMLOListElement>}
       type={type}
       {...(isPlain && { role: 'list' })}
-      aria-label={ariaLabel}
       {...props}
       className={css(
         styles.list,
@@ -75,7 +73,6 @@ export const List: React.FunctionComponent<ListProps> = ({
     <ul
       ref={ref as React.LegacyRef<HTMLUListElement>}
       {...(isPlain && { role: 'list' })}
-      {...(ariaLabel && { 'aria-label': ariaLabel })}
       {...props}
       className={css(
         styles.list,

--- a/packages/react-core/src/components/List/__tests__/__snapshots__/List.test.tsx.snap
+++ b/packages/react-core/src/components/List/__tests__/__snapshots__/List.test.tsx.snap
@@ -79,6 +79,7 @@ exports[`List icon list 1`] = `
 <DocumentFragment>
   <ul
     class="pf-c-list pf-m-plain"
+    role="list"
   >
     <li
       class="pf-c-list__item"

--- a/packages/react-core/src/components/LoginPage/LoginMainFooter.tsx
+++ b/packages/react-core/src/components/LoginPage/LoginMainFooter.tsx
@@ -7,8 +7,10 @@ export interface LoginMainFooterProps extends React.HTMLProps<HTMLDivElement> {
   className?: string;
   /** Content rendered inside the login main footer */
   children?: React.ReactNode;
-  /** Content rendered inside the login main footer as social media links* */
+  /** Content rendered inside the login main footer as social media links */
   socialMediaLoginContent?: React.ReactNode;
+  /** Adds an accessible name to the social media login list. */
+  socialMediaLoginAriaLabel?: string;
   /** Content rendered inside of login main footer band to display a sign up for account message */
   signUpForAccountMessage?: React.ReactNode;
   /** Content rendered inside of login main footer band do display a forgot credentials link* */
@@ -21,11 +23,16 @@ export const LoginMainFooter: React.FunctionComponent<LoginMainFooterProps> = ({
   signUpForAccountMessage = null,
   forgotCredentials = null,
   className = '',
+  socialMediaLoginAriaLabel,
   ...props
 }: LoginMainFooterProps) => (
   <div className={css(styles.loginMainFooter, className)} {...props}>
     {children}
-    {socialMediaLoginContent && <ul className={css(styles.loginMainFooterLinks)}>{socialMediaLoginContent}</ul>}
+    {socialMediaLoginContent && (
+      <ul className={css(styles.loginMainFooterLinks)} aria-label={socialMediaLoginAriaLabel} role="list">
+        {socialMediaLoginContent}
+      </ul>
+    )}
     {(signUpForAccountMessage || forgotCredentials) && (
       <div className={css(styles.loginMainFooterBand)}>
         {signUpForAccountMessage}

--- a/packages/react-core/src/components/LoginPage/LoginPage.tsx
+++ b/packages/react-core/src/components/LoginPage/LoginPage.tsx
@@ -43,6 +43,8 @@ export interface LoginPageProps extends React.HTMLProps<HTMLDivElement> {
   forgotCredentials?: React.ReactNode;
   /** Content rendered inside of social media login footer section */
   socialMediaLoginContent?: React.ReactNode;
+  /** Adds an accessible name to the social media login list. */
+  socialMediaLoginAriaLabel?: string;
 }
 
 export const LoginPage: React.FunctionComponent<LoginPageProps> = ({
@@ -61,6 +63,7 @@ export const LoginPage: React.FunctionComponent<LoginPageProps> = ({
   signUpForAccountMessage = null,
   forgotCredentials = null,
   socialMediaLoginContent = null,
+  socialMediaLoginAriaLabel,
   ...props
 }: LoginPageProps) => {
   const HeaderBrand = (
@@ -85,6 +88,7 @@ export const LoginPage: React.FunctionComponent<LoginPageProps> = ({
         {(socialMediaLoginContent || forgotCredentials || signUpForAccountMessage) && (
           <LoginMainFooter
             socialMediaLoginContent={socialMediaLoginContent}
+            socialMediaLoginAriaLabel={socialMediaLoginAriaLabel}
             forgotCredentials={forgotCredentials}
             signUpForAccountMessage={signUpForAccountMessage}
           />

--- a/packages/react-core/src/components/LoginPage/__tests__/__snapshots__/LoginPage.test.tsx.snap
+++ b/packages/react-core/src/components/LoginPage/__tests__/__snapshots__/LoginPage.test.tsx.snap
@@ -82,6 +82,7 @@ exports[`check loginpage example against snapshot 1`] = `
         >
           <ul
             class="pf-c-login__main-footer-links"
+            role="list"
           >
             Footer
           </ul>

--- a/packages/react-core/src/components/LoginPage/examples/LoginPageBasic.tsx
+++ b/packages/react-core/src/components/LoginPage/examples/LoginPageBasic.tsx
@@ -134,6 +134,7 @@ export const SimpleLoginPage: React.FunctionComponent = () => {
       loginTitle="Log in to your account"
       loginSubtitle="Enter your single sign-on LDAP credentials."
       socialMediaLoginContent={socialMediaLoginContent}
+      socialMediaLoginAriaLabel="Log in with social media"
       signUpForAccountMessage={signUpForAccountMessage}
       forgotCredentials={forgotCredentials}
     >

--- a/packages/react-core/src/components/LoginPage/examples/LoginPageLanguageSelect.tsx
+++ b/packages/react-core/src/components/LoginPage/examples/LoginPageLanguageSelect.tsx
@@ -185,6 +185,7 @@ export const LoginPageLanguageSelect: React.FunctionComponent = () => {
       loginSubtitle="Enter your single sign-on LDAP credentials."
       headerUtilities={headerUtils}
       socialMediaLoginContent={socialMediaLoginContent}
+      socialMediaLoginAriaLabel="Log in with social media"
       signUpForAccountMessage={signUpForAccountMessage}
       forgotCredentials={forgotCredentials}
     >

--- a/packages/react-core/src/components/LoginPage/examples/LoginPageShowHidePassword.tsx
+++ b/packages/react-core/src/components/LoginPage/examples/LoginPageShowHidePassword.tsx
@@ -135,6 +135,7 @@ export const LoginPageHideShowPassword: React.FunctionComponent = () => {
       loginTitle="Log in to your account"
       loginSubtitle="Enter your single sign-on LDAP credentials."
       socialMediaLoginContent={socialMediaLoginContent}
+      socialMediaLoginAriaLabel="Log in with social media"
       signUpForAccountMessage={signUpForAccountMessage}
       forgotCredentials={forgotCredentials}
     >

--- a/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadStatus.tsx
+++ b/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadStatus.tsx
@@ -21,6 +21,8 @@ export interface MultipleFileUploadStatusProps extends React.HTMLProps<HTMLDivEl
   statusToggleText?: string;
   /** Icon to show in the status toggle */
   statusToggleIcon?: 'danger' | 'success' | 'inProgress' | React.ReactNode;
+  /** Adds an accessible label to the list of status items. */
+  'aria-label'?: string;
 }
 
 export const MultipleFileUploadStatus: React.FunctionComponent<MultipleFileUploadStatusProps> = ({
@@ -28,6 +30,7 @@ export const MultipleFileUploadStatus: React.FunctionComponent<MultipleFileUploa
   className,
   statusToggleText,
   statusToggleIcon,
+  'aria-label': ariaLabel,
   ...props
 }: MultipleFileUploadStatusProps) => {
   const [icon, setIcon] = React.useState<React.ReactNode>();
@@ -63,7 +66,9 @@ export const MultipleFileUploadStatus: React.FunctionComponent<MultipleFileUploa
   return (
     <div className={css(styles.multipleFileUploadStatus, className)} {...props}>
       <ExpandableSection toggleContent={toggle} isExpanded={isOpen} onToggle={toggleExpandableSection}>
-        <ul className="pf-c-multiple-file-upload__status-list">{children}</ul>
+        <ul className="pf-c-multiple-file-upload__status-list" role="list" aria-label={ariaLabel}>
+          {children}
+        </ul>
       </ExpandableSection>
     </div>
   );

--- a/packages/react-core/src/components/MultipleFileUpload/__tests__/__snapshots__/MultipleFileUploadStatus.test.tsx.snap
+++ b/packages/react-core/src/components/MultipleFileUpload/__tests__/__snapshots__/MultipleFileUploadStatus.test.tsx.snap
@@ -51,6 +51,7 @@ exports[`MultipleFileUploadStatus renders custom class names 1`] = `
       >
         <ul
           class="pf-c-multiple-file-upload__status-list"
+          role="list"
         >
           Foo
         </ul>
@@ -125,6 +126,7 @@ exports[`MultipleFileUploadStatus renders status toggle icon 1`] = `
       >
         <ul
           class="pf-c-multiple-file-upload__status-list"
+          role="list"
         >
           Foo
         </ul>
@@ -187,6 +189,7 @@ exports[`MultipleFileUploadStatus renders status toggle text 1`] = `
       >
         <ul
           class="pf-c-multiple-file-upload__status-list"
+          role="list"
         >
           Foo
         </ul>
@@ -247,6 +250,7 @@ exports[`MultipleFileUploadStatus renders with expected class names 1`] = `
       >
         <ul
           class="pf-c-multiple-file-upload__status-list"
+          role="list"
         >
           Foo
         </ul>

--- a/packages/react-core/src/components/MultipleFileUpload/examples/MultipleFileUploadBasic.tsx
+++ b/packages/react-core/src/components/MultipleFileUpload/examples/MultipleFileUploadBasic.tsx
@@ -34,7 +34,7 @@ export const MultipleFileUploadBasic: React.FunctionComponent = () => {
   React.useEffect(() => {
     if (readFileData.length < currentFiles.length) {
       setStatusIcon('inProgress');
-    } else if (readFileData.every(file => file.loadResult === 'success')) {
+    } else if (readFileData.every((file) => file.loadResult === 'success')) {
       setStatusIcon('success');
     } else {
       setStatusIcon('danger');
@@ -44,13 +44,13 @@ export const MultipleFileUploadBasic: React.FunctionComponent = () => {
   // remove files from both state arrays based on their name
   const removeFiles = (namesOfFilesToRemove: string[]) => {
     const newCurrentFiles = currentFiles.filter(
-      currentFile => !namesOfFilesToRemove.some(fileName => fileName === currentFile.name)
+      (currentFile) => !namesOfFilesToRemove.some((fileName) => fileName === currentFile.name)
     );
 
     setCurrentFiles(newCurrentFiles);
 
     const newReadFiles = readFileData.filter(
-      readFile => !namesOfFilesToRemove.some(fileName => fileName === readFile.fileName)
+      (readFile) => !namesOfFilesToRemove.some((fileName) => fileName === readFile.fileName)
     );
 
     setReadFileData(newReadFiles);
@@ -60,34 +60,34 @@ export const MultipleFileUploadBasic: React.FunctionComponent = () => {
    * only used in this example for demonstration purposes */
   const updateCurrentFiles = (files: File[]) => {
     if (fileUploadShouldFail) {
-      const corruptedFiles = files.map(file => ({ ...file, lastModified: ('foo' as unknown) as number }));
-      setCurrentFiles(prevFiles => [...prevFiles, ...corruptedFiles]);
+      const corruptedFiles = files.map((file) => ({ ...file, lastModified: 'foo' as unknown as number }));
+      setCurrentFiles((prevFiles) => [...prevFiles, ...corruptedFiles]);
     } else {
-      setCurrentFiles(prevFiles => [...prevFiles, ...files]);
+      setCurrentFiles((prevFiles) => [...prevFiles, ...files]);
     }
   };
 
   // callback that will be called by the react dropzone with the newly dropped file objects
   const handleFileDrop = (droppedFiles: File[]) => {
     // identify what, if any, files are re-uploads of already uploaded files
-    const currentFileNames = currentFiles.map(file => file.name);
-    const reUploads = droppedFiles.filter(droppedFile => currentFileNames.includes(droppedFile.name));
+    const currentFileNames = currentFiles.map((file) => file.name);
+    const reUploads = droppedFiles.filter((droppedFile) => currentFileNames.includes(droppedFile.name));
 
     /** this promise chain is needed because if the file removal is done at the same time as the file adding react
      * won't realize that the status items for the re-uploaded files needs to be re-rendered */
     Promise.resolve()
-      .then(() => removeFiles(reUploads.map(file => file.name)))
+      .then(() => removeFiles(reUploads.map((file) => file.name)))
       .then(() => updateCurrentFiles(droppedFiles));
   };
 
   // callback called by the status item when a file is successfully read with the built-in file reader
   const handleReadSuccess = (data: string, file: File) => {
-    setReadFileData(prevReadFiles => [...prevReadFiles, { data, fileName: file.name, loadResult: 'success' }]);
+    setReadFileData((prevReadFiles) => [...prevReadFiles, { data, fileName: file.name, loadResult: 'success' }]);
   };
 
   // callback called by the status item when a file encounters an error while being read with the built-in file reader
   const handleReadFail = (error: DOMException, file: File) => {
-    setReadFileData(prevReadFiles => [
+    setReadFileData((prevReadFiles) => [
       ...prevReadFiles,
       { loadError: error, fileName: file.name, loadResult: 'danger' }
     ]);
@@ -95,7 +95,7 @@ export const MultipleFileUploadBasic: React.FunctionComponent = () => {
 
   // add helper text to a status item showing any error encountered during the file reading process
   const createHelperText = (file: File) => {
-    const fileResult = readFileData.find(readFile => readFile.fileName === file.name);
+    const fileResult = readFileData.find((readFile) => readFile.fileName === file.name);
     if (fileResult?.loadError) {
       return (
         <HelperText isLiveRegion>
@@ -105,7 +105,7 @@ export const MultipleFileUploadBasic: React.FunctionComponent = () => {
     }
   };
 
-  const successfullyReadFileCount = readFileData.filter(fileData => fileData.loadResult === 'success').length;
+  const successfullyReadFileCount = readFileData.filter((fileData) => fileData.loadResult === 'success').length;
 
   return (
     <>
@@ -131,8 +131,9 @@ export const MultipleFileUploadBasic: React.FunctionComponent = () => {
           <MultipleFileUploadStatus
             statusToggleText={`${successfullyReadFileCount} of ${currentFiles.length} files uploaded`}
             statusToggleIcon={statusIcon}
+            aria-label="Current uploads"
           >
-            {currentFiles.map(file => (
+            {currentFiles.map((file) => (
               <MultipleFileUploadStatusItem
                 file={file}
                 key={file.name}

--- a/packages/react-core/src/components/Nav/NavExpandable.tsx
+++ b/packages/react-core/src/components/Nav/NavExpandable.tsx
@@ -82,7 +82,7 @@ export class NavExpandable extends React.Component<NavExpandableProps, NavExpand
     if (this.props.onExpand) {
       this.props.onExpand(e, !expandedState);
     } else {
-      this.setState(prevState => ({ expandedState: !prevState.expandedState }));
+      this.setState((prevState) => ({ expandedState: !prevState.expandedState }));
       const { groupId } = this.props;
       onToggle(e, groupId, !expandedState);
     }
@@ -112,7 +112,7 @@ export class NavExpandable extends React.Component<NavExpandableProps, NavExpand
 
     return (
       <NavContext.Consumer>
-        {context => (
+        {(context) => (
           <li
             className={css(
               styles.navItem,
@@ -129,7 +129,7 @@ export class NavExpandable extends React.Component<NavExpandableProps, NavExpand
                 <button
                   className={styles.navLink}
                   id={srText ? null : this.id}
-                  onClick={e => this.onExpand(e, context.onToggle)}
+                  onClick={(e) => this.onExpand(e, context.onToggle)}
                   aria-expanded={expandedState}
                   tabIndex={isNavOpen ? null : -1}
                   {...buttonProps}
@@ -149,7 +149,9 @@ export class NavExpandable extends React.Component<NavExpandableProps, NavExpand
                   {srText}
                 </h2>
               )}
-              <ul className={css(styles.navList)}>{children}</ul>
+              <ul className={css(styles.navList)} role="list">
+                {children}
+              </ul>
             </section>
           </li>
         )}

--- a/packages/react-core/src/components/Nav/NavGroup.tsx
+++ b/packages/react-core/src/components/Nav/NavGroup.tsx
@@ -35,7 +35,9 @@ export const NavGroup: React.FunctionComponent<NavGroupProps> = ({
           {title}
         </h2>
       )}
-      <ul className={css(styles.navList, className)}>{children}</ul>
+      <ul className={css(styles.navList, className)} role="list">
+        {children}
+      </ul>
     </section>
   );
 };

--- a/packages/react-core/src/components/Nav/NavList.tsx
+++ b/packages/react-core/src/components/Nav/NavList.tsx
@@ -125,6 +125,7 @@ export class NavList extends React.Component<NavListProps> {
                   ref={this.navList}
                   className={css(styles.navList, className)}
                   onScroll={this.handleScrollButtons}
+                  role="list"
                   {...props}
                 >
                   {children}

--- a/packages/react-core/src/components/Nav/__tests__/Generated/__snapshots__/NavExpandable.test.tsx.snap
+++ b/packages/react-core/src/components/Nav/__tests__/Generated/__snapshots__/NavExpandable.test.tsx.snap
@@ -48,6 +48,7 @@ exports[`NavExpandable should match snapshot (auto-generated) 1`] = `
       </h2>
       <ul
         class="pf-c-nav__list"
+        role="list"
       />
     </section>
   </li>

--- a/packages/react-core/src/components/Nav/__tests__/Generated/__snapshots__/NavGroup.test.tsx.snap
+++ b/packages/react-core/src/components/Nav/__tests__/Generated/__snapshots__/NavGroup.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`NavGroup should match snapshot (auto-generated) 1`] = `
     </h2>
     <ul
       class="pf-c-nav__list ''"
+      role="list"
     >
       ReactNode
     </ul>

--- a/packages/react-core/src/components/Nav/__tests__/Generated/__snapshots__/NavList.test.tsx.snap
+++ b/packages/react-core/src/components/Nav/__tests__/Generated/__snapshots__/NavList.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`NavList should match snapshot 1`] = `
 <DocumentFragment>
   <ul
     class="pf-c-nav__list"
+    role="list"
   >
     ReactNode
   </ul>

--- a/packages/react-core/src/components/Nav/__tests__/__snapshots__/Nav.test.tsx.snap
+++ b/packages/react-core/src/components/Nav/__tests__/__snapshots__/Nav.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`Nav Dark Nav List 1`] = `
   >
     <ul
       class="pf-c-nav__list test-nav-list-class"
+      role="list"
     >
       <li
         class="pf-c-nav__item test-nav-item-class"
@@ -80,6 +81,7 @@ exports[`Nav Default Nav List - Trigger item active update 1`] = `
   >
     <ul
       class="pf-c-nav__list"
+      role="list"
     >
       <li
         class="pf-c-nav__item"
@@ -149,6 +151,7 @@ exports[`Nav Default Nav List 1`] = `
   >
     <ul
       class="pf-c-nav__list test-nav-list-class"
+      role="list"
     >
       <li
         class="pf-c-nav__item test-nav-item-class"
@@ -218,6 +221,7 @@ exports[`Nav Expandable Nav List - Trigger toggle 1`] = `
   >
     <ul
       class="pf-c-nav__list"
+      role="list"
     >
       <li
         class="pf-c-nav__item pf-m-expandable expandable-group"
@@ -260,6 +264,7 @@ exports[`Nav Expandable Nav List - Trigger toggle 1`] = `
         >
           <ul
             class="pf-c-nav__list"
+            role="list"
           >
             <li
               class="pf-c-nav__item"
@@ -332,6 +337,7 @@ exports[`Nav Expandable Nav List 1`] = `
   >
     <ul
       class="pf-c-nav__list"
+      role="list"
     >
       <li
         class="pf-c-nav__item pf-m-expandable"
@@ -374,6 +380,7 @@ exports[`Nav Expandable Nav List 1`] = `
         >
           <ul
             class="pf-c-nav__list"
+            role="list"
           >
             <li
               class="pf-c-nav__item"
@@ -446,6 +453,7 @@ exports[`Nav Expandable Nav List with aria label 1`] = `
   >
     <ul
       class="pf-c-nav__list"
+      role="list"
     >
       <li
         class="pf-c-nav__item pf-m-expandable"
@@ -493,6 +501,7 @@ exports[`Nav Expandable Nav List with aria label 1`] = `
           </h2>
           <ul
             class="pf-c-nav__list"
+            role="list"
           >
             <li
               class="pf-c-nav__item"
@@ -584,6 +593,7 @@ exports[`Nav Horizontal Nav List 1`] = `
     </button>
     <ul
       class="pf-c-nav__list"
+      role="list"
     >
       <li
         class="pf-c-nav__item"
@@ -691,6 +701,7 @@ exports[`Nav Horizontal SubNav List 1`] = `
     </button>
     <ul
       class="pf-c-nav__list"
+      role="list"
     >
       <li
         class="pf-c-nav__item"
@@ -789,9 +800,11 @@ exports[`Nav Nav Grouped List 1`] = `
       </h2>
       <ul
         class="pf-c-nav__list"
+        role="list"
       >
         <ul
           class="pf-c-nav__list"
+          role="list"
         >
           <li
             class="pf-c-nav__item"
@@ -860,9 +873,11 @@ exports[`Nav Nav Grouped List 1`] = `
       </h2>
       <ul
         class="pf-c-nav__list"
+        role="list"
       >
         <ul
           class="pf-c-nav__list"
+          role="list"
         >
           <li
             class="pf-c-nav__item"
@@ -953,6 +968,7 @@ exports[`Nav Nav List with custom item nodes 1`] = `
     </button>
     <ul
       class="pf-c-nav__list"
+      role="list"
     >
       <li
         class="pf-c-nav__item test-nav-item-class"
@@ -1020,6 +1036,7 @@ exports[`Nav Nav List with flyout 1`] = `
     </button>
     <ul
       class="pf-c-nav__list"
+      role="list"
     >
       <li
         class="pf-c-nav__item pf-m-flyout test-nav-item-class"
@@ -1100,6 +1117,7 @@ exports[`Nav Renders nav list in strict mode 1`] = `
   >
     <ul
       class="pf-c-nav__list test-nav-list-class"
+      role="list"
     >
       <li
         class="pf-c-nav__item test-nav-item-class"
@@ -1188,6 +1206,7 @@ exports[`Nav Tertiary Nav List 1`] = `
     </button>
     <ul
       class="pf-c-nav__list"
+      role="list"
     >
       <li
         class="pf-c-nav__item"

--- a/packages/react-core/src/components/NotificationDrawer/NotificationDrawerList.tsx
+++ b/packages/react-core/src/components/NotificationDrawer/NotificationDrawerList.tsx
@@ -9,15 +9,24 @@ export interface NotificationDrawerListProps extends React.HTMLProps<HTMLUListEl
   className?: string;
   /**  Adds styling to the notification drawer list to indicate expand/hide state */
   isHidden?: boolean;
+  /** Adds an accessible label to the notification drawer list. */
+  'aria-label'?: string;
 }
 
 export const NotificationDrawerList: React.FunctionComponent<NotificationDrawerListProps> = ({
   children,
   className = '',
   isHidden = false,
+  'aria-label': ariaLabel,
   ...props
 }: NotificationDrawerListProps) => (
-  <ul {...props} className={css('pf-c-notification-drawer__list', className)} hidden={isHidden}>
+  <ul
+    {...props}
+    className={css('pf-c-notification-drawer__list', className)}
+    hidden={isHidden}
+    role="list"
+    aria-label={ariaLabel}
+  >
     {children}
   </ul>
 );

--- a/packages/react-core/src/components/NotificationDrawer/__tests__/__snapshots__/NotificationDrawerList.test.tsx.snap
+++ b/packages/react-core/src/components/NotificationDrawer/__tests__/__snapshots__/NotificationDrawerList.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`NotificationDrawerList drawer list with hidden applied  1`] = `
   <ul
     class="pf-c-notification-drawer__list"
     hidden=""
+    role="list"
   />
 </DocumentFragment>
 `;
@@ -13,6 +14,7 @@ exports[`NotificationDrawerList renders with PatternFly Core styles 1`] = `
 <DocumentFragment>
   <ul
     class="pf-c-notification-drawer__list"
+    role="list"
   />
 </DocumentFragment>
 `;

--- a/packages/react-core/src/components/NotificationDrawer/examples/NotificationDrawerBasic.tsx
+++ b/packages/react-core/src/components/NotificationDrawer/examples/NotificationDrawerBasic.tsx
@@ -57,7 +57,7 @@ export const NotificationDrawerBasic: React.FunctionComponent = () => {
         />
       </NotificationDrawerHeader>
       <NotificationDrawerBody>
-        <NotificationDrawerList>
+        <NotificationDrawerList aria-label="Notifications in the basic example">
           <NotificationDrawerListItem variant="info">
             <NotificationDrawerListItemHeader
               variant="info"

--- a/packages/react-core/src/components/NotificationDrawer/examples/NotificationDrawerGroups.tsx
+++ b/packages/react-core/src/components/NotificationDrawer/examples/NotificationDrawerGroups.tsx
@@ -94,7 +94,7 @@ export const NotificationDrawerGroups: React.FunctionComponent = () => {
             count={2}
             onExpand={toggleFirstDrawer}
           >
-            <NotificationDrawerList isHidden={!firstGroupExpanded}>
+            <NotificationDrawerList isHidden={!firstGroupExpanded} aria-label="Notifications in the first group">
               <NotificationDrawerListItem variant="info">
                 <NotificationDrawerListItemHeader
                   variant="info"
@@ -205,7 +205,7 @@ export const NotificationDrawerGroups: React.FunctionComponent = () => {
             count={2}
             onExpand={toggleSecondDrawer}
           >
-            <NotificationDrawerList isHidden={!secondGroupExpanded}>
+            <NotificationDrawerList isHidden={!secondGroupExpanded} aria-label="Notifications in the second group">
               <NotificationDrawerListItem variant="info">
                 <NotificationDrawerListItemHeader
                   variant="info"
@@ -317,7 +317,7 @@ export const NotificationDrawerGroups: React.FunctionComponent = () => {
             onExpand={toggleThirdDrawer}
             truncateTitle={1}
           >
-            <NotificationDrawerList isHidden={!thirdGroupExpanded}>
+            <NotificationDrawerList isHidden={!thirdGroupExpanded} aria-label="Notifications in the third group">
               <EmptyState variant={EmptyStateVariant.full}>
                 <EmptyStateIcon icon={SearchIcon} />
                 <Title headingLevel="h2" size="lg">

--- a/packages/react-core/src/components/NotificationDrawer/examples/NotificationDrawerLightweight.tsx
+++ b/packages/react-core/src/components/NotificationDrawer/examples/NotificationDrawerLightweight.tsx
@@ -58,7 +58,10 @@ export const NotificationDrawerLightweight: React.FunctionComponent = () => {
             isRead={true}
             onExpand={toggleFirstDrawer}
           >
-            <NotificationDrawerList isHidden={!firstGroupExpanded}>
+            <NotificationDrawerList
+              isHidden={!firstGroupExpanded}
+              aria-label="Notifications in the first lightweight group"
+            >
               <NotificationDrawerListItem variant="info">
                 <NotificationDrawerListItemHeader
                   variant="info"
@@ -109,7 +112,10 @@ export const NotificationDrawerLightweight: React.FunctionComponent = () => {
             isRead={true}
             onExpand={toggleSecondDrawer}
           >
-            <NotificationDrawerList isHidden={!secondGroupExpanded}>
+            <NotificationDrawerList
+              isHidden={!secondGroupExpanded}
+              aria-label="Notifications in the second lightweight group"
+            >
               <NotificationDrawerListItem variant="info">
                 <NotificationDrawerListItemHeader
                   variant="info"
@@ -162,7 +168,10 @@ export const NotificationDrawerLightweight: React.FunctionComponent = () => {
             isRead={true}
             onExpand={toggleThirdDrawer}
           >
-            <NotificationDrawerList isHidden={!thirdGroupExpanded}>
+            <NotificationDrawerList
+              isHidden={!thirdGroupExpanded}
+              aria-label="Notifications in the third lightweight group"
+            >
               <EmptyState variant={EmptyStateVariant.full}>
                 <EmptyStateIcon icon={SearchIcon} />
                 <Title headingLevel="h2" size="lg">

--- a/packages/react-core/src/components/Page/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/packages/react-core/src/components/Page/__tests__/__snapshots__/Page.test.tsx.snap
@@ -176,6 +176,7 @@ exports[`Page Check page to verify breadcrumb is created - PageBreadcrumb syntax
         >
           <ol
             class="pf-c-breadcrumb__list"
+            role="list"
           >
             <li
               class="pf-c-breadcrumb__item"
@@ -343,6 +344,7 @@ exports[`Page Check page to verify breadcrumb is created 1`] = `
         >
           <ol
             class="pf-c-breadcrumb__list"
+            role="list"
           >
             <li
               class="pf-c-breadcrumb__item"
@@ -513,6 +515,7 @@ exports[`Page Check page to verify grouped nav and breadcrumb - new components s
           >
             <ol
               class="pf-c-breadcrumb__list"
+              role="list"
             >
               <li
                 class="pf-c-breadcrumb__item"
@@ -635,6 +638,7 @@ exports[`Page Check page to verify grouped nav and breadcrumb - new components s
             </button>
             <ul
               class="pf-c-nav__list"
+              role="list"
             >
               <li
                 class="pf-c-nav__item"
@@ -821,6 +825,7 @@ exports[`Page Check page to verify grouped nav and breadcrumb - old / props synt
             </button>
             <ul
               class="pf-c-nav__list"
+              role="list"
             >
               <li
                 class="pf-c-nav__item"
@@ -920,6 +925,7 @@ exports[`Page Check page to verify grouped nav and breadcrumb - old / props synt
             >
               <ol
                 class="pf-c-breadcrumb__list"
+                role="list"
               >
                 <li
                   class="pf-c-breadcrumb__item"
@@ -1108,6 +1114,7 @@ exports[`Page Check page to verify nav is created - PageNavigation syntax 1`] = 
           </button>
           <ul
             class="pf-c-nav__list"
+            role="list"
           >
             <li
               class="pf-c-nav__item"
@@ -1284,6 +1291,7 @@ exports[`Page Check page to verify skip to content points to main content region
         >
           <ol
             class="pf-c-breadcrumb__list"
+            role="list"
           >
             <li
               class="pf-c-breadcrumb__item"
@@ -1512,6 +1520,7 @@ exports[`Page Sticky bottom breadcrumb on all height breakpoints - PageBreadcrum
         >
           <ol
             class="pf-c-breadcrumb__list"
+            role="list"
           >
             <li
               class="pf-c-breadcrumb__item"
@@ -1679,6 +1688,7 @@ exports[`Page Verify sticky bottom breadcrumb on all height breakpoints 1`] = `
         >
           <ol
             class="pf-c-breadcrumb__list"
+            role="list"
           >
             <li
               class="pf-c-breadcrumb__item"
@@ -1846,6 +1856,7 @@ exports[`Page Verify sticky top breadcrumb on all height breakpoints - PageBread
         >
           <ol
             class="pf-c-breadcrumb__list"
+            role="list"
           >
             <li
               class="pf-c-breadcrumb__item"
@@ -2013,6 +2024,7 @@ exports[`Page Verify sticky top breadcrumb on all height breakpoints 1`] = `
         >
           <ol
             class="pf-c-breadcrumb__list"
+            role="list"
           >
             <li
               class="pf-c-breadcrumb__item"

--- a/packages/react-core/src/components/ProgressStepper/ProgressStep.tsx
+++ b/packages/react-core/src/components/ProgressStepper/ProgressStep.tsx
@@ -88,6 +88,8 @@ export const ProgressStep: React.FunctionComponent<ProgressStepProps> = ({
         className
       )}
       aria-label={ariaLabel}
+      // CSS style `display: contents` gives this li a generic role, we need to override that
+      role="listitem"
       {...(isCurrent && { 'aria-current': 'step' })}
       {...props}
     >

--- a/packages/react-core/src/components/ProgressStepper/ProgressStepper.tsx
+++ b/packages/react-core/src/components/ProgressStepper/ProgressStepper.tsx
@@ -14,6 +14,8 @@ export interface ProgressStepperProps
   isVertical?: boolean;
   /** Flag indicating the progress stepper should be rendered compactly. */
   isCompact?: boolean;
+  /** Adds an accessible label to the progress stepper. */
+  'aria-label'?: string;
 }
 
 export const ProgressStepper: React.FunctionComponent<ProgressStepperProps> = ({
@@ -22,6 +24,7 @@ export const ProgressStepper: React.FunctionComponent<ProgressStepperProps> = ({
   isCenterAligned,
   isVertical,
   isCompact,
+  'aria-label': ariaLabel,
   ...props
 }: ProgressStepperProps) => (
   <ol
@@ -32,6 +35,8 @@ export const ProgressStepper: React.FunctionComponent<ProgressStepperProps> = ({
       isCompact && styles.modifiers.compact,
       className
     )}
+    role="list"
+    aria-label={ariaLabel}
     {...props}
   >
     {children}

--- a/packages/react-core/src/components/ProgressStepper/__tests__/__snapshots__/ProgressStep.test.tsx.snap
+++ b/packages/react-core/src/components/ProgressStepper/__tests__/__snapshots__/ProgressStep.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`Matches snapshot 1`] = `
 <DocumentFragment>
   <li
     class="pf-c-progress-stepper__step"
+    role="listitem"
   >
     <div
       class="pf-c-progress-stepper__step-connector"

--- a/packages/react-core/src/components/ProgressStepper/__tests__/__snapshots__/ProgressStepper.test.tsx.snap
+++ b/packages/react-core/src/components/ProgressStepper/__tests__/__snapshots__/ProgressStepper.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`Matches the snapshot 1`] = `
 <DocumentFragment>
   <ol
     class="pf-c-progress-stepper"
+    role="list"
   >
     Test
   </ol>

--- a/packages/react-core/src/components/ProgressStepper/examples/ProgressStepperBasic.tsx
+++ b/packages/react-core/src/components/ProgressStepper/examples/ProgressStepperBasic.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ProgressStepper, ProgressStep } from '@patternfly/react-core';
 
 export const ProgressStepperBasic: React.FunctionComponent = () => (
-  <ProgressStepper>
+  <ProgressStepper aria-label="Basic progress stepper">
     <ProgressStep
       variant="success"
       id="basic-step1"

--- a/packages/react-core/src/components/ProgressStepper/examples/ProgressStepperBasicFailure.tsx
+++ b/packages/react-core/src/components/ProgressStepper/examples/ProgressStepperBasicFailure.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ProgressStepper, ProgressStep } from '@patternfly/react-core';
 
 export const ProgressStepperBasicFailure: React.FunctionComponent = () => (
-  <ProgressStepper>
+  <ProgressStepper aria-label="Basic progress stepper with failure">
     <ProgressStep
       variant="success"
       id="basic-with-failure-step1"

--- a/packages/react-core/src/components/ProgressStepper/examples/ProgressStepperBasicIssue.tsx
+++ b/packages/react-core/src/components/ProgressStepper/examples/ProgressStepperBasicIssue.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ProgressStepper, ProgressStep } from '@patternfly/react-core';
 
 export const ProgressStepperBasicIssue: React.FunctionComponent = () => (
-  <ProgressStepper>
+  <ProgressStepper aria-label="Basic progress stepper with issue">
     <ProgressStep
       variant="success"
       id="basic-with-issue-step1"

--- a/packages/react-core/src/components/ProgressStepper/examples/ProgressStepperBasicWithAlignment.tsx
+++ b/packages/react-core/src/components/ProgressStepper/examples/ProgressStepperBasicWithAlignment.tsx
@@ -24,7 +24,11 @@ export const ProgressStepperBasicWithAlignment: React.FunctionComponent = () => 
         name="toggle-center"
       />
       <br />
-      <ProgressStepper isVertical={isVertical} isCenterAligned={isCenterAligned}>
+      <ProgressStepper
+        isVertical={isVertical}
+        isCenterAligned={isCenterAligned}
+        aria-label="Basic progress stepper with alignment"
+      >
         <ProgressStep
           variant="success"
           description="This is the first thing to happen"

--- a/packages/react-core/src/components/ProgressStepper/examples/ProgressStepperBasicWithDescription.tsx
+++ b/packages/react-core/src/components/ProgressStepper/examples/ProgressStepperBasicWithDescription.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ProgressStepper, ProgressStep } from '@patternfly/react-core';
 
 export const ProgressStepperBasicWithDescription: React.FunctionComponent = () => (
-  <ProgressStepper>
+  <ProgressStepper aria-label="Basic progress stepper with description">
     <ProgressStep
       variant="success"
       description="This is the first thing to happen"

--- a/packages/react-core/src/components/ProgressStepper/examples/ProgressStepperCompact.tsx
+++ b/packages/react-core/src/components/ProgressStepper/examples/ProgressStepperCompact.tsx
@@ -6,7 +6,7 @@ export const ProgressStepperCompact: React.FunctionComponent = () => {
   const [isCenterAligned, setIsCenterAligned] = React.useState(false);
 
   return (
-    <React.Fragment>
+    <React.Fragment aria-label="Compact progress stepper">
       <Checkbox
         label="Vertical alignment"
         isChecked={isVertical}

--- a/packages/react-core/src/components/ProgressStepper/examples/ProgressStepperCustomIcons.tsx
+++ b/packages/react-core/src/components/ProgressStepper/examples/ProgressStepperCustomIcons.tsx
@@ -4,7 +4,7 @@ import InProgressIcon from '@patternfly/react-icons/dist/esm/icons/in-progress-i
 import PendingIcon from '@patternfly/react-icons/dist/esm/icons/pending-icon';
 
 export const ProgressStepperCustomIcons: React.FunctionComponent = () => (
-  <ProgressStepper>
+  <ProgressStepper aria-label="Progress stepper with custom icons">
     <ProgressStep
       variant="success"
       id="custom-step1"

--- a/packages/react-core/src/components/ProgressStepper/examples/ProgressStepperHelpPopover.tsx
+++ b/packages/react-core/src/components/ProgressStepper/examples/ProgressStepperHelpPopover.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ProgressStepper, ProgressStep, Popover } from '@patternfly/react-core';
 
 export const PopoverProgressStep = () => (
-  <ProgressStepper>
+  <ProgressStepper aria-label="Progress stepper with help popover">
     <ProgressStep
       variant="success"
       id="popover-step1"

--- a/packages/react-core/src/components/SimpleList/SimpleList.tsx
+++ b/packages/react-core/src/components/SimpleList/SimpleList.tsx
@@ -76,7 +76,11 @@ export class SimpleList extends React.Component<SimpleListProps, SimpleListState
       >
         <div className={css(styles.simpleList, className)} {...props}>
           {isGrouped && children}
-          {!isGrouped && <ul aria-label={ariaLabel}>{children}</ul>}
+          {!isGrouped && (
+            <ul role="list" aria-label={ariaLabel}>
+              {children}
+            </ul>
+          )}
         </div>
       </SimpleListContext.Provider>
     );

--- a/packages/react-core/src/components/SimpleList/SimpleListGroup.tsx
+++ b/packages/react-core/src/components/SimpleList/SimpleListGroup.tsx
@@ -27,7 +27,7 @@ export const SimpleListGroup: React.FunctionComponent<SimpleListGroupProps> = ({
     <h2 id={id} className={css(styles.simpleListTitle, titleClassName)} aria-hidden="true">
       {title}
     </h2>
-    <ul className={css(className)} aria-labelledby={id}>
+    <ul className={css(className)} role="list" aria-labelledby={id}>
       {children}
     </ul>
   </section>

--- a/packages/react-core/src/components/SimpleList/__tests__/Generated/__snapshots__/SimpleListGroup.test.tsx.snap
+++ b/packages/react-core/src/components/SimpleList/__tests__/Generated/__snapshots__/SimpleListGroup.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`SimpleListGroup should match snapshot (auto-generated) 1`] = `
     <ul
       aria-labelledby="''"
       class="''"
+      role="list"
     >
       ReactNode
     </ul>

--- a/packages/react-core/src/components/SimpleList/__tests__/__snapshots__/SimpleList.test.tsx.snap
+++ b/packages/react-core/src/components/SimpleList/__tests__/__snapshots__/SimpleList.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`SimpleList renders aria-labelled content 1`] = `
   >
     <ul
       aria-label="This is a simple list"
+      role="list"
     >
       <li
         class=""
@@ -48,7 +49,9 @@ exports[`SimpleList renders content 1`] = `
   <div
     class="pf-c-simple-list"
   >
-    <ul>
+    <ul
+      role="list"
+    >
       <li
         class=""
       >
@@ -102,6 +105,7 @@ exports[`SimpleList renders grouped content 1`] = `
       <ul
         aria-labelledby=""
         class=""
+        role="list"
       >
         <li
           class=""

--- a/packages/react-core/src/components/Wizard/WizardNav.tsx
+++ b/packages/react-core/src/components/Wizard/WizardNav.tsx
@@ -27,7 +27,11 @@ export const WizardNav: React.FunctionComponent<WizardNavProps> = ({
 }: WizardNavProps) => {
   const ouiaProps = useOUIAProps(WizardNav.displayName, ouiaId, ouiaSafe);
 
-  const innerList = <ol className={css(styles.wizardNavList)}>{children}</ol>;
+  const innerList = (
+    <ol className={css(styles.wizardNavList)} role="list">
+      {children}
+    </ol>
+  );
 
   if (returnList) {
     return innerList;

--- a/packages/react-core/src/components/Wizard/WizardNav.tsx
+++ b/packages/react-core/src/components/Wizard/WizardNav.tsx
@@ -40,7 +40,9 @@ export const WizardNav: React.FunctionComponent<WizardNavProps> = ({
       aria-labelledby={ariaLabelledBy}
       {...ouiaProps}
     >
-      <ol className={css(styles.wizardNavList)}>{children}</ol>
+      <ol className={css(styles.wizardNavList)} role="list">
+        {children}
+      </ol>
     </nav>
   );
 };

--- a/packages/react-core/src/components/Wizard/__tests__/Generated/__snapshots__/WizardNav.test.tsx.snap
+++ b/packages/react-core/src/components/Wizard/__tests__/Generated/__snapshots__/WizardNav.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`WizardNav should match snapshot (auto-generated) 1`] = `
   >
     <ol
       class="pf-c-wizard__nav-list"
+      role="list"
     >
       any
     </ol>

--- a/packages/react-core/src/components/Wizard/__tests__/__snapshots__/Wizard.test.tsx.snap
+++ b/packages/react-core/src/components/Wizard/__tests__/__snapshots__/Wizard.test.tsx.snap
@@ -100,6 +100,7 @@ exports[`Wizard Expandable Nav Wizard should match snapshot 1`] = `
         >
           <ol
             class="pf-c-wizard__nav-list"
+            role="list"
           >
             <li
               class="pf-c-wizard__nav-item"
@@ -367,6 +368,7 @@ exports[`Wizard Wizard should match snapshot 1`] = `
         >
           <ol
             class="pf-c-wizard__nav-list"
+            role="list"
           >
             <li
               class="pf-c-wizard__nav-item"
@@ -571,6 +573,7 @@ exports[`Wizard bare wiz 1`] = `
         >
           <ol
             class="pf-c-wizard__nav-list"
+            role="list"
           >
             <li
               class="pf-c-wizard__nav-item"

--- a/packages/react-core/src/components/Wizard/__tests__/__snapshots__/Wizard.test.tsx.snap
+++ b/packages/react-core/src/components/Wizard/__tests__/__snapshots__/Wizard.test.tsx.snap
@@ -155,6 +155,7 @@ exports[`Wizard Expandable Nav Wizard should match snapshot 1`] = `
               </button>
               <ol
                 class="pf-c-wizard__nav-list"
+                role="list"
               >
                 <li
                   class="pf-c-wizard__nav-item"
@@ -399,6 +400,7 @@ exports[`Wizard Wizard should match snapshot 1`] = `
               </button>
               <ol
                 class="pf-c-wizard__nav-list"
+                role="list"
               >
                 <li
                   class="pf-c-wizard__nav-item"

--- a/packages/react-core/src/next/components/Wizard/WizardNav.tsx
+++ b/packages/react-core/src/next/components/Wizard/WizardNav.tsx
@@ -23,7 +23,11 @@ export const WizardNav: React.FunctionComponent<WizardNavProps> = ({
   isInnerList = false
 }: WizardNavProps) => {
   if (isInnerList) {
-    return <ol className={css(styles.wizardNavList)}>{children}</ol>;
+    return (
+      <ol className={css(styles.wizardNavList)} role="list">
+        {children}
+      </ol>
+    );
   }
 
   return (

--- a/packages/react-core/src/next/components/Wizard/WizardNav.tsx
+++ b/packages/react-core/src/next/components/Wizard/WizardNav.tsx
@@ -36,7 +36,9 @@ export const WizardNav: React.FunctionComponent<WizardNavProps> = ({
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledBy}
     >
-      <ol className={css(styles.wizardNavList)}>{children}</ol>
+      <ol className={css(styles.wizardNavList)} role="list">
+        {children}
+      </ol>
     </nav>
   );
 };


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8453

Mainly added `role="list"` where applicable (also updating snapshots), but also exposed/added aria-label prop to several components.

I added `role="listitem"` to ProgressStep as the semantic role was being removed by `display: contents` in the CSS. Adding this role isn't a perfect fix as it now announces list items as "groups" rather than list items due to the aria labeling we have on `li.pf-c-progress-stepper__step` and `.pf-c-progress-stepper__step-title`. cc @mcoker looks like this was mentioned when the component was created: https://github.com/patternfly/patternfly/pull/4357/files#r703742528

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
