### PR TITLE
fix(topology): Allow tooltip customization on TaskNode

### DIFF
--- a/packages/react-topology/src/pipelines/components/nodes/TaskNode.tsx
+++ b/packages/react-topology/src/pipelines/components/nodes/TaskNode.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { TooltipProps } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Topology/topology-pipelines';
 import topologyStyles from '@patternfly/react-styles/css/components/Topology/topology-components';
@@ -85,6 +86,8 @@ export interface TaskNodeProps {
   disableTooltip?: boolean;
   /** Tooltip to show on node hover */
   toolTip?: React.ReactNode;
+  /** Tooltip properties to pass along to the node's tooltip */
+  toolTipProps?: Omit<TooltipProps, 'content'>;
   /** Flag if the node has a 'when expression' */
   hasWhenExpression?: boolean;
   /** Size of the when expression indicator */
@@ -134,6 +137,7 @@ export const TaskNode: React.FC<TaskNodeProps> = ({
   hover,
   truncateLength = 14,
   toolTip,
+  toolTipProps,
   disableTooltip = false,
   selected,
   onSelect,
@@ -475,7 +479,7 @@ export const TaskNode: React.FC<TaskNodeProps> = ({
       {!toolTip || disableTooltip ? (
         renderTask()
       ) : (
-        <Tooltip position="bottom" enableFlip={false} content={toolTip}>
+        <Tooltip position="bottom" enableFlip={false} {...(toolTipProps ?? {})} content={toolTip}>
           {renderTask()}
         </Tooltip>
       )}


### PR DESCRIPTION
**What**: 
Closes https://github.com/patternfly/patternfly-react/issues/8780

Allows customization of the tooltip on a TaskNode by passing along TooltipProps.