### PR TITLE
feat(DropdownItem): add missing props to prop table

### DIFF
--- a/packages/react-core/src/components/Dropdown/DropdownItem.tsx
+++ b/packages/react-core/src/components/Dropdown/DropdownItem.tsx
@@ -10,8 +10,12 @@ export interface DropdownItemProps extends Omit<MenuItemProps, 'ref'>, OUIAProps
   className?: string;
   /** Description of the dropdown item */
   description?: React.ReactNode;
+  /** Render item as disabled option */
+  isDisabled?: boolean;
   /** Identifies the component in the dropdown onSelect callback */
   itemId?: any;
+  /** Callback for item click */
+  onClick?: (event?: any) => void;
   /** Value to overwrite the randomly generated data-ouia-component-id.*/
   ouiaId?: number | string;
   /** Set the value of data-ouia-safe. Only set to true when the component is in a static state, i.e. no animations are occurring. At all other times, this value must be false. */
@@ -22,14 +26,24 @@ export const DropdownItem: React.FunctionComponent<MenuItemProps> = ({
   children,
   className,
   description,
+  isDisabled,
   itemId,
+  onClick,
   ouiaId,
   ouiaSafe,
   ...props
 }: DropdownItemProps) => {
   const ouiaProps = useOUIAProps(DropdownItem.displayName, ouiaId, ouiaSafe);
   return (
-    <MenuItem className={css(className)} description={description} itemId={itemId} {...ouiaProps} {...props}>
+    <MenuItem
+      className={css(className)}
+      description={description}
+      isDisabled={isDisabled}
+      itemId={itemId}
+      onClick={onClick}
+      {...ouiaProps}
+      {...props}
+    >
       {children}
     </MenuItem>
   );


### PR DESCRIPTION
**What**: Closes #8509

Adds `isDisabled` and `onClick` props to `DropdownItem` prop table since they are used in the examples.
