### PR TITLE
fix(ChartScatter): consider bubbleProperty if it is set

### DIFF
--- a/packages/react-charts/src/components/ChartScatter/ChartScatter.tsx
+++ b/packages/react-charts/src/components/ChartScatter/ChartScatter.tsx
@@ -446,7 +446,6 @@ export const ChartScatter: React.FunctionComponent<ChartScatterProps> = ({
 
   // destructure last
   theme = getTheme(themeColor),
-  size = ({ active }) => (active ? ChartScatterStyles.activeSize : ChartScatterStyles.size),
   ...rest
 }: ChartScatterProps) => {
   // Clone so users can override container props
@@ -455,8 +454,14 @@ export const ChartScatter: React.FunctionComponent<ChartScatterProps> = ({
     ...containerComponent.props
   });
 
+  // bubbleProperty is only considered if the size prop is undefined, therefore set
+  // default size function only if bubbleProperty is not set.
+  if (typeof rest.size === "undefined" && typeof rest.bubbleProperty === "undefined") {
+    rest.size = ({ active }) => (active ? ChartScatterStyles.activeSize : ChartScatterStyles.size);
+  }
+
   // Note: containerComponent is required for theme
-  return <VictoryScatter containerComponent={container} size={size} theme={theme} {...rest} />;
+  return <VictoryScatter containerComponent={container} theme={theme} {...rest} />;
 };
 ChartScatter.displayName = 'ChartScatter';
 


### PR DESCRIPTION
**What**: `bubbleProperty` of `VictoryScatter` is only considered if the size prop is undefined (see https://github.com/FormidableLabs/victory/blob/bbc1e2a39448d7fb6724f916afacf5f6eab7d1b3/packages/victory-scatter/src/helper-methods.tsx#L35-L43)

This PR updates the code to set the default `size` function only if `bubbleProperty` is not set.

closes: #9504 