### PR TITLE
chore(DualListSelectorListItem) change the parameter name from e to event in onOptionSelect

### DIFF
--- a/packages/react-core/src/components/DualListSelector/DualListSelectorListItem.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorListItem.tsx
@@ -18,7 +18,7 @@ export interface DualListSelectorListItemProps extends React.HTMLProps<HTMLLIEle
   /** Flag indicating the list item is currently selected. */
   isSelected?: boolean;
   /** Callback fired when an option is selected.  */
-  onOptionSelect?: (e: React.MouseEvent | React.ChangeEvent | React.KeyboardEvent, id?: string) => void;
+  onOptionSelect?: (event: React.MouseEvent | React.ChangeEvent | React.KeyboardEvent, id?: string) => void;
   /** ID of the option. */
   id?: string;
   /** @hide Internal field used to keep track of order of unfiltered options. */


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8785
