### PR TITLE
feature(Select): Add simplified Select with state/toggle override capability

### DIFF
--- a/packages/react-core/src/components/Select/__tests__/Select.test.tsx
+++ b/packages/react-core/src/components/Select/__tests__/Select.test.tsx
@@ -1,0 +1,203 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { Select } from '../Select';
+import { SelectOption } from '../SelectOption';
+import { SelectList } from '../SelectList';
+import { MenuToggle, MenuToggleElement } from '../../MenuToggle';
+
+it('shows all select options when isOpen is true', () => {
+  render(
+    <Select isOpen>
+      <SelectOption value="Option 1">Option 1</SelectOption>
+      <SelectOption value="Option 2">Option 2</SelectOption>
+      <SelectOption value="Option 3">Option 3</SelectOption>
+    </Select>
+  );
+
+  expect(screen.getAllByRole('option')).toHaveLength(3);
+  ['Option 1', 'Option 2', 'Option 3'].map((value) =>
+    expect(screen.getByRole('option', { name: value })).toBeVisible()
+  );
+});
+
+it('does not show select options by default', () => {
+  render(
+    <Select>
+      <SelectOption value="Option 1">Option 1</SelectOption>
+    </Select>
+  );
+
+  expect(screen.queryByRole('option')).not.toBeInTheDocument();
+});
+
+it('shows placeholder text when specified', () => {
+  render(
+    <Select placeholder="Select a value">
+      <SelectOption value="Option 1">Option 1</SelectOption>
+    </Select>
+  );
+
+  expect(screen.getByRole('button', { name: 'Select a value' })).toBeVisible();
+});
+
+it('has disabled attributes when isDisabled is true', () => {
+  render(
+    <Select isDisabled>
+      <SelectOption value="Option 1">Option 1</SelectOption>
+    </Select>
+  );
+
+  const selectButton = screen.getByRole('button');
+
+  expect(selectButton).toHaveClass('pf-m-disabled');
+  expect(selectButton).toHaveAttribute('disabled');
+});
+
+it('has full width modifier class by default', () => {
+  render(
+    <Select>
+      <SelectOption value="Option 1">Option 1</SelectOption>
+    </Select>
+  );
+
+  expect(screen.getByRole('button')).toHaveClass('pf-m-full-width');
+});
+
+it('does not have a full width modifier class when isFullWidth is set to false', () => {
+  render(
+    <Select isFullWidth={false}>
+      <SelectOption value="Option 1">Option 1</SelectOption>
+    </Select>
+  );
+
+  expect(screen.getByRole('button')).not.toHaveClass('pf-m-full-width');
+});
+
+it('can select option with internal isOpen and selected state', async () => {
+  const user = userEvent.setup();
+
+  render(
+    <Select>
+      <SelectOption value="Option 1">Option 1</SelectOption>
+    </Select>
+  );
+
+  await user.click(screen.getByRole('button'));
+
+  const selectOption = screen.getByRole('option', { name: 'Option 1' });
+  expect(selectOption).toBeVisible();
+
+  await user.click(selectOption);
+  expect(screen.queryByRole('option')).not.toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Option 1' })).toBeVisible();
+});
+
+it('can select option with internal selected state and a custom toggle', async () => {
+  const user = userEvent.setup();
+
+  const toggle = (toggleRef: React.RefObject<any>, selected: any, isOpen: boolean, toggleOpen: () => void) => (
+    <MenuToggle ref={toggleRef} onClick={toggleOpen} isExpanded={isOpen} isFullWidth>
+      {selected}
+    </MenuToggle>
+  );
+
+  render(
+    <Select toggle={toggle}>
+      <SelectOption value="Option 1">Option 1</SelectOption>
+    </Select>
+  );
+
+  await user.click(screen.getByRole('button'));
+
+  const selectOption = screen.getByRole('option', { name: 'Option 1' });
+  expect(selectOption).toBeVisible();
+
+  await user.click(selectOption);
+
+  expect(screen.queryByRole('option')).not.toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Option 1' })).toBeVisible();
+});
+
+it('can select option with all custom handlers', async () => {
+  const user = userEvent.setup();
+
+  const CustomSelect = ({ children }) => {
+    const [isOpen, setIsOpen] = React.useState(false);
+    const [selected, setSelected] = React.useState<string>('Select a value');
+
+    const onToggleClick = () => {
+      setIsOpen(!isOpen);
+    };
+
+    const onSelect = (
+      _event: React.MouseEvent<Element, MouseEvent> | undefined,
+      value: string | number | undefined
+    ) => {
+      setSelected(value as string);
+      setIsOpen(false);
+    };
+
+    const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+      <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
+        {selected}
+      </MenuToggle>
+    );
+
+    return (
+      <Select
+        id="single-select"
+        isOpen={isOpen}
+        selected={selected}
+        onSelect={onSelect}
+        onOpenChange={(isOpen) => setIsOpen(isOpen)}
+        toggle={toggle}
+      >
+        {children}
+      </Select>
+    );
+  };
+
+  render(
+    <CustomSelect>
+      <SelectOption value="Option 1">Option 1</SelectOption>
+    </CustomSelect>
+  );
+
+  await user.click(screen.getByRole('button'));
+
+  const selectOption = screen.getByRole('option', { name: 'Option 1' });
+  expect(selectOption).toBeVisible();
+
+  await user.click(selectOption);
+
+  expect(screen.queryByRole('option')).not.toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Option 1' })).toBeVisible();
+});
+
+it('shows selected value instead of placeholder when one is specified', () => {
+  render(
+    <Select selected="Option 2" placeholder="Select a value">
+      <SelectOption value="Option 1">Option 1</SelectOption>
+      <SelectOption value="Option 2">Option 2</SelectOption>
+    </Select>
+  );
+
+  expect(screen.getByRole('button', { name: 'Option 2' })).toBeVisible();
+});
+
+it('calls onSelect when an option is clicked', async () => {
+  const user = userEvent.setup();
+  const onSelect = jest.fn();
+
+  render(
+    <Select isOpen onSelect={onSelect}>
+      <SelectOption value="Option 1">Option 1</SelectOption>
+    </Select>
+  );
+
+  await user.click(screen.getByRole('option', { name: 'Option 1' }));
+  expect(onSelect).toHaveBeenCalled();
+});

