### PR TITLE
fix: changed the button lable from Upload to Browse

### DIFF
--- a/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadButton.tsx
+++ b/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadButton.tsx
@@ -21,7 +21,7 @@ export const MultipleFileUploadButton: React.FunctionComponent<MultipleFileUploa
   return (
     <div className={css(styles.multipleFileUploadUpload, className)} {...props}>
       <Button variant="secondary" aria-label={ariaLabel} onClick={open}>
-        Upload
+        Browse
       </Button>
     </div>
   );

--- a/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadButton.tsx
+++ b/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadButton.tsx
@@ -9,11 +9,13 @@ export interface MultipleFileUploadButtonProps extends React.HTMLProps<HTMLDivEl
   className?: string;
   /** Aria-label for the button */
   'aria-label'?: string;
+  'label'?: string;
 }
 
 export const MultipleFileUploadButton: React.FunctionComponent<MultipleFileUploadButtonProps> = ({
   className,
   'aria-label': ariaLabel,
+  label,
   ...props
 }: MultipleFileUploadButtonProps) => {
   const { open } = React.useContext(MultipleFileUploadContext);
@@ -21,7 +23,7 @@ export const MultipleFileUploadButton: React.FunctionComponent<MultipleFileUploa
   return (
     <div className={css(styles.multipleFileUploadUpload, className)} {...props}>
       <Button variant="secondary" aria-label={ariaLabel} onClick={open}>
-        Browse
+        {label}
       </Button>
     </div>
   );

--- a/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadButton.tsx
+++ b/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadButton.tsx
@@ -10,25 +10,25 @@ export interface MultipleFileUploadButtonProps extends React.HTMLProps<HTMLDivEl
   /** Aria-label for the button */
   'aria-label'?: string;
   /** Visible text label for the button */
-  'label'?: string;
+  'browseButtonText'?: string;
 }
 
 export const MultipleFileUploadButton: React.FunctionComponent<MultipleFileUploadButtonProps> = ({
   className,
   'aria-label': ariaLabel,
-  label = "Upload",
+  browseButtonText = "Upload",
   ...props
 }: MultipleFileUploadButtonProps) => {
-  if (!ariaLabel && !label) {
+  if (!ariaLabel && !browseButtonText) {
     // eslint-disable-next-line no-console
-    console.warn("For accessibility reasons an aria-label should be specified on MultipleFileUploadButton if a label isn't");
+    console.warn("For accessibility reasons an aria-label should be specified on MultipleFileUploadButton if a browseButtonText isn't");
   }
   const { open } = React.useContext(MultipleFileUploadContext);
 
   return (
     <div className={css(styles.multipleFileUploadUpload, className)} {...props}>
       <Button variant="secondary" aria-label={ariaLabel} onClick={open}>
-        {label}
+        {browseButtonText}
       </Button>
     </div>
   );

--- a/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadButton.tsx
+++ b/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadButton.tsx
@@ -9,15 +9,20 @@ export interface MultipleFileUploadButtonProps extends React.HTMLProps<HTMLDivEl
   className?: string;
   /** Aria-label for the button */
   'aria-label'?: string;
+  /** Visible text label for the button */
   'label'?: string;
 }
 
 export const MultipleFileUploadButton: React.FunctionComponent<MultipleFileUploadButtonProps> = ({
   className,
   'aria-label': ariaLabel,
-  label,
+  label = "Upload",
   ...props
 }: MultipleFileUploadButtonProps) => {
+  if (!ariaLabel && !label) {
+    // eslint-disable-next-line no-console
+    console.warn("For accessibility reasons an aria-label should be specified on MultipleFileUploadButton if a label isn't");
+  }
   const { open } = React.useContext(MultipleFileUploadContext);
 
   return (

--- a/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadMain.tsx
+++ b/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadMain.tsx
@@ -21,6 +21,8 @@ export interface MultipleFileUploadMainProps extends React.HTMLProps<HTMLDivElem
   infoText?: React.ReactNode;
   /** Flag to prevent the upload button from being rendered */
   isUploadButtonHidden?: boolean;
+  /** label for the browseButtonText */
+  'browseButtonText'?: string
 }
 
 export const MultipleFileUploadMain: React.FunctionComponent<MultipleFileUploadMainProps> = ({
@@ -30,6 +32,7 @@ export const MultipleFileUploadMain: React.FunctionComponent<MultipleFileUploadM
   titleTextSeparator,
   infoText,
   isUploadButtonHidden,
+  browseButtonText="Upload",
   ...props
 }: MultipleFileUploadMainProps) => {
   const showTitle = !!titleIcon || !!titleText || !!titleTextSeparator;
@@ -37,7 +40,7 @@ export const MultipleFileUploadMain: React.FunctionComponent<MultipleFileUploadM
   return (
     <div className={css(styles.multipleFileUploadMain, className)} {...props}>
       {showTitle && <MultipleFileUploadTitle icon={titleIcon} text={titleText} textSeparator={titleTextSeparator} />}
-      {isUploadButtonHidden || <MultipleFileUploadButton />}
+      {isUploadButtonHidden || <MultipleFileUploadButton browseButtonText/>}
       {!!infoText && <MultipleFileUploadInfo>{infoText}</MultipleFileUploadInfo>}
     </div>
   );

--- a/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadMain.tsx
+++ b/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadMain.tsx
@@ -37,7 +37,7 @@ export const MultipleFileUploadMain: React.FunctionComponent<MultipleFileUploadM
   return (
     <div className={css(styles.multipleFileUploadMain, className)} {...props}>
       {showTitle && <MultipleFileUploadTitle icon={titleIcon} text={titleText} textSeparator={titleTextSeparator} />}
-      {isUploadButtonHidden || <MultipleFileUploadButton />}
+      {isUploadButtonHidden || <MultipleFileUploadButton label="Browse"/>}
       {!!infoText && <MultipleFileUploadInfo>{infoText}</MultipleFileUploadInfo>}
     </div>
   );

--- a/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadMain.tsx
+++ b/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadMain.tsx
@@ -22,7 +22,7 @@ export interface MultipleFileUploadMainProps extends React.HTMLProps<HTMLDivElem
   /** Flag to prevent the upload button from being rendered */
   isUploadButtonHidden?: boolean;
   /** label for the browseButtonText */
-  'browseButtonText'?: string
+  browseButtonText?: string;
 }
 
 export const MultipleFileUploadMain: React.FunctionComponent<MultipleFileUploadMainProps> = ({

--- a/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadMain.tsx
+++ b/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadMain.tsx
@@ -21,8 +21,8 @@ export interface MultipleFileUploadMainProps extends React.HTMLProps<HTMLDivElem
   infoText?: React.ReactNode;
   /** Flag to prevent the upload button from being rendered */
   isUploadButtonHidden?: boolean;
-  /** label for the browseButtonText */
-  browseButtonText?: string;
+  /** Visible text label for the upload button */
+  browseButtonText?: string
 }
 
 export const MultipleFileUploadMain: React.FunctionComponent<MultipleFileUploadMainProps> = ({
@@ -40,7 +40,7 @@ export const MultipleFileUploadMain: React.FunctionComponent<MultipleFileUploadM
   return (
     <div className={css(styles.multipleFileUploadMain, className)} {...props}>
       {showTitle && <MultipleFileUploadTitle icon={titleIcon} text={titleText} textSeparator={titleTextSeparator} />}
-      {isUploadButtonHidden || <MultipleFileUploadButton browseButtonText/>}
+      {isUploadButtonHidden || <MultipleFileUploadButton browseButtonText={browseButtonText}/>}
       {!!infoText && <MultipleFileUploadInfo>{infoText}</MultipleFileUploadInfo>}
     </div>
   );

--- a/packages/react-core/src/components/MultipleFileUpload/__tests__/MultipleFileUploadButton.test.tsx
+++ b/packages/react-core/src/components/MultipleFileUpload/__tests__/MultipleFileUploadButton.test.tsx
@@ -19,7 +19,7 @@ describe('MultipleFileUploadButton', () => {
   });
 
   test('renders with label applied to the button', () => {
-    const { asFragment } = render(<MultipleFileUploadButton label="test">Foo</MultipleFileUploadButton>);
+    const { asFragment } = render(<MultipleFileUploadButton browseButtonText="test">Foo</MultipleFileUploadButton>);
     expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/packages/react-core/src/components/MultipleFileUpload/__tests__/MultipleFileUploadButton.test.tsx
+++ b/packages/react-core/src/components/MultipleFileUpload/__tests__/MultipleFileUploadButton.test.tsx
@@ -17,4 +17,9 @@ describe('MultipleFileUploadButton', () => {
     const { asFragment } = render(<MultipleFileUploadButton aria-label="test">Foo</MultipleFileUploadButton>);
     expect(asFragment()).toMatchSnapshot();
   });
+
+  test('renders with label applied to the button', () => {
+    const { asFragment } = render(<MultipleFileUploadButton label="test">Foo</MultipleFileUploadButton>);
+    expect(asFragment()).toMatchSnapshot();
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4003,9 +4003,9 @@
     astring "^1.7.5"
 
 "@patternfly/documentation-framework@^2.0.0-alpha.55":
-  version "2.0.0-alpha.57"
-  resolved "https://registry.yarnpkg.com/@patternfly/documentation-framework/-/documentation-framework-2.0.0-alpha.57.tgz#e1963d1f16fafa8eca2af2adff1f31f7db2cc3cc"
-  integrity sha512-pZObpD8lgKBaH3RdPXhjtiiKooRo2IXnkjWsM+Sbx+DSZjLgg0nHBCMJDPsJJrtRPti+zw7j1uUTdZ9qWu2jFg==
+  version "2.0.0-alpha.60"
+  resolved "https://registry.yarnpkg.com/@patternfly/documentation-framework/-/documentation-framework-2.0.0-alpha.60.tgz#70a52faf2a911618358c91cd8339be6dc5333002"
+  integrity sha512-D4SL6iKrPdihOP/LfP4gsL/0Yscm8/68ozVWfmfz1rnzGTvIOq4rfsff9fsOLvTXUac0qkzfzyRG5dXMkpMLYA==
   dependencies:
     "@babel/core" "7.18.2"
     "@babel/plugin-proposal-class-properties" "7.17.12"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #9274 

**Issue Description:**

The 'Upload' button text in the ['File upload - multiple' PF component](https://www.patternfly.org/v4/components/file-upload---multiple#examples) is [hardcoded](https://github.com/patternfly/patternfly-react/blob/004483dd6c2729052170b8fe72faa1658fa2bd2a/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadButton.tsx) and cannot be changed.

I expect to be able to change the button text. E.g., label it as 'Browse' instead of 'Upload'.

Currently, this is not a blocker.

I am trying to use this component for a feature in Apicurio Registry. We are expecting to implement this feature in Q4.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
