### PR TITLE
feat(Datepicker, Timepicker): use HelperText

### DIFF
--- a/packages/react-core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-core/src/components/DatePicker/DatePicker.tsx
@@ -10,6 +10,7 @@ import { CalendarMonth, CalendarFormat } from '../CalendarMonth';
 import { useImperativeHandle } from 'react';
 import { KeyTypes } from '../../helpers';
 import { isValidDate } from '../../helpers/datetimeUtils';
+import { HelperText, HelperTextItem } from '../HelperText';
 
 /** The main date picker component. */
 
@@ -34,7 +35,7 @@ export interface DatePickerProps
   /** How to format the date in the text input. */
   dateParse?: (value: string) => Date;
   /** Helper text to display alongside the date picker. */
-  helperText?: React.ReactNode;
+  helperText?: React.ReactNode | string;
   /** Additional props for the text input. */
   inputProps?: TextInputProps;
   /** Flag indicating the date picker is disabled. */
@@ -272,8 +273,17 @@ const DatePickerBase = (
           </InputGroup>
         </div>
       </Popover>
-      {helperText && <div className={styles.datePickerHelperText}>{helperText}</div>}
-      {errorText.trim() && <div className={css(styles.datePickerHelperText)}>{errorText}</div>}
+      {helperText && React.isValidElement(helperText) && helperText}
+      {helperText && typeof helperText === 'string' && (
+        <HelperText>
+          <HelperTextItem>{helperText}</HelperTextItem>
+        </HelperText>
+      )}
+      {errorText.trim() && (
+        <HelperText>
+          <HelperTextItem variant="error">{errorText}</HelperTextItem>
+        </HelperText>
+      )}
     </div>
   );
 };

