### PR TITLE
feat(Pagination): add offset example

### DIFF
--- a/packages/react-core/src/components/Pagination/Pagination.tsx
+++ b/packages/react-core/src/components/Pagination/Pagination.tsx
@@ -246,7 +246,9 @@ export const Pagination: React.FunctionComponent<PaginationProps> = ({
 
   let page = pageProp;
   if (offset !== null) {
-    page = Math.max(Math.ceil(offset / perPage), 1);
+    itemsStart = offset + 1;
+    page = Math.max(Math.ceil(itemsStart / perPage), 1);
+    itemsEnd = offset + perPage;
   }
 
   const lastPage = getLastPage();

--- a/packages/react-core/src/components/Pagination/examples/Pagination.md
+++ b/packages/react-core/src/components/Pagination/examples/Pagination.md
@@ -45,6 +45,11 @@ By not passing `itemCount` and passing `toggleTemplate` you can customize the to
 ```ts file="./PaginationCompact.tsx"
 ```
 
+### Offset
+
+```ts file="./PaginationOffset.tsx"
+```
+
 ### Sticky
 
 ```ts isFullscreen file="./PaginationSticky.tsx"

--- a/packages/react-core/src/components/Pagination/examples/PaginationOffset.tsx
+++ b/packages/react-core/src/components/Pagination/examples/PaginationOffset.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Pagination } from '@patternfly/react-core';
+
+export const PaginationOffset: React.FunctionComponent = () => {
+  const [offset, setOffset] = React.useState(7);
+  const [perPage, setPerPage] = React.useState(20);
+
+  const onSetPage = (
+    _event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
+    newPage: number,
+    _perPage: number | undefined,
+    startIdx: number | undefined
+  ) => {
+    setOffset(startIdx || 0);
+  };
+  const onPerPageSelect = (_event: React.MouseEvent | React.KeyboardEvent | MouseEvent, newPerPage: number) => {
+    setPerPage(newPerPage);
+    setOffset(0);
+  };
+
+  return (
+    <Pagination
+      itemCount={523}
+      perPage={perPage}
+      offset={offset}
+      onSetPage={onSetPage}
+      widgetId="offset-pagination-example"
+      onPerPageSelect={onPerPageSelect}
+      ouiaId="PaginationOffset"
+    />
+  );
+};


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #9231
when having a per_page=20, and offset is 20  (skip the first 20 items ,show item numbers 21,22,23...), page should be calculated to 2, but before this change it was calculated as 1