### PR TITLE
Bug - Fileupload - Fix browse

### DIFF
--- a/packages/react-core/src/components/FileUpload/FileUpload.tsx
+++ b/packages/react-core/src/components/FileUpload/FileUpload.tsx
@@ -99,9 +99,8 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
   const onDropAccepted = (acceptedFiles: File[], event: DropEvent) => {
     if (acceptedFiles.length > 0) {
       const fileHandle = acceptedFiles[0];
-      if (event.type === 'drop') {
-        onFileInputChange?.(event, fileHandle);
-      }
+      onFileInputChange?.(event, fileHandle);
+
       if (type === fileReaderType.text || type === fileReaderType.dataURL) {
         onReadStarted(fileHandle);
         readFile(fileHandle, type as fileReaderType)
@@ -129,6 +128,7 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
   };
 
   const { getRootProps, getInputProps, isDragActive, open, inputRef } = useDropzone({
+    noClick: true,
     multiple: false,
     ...dropzoneProps,
     onDropAccepted,


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8969
Before the fix, in fileupload examples, clicking on browse would open 2 file upload dialogs and after selecting a file the file name will not be shown.

onFileInputChange should also be called when a file is browsed and not only on drop, event is null on browse upload.
adding noClick as suggested in the react-dropzone docs:
> If you bind a click event on an inner element and use open(), it will trigger a click on the root element too, resulting in the file dialog opening twice. To prevent this, use the noClick on the root

