### PR TITLE
fix(TimePicker): resolved border styling on open menu

### DIFF
--- a/packages/react-core/src/components/TimePicker/TimePicker.tsx
+++ b/packages/react-core/src/components/TimePicker/TimePicker.tsx
@@ -512,6 +512,7 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
         onChange={this.onInputChange}
         autoComplete="off"
         isDisabled={isDisabled}
+        isExpanded={isTimeOptionsOpen}
         ref={this.inputRef}
         {...inputProps}
       />
@@ -539,7 +540,7 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
                   <Popper
                     appendTo={calculatedAppendTo}
                     trigger={textInput}
-                    triggerRef={this.inputRef}
+                    triggerRef={this.toggleRef}
                     popper={menuContainer}
                     popperRef={this.menuRef}
                     isVisible={isTimeOptionsOpen}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #9156 

[Timepicker preview](https://patternfly-react-pr-9214.surge.sh/components/date-and-time/time-picker)

Issue seemed to be still pointing to the inputRef, which was no longer viable after we updated the markup for form control components to include a wrapper div.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
