### PR TITLE
Charts - back port label IDs

### DIFF
--- a/packages/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/react-charts/src/components/Chart/Chart.tsx
@@ -610,6 +610,7 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
       colorScale={colorScale}
       containerComponent={container}
       height={height}
+      name={name}
       padding={defaultPadding}
       theme={theme}
       width={width}

--- a/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
+++ b/packages/react-charts/src/components/ChartAxis/ChartAxis.tsx
@@ -448,6 +448,7 @@ export interface ChartAxisProps extends VictoryAxisProps {
 }
 
 export const ChartAxis: React.FunctionComponent<ChartAxisProps> = ({
+  axisLabelComponent = <ChartLabel />,
   containerComponent = <ChartContainer />,
   name,
   showGrid = false,
@@ -465,6 +466,14 @@ export const ChartAxis: React.FunctionComponent<ChartAxisProps> = ({
     ...containerComponent.props
   });
 
+  const getAxisLabelComponent = () =>
+    React.cloneElement(axisLabelComponent, {
+      ...(name && {
+        id: () => `${name}-${(axisLabelComponent as any).type.displayName}`
+      }),
+      ...axisLabelComponent.props
+    });
+
   const getTickLabelComponent = () =>
     React.cloneElement(tickLabelComponent, {
       ...(name && {
@@ -476,7 +485,9 @@ export const ChartAxis: React.FunctionComponent<ChartAxisProps> = ({
   // Note: containerComponent is required for theme
   return (
     <VictoryAxis
+      axisLabelComponent={getAxisLabelComponent()}
       containerComponent={container}
+      name={name}
       theme={showGrid ? getAxisTheme(themeColor) : theme}
       tickLabelComponent={getTickLabelComponent()}
       {...rest}

--- a/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
@@ -582,6 +582,7 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
   // Bullet group title
   const bulletGroupTitle = React.cloneElement(groupTitleComponent, {
     height,
+    ...(name && { name: `${name}-${(groupTitleComponent as any).type.displayName}` }),
     standalone: false,
     subTitle: groupSubTitle,
     title: groupTitle,
@@ -594,6 +595,7 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
     height,
     horizontal,
     legendPosition,
+    ...(name && { name: `${name}-${(titleComponent as any).type.displayName}` }),
     padding,
     standalone: false,
     subTitle,

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletGroupTitle.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletGroupTitle.tsx
@@ -48,6 +48,12 @@ export interface ChartBulletGroupTitleProps {
    */
   height?: number;
   /**
+   * The name prop is typically used to reference a component instance when defining shared events. However, this
+   * optional prop may also be applied to child elements as an ID prefix. This is a workaround to ensure Victory
+   * based components output unique IDs when multiple charts appear in a page.
+   */
+  name?: string;
+  /**
    * The padding props specifies the amount of padding in number of pixels between
    * the edge of the chart and any rendered child components. This prop can be given
    * as a number or as an object with padding specified for top, bottom, left
@@ -122,6 +128,7 @@ export const ChartBulletGroupTitle: React.FunctionComponent<ChartBulletGroupTitl
   ariaTitle,
   capHeight = 1.1,
   dividerComponent = <Line />,
+  name,
   padding,
   standalone = true,
   subTitle,
@@ -175,6 +182,7 @@ export const ChartBulletGroupTitle: React.FunctionComponent<ChartBulletGroupTitl
     const showBoth = title && subTitle;
     return React.cloneElement(titleComponent, {
       ...(showBoth && { capHeight }),
+      ...(name && { id: () => `${name}-${(titleComponent as any).type.displayName}` }),
       style: [ChartBulletStyles.label.groupTitle, ChartBulletStyles.label.subTitle],
       text: showBoth ? [title, subTitle] : title,
       textAnchor: 'middle',

--- a/packages/react-charts/src/components/ChartBullet/ChartBulletTitle.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBulletTitle.tsx
@@ -49,6 +49,12 @@ export interface ChartBulletTitleProps {
    */
   legendPosition?: 'bottom' | 'bottom-left' | 'right';
   /**
+   * The name prop is typically used to reference a component instance when defining shared events. However, this
+   * optional prop may also be applied to child elements as an ID prefix. This is a workaround to ensure Victory
+   * based components output unique IDs when multiple charts appear in a page.
+   */
+  name?: string;
+  /**
    * The padding props specifies the amount of padding in number of pixels between
    * the edge of the chart and any rendered child components. This prop can be given
    * as a number or as an object with padding specified for top, bottom, left
@@ -131,6 +137,7 @@ export const ChartBulletTitle: React.FunctionComponent<ChartBulletTitleProps> = 
   capHeight = 1.1,
   horizontal = true,
   legendPosition = 'bottom' as ChartLegendPosition,
+  name,
   padding,
   standalone = true,
   subTitle,
@@ -191,6 +198,7 @@ export const ChartBulletTitle: React.FunctionComponent<ChartBulletTitleProps> = 
     // This ensures that when padding is adjusted, the title moves along with the chart's position.
     return React.cloneElement(titleComponent, {
       ...(showBoth && { capHeight }),
+      ...(name && { id: () => `${name}-${(titleComponent as any).type.displayName}` }),
       style: [ChartBulletStyles.label.title, ChartBulletStyles.label.subTitle],
       text: showBoth ? [title, subTitle] : title,
       textAnchor,

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
@@ -551,7 +551,7 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
           height,
           ...(name &&
             typeof (child as any).name !== undefined && {
-              name: `${name}-${(child as any).type.displayName}`
+              name: `${name}-${(child as any).type.displayName}-${index}`
             }),
           invert,
           isStatic: false,
@@ -580,6 +580,7 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
       hasPatterns={hasPatterns}
       key="pf-chart-donut-threshold"
       labels={labels}
+      name={name}
       padding={defaultPadding}
       standalone={false}
       theme={theme}

--- a/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
+++ b/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
@@ -291,8 +291,8 @@ export interface ChartLegendProps extends VictoryLegendProps {
   title?: string | string[];
   /**
    * The titleComponent prop takes a component instance which will be used to render
-   * a title for the component. The new element created from the passed
-   * titleComponent will be supplied with the following properties: x, y, index, data,
+   * a title for the component. The new element created from the passed label
+   * component will be supplied with the following properties: x, y, index, data,
    * datum, verticalAnchor, textAnchor, style, text, and events. Any of these props
    * may be overridden by passing in props to the supplied component, or modified
    * or ignored within the custom component itself. If labelComponent is omitted,
@@ -300,7 +300,7 @@ export interface ChartLegendProps extends VictoryLegendProps {
    */
   titleComponent?: React.ReactElement<any>;
   /**
-   * The titleOrientation prop specifies where the a title should be rendered
+   * The titleOrientation prop specifies where the title should be rendered
    * in relation to the rest of the legend. Possible values
    * for this prop are “top”, “bottom”, “left”, and “right”.
    *

--- a/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
+++ b/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
@@ -292,7 +292,7 @@ export interface ChartLegendProps extends VictoryLegendProps {
   /**
    * The titleComponent prop takes a component instance which will be used to render
    * a title for the component. The new element created from the passed
-   * labelComponent will be supplied with the following properties: x, y, index, data,
+   * titleComponent will be supplied with the following properties: x, y, index, data,
    * datum, verticalAnchor, textAnchor, style, text, and events. Any of these props
    * may be overridden by passing in props to the supplied component, or modified
    * or ignored within the custom component itself. If labelComponent is omitted,
@@ -382,7 +382,9 @@ export const ChartLegend: React.FunctionComponent<ChartLegendProps> = ({
 
   const getTitleComponent = () =>
     React.cloneElement(titleComponent, {
-      ...titleComponent.props
+      // Victory doesn't appear to call the id function here, but it's valid for label components
+      ...(name && { id: () => `${name}-${(titleComponent as any).type.displayName}` }),
+      ...titleComponent.props,
     });
 
   // Note: containerComponent is required for theme
@@ -392,6 +394,7 @@ export const ChartLegend: React.FunctionComponent<ChartLegendProps> = ({
       containerComponent={container}
       dataComponent={dataComponent}
       labelComponent={getLabelComponent()}
+      name={name}
       style={getDefaultStyle()}
       theme={theme}
       titleComponent={getTitleComponent()}

--- a/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
+++ b/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
@@ -384,7 +384,7 @@ export const ChartLegend: React.FunctionComponent<ChartLegendProps> = ({
     React.cloneElement(titleComponent, {
       // Victory doesn't appear to call the id function here, but it's valid for label components
       ...(name && { id: () => `${name}-${(titleComponent as any).type.displayName}` }),
-      ...titleComponent.props,
+      ...titleComponent.props
     });
 
   // Note: containerComponent is required for theme

--- a/packages/react-charts/src/components/ChartPie/ChartPie.tsx
+++ b/packages/react-charts/src/components/ChartPie/ChartPie.tsx
@@ -582,6 +582,7 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
       height={height}
       key="pf-chart-pie"
       labelComponent={labelComponent}
+      name={name}
       padding={padding}
       radius={chartRadius}
       standalone={false}


### PR DESCRIPTION
This is a v5 pack port of https://github.com/patternfly/patternfly-react/pull/8732, which ensure labels are assigned unique IDs. 

Closes https://github.com/patternfly/patternfly-react/issues/8739