### PR TITLE
fix(Topology): Fix ColaGroupLayout crash on add

### DIFF
--- a/packages/react-topology/src/layouts/BaseLayout.ts
+++ b/packages/react-topology/src/layouts/BaseLayout.ts
@@ -66,6 +66,7 @@ export class BaseLayout implements Layout {
     this.options = {
       ...LAYOUT_DEFAULTS,
       onSimulationEnd: this.onSimulationEnd,
+      listenForChanges: true,
       ...options
     };
 
@@ -174,7 +175,7 @@ export class BaseLayout implements Layout {
 
   private startListening(): void {
     const controller = this.graph.getController();
-    if (controller) {
+    if (controller && this.options.listenForChanges) {
       controller.addEventListener(ADD_CHILD_EVENT, this.handleChildAdded);
       controller.addEventListener(REMOVE_CHILD_EVENT, this.handleChildRemoved);
       controller.addEventListener(ELEMENT_VISIBILITY_CHANGE_EVENT, this.handleElementVisibilityChange);

--- a/packages/react-topology/src/layouts/ColaGroupsLayout.ts
+++ b/packages/react-topology/src/layouts/ColaGroupsLayout.ts
@@ -81,6 +81,11 @@ class ColaGroupsLayout extends ColaLayout implements Layout {
     });
   }
 
+  protected stopSimulation(): void {
+    super.stopSimulation();
+    this.childLayouts.forEach(layout => layout.stop());
+  }
+
   protected createLayoutNode(node: Node, nodeDistance: number, index: number) {
     return new ColaGroupsNode(node, nodeDistance, index);
   }
@@ -119,7 +124,7 @@ class ColaGroupsLayout extends ColaLayout implements Layout {
     edges: LayoutLink[],
     groups: LayoutGroup[]
   ): BaseLayout {
-    const layout = new ColaGroupsLayout(graph, this.options);
+    const layout = new ColaGroupsLayout(graph, { ...this.options, listenForChanges: false });
     layout.setupLayout(graph, nodes, edges, groups);
     return layout;
   }

--- a/packages/react-topology/src/layouts/LayoutOptions.ts
+++ b/packages/react-topology/src/layouts/LayoutOptions.ts
@@ -8,4 +8,5 @@ export interface LayoutOptions {
   allowDrag: boolean;
   layoutOnDrag: boolean;
   onSimulationEnd?: () => void;
+  listenForChanges?: boolean;
 }


### PR DESCRIPTION
**What**:
Fixes https://github.com/patternfly/patternfly-react/issues/8638

**Description**
Only the top level layout should listen for changes to the graph. Sub layouts will run when the top level layout is run.
On layout stop, stop all child layouts.