### PR TITLE
feat(Flex): add gap support

### DIFF
--- a/packages/react-core/src/layouts/Flex/Flex.tsx
+++ b/packages/react-core/src/layouts/Flex/Flex.tsx
@@ -136,6 +136,141 @@ export interface FlexProps extends React.HTMLProps<HTMLDivElement> {
       | 'spaceItems3xl'
       | 'spaceItems4xl';
   };
+  /** Whether to add a gap at various breakpoints. This will override spacers for the main axis. */
+  gap?: {
+    default?: 'gapNone' | 'gapXs' | 'gapSm' | 'gapMd' | 'gapLg' | 'gapXl' | 'gap2xl' | 'gap3xl' | 'gap4xl';
+    sm?: 'gapNone' | 'gapXs' | 'gapSm' | 'gapMd' | 'gapLg' | 'gapXl' | 'gap2xl' | 'gap3xl' | 'gap4xl';
+    md?: 'gapNone' | 'gapXs' | 'gapSm' | 'gapMd' | 'gapLg' | 'gapXl' | 'gap2xl' | 'gap3xl' | 'gap4xl';
+    lg?: 'gapNone' | 'gapXs' | 'gapSm' | 'gapMd' | 'gapLg' | 'gapXl' | 'gap2xl' | 'gap3xl' | 'gap4xl';
+    xl?: 'gapNone' | 'gapXs' | 'gapSm' | 'gapMd' | 'gapLg' | 'gapXl' | 'gap2xl' | 'gap3xl' | 'gap4xl';
+    '2xl'?: 'gapNone' | 'gapXs' | 'gapSm' | 'gapMd' | 'gapLg' | 'gapXl' | 'gap2xl' | 'gap3xl' | 'gap4xl';
+  };
+  /** Whether to add a gap at various breakpoints. This will override spacers for the main axis. */
+  rowGap?: {
+    default?:
+      | 'rowGapNone'
+      | 'rowGapXs'
+      | 'rowGapSm'
+      | 'rowGapMd'
+      | 'rowGapLg'
+      | 'rowGapXl'
+      | 'rowGap2xl'
+      | 'rowGap3xl'
+      | 'rowGap4xl';
+    sm?:
+      | 'rowGapNone'
+      | 'rowGapXs'
+      | 'rowGapSm'
+      | 'rowGapMd'
+      | 'rowGapLg'
+      | 'rowGapXl'
+      | 'rowGap2xl'
+      | 'rowGap3xl'
+      | 'rowGap4xl';
+    md?:
+      | 'rowGapNone'
+      | 'rowGapXs'
+      | 'rowGapSm'
+      | 'rowGapMd'
+      | 'rowGapLg'
+      | 'rowGapXl'
+      | 'rowGap2xl'
+      | 'rowGap3xl'
+      | 'rowGap4xl';
+    lg?:
+      | 'rowGapNone'
+      | 'rowGapXs'
+      | 'rowGapSm'
+      | 'rowGapMd'
+      | 'rowGapLg'
+      | 'rowGapXl'
+      | 'rowGap2xl'
+      | 'rowGap3xl'
+      | 'rowGap4xl';
+    xl?:
+      | 'rowGapNone'
+      | 'rowGapXs'
+      | 'rowGapSm'
+      | 'rowGapMd'
+      | 'rowGapLg'
+      | 'rowGapXl'
+      | 'rowGap2xl'
+      | 'rowGap3xl'
+      | 'rowGap4xl';
+    '2xl'?:
+      | 'rowGapNone'
+      | 'rowGapXs'
+      | 'rowGapSm'
+      | 'rowGapMd'
+      | 'rowGapLg'
+      | 'rowGapXl'
+      | 'rowGap2xl'
+      | 'rowGap3xl'
+      | 'rowGap4xl';
+  };
+  /** Whether to add a gap at various breakpoints. This will override spacers for the main axis. */
+  columnGap?: {
+    default?:
+      | 'columnGapNone'
+      | 'columnGapXs'
+      | 'columnGapSm'
+      | 'columnGapMd'
+      | 'columnGapLg'
+      | 'columnGapXl'
+      | 'columnGap2xl'
+      | 'columnGap3xl'
+      | 'columnGap4xl';
+    sm?:
+      | 'columnGapNone'
+      | 'columnGapXs'
+      | 'columnGapSm'
+      | 'columnGapMd'
+      | 'columnGapLg'
+      | 'columnGapXl'
+      | 'columnGap2xl'
+      | 'columnGap3xl'
+      | 'columnGap4xl';
+    md?:
+      | 'columnGapNone'
+      | 'columnGapXs'
+      | 'columnGapSm'
+      | 'columnGapMd'
+      | 'columnGapLg'
+      | 'columnGapXl'
+      | 'columnGap2xl'
+      | 'columnGap3xl'
+      | 'columnGap4xl';
+    lg?:
+      | 'columnGapNone'
+      | 'columnGapXs'
+      | 'columnGapSm'
+      | 'columnGapMd'
+      | 'columnGapLg'
+      | 'columnGapXl'
+      | 'columnGap2xl'
+      | 'columnGap3xl'
+      | 'columnGap4xl';
+    xl?:
+      | 'columnGapNone'
+      | 'columnGapXs'
+      | 'columnGapSm'
+      | 'columnGapMd'
+      | 'columnGapLg'
+      | 'columnGapXl'
+      | 'columnGap2xl'
+      | 'columnGap3xl'
+      | 'columnGap4xl';
+    '2xl'?:
+      | 'columnGapNone'
+      | 'columnGapXs'
+      | 'columnGapSm'
+      | 'columnGapMd'
+      | 'columnGapLg'
+      | 'columnGapXl'
+      | 'columnGap2xl'
+      | 'columnGap3xl'
+      | 'columnGap4xl';
+  };
   /** Whether to add flex: grow at various breakpoints */
   grow?: {
     default?: 'grow';
@@ -344,6 +479,9 @@ export const Flex: React.FunctionComponent<FlexProps> = ({
   component = 'div',
   spacer,
   spaceItems,
+  gap,
+  rowGap,
+  columnGap,
   grow,
   shrink,
   flex,
@@ -380,6 +518,9 @@ export const Flex: React.FunctionComponent<FlexProps> = ({
         formatBreakpointMods(display, styles),
         formatBreakpointMods(fullWidth, styles),
         formatBreakpointMods(flexWrap, styles),
+        formatBreakpointMods(gap, styles),
+        formatBreakpointMods(rowGap, styles),
+        formatBreakpointMods(columnGap, styles),
         className
       )}
       style={

--- a/packages/react-core/src/layouts/Flex/Flex.tsx
+++ b/packages/react-core/src/layouts/Flex/Flex.tsx
@@ -136,7 +136,7 @@ export interface FlexProps extends React.HTMLProps<HTMLDivElement> {
       | 'spaceItems3xl'
       | 'spaceItems4xl';
   };
-  /** Whether to add a gap at various breakpoints. This will override spacers for the main axis. */
+  /** Gap between items at various breakpoints. This will override spacers for the main axis. */
   gap?: {
     default?: 'gapNone' | 'gapXs' | 'gapSm' | 'gapMd' | 'gapLg' | 'gapXl' | 'gap2xl' | 'gap3xl' | 'gap4xl';
     sm?: 'gapNone' | 'gapXs' | 'gapSm' | 'gapMd' | 'gapLg' | 'gapXl' | 'gap2xl' | 'gap3xl' | 'gap4xl';
@@ -145,7 +145,7 @@ export interface FlexProps extends React.HTMLProps<HTMLDivElement> {
     xl?: 'gapNone' | 'gapXs' | 'gapSm' | 'gapMd' | 'gapLg' | 'gapXl' | 'gap2xl' | 'gap3xl' | 'gap4xl';
     '2xl'?: 'gapNone' | 'gapXs' | 'gapSm' | 'gapMd' | 'gapLg' | 'gapXl' | 'gap2xl' | 'gap3xl' | 'gap4xl';
   };
-  /** Whether to add a gap at various breakpoints. This will override spacers for the main axis. */
+  /** Gap between rows at various breakpoints. This will override spacers for the main axis. */
   rowGap?: {
     default?:
       | 'rowGapNone'
@@ -208,7 +208,7 @@ export interface FlexProps extends React.HTMLProps<HTMLDivElement> {
       | 'rowGap3xl'
       | 'rowGap4xl';
   };
-  /** Whether to add a gap at various breakpoints. This will override spacers for the main axis. */
+  /** Gap beween columns at various breakpoints. This will override spacers for the main axis. */
   columnGap?: {
     default?:
       | 'columnGapNone'

--- a/packages/react-core/src/layouts/Flex/__tests__/Flex.test.tsx
+++ b/packages/react-core/src/layouts/Flex/__tests__/Flex.test.tsx
@@ -85,16 +85,40 @@ describe('Flex', () => {
     ],
     display: ['inlineFlex'],
     fullWidth: ['fullWidth'],
-    flexWrap: ['wrap', 'wrapReverse', 'nowrap']
+    flexWrap: ['wrap', 'wrapReverse', 'nowrap'],
+    gap: ['gapNone', 'gapXs', 'gapSm', 'gapMd', 'gapLg', 'gapXl', 'gap2xl', 'gap3xl', 'gap4xl'],
+    rowGap: [
+      'rowGapNone',
+      'rowGapXs',
+      'rowGapSm',
+      'rowGapMd',
+      'rowGapLg',
+      'rowGapXl',
+      'rowGap2xl',
+      'rowGap3xl',
+      'rowGap4xl'
+    ],
+    columnGap: [
+      'columnGapNone',
+      'columnGapXs',
+      'columnGapSm',
+      'columnGapMd',
+      'columnGapLg',
+      'columnGapXl',
+      'columnGap2xl',
+      'columnGap3xl',
+      'columnGap4xl'
+    ]
   };
 
   describe('flex modifiers', () => {
     Object.entries(flexModifiers)
       .map(([mod, values]) =>
-        values.map(value => ({
+        values.map((value) => ({
           [mod]: {
             default: value,
             sm: value,
+            md: value,
             lg: value,
             xl: value,
             '2xl': value
@@ -102,7 +126,7 @@ describe('Flex', () => {
         }))
       )
       .reduce((acc, val) => acc.concat(val), [])
-      .forEach(props =>
+      .forEach((props) =>
         test(`${JSON.stringify(props)} add valid classes to Flex`, () => {
           render(
             <Flex {...props} data-testid="test-id">
@@ -110,11 +134,7 @@ describe('Flex', () => {
             </Flex>
           );
 
-          const className = screen
-            .getByTestId('test-id')
-            .className.replace('pf-l-flex', '')
-            .trim();
-
+          const className = screen.getByTestId('test-id').className.replace('pf-l-flex', '').trim();
           expect(className).not.toBe("''");
           expect(className).not.toBe('');
         })
@@ -134,7 +154,7 @@ describe('Flex', () => {
   describe('flexItem modifiers', () => {
     Object.entries(flexItemModifiers)
       .map(([mod, values]) =>
-        values.map(value => ({
+        values.map((value) => ({
           [mod]: {
             default: value,
             sm: value,
@@ -145,7 +165,7 @@ describe('Flex', () => {
         }))
       )
       .reduce((acc, val) => acc.concat(val), [])
-      .forEach(props =>
+      .forEach((props) =>
         test(`${JSON.stringify(props)} add valid classes to FlexItem`, () => {
           render(
             <FlexItem {...props} data-testid="test-id">

--- a/packages/react-core/src/layouts/Flex/examples/Flex.md
+++ b/packages/react-core/src/layouts/Flex/examples/Flex.md
@@ -7,7 +7,7 @@ propComponents: ['Flex', 'FlexItem']
 
 import './flex.css';
 
-## Flex Basics
+## Flex basics
 
 ### Basic
 
@@ -62,7 +62,7 @@ import { Flex, FlexItem } from '@patternfly/react-core';
 </Flex>;
 ```
 
-### Flex Spacing
+### Flex spacing
 
 ### Individually spaced
 
@@ -112,7 +112,7 @@ import { Flex, FlexItem } from '@patternfly/react-core';
 </Flex>;
 ```
 
-### Flex Gap
+### Flex gap spacing
 
 ### Row gap
 

--- a/packages/react-core/src/layouts/Flex/examples/Flex.md
+++ b/packages/react-core/src/layouts/Flex/examples/Flex.md
@@ -62,6 +62,16 @@ import { Flex, FlexItem } from '@patternfly/react-core';
 </Flex>;
 ```
 
+### Spacing
+
+The flex layout provides two ways of spacing its direct children.
+
+- [Spacing system](#flex-spacing)
+  - The spacing system applies a margin between the flex layout's direct children to create space between items along the main axis only. The benefit of the spacing system is that it allows for variable spacing between direct children. Use the spacing system when individual flex items along the main axis require a different spacer than sibling items.
+- [Gap spacing](#flex-gap-spacing)
+  - Gap spacing uses flex `gap` to space the flex layout's direct children, and can be applied to space rows (`row-gap`), columns (`column-gap`), or both (`gap`). The benefit of gap spacing is that item wrapping is improved and improved item spacing that works better with CSS flex's logical layout properties. E.g., spacing in RTL layouts that rely on logical properties is improved. Use the gap system when all direct children should use the same spacer for rows, columns, or both.
+  - **Note** using `gap` along the main axis will override any other spacing applied using the spacing system.
+
 ### Flex spacing
 
 ### Individually spaced

--- a/packages/react-core/src/layouts/Flex/examples/Flex.md
+++ b/packages/react-core/src/layouts/Flex/examples/Flex.md
@@ -8,7 +8,9 @@ propComponents: ['Flex', 'FlexItem']
 import './flex.css';
 
 ## Flex Basics
+
 ### Basic
+
 ```js
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
@@ -19,10 +21,11 @@ import { Flex, FlexItem } from '@patternfly/react-core';
   <FlexItem>Flex item</FlexItem>
   <FlexItem>Flex item</FlexItem>
   <FlexItem>Flex item</FlexItem>
-</Flex>
+</Flex>;
 ```
 
 ### Nesting
+
 ```js
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
@@ -37,10 +40,11 @@ import { Flex, FlexItem } from '@patternfly/react-core';
     <FlexItem>Flex item</FlexItem>
     <FlexItem>Flex item</FlexItem>
   </Flex>
-</Flex>
+</Flex>;
 ```
 
 ### Nested with items
+
 ```js
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
@@ -55,11 +59,13 @@ import { Flex, FlexItem } from '@patternfly/react-core';
   <Flex>
     <FlexItem>Flex item</FlexItem>
   </Flex>
-</Flex>
+</Flex>;
 ```
 
 ### Flex Spacing
+
 ### Individually spaced
+
 ```js
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
@@ -73,10 +79,11 @@ import { Flex, FlexItem } from '@patternfly/react-core';
   <FlexItem spacer={{ default: 'spacerXl' }}>Item - xl</FlexItem>
   <FlexItem spacer={{ default: 'spacer2xl' }}>Item - 2xl</FlexItem>
   <FlexItem spacer={{ default: 'spacer3xl' }}>Item - 3xl</FlexItem>
-</Flex>
+</Flex>;
 ```
 
 ### Spacing xl
+
 ```js
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
@@ -87,10 +94,11 @@ import { Flex, FlexItem } from '@patternfly/react-core';
   <FlexItem>Flex item</FlexItem>
   <FlexItem>Flex item</FlexItem>
   <FlexItem>Flex item</FlexItem>
-</Flex>
+</Flex>;
 ```
 
 ### Spacing none
+
 ```js
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
@@ -101,11 +109,75 @@ import { Flex, FlexItem } from '@patternfly/react-core';
   <FlexItem>Flex item</FlexItem>
   <FlexItem>Flex item</FlexItem>
   <FlexItem>Flex item</FlexItem>
-</Flex>
+</Flex>;
+```
+
+### Flex Gap
+
+### Row gap
+
+```js
+import React from 'react';
+import { Flex, FlexItem } from '@patternfly/react-core';
+
+<Flex rowGap={{ default: 'rowGap2xl' }}>
+  <FlexItem>Flex item</FlexItem>
+  <FlexItem>Flex item</FlexItem>
+  <FlexItem>Flex item</FlexItem>
+  <FlexItem>Flex item</FlexItem>
+  <FlexItem>Flex item</FlexItem>
+  <FlexItem>Flex item</FlexItem>
+  <FlexItem>Flex item</FlexItem>
+  <FlexItem>Flex item</FlexItem>
+  <FlexItem>Flex item</FlexItem>
+  <FlexItem>Flex item</FlexItem>
+</Flex>;
+```
+
+### Column gap
+
+```js
+import React from 'react';
+import { Flex, FlexItem } from '@patternfly/react-core';
+
+<Flex columnGap={{ default: 'columnGap2xl' }}>
+  <FlexItem>Flex item</FlexItem>
+  <FlexItem>Flex item</FlexItem>
+  <FlexItem>Flex item</FlexItem>
+  <FlexItem>Flex item</FlexItem>
+  <FlexItem>Flex item</FlexItem>
+  <FlexItem>Flex item</FlexItem>
+  <FlexItem>Flex item</FlexItem>
+  <FlexItem>Flex item</FlexItem>
+  <FlexItem>Flex item</FlexItem>
+  <FlexItem>Flex item</FlexItem>
+</Flex>;
+```
+
+### Gap
+
+```js
+import React from 'react';
+import { Flex, FlexItem } from '@patternfly/react-core';
+
+<Flex gap={{ default: 'gap2xl' }}>
+  <FlexItem>Flex item</FlexItem>
+  <FlexItem>Flex item</FlexItem>
+  <FlexItem>Flex item</FlexItem>
+  <FlexItem>Flex item</FlexItem>
+  <FlexItem>Flex item</FlexItem>
+  <FlexItem>Flex item</FlexItem>
+  <FlexItem>Flex item</FlexItem>
+  <FlexItem>Flex item</FlexItem>
+  <FlexItem>Flex item</FlexItem>
+  <FlexItem>Flex item</FlexItem>
+</Flex>;
 ```
 
 ### Flex layout modifiers
+
 ### Default layout
+
 ```js
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
@@ -116,10 +188,11 @@ import { Flex, FlexItem } from '@patternfly/react-core';
   <FlexItem>Flex item</FlexItem>
   <FlexItem>Flex item</FlexItem>
   <FlexItem>Flex item</FlexItem>
-</Flex>
+</Flex>;
 ```
 
 ### Inline
+
 ```js
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
@@ -130,10 +203,11 @@ import { Flex, FlexItem } from '@patternfly/react-core';
   <FlexItem>Flex item</FlexItem>
   <FlexItem>Flex item</FlexItem>
   <FlexItem>Flex item</FlexItem>
-</Flex>
+</Flex>;
 ```
 
 ### Using canGrow
+
 ```js
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
@@ -151,10 +225,11 @@ import { Flex, FlexItem } from '@patternfly/react-core';
   <Flex>
     <FlexItem>Flex item</FlexItem>
   </Flex>
-</Flex>
+</Flex>;
 ```
 
 ### Adjusting width
+
 ```js
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
@@ -172,10 +247,11 @@ import { Flex, FlexItem } from '@patternfly/react-core';
     <FlexItem>Flex item</FlexItem>
     <FlexItem>Flex item</FlexItem>
   </Flex>
-</Flex>
+</Flex>;
 ```
 
 ### Specifying column widths
+
 ```js
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
@@ -193,12 +269,13 @@ import { Flex, FlexItem } from '@patternfly/react-core';
     <FlexItem>Flex item</FlexItem>
     <FlexItem>Flex item</FlexItem>
   </Flex>
-</Flex>
+</Flex>;
 ```
 
 ## Column layout modifiers
 
 ### Column layout
+
 ```js
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
@@ -207,10 +284,11 @@ import { Flex, FlexItem } from '@patternfly/react-core';
   <FlexItem>Flex item</FlexItem>
   <FlexItem>Flex item</FlexItem>
   <FlexItem>Flex item</FlexItem>
-</Flex>
+</Flex>;
 ```
 
 ### Stacking elements
+
 ```js
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
@@ -228,10 +306,11 @@ import { Flex, FlexItem } from '@patternfly/react-core';
   <Flex>
     <FlexItem>Flex item</FlexItem>
   </Flex>
-</Flex>
+</Flex>;
 ```
 
 ### Nesting elements in columns
+
 ```js
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
@@ -246,12 +325,13 @@ import { Flex, FlexItem } from '@patternfly/react-core';
     <FlexItem>Flex item</FlexItem>
     <FlexItem>Flex item</FlexItem>
   </Flex>
-</Flex>
+</Flex>;
 ```
 
 ## Responsive layout modifiers
 
 ### Switching between direction column and row
+
 ```js
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
@@ -267,10 +347,11 @@ import { Flex, FlexItem } from '@patternfly/react-core';
     <FlexItem>Flex item</FlexItem>
     <FlexItem>Flex item</FlexItem>
   </Flex>
-</Flex>
+</Flex>;
 ```
 
 ### Controlling width of text
+
 ```js
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
@@ -278,18 +359,22 @@ import { Flex, FlexItem } from '@patternfly/react-core';
 <Flex direction={{ default: 'column', lg: 'row' }}>
   <Flex flex={{ default: 'flex_1' }}>
     <FlexItem>Flex item</FlexItem>
-    <FlexItem>Lorem ipsum dolor sit amet consectetur adipisicing elit. Est animi modi temporibus, alias qui obcaecati ullam dolor nam, nulla magni iste rem praesentium numquam provident amet ut nesciunt harum accusamus.</FlexItem>
+    <FlexItem>
+      Lorem ipsum dolor sit amet consectetur adipisicing elit. Est animi modi temporibus, alias qui obcaecati ullam
+      dolor nam, nulla magni iste rem praesentium numquam provident amet ut nesciunt harum accusamus.
+    </FlexItem>
   </Flex>
   <Flex direction={{ default: 'column' }}>
     <FlexItem>Flex item</FlexItem>
     <FlexItem>Flex item</FlexItem>
   </Flex>
-</Flex>
+</Flex>;
 ```
 
 ## Flex alignment
 
 ### Aligning right
+
 ```js
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
@@ -300,10 +385,11 @@ import { Flex, FlexItem } from '@patternfly/react-core';
   <FlexItem>Flex item</FlexItem>
   <FlexItem align={{ default: 'alignRight' }}>Flex item</FlexItem>
   <FlexItem>Flex item</FlexItem>
-</Flex>
+</Flex>;
 ```
 
 ### Align right on single item
+
 ```js
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
@@ -311,10 +397,11 @@ import { Flex, FlexItem } from '@patternfly/react-core';
 <Flex className="example-border">
   <FlexItem align={{ default: 'alignRight' }}>Flex item</FlexItem>
   <FlexItem>Flex item</FlexItem>
-</Flex>
+</Flex>;
 ```
 
 ### Align right on multiple groups
+
 ```js
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
@@ -332,10 +419,11 @@ import { Flex, FlexItem } from '@patternfly/react-core';
     <FlexItem>Flex item</FlexItem>
     <FlexItem>Flex item</FlexItem>
   </Flex>
-</Flex>
+</Flex>;
 ```
 
 ### Align adjacent content
+
 ```js
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
@@ -351,10 +439,11 @@ import { Flex, FlexItem } from '@patternfly/react-core';
     <FlexItem>Flex item</FlexItem>
     <FlexItem>Flex item</FlexItem>
   </Flex>
-</Flex>
+</Flex>;
 ```
 
 ### Align self flex end
+
 ```js
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
@@ -369,10 +458,11 @@ import { Flex, FlexItem } from '@patternfly/react-core';
     <FlexItem>Flex item</FlexItem>
     <FlexItem>Flex item</FlexItem>
   </Flex>
-</Flex>
+</Flex>;
 ```
 
 ### Align self center
+
 ```js
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
@@ -387,10 +477,11 @@ import { Flex, FlexItem } from '@patternfly/react-core';
     <FlexItem>Flex item</FlexItem>
     <FlexItem>Flex item</FlexItem>
   </Flex>
-</Flex>
+</Flex>;
 ```
 
 ### Align self baseline
+
 ```js
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
@@ -405,10 +496,11 @@ import { Flex, FlexItem } from '@patternfly/react-core';
     <FlexItem>Flex item</FlexItem>
     <FlexItem>Flex item</FlexItem>
   </Flex>
-</Flex>
+</Flex>;
 ```
 
 ### Align self stretch
+
 ```js
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
@@ -423,12 +515,13 @@ import { Flex, FlexItem } from '@patternfly/react-core';
     <FlexItem>Flex item</FlexItem>
     <FlexItem>Flex item</FlexItem>
   </Flex>
-</Flex>
+</Flex>;
 ```
 
 ## Flex justification
 
 ### Justify content flex end
+
 ```js
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
@@ -438,22 +531,24 @@ import { Flex, FlexItem } from '@patternfly/react-core';
   <FlexItem>Flex item</FlexItem>
   <FlexItem>Flex item</FlexItem>
   <FlexItem>Flex item</FlexItem>
-</Flex>
+</Flex>;
 ```
 
 ### Justify content space between
+
 ```js
 import React from 'react';
-import { Flex, FlexItem  } from '@patternfly/react-core';
+import { Flex, FlexItem } from '@patternfly/react-core';
 
 <Flex className="example-border" justifyContent={{ default: 'justifyContentSpaceBetween' }}>
   <FlexItem>Flex item</FlexItem>
   <FlexItem>Flex item</FlexItem>
   <FlexItem>Flex item</FlexItem>
-</Flex>
+</Flex>;
 ```
 
 ### Justify content flex start
+
 ```js
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
@@ -462,7 +557,7 @@ import { Flex, FlexItem } from '@patternfly/react-core';
   <FlexItem>Flex item</FlexItem>
   <FlexItem>Flex item</FlexItem>
   <FlexItem>Flex item</FlexItem>
-</Flex>
+</Flex>;
 ```
 
 ## Flex item order
@@ -474,10 +569,14 @@ import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
 
 <Flex className="example-border">
-  <FlexItem spacer={{default: "spacerNone"}} order={{default: "2"}} >Item A</FlexItem>
+  <FlexItem spacer={{ default: 'spacerNone' }} order={{ default: '2' }}>
+    Item A
+  </FlexItem>
   <FlexItem>Item B</FlexItem>
-  <FlexItem spacer={{default: "spacerMd"}} order={{default: "-1"}}>Item C</FlexItem>
-</Flex>
+  <FlexItem spacer={{ default: 'spacerMd' }} order={{ default: '-1' }}>
+    Item C
+  </FlexItem>
+</Flex>;
 ```
 
 ### Responsive first last ordering
@@ -487,10 +586,16 @@ import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
 
 <Flex className="example-border">
-  <FlexItem spacer={{lg: "spacerNone"}} order={{lg: "2"}} >Item A</FlexItem>
-  <FlexItem spacer={{md: "spacerNone", lg: "spacerMd"}} order={{default: "-1", md: "1"}}>Item B</FlexItem>
-  <FlexItem spacer={{default: "spacerMd"}} order={{md: "-1"}}>Item C</FlexItem>
-</Flex>
+  <FlexItem spacer={{ lg: 'spacerNone' }} order={{ lg: '2' }}>
+    Item A
+  </FlexItem>
+  <FlexItem spacer={{ md: 'spacerNone', lg: 'spacerMd' }} order={{ default: '-1', md: '1' }}>
+    Item B
+  </FlexItem>
+  <FlexItem spacer={{ default: 'spacerMd' }} order={{ md: '-1' }}>
+    Item C
+  </FlexItem>
+</Flex>;
 ```
 
 ### Ordering
@@ -500,19 +605,25 @@ import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
 
 <Flex className="example-border">
-  <Flex spacer={{default: "spacerNone"}} order={{ lg: "1" }} className="example-border">
-    <FlexItem order={{md: "2"}} >Set 1, Item A</FlexItem>
-    <FlexItem order={{ md: "-1" }}>Set 1, Item B</FlexItem>
-    <FlexItem order={{ xl: "1" }}>Set 1, Item C</FlexItem>
-    <FlexItem spacer={{xl: "spacerNone"}} order={{ xl: "1" }}>Set 1, Item D</FlexItem>
+  <Flex spacer={{ default: 'spacerNone' }} order={{ lg: '1' }} className="example-border">
+    <FlexItem order={{ md: '2' }}>Set 1, Item A</FlexItem>
+    <FlexItem order={{ md: '-1' }}>Set 1, Item B</FlexItem>
+    <FlexItem order={{ xl: '1' }}>Set 1, Item C</FlexItem>
+    <FlexItem spacer={{ xl: 'spacerNone' }} order={{ xl: '1' }}>
+      Set 1, Item D
+    </FlexItem>
   </Flex>
-  <Flex spacer={{lg: "spacerMd"}} className="example-border">
-    <FlexItem spacer={{default: "spacerNone"}} order={{default: "3"}} >Set 2, Item A</FlexItem>
-    <FlexItem order={{ default: "1" }}>Set 2, Item B</FlexItem>
+  <Flex spacer={{ lg: 'spacerMd' }} className="example-border">
+    <FlexItem spacer={{ default: 'spacerNone' }} order={{ default: '3' }}>
+      Set 2, Item A
+    </FlexItem>
+    <FlexItem order={{ default: '1' }}>Set 2, Item B</FlexItem>
     <FlexItem>Set 2, Item C</FlexItem>
-    <FlexItem spacer={{default: "spacerMd"}} order={{ default: "2" }}>Set 2, Item D</FlexItem>
+    <FlexItem spacer={{ default: 'spacerMd' }} order={{ default: '2' }}>
+      Set 2, Item D
+    </FlexItem>
   </Flex>
-</Flex>
+</Flex>;
 ```
 
 ### Responsive ordering
@@ -522,20 +633,26 @@ import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
 
 <Flex className="example-border">
-  <Flex spacer={{default: "spacerNone"}} order={{ default: "1" }} className="example-border">
-    <FlexItem spacer={{default: "spacerNone"}} order={{default: "3"}} >Set 1, Item A</FlexItem>
-    <FlexItem order={{ default: "1" }}>Set 1, Item B</FlexItem>
+  <Flex spacer={{ default: 'spacerNone' }} order={{ default: '1' }} className="example-border">
+    <FlexItem spacer={{ default: 'spacerNone' }} order={{ default: '3' }}>
+      Set 1, Item A
+    </FlexItem>
+    <FlexItem order={{ default: '1' }}>Set 1, Item B</FlexItem>
     <FlexItem>Set 1, Item C</FlexItem>
-    <FlexItem spacer={{default: "spacerMd"}}>Set 1, Item D</FlexItem>
+    <FlexItem spacer={{ default: 'spacerMd' }}>Set 1, Item D</FlexItem>
   </Flex>
 
-  <Flex spacer={{default: "spacerMd"}} className="example-border">
-    <FlexItem spacer={{default: "spacerNone"}} order={{default: "3"}} >Set 2, Item A</FlexItem>
-    <FlexItem order={{ lg: "1" }}>Set 2, Item B</FlexItem>
+  <Flex spacer={{ default: 'spacerMd' }} className="example-border">
+    <FlexItem spacer={{ default: 'spacerNone' }} order={{ default: '3' }}>
+      Set 2, Item A
+    </FlexItem>
+    <FlexItem order={{ lg: '1' }}>Set 2, Item B</FlexItem>
     <FlexItem>Set 2, Item C</FlexItem>
-    <FlexItem spacer={{default: "spacerMd"}} order={{ default: "2" }}>Set 2, Item D</FlexItem>
+    <FlexItem spacer={{ default: 'spacerMd' }} order={{ default: '2' }}>
+      Set 2, Item D
+    </FlexItem>
   </Flex>
-</Flex>
+</Flex>;
 ```
 
 ### Alternative components
@@ -544,11 +661,11 @@ import { Flex, FlexItem } from '@patternfly/react-core';
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
 
-<Flex component='ul'>
-  <FlexItem component='li'>Flex item</FlexItem>
-  <FlexItem component='li'>Flex item</FlexItem>
-  <FlexItem component='li'>Flex item</FlexItem>
-  <FlexItem component='li'>Flex item</FlexItem>
-  <FlexItem component='li'>Flex item</FlexItem>
-</Flex>
+<Flex component="ul">
+  <FlexItem component="li">Flex item</FlexItem>
+  <FlexItem component="li">Flex item</FlexItem>
+  <FlexItem component="li">Flex item</FlexItem>
+  <FlexItem component="li">Flex item</FlexItem>
+  <FlexItem component="li">Flex item</FlexItem>
+</Flex>;
 ```


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8397

Adds `gap`, `rowGap`, and `columnGap` to `Flex` with breakpoints.
Adds examples & updates tests.

@mcoker The issue mentions a plain `pf-m-gap` class (without the size or breakpoints) that I don't see on the modifiers list, so I left it out for now. Did I miss something?