--- a/packages/react-core/src/components/Select/examples/Select.md
+++ b/packages/react-core/src/components/Select/examples/Select.md
@@ -4,7 +4,16 @@ section: components
 subsection: menus
 cssPrefix: pf-v5-c-select
 propComponents:
-  ['Select', 'SelectOption', 'SelectGroup', 'SelectList', 'MenuToggle', 'SelectToggleProps', 'SelectPopperProps']
+  [
+    'Select',
+    'SelectOption',
+    'SelectGroup',
+    'SelectList',
+    'MenuToggle',
+    'SelectBaseProps',
+    'SelectToggleProps',
+    'SelectPopperProps'
+  ]
 ouia: true
 ---
 
@@ -18,6 +27,12 @@ import BellIcon from '@patternfly/react-icons/dist/esm/icons/bell-icon';
 ### Single
 
 ```ts file="./SelectBasic.tsx"
+
+```
+
+### Single disabled
+
+```ts file="./SelectDisabled.tsx"
 
 ```
 

--- a/packages/react-core/src/components/Select/examples/SelectCheckbox.tsx
+++ b/packages/react-core/src/components/Select/examples/SelectCheckbox.tsx
@@ -21,16 +21,7 @@ export const SelectCheckbox: React.FunctionComponent = () => {
   };
 
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
-    <MenuToggle
-      ref={toggleRef}
-      onClick={onToggleClick}
-      isExpanded={isOpen}
-      style={
-        {
-          width: '200px'
-        } as React.CSSProperties
-      }
-    >
+    <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen} isFullWidth>
       Filter by status
       {selectedItems.length > 0 && <Badge isRead>{selectedItems.length}</Badge>}
     </MenuToggle>

--- a/packages/react-core/src/components/Select/examples/SelectDisabled.tsx
+++ b/packages/react-core/src/components/Select/examples/SelectDisabled.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Select, SelectList, SelectOption } from '@patternfly/react-core';
 
