### PR TITLE
fix(InputGroupText): drop variants and fix missing padding because of wrong classes

### DIFF
--- a/packages/react-core/src/components/InputGroup/InputGroupText.tsx
+++ b/packages/react-core/src/components/InputGroup/InputGroupText.tsx
@@ -2,11 +2,6 @@ import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/InputGroup/input-group';
 import { css } from '@patternfly/react-styles';
 
-export enum InputGroupTextVariant {
-  default = 'default',
-  plain = 'plain'
-}
-
 export interface InputGroupTextProps extends React.HTMLProps<HTMLSpanElement | HTMLLabelElement> {
   /** Additional classes added to the input group text. */
   className?: string;
@@ -14,23 +9,22 @@ export interface InputGroupTextProps extends React.HTMLProps<HTMLSpanElement | H
   children: React.ReactNode;
   /** Component that wraps the input group text. */
   component?: React.ReactNode;
-  /** Input group text variant */
-  variant?: InputGroupTextVariant | 'default' | 'plain';
 }
 
 export const InputGroupText: React.FunctionComponent<InputGroupTextProps> = ({
   className = '',
   component = 'span',
   children,
-  variant = InputGroupTextVariant.default,
   ...props
 }: InputGroupTextProps) => {
   const Component = component as any;
   return (
     <Component
       className={css(
+        styles.inputGroupItem,
         styles.inputGroupText,
-        variant === InputGroupTextVariant.plain && styles.modifiers.plain,
+        styles.modifiers.plain,
+        styles.modifiers.box,
         className
       )}
       {...props}

--- a/packages/react-core/src/components/InputGroup/__tests__/InputGroupText.test.tsx
+++ b/packages/react-core/src/components/InputGroup/__tests__/InputGroupText.test.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 
 import { render, screen } from '@testing-library/react';
 
-import { InputGroupText, InputGroupTextVariant } from '../InputGroupText';
+import { InputGroupText } from '../InputGroupText';
 
 describe('InputGroupText', () => {
   test('renders', () => {
     render(
-      <InputGroupText className="inpt-grp-text" variant={InputGroupTextVariant.plain} id="email-npt-grp">
+      <InputGroupText className="inpt-grp-text" id="email-npt-grp">
         @
       </InputGroupText>
     );

--- a/packages/react-core/src/components/InputGroup/examples/InputGroupBasic.tsx
+++ b/packages/react-core/src/components/InputGroup/examples/InputGroupBasic.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import AtIcon from '@patternfly/react-icons/dist/esm/icons/at-icon';
-import { InputGroup, InputGroupText, InputGroupTextVariant, TextInput, ValidatedOptions } from '@patternfly/react-core';
+import { InputGroup, InputGroupText, TextInput, ValidatedOptions } from '@patternfly/react-core';
 
 export const InputGroupBasic: React.FunctionComponent = () => (
   <React.Fragment>
@@ -23,7 +23,7 @@ export const InputGroupBasic: React.FunctionComponent = () => (
     <br />
     <InputGroup>
       <TextInput name="textInput-basic-3" id="textInput-basic-3" type="text" aria-label="percentage" />
-      <InputGroupText id="plain-example" variant={InputGroupTextVariant.plain}>
+      <InputGroupText id="plain-example">
         %
       </InputGroupText>
     </InputGroup>

--- a/packages/react-core/src/components/Slider/_tests_/__snapshots__/Slider.test.tsx.snap
+++ b/packages/react-core/src/components/Slider/_tests_/__snapshots__/Slider.test.tsx.snap
@@ -424,7 +424,7 @@ exports[`slider renders slider with input 1`] = `
           value="50"
         />
         <span
-          class="pf-c-input-group__text"
+          class="pf-c-input-group__item pf-c-input-group__text pf-m-plain pf-m-box"
         >
            %
         </span>
@@ -492,7 +492,7 @@ exports[`slider renders slider with input above thumb 1`] = `
             value="50"
           />
           <span
-            class="pf-c-input-group__text"
+            class="pf-c-input-group__item pf-c-input-group__text pf-m-plain pf-m-box"
           >
              %
           </span>

--- a/packages/react-integration/demo-app-ts/src/components/demos/InputGroupDemo/InputGroupDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/InputGroupDemo/InputGroupDemo.tsx
@@ -10,7 +10,6 @@ import {
   TextArea,
   InputGroup,
   InputGroupText,
-  InputGroupTextVariant,
   TextInput,
   Popover,
   PopoverPosition,
@@ -168,7 +167,7 @@ export class InputGroupDemo extends React.Component<{}, InputGroupState> {
         <br />
         <InputGroup>
           <TextInput name="textIndex12" id="textInput12" type="text" aria-label="percentage" />
-          <InputGroupText id="plain-example" variant={InputGroupTextVariant.plain}>
+          <InputGroupText id="plain-example">
             %
           </InputGroupText>
         </InputGroup>


### PR DESCRIPTION
Follow the html docs on how input-group text component should look like. https://pf5.patternfly.org/components/input-group/#overview

InputGroupText is meant to contain plain text. Any kind of variant setting is overkill, we should just provide users with a straightforward way to put a plain text inside an input group and have all the needed padding sets.

Fixes #8952
