### PR TITLE
fix(CalendarMonth): switch to a correct month

### DIFF
--- a/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
+++ b/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
@@ -155,7 +155,7 @@ export const CalendarMonth = ({
 
   const getInitialDate = () => {
     const initDate = new Date(dateProp);
-    if (dateProp && isValidDate(initDate)) {
+    if (isValidDate(initDate)) {
       return initDate;
     } else {
       return isValidDate(rangeStart) ? rangeStart : today;


### PR DESCRIPTION
**What**: Closes #8901

One more thing which could be fixed:
In Datepicker, when today is let's say 31st of July and we switch to a month with less than 31 days, it changes the focused date to 30th. But then when going back to a month with 31 days, 30 will stay. This is not an issue when the date is selected in the calendar.

It is due to this function:
```
const getInitialDate = () => {
    const initDate = new Date(dateProp);
    if (isValidDate(initDate)) {
      return initDate;
    } else {
      return isValidDate(rangeStart) ? rangeStart : today;
    }
  };
```
which returns 1 / 1 / 1970 when no date is picked (dateProp is null and `new Date(null)` creates this date).

Could be fixed with `if (dateProp && isValidDate(initDate))` which would then return `today` as the initial date. Problem is however with test snapshots, which would have to be rebuilt every day.

Let me know what do you think. I think the UX should be the priority over snapshots.