-export const SelectBasic: React.FunctionComponent = () => (
-  <Select id="single-select" placeholder="Select a value">
+export const SelectDisabled: React.FunctionComponent = () => (
+  <Select id="select-basic" placeholder="Select a value" isDisabled>
     <SelectList>
       <SelectOption value="Option 1">Option 1</SelectOption>
       <SelectOption value="Option 2">Option 2</SelectOption>

--- a/packages/react-core/src/components/Select/examples/SelectFooter.tsx
+++ b/packages/react-core/src/components/Select/examples/SelectFooter.tsx
@@ -10,21 +10,12 @@ export const SelectFooter: React.FunctionComponent = () => {
   };
 
   const toggle = (toggleRef) => (
-    <MenuToggle
-      ref={toggleRef}
-      onClick={onToggleClick}
-      isExpanded={isOpen}
-      style={
-        {
-          width: '200px'
-        } as React.CSSProperties
-      }
-    >
+    <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen} isFullWidth>
       {selected}
     </MenuToggle>
   );
 
-  function onSelect(event: React.MouseEvent | undefined, value: string | number | undefined) {
+  function onSelect(_event: React.MouseEvent | undefined, value: string | number | undefined) {
     if (typeof value === 'undefined') {
       return;
     }

--- a/packages/react-core/src/components/Select/examples/SelectGrouped.tsx
+++ b/packages/react-core/src/components/Select/examples/SelectGrouped.tsx
@@ -1,70 +1,22 @@
 import React from 'react';
-import {
-  Select,
-  SelectOption,
-  SelectList,
-  SelectGroup,
-  MenuToggle,
-  MenuToggleElement,
-  Divider
-} from '@patternfly/react-core';
+import { Select, SelectOption, SelectList, SelectGroup, Divider } from '@patternfly/react-core';
 
-export const SelectGrouped: React.FunctionComponent = () => {
-  const [isOpen, setIsOpen] = React.useState(false);
-  const [selected, setSelected] = React.useState<string>('Select a value');
-
-  const onToggleClick = () => {
-    setIsOpen(!isOpen);
-  };
-
-  const onSelect = (_event: React.MouseEvent<Element, MouseEvent> | undefined, value: string | number | undefined) => {
-    // eslint-disable-next-line no-console
-    console.log('selected', value);
-
-    setSelected(value as string);
-    setIsOpen(false);
-  };
-
-  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
-    <MenuToggle
-      ref={toggleRef}
-      onClick={onToggleClick}
-      isExpanded={isOpen}
-      style={
-        {
-          width: '200px'
-        } as React.CSSProperties
-      }
-    >
-      {selected}
-    </MenuToggle>
-  );
-
-  return (
-    <Select
-      id="single-grouped-select"
-      isOpen={isOpen}
-      selected={selected}
-      onSelect={onSelect}
-      onOpenChange={(isOpen) => setIsOpen(isOpen)}
-      toggle={toggle}
-      shouldFocusToggleOnSelect
-    >
-      <SelectGroup label="Group 1">
-        <SelectList>
-          <SelectOption value="Option 1">Option 1</SelectOption>
-          <SelectOption value="Option 2">Option 2</SelectOption>
-          <SelectOption value="Option 3">Option 3</SelectOption>
-        </SelectList>
-      </SelectGroup>
-      <Divider />
-      <SelectGroup label="Group 2">
-        <SelectList>
-          <SelectOption value="Option 4">Option 4</SelectOption>
-          <SelectOption value="Option 5">Option 5</SelectOption>
-          <SelectOption value="Option 6">Option 6</SelectOption>
-        </SelectList>
-      </SelectGroup>
-    </Select>
-  );
-};
+export const SelectGrouped: React.FunctionComponent = () => (
+  <Select id="single-grouped-select" placeholder="Select a value">
+    <SelectGroup label="Group 1">
+      <SelectList>
+        <SelectOption value="Option 1">Option 1</SelectOption>
+        <SelectOption value="Option 2">Option 2</SelectOption>
+        <SelectOption value="Option 3">Option 3</SelectOption>
+      </SelectList>
+    </SelectGroup>
+    <Divider />
+    <SelectGroup label="Group 2">
+      <SelectList>
+        <SelectOption value="Option 4">Option 4</SelectOption>
+        <SelectOption value="Option 5">Option 5</SelectOption>
+        <SelectOption value="Option 6">Option 6</SelectOption>
+      </SelectList>
+    </SelectGroup>
+  </Select>
+);

--- a/packages/react-core/src/components/Select/examples/SelectMultiTypeahead.tsx
+++ b/packages/react-core/src/components/Select/examples/SelectMultiTypeahead.tsx
@@ -58,7 +58,7 @@ export const SelectMultiTypeahead: React.FunctionComponent = () => {
     setSelectOptions(newSelectOptions);
     setFocusedItemIndex(null);
     setActiveItem(null);
-  }, [inputValue]);
+  }, [inputValue, isOpen]);
 
   const handleMenuArrowKeys = (key: string) => {
     let indexToFocus;

--- a/packages/react-core/src/components/Select/examples/SelectMultiTypeaheadCheckbox.tsx
+++ b/packages/react-core/src/components/Select/examples/SelectMultiTypeaheadCheckbox.tsx
@@ -57,7 +57,7 @@ export const SelectMultiTypeaheadCheckbox: React.FunctionComponent = () => {
     setSelectOptions(newSelectOptions);
     setFocusedItemIndex(null);
     setActiveItem(null);
-  }, [inputValue]);
+  }, [inputValue, isOpen]);
 
   const handleMenuArrowKeys = (key: string) => {
     let indexToFocus;

--- a/packages/react-core/src/components/Select/examples/SelectMultiTypeaheadCreatable.tsx
+++ b/packages/react-core/src/components/Select/examples/SelectMultiTypeaheadCreatable.tsx
@@ -57,7 +57,7 @@ export const SelectMultiTypeaheadCreatable: React.FunctionComponent = () => {
     setSelectOptions(newSelectOptions);
     setFocusedItemIndex(null);
     setActiveItem(null);
-  }, [inputValue, onCreation]);
+  }, [inputValue, isOpen, onCreation]);
 
   const handleMenuArrowKeys = (key: string) => {
     let indexToFocus;

--- a/packages/react-core/src/components/Select/examples/SelectOptionVariations.tsx
+++ b/packages/react-core/src/components/Select/examples/SelectOptionVariations.tsx
@@ -19,16 +19,7 @@ export const SelectOptionVariations: React.FunctionComponent = () => {
   };
 
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
-    <MenuToggle
-      ref={toggleRef}
-      onClick={onToggleClick}
-      isExpanded={isOpen}
-      style={
-        {
-          width: '200px'
-        } as React.CSSProperties
-      }
-    >
+    <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen} isFullWidth>
       {selected}
     </MenuToggle>
   );
