### PR TITLE
fix(Modal): remove `aria-hidden` from siblings when unmounting the component

### DIFF
--- a/packages/react-core/src/components/Modal/Modal.tsx
+++ b/packages/react-core/src/components/Modal/Modal.tsx
@@ -212,6 +212,7 @@ export class Modal extends React.Component<ModalProps, ModalState> {
     }
     target.removeEventListener('keydown', this.handleEscKeyClick, false);
     target.classList.remove(css(styles.backdropOpen));
+    this.toggleSiblingsFromScreenReaders(false);
   }
 
   render() {

--- a/packages/react-core/src/components/Modal/__tests__/Modal.test.tsx
+++ b/packages/react-core/src/components/Modal/__tests__/Modal.test.tsx
@@ -19,6 +19,26 @@ const props = {
   children: 'modal content'
 };
 
+const target = document.createElement('div');
+
+const ModalWithSiblings = () => {
+  const [isOpen, setIsOpen] = React.useState(true);
+  const [isModalMounted, setIsModalMounted] = React.useState(true);
+  const modalProps = { ...props, isOpen, appendTo: target, onClose: () => setIsOpen(false) };
+
+  return (
+    <>
+      <aside>Aside sibling</aside>
+      <article>Section sibling</article>
+      {isModalMounted && (
+        <Modal {...modalProps}>
+          <button onClick={() => setIsModalMounted(false)}>Unmount Modal</button>
+        </Modal>
+      )}
+    </>
+  );
+};
+
 describe('Modal', () => {
   test('Modal creates a container element once for div', () => {
     render(<Modal {...props} />);
@@ -89,6 +109,51 @@ describe('Modal', () => {
     expect(consoleErrorMock).toHaveBeenCalled();
   });
 
+  test('modal adds aria-hidden attribute to its siblings when open', () => {
+    render(<ModalWithSiblings />, { container: document.body.appendChild(target) });
+
+    const asideSibling = screen.getByRole('complementary', { hidden: true });
+    const articleSibling = screen.getByRole('article', { hidden: true });
+
+    expect(asideSibling).toHaveAttribute('aria-hidden');
+    expect(articleSibling).toHaveAttribute('aria-hidden');
+  });
+
+  test('modal removes the aria-hidden attribute from its siblings when closed', async () => {
+    const user = userEvent.setup();
+
+    render(<ModalWithSiblings />, { container: document.body.appendChild(target) });
+
+    const asideSibling = screen.getByRole('complementary', { hidden: true });
+    const articleSibling = screen.getByRole('article', { hidden: true });
+    const closeButton = screen.getByRole('button', { name: 'Close' });
+
+    expect(articleSibling).toHaveAttribute('aria-hidden');
+    expect(asideSibling).toHaveAttribute('aria-hidden');
+
+    await user.click(closeButton);
+
+    expect(articleSibling).not.toHaveAttribute('aria-hidden');
+    expect(asideSibling).not.toHaveAttribute('aria-hidden');
+  });
+
+  test('modal removes the aria-hidden attribute from its siblings when unmounted', async () => {
+    const user = userEvent.setup();
+
+    render(<ModalWithSiblings />, { container: document.body.appendChild(target) });
+
+    const asideSibling = screen.getByRole('complementary', { hidden: true });
+    const articleSibling = screen.getByRole('article', { hidden: true });
+    const unmountButton = screen.getByRole('button', { name: 'Unmount Modal' });
+
+    expect(asideSibling).toHaveAttribute('aria-hidden');
+    expect(articleSibling).toHaveAttribute('aria-hidden');
+
+    await user.click(unmountButton);
+
+    expect(asideSibling).not.toHaveAttribute('aria-hidden');
+    expect(articleSibling).not.toHaveAttribute('aria-hidden');
+  });
   test('The modalBoxBody has no aria-label when bodyAriaLabel is not passed', () => {
     const props = {
       isOpen: true

--- a/packages/react-core/src/components/Modal/__tests__/Modal.test.tsx
+++ b/packages/react-core/src/components/Modal/__tests__/Modal.test.tsx
@@ -47,7 +47,7 @@ describe('Modal', () => {
 
   test('modal closes with escape', async () => {
     const user = userEvent.setup();
-    
+
     render(<Modal {...props} isOpen appendTo={document.body} />);
 
     await user.type(screen.getByText(props.title), `{${KeyTypes.Escape}}`);


### PR DESCRIPTION
## What

At Agama project, we've found an _issue_ with the `aria-hidden` attributes added by the PatternFly Modal component: [some dialogs do not remove them](https://github.com/openSUSE/agama/pull/564#issuecomment-1539158432).

As far as I can see, this happens to us with _open dialogs_ that are included dynamically. I.e., dialogs that are mounted as open and then simply unmounted instead of closed.

Of course, we should re-evaluate such a use case and stop doing so if we do not have strong reasons for it. However, it looks straight forward and safe to **trigger the logic for removing these attributes when the component is unmounted** too. I cannot envision a scenario where this would not be convenient

## Additional issues

Prior to digging into the problem, I quickly searched the issue list and found https://github.com/patternfly/patternfly-react/issues/8925. Based on a quick glance at the linked source code, the problem appears to be the same: [the MemberModal is unmounted, not closed](https://github.com/agagancarczyk/keycloak/blob/251f6151e86b55efdfe2a688989ac15795481e59/js/apps/admin-ui/src/groups/Members.tsx#L120-L128), so the aria-hidden attributes remain.

## Other notes

Just in case it can be useful for someone else doing a first contribution to patternfly/patternfly-react:

Getting the project working locally was a bit challenging to me because neither [GETTING-STARTED.md](https://github.com/patternfly/patternfly-react/blob/main/GETTING-STARTED.md) nor the [CONTRIBUTING.md](https://github.com/patternfly/patternfly-react/blob/main/CONTRIBUTING.md) helped me to understand the errors related to missing modules/dependencies I got at the beginning when trying either, to build the project and to run the test suite. The [Getting Started as a Contributor](https://github.com/patternfly/patternfly-react/wiki/Getting-Started-as-a-Contributor) guide looks outdated too.

Fortunately, I could get some hints about how to move forward from the [Maintainer's Guide](https://github.com/patternfly/patternfly-react/wiki/Maintainer's-Guide) and the [_dist_ CI partial](https://github.com/patternfly/patternfly-react/blob/main/.github/workflows-src/partials/dist.yml). Summarizing:

* **DO NOT** use `npm install`
* **Use** `yarn install` instead (you might need to install `yarn` first)
* Run `yarn build && yarn build:umd`
* Run `yarn test`

Furthermore, I learned [how to run a single test in a project using yarn workspaces](https://stackoverflow.com/a/74730919). In my case, I have used below command from the root of the project

```bash
yarn jest packages/react-core/src/components/Modal/__tests__/Modal.test.tsx -c jest.config.js 
```

and also I run the linter with 

```bash
yarn eslint --no-ignore packages/react-core/src/components/Modal/__tests__/Modal.test.tsx
```