--- a/packages/react-core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-core/src/components/DatePicker/DatePicker.tsx
@@ -273,16 +273,7 @@ const DatePickerBase = (
           </InputGroup>
         </div>
       </Popover>
-      {helperText && React.isValidElement(helperText) && (
-        <div className={styles.datePickerHelperText}>{helperText}</div>
-      )}
-      {helperText && typeof helperText === 'string' && (
-        <div className={styles.datePickerHelperText}>
-          <HelperText>
-            <HelperTextItem>{helperText}</HelperTextItem>
-          </HelperText>
-        </div>
-      )}
+      {helperText && <div className={styles.datePickerHelperText}>{helperText}</div>}
       {errorText.trim() && (
         <div className={styles.datePickerHelperText}>
           <HelperText>

--- a/packages/react-core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-core/src/components/DatePicker/DatePicker.tsx
@@ -34,7 +34,7 @@ export interface DatePickerProps
   dateFormat?: (date: Date) => string;
   /** How to format the date in the text input. */
   dateParse?: (value: string) => Date;
-  /** Helper text to display alongside the date picker. */
+  /** Helper text to display alongside the date picker. Expects a HelperText component. */
   helperText?: React.ReactNode;
   /** Additional props for the text input. */
   inputProps?: TextInputProps;

--- a/packages/react-core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-core/src/components/DatePicker/DatePicker.tsx
@@ -35,7 +35,7 @@ export interface DatePickerProps
   /** How to format the date in the text input. */
   dateParse?: (value: string) => Date;
   /** Helper text to display alongside the date picker. */
-  helperText?: React.ReactNode | string;
+  helperText?: React.ReactNode;
   /** Additional props for the text input. */
   inputProps?: TextInputProps;
   /** Flag indicating the date picker is disabled. */

--- a/packages/react-core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-core/src/components/DatePicker/DatePicker.tsx
@@ -273,16 +273,22 @@ const DatePickerBase = (
           </InputGroup>
         </div>
       </Popover>
-      {helperText && React.isValidElement(helperText) && helperText}
+      {helperText && React.isValidElement(helperText) && (
+        <div className={styles.datePickerHelperText}>{helperText}</div>
+      )}
       {helperText && typeof helperText === 'string' && (
-        <HelperText>
-          <HelperTextItem>{helperText}</HelperTextItem>
-        </HelperText>
+        <div className={styles.datePickerHelperText}>
+          <HelperText>
+            <HelperTextItem>{helperText}</HelperTextItem>
+          </HelperText>
+        </div>
       )}
       {errorText.trim() && (
-        <HelperText>
-          <HelperTextItem variant="error">{errorText}</HelperTextItem>
-        </HelperText>
+        <div className={styles.datePickerHelperText}>
+          <HelperText>
+            <HelperTextItem variant="error">{errorText}</HelperTextItem>
+          </HelperText>
+        </div>
       )}
     </div>
   );

--- a/packages/react-core/src/components/DatePicker/examples/DatePickerHelperText.tsx
+++ b/packages/react-core/src/components/DatePicker/examples/DatePickerHelperText.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
-import { DatePicker } from '@patternfly/react-core';
+import { DatePicker, HelperText, HelperTextItem } from '@patternfly/react-core';
 
 export const DatePickerHelperText: React.FunctionComponent = () => (
-  <DatePicker value="2020-03-05" helperText="Select a date." />
+  <DatePicker
+    value="2020-03-05"
+    helperText={
+      <HelperText>
+        <HelperTextItem>Select a date.</HelperTextItem>
+      </HelperText>
+    }
+  />
 );

--- a/packages/react-core/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react-core/src/components/TimePicker/TimePicker.tsx
@@ -20,6 +20,7 @@ import {
   isWithinMinMax,
   getSeconds
 } from './TimePickerUtils';
+import { HelperText, HelperTextItem } from '../HelperText';
 
 export interface TimePickerProps
   extends Omit<React.HTMLProps<HTMLDivElement>, 'onChange' | 'onFocus' | 'onBlur' | 'disabled' | 'ref'> {
@@ -242,7 +243,7 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
   }
 
   updateFocusedIndex = (increment: number) => {
-    this.setState(prevState => {
+    this.setState((prevState) => {
       const maxIndex = this.getOptions().length - 1;
       let nextIndex =
         prevState.focusedIndex !== null ? prevState.focusedIndex + increment : prevState.scrollIndex + increment;
@@ -267,9 +268,8 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
   };
 
   scrollToIndex = (index: number) => {
-    this.getOptions()[index].closest(`.${menuStyles.menuContent}`).scrollTop = this.getOptions()[
-      this.getIndexToScroll(index)
-    ].offsetTop;
+    this.getOptions()[index].closest(`.${menuStyles.menuContent}`).scrollTop =
+      this.getOptions()[this.getIndexToScroll(index)].offsetTop;
   };
 
   focusSelection = (index: number) => {
@@ -308,7 +308,7 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
     ) {
       time = `${time}${new Date().getHours() > 11 ? pmSuffix : amSuffix}`;
     }
-    let scrollIndex = this.getOptions().findIndex(option => option.textContent === time);
+    let scrollIndex = this.getOptions().findIndex((option) => option.textContent === time);
 
     // if we found an exact match, scroll to match and return index of match for focus
     if (scrollIndex !== -1) {
@@ -325,7 +325,7 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
         }
       }
       time = `${splitTime[0]}${delimiter}00${amPm}`;
-      scrollIndex = this.getOptions().findIndex(option => option.textContent === time);
+      scrollIndex = this.getOptions().findIndex((option) => option.textContent === time);
       if (scrollIndex !== -1) {
         this.scrollToIndex(scrollIndex);
       }
@@ -372,7 +372,7 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
 
   onToggle = (isOpen: boolean) => {
     // on close, parse and validate input
-    this.setState(prevState => {
+    this.setState((prevState) => {
       const { timeRegex, isInvalid, timeState } = prevState;
       const { delimiter, is24Hour, includeSeconds, onChange } = this.props;
       const time = parseTime(timeState, timeRegex, delimiter, !is24Hour, includeSeconds);
@@ -550,9 +550,11 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
             </div>
           </InputGroup>
           {isInvalid && (
-            <div className={css(datePickerStyles.datePickerHelperText)}>
-              {!isValidFormat ? invalidFormatErrorMessage : invalidMinMaxErrorMessage}
-            </div>
+            <HelperText>
+              <HelperTextItem variant="error">
+                {!isValidFormat ? invalidFormatErrorMessage : invalidMinMaxErrorMessage}
+              </HelperTextItem>
+            </HelperText>
           )}
         </div>
       </div>

--- a/packages/react-core/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react-core/src/components/TimePicker/TimePicker.tsx
@@ -550,11 +550,13 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
             </div>
           </InputGroup>
           {isInvalid && (
-            <HelperText>
-              <HelperTextItem variant="error">
-                {!isValidFormat ? invalidFormatErrorMessage : invalidMinMaxErrorMessage}
-              </HelperTextItem>
-            </HelperText>
+            <div className={css(datePickerStyles.datePickerHelperText)}>
+              <HelperText>
+                <HelperTextItem variant="error">
+                  {!isValidFormat ? invalidFormatErrorMessage : invalidMinMaxErrorMessage}
+                </HelperTextItem>
+              </HelperText>
+            </div>
           )}
         </div>
       </div>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8457 

Updates Datepicker and Timepicker to use `HelperText` internally. For `Datepicker`, if the passed `helperText` is a node it will directly render the node instead of wrapping it to allow a user to manually pass a `HelperText`.
