### PR TITLE
Move items in main nav

### DIFF
--- a/packages/react-core/src/components/ApplicationLauncher/examples/ApplicationLauncher.md
+++ b/packages/react-core/src/components/ApplicationLauncher/examples/ApplicationLauncher.md
@@ -1,6 +1,7 @@
 ---
 id: Application launcher
 section: components
+subsection: menus
 cssPrefix: pf-c-app-launcher
 propComponents: ['ApplicationLauncher', 'ApplicationLauncherItem', 'ApplicationLauncherContent']
 ouia: true

--- a/packages/react-core/src/components/CalendarMonth/examples/CalendarMonth.md
+++ b/packages/react-core/src/components/CalendarMonth/examples/CalendarMonth.md
@@ -1,6 +1,7 @@
 ---
 id: Calendar month
 section: components
+subsection: date-and-time
 cssPrefix: pf-c-calendar-month
 propComponents: ['CalendarMonth', 'CalendarFormat', 'CalendarMonthInlineProps']
 ---

--- a/packages/react-core/src/components/Checkbox/examples/Checkbox.md
+++ b/packages/react-core/src/components/Checkbox/examples/Checkbox.md
@@ -1,6 +1,7 @@
 ---
 id: Checkbox
 section: components
+subsection: forms
 cssPrefix: pf-c-check
 propComponents: ['Checkbox']
 ---

--- a/packages/react-core/src/components/DatePicker/examples/DatePicker.md
+++ b/packages/react-core/src/components/DatePicker/examples/DatePicker.md
@@ -1,6 +1,7 @@
 ---
 id: Date picker
 section: components
+subsection: date-and-time
 cssPrefix: pf-c-date-picker
 propComponents: ['DatePicker', 'CalendarFormat', 'DatePickerRef']
 beta: true

--- a/packages/react-core/src/components/Dropdown/examples/Dropdown.md
+++ b/packages/react-core/src/components/Dropdown/examples/Dropdown.md
@@ -1,6 +1,7 @@
 ---
 id: Dropdown
 section: components
+subsection: menus
 cssPrefix: pf-c-menu
 propComponents: ['Dropdown', DropdownGroup, 'DropdownItem', 'DropdownList', 'MenuToggle']
 beta: true

--- a/packages/react-core/src/components/FileUpload/examples/FileUpload.md
+++ b/packages/react-core/src/components/FileUpload/examples/FileUpload.md
@@ -1,5 +1,5 @@
 ---
-id: Text file upload
+id: Simple file upload
 cssPrefix: pf-c-file-upload
 propComponents: ['FileUpload', 'FileUploadField']
 section: components
@@ -10,7 +10,7 @@ import FileUploadIcon from '@patternfly/react-icons/dist/esm/icons/file-upload-i
 
 ## Examples
 
-The basic `FileUpload` component can accept a file via browse or drag-and-drop, and behaves like a standard form field with its `value` and `onFileInputChange` event that is similar to `<input onChange="...">` prop. The `type` prop determines how the `FileUpload` component behaves upon accepting a file, what type of value it passes to its `onDataChange` event.
+The `FileUpload` component can accept a file via browse or drag-and-drop, and behaves like a standard form field with its `value` and `onFileInputChange` event that is similar to `<input onChange="...">` prop. The `type` prop determines how the `FileUpload` component behaves upon accepting a file, what type of value it passes to its `onDataChange` event.
 
 ### Text files
 

--- a/packages/react-core/src/components/FileUpload/examples/FileUpload.md
+++ b/packages/react-core/src/components/FileUpload/examples/FileUpload.md
@@ -1,8 +1,9 @@
 ---
-id: File upload
+id: Text file upload
 cssPrefix: pf-c-file-upload
 propComponents: ['FileUpload', 'FileUploadField']
 section: components
+subsection: file-upload
 ---
 
 import FileUploadIcon from '@patternfly/react-icons/dist/esm/icons/file-upload-icon';

--- a/packages/react-core/src/components/Form/examples/Form.md
+++ b/packages/react-core/src/components/Form/examples/Form.md
@@ -1,6 +1,7 @@
 ---
 id: Form
 section: components
