### PR TITLE
fix(release): ensure component package.json file has correct data

### DIFF
--- a/packages/react-charts/single-packages.config.json
+++ b/packages/react-charts/single-packages.config.json
@@ -1,15 +1,5 @@
 {
     "packageName": "@patternfly/react-charts",
-    "modules": [ 
-        {
-            "name": "dist/esm",
-            "type": "esm"
-        },
-        {
-            "name": "dist/js",
-            "type": "cjs"
-        }
-    ],
     "exclude": [
         "dist/esm/deprecated/index.js",
         "dist/esm/next/index.js"

--- a/packages/react-core/single-packages.config.json
+++ b/packages/react-core/single-packages.config.json
@@ -1,14 +1,4 @@
 {
     "packageName": "@patternfly/react-core",
-    "modules": [ 
-        {
-            "name": "dist/esm",
-            "type": "esm"
-        },
-        {
-            "name": "dist/js",
-            "type": "cjs"
-        }
-    ],
     "exclude": []
 }

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -25,8 +25,9 @@
   },
   "homepage": "https://github.com/patternfly/patternfly-react#readme",
   "scripts": {
-    "generate": "rimraf dist/esm/icons dist/js/icons && node scripts/writeIcons.mjs",
-    "clean": "rimraf dist src/icons src/index.js src/index.d.ts"
+    "build:single:packages": "node ../../scripts/build-single-packages.js --config single-packages.config.json",
+    "clean": "rimraf dist src/icons src/index.js src/index.d.ts",
+    "generate": "rimraf dist/esm/icons dist/js/icons && node scripts/writeIcons.mjs"
   },
   "devDependencies": {
     "@fortawesome/free-brands-svg-icons": "^5.14.0",

--- a/packages/react-icons/single-packages.config.json
+++ b/packages/react-icons/single-packages.config.json
@@ -1,0 +1,5 @@
+{
+    "packageName": "@patternfly/react-icons",
+    "moduleGlob": "/dist/esm/icons/*.js",
+    "exclude": []
+}

--- a/packages/react-table/single-packages.config.json
+++ b/packages/react-table/single-packages.config.json
@@ -1,19 +1,5 @@
 {
     "packageName": "@patternfly/react-table",
-    "modules": [ 
-        {
-            "name": "components",
-            "type": "esm"
-        },
-        {
-            "name": "deprecated",
-            "type": "esm"
-        },
-        {
-            "name": "dist/js",
-            "type": "cjs"
-        }
-    ],
     "exclude": [
         "dist/esm/deprecated/index.js",
         "dist/esm/next/index.js"


### PR DESCRIPTION
cc @dlabaj 

### Changes
- fixes up the build for the module federation environment
  - create a new `dynamic` directory in the `dist` folder for all dynamically resolved modules
  - enable dynamic output for the icons package
  - remove duplicate runs for different output types (ems, cjs)

Based on local testing the packages are correctly shared and "tree shaken" if we use the absolute module paths to the `dynamic` directory.

> __NOTE__: I am using the `pf-5` alias for the module because I also have the v4 running in my test env

**Import example**

```jsx
import { Button as PF5Button } from 'pf-5/dist/dynamic/components/Button';
import { Icon } from 'pf-5/dist/dynamic/components/Icon';
import AdIcon from 'pf-5-icons/dist/dynamic/icons/ad-icon';
```
**Module federation sharing config example**

```js
    new ModuleFederationPlugin({
    ...,
      shared: [
            {
              'pf-5/dist/dynamic/components/Button': {
                requiredVersion: '5.0.0-prerelease.8',
              },
              'pf-5-icons/dist/dynamic/icons/ad-icon': {
                requiredVersion: '5.0.0-prerelease.3',
              },
           }
        ],
    })
```

**Shared scope result**

the `import { Icon } from 'pf-5/dist/dynamic/components/Icon';` was not marked for sharing deliberately, hence it's not in the shared scope.

```js
{
  __webpack_share_scopes__: {
    default: {
      'pf-5-icons/dist/dynamic/icons/ad-icon': {
        '5.0.0-prerelease.3': { from: 'landing-page-frontend', eager: false, get: ƒ },
      },
      'pf-5/dist/dynamic/components/Button': {
        '5.0.0-prerelease.8': { from: 'landing-page-frontend', eager: false, get: ƒ },
      },
    },
  },
}
```

Only these modules were used in the testing and only these modules were included within the webpack build. Thanks to the absolute import paths. All shared modules were loaded only once during runtime