@@ -41,7 +32,6 @@ export const SelectOptionVariations: React.FunctionComponent = () => {
       onSelect={onSelect}
       onOpenChange={(isOpen) => setIsOpen(isOpen)}
       toggle={toggle}
-      shouldFocusToggleOnSelect
     >
       <SelectList>
         <SelectOption value="Basic option">Basic option</SelectOption>

--- a/packages/react-core/src/components/Select/examples/SelectTypeahead.tsx
+++ b/packages/react-core/src/components/Select/examples/SelectTypeahead.tsx
@@ -22,7 +22,7 @@ const initialSelectOptions: SelectOptionProps[] = [
   { value: 'North Carolina', children: 'North Carolina' }
 ];
 
-export const SelectBasic: React.FunctionComponent = () => {
+export const SelectTypeahead: React.FunctionComponent = () => {
   const [isOpen, setIsOpen] = React.useState(false);
   const [selected, setSelected] = React.useState<string>('');
   const [inputValue, setInputValue] = React.useState<string>('');
@@ -57,7 +57,7 @@ export const SelectBasic: React.FunctionComponent = () => {
     setSelectOptions(newSelectOptions);
     setActiveItem(null);
     setFocusedItemIndex(null);
-  }, [filterValue]);
+  }, [filterValue, isOpen]);
 
   const onToggleClick = () => {
     setIsOpen(!isOpen);

--- a/packages/react-core/src/components/Select/examples/SelectTypeaheadCreatable.tsx
+++ b/packages/react-core/src/components/Select/examples/SelectTypeaheadCreatable.tsx
@@ -56,7 +56,7 @@ export const SelectTypeaheadCreatable: React.FunctionComponent = () => {
     setSelectOptions(newSelectOptions);
     setActiveItem(null);
     setFocusedItemIndex(null);
-  }, [filterValue, onCreation]);
+  }, [filterValue, isOpen, onCreation]);
 
   const onToggleClick = () => {
     setIsOpen(!isOpen);

--- a/packages/react-core/src/components/Select/examples/SelectViewMore.tsx
+++ b/packages/react-core/src/components/Select/examples/SelectViewMore.tsx
@@ -100,16 +100,7 @@ export const SelectViewMore: React.FunctionComponent = () => {
   };
 
   const toggle = (
-    <MenuToggle
-      ref={toggleRef}
-      onClick={onToggleClick}
-      isExpanded={isOpen}
-      style={
-        {
-          width: '200px'
-        } as React.CSSProperties
-      }
-    >
+    <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen} isFullWidth>
       {selected}
     </MenuToggle>
   );


### PR DESCRIPTION
**What**: Addresses [#5537](https://github.com/orgs/patternfly/discussions/5537)

This solution, which is open to discussion to be changed, rearranged, moved, etc adds a layer on top of the component coincidentally already named `SelectBase`, which utilizes open/selected state management internally. The `SelectProps` expand upon the `SelectBaseProps` for a simpler developer experience that uses `MenuToggle` by default. 

Unit tests supporting the expansion/simplification of Select were added. Prior to this change, there were no unit tests for the latest Select. The component could use more on top of what is added here.

All existing examples should still work as expected, as users can override the default behavior, and some of the simpler examples (`SelectBasic`, `SelectDisabled` (new - split from previous SelectBasic), and `SelectGrouped`) were updated to use default behavior that now comes with `Select`.

Users also have the ability to use `SelectBase` separately if they so choose to eliminate any possible default behavior they'd get from `Select`.
