### PR TITLE
Charts - add legendAllowWrap callback

### DIFF
--- a/packages/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/react-charts/src/components/Chart/Chart.tsx
@@ -249,7 +249,7 @@ export interface ChartProps extends VictoryChartProps {
    */
   legendAllowWrap?: boolean;
   /**
-   * If legendAllowWrap is true, this function will be called after the legend's itemsPerRow property has been
+   * @beta If legendAllowWrap is true, this function will be called after the legend's itemsPerRow property has been
    * calculated, based on available width. The value provided can be used to increase the chart's parent container
    * height as legend items wrap onto the next line. If no adjustment is necessary, the value will be zero.
    */

--- a/packages/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/react-charts/src/components/Chart/Chart.tsx
@@ -237,23 +237,20 @@ export interface ChartProps extends VictoryChartProps {
    */
   innerRadius?: number;
   /**
-   * Allows legend items to wrap. A value of true allows the legend to wrap onto the next line
-   * if the chart is not wide enough.
+   * @beta Allows legend items to wrap onto the next line if the chart is not wide enough.
    *
    * Note that the chart's SVG height and width are 100% by default, so it can be responsive itself. However, if you
    * define the height and width of the chart's parent container, you must accommodate for extra legend height due to
    * legend items wrapping onto the next line. When the height of the chart's parent container is too small, some legend
    * items may not be visible.
    *
+   * Alternatively, a callback function may be provided, which will be called after the legend's itemsPerRow property
+   * has been calculated. The value provided can be used to increase the chart's parent container height as legend
+   * items wrap onto the next line. If no adjustment is necessary, the value will be zero.
+   *
    * Note: This is overridden by the legendItemsPerRow property
    */
-  legendAllowWrap?: boolean;
-  /**
-   * @beta If legendAllowWrap is true, this function will be called after the legend's itemsPerRow property has been
-   * calculated, based on available width. The value provided can be used to increase the chart's parent container
-   * height as legend items wrap onto the next line. If no adjustment is necessary, the value will be zero.
-   */
-  legendAllowWrapCallback?: (extraHeight: number) => void;
+  legendAllowWrap?: boolean | ((extraHeight: number) => void);
   /**
    * The legend component to render with chart.
    *
@@ -477,7 +474,6 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
   colorScale,
   hasPatterns,
   legendAllowWrap = false,
-  legendAllowWrapCallback,
   legendComponent = <ChartLegend />,
   legendData,
   legendPosition = ChartCommonStyles.legend.position as ChartLegendPosition,
@@ -571,7 +567,7 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
     }
 
     return getComputedLegend({
-      allowWrap: legendAllowWrap,
+      allowWrap: legendAllowWrap === true || typeof legendAllowWrap === 'function',
       chartType: 'chart',
       colorScale,
       dx,
@@ -611,16 +607,16 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
   // Callback to compliment legendAllowWrap
   const computedLegend = getLegend();
   useEffect(() => {
-    if (legendAllowWrap && legendAllowWrapCallback) {
+    if (typeof legendAllowWrap === 'function') {
       const extraHeight = getLegendItemsExtraHeight({
         legendData: computedLegend.props.data,
         legendOrientation: computedLegend.props.orientation,
         legendProps: computedLegend.props,
         theme
       });
-      legendAllowWrapCallback(extraHeight);
+      legendAllowWrap(extraHeight);
     }
-  }, [computedLegend, legendAllowWrap, legendAllowWrapCallback, theme, width]);
+  }, [computedLegend, legendAllowWrap, theme, width]);
 
   // Note: containerComponent is required for theme
   return (

--- a/packages/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/react-charts/src/components/Chart/Chart.tsx
@@ -609,9 +609,9 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
     });
 
   // Callback to compliment legendAllowWrap
+  const computedLegend = getLegend();
   useEffect(() => {
     if (legendAllowWrap && legendAllowWrapCallback) {
-      const computedLegend = getLegend();
       const extraHeight = getLegendItemsExtraHeight({
         legendData: computedLegend.props.data,
         legendOrientation: computedLegend.props.orientation,
@@ -620,7 +620,7 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
       });
       legendAllowWrapCallback(extraHeight);
     }
-  }, [width]);
+  }, [computedLegend, legendAllowWrap, legendAllowWrapCallback, theme, width]);
 
   // Note: containerComponent is required for theme
   return (
@@ -634,7 +634,7 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
       {...rest}
     >
       {renderChildren()}
-      {getLegend()}
+      {computedLegend}
       {isPatternDefs && getPatternDefs({ patternId, colorScale: defaultColorScale })}
     </VictoryChart>
   );

--- a/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
@@ -839,6 +839,7 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
     ...axisComponent.props
   });
 
+  const computedLegend = getLegend();
   const bulletChart = (
     <React.Fragment>
       {axis}
@@ -850,14 +851,13 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
       {comparativeErrorMeasure}
       {comparativeWarningMeasure}
       {getComparativeZeroMeasure()}
-      {getLegend()}
+      {computedLegend}
     </React.Fragment>
   );
 
   // Callback to compliment legendAllowWrap
   useEffect(() => {
     if (legendAllowWrap && legendAllowWrapCallback) {
-      const computedLegend = getLegend();
       const extraHeight = getLegendItemsExtraHeight({
         legendData: computedLegend.props.data,
         legendOrientation: computedLegend.props.orientation,
@@ -866,7 +866,7 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
       });
       legendAllowWrapCallback(extraHeight);
     }
-  }, [width]);
+  }, [computedLegend, legendAllowWrap, legendAllowWrapCallback, theme, width]);
 
   return standalone ? (
     <ChartContainer desc={ariaDesc} height={height} title={ariaTitle} theme={theme} width={width}>

--- a/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
@@ -208,23 +208,20 @@ export interface ChartBulletProps {
    */
   labels?: string[] | number[] | ((data: any) => string | number | null);
   /**
-   * Allows legend items to wrap. A value of true allows the legend to wrap onto the next line
-   * if the chart is not wide enough.
+   * @beta Allows legend items to wrap onto the next line if the chart is not wide enough.
    *
    * Note that the chart's SVG height and width are 100% by default, so it can be responsive itself. However, if you
    * define the height and width of the chart's parent container, you must accommodate for extra legend height due to
    * legend items wrapping onto the next line. When the height of the chart's parent container is too small, some legend
    * items may not be visible.
    *
+   * Alternatively, a callback function may be provided, which will be called after the legend's itemsPerRow property
+   * has been calculated. The value provided can be used to increase the chart's parent container height as legend
+   * items wrap onto the next line. If no adjustment is necessary, the value will be zero.
+   *
    * Note: This is overridden by the legendItemsPerRow property
    */
-  legendAllowWrap?: boolean;
-  /**
-   * @beta If legendAllowWrap is true, this function will be called after the legend's itemsPerRow property has been
-   * calculated, based on available width. The value provided can be used to increase the chart's parent container
-   * height as legend items wrap onto the next line. If no adjustment is necessary, the value will be zero.
-   */
-  legendAllowWrapCallback?: (extraHeight: number) => void;
+  legendAllowWrap?: boolean | ((extraHeight: number) => void);
   /**
    * The legend component to render with chart.
    */
@@ -507,7 +504,6 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
   invert = false,
   labels,
   legendAllowWrap = false,
-  legendAllowWrapCallback,
   legendComponent = <ChartLegend />,
   legendItemsPerRow,
   legendPosition = 'bottom' as ChartLegendPosition,
@@ -781,7 +777,7 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
     }
 
     return getComputedLegend({
-      allowWrap: legendAllowWrap,
+      allowWrap: legendAllowWrap === true || typeof legendAllowWrap === 'function',
       chartType: 'bullet',
       dx,
       dy,
@@ -857,16 +853,16 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
 
   // Callback to compliment legendAllowWrap
   useEffect(() => {
-    if (legendAllowWrap && legendAllowWrapCallback) {
+    if (typeof legendAllowWrap === 'function') {
       const extraHeight = getLegendItemsExtraHeight({
         legendData: computedLegend.props.data,
         legendOrientation: computedLegend.props.orientation,
         legendProps: computedLegend.props,
         theme
       });
-      legendAllowWrapCallback(extraHeight);
+      legendAllowWrap(extraHeight);
     }
-  }, [computedLegend, legendAllowWrap, legendAllowWrapCallback, theme, width]);
+  }, [computedLegend, legendAllowWrap, theme, width]);
 
   return standalone ? (
     <ChartContainer desc={ariaDesc} height={height} title={ariaTitle} theme={theme} width={width}>

--- a/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
@@ -220,7 +220,7 @@ export interface ChartBulletProps {
    */
   legendAllowWrap?: boolean;
   /**
-   * If legendAllowWrap is true, this function will be called after the legend's itemsPerRow property has been
+   * @beta If legendAllowWrap is true, this function will be called after the legend's itemsPerRow property has been
    * calculated, based on available width. The value provided can be used to increase the chart's parent container
    * height as legend items wrap onto the next line. If no adjustment is necessary, the value will be zero.
    */

--- a/packages/react-charts/src/components/ChartBullet/examples/ChartBullet.md
+++ b/packages/react-charts/src/components/ChartBullet/examples/ChartBullet.md
@@ -92,12 +92,22 @@ class BulletChart extends React.Component {
     this.containerRef = React.createRef();
     this.observer = () => {};
     this.state = {
+      extraHeight: 0,
       width: 0
     };
     this.handleResize = () => {
       if (this.containerRef.current && this.containerRef.current.clientWidth) {
         this.setState({ width: this.containerRef.current.clientWidth });
       }
+    };
+    this.handleLegendAllowWrapCallback = (extraHeight) => {
+      if (extraHeight !== this.state.extraHeight) {
+        this.setState({ extraHeight });
+      }
+    }
+    this.getHeight = (baseHeight) => {
+      const { extraHeight } = this.state;
+      return baseHeight + extraHeight;
     };
   }
 
@@ -112,17 +122,19 @@ class BulletChart extends React.Component {
 
   render() {
     const { width } = this.state;
+    const height = this.getHeight(200);
     return (
-      <div ref={this.containerRef} style={{ height: '250px' }}>
+      <div ref={this.containerRef} style={{ height: height + "px" }}>
         <ChartBullet
           ariaDesc="Storage capacity"
           ariaTitle="Bullet chart example"
           comparativeWarningMeasureData={[{name: 'Warning', y: 88}]}
           comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
           constrainToVisibleArea
-          height={250}
+          height={height}
           labels={({ datum }) => `${datum.name}: ${datum.y}`}
           legendAllowWrap
+          legendAllowWrapCallback={this.handleLegendAllowWrapCallback}
           legendPosition="bottom-left"
           maxDomain={{y: 100}}
           name="chart3"

--- a/packages/react-charts/src/components/ChartBullet/examples/ChartBullet.md
+++ b/packages/react-charts/src/components/ChartBullet/examples/ChartBullet.md
@@ -100,7 +100,7 @@ class BulletChart extends React.Component {
         this.setState({ width: this.containerRef.current.clientWidth });
       }
     };
-    this.handleLegendAllowWrapCallback = (extraHeight) => {
+    this.handleLegendAllowWrap = (extraHeight) => {
       if (extraHeight !== this.state.extraHeight) {
         this.setState({ extraHeight });
       }
@@ -133,8 +133,7 @@ class BulletChart extends React.Component {
           constrainToVisibleArea
           height={height}
           labels={({ datum }) => `${datum.name}: ${datum.y}`}
-          legendAllowWrap
-          legendAllowWrapCallback={this.handleLegendAllowWrapCallback}
+          legendAllowWrap={this.handleLegendAllowWrap}
           legendPosition="bottom-left"
           maxDomain={{y: 100}}
           name="chart3"

--- a/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -320,7 +320,7 @@ export interface ChartDonutProps extends ChartPieProps {
    */
   legendAllowWrap?: boolean;
   /**
-   * If legendAllowWrap is true, this function will be called after the legend's itemsPerRow property has been
+   * @beta If legendAllowWrap is true, this function will be called after the legend's itemsPerRow property has been
    * calculated, based on available width. The value provided can be used to increase the chart's parent container
    * height as legend items wrap onto the next line. If no adjustment is necessary, the value will be zero.
    */

--- a/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -308,23 +308,20 @@ export interface ChartDonutProps extends ChartPieProps {
    */
   labels?: string[] | number[] | ((data: any) => string | number | null);
   /**
-   * Allows legend items to wrap. A value of true allows the legend to wrap onto the next line
-   * if the chart is not wide enough.
+   * @beta Allows legend items to wrap onto the next line if the chart is not wide enough.
    *
    * Note that the chart's SVG height and width are 100% by default, so it can be responsive itself. However, if you
    * define the height and width of the chart's parent container, you must accommodate for extra legend height due to
    * legend items wrapping onto the next line. When the height of the chart's parent container is too small, some legend
    * items may not be visible.
    *
+   * Alternatively, a callback function may be provided, which will be called after the legend's itemsPerRow property
+   * has been calculated. The value provided can be used to increase the chart's parent container height as legend
+   * items wrap onto the next line. If no adjustment is necessary, the value will be zero.
+   *
    * Note: This is overridden by the legendItemsPerRow property
    */
-  legendAllowWrap?: boolean;
-  /**
-   * @beta If legendAllowWrap is true, this function will be called after the legend's itemsPerRow property has been
-   * calculated, based on available width. The value provided can be used to increase the chart's parent container
-   * height as legend items wrap onto the next line. If no adjustment is necessary, the value will be zero.
-   */
-  legendAllowWrapCallback?: (extraHeight: number) => void;
+  legendAllowWrap?: boolean | ((extraHeight: number) => void);
   /**
    * The legend component to render with chart.
    *

--- a/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -309,11 +309,22 @@ export interface ChartDonutProps extends ChartPieProps {
   labels?: string[] | number[] | ((data: any) => string | number | null);
   /**
    * Allows legend items to wrap. A value of true allows the legend to wrap onto the next line
-   * if its container is not wide enough.
+   * if the chart is not wide enough.
+   *
+   * Note that the chart's SVG height and width are 100% by default, so it can be responsive itself. However, if you
+   * define the height and width of the chart's parent container, you must accommodate for extra legend height due to
+   * legend items wrapping onto the next line. When the height of the chart's parent container is too small, some legend
+   * items may not be visible.
    *
    * Note: This is overridden by the legendItemsPerRow property
    */
   legendAllowWrap?: boolean;
+  /**
+   * If legendAllowWrap is true, this function will be called after the legend's itemsPerRow property has been
+   * calculated, based on available width. The value provided can be used to increase the chart's parent container
+   * height as legend items wrap onto the next line. If no adjustment is necessary, the value will be zero.
+   */
+  legendAllowWrapCallback?: (extraHeight: number) => void;
   /**
    * The legend component to render with chart.
    *
@@ -580,7 +591,6 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
   capHeight = 1.1,
   containerComponent = <ChartContainer />,
   innerRadius,
-  legendAllowWrap,
   legendPosition = ChartCommonStyles.legend.position as ChartPieLegendPosition,
   name,
   padAngle,
@@ -706,7 +716,6 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
       height={height}
       innerRadius={chartInnerRadius > 0 ? chartInnerRadius : 0}
       key="pf-chart-donut-pie"
-      legendAllowWrap={legendAllowWrap}
       legendPosition={legendPosition}
       name={name}
       padAngle={padAngle !== undefined ? padAngle : getPadAngle}

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
@@ -292,23 +292,20 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    */
   isStatic?: boolean;
   /**
-   * Allows legend items to wrap. A value of true allows the legend to wrap onto the next line
-   * if the chart is not wide enough.
+   * @beta Allows legend items to wrap onto the next line if the chart is not wide enough.
    *
    * Note that the chart's SVG height and width are 100% by default, so it can be responsive itself. However, if you
    * define the height and width of the chart's parent container, you must accommodate for extra legend height due to
    * legend items wrapping onto the next line. When the height of the chart's parent container is too small, some legend
    * items may not be visible.
    *
+   * Alternatively, a callback function may be provided, which will be called after the legend's itemsPerRow property
+   * has been calculated. The value provided can be used to increase the chart's parent container height as legend
+   * items wrap onto the next line. If no adjustment is necessary, the value will be zero.
+   *
    * Note: This is overridden by the legendItemsPerRow property
    */
-  legendAllowWrap?: boolean;
-  /**
-   * @beta If legendAllowWrap is true, this function will be called after the legend's itemsPerRow property has been
-   * calculated, based on available width. The value provided can be used to increase the chart's parent container
-   * height as legend items wrap onto the next line. If no adjustment is necessary, the value will be zero.
-   */
-  legendAllowWrapCallback?: (extraHeight: number) => void;
+  legendAllowWrap?: boolean | ((extraHeight: number) => void);
   /**
    * The labelComponent prop takes in an entire label component which will be used
    * to create a label for the area. The new element created from the passed labelComponent

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
@@ -304,7 +304,7 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    */
   legendAllowWrap?: boolean;
   /**
-   * If legendAllowWrap is true, this function will be called after the legend's itemsPerRow property has been
+   * @beta If legendAllowWrap is true, this function will be called after the legend's itemsPerRow property has been
    * calculated, based on available width. The value provided can be used to increase the chart's parent container
    * height as legend items wrap onto the next line. If no adjustment is necessary, the value will be zero.
    */

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
@@ -293,11 +293,22 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
   isStatic?: boolean;
   /**
    * Allows legend items to wrap. A value of true allows the legend to wrap onto the next line
-   * if its container is not wide enough.
+   * if the chart is not wide enough.
+   *
+   * Note that the chart's SVG height and width are 100% by default, so it can be responsive itself. However, if you
+   * define the height and width of the chart's parent container, you must accommodate for extra legend height due to
+   * legend items wrapping onto the next line. When the height of the chart's parent container is too small, some legend
+   * items may not be visible.
    *
    * Note: This is overridden by the legendItemsPerRow property
    */
   legendAllowWrap?: boolean;
+  /**
+   * If legendAllowWrap is true, this function will be called after the legend's itemsPerRow property has been
+   * calculated, based on available width. The value provided can be used to increase the chart's parent container
+   * height as legend items wrap onto the next line. If no adjustment is necessary, the value will be zero.
+   */
+  legendAllowWrapCallback?: (extraHeight: number) => void;
   /**
    * The labelComponent prop takes in an entire label component which will be used
    * to create a label for the area. The new element created from the passed labelComponent

--- a/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
+++ b/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
@@ -139,7 +139,7 @@ class BulletChart extends React.Component {
         this.setState({ width: this.containerRef.current.clientWidth });
       }
     };
-    this.handleLegendAllowWrapCallback = (extraHeight) => {
+    this.handleLegendAllowWrap = (extraHeight) => {
       if (extraHeight !== this.state.extraHeight) {
         this.setState({ extraHeight });
       }
@@ -172,8 +172,7 @@ class BulletChart extends React.Component {
           constrainToVisibleArea
           height={height}
           labels={({ datum }) => `${datum.name}: ${datum.y}`}
-          legendAllowWrap
-          legendAllowWrapCallback={this.handleLegendAllowWrapCallback}
+          legendAllowWrap={this.handleLegendAllowWrap}
           legendPosition="bottom-left"
           maxDomain={{y: 100}}
           name="chart3"

--- a/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
+++ b/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
@@ -131,12 +131,22 @@ class BulletChart extends React.Component {
     this.containerRef = React.createRef();
     this.observer = () => {};
     this.state = {
+      extraHeight: 0,
       width: 0
     };
     this.handleResize = () => {
-      if(this.containerRef.current && this.containerRef.current.clientWidth){
+      if (this.containerRef.current && this.containerRef.current.clientWidth) {
         this.setState({ width: this.containerRef.current.clientWidth });
       }
+    };
+    this.handleLegendAllowWrapCallback = (extraHeight) => {
+      if (extraHeight !== this.state.extraHeight) {
+        this.setState({ extraHeight });
+      }
+    }
+    this.getHeight = (baseHeight) => {
+      const { extraHeight } = this.state;
+      return baseHeight + extraHeight;
     };
   }
 
@@ -151,37 +161,37 @@ class BulletChart extends React.Component {
 
   render() {
     const { width } = this.state;
+    const height = this.getHeight(200);
     return (
-      <div ref={this.containerRef}>
-        <div style={{ height: '250px' }}>
-          <ChartBullet
-            ariaDesc="Storage capacity"
-            ariaTitle="Bullet chart example"
-            comparativeWarningMeasureData={[{name: 'Warning', y: 88}]}
-            comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
-            constrainToVisibleArea
-            height={250}
-            labels={({ datum }) => `${datum.name}: ${datum.y}`}
-            legendAllowWrap
-            legendPosition="bottom-left"
-            maxDomain={{y: 100}}
-            name="chart3"
-            padding={{
-              bottom: 50,
-              left: 50,
-              right: 50,
-              top: 100 // Adjusted to accommodate labels
-            }}
-            primarySegmentedMeasureData={[{ name: 'Measure', y: 25 }, { name: 'Measure', y: 60 }]}
-            primarySegmentedMeasureLegendData={[{ name: 'Measure 1' }, { name: 'Measure 2' }]}
-            qualitativeRangeData={[{ name: 'Range', y: 50 }, { name: 'Range', y: 75 }]}
-            qualitativeRangeLegendData={[{ name: 'Range 1' }, { name: 'Range 2' }]}
-            subTitle="Measure details"
-            title="Text label"
-            titlePosition="top-left"
-            width={width}
-          />
-        </div>
+      <div ref={this.containerRef} style={{ height: height + "px" }}>
+        <ChartBullet
+          ariaDesc="Storage capacity"
+          ariaTitle="Bullet chart example"
+          comparativeWarningMeasureData={[{name: 'Warning', y: 88}]}
+          comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
+          constrainToVisibleArea
+          height={height}
+          labels={({ datum }) => `${datum.name}: ${datum.y}`}
+          legendAllowWrap
+          legendAllowWrapCallback={this.handleLegendAllowWrapCallback}
+          legendPosition="bottom-left"
+          maxDomain={{y: 100}}
+          name="chart3"
+          padding={{
+            bottom: 50,
+            left: 50,
+            right: 50,
+            top: 100 // Adjusted to accommodate labels
+          }}
+          primarySegmentedMeasureData={[{ name: 'Measure', y: 25 }, { name: 'Measure', y: 60 }]}
+          primarySegmentedMeasureLegendData={[{ name: 'Measure 1' }, { name: 'Measure 2' }]}
+          qualitativeRangeData={[{ name: 'Range', y: 50 }, { name: 'Range', y: 75 }]}
+          qualitativeRangeLegendData={[{ name: 'Range 1' }, { name: 'Range 2' }]}
+          subTitle="Measure details"
+          title="Text label"
+          titlePosition="top-left"
+          width={width}
+        />
       </div>
     );
   }

--- a/packages/react-charts/src/components/ChartPie/ChartPie.tsx
+++ b/packages/react-charts/src/components/ChartPie/ChartPie.tsx
@@ -301,23 +301,20 @@ export interface ChartPieProps extends VictoryPieProps {
    */
   labels?: string[] | number[] | ((data: any) => string | number | null);
   /**
-   * Allows legend items to wrap. A value of true allows the legend to wrap onto the next line
-   * if the chart is not wide enough.
+   * @beta Allows legend items to wrap onto the next line if the chart is not wide enough.
    *
    * Note that the chart's SVG height and width are 100% by default, so it can be responsive itself. However, if you
    * define the height and width of the chart's parent container, you must accommodate for extra legend height due to
    * legend items wrapping onto the next line. When the height of the chart's parent container is too small, some legend
    * items may not be visible.
    *
+   * Alternatively, a callback function may be provided, which will be called after the legend's itemsPerRow property
+   * has been calculated. The value provided can be used to increase the chart's parent container height as legend
+   * items wrap onto the next line. If no adjustment is necessary, the value will be zero.
+   *
    * Note: This is overridden by the legendItemsPerRow property
    */
-  legendAllowWrap?: boolean;
-  /**
-   * @beta If legendAllowWrap is true, this function will be called after the legend's itemsPerRow property has been
-   * calculated, based on available width. The value provided can be used to increase the chart's parent container
-   * height as legend items wrap onto the next line. If no adjustment is necessary, the value will be zero.
-   */
-  legendAllowWrapCallback?: (extraHeight: number) => void;
+  legendAllowWrap?: boolean | ((extraHeight: number) => void);
   /**
    * The legend component to render with chart.
    *
@@ -519,7 +516,6 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
   containerComponent = <ChartContainer />,
   hasPatterns,
   legendAllowWrap = false,
-  legendAllowWrapCallback,
   legendComponent = <ChartLegend />,
   legendData,
   legendPosition = ChartCommonStyles.legend.position as ChartPieLegendPosition,
@@ -618,7 +614,7 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
       return null;
     }
     return getComputedLegend({
-      allowWrap: legendAllowWrap,
+      allowWrap: legendAllowWrap === true || typeof legendAllowWrap === 'function',
       chartType: 'pie',
       height,
       legendComponent: legend,
@@ -653,16 +649,16 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
   // Callback to compliment legendAllowWrap
   const computedLegend = getLegend();
   useEffect(() => {
-    if (legendAllowWrap && legendAllowWrapCallback) {
+    if (typeof legendAllowWrap === 'function') {
       const extraHeight = getLegendItemsExtraHeight({
         legendData: computedLegend.props.data,
         legendOrientation: computedLegend.props.orientation,
         legendProps: computedLegend.props,
         theme
       });
-      legendAllowWrapCallback(extraHeight);
+      legendAllowWrap(extraHeight);
     }
-  }, [computedLegend, legendAllowWrap, legendAllowWrapCallback, theme, width]);
+  }, [computedLegend, legendAllowWrap, theme, width]);
 
   return standalone ? (
     <React.Fragment>{container}</React.Fragment>

--- a/packages/react-charts/src/components/ChartPie/ChartPie.tsx
+++ b/packages/react-charts/src/components/ChartPie/ChartPie.tsx
@@ -651,9 +651,9 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
     : null;
 
   // Callback to compliment legendAllowWrap
+  const computedLegend = getLegend();
   useEffect(() => {
     if (legendAllowWrap && legendAllowWrapCallback) {
-      const computedLegend = getLegend();
       const extraHeight = getLegendItemsExtraHeight({
         legendData: computedLegend.props.data,
         legendOrientation: computedLegend.props.orientation,
@@ -662,14 +662,14 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
       });
       legendAllowWrapCallback(extraHeight);
     }
-  }, [width]);
+  }, [computedLegend, legendAllowWrap, legendAllowWrapCallback, theme, width]);
 
   return standalone ? (
     <React.Fragment>{container}</React.Fragment>
   ) : (
     <React.Fragment>
       {chart}
-      {getLegend()}
+      {computedLegend}
       {isPatternDefs && getPatternDefs({ patternId, colorScale: defaultColorScale, patternUnshiftIndex })}
     </React.Fragment>
   );

--- a/packages/react-charts/src/components/ChartPie/ChartPie.tsx
+++ b/packages/react-charts/src/components/ChartPie/ChartPie.tsx
@@ -313,7 +313,7 @@ export interface ChartPieProps extends VictoryPieProps {
    */
   legendAllowWrap?: boolean;
   /**
-   * If legendAllowWrap is true, this function will be called after the legend's itemsPerRow property has been
+   * @beta If legendAllowWrap is true, this function will be called after the legend's itemsPerRow property has been
    * calculated, based on available width. The value provided can be used to increase the chart's parent container
    * height as legend items wrap onto the next line. If no adjustment is necessary, the value will be zero.
    */

--- a/packages/react-charts/src/components/ChartUtils/chart-legend.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-legend.ts
@@ -73,7 +73,6 @@ export const getComputedLegend = ({
   const legendItemsProps = legendComponent.props ? legendComponent.props : {};
   const legendItemsPerRow = allowWrap
     ? getLegendItemsPerRow({
-        chartType,
         dx,
         height,
         legendData: legendItemsProps.data,
@@ -231,6 +230,38 @@ export const getLegendItemsPerRow = ({
     }
   }
   return itemsPerRow;
+};
+
+/**
+ * Returns the extra height required to accommodate wrapped legend items
+ * @private
+ */
+export const getLegendItemsExtraHeight = ({
+  legendData,
+  legendOrientation,
+  legendProps,
+  theme
+}: ChartLegendDimensionsInterface) => {
+  // Get legend dimensions
+  const legendDimensions = getLegendDimensions({
+    legendData,
+    legendOrientation,
+    legendProps,
+    theme
+  });
+
+  // Get legend dimensions without any wrapped items
+  const legendDimensionsNoWrap = getLegendDimensions({
+    legendData,
+    legendOrientation,
+    legendProps: {
+      ...legendProps,
+      itemsPerRow: undefined
+    },
+    theme
+  });
+
+  return Math.abs(legendDimensions.height - legendDimensionsNoWrap.height);
 };
 
 /**

--- a/packages/react-charts/src/components/Patterns/examples/patterms.md
+++ b/packages/react-charts/src/components/Patterns/examples/patterms.md
@@ -713,62 +713,105 @@ import chart_color_green_300 from '@patternfly/react-tokens/dist/esm/chart_color
 ```js
 import React from 'react';
 import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
+import { getResizeObserver } from '@patternfly/react-core';
 
-<div style={{ height: '325px', width: '600px' }}>
-  <ChartPie
-    ariaDesc="Average number of pets"
-    ariaTitle="Pie chart example"
-    constrainToVisibleArea
-    data={[
-      { x: 'Cats', y: 6 },
-      { x: 'Dogs', y: 6 },
-      { x: 'Birds', y: 6 },
-      { x: 'Fish', y: 6 },
-      { x: 'Rabbits', y: 6 },
-      { x: 'Squirels', y: 6 },
-      { x: 'Chipmunks', y: 6 },
-      { x: 'Bats', y: 6 },
-      { x: 'Ducks', y: 6 },
-      { x: 'Geese', y: 6 },
-      { x: 'Bobcats', y: 6 },
-      { x: 'Foxes', y: 6 },
-      { x: 'Coyotes', y: 6 },
-      { x: 'Deer', y: 6 },
-      { x: 'Bears', y: 10 }
-    ]}
-    hasPatterns
-    height={325}
-    labels={({ datum }) => `${datum.x}: ${datum.y}`}
-    legendData={[
-      { name: 'Cats: 6' },
-      { name: 'Dogs: 6' },
-      { name: 'Birds: 6' },
-      { name: 'Fish: 6' },
-      { name: 'Rabbits: 6' },
-      { name: 'Squirels: 6' },
-      { name: 'Chipmunks: 6' },
-      { name: 'Bats: 6' },
-      { name: 'Ducks: 6' },
-      { name: 'Geese: 6' },
-      { name: 'Bobcat: 6' },
-      { name: 'Foxes: 6' },
-      { name: 'Coyotes: 6' },
-      { name: 'Deer: 6' },
-      { name: 'Bears: 6' },
-    ]}
-    legendAllowWrap
-    legendPosition="bottom"
-    name="chart12"
-    padding={{
-      bottom: 110,
-      left: 20,
-      right: 20,
-      top: 20
-    }}
-    themeColor={ChartThemeColor.multiOrdered}
-    width={600}
-  />
-</div>
+class PatternsPie extends React.Component {
+  constructor(props) {
+    super(props);
+    this.containerRef = React.createRef();
+    this.observer = () => {};
+    this.state = {
+      extraHeight: 0,
+      width: 0
+    };
+    this.handleResize = () => {
+      if (this.containerRef.current && this.containerRef.current.clientWidth) {
+        this.setState({ width: this.containerRef.current.clientWidth });
+      }
+    };
+    this.handleLegendAllowWrapCallback = (extraHeight) => {
+      if (extraHeight !== this.state.extraHeight) {
+        this.setState({ extraHeight });
+      }
+    }
+    this.getHeight = (baseHeight) => {
+      const { extraHeight } = this.state;
+      return baseHeight + extraHeight;
+    };
+  }
+
+  componentDidMount() {
+    this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
+    this.handleResize();
+  }
+
+  componentWillUnmount() {
+    this.observer();
+  }
+
+  render() {
+    const { width } = this.state;
+    const height = this.getHeight(260);
+    return (
+      <div ref={this.containerRef} style={{ height: height + "px" }}>
+        <ChartPie
+          ariaDesc="Average number of pets"
+          ariaTitle="Pie chart example"
+          constrainToVisibleArea
+          data={[
+            { x: 'Cats', y: 6 },
+            { x: 'Dogs', y: 6 },
+            { x: 'Birds', y: 6 },
+            { x: 'Fish', y: 6 },
+            { x: 'Rabbits', y: 6 },
+            { x: 'Squirels', y: 6 },
+            { x: 'Chipmunks', y: 6 },
+            { x: 'Bats', y: 6 },
+            { x: 'Ducks', y: 6 },
+            { x: 'Geese', y: 6 },
+            { x: 'Bobcats', y: 6 },
+            { x: 'Foxes', y: 6 },
+            { x: 'Coyotes', y: 6 },
+            { x: 'Deer', y: 6 },
+            { x: 'Bears', y: 10 }
+          ]}
+          hasPatterns
+          height={height}
+          labels={({ datum }) => `${datum.x}: ${datum.y}`}
+          legendData={[
+            { name: 'Cats: 6' },
+            { name: 'Dogs: 6' },
+            { name: 'Birds: 6' },
+            { name: 'Fish: 6' },
+            { name: 'Rabbits: 6' },
+            { name: 'Squirels: 6' },
+            { name: 'Chipmunks: 6' },
+            { name: 'Bats: 6' },
+            { name: 'Ducks: 6' },
+            { name: 'Geese: 6' },
+            { name: 'Bobcat: 6' },
+            { name: 'Foxes: 6' },
+            { name: 'Coyotes: 6' },
+            { name: 'Deer: 6' },
+            { name: 'Bears: 6' },
+          ]}
+          legendAllowWrap
+          legendAllowWrapCallback={this.handleLegendAllowWrapCallback}
+          legendPosition="bottom"
+          name="chart12"
+          padding={{
+            bottom: this.getHeight(50), // This must be adjusted to maintain the aspec ratio
+            left: 20,
+            right: 20,
+            top: 20
+          }}
+          themeColor={ChartThemeColor.multiOrdered}
+          width={width}
+        />
+      </div>
+    );
+  }
+}
 ```
 
 ## Documentation

--- a/packages/react-charts/src/components/Patterns/examples/patterms.md
+++ b/packages/react-charts/src/components/Patterns/examples/patterms.md
@@ -729,7 +729,7 @@ class PatternsPie extends React.Component {
         this.setState({ width: this.containerRef.current.clientWidth });
       }
     };
-    this.handleLegendAllowWrapCallback = (extraHeight) => {
+    this.handleLegendAllowWrap = (extraHeight) => {
       if (extraHeight !== this.state.extraHeight) {
         this.setState({ extraHeight });
       }
@@ -795,8 +795,7 @@ class PatternsPie extends React.Component {
             { name: 'Deer: 6' },
             { name: 'Bears: 6' },
           ]}
-          legendAllowWrap
-          legendAllowWrapCallback={this.handleLegendAllowWrapCallback}
+          legendAllowWrap={this.handleLegendAllowWrap}
           legendPosition="bottom"
           name="chart12"
           padding={{

--- a/packages/react-charts/src/components/ResizeObserver/examples/resizeObserver.md
+++ b/packages/react-charts/src/components/ResizeObserver/examples/resizeObserver.md
@@ -70,7 +70,7 @@ class BulletChart extends React.Component {
         this.setState({ width: this.containerRef.current.clientWidth });
       }
     };
-    this.handleLegendAllowWrapCallback = (extraHeight) => {
+    this.handleLegendAllowWrap = (extraHeight) => {
       if (extraHeight !== this.state.extraHeight) {
         this.setState({ extraHeight });
       }
@@ -103,8 +103,7 @@ class BulletChart extends React.Component {
           constrainToVisibleArea
           height={height}
           labels={({ datum }) => `${datum.name}: ${datum.y}`}
-          legendAllowWrap
-          legendAllowWrapCallback={this.handleLegendAllowWrapCallback}
+          legendAllowWrap={this.handleLegendAllowWrap}
           legendPosition="bottom-left"
           maxDomain={{y: 100}}
           name="chart1"

--- a/packages/react-charts/src/components/ResizeObserver/examples/resizeObserver.md
+++ b/packages/react-charts/src/components/ResizeObserver/examples/resizeObserver.md
@@ -62,12 +62,22 @@ class BulletChart extends React.Component {
     this.containerRef = React.createRef();
     this.observer = () => {};
     this.state = {
+      extraHeight: 0,
       width: 0
     };
     this.handleResize = () => {
       if (this.containerRef.current && this.containerRef.current.clientWidth) {
         this.setState({ width: this.containerRef.current.clientWidth });
       }
+    };
+    this.handleLegendAllowWrapCallback = (extraHeight) => {
+      if (extraHeight !== this.state.extraHeight) {
+        this.setState({ extraHeight });
+      }
+    }
+    this.getHeight = (baseHeight) => {
+      const { extraHeight } = this.state;
+      return baseHeight + extraHeight;
     };
   }
 
@@ -82,17 +92,19 @@ class BulletChart extends React.Component {
 
   render() {
     const { width } = this.state;
+    const height = this.getHeight(200);
     return (
-      <div ref={this.containerRef} style={{ height: '250px' }}>
+      <div ref={this.containerRef} style={{ height: height + "px" }}>
         <ChartBullet
           ariaDesc="Storage capacity"
           ariaTitle="Bullet chart example"
           comparativeWarningMeasureData={[{name: 'Warning', y: 88}]}
           comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
           constrainToVisibleArea
-          height={250}
+          height={height}
           labels={({ datum }) => `${datum.name}: ${datum.y}`}
           legendAllowWrap
+          legendAllowWrapCallback={this.handleLegendAllowWrapCallback}
           legendPosition="bottom-left"
           maxDomain={{y: 100}}
           name="chart1"


### PR DESCRIPTION
Added an optional callback to compliment the chart's `legendAllowWrap` property. The `legendAllowWrapCallback` prop will be used to adjust the chart's parent container `height` as legend items wrap in response to the available `width`.

Example:
![chrome-capture-2023-1-16](https://user-images.githubusercontent.com/17481322/219545104-7379eee0-f6ee-4f60-92ce-a8aa3cbe2e3b.gif)

Closes https://github.com/patternfly/patternfly-react/issues/8643

