### PR TITLE
 react-table: import from dist/esm like we do in react-core

### DIFF
--- a/packages/react-table/src/components/Table/ActionsColumn.tsx
+++ b/packages/react-table/src/components/Table/ActionsColumn.tsx
@@ -1,14 +1,10 @@
 import * as React from 'react';
-import { Dropdown } from '@patternfly/react-core/dist/esm/components/Dropdown';
-import { KebabToggle } from '@patternfly/react-core/dist/esm/components/Dropdown/KebabToggle';
-import { DropdownItem } from '@patternfly/react-core/dist/esm/components/Dropdown/DropdownItem';
-import { DropdownSeparator } from '@patternfly/react-core/dist/esm/components/Dropdown/DropdownSeparator';
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
+import { Dropdown, KebabToggle } from '@patternfly/react-core/dist/esm/components/Dropdown';
+import { DropdownItem } from '@patternfly/react-core/dist/esm/components/Dropdown';
+import { DropdownSeparator } from '@patternfly/react-core/dist/esm/components/Dropdown';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
 
-import {
-  DropdownDirection,
-  DropdownPosition
-} from '@patternfly/react-core/dist/esm/components/Dropdown/dropdownConstants';
+import { DropdownDirection, DropdownPosition } from '@patternfly/react-core/dist/esm/components/Dropdown';
 
 import { IAction, IExtraData, IRowData } from './TableTypes';
 