+subsection: forms
 cssPrefix: pf-c-form
 propComponents:
   [

--- a/packages/react-core/src/components/FormSelect/examples/FormSelect.md
+++ b/packages/react-core/src/components/FormSelect/examples/FormSelect.md
@@ -1,6 +1,7 @@
 ---
 id: Form select
 section: components
+subsection: forms
 cssPrefix: pf-c-form-control
 propComponents: ['FormSelect', 'FormSelectOption', 'FormSelectOptionGroup']
 ouia: true

--- a/packages/react-core/src/components/Menu/examples/Menu.md
+++ b/packages/react-core/src/components/Menu/examples/Menu.md
@@ -1,6 +1,7 @@
 ---
 id: Menu
 section: components
+subsection: menus
 cssPrefix: pf-c-menu
 propComponents: ['Menu', 'MenuList', 'MenuItem', 'MenuItemAction', 'MenuContent', 'MenuInput', 'MenuGroup']
 ouia: true

--- a/packages/react-core/src/components/MenuToggle/examples/MenuToggle.md
+++ b/packages/react-core/src/components/MenuToggle/examples/MenuToggle.md
@@ -1,6 +1,7 @@
 ---
 id: Menu toggle
 section: components
+subsection: menus
 cssPrefix: pf-c-menu-toggle
 propComponents: ['MenuToggle', 'MenuToggleAction', 'MenuToggleCheckbox', 'SplitButtonOptions']
 ---

--- a/packages/react-core/src/components/MultipleFileUpload/examples/MultipleFileUpload.md
+++ b/packages/react-core/src/components/MultipleFileUpload/examples/MultipleFileUpload.md
@@ -1,6 +1,7 @@
 ---
-id: File upload - multiple
+id: Multiple file upload
 section: components
+subsection: file-upload
 cssPrefix: pf-c-multiple-file-upload
 propComponents:
   ['MultipleFileUpload', 'MultipleFileUploadMain', 'MultipleFileUploadStatus', 'MultipleFileUploadStatusItem']

--- a/packages/react-core/src/components/MultipleFileUpload/examples/MultipleFileUpload.md
+++ b/packages/react-core/src/components/MultipleFileUpload/examples/MultipleFileUpload.md
@@ -9,7 +9,7 @@ propComponents:
 
 import UploadIcon from '@patternfly/react-icons/dist/esm/icons/upload-icon';
 
-File upload - multiple is able to:
+Multiple file upload is able to:
 
 - Accept one or more files via browse or drag-and-drop
 - Provide their data to you using file objects via the `onFileDrop` callback prop

--- a/packages/react-core/src/components/Radio/examples/Radio.md
+++ b/packages/react-core/src/components/Radio/examples/Radio.md
@@ -1,6 +1,7 @@
 ---
 id: Radio
 section: components
+subsection: forms
 cssPrefix: pf-c-radio
 propComponents: ['Radio']
 ouia: true

--- a/packages/react-core/src/components/Select/examples/Select.md
+++ b/packages/react-core/src/components/Select/examples/Select.md
@@ -1,6 +1,7 @@
 ---
 id: Select
 section: components
+subsection: menus
 cssPrefix: pf-c-select
 propComponents: ['Select', 'SelectOption', 'SelectGroup', 'SelectOptionObject', 'SelectViewMoreObject']
 ouia: true

--- a/packages/react-core/src/components/TextArea/examples/TextArea.md
+++ b/packages/react-core/src/components/TextArea/examples/TextArea.md
@@ -1,6 +1,7 @@
 ---
 id: Text area
 section: components
+subsection: forms
 cssPrefix: pf-c-form-control
 propComponents: ['TextArea']
 ---

--- a/packages/react-core/src/components/TextInput/examples/TextInput.md
+++ b/packages/react-core/src/components/TextInput/examples/TextInput.md
@@ -1,6 +1,7 @@
 ---
 id: Text input
 section: components
+subsection: forms
 cssPrefix: pf-c-form-control
 propComponents: ['TextInput']
 ---

--- a/packages/react-core/src/components/TimePicker/examples/TimePicker.md
+++ b/packages/react-core/src/components/TimePicker/examples/TimePicker.md
@@ -1,6 +1,7 @@
 ---
 id: Time picker
 section: components
+subsection: date-and-time
 cssPrefix: pf-c-time-picker
 propComponents: ['TimePicker']
 beta: true

--- a/packages/react-core/src/demos/Card/Card.md
+++ b/packages/react-core/src/demos/Card/Card.md
@@ -1,6 +1,6 @@
 ---
 id: Card view
-section: demos
+section: patterns
 ---
 
 import DashboardWrapper from '@patternfly/react-core/src/demos/examples/DashboardWrapper';

--- a/packages/react-core/src/demos/ComposableMenu/ComposableMenu.md
+++ b/packages/react-core/src/demos/ComposableMenu/ComposableMenu.md
@@ -1,6 +1,7 @@
 ---
 id: Composable menu
-section: demos
+section: components
+subsection: menus
 ---
 
 import { Link } from '@reach/router';

--- a/packages/react-core/src/demos/ComposableMenu/ComposableMenu.md
+++ b/packages/react-core/src/demos/ComposableMenu/ComposableMenu.md
@@ -1,5 +1,5 @@
 ---
-id: Composable menu
+id: Custom menus
 section: components
 subsection: menus
 ---
@@ -27,7 +27,7 @@ import styles from '@patternfly/react-styles/css/components/Menu/menu';
 
 ## Demos
 
-Composable menus currently require consumer keyboard handling and use of our undocumented [popper.js](https://popper.js.org/) wrapper component called Popper. We understand this is inconvientent boilerplate and these examples will be updated to use [Dropdown](/components/dropdown) in a future release.
+Custom menus can be constructed using a composable approach by combining the [Menu](components/menus/menu) and [Menu toggle](components/menus/menu-toggle) components in unique ways. Composable menus currently require consumer keyboard handling and use of our undocumented [popper.js](https://popper.js.org/) wrapper component called Popper. We understand this is inconvientent boilerplate and these examples will be updated to use [Dropdown](/components/dropdown) in a future release.
 
 ### Composable simple dropdown
 

--- a/packages/react-core/src/demos/ComposableMenu/ComposableMenu.md
+++ b/packages/react-core/src/demos/ComposableMenu/ComposableMenu.md
@@ -27,7 +27,7 @@ import styles from '@patternfly/react-styles/css/components/Menu/menu';
 
 ## Demos
 
-Custom menus can be constructed using a composable approach by combining the [Menu](components/menus/menu) and [Menu toggle](components/menus/menu-toggle) components in unique ways. Composable menus currently require consumer keyboard handling and use of our undocumented [popper.js](https://popper.js.org/) wrapper component called Popper. We understand this is inconvientent boilerplate and these examples will be updated to use [Dropdown](/components/dropdown) in a future release.
+Custom menus can be constructed using a composable approach by combining the [Menu](/components/menus/menu) and [Menu toggle](/components/menus/menu-toggle) components in unique ways. Composable menus currently require consumer keyboard handling and use of our undocumented [popper.js](https://popper.js.org/) wrapper component called Popper. We understand this is inconvientent boilerplate and these examples will be updated to use [Dropdown](/components/dropdown) in a future release.
 
 ### Composable simple dropdown
 

--- a/packages/react-core/src/demos/DatePicker/DatePicker.md
+++ b/packages/react-core/src/demos/DatePicker/DatePicker.md
@@ -1,6 +1,7 @@
 ---
-id: Date picker
+id: Date range picker
 section: components
+subsection: date-and-time
 beta: true
 ---
 

--- a/packages/react-core/src/demos/DateTimePicker.md
+++ b/packages/react-core/src/demos/DateTimePicker.md
@@ -1,6 +1,7 @@
 ---
 id: Date and time picker
-section: demos
+section: components
+subsection: date-and-time
 beta: true
 ---
 

--- a/packages/react-core/src/demos/Filters/FilterDemos.md
+++ b/packages/react-core/src/demos/Filters/FilterDemos.md
@@ -1,6 +1,6 @@
 ---
 id: Filters
-section: demos
+section: patterns
 ---
 
 import {

--- a/packages/react-core/src/demos/MultipleFileUploadDemos.md
+++ b/packages/react-core/src/demos/MultipleFileUploadDemos.md
@@ -1,6 +1,7 @@
 ---
-id: File upload - multiple
+id: Multiple file upload
 section: components
+subsection: file-upload
 ---
 
 import UploadIcon from '@patternfly/react-icons/dist/esm/icons/upload-icon';

--- a/packages/react-core/src/demos/PasswordGenerator.md
+++ b/packages/react-core/src/demos/PasswordGenerator.md
@@ -1,6 +1,6 @@
 ---
 id: Password generator
-section: demos
+section: components
 ---
 
 import RedoIcon from '@patternfly/react-icons/dist/esm/icons/redo-icon';

--- a/packages/react-core/src/demos/PasswordStrength.md
+++ b/packages/react-core/src/demos/PasswordStrength.md
@@ -1,6 +1,6 @@
 ---
 id: Password strength
-section: demos
+section: components
 ---
 
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';

--- a/packages/react-core/src/demos/PrimaryDetail.md
+++ b/packages/react-core/src/demos/PrimaryDetail.md
@@ -1,6 +1,6 @@
 ---
 id: Primary-detail
-section: demos
+section: patterns
 ---
 
 import {

--- a/packages/react-core/src/deprecated/components/ContextSelector/examples/ContextSelector.md
+++ b/packages/react-core/src/deprecated/components/ContextSelector/examples/ContextSelector.md
@@ -1,6 +1,7 @@
 ---
 id: Context selector
 section: components
+subsection: menus
 propComponents: ['ContextSelector', 'ContextSelectorItem', 'ContextSelectorFooter']
 
 ouia: true

--- a/packages/react-core/src/deprecated/components/Dropdown/examples/Dropdown.md
+++ b/packages/react-core/src/deprecated/components/Dropdown/examples/Dropdown.md
@@ -1,6 +1,7 @@
 ---
 id: Dropdown
 section: components
+subsection: menus
 cssPrefix: pf-c-dropdown
 propComponents:
   [

--- a/packages/react-core/src/deprecated/components/OptionsMenu/examples/OptionsMenu.md
+++ b/packages/react-core/src/deprecated/components/OptionsMenu/examples/OptionsMenu.md
@@ -1,6 +1,7 @@
 ---
 id: Options menu
 section: components
+subsection: menus
 cssPrefix: pf-c-options-menu
 propComponents: ['OptionsMenu', 'OptionsMenuItem', 'OptionsMenuSeparator', 'OptionsMenuToggle', 'OptionsMenuToggleWithText']
 ouia: true

--- a/packages/react-core/src/next/components/Select/examples/Select.md
+++ b/packages/react-core/src/next/components/Select/examples/Select.md
@@ -1,6 +1,7 @@
 ---
 id: Select
 section: components
+subsection: menus
 cssPrefix: pf-c-menu
 propComponents: ['Select', SelectGroup, 'SelectOption', 'SelectList']
 beta: true

--- a/packages/react-docs/RELEASE-NOTES.md
+++ b/packages/react-docs/RELEASE-NOTES.md
@@ -1,6 +1,6 @@
 ---
 id: Release notes
-section: developer-resources
+section: get-started
 ---
 
 ## 2023.01 release notes (2023-02-02)

--- a/packages/react-docs/patternfly-docs/patternfly-docs.config.js
+++ b/packages/react-docs/patternfly-docs/patternfly-docs.config.js
@@ -7,10 +7,11 @@ module.exports = {
   hasDarkThemeSwitcher: true,
   hasDesignGuidelines: false,
   sideNavItems: [
+    { section: 'get-started' },
     { section: 'developer-resources' },
     { section: 'charts' },
     { section: 'components' },
-    { section: 'demos' },
+    { section: 'patterns' },
     { section: 'layouts' }
   ],
   topNavItems: [{ text: 'Icons', path: '/icons' }],


### PR DESCRIPTION
Reorganizes items it the workspace towards improved findability on patternfly.org. Tertiary expandable navigation is now used to group items in the component nav. A new "Patterns" section is introduced to replace Demos. Specific changes include the following:

* Group Date and Time related components together in the Components navigation.
* Move menu related components into a group named "Menus"
* Move form related components into a group names "Forms."
* Group File Upload and File-Upload multiple into a new group named File Upload and rename components to Simple and Multiple File upload.
* Move password strength, password generator, and composable menu demos to Components and rename Demos section to Patterns where the remaining full page demos can live.

Closes #8777

