### PR TITLE
fix(Pagination): default page should be 1

### DIFF
--- a/packages/react-core/src/components/Pagination/Pagination.tsx
+++ b/packages/react-core/src/components/Pagination/Pagination.tsx
@@ -210,8 +210,8 @@ export const Pagination: React.FunctionComponent<PaginationProps> = ({
     ofWord: 'of'
   },
   firstPage = 1,
-  page: pageProp = 0,
-  offset = 0,
+  page: pageProp = 1,
+  offset = null,
   isLastFullPageShown = false,
   itemsStart = null,
   itemsEnd = null,
@@ -245,11 +245,8 @@ export const Pagination: React.FunctionComponent<PaginationProps> = ({
   const dropDirection = dropDirectionProp || (variant === 'bottom' && !isStatic ? 'up' : 'down');
 
   let page = pageProp;
-  if (!page && offset) {
-    page = Math.ceil(offset / perPage);
-  }
-  if (page === 0 && !itemCount) {
-    page = 1;
+  if (offset !== null) {
+    page = Math.max(Math.ceil(offset / perPage), 1);
   }
 
   const lastPage = getLastPage();

--- a/packages/react-core/src/components/Pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/react-core/src/components/Pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -1159,7 +1159,7 @@ exports[`Pagination component render custom pagination toggle 1`] = `
     <div
       class="pf-v5-c-pagination__total-items"
     >
-      -9 - 10 - 40 - 
+      1 - 10 - 40 - 
     </div>
     <div>
       <button
@@ -1172,7 +1172,7 @@ exports[`Pagination component render custom pagination toggle 1`] = `
         <span
           class="pf-v5-c-menu-toggle__text"
         >
-          -9 - 10 - 40 - 
+          1 - 10 - 40 - 
         </span>
         <span
           class="pf-v5-c-menu-toggle__controls"
@@ -1341,7 +1341,7 @@ exports[`Pagination component render custom perPageOptions 1`] = `
       class="pf-v5-c-pagination__total-items"
     >
       <b>
-        -9 - 10
+        1 - 10
       </b>
        of 
       <b>
@@ -1361,7 +1361,7 @@ exports[`Pagination component render custom perPageOptions 1`] = `
           class="pf-v5-c-menu-toggle__text"
         >
           <b>
-            -9 - 10
+            1 - 10
           </b>
            of 
           <b>
@@ -1536,7 +1536,7 @@ exports[`Pagination component render custom start end 1`] = `
       class="pf-v5-c-pagination__total-items"
     >
       <b>
-        -9 - 10
+        1 - 10
       </b>
        of 
       <b>
@@ -1729,7 +1729,7 @@ exports[`Pagination component render empty per page options 1`] = `
       class="pf-v5-c-pagination__total-items"
     >
       <b>
-        -9 - 10
+        1 - 10
       </b>
        of 
       <b>
@@ -2078,7 +2078,7 @@ exports[`Pagination component render limited number of pages 1`] = `
       class="pf-v5-c-pagination__total-items"
     >
       <b>
-        -19 - 20
+        1 - 20
       </b>
        of 
       <b>
@@ -2098,7 +2098,7 @@ exports[`Pagination component render limited number of pages 1`] = `
           class="pf-v5-c-menu-toggle__text"
         >
           <b>
-            -19 - 20
+            1 - 20
           </b>
            of 
           <b>
@@ -2284,7 +2284,7 @@ exports[`Pagination component render should render correctly bottom 1`] = `
           class="pf-v5-c-menu-toggle__text"
         >
           <b>
-            -9 - 10
+            1 - 10
           </b>
            of 
           <b>
@@ -2467,7 +2467,7 @@ exports[`Pagination component render should render correctly bottom sticky 1`] =
           class="pf-v5-c-menu-toggle__text"
         >
           <b>
-            -9 - 10
+            1 - 10
           </b>
            of 
           <b>
@@ -2642,7 +2642,7 @@ exports[`Pagination component render should render correctly compact 1`] = `
       class="pf-v5-c-pagination__total-items"
     >
       <b>
-        -9 - 10
+        1 - 10
       </b>
        of 
       <b>
@@ -2662,7 +2662,7 @@ exports[`Pagination component render should render correctly compact 1`] = `
           class="pf-v5-c-menu-toggle__text"
         >
           <b>
-            -9 - 10
+            1 - 10
           </b>
            of 
           <b>
@@ -2767,7 +2767,7 @@ exports[`Pagination component render should render correctly disabled 1`] = `
       class="pf-v5-c-pagination__total-items"
     >
       <b>
-        -9 - 10
+        1 - 10
       </b>
        of 
       <b>
@@ -2788,7 +2788,7 @@ exports[`Pagination component render should render correctly disabled 1`] = `
           class="pf-v5-c-menu-toggle__text"
         >
           <b>
-            -9 - 10
+            1 - 10
           </b>
            of 
           <b>
@@ -2966,7 +2966,7 @@ exports[`Pagination component render should render correctly sticky 1`] = `
       class="pf-v5-c-pagination__total-items"
     >
       <b>
-        -9 - 10
+        1 - 10
       </b>
        of 
       <b>
@@ -2986,7 +2986,7 @@ exports[`Pagination component render should render correctly sticky 1`] = `
           class="pf-v5-c-menu-toggle__text"
         >
           <b>
-            -9 - 10
+            1 - 10
           </b>
            of 
           <b>
@@ -3161,7 +3161,7 @@ exports[`Pagination component render should render correctly top 1`] = `
       class="pf-v5-c-pagination__total-items"
     >
       <b>
-        -9 - 10
+        1 - 10
       </b>
        of 
       <b>
@@ -3181,7 +3181,7 @@ exports[`Pagination component render should render correctly top 1`] = `
           class="pf-v5-c-menu-toggle__text"
         >
           <b>
-            -9 - 10
+            1 - 10
           </b>
            of 
           <b>
@@ -3356,7 +3356,7 @@ exports[`Pagination component render titles 1`] = `
       class="pf-v5-c-pagination__total-items"
     >
       <b>
-        -9 - 10
+        1 - 10
       </b>
        of 
       <b>
@@ -3376,7 +3376,7 @@ exports[`Pagination component render titles 1`] = `
           class="pf-v5-c-menu-toggle__text"
         >
           <b>
-            -9 - 10
+            1 - 10
           </b>
            of 
           <b>
@@ -3551,7 +3551,7 @@ exports[`Pagination component render up drop direction 1`] = `
       class="pf-v5-c-pagination__total-items"
     >
       <b>
-        -9 - 10
+        1 - 10
       </b>
        of 
       <b>
@@ -3571,7 +3571,7 @@ exports[`Pagination component render up drop direction 1`] = `
           class="pf-v5-c-menu-toggle__text"
         >
           <b>
-            -9 - 10
+            1 - 10
           </b>
            of 
           <b>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #9165

I'm not sure why the default is set to 0 here: https://github.com/patternfly/patternfly-react/pull/3383
but users cant type in 0 anyway because of: 
https://github.com/patternfly/patternfly-react/blob/1da6f5e5ad3c3665e0022693a5ce9de2588aa136/packages/react-core/src/components/Pagination/Navigation.tsx#L100
