### PR TITLE
docs full page mastheads toolbar formatting fix

### DIFF
--- a/packages/react-core/src/demos/NotificationDrawer/NotificationDrawer.md
+++ b/packages/react-core/src/demos/NotificationDrawer/NotificationDrawer.md
@@ -238,7 +238,7 @@ class BasicNotificationDrawer extends React.Component {
       </DropdownGroup>
     ];
     const headerToolbar = (
-      <Toolbar>
+      <Toolbar isFullHeight>
         <ToolbarContent>
           <ToolbarGroup spaceItems={{ default: 'spacerNone' }} align={{ default: 'alignRight' }}>
             <ToolbarGroup variant="icon-button-group">
@@ -293,6 +293,7 @@ class BasicNotificationDrawer extends React.Component {
                   position="right"
                   onSelect={this.onDropdownSelect}
                   isOpen={isDropdownOpen}
+                  isFullHeight
                   toggle={
                     <DropdownToggle icon={<Avatar src={imgAvatar} alt="Avatar" />} onToggle={this.onDropdownToggle}>
                       John Smith
@@ -832,7 +833,7 @@ class GroupedNotificationDrawer extends React.Component {
       </DropdownGroup>
     ];
     const headerToolbar = (
-      <Toolbar>
+      <Toolbar isFullHeight>
         <ToolbarContent>
           <ToolbarGroup spaceItems={{ default: 'spacerNone' }} align={{ default: 'alignRight' }}>
             <ToolbarGroup variant="icon-button-group">
@@ -887,6 +888,7 @@ class GroupedNotificationDrawer extends React.Component {
                   position="right"
                   onSelect={this.onDropdownSelect}
                   isOpen={isDropdownOpen}
+                  isFullHeight
                   toggle={
                     <DropdownToggle icon={<Avatar src={imgAvatar} alt="Avatar" />} onToggle={this.onDropdownToggle}>
                       John Smith

--- a/packages/react-core/src/demos/examples/AlertGroup/AlertGroupToastWithNotificationDrawer.tsx
+++ b/packages/react-core/src/demos/examples/AlertGroup/AlertGroupToastWithNotificationDrawer.tsx
@@ -27,7 +27,8 @@ import {
   Alert,
   AlertProps,
   AlertGroup,
-  AlertActionCloseButton
+  AlertActionCloseButton,
+  ToolbarItem,
 } from '@patternfly/react-core';
 
 import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon';
@@ -206,11 +207,13 @@ export const AlertGroupToastWithNotificationDrawer: React.FunctionComponent = ()
   const alertButtonStyle = { marginRight: '8px', marginTop: '8px' };
 
   const notificationBadge = (
-    <NotificationBadge
-      variant={getNotificationBadgeVariant()}
-      onClick={onNotificationBadgeClick}
-      aria-label="Notifications"
-    ></NotificationBadge>
+    <ToolbarItem>
+      <NotificationBadge
+        variant={getNotificationBadgeVariant()}
+        onClick={onNotificationBadgeClick}
+        aria-label="Notifications"
+      ></NotificationBadge>
+    </ToolbarItem>
   );
 
   const notificationDrawerActions = [


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8797 

Checked all other full page demos and they look fine