### PR TITLE
fix(DataList, Table): update hoverable reference to clickable

### DIFF
--- a/packages/react-core/src/components/Badge/Badge.tsx
+++ b/packages/react-core/src/components/Badge/Badge.tsx
@@ -25,7 +25,7 @@ export const Badge: React.FunctionComponent<BadgeProps> = ({
     className={css(styles.badge, (isRead ? styles.modifiers.read : styles.modifiers.unread) as any, className)}
   >
     {children}
-    {screenReaderText && <span className="pf-screen-reader">{screenReaderText}</span>}
+    {screenReaderText && <span className="pf-v5-screen-reader">{screenReaderText}</span>}
   </span>
 );
 Badge.displayName = 'Badge';

--- a/packages/react-core/src/components/Badge/__tests__/Badge.test.tsx
+++ b/packages/react-core/src/components/Badge/__tests__/Badge.test.tsx
@@ -31,9 +31,9 @@ test('Renders with class name pf-m-read when isRead prop is true', () => {
   expect(screen.getByText('Test')).toHaveClass('pf-m-read');
 });
 
-test('Does not render pf-screen-reader class by default', () => {
+test('Does not render pf-v5-screen-reader class by default', () => {
   render(<Badge>Test</Badge>);
-  expect(screen.getByText('Test')).not.toContainHTML('<span class="pf-screen-reader"></span>');
+  expect(screen.getByText('Test')).not.toContainHTML('<span class="pf-v5-screen-reader"></span>');
 });
 
 test('Renders screenReaderText passed via prop', () => {

--- a/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
+++ b/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
@@ -336,7 +336,7 @@ export const CalendarMonth = ({
           <tr>
             {calendar[0].map(({ date }, index) => (
               <th key={index} className={styles.calendarMonthDay} scope="col">
-                <span className="pf-screen-reader">{longWeekdayFormat(date)}</span>
+                <span className="pf-v5-screen-reader">{longWeekdayFormat(date)}</span>
                 <span aria-hidden>{weekdayFormat(date)}</span>
               </th>
             ))}

--- a/packages/react-core/src/components/Card/Card.tsx
+++ b/packages/react-core/src/components/Card/Card.tsx
@@ -141,7 +141,7 @@ export const Card: React.FunctionComponent<CardProps> = ({
     >
       {hasSelectableInput && (
         <input
-          className="pf-screen-reader"
+          className="pf-v5-screen-reader"
           id={`${id}-input`}
           {...ariaProps}
           type="checkbox"

--- a/packages/react-core/src/components/DataList/DataListItem.tsx
+++ b/packages/react-core/src/components/DataList/DataListItem.tsx
@@ -93,7 +93,7 @@ export class DataListItem extends React.Component<DataListItemProps> {
             >
               {onSelectableRowChange && (
                 <input
-                  className="pf-screen-reader"
+                  className="pf-v5-screen-reader"
                   type="radio"
                   checked={isSelected}
                   onChange={(event) => onSelectableRowChange(event, id)}

--- a/packages/react-core/src/components/DataList/examples/DataList.md
+++ b/packages/react-core/src/components/DataList/examples/DataList.md
@@ -68,9 +68,9 @@ import { css } from '@patternfly/react-styles';
 
 ```
 
-### Selectable rows
+### Clickable rows
 
-```ts file="./DataListSelectableRows.tsx"
+```ts file="./DataListClickableRows.tsx"
 
 ```
 

--- a/packages/react-core/src/components/DataList/examples/DataListClickableRows.tsx
+++ b/packages/react-core/src/components/DataList/examples/DataListClickableRows.tsx
@@ -14,7 +14,7 @@ import {
 } from '@patternfly/react-core';
 import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
 
-export const DataListSelectableRows: React.FunctionComponent = () => {
+export const DataListClickableRows: React.FunctionComponent = () => {
   const [isOpen1, setIsOpen1] = React.useState(false);
   const [isOpen2, setIsOpen2] = React.useState(false);
   const [selectedDataListItemId, setSelectedDataListItemId] = React.useState('');
@@ -46,24 +46,24 @@ export const DataListSelectableRows: React.FunctionComponent = () => {
   return (
     <React.Fragment>
       <DataList
-        aria-label="selectable data list example"
+        aria-label="clickable data list example"
         selectedDataListItemId={selectedDataListItemId}
         onSelectDataListItem={onSelectDataListItem}
         onSelectableRowChange={handleInputChange}
       >
-        <DataListItem aria-labelledby="selectable-action-item1" id="item1">
+        <DataListItem aria-labelledby="clickable-action-item1" id="item1">
           <DataListItemRow>
             <DataListItemCells
               dataListCells={[
                 <DataListCell key="primary content">
-                  <span id="selectable-action-item1">Single actionable Primary content</span>
+                  <span id="clickable-action-item1">Single actionable Primary content</span>
                 </DataListCell>,
                 <DataListCell key="secondary content">Single actionable Secondary content</DataListCell>
               ]}
             />
             <DataListAction
-              aria-labelledby="selectable-action-item1 selectable-action-action1"
-              id="selectable-action-action1"
+              aria-labelledby="clickable-action-item1 clickable-action-action1"
+              id="clickable-action-action1"
               aria-label="Actions"
               isPlainButtonAction
             >
@@ -76,7 +76,7 @@ export const DataListSelectableRows: React.FunctionComponent = () => {
                     isExpanded={isOpen1}
                     onClick={onToggle1}
                     variant="plain"
-                    aria-label="Data list selectable rows example kebab toggle 1"
+                    aria-label="Data list clickable rows example kebab toggle 1"
                   >
                     <EllipsisVIcon aria-hidden="true" />
                   </MenuToggle>
@@ -102,19 +102,19 @@ export const DataListSelectableRows: React.FunctionComponent = () => {
             </DataListAction>
           </DataListItemRow>
         </DataListItem>
-        <DataListItem aria-labelledby="selectable-actions-item2" id="item2">
+        <DataListItem aria-labelledby="clickable-actions-item2" id="item2">
           <DataListItemRow>
             <DataListItemCells
               dataListCells={[
                 <DataListCell key="primary content">
-                  <span id="selectable-actions-item2">Selectable actions Primary content</span>
+                  <span id="clickable-actions-item2">clickable actions Primary content</span>
                 </DataListCell>,
-                <DataListCell key="secondary content">Selectable actions Secondary content</DataListCell>
+                <DataListCell key="secondary content">clickable actions Secondary content</DataListCell>
               ]}
             />
             <DataListAction
-              aria-labelledby="selectable-actions-item2 selectable-actions-action2"
-              id="selectable-actions-action2"
+              aria-labelledby="clickable-actions-item2 clickable-actions-action2"
+              id="clickable-actions-action2"
               aria-label="Actions"
               isPlainButtonAction
             >
@@ -127,7 +127,7 @@ export const DataListSelectableRows: React.FunctionComponent = () => {
                     isExpanded={isOpen2}
                     onClick={onToggle2}
                     variant="plain"
-                    aria-label="Data list selectable rows example kebab toggle 2"
+                    aria-label="Data list clickable rows example kebab toggle 2"
                   >
                     <EllipsisVIcon aria-hidden="true" />
                   </MenuToggle>

--- a/packages/react-core/src/components/DataList/examples/DataListDraggable.tsx
+++ b/packages/react-core/src/components/DataList/examples/DataListDraggable.tsx
@@ -93,10 +93,10 @@ export const DataListDraggable: React.FunctionComponent = () => {
           ))}
         </DataList>
       </Droppable>
-      <div className="pf-screen-reader" aria-live="assertive">
+      <div className="pf-v5-screen-reader" aria-live="assertive">
         {liveText}
       </div>
-      <div className="pf-screen-reader" id={`description-${uniqueId}`}>
+      <div className="pf-v5-screen-reader" id={`description-${uniqueId}`}>
         Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm
         the drag, or any other key to cancel the drag operation.
       </div>

--- a/packages/react-core/src/components/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react-core/src/components/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -190,7 +190,7 @@ exports[`With popover opened 1`] = `
                     scope="col"
                   >
                     <span
-                      class="pf-screen-reader"
+                      class="pf-v5-screen-reader"
                     >
                       Sunday
                     </span>
@@ -205,7 +205,7 @@ exports[`With popover opened 1`] = `
                     scope="col"
                   >
                     <span
-                      class="pf-screen-reader"
+                      class="pf-v5-screen-reader"
                     >
                       Monday
                     </span>
@@ -220,7 +220,7 @@ exports[`With popover opened 1`] = `
                     scope="col"
                   >
                     <span
-                      class="pf-screen-reader"
+                      class="pf-v5-screen-reader"
                     >
                       Tuesday
                     </span>
@@ -235,7 +235,7 @@ exports[`With popover opened 1`] = `
                     scope="col"
                   >
                     <span
-                      class="pf-screen-reader"
+                      class="pf-v5-screen-reader"
                     >
                       Wednesday
                     </span>
@@ -250,7 +250,7 @@ exports[`With popover opened 1`] = `
                     scope="col"
                   >
                     <span
-                      class="pf-screen-reader"
+                      class="pf-v5-screen-reader"
                     >
                       Thursday
                     </span>
@@ -265,7 +265,7 @@ exports[`With popover opened 1`] = `
                     scope="col"
                   >
                     <span
-                      class="pf-screen-reader"
+                      class="pf-v5-screen-reader"
                     >
                       Friday
                     </span>
@@ -280,7 +280,7 @@ exports[`With popover opened 1`] = `
                     scope="col"
                   >
                     <span
-                      class="pf-screen-reader"
+                      class="pf-v5-screen-reader"
                     >
                       Saturday
                     </span>

--- a/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadStatusItem.tsx
+++ b/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadStatusItem.tsx
@@ -148,7 +148,7 @@ export const MultipleFileUploadStatusItem: React.FunctionComponent<MultipleFileU
     <li className={css(styles.multipleFileUploadStatusItem, className)} {...props}>
       <div className={styles.multipleFileUploadStatusItemIcon}>{fileIcon || <FileIcon />}</div>
       <div className={styles.multipleFileUploadStatusItemMain}>
-        <div className="pf-screen-reader" aria-live="polite">
+        <div className="pf-v5-screen-reader" aria-live="polite">
           {progressAriaLiveMessage &&
             typeof progressAriaLiveMessage === 'function' &&
             progressAriaLiveMessage(+loadPercentage.toFixed(2))}

--- a/packages/react-core/src/components/MultipleFileUpload/__tests__/__snapshots__/MultipleFileUploadStatusItem.test.tsx.snap
+++ b/packages/react-core/src/components/MultipleFileUpload/__tests__/__snapshots__/MultipleFileUploadStatusItem.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`MultipleFileUploadStatusItem renders custom aria labels 1`] = `
     >
       <div
         aria-live="polite"
-        class="pf-screen-reader"
+        class="pf-v5-screen-reader"
       >
         Progress value is 0%.
       </div>
@@ -137,7 +137,7 @@ exports[`MultipleFileUploadStatusItem renders custom class names 1`] = `
     >
       <div
         aria-live="polite"
-        class="pf-screen-reader"
+        class="pf-v5-screen-reader"
       >
         Progress value is 0%.
       </div>
@@ -246,7 +246,7 @@ exports[`MultipleFileUploadStatusItem renders custom file name/size/icon/progres
     >
       <div
         aria-live="polite"
-        class="pf-screen-reader"
+        class="pf-v5-screen-reader"
       >
         test message
       </div>
@@ -357,7 +357,7 @@ exports[`MultipleFileUploadStatusItem renders custom function progressAriaLiveMe
     >
       <div
         aria-live="polite"
-        class="pf-screen-reader"
+        class="pf-v5-screen-reader"
       >
         test message 0
       </div>
@@ -468,7 +468,7 @@ exports[`MultipleFileUploadStatusItem renders custom progress value/variant when
     >
       <div
         aria-live="polite"
-        class="pf-screen-reader"
+        class="pf-v5-screen-reader"
       >
         Progress value is 42%.
       </div>
@@ -594,7 +594,7 @@ exports[`MultipleFileUploadStatusItem renders expected values from a passed file
     >
       <div
         aria-live="polite"
-        class="pf-screen-reader"
+        class="pf-v5-screen-reader"
       >
         Progress value is 0%.
       </div>
@@ -705,7 +705,7 @@ exports[`MultipleFileUploadStatusItem renders with expected class names 1`] = `
     >
       <div
         aria-live="polite"
-        class="pf-screen-reader"
+        class="pf-v5-screen-reader"
       >
         Progress value is 0%.
       </div>
@@ -814,7 +814,7 @@ exports[`MultipleFileUploadStatusItem rendersdefault progressAriaLiveMessage whe
     >
       <div
         aria-live="polite"
-        class="pf-screen-reader"
+        class="pf-v5-screen-reader"
       >
         Progress value is 0%.
       </div>

--- a/packages/react-core/src/demos/ProgressDemo.md
+++ b/packages/react-core/src/demos/ProgressDemo.md
@@ -31,7 +31,7 @@ ProgressStepperDemo = () => {
         <br />
       </StackItem>
       <StackItem>
-        <div className="pf-screen-reader" aria-live="polite">
+        <div className="pf-v5-screen-reader" aria-live="polite">
           {`Progress value is ${currentValue}%.`}
         </div>
         <Progress value={currentValue} title="Title" />
@@ -71,7 +71,7 @@ ProgressStepperDemo = () => {
         <br />
       </StackItem>
       <StackItem>
-        <div className="pf-screen-reader" aria-live="polite">
+        <div className="pf-v5-screen-reader" aria-live="polite">
           {`Progress value is ${currentValue}%.`}
         </div>
         <Progress value={currentValue} title="Title" />

--- a/packages/react-core/src/demos/ProgressStepperDemo.md
+++ b/packages/react-core/src/demos/ProgressStepperDemo.md
@@ -46,7 +46,7 @@ ProgressStepperDemo = () => {
         <br />
       </StackItem>
       <StackItem>
-        <div className="pf-screen-reader" aria-live="polite">
+        <div className="pf-v5-screen-reader" aria-live="polite">
           {steps[currentStep] && `On ${steps[currentStep].title}.`}
           {steps[currentStep - 1] && `${steps[currentStep - 1].title} was successful.`}
         </div>

--- a/packages/react-integration/demo-app-ts/src/components/demos/DataListDemo/DataListDraggableDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DataListDemo/DataListDraggableDemo.tsx
@@ -101,7 +101,7 @@ export class DataListDraggableDemo extends React.Component {
             ))}
           </DataList>
         </Droppable>
-        <div className="pf-screen-reader" aria-live="assertive">
+        <div className="pf-v5-screen-reader" aria-live="assertive">
           {liveText}
         </div>
       </DragDrop>

--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableRowClickDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableRowClickDemo.tsx
@@ -22,17 +22,17 @@ export class TableRowClickDemo extends React.Component<TableProps, ITableRowClic
       rows: [
         {
           cells: ['Repositories one', 'Branches one', 'Pull requests one', 'Workspaces one'],
-          isHoverable: true,
+          isClickable: true,
           isRowSelected: true
         },
         {
           cells: ['Repositories two', 'Branches two', 'Pull requests two', 'Workspaces two'],
-          isHoverable: true,
+          isClickable: true,
           isRowSelected: false
         },
         {
           cells: ['Repositories three', 'Branches three', 'Pull requests three', 'Workspaces three'],
-          isHoverable: true,
+          isClickable: true,
           isRowSelected: false
         }
       ]

--- a/packages/react-table/src/components/Table/RowWrapper.tsx
+++ b/packages/react-table/src/components/Table/RowWrapper.tsx
@@ -94,7 +94,7 @@ export class RowWrapper extends React.Component<RowWrapperProps> {
       /* eslint-disable @typescript-eslint/no-unused-vars */
       onScroll,
       onResize,
-      row: { isExpanded, isEditable, isHoverable, isRowSelected },
+      row: { isExpanded, isEditable, isClickable, isRowSelected },
       rowProps,
       /* eslint-enable @typescript-eslint/no-unused-vars */
       trRef,
@@ -111,7 +111,7 @@ export class RowWrapper extends React.Component<RowWrapperProps> {
         isEditable={isEditable}
         className={className}
         ouiaId={ouiaId}
-        isHoverable={isHoverable}
+        isClickable={isClickable}
         isRowSelected={isRowSelected}
       />
     );

--- a/packages/react-table/src/components/Table/Table.tsx
+++ b/packages/react-table/src/components/Table/Table.tsx
@@ -121,7 +121,7 @@ const TableBase: React.FunctionComponent<TableProps> = ({
       setTableCaption(
         <caption>
           {selectableRowCaptionText}
-          <div className="pf-screen-reader">
+          <div className="pf-v5-screen-reader">
             This table has selectable rows. It can be navigated by row using tab, and each row can be selected using
             space or enter.
           </div>
@@ -129,7 +129,7 @@ const TableBase: React.FunctionComponent<TableProps> = ({
       );
     } else {
       setTableCaption(
-        <caption className="pf-screen-reader">
+        <caption className="pf-v5-screen-reader">
           This table has selectable rows. It can be navigated by row using tab, and each row can be selected using space
           or enter.
         </caption>

--- a/packages/react-table/src/components/Table/TableTypes.tsx
+++ b/packages/react-table/src/components/Table/TableTypes.tsx
@@ -238,7 +238,7 @@ export interface IRow extends RowType {
   cells?: (React.ReactNode | IRowCell)[];
   isOpen?: boolean;
   isEditable?: boolean;
-  isHoverable?: boolean;
+  isClickable?: boolean;
   isRowSelected?: boolean;
   isValid?: boolean;
   /** An array of validation functions to run against every cell for a given row */

--- a/packages/react-table/src/components/Table/Tr.tsx
+++ b/packages/react-table/src/components/Table/Tr.tsx
@@ -89,7 +89,7 @@ const TrBase: React.FunctionComponent<TrProps> = ({
 
   return (
     <>
-      {isSelectable && <output className="pf-screen-reader">{ariaLabel}</output>}
+      {isSelectable && <output className="pf-v5-screen-reader">{ariaLabel}</output>}
       <tr
         className={css(
           className,

--- a/packages/react-table/src/components/Table/Tr.tsx
+++ b/packages/react-table/src/components/Table/Tr.tsx
@@ -20,8 +20,8 @@ export interface TrProps extends React.HTMLProps<HTMLTableRowElement>, OUIAProps
   isExpanded?: boolean;
   /** Only applicable to Tr within the Tbody: Whether the row is editable */
   isEditable?: boolean;
-  /** Flag which adds hover styles for the table row */
-  isHoverable?: boolean;
+  /** Flag which adds hover styles for the clickable table row */
+  isClickable?: boolean;
   /** Flag indicating the row is selected - adds selected styling */
   isRowSelected?: boolean;
   /** Flag indicating the row is striped */
@@ -46,7 +46,7 @@ const TrBase: React.FunctionComponent<TrProps> = ({
   isExpanded,
   isEditable,
   isHidden = false,
-  isHoverable = false,
+  isClickable = false,
   isRowSelected = false,
   isStriped = false,
   isBorderRow = false,
@@ -96,14 +96,14 @@ const TrBase: React.FunctionComponent<TrProps> = ({
           isExpanded !== undefined && styles.tableExpandableRow,
           isExpanded && styles.modifiers.expanded,
           isEditable && inlineStyles.modifiers.inlineEditable,
-          isHoverable && styles.modifiers.clickable,
+          isClickable && styles.modifiers.clickable,
           isRowSelected && styles.modifiers.selected,
           isStriped && styles.modifiers.striped,
           isBorderRow && styles.modifiers.borderRow,
           resetOffset && styles.modifiers.firstCellOffsetReset
         )}
         hidden={rowIsHidden}
-        {...(isHoverable && { tabIndex: 0 })}
+        {...(isClickable && { tabIndex: 0 })}
         aria-label={ariaLabel}
         ref={innerRef}
         {...(onRowClick && { onClick: onRowClick, onKeyDown })}

--- a/packages/react-table/src/components/Table/examples/Table.md
+++ b/packages/react-table/src/components/Table/examples/Table.md
@@ -147,11 +147,11 @@ Similarly to the selectable example above, the radio buttons use the first colum
 ```ts file="TableSelectableRadio.tsx"
 ```
 
-### Row click handler, hoverable & selected rows
+### Row click handler, clickable rows
 
 This selectable rows feature is intended for use when a table is used to present a list of objects in a Primary-detail view.
 
-```ts file="TableHoverable.tsx"
+```ts file="TableClickable.tsx"
 ```
 
 ### Actions

--- a/packages/react-table/src/components/Table/examples/TableClickable.tsx
+++ b/packages/react-table/src/components/Table/examples/TableClickable.tsx
@@ -9,7 +9,7 @@ interface Repository {
   lastCommit: string;
 }
 
-export const TableHoverable: React.FunctionComponent = () => {
+export const TableClickable: React.FunctionComponent = () => {
   // In real usage, this data would come from some external source like an API via props.
   const repositories: Repository[] = [
     { name: 'one', branches: 'two', prs: 'three', workspaces: 'four', lastCommit: 'five' },
@@ -30,7 +30,7 @@ export const TableHoverable: React.FunctionComponent = () => {
   const [selectedRepoName, setSelectedRepoName] = React.useState('');
 
   return (
-    <Table aria-label="Hoverable table">
+    <Table aria-label="Clickable table">
       <Thead>
         <Tr>
           <Th>{columnNames.name}</Th>
@@ -46,7 +46,7 @@ export const TableHoverable: React.FunctionComponent = () => {
             key={repo.name}
             onRowClick={() => setSelectedRepoName(repo.name)}
             isSelectable
-            isHoverable
+            isClickable
             isRowSelected={selectedRepoName === repo.name}
           >
             <Td dataLabel={columnNames.name}>{repo.name}</Td>

--- a/packages/react-table/src/deprecated/components/Table/examples/LegacyTableClickable.tsx
+++ b/packages/react-table/src/deprecated/components/Table/examples/LegacyTableClickable.tsx
@@ -11,7 +11,7 @@ interface Repository {
   lastCommit: string;
 }
 
-export const LegacyTableHoverable: React.FunctionComponent = () => {
+export const LegacyTableClickable: React.FunctionComponent = () => {
   // In real usage, this data would come from some external source like an API via props.
   const repositories: Repository[] = [
     {
@@ -98,7 +98,7 @@ export const LegacyTableHoverable: React.FunctionComponent = () => {
     }
     return {
       cells,
-      isHoverable: true,
+      isClickable: true,
       isRowSelected: selectedRepoName === repo.name
     };
   });

--- a/packages/react-table/src/deprecated/components/Table/examples/Table.md
+++ b/packages/react-table/src/deprecated/components/Table/examples/Table.md
@@ -205,11 +205,11 @@ To disable selection for a row, set `disableSelection: true` on the row definiti
 ```ts file="LegacyTableSelectableRadio.tsx"
 ```
 
-### Hoverable rows, selectable rows, and header cell tooltips/popovers
+### Clickable rows, selectable rows, and header cell tooltips/popovers
 
 This selectable rows feature is intended for use when a table is used to present a list of objects in a Primary-detail view.
 
-```ts file="LegacyTableHoverable.tsx"
+```ts file="LegacyTableClickable.tsx"
 ```
 
 ### Actions and first cell in body rows as th


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes https://github.com/patternfly/patternfly-react/issues/9001

This is clean up after core work: https://github.com/patternfly/patternfly/pull/5397
basically, hoverable classnames for DataList and Table have been changed to clickable. 
Changes here:

- updated the relevant Datalist, Table, Deprecated table example titles to match the corresponding core titles.
- changed the table's `isHoverable` prop to `isClickable`