### PR TITLE
fix(Topology) Cola animation makes page crash on layout change

### DIFF
--- a/packages/react-topology/src/components/ElementWrapper.tsx
+++ b/packages/react-topology/src/components/ElementWrapper.tsx
@@ -15,8 +15,11 @@ const NodeElementComponent: React.FunctionComponent<{ element: Node }> = observe
   const dndManager = useDndManager();
   const isDragging = dndManager.isDragging();
   const dragItem = dndManager.getItem();
-  const controller = element.getController();
-  const isVisible = React.useMemo(() => computed(() => controller.shouldRenderNode(element)), [element, controller]);
+  const controller = element.hasController() && element.getController();
+  const isVisible = React.useMemo(() => computed(() => controller && controller.shouldRenderNode(element)), [
+    element,
+    controller
+  ]);
   if (isVisible.get() || (isDragging && dragItem === element)) {
     return <ElementComponent element={element} />;
   }
@@ -27,15 +30,18 @@ const NodeElementComponent: React.FunctionComponent<{ element: Node }> = observe
 const ElementComponent: React.FunctionComponent<ElementWrapperProps> = observer(({ element }) => {
   const kind = element.getKind();
   const type = element.getType();
-  const controller = element.getController();
+  const controller = element.hasController() && element.getController();
 
-  const Component = React.useMemo(() => controller.getComponent(kind, type), [controller, kind, type]);
+  const Component = React.useMemo(() => controller && controller.getComponent(kind, type), [controller, kind, type]);
 
-  return (
-    <ElementContext.Provider value={element}>
-      <Component {...element.getState()} element={element} />
-    </ElementContext.Provider>
-  );
+  if (Component) {
+    return (
+      <ElementContext.Provider value={element}>
+        <Component {...element.getState()} element={element} />
+      </ElementContext.Provider>
+    );
+  }
+  return null;
 });
 
 const ElementChildren: React.FunctionComponent<ElementWrapperProps> = observer(({ element }) => (

--- a/packages/react-topology/src/elements/BaseElement.ts
+++ b/packages/react-topology/src/elements/BaseElement.ts
@@ -67,6 +67,10 @@ export default abstract class BaseElement<E extends ElementModel = ElementModel,
     return this.ordering;
   }
 
+  hasController(): boolean {
+    return this.controller !== undefined;
+  }
+
   getController(): Controller {
     if (!this.controller) {
       throw new Error(`GraphElement with ID '${this.getId()}' has no controller.`);

--- a/packages/react-topology/src/types.ts
+++ b/packages/react-topology/src/types.ts
@@ -175,6 +175,7 @@ export interface GraphElement<E extends ElementModel = ElementModel, D = any> ex
   getLabel(): string;
   setLabel(label: string): void;
   getOrderKey(): number[];
+  hasController(): boolean;
   getController(): Controller;
   setController(controller?: Controller): void;
   getGraph(): Graph;


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes https://github.com/patternfly/patternfly-react/issues/8659

This solution skip `Elements` rendering when controller is not available.
Cola animation `tick` schedule mobx observer update and controller is destroyed in between so I was not able to skip the [update action from ColaLayout](https://github.com/patternfly/patternfly-react/blob/main/packages/react-topology/src/layouts/ColaLayout.ts#L66).

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
