### PR TITLE
fix(beta): promote components + features out of beta for v5

### DIFF
--- a/packages/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/react-charts/src/components/Chart/Chart.tsx
@@ -208,7 +208,6 @@ export interface ChartProps extends VictoryChartProps {
    *
    * @example hasPatterns={ true }
    * @example hasPatterns={[ true, true, false ]}
-   * @beta
    */
   hasPatterns?: boolean | boolean[];
   /**
@@ -338,7 +337,6 @@ export interface ChartProps extends VictoryChartProps {
    * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
    *
    * @example patternScale={[ 'url("#pattern1")', 'url("#pattern2")', null ]}
-   * @beta
    */
   patternScale?: string[];
   /**

--- a/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -230,7 +230,6 @@ export interface ChartDonutProps extends ChartPieProps {
    *
    * @example hasPatterns={ true }
    * @example hasPatterns={[ true, true, false ]}
-   * @beta
    */
   hasPatterns?: boolean | boolean[];
   /**
@@ -375,7 +374,6 @@ export interface ChartDonutProps extends ChartPieProps {
    * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
    *
    * @example patternScale={[ 'url("#pattern1")', 'url("#pattern2")', null ]}
-   * @beta
    */
   patternScale?: string[];
   /**

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
@@ -229,7 +229,6 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    *
    * @example hasPatterns={ true }
    * @example hasPatterns={[ true, true, false ]}
-   * @beta
    */
   hasPatterns?: boolean | boolean[];
   /**
@@ -307,7 +306,6 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
    *
    * @example patternScale={[ 'url("#pattern1")', 'url("#pattern2")', null ]}
-   * @beta
    */
   patternScale?: string[];
   /**

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
@@ -229,7 +229,6 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    *
    * @example hasPatterns={ true }
    * @example hasPatterns={[ true, true, false ]}
-   * @beta
    */
   hasPatterns?: boolean | boolean[];
   /**
@@ -393,7 +392,6 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
    *
    * @example patternScale={[ 'url("#pattern1")', 'url("#pattern2")', null ]}
-   * @beta
    */
   patternScale?: string[];
   /**

--- a/packages/react-charts/src/components/ChartGroup/ChartGroup.tsx
+++ b/packages/react-charts/src/components/ChartGroup/ChartGroup.tsx
@@ -212,7 +212,6 @@ export interface ChartGroupProps extends VictoryGroupProps {
    *
    * @example hasPatterns={ true }
    * @example hasPatterns={[ true, true, false ]}
-   * @beta
    */
   hasPatterns?: boolean | boolean[];
   /**
@@ -314,7 +313,6 @@ export interface ChartGroupProps extends VictoryGroupProps {
    * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
    *
    * @example patternScale={[ 'url("#pattern1")', 'url("#pattern2")', null ]}
-   * @beta
    */
   patternScale?: string[];
   /**

--- a/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
+++ b/packages/react-charts/src/components/ChartLegend/ChartLegend.tsx
@@ -191,7 +191,6 @@ export interface ChartLegendProps extends VictoryLegendProps {
    * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
    *
    * @example patternScale={[ 'url("#pattern1")', 'url("#pattern2")', null ]}
-   * @beta
    */
   patternScale?: string[];
   /**

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltip.tsx
@@ -235,7 +235,6 @@ export interface ChartLegendTooltipProps extends ChartCursorTooltipProps {
    * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
    *
    * @example patternScale={[ 'url("#pattern1")', 'url("#pattern2")', null ]}
-   * @beta
    */
   patternScale?: string[];
   /**

--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipContent.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipContent.tsx
@@ -127,7 +127,6 @@ export interface ChartLegendTooltipContentProps {
    * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
    *
    * @example patternScale={[ 'url("#pattern1")', 'url("#pattern2")', null ]}
-   * @beta
    */
   patternScale?: string[];
   /**

--- a/packages/react-charts/src/components/ChartPie/ChartPie.tsx
+++ b/packages/react-charts/src/components/ChartPie/ChartPie.tsx
@@ -216,7 +216,6 @@ export interface ChartPieProps extends VictoryPieProps {
    *
    * @example hasPatterns={ true }
    * @example hasPatterns={[ true, true, false ]}
-   * @beta
    */
   hasPatterns?: boolean | boolean[];
   /**
@@ -372,7 +371,6 @@ export interface ChartPieProps extends VictoryPieProps {
    * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
    *
    * @example patternScale={[ 'url("#pattern1")', 'url("#pattern2")', null ]}
-   * @beta
    */
   patternScale?: string[];
   /**

--- a/packages/react-charts/src/components/ChartStack/ChartStack.tsx
+++ b/packages/react-charts/src/components/ChartStack/ChartStack.tsx
@@ -197,7 +197,6 @@ export interface ChartStackProps extends VictoryStackProps {
    *
    * @example hasPatterns={ true }
    * @example hasPatterns={[ true, true, false ]}
-   * @beta
    */
   hasPatterns?: boolean | boolean[];
   /**
@@ -292,7 +291,6 @@ export interface ChartStackProps extends VictoryStackProps {
    * Note: Not all components are supported; for example, ChartLine, ChartBullet, ChartThreshold, etc.
    *
    * @example patternScale={[ 'url("#pattern1")', 'url("#pattern2")', null ]}
-   * @beta
    */
   patternScale?: string[];
   /**

--- a/packages/react-charts/src/components/ChartUtils/chart-patterns.tsx
+++ b/packages/react-charts/src/components/ChartUtils/chart-patterns.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import uniqueId from 'lodash/uniqueId';
 
-// @beta
 interface PatternPropsInterface {
   children?: any;
   colorScale?: any;

--- a/packages/react-charts/src/components/Patterns/examples/patterns.md
+++ b/packages/react-charts/src/components/Patterns/examples/patterns.md
@@ -18,7 +18,6 @@ propComponents: [
   'ChartVoronoiContainer'
 ]
 hideDarkMode: true
-beta: true
 ---
 
 import { 

--- a/packages/react-core/src/components/DatePicker/examples/DatePicker.md
+++ b/packages/react-core/src/components/DatePicker/examples/DatePicker.md
@@ -4,7 +4,6 @@ section: components
 subsection: date-and-time
 cssPrefix: pf-c-date-picker
 propComponents: ['DatePicker', 'CalendarFormat', 'DatePickerRef']
-beta: true
 ---
 
 ## Examples

--- a/packages/react-core/src/components/Icon/examples/Icon.md
+++ b/packages/react-core/src/components/Icon/examples/Icon.md
@@ -3,7 +3,6 @@ id: Icon
 section: components
 cssPrefix: pf-c-icon
 propComponents: ['Icon']
-beta: true
 ---
 
 import LongArrowAltDownIcon from '@patternfly/react-icons/dist/esm/icons/long-arrow-alt-down-icon';

--- a/packages/react-core/src/components/Menu/MenuItem.tsx
+++ b/packages/react-core/src/components/Menu/MenuItem.tsx
@@ -24,7 +24,7 @@ export interface MenuItemProps extends Omit<React.HTMLProps<HTMLLIElement>, 'onC
   itemId?: any;
   /** Target navigation link. Should not be used if the flyout prop is defined. */
   to?: string;
-  /** @beta Flag indicating the item has a checkbox */
+  /** Flag indicating the item has a checkbox */
   hasCheckbox?: boolean;
   /** Flag indicating whether the item is active */
   isActive?: boolean;

--- a/packages/react-core/src/components/Menu/examples/Menu.md
+++ b/packages/react-core/src/components/Menu/examples/Menu.md
@@ -81,7 +81,7 @@ Use the `description` property to add short descriptive text below any menu item
 
 Use the `hasCheck` property to add a checkbox to a `<MenuItem>`. Use the `isSelected` property to indicate when a `<MenuItem>` is selected.
 
-```ts file="./MenuWithCheckbox.tsx" isBeta
+```ts file="./MenuWithCheckbox.tsx"
 
 ```
 

--- a/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadStatusItem.tsx
+++ b/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadStatusItem.tsx
@@ -54,7 +54,7 @@ export interface MultipleFileUploadStatusItemProps extends React.HTMLProps<HTMLL
   progressAriaLiveMessage?: string | ((loadPercentage: number) => string);
   /** Unique identifier for progress. Generated if not specified. */
   progressId?: string;
-  /** @beta Additional content related to the status item. */
+  /** Additional content related to the status item. */
   progressHelperText?: React.ReactNode;
 }
 

--- a/packages/react-core/src/components/Progress/Progress.tsx
+++ b/packages/react-core/src/components/Progress/Progress.tsx
@@ -42,7 +42,7 @@ export interface ProgressProps extends Omit<React.HTMLProps<HTMLDivElement>, 'si
   'aria-label'?: string;
   /** Associates the ProgressBar with it's label for accessibility purposes. Required when title not used */
   'aria-labelledby'?: string;
-  /** @beta Content which can be used to convey additional information about the progress component.
+  /** Content which can be used to convey additional information about the progress component.
    * We recommend the helper text component as it was designed for this purpose.
    */
   helperText?: React.ReactNode;

--- a/packages/react-core/src/components/Progress/ProgressContainer.tsx
+++ b/packages/react-core/src/components/Progress/ProgressContainer.tsx
@@ -54,7 +54,7 @@ export interface ProgressContainerProps extends Omit<React.HTMLProps<HTMLDivElem
     | 'left-end'
     | 'right-start'
     | 'right-end';
-  /** @beta Content which can be used to convey additional information about the progress component.
+  /** Content which can be used to convey additional information about the progress component.
    * We recommend the helper text component as it was designed for this purpose.
    */
   helperText?: React.ReactNode;

--- a/packages/react-core/src/components/Progress/examples/Progress.md
+++ b/packages/react-core/src/components/Progress/examples/Progress.md
@@ -76,5 +76,5 @@ propComponents: ['Progress']
 ```
 
 ### Helper text
-```ts file="./ProgressHelperText.tsx" isBeta
+```ts file="./ProgressHelperText.tsx"
 ```

--- a/packages/react-core/src/components/ProgressStepper/examples/ProgressStepper.md
+++ b/packages/react-core/src/components/ProgressStepper/examples/ProgressStepper.md
@@ -3,7 +3,6 @@ id: Progress stepper
 section: components
 cssPrefix: pf-c-progress-stepper
 propComponents: ['ProgressStepper', 'ProgressStep']
-beta: true
 ---
 
 import InProgressIcon from '@patternfly/react-icons/dist/esm/icons/in-progress-icon';

--- a/packages/react-core/src/components/SearchInput/examples/SearchInput.md
+++ b/packages/react-core/src/components/SearchInput/examples/SearchInput.md
@@ -3,7 +3,6 @@ id: 'Search input'
 section: components
 cssPrefix: 'pf-c-search-input'
 propComponents: ['SearchInput', 'SearchInputSearchAttribute', 'SearchInputExpandable']
-beta: true
 ---
 
 import { ExternalLinkSquareAltIcon } from '@patternfly/react-icons';

--- a/packages/react-core/src/components/Tabs/Tab.tsx
+++ b/packages/react-core/src/components/Tabs/Tab.tsx
@@ -37,11 +37,11 @@ export interface TabProps
   innerRef?: React.Ref<any>;
   /** Optional Tooltip rendered to a Tab. Should be <Tooltip> with appropriate props for proper rendering. */
   tooltip?: React.ReactElement<any>;
-  /** @beta Aria-label for the close button added by passing the onClose property to Tabs. */
+  /** Aria-label for the close button added by passing the onClose property to Tabs. */
   closeButtonAriaLabel?: string;
-  /** @beta Flag indicating the close button should be disabled */
+  /** Flag indicating the close button should be disabled */
   isCloseDisabled?: boolean;
-  /** @beta Actions rendered beside the tab content */
+  /** Actions rendered beside the tab content */
   actions?: React.ReactNode;
   /** Value to set the data-ouia-component-id for the tab button.*/
   ouiaId?: number | string;

--- a/packages/react-core/src/components/Tabs/Tabs.tsx
+++ b/packages/react-core/src/components/Tabs/Tabs.tsx
@@ -105,7 +105,7 @@ export interface TabsProps extends Omit<React.HTMLProps<HTMLElement | HTMLDivEle
   toggleAriaLabel?: string;
   /** Callback function to toggle the expandable tabs. */
   onToggle?: (event: React.MouseEvent, isExpanded: boolean) => void;
-  /** @beta Flag which places overflowing tabs into a menu triggered by the last tab. Additionally an object can be passed with custom settings for the overflow tab. */
+  /** Flag which places overflowing tabs into a menu triggered by the last tab. Additionally an object can be passed with custom settings for the overflow tab. */
   isOverflowHorizontal?: boolean | HorizontalOverflowObject;
   /** Value to overwrite the randomly generated data-ouia-component-id.*/
   ouiaId?: number | string;

--- a/packages/react-core/src/components/Tabs/examples/Tabs.md
+++ b/packages/react-core/src/components/Tabs/examples/Tabs.md
@@ -89,7 +89,7 @@ To enable horizontal overflow, use the `isOverflowHorizontal` property.
 
 In the following example, select the 'Show overflowing tab count' checkbox to add a count of overflow items to the final “more” tab.
 
-```ts file="./TabsHorizontalOverflow.tsx" isBeta
+```ts file="./TabsHorizontalOverflow.tsx"
 ```
 
 ### With tooltip react ref
@@ -218,7 +218,7 @@ You may add a help action to a tab to provide users with additional context in a
 
 To render an action beside the tab content, use the `actions` property of a `<Tab>`. Pass a popover and a `<TabsAction>` component into the `actions` property. 
 
-```ts file="./TabsHelp.tsx" isBeta
+```ts file="./TabsHelp.tsx"
 ```
 
 ### With help and close actions
@@ -227,5 +227,5 @@ To add multiple actions to a tab, create a `<TabAction>` component for each acti
 
 The following example passes in both help popover and close actions.
 
-```ts file="./TabsHelpAndClose.tsx" isBeta
+```ts file="./TabsHelpAndClose.tsx"
 ```

--- a/packages/react-core/src/components/TextInputGroup/examples/TextInputGroup.md
+++ b/packages/react-core/src/components/TextInputGroup/examples/TextInputGroup.md
@@ -3,7 +3,6 @@ id: Text input group
 section: components
 cssPrefix: pf-c-text-input-group
 propComponents: ['TextInputGroup', 'TextInputGroupMain', 'TextInputGroupUtilities']
-beta: true
 ---
 
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';

--- a/packages/react-core/src/components/Tile/examples/Tile.md
+++ b/packages/react-core/src/components/Tile/examples/Tile.md
@@ -3,7 +3,6 @@ id: Tile
 section: components
 cssPrefix: pf-c-tile
 propComponents: ['Tile']
-beta: true
 ---
 
 import PlusIcon from '@patternfly/react-icons/dist/esm/icons/plus-icon';

--- a/packages/react-core/src/components/Truncate/examples/Truncate.md
+++ b/packages/react-core/src/components/Truncate/examples/Truncate.md
@@ -2,7 +2,6 @@
 id: Truncate
 section: components
 propComponents: [Truncate]
-beta: true
 ---
 
 import './TruncateExamples.css';

--- a/packages/react-core/src/demos/ComposableMenu/ComposableMenu.md
+++ b/packages/react-core/src/demos/ComposableMenu/ComposableMenu.md
@@ -46,17 +46,17 @@ Custom menus can be constructed using a composable approach by combining the [Me
 
 ### Composable simple checkbox select
 
-```ts isBeta file="./examples/ComposableSimpleCheckboxSelect.tsx"
+```ts file="./examples/ComposableSimpleCheckboxSelect.tsx"
 ```
 
 ### Composable typeahead select
 
-```ts isBeta file="./examples/ComposableTypeaheadSelect.tsx"
+```ts file="./examples/ComposableTypeaheadSelect.tsx"
 ```
 
 ### Composable multiple typeahead select
 
-```ts isBeta file="./examples/ComposableMultipleTypeaheadSelect.tsx"
+```ts file="./examples/ComposableMultipleTypeaheadSelect.tsx"
 ```
 
 ### Composable drilldown menu

--- a/packages/react-core/src/demos/DatePicker/DatePicker.md
+++ b/packages/react-core/src/demos/DatePicker/DatePicker.md
@@ -2,7 +2,6 @@
 id: Date picker
 section: components
 subsection: date-and-time
-beta: true
 ---
 
 ## Demos

--- a/packages/react-core/src/demos/ProgressStepperDemo.md
+++ b/packages/react-core/src/demos/ProgressStepperDemo.md
@@ -1,7 +1,6 @@
 ---
 id: Progress stepper
 section: components
-beta: true
 ---
 
 ## Demos

--- a/packages/react-core/src/demos/SearchInput/SearchInput.md
+++ b/packages/react-core/src/demos/SearchInput/SearchInput.md
@@ -1,7 +1,6 @@
 ---
 id: Search input
 section: components
-beta: true
 ---
 
 import {

--- a/packages/react-core/src/demos/TextInputGroupDemo.md
+++ b/packages/react-core/src/demos/TextInputGroupDemo.md
@@ -1,7 +1,6 @@
 ---
 id: Text input group
 section: components
-beta: true
 ---
 
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';

--- a/packages/react-core/src/deprecated/components/Dropdown/DropdownToggleCheckbox.tsx
+++ b/packages/react-core/src/deprecated/components/Dropdown/DropdownToggleCheckbox.tsx
@@ -16,7 +16,7 @@ export interface DropdownToggleCheckboxProps
   isDisabled?: boolean;
   /** Flag to show if the checkbox is checked */
   isChecked?: boolean | null;
-  /** @beta Flag to show if the checkbox is in progress */
+  /** Flag to show if the checkbox is in progress */
   isInProgress?: boolean | null;
   /** Alternate Flag to show if the checkbox is checked */
   checked?: boolean | null;
@@ -28,9 +28,9 @@ export interface DropdownToggleCheckboxProps
   id: string;
   /** Aria-label of the checkbox */
   'aria-label': string;
-  /** @beta Text describing current loading status or progress */
+  /** Text describing current loading status or progress */
   defaultProgressAriaValueText?: string;
-  /** @beta Aria-label for the default progress icon to describe what is loading */
+  /** Aria-label for the default progress icon to describe what is loading */
   defaultProgressAriaLabel?: string;
   /** Value to overwrite the randomly generated data-ouia-component-id.*/
   ouiaId?: number | string;

--- a/packages/react-core/src/deprecated/components/Dropdown/examples/Dropdown.md
+++ b/packages/react-core/src/deprecated/components/Dropdown/examples/Dropdown.md
@@ -161,7 +161,7 @@ Text labels may optionally be used alongside actions within split buttons.
 
 The `isInProgress` property can be used to indicate a progress state by rendering a spinner in place of a checkbox.
 
-```ts isBeta file="./DropdownSplitButtonProgressCheckbox.tsx"
+```ts file="./DropdownSplitButtonProgressCheckbox.tsx"
 
 ```
 


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8536

promotes:
Charts: Patterns
 Date picker
 Dropdown: bulk select loading state
 Dropdown - next
 Icon
 LoginPage: header utilities
 MenuItem: hasCheck
 Multiple file upload with helper text
 Progress stepper
 Progress helper text
 removeFindDomNode
 SearchInput
 Select next
 Select: isCreateSelectOptionObject
 Select: loadingVariant
 Select: isInputFilterPersisted
 Tabs: dynamic
 Tabs: horizontal overflow
 Tabs: actions
 Tabs: close button props
 Text area: icon sprite
 Text input group
 Tile
 Truncate
 Wizard next

Components/features still in beta after v5: https://docs.google.com/spreadsheets/d/17aEfvG1DZ0dZmpwacYaCzKv4sog0LuatXCwNizJ7HhE/edit#gid=1239116046