### PR TITLE
fix(DataListItem): made items selectable via space key

### DIFF
--- a/packages/react-core/src/components/DataList/DataListItem.tsx
+++ b/packages/react-core/src/components/DataList/DataListItem.tsx
@@ -64,7 +64,8 @@ export class DataListItem extends React.Component<DataListItemProps> {
           };
 
           const onKeyDown = (event: React.KeyboardEvent) => {
-            if (event.key === KeyTypes.Enter) {
+            if ([KeyTypes.Enter, KeyTypes.Space].includes(event.key)) {
+              event.preventDefault();
               updateSelectedDataListItem(id);
             }
           };
@@ -95,14 +96,14 @@ export class DataListItem extends React.Component<DataListItemProps> {
                   className="pf-screen-reader"
                   type="radio"
                   checked={isSelected}
-                  onChange={event => selectableRow.onChange(id, event)}
+                  onChange={(event) => selectableRow.onChange(id, event)}
                   tabIndex={-1}
                   {...selectableInputAriaProps}
                 />
               )}
               {React.Children.map(
                 children,
-                child =>
+                (child) =>
                   React.isValidElement(child) &&
                   React.cloneElement(child as React.ReactElement<any>, {
                     rowid: ariaLabelledBy


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8370 

The logic for DataListItem and Tile demos for selecting an item via keyboard look okay on another look. Since the `click` events are on `<div>` elements a Space/Enter keydown won't trigger the click event, so calling an internal function works.

I did update the DataListItem logic to take into account Space key presses, though.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
