### PR TITLE
fix(react-core): fix dynamic helpers modules output

### DIFF
--- a/packages/react-core/single-packages.config.json
+++ b/packages/react-core/single-packages.config.json
@@ -1,4 +1,5 @@
 {
     "packageName": "@patternfly/react-core",
-    "exclude": []
+    "moduleGlob": ["/dist/esm/helpers/**/*.js", "/dist/esm/*/*/**/index.js"],
+    "exclude": ["/dist/esm/helpers/Popper/thirdparty"]
 }

--- a/scripts/build-single-packages.js
+++ b/scripts/build-single-packages.js
@@ -15,17 +15,23 @@ const configJson = require(`${root}/${process.argv[process.argv.indexOf('--confi
 
 const foldersExclude = configJson.exclude ? configJson.exclude : []
 
-const moduleGlob = configJson.moduleGlob
+let moduleGlob = configJson.moduleGlob
+if(moduleGlob && !Array.isArray(moduleGlob)) {
+  moduleGlob = [moduleGlob]
+} else if (!moduleGlob) {
+  moduleGlob = ['/dist/esm/*/*/**/index.js']
+}
 const components = {
   // need the /*/*/ to avoid grabbing top level index files
   /**
    * We don't want the /index.js or /components/index.js to be have packages
    * These files will not help with tree shaking in module federation environments
    */
-    files: glob
-      .sync(moduleGlob ? `${root}${moduleGlob}` : `${root}/dist/esm/*/*/**/index.js`)
+    files: moduleGlob.map(pattern => glob
+      .sync(`${root}${pattern}`)
       .filter((item) => !foldersExclude.some((name) => item.includes(name)))
-      .map((name) => name.replace(/\/$/, '')),
+      .map((name) => name.replace(/\/$/, '')))
+      .flat(),
   }
 
 


### PR DESCRIPTION
The current `dynamic` output works well if all modules follow the same directory structure. There is an issue with the `react-core` package that has a mixed directory structure. The `helpers` dir is different from the rest of the modules and can cause issues when building the dynamic output.

### Changes
- allow multiple custom modules glob pattern to enable mixed source directory structure for building dynamic output
- exclude third-party module directory for the Popper helper.