### PR TITLE
feat(MenuItem): allow target and rel on links

### DIFF
--- a/packages/react-core/src/components/Menu/MenuItem.tsx
+++ b/packages/react-core/src/components/Menu/MenuItem.tsx
@@ -27,7 +27,7 @@ export interface MenuItemProps extends Omit<React.HTMLProps<HTMLLIElement>, 'onC
   to?: string;
   /** Navigation link target. Only set when the to property is present. */
   target?: string;
-  /** Navigation link relationship. Only set when the to property is present. */
+  /** Navigation link relationship. Only set when the to property is present. If isExternalLink is also passed in, this property will be set to "_blank". */
   rel?: string;
   /** Flag indicating the item has a checkbox */
   hasCheckbox?: boolean;

--- a/packages/react-core/src/components/Menu/MenuItem.tsx
+++ b/packages/react-core/src/components/Menu/MenuItem.tsx
@@ -25,6 +25,10 @@ export interface MenuItemProps extends Omit<React.HTMLProps<HTMLLIElement>, 'onC
   itemId?: any;
   /** Target navigation link. Should not be used if the flyout prop is defined. */
   to?: string;
+  /** Navigation link target. Only set when the to property is present. */
+  target?: string;
+  /** Navigation link relationship. Only set when the to property is present. */
+  rel?: string;
   /** Flag indicating the item has a checkbox */
   hasCheckbox?: boolean;
   /** Flag indicating whether the item is active */
@@ -113,6 +117,8 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
   id,
   'aria-label': ariaLabel,
   tooltipProps,
+  rel,
+  target,
   ...props
 }: MenuItemProps) => {
   const {
@@ -264,7 +270,8 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
       'aria-disabled': isDisabled || isAriaDisabled ? true : null,
       // prevent invalid 'disabled' attribute on <a> tags
       disabled: null,
-      target: isExternalLink ? '_blank' : null
+      target: isExternalLink ? '_blank' : target,
+      rel
     };
   } else if (Component === 'button') {
     additionalProps = {
@@ -428,13 +435,7 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
       {...(hasCheckbox && { 'aria-label': ariaLabel })}
       {...props}
     >
-      {tooltipProps ? (
-        <Tooltip {...tooltipProps}>
-          {renderItem}
-        </Tooltip>
-      ) : (
-        renderItem
-      )}
+      {tooltipProps ? <Tooltip {...tooltipProps}>{renderItem}</Tooltip> : renderItem}
     </li>
   );
 };

--- a/packages/react-core/src/components/Menu/MenuItem.tsx
+++ b/packages/react-core/src/components/Menu/MenuItem.tsx
@@ -25,9 +25,9 @@ export interface MenuItemProps extends Omit<React.HTMLProps<HTMLLIElement>, 'onC
   itemId?: any;
   /** Target navigation link. Should not be used if the flyout prop is defined. */
   to?: string;
-  /** Navigation link target. Only set when the to property is present. */
+  /** Navigation link target. Only set when the to property is present. If isExternalLink is also passed in, this property will be set to "_blank". */
   target?: string;
-  /** Navigation link relationship. Only set when the to property is present. If isExternalLink is also passed in, this property will be set to "_blank". */
+  /** Navigation link relationship. Only set when the to property is present. */
   rel?: string;
   /** Flag indicating the item has a checkbox */
   hasCheckbox?: boolean;


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8593

Adds `target` and `rel` to the props list and passed to anchor menu items.

LMK if these would be better off as a generic `linkProps` property that is spread directly onto the link.
