### PR TITLE
feat(Table): allow action tooltip

### DIFF
--- a/packages/react-table/src/components/Table/ActionsColumn.tsx
+++ b/packages/react-table/src/components/Table/ActionsColumn.tsx
@@ -5,6 +5,7 @@ import { Divider } from '@patternfly/react-core/dist/esm/components/Divider';
 import { MenuToggle } from '@patternfly/react-core/dist/esm/components/MenuToggle';
 import { IAction, IExtraData, IRowData } from './TableTypes';
 import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
+import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip';
 
 export interface CustomActionsToggleProps {
   onToggle: (event: React.MouseEvent) => void;
@@ -108,10 +109,11 @@ const ActionsColumnBase: React.FunctionComponent<ActionsColumnProps> = ({
         <DropdownList>
           {items
             .filter((item) => !item.isOutsideDropdown)
-            .map(({ title, itemKey, onClick, isSeparator, ...props }, key) =>
-              isSeparator ? (
-                <Divider key={itemKey || key} data-key={itemKey || key} />
-              ) : (
+            .map(({ title, itemKey, onClick, tooltip, tooltipProps, isSeparator, ...props }, key) => {
+              if (isSeparator) {
+                return <Divider key={itemKey || key} data-key={itemKey || key} />;
+              }
+              const item = (
                 <DropdownItem
                   onClick={(event) => {
                     onActionClick(event, onClick);
@@ -123,8 +125,18 @@ const ActionsColumnBase: React.FunctionComponent<ActionsColumnProps> = ({
                 >
                   {title}
                 </DropdownItem>
-              )
-            )}
+              );
+
+              if (tooltip) {
+                return (
+                  <Tooltip key={itemKey || key} content={tooltip} {...tooltipProps}>
+                    {item}
+                  </Tooltip>
+                );
+              } else {
+                return item;
+              }
+            })}
         </DropdownList>
       </Dropdown>
     </React.Fragment>

--- a/packages/react-table/src/components/Table/TableTypes.tsx
+++ b/packages/react-table/src/components/Table/TableTypes.tsx
@@ -157,6 +157,10 @@ export interface IAction extends Omit<DropdownItemProps, 'title' | 'onClick'>, P
   itemKey?: string;
   /** Content to display in the actions menu item */
   title?: string | React.ReactNode;
+  /** Tooltip to display when hovered over the item */
+  tooltip?: React.ReactNode;
+  /** Additional props forwarded to the tooltip component */
+  tooltipProps?: any;
   /** Click handler for the actions menu item */
   onClick?: (event: React.MouseEvent, rowIndex: number, rowData: IRowData, extraData: IExtraData) => void;
   /** Flag indicating this action should be placed outside the actions menu, beside the toggle */


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8709 

Adds `tooltip` and `tooltipProps` to `IAction` and `ActionsColumn` to match the old Dropdown's functionality for tooltip use. Kept the `isSeparator` flag as that was not a flag for the dropdown specifically but for the ActionsColumn to render a divider. 

We could probably refactor ActionsColumn to more directly use `Menu` or Dropdown-next instead of passing data and mapping that to the components if we wanted, but I kept the API the same for now.
