### PR TITLE
fix(Popover): reverted appendTo to document body

### DIFF
--- a/packages/react-core/src/components/Popover/Popover.tsx
+++ b/packages/react-core/src/components/Popover/Popover.tsx
@@ -233,7 +233,7 @@ export const Popover: React.FunctionComponent<PopoverProps> = ({
   alertSeverityVariant,
   alertSeverityScreenReaderText,
   footerContent = null,
-  appendTo = 'inline',
+  appendTo = () => document.body,
   hideOnOutsideClick = true,
   onHide = (): void => null,
   onHidden = (): void => null,

--- a/packages/react-core/src/components/Popover/examples/Popover.md
+++ b/packages/react-core/src/components/Popover/examples/Popover.md
@@ -14,10 +14,7 @@ import BullhornIcon from '@patternfly/react-icons/dist/esm/icons/bullhorn-icon';
 
 ## Examples
 
-By default, the `appendTo` prop of the popover will append it to the parent element. However, in some cases, the popover might be too big for the parent and not fully visible. To solve this issue, users have two options:
-
-1. Add the prop `appendTo={() => document.body}` to append the popover to the document body instead of the parent element.
-2. Increase the z-index of the parent element to be higher than the z-index of the element that is hiding the popover.
+By default, the `appendTo` prop of the popover will append to the document body in order to avoid the popover content not being fully visible. Another option is to increase the z-index of the element the popover is appended to to be higher than the z-index of the element that is hiding the popover.
 
 ### Basic
 

--- a/packages/react-integration/demo-app-ts/package.json
+++ b/packages/react-integration/demo-app-ts/package.json
@@ -9,7 +9,7 @@
     "serve:demo-app": "node scripts/serve"
   },
   "dependencies": {
-    "@patternfly/react-core": "^5.0.0-prerelease.2",
+    "@patternfly/react-core": "^5.0.0-prerelease.3",
     "react": "^18",
     "react-dom": "^18",
     "react-router": "^5.3.3",


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #9237 

We could instead update Popover's `position` prop to "auto", which would cause it to reposition before scrolling, though there may still be an issue of it getting cut off by a masthead depending on the layout.

There were also some other components that might be affected (menu like components), but since they don't use a focus trap like Popover does, I'm hesitent to revert those appendTo props to document body. Those could also have scrollbars to reduce the height and avoid the issue, though I don't believe the new dropdown/select currently can be passed the necessary props to achieve that (could be a followup for after v5)

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
