### PR TITLE
docs(charts): remove references to broken katacoda trainings

### DIFF
--- a/packages/react-charts/src/components/ChartArea/examples/ChartArea.md
+++ b/packages/react-charts/src/components/ChartArea/examples/ChartArea.md
@@ -20,10 +20,6 @@ Note: PatternFly React charts live in its own package at [@patternfly/react-char
 
 PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
 
-Learn to build an area chart using a Katacoda tutorial starting with a simple chart, adding multiple datasets, tooltips, axis labels, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
-
-[Start course](https://katacoda.com/patternfly/courses/react-charts/area-chart)
-
 ## Examples
 ### Basic with right aligned legend
 ```js

--- a/packages/react-charts/src/components/ChartBar/examples/ChartBar.md
+++ b/packages/react-charts/src/components/ChartBar/examples/ChartBar.md
@@ -19,10 +19,6 @@ Note: PatternFly React charts live in its own package at [@patternfly/react-char
 
 PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
 
-Learn to build a bar chart using a Katacoda tutorial starting with a simple chart, adding multiple datasets, tooltips, axis labels, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
-
-[Start course](https://katacoda.com/patternfly/courses/react-charts/bar-chart)
-
 ## Examples
 ### Basic with right aligned legend
 ```js

--- a/packages/react-charts/src/components/ChartBullet/examples/ChartBullet.md
+++ b/packages/react-charts/src/components/ChartBullet/examples/ChartBullet.md
@@ -17,10 +17,6 @@ Note: PatternFly React charts live in its own package at [@patternfly/react-char
 
 PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
 
-Learn to build a bullet chart using a Katacoda tutorial starting with a simple chart, adding qualitative ranges, primary comparative measures, a comparative warning measure, tooltips, labels, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
-
-[Start course](https://katacoda.com/patternfly/courses/react-charts/bullet-chart)
-
 ## Examples
 ### Basic
 ```js

--- a/packages/react-charts/src/components/ChartDonut/examples/ChartDonut.md
+++ b/packages/react-charts/src/components/ChartDonut/examples/ChartDonut.md
@@ -14,10 +14,6 @@ Note: PatternFly React charts live in its own package at [@patternfly/react-char
 
 PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
 
-Learn to build a donut chart using a Katacoda tutorial starting with a simple chart, adding thresholds, tooltips, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
-
-[Start course](https://katacoda.com/patternfly/courses/react-charts/donut-chart)
-
 ## Examples
 ### Basic
 ```js

--- a/packages/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
+++ b/packages/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
@@ -15,10 +15,6 @@ Note: PatternFly React charts live in its own package at [@patternfly/react-char
 
 PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
 
-Learn to build a donut utilization chart using a Katacoda tutorial starting with a simple chart, adding thresholds, tooltips, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
-
-[Start course](https://katacoda.com/patternfly/courses/react-charts/donut-utilization-chart)
-
 ## Donut utilization examples
 ### Basic
 ```js

--- a/packages/react-charts/src/components/ChartLine/examples/ChartLine.md
+++ b/packages/react-charts/src/components/ChartLine/examples/ChartLine.md
@@ -20,10 +20,6 @@ Note: PatternFly React charts live in its own package at [@patternfly/react-char
 
 PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
 
-Learn to build a line chart using a Katacoda tutorial starting with a simple chart, adding multiple datasets, tooltips, axis labels, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
-
-[Start course](https://katacoda.com/patternfly/courses/react-charts/line-chart)
-
 ## Examples
 ### Basic with right aligned legend
 ```js

--- a/packages/react-charts/src/components/ChartPie/examples/ChartPie.md
+++ b/packages/react-charts/src/components/ChartPie/examples/ChartPie.md
@@ -12,10 +12,6 @@ Note: PatternFly React charts live in its own package at [@patternfly/react-char
 
 PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
 
-Learn to build a pie chart using a Katacoda tutorial starting with a simple chart, adding tooltips, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
-
-[Start course](https://katacoda.com/patternfly/courses/react-charts/pie-chart)
-
 ## Examples
 ### Basic with right aligned legend
 ```js

--- a/packages/react-charts/src/components/ChartStack/examples/ChartStack.md
+++ b/packages/react-charts/src/components/ChartStack/examples/ChartStack.md
@@ -30,10 +30,6 @@ Note: PatternFly React charts live in its own package at [@patternfly/react-char
 
 PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
 
-Learn to build a stack chart using a Katacoda tutorial starting with a simple chart, adding multiple datasets, tooltips, axis labels, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
-
-[Start course](https://katacoda.com/patternfly/courses/react-charts/stack-chart)
-
 ## Examples
 ### Basic with right aligned legend
 ```js

--- a/packages/react-charts/src/components/Sparkline/examples/sparkline.md
+++ b/packages/react-charts/src/components/Sparkline/examples/sparkline.md
@@ -19,10 +19,6 @@ Note: PatternFly React charts live in its own package at [@patternfly/react-char
 
 PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
 
-Learn to build a sparkline chart using a Katacoda tutorial starting with a simple chart, adding tooltips, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
-
-[Start course](https://katacoda.com/patternfly/courses/react-charts/sparkline-chart)
-
 ## Examples
 ### Basic
 ```js


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8902