--- a/packages/react-table/src/components/Table/BodyCell.tsx
+++ b/packages/react-table/src/components/Table/BodyCell.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
-import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip/Tooltip';
-import { Bullseye, EmptyState, SelectProps } from '@patternfly/react-core';
+import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip';
+import { Bullseye } from '@patternfly/react-core/dist/esm/layouts/Bullseye';
+import { EmptyState } from '@patternfly/react-core/dist/esm/components/EmptyState';
+import { SelectProps } from '@patternfly/react-core/dist/esm/components/Select';
 import { Td } from '../TableComposable/Td';
 
 export interface BodyCellProps {

--- a/packages/react-table/src/components/Table/CollapseColumn.tsx
+++ b/packages/react-table/src/components/Table/CollapseColumn.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import AngleDownIcon from '@patternfly/react-icons/dist/esm/icons/angle-down-icon';
 import { css } from '@patternfly/react-styles';
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 
 export interface CollapseColumnProps {

--- a/packages/react-table/src/components/Table/DraggableCell.tsx
+++ b/packages/react-table/src/components/Table/DraggableCell.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import GripVerticalIcon from '@patternfly/react-icons/dist/esm/icons/grip-vertical-icon';
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
 
 export interface DraggableCellProps {
   id: string;

--- a/packages/react-table/src/components/Table/EditableSelectInputCell.tsx
+++ b/packages/react-table/src/components/Table/EditableSelectInputCell.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { css } from '@patternfly/react-styles';
-import { Select, SelectOptionObject } from '@patternfly/react-core';
+import { Select, SelectOptionObject } from '@patternfly/react-core/dist/esm/components/Select';
 import inlineStyles from '@patternfly/react-styles/css/components/InlineEdit/inline-edit';
 import formStyles from '@patternfly/react-styles/css/components/Form/form';
 import { EditableSelectInputProps } from './base';

--- a/packages/react-table/src/components/Table/FavoritesCell.tsx
+++ b/packages/react-table/src/components/Table/FavoritesCell.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import StarIcon from '@patternfly/react-icons/dist/esm/icons/star-icon';
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
 
 export interface FavoritesCellProps {
   id?: string;

--- a/packages/react-table/src/components/Table/HeaderCellInfoWrapper.tsx
+++ b/packages/react-table/src/components/Table/HeaderCellInfoWrapper.tsx
@@ -2,7 +2,9 @@ import * as React from 'react';
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
-import { Button, Tooltip, Popover, TooltipProps, PopoverProps } from '@patternfly/react-core';
+import { Tooltip, TooltipProps } from '@patternfly/react-core/dist/esm/components/Tooltip';
+import { Popover, PopoverProps } from '@patternfly/react-core/dist/esm/components/Popover';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
 import { TableText } from './TableText';
 
 export interface ColumnHelpWrapperProps {

--- a/packages/react-table/src/components/Table/Table.tsx
+++ b/packages/react-table/src/components/Table/Table.tsx
@@ -1,9 +1,6 @@
 import * as React from 'react';
-import { OUIAProps, getDefaultOUIAId } from '@patternfly/react-core';
-import {
-  DropdownDirection,
-  DropdownPosition
-} from '@patternfly/react-core/dist/esm/components/Dropdown/dropdownConstants';
+import { OUIAProps, getDefaultOUIAId } from '@patternfly/react-core/dist/esm/helpers';
+import { DropdownDirection, DropdownPosition } from '@patternfly/react-core/dist/esm/components/Dropdown';
 import inlineStyles from '@patternfly/react-styles/css/components/InlineEdit/inline-edit';
 import { css } from '@patternfly/react-styles';
 import { Provider } from './base';

--- a/packages/react-table/src/components/Table/TableText.tsx
+++ b/packages/react-table/src/components/Table/TableText.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 import { css } from '@patternfly/react-styles';
-import { Tooltip, TooltipProps } from '@patternfly/react-core/dist/esm/components/Tooltip/Tooltip';
+import { Tooltip, TooltipProps } from '@patternfly/react-core/dist/esm/components/Tooltip';
 
 export enum TableTextVariant {
   div = 'div',

--- a/packages/react-table/src/components/Table/TableTypes.tsx
+++ b/packages/react-table/src/components/Table/TableTypes.tsx
@@ -1,13 +1,13 @@
-import { DropdownItemProps } from '@patternfly/react-core/dist/esm/components/Dropdown/DropdownItem';
+import { ButtonProps } from '@patternfly/react-core/dist/esm/components/Button';
 import { formatterValueType, ColumnType, RowType, RowKeyType, HeaderType } from './base';
 import { SortByDirection } from './SortColumn';
 import {
+  DropdownItemProps,
   DropdownDirection,
   DropdownPosition
-} from '@patternfly/react-core/dist/esm/components/Dropdown/dropdownConstants';
+} from '@patternfly/react-core/dist/esm/components/Dropdown';
 import * as React from 'react';
 import { CustomActionsToggleProps } from './ActionsColumn';
-import { ButtonProps } from '@patternfly/react-core';
 
 export enum TableGridBreakpoint {
   none = '',

--- a/packages/react-table/src/components/Table/base/types.tsx
+++ b/packages/react-table/src/components/Table/base/types.tsx
@@ -6,14 +6,10 @@
  */
 
 import * as React from 'react';
-import {
-  TooltipProps,
-  PopoverProps,
-  DropdownPosition,
-  DropdownDirection,
-  SelectOptionObject,
-  SelectProps
-} from '@patternfly/react-core';
+import { TooltipProps } from '@patternfly/react-core/dist/esm/components/Tooltip';
+import { PopoverProps } from '@patternfly/react-core/dist/esm/components/Popover';
+import { DropdownPosition, DropdownDirection } from '@patternfly/react-core/dist/esm/components/Dropdown';
+import { SelectProps, SelectOptionObject } from '@patternfly/react-core/dist/esm/components/Select';
 import { TableComposable } from '../../TableComposable/TableComposable';
 import { Thead } from '../../TableComposable/Thead';
 import { Tbody } from '../../TableComposable/Tbody';

--- a/packages/react-table/src/components/Table/utils/decorators/treeRow.tsx
+++ b/packages/react-table/src/components/Table/utils/decorators/treeRow.tsx
@@ -3,7 +3,8 @@ import { IExtra, IFormatterValueType, OnCheckChange, OnTreeRowCollapse, OnToggle
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 import stylesTreeView from '@patternfly/react-styles/css/components/Table/table-tree-view';
-import { Button, Checkbox } from '@patternfly/react-core';
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import { Checkbox } from '@patternfly/react-core/dist/esm/components/Checkbox';
 import AngleDownIcon from '@patternfly/react-icons/dist/esm/icons/angle-down-icon';
 import EllipsisHIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-h-icon';
 

--- a/packages/react-table/src/components/Table/utils/transformers.test.tsx
+++ b/packages/react-table/src/components/Table/utils/transformers.test.tsx
@@ -18,7 +18,7 @@ import {
   textCenter,
   cellActions
 } from './';
-import { DropdownPosition, DropdownDirection } from '@patternfly/react-core';
+import { DropdownPosition, DropdownDirection } from '@patternfly/react-core/dist/esm/components/Dropdown';
 import {
   IAction,
   IActions,

--- a/packages/react-table/src/components/TableComposable/TableComposable.tsx
+++ b/packages/react-table/src/components/TableComposable/TableComposable.tsx
@@ -5,7 +5,7 @@ import stylesTreeView from '@patternfly/react-styles/css/components/Table/table-
 import { css } from '@patternfly/react-styles';
 import { toCamel } from '../Table/utils/utils';
 import { IVisibility } from '../Table/utils/decorators/classNames';
-import { useOUIAProps, OUIAProps, handleArrows, setTabIndex } from '@patternfly/react-core';
+import { useOUIAProps, OUIAProps, handleArrows, setTabIndex } from '@patternfly/react-core/dist/esm/helpers';
 import { TableGridBreakpoint, TableVariant } from '../Table/TableTypes';
 
 export interface BaseCellProps {

--- a/packages/react-table/src/components/TableComposable/Td.tsx
+++ b/packages/react-table/src/components/TableComposable/Td.tsx
@@ -14,7 +14,7 @@ import { draggable } from '../Table/utils/decorators/draggable';
 import { treeRow } from '../Table/utils/decorators/treeRow';
 import { mergeProps } from '../Table/base/merge-props';
 import { IVisibility } from '../Table/utils/decorators/classNames';
-import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip/Tooltip';
+import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip';
 import { IFormatterValueType, IExtra } from '../Table/TableTypes';
 import {
   TdActionsType,

--- a/packages/react-table/src/components/TableComposable/Th.tsx
+++ b/packages/react-table/src/components/TableComposable/Th.tsx
@@ -11,7 +11,7 @@ import { Visibility, classNames } from './../Table/utils/decorators/classNames';
 import { ThInfoType, ThSelectType, ThExpandType, ThSortType, formatterValueType } from '../Table/base/types';
 import { mergeProps } from '../Table/base/merge-props';
 import { IVisibility } from '../Table/utils/decorators/classNames';
-import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip/Tooltip';
+import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip';
 import { BaseCellProps } from './TableComposable';
 import { IFormatterValueType, IColumn } from '../Table/TableTypes';
 

--- a/packages/react-table/src/components/TableComposable/Tr.tsx
+++ b/packages/react-table/src/components/TableComposable/Tr.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useOUIAProps, OUIAProps } from '@patternfly/react-core';
+import { useOUIAProps, OUIAProps } from '@patternfly/react-core/dist/esm/helpers';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 import inlineStyles from '@patternfly/react-styles/css/components/InlineEdit/inline-edit';
 import { css } from '@patternfly/react-styles';


### PR DESCRIPTION
This by large avoids importing from the high level export file from
@patternfly/react-core as that exports the whole patternfly react
exported modules, which affects consumers if tree-shaking algorithm does not mark
them as dead code.
    
Noticed these problematic imports while trying to port our project's build tool to
'esbuild' which created a noticably big dist'ed CSS because of these. [1]
    
[1] https://github.com/evanw/esbuild/issues/2933