### PR TITLE
chore(deps): Removed @testing-library/react-hooks dep

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,7 +14,6 @@
         "@patternfly/documentation-framework",
         "@rollup/*",
         "@testing-library/jest-dom",
-        "@testing-library/react-hooks",
         "@testing-library/user-event",
         "@types/jest",
         "@types/react",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@octokit/rest": "^19.0.7",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
-    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "14.4.3",
     "@types/jest": "29.5.1",
     "@types/react": "^18",

--- a/packages/react-core/src/components/Wizard/hooks/__tests__/useWizardFooter.test.tsx
+++ b/packages/react-core/src/components/Wizard/hooks/__tests__/useWizardFooter.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 
 import { useWizardFooter } from '../useWizardFooter';
 import * as WizardContext from '../../WizardContext';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4256,14 +4256,6 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
-"@testing-library/react-hooks@^8.0.1":
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
-  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    react-error-boundary "^3.1.0"
-
 "@testing-library/react@^13.4.0":
   version "13.4.0"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-13.4.0.tgz#6a31e3bf5951615593ad984e96b9e5e2d9380966"
@@ -15953,13 +15945,6 @@ react-dropzone@14.2.3, react-dropzone@^14.2.3:
     attr-accept "^2.2.2"
     file-selector "^0.6.0"
     prop-types "^15.8.1"
-
-react-error-boundary@^3.1.0:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
-  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
 
 react-fast-compare@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: towards #8003 

Removed @testing-library/react-hooks dependencies as it does not support react 18.  support for render hook as been added to @testing-library/react.
