### PR TITLE
fix(Menu): hid innerRef prop from docs

### DIFF
--- a/packages/react-core/src/components/Menu/MenuContent.tsx
+++ b/packages/react-core/src/components/Menu/MenuContent.tsx
@@ -6,7 +6,7 @@ import { MenuContext } from './MenuContext';
 export interface MenuContentProps extends React.HTMLProps<HTMLElement> {
   /** Items within group */
   children?: React.ReactNode;
-  /** Forwarded ref */
+  /** @hide Forwarded ref */
   innerRef?: React.Ref<any>;
   /** Height of the menu content */
   menuHeight?: string;

--- a/packages/react-integration/demo-app-ts/package.json
+++ b/packages/react-integration/demo-app-ts/package.json
@@ -9,7 +9,7 @@
     "serve:demo-app": "node scripts/serve"
   },
   "dependencies": {
-    "@patternfly/react-core": "^5.0.0-alpha.14",
+    "@patternfly/react-core": "^5.0.0-alpha.15",
     "react": "^18",
     "react-dom": "^18",
     "react-router": "^5.3.3",


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8180 

All other innerRef props mentioned in the issue were fixed as part of https://github.com/patternfly/patternfly-react/pull/8648