### PR TITLE
feat(Table): add right sticky column support

### DIFF
--- a/packages/react-table/src/components/TableComposable/Td.tsx
+++ b/packages/react-table/src/components/TableComposable/Td.tsx
@@ -62,10 +62,14 @@ export interface TdProps extends BaseCellProps, Omit<React.HTMLProps<HTMLTableDa
   isStickyColumn?: boolean;
   /** Adds a border to the right side of the cell */
   hasRightBorder?: boolean;
+  /** Adds a border to the left side of the cell */
+  hasLeftBorder?: boolean;
   /** Minimum width for a sticky column */
   stickyMinWidth?: string;
   /** Left offset of a sticky column. This will typically be equal to the combined value set by stickyMinWidth of any sticky columns that precede the current sticky column. */
   stickyLeftOffset?: string;
+  /** Right offset of a sticky column. This will typically be equal to the combined value set by stickyMinWidth of any sticky columns that precede the current sticky column. */
+  stickyRightOffset?: string;
 }
 
 const TdBase: React.FunctionComponent<TdProps> = ({
@@ -91,8 +95,10 @@ const TdBase: React.FunctionComponent<TdProps> = ({
   onMouseEnter: onMouseEnterProp = () => {},
   isStickyColumn = false,
   hasRightBorder = false,
+  hasLeftBorder = false,
   stickyMinWidth = '120px',
   stickyLeftOffset,
+  stickyRightOffset,
   ...props
 }: TdProps) => {
   const [showTooltip, setShowTooltip] = React.useState(false);
@@ -255,6 +261,7 @@ const TdBase: React.FunctionComponent<TdProps> = ({
         noPadding && styles.modifiers.noPadding,
         isStickyColumn && scrollStyles.tableStickyColumn,
         hasRightBorder && scrollStyles.modifiers.borderRight,
+        hasLeftBorder && scrollStyles.modifiers.borderLeft,
         styles.modifiers[modifier as 'breakWord' | 'fitContent' | 'nowrap' | 'truncate' | 'wrap' | undefined],
         draggableParams && styles.tableDraggable,
         mergedClassName
@@ -266,6 +273,7 @@ const TdBase: React.FunctionComponent<TdProps> = ({
         style: {
           '--pf-c-table__sticky-column--MinWidth': stickyMinWidth ? stickyMinWidth : undefined,
           '--pf-c-table__sticky-column--Left': stickyLeftOffset ? stickyLeftOffset : undefined,
+          right: stickyRightOffset ? stickyRightOffset : 0,
           ...props.style
         } as React.CSSProperties
       })}

--- a/packages/react-table/src/components/TableComposable/Td.tsx
+++ b/packages/react-table/src/components/TableComposable/Td.tsx
@@ -68,7 +68,7 @@ export interface TdProps extends BaseCellProps, Omit<React.HTMLProps<HTMLTableDa
   stickyMinWidth?: string;
   /** Left offset of a sticky column. This will typically be equal to the combined value set by stickyMinWidth of any sticky columns that precede the current sticky column. */
   stickyLeftOffset?: string;
-  /** Right offset of a sticky column. This will typically be equal to the combined value set by stickyMinWidth of any sticky columns that precede the current sticky column. */
+  /** Right offset of a sticky column. This will typically be equal to the combined value set by stickyMinWidth of any sticky columns that come after the current sticky column. */
   stickyRightOffset?: string;
 }
 

--- a/packages/react-table/src/components/TableComposable/Th.tsx
+++ b/packages/react-table/src/components/TableComposable/Th.tsx
@@ -52,7 +52,7 @@ export interface ThProps
   stickyMinWidth?: string;
   /** Left offset of a sticky column. This will typically be equal to the combined value set by stickyMinWidth of any sticky columns that precede the current sticky column. */
   stickyLeftOffset?: string;
-  /** Right offset of a sticky column. This will typically be equal to the combined value set by stickyMinWidth of any sticky columns that precede the current sticky column. */
+  /** Right offset of a sticky column. This will typically be equal to the combined value set by stickyMinWidth of any sticky columns that come after the current sticky column. */
   stickyRightOffset?: string;
   /** Indicates the <th> is part of a subheader of a nested header */
   isSubheader?: boolean;

--- a/packages/react-table/src/components/TableComposable/Th.tsx
+++ b/packages/react-table/src/components/TableComposable/Th.tsx
@@ -46,10 +46,14 @@ export interface ThProps
   isStickyColumn?: boolean;
   /** Adds a border to the right side of the cell */
   hasRightBorder?: boolean;
+  /** Adds a border to the left side of the cell */
+  hasLeftBorder?: boolean;
   /** Minimum width for a sticky column */
   stickyMinWidth?: string;
   /** Left offset of a sticky column. This will typically be equal to the combined value set by stickyMinWidth of any sticky columns that precede the current sticky column. */
   stickyLeftOffset?: string;
+  /** Right offset of a sticky column. This will typically be equal to the combined value set by stickyMinWidth of any sticky columns that precede the current sticky column. */
+  stickyRightOffset?: string;
   /** Indicates the <th> is part of a subheader of a nested header */
   isSubheader?: boolean;
 }
@@ -73,8 +77,10 @@ const ThBase: React.FunctionComponent<ThProps> = ({
   info: infoProps,
   isStickyColumn = false,
   hasRightBorder = false,
+  hasLeftBorder = false,
   stickyMinWidth = '120px',
   stickyLeftOffset,
+  stickyRightOffset,
   isSubheader = false,
   ...props
 }: ThProps) => {
@@ -171,6 +177,7 @@ const ThBase: React.FunctionComponent<ThProps> = ({
         isSubheader && styles.tableSubhead,
         isStickyColumn && scrollStyles.tableStickyColumn,
         hasRightBorder && scrollStyles.modifiers.borderRight,
+        hasLeftBorder && scrollStyles.modifiers.borderLeft,
         modifier && styles.modifiers[modifier as 'breakWord' | 'fitContent' | 'nowrap' | 'truncate' | 'wrap'],
         mergedClassName
       )}
@@ -180,6 +187,7 @@ const ThBase: React.FunctionComponent<ThProps> = ({
         style: {
           '--pf-c-table__sticky-column--MinWidth': stickyMinWidth ? stickyMinWidth : undefined,
           '--pf-c-table__sticky-column--Left': stickyLeftOffset ? stickyLeftOffset : undefined,
+          right: stickyRightOffset ? stickyRightOffset : 0,
           ...props.style
         } as React.CSSProperties
       })}

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
@@ -340,6 +340,13 @@ To make multiple columns sticky, wrap `TableComposable` with `InnerScrollContain
 ```ts file="ComposableTableMultipleStickyColumns.tsx"
 ```
 
+### Composable: Multiple right-aligned sticky columns
+
+To make multiple columns sticky, wrap `TableComposable` with `InnerScrollContainer` and add `isStickyColumn` to all columns that should be sticky. The leftmost sticky column should also have the `hasLeftBorder` property, and each sticky column left of the last column must define a `stickyRightOffset` property that equals the combined width of the previous sticky columns - set by `stickyMinWidth`. To prevent the default text wrapping behavior and allow horizontal scrolling, all `Th` or `Td` cells should also have the `modifier="nowrap"` property.
+
+```ts file="ComposableTableRightStickyColumn.tsx"
+```
+
 ### Composable: Sticky columns and header
 
 To maintain proper sticky behavior across sticky columns and header, `TableComposable` must be wrapped with `OuterScrollContainer` and `InnerScrollContainer`.

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTable.md
@@ -333,16 +333,30 @@ To make a column sticky, wrap `TableComposable` with `InnerScrollContainer` and 
 ```ts file="ComposableTableStickyColumn.tsx"
 ```
 
-### Composable: Multiple sticky columns
+### Composable: Multiple left-aligned sticky columns
 
-To make multiple columns sticky, wrap `TableComposable` with `InnerScrollContainer` and add `isStickyColumn` to all columns that should be sticky. The rightmost column should also have the `hasRightBorder` property, and each sticky column after the first must define a `stickyLeftOffset` property that equals the combined width of the previous sticky columns - set by `stickyMinWidth`. To prevent the default text wrapping behavior and allow horizontal scrolling, all `Th` or `Td` cells should also have the `modifier="nowrap"` property.
+To make multiple left-aligned columns sticky:
+
+- wrap `TableComposable` with `InnerScrollContainer`
+- add `isStickyColumn` to all columns that should be sticky
+- add `hasRightBorder` to the rightmost sticky column
+- add `stickyLeftOffset` to each sticky column after the first, with a value that equals the combined width - set by `stickyMindWidth` - of the previous sticky columns
+
+To prevent the default text wrapping behavior and allow horizontal scrolling, all `Th` or `Td` cells should also have the `modifier="nowrap"` property.
 
 ```ts file="ComposableTableMultipleStickyColumns.tsx"
 ```
 
 ### Composable: Multiple right-aligned sticky columns
 
-To make multiple columns sticky, wrap `TableComposable` with `InnerScrollContainer` and add `isStickyColumn` to all columns that should be sticky. The leftmost sticky column should also have the `hasLeftBorder` property, and each sticky column left of the last column must define a `stickyRightOffset` property that equals the combined width of the previous sticky columns - set by `stickyMinWidth`. To prevent the default text wrapping behavior and allow horizontal scrolling, all `Th` or `Td` cells should also have the `modifier="nowrap"` property.
+To make multiple right-aligned columns sticky:
+
+- wrap `TableComposable` with `InnerScrollContainer`
+- add `isStickyColumn` to all columns that should be sticky
+- add `hasLeftBorder` to the leftmost sticky column
+- add `stickyRightOffset` to each sticky column preceding the last, with a value that equals the combined width - set by `stickyMindWidth` - of the next sticky columns
+
+To prevent the default text wrapping behavior and allow horizontal scrolling, all `Th` or `Td` cells should also have the `modifier="nowrap"` property.
 
 ```ts file="ComposableTableRightStickyColumn.tsx"
 ```

--- a/packages/react-table/src/components/TableComposable/examples/ComposableTableRightStickyColumn.tsx
+++ b/packages/react-table/src/components/TableComposable/examples/ComposableTableRightStickyColumn.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import { TableComposable, Thead, Tr, Th, Tbody, Td, InnerScrollContainer, ThProps } from '@patternfly/react-table';
+
+interface Fact {
+  name: string;
+  state: string;
+  detail1: string;
+  detail2: string;
+  detail3: string;
+  detail4: string;
+  detail5: string;
+  detail6: string;
+  detail7: string;
+}
+
+export const ComposableTableRightStickyColumn: React.FunctionComponent = () => {
+  // In real usage, this data would come from some external source like an API via props.
+  const facts: Fact[] = Array.from({ length: 9 }, (_, index) => ({
+    name: `Fact ${index + 1}`,
+    state: `State ${index + 1}`,
+    detail1: `Test cell ${index + 1}-3`,
+    detail2: `Test cell ${index + 1}-4`,
+    detail3: `Test cell ${index + 1}-5`,
+    detail4: `Test cell ${index + 1}-6`,
+    detail5: `Test cell ${index + 1}-7`,
+    detail6: `Test cell ${index + 1}-8`,
+    detail7: `Test cell ${index + 1}-9`
+  }));
+
+  const columnNames = {
+    name: 'Fact',
+    state: 'State',
+    header3: 'Header 3',
+    header4: 'Header 4',
+    header5: 'Header 5',
+    header6: 'Header 6',
+    header7: 'Header 7',
+    header8: 'Header 8',
+    header9: 'Header 9'
+  };
+
+  // Index of the currently sorted column
+  // Note: if you intend to make columns reorderable, you may instead want to use a non-numeric key
+  // as the identifier of the sorted column. See the "Compound expandable" example.
+  const [activeSortIndex, setActiveSortIndex] = React.useState<number | null>(null);
+
+  // Sort direction of the currently sorted column
+  const [activeSortDirection, setActiveSortDirection] = React.useState<'asc' | 'desc' | null>(null);
+
+  // Since OnSort specifies sorted columns by index, we need sortable values for our object by column index.
+  // This example is trivial since our data objects just contain strings, but if the data was more complex
+  // this would be a place to return simplified string or number versions of each column to sort by.
+  const getSortableRowValues = (fact: Fact): (string | number)[] => {
+    const { name, state, detail1, detail2, detail3, detail4, detail5, detail6, detail7 } = fact;
+    return [name, state, detail1, detail2, detail3, detail4, detail5, detail6, detail7];
+  };
+
+  // Note that we perform the sort as part of the component's render logic and not in onSort.
+  // We shouldn't store the list of data in state because we don't want to have to sync that with props.
+  let sortedFacts = facts;
+  if (activeSortIndex !== null) {
+    sortedFacts = facts.sort((a, b) => {
+      const aValue = getSortableRowValues(a)[activeSortIndex];
+      const bValue = getSortableRowValues(b)[activeSortIndex];
+      if (aValue === bValue) {
+        return 0;
+      }
+      if (activeSortDirection === 'asc') {
+        return aValue > bValue ? 1 : -1;
+      } else {
+        return bValue > aValue ? 1 : -1;
+      }
+    });
+  }
+
+  const getSortParams = (columnIndex: number): ThProps['sort'] => ({
+    sortBy: {
+      index: activeSortIndex,
+      direction: activeSortDirection
+    },
+    onSort: (_event, index, direction) => {
+      setActiveSortIndex(index);
+      setActiveSortDirection(direction);
+    },
+    columnIndex
+  });
+
+  return (
+    <InnerScrollContainer>
+      <TableComposable aria-label="Sticky column table" gridBreakPoint="">
+        <Thead>
+          <Tr>
+            <Th modifier="truncate" sort={getSortParams(0)}>
+              {columnNames.name}
+            </Th>
+            <Th modifier="truncate" sort={getSortParams(1)}>
+              {columnNames.state}
+            </Th>
+            <Th modifier="truncate">{columnNames.header3}</Th>
+            <Th modifier="truncate">{columnNames.header4}</Th>
+            <Th modifier="truncate">{columnNames.header5}</Th>
+            <Th modifier="truncate">{columnNames.header6}</Th>
+            <Th modifier="truncate">{columnNames.header7}</Th>
+            <Th isStickyColumn hasLeftBorder stickyMinWidth="130px" stickyRightOffset="130px" modifier="truncate">
+              {columnNames.header8}
+            </Th>
+            <Th isStickyColumn stickyMinWidth="130px" modifier="truncate">
+              {columnNames.header9}
+            </Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {sortedFacts.map(fact => (
+            <Tr key={fact.name}>
+              <Th modifier="nowrap">{fact.name}</Th>
+              <Td modifier="nowrap" dataLabel={columnNames.state}>
+                {fact.state}
+              </Td>
+              <Td modifier="nowrap" dataLabel={columnNames.header3}>
+                {fact.detail1}
+              </Td>
+              <Td modifier="nowrap" dataLabel={columnNames.header4}>
+                {fact.detail2}
+              </Td>
+              <Td modifier="nowrap" dataLabel={columnNames.header5}>
+                {fact.detail3}
+              </Td>
+              <Td modifier="nowrap" dataLabel={columnNames.header6}>
+                {fact.detail4}
+              </Td>
+              <Td modifier="nowrap" dataLabel={columnNames.header7}>
+                {fact.detail5}
+              </Td>
+              <Td
+                isStickyColumn
+                hasLeftBorder
+                stickyMinWidth="130px"
+                stickyRightOffset="130px"
+                modifier="nowrap"
+                dataLabel={columnNames.header8}
+              >
+                {fact.detail6}
+              </Td>
+              <Td isStickyColumn stickyMinWidth="130px" modifier="nowrap" dataLabel={columnNames.header9}>
+                {fact.detail7}
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </TableComposable>
+    </InnerScrollContainer>
+  );
+};


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8632

Currently setting the `right` property manually. Will be updated to set `--pf-c-table__sticky-column--Right` after https://github.com/patternfly/patternfly/pull/5393 is merged and rebased in.
