### PR TITLE
fix(Drawer): expand only onTransitionEnd of the drawer

### DIFF
--- a/packages/react-core/src/components/Drawer/DrawerPanelContent.tsx
+++ b/packages/react-core/src/components/Drawer/DrawerPanelContent.tsx
@@ -261,10 +261,12 @@ export const DrawerPanelContent: React.FunctionComponent<DrawerPanelContentProps
           )}
           ref={panel}
           onTransitionEnd={(ev) => {
-            if (!hidden && ev.nativeEvent.propertyName === 'transform') {
-              onExpand();
+            if (ev.target as HTMLElement === panel.current) {
+              if (!hidden && ev.nativeEvent.propertyName === 'transform') {
+                onExpand();
+              }
+              setIsExpandedInternal(!hidden);
             }
-            setIsExpandedInternal(!hidden);
           }}
           hidden={hidden}
           {...((defaultSize || minSize || maxSize) && {


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8510

can be tested by replacing `packages/react-core/src/components/Drawer/examples/DrawerStackedContentBodyElements.tsx` with: https://codesandbox.io/s/drawerstackedcontentbodyelements-t8v58c?file=/index.tsx
and seeing that `onExpand` counter is not growing when `Show more` is clicked