### PR TITLE
feat(NavExpandable): allows title prop to accept ReactNodes

### DIFF
--- a/packages/react-core/src/components/Nav/NavExpandable.tsx
+++ b/packages/react-core/src/components/Nav/NavExpandable.tsx
@@ -10,10 +10,10 @@ import { PickOptional } from '../../helpers/typeUtils';
 import { getOUIAProps, OUIAProps, getDefaultOUIAId } from '../../helpers';
 
 export interface NavExpandableProps
-  extends React.DetailedHTMLProps<React.LiHTMLAttributes<HTMLLIElement>, HTMLLIElement>,
+  extends Omit<React.DetailedHTMLProps<React.LiHTMLAttributes<HTMLLIElement>, HTMLLIElement>, 'title'>,
     OUIAProps {
-  /** Title shown for the expandable list */
-  title: string;
+  /** Title content shown for the expandable list */
+  title: React.ReactNode;
   /** If defined, screen readers will read this text instead of the list title */
   srText?: string;
   /** Boolean to programatically expand or collapse section */

--- a/packages/react-core/src/components/Nav/examples/NavExpandableThirdLevel.tsx
+++ b/packages/react-core/src/components/Nav/examples/NavExpandableThirdLevel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Nav, NavExpandable, NavItem, NavList } from '@patternfly/react-core';
+import { Flex, Label, Nav, NavExpandable, NavItem, NavList } from '@patternfly/react-core';
 
 export const NavExpandableThirdLevel: React.FunctionComponent = () => {
   const [activeGroup, setActiveGroup] = React.useState('nav-expand3rd-group-1');
@@ -62,7 +62,12 @@ export const NavExpandableThirdLevel: React.FunctionComponent = () => {
           </NavItem>
         </NavExpandable>
         <NavExpandable
-          title="Expandable section title 2"
+          title={
+            <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+              <span>Expandable section title 2</span>
+              <Label isCompact color="blue">New</Label>
+            </Flex>
+          }
           groupId="nav-expand3rd-group-2"
           isActive={activeGroup === 'nav-expand3rd-group-2'}
           isExpanded


### PR DESCRIPTION
Potential fix for patternfly/patternfly-design#1267 

Changes the `<NavExpandable>` `title` prop to accept any `ReactNode`. This also adds [an example](https://patternfly-react-pr-9264.surge.sh/components/navigation#expandable-third-level) to the documentation. (Is this wanted, or is it more of a distraction in it's current location?)
