### PR TITLE
fix(Select deprecated): added width auto to prevent menu overflow in modal

### DIFF
--- a/packages/react-core/src/deprecated/components/Select/Select.tsx
+++ b/packages/react-core/src/deprecated/components/Select/Select.tsx
@@ -1475,6 +1475,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
               mainContainer
             ) : (
               <Popper
+                width="auto"
                 trigger={mainContainer}
                 triggerRef={this.parentRef}
                 popper={popperContainer}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #9233 

Tested by adding a deprecated Select to a Modal and appending the Select menu to document body.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
