### PR TITLE
feat(Modal): use css vars to set width, add maxWidth

### DIFF
--- a/packages/react-core/src/components/Modal/Modal.tsx
+++ b/packages/react-core/src/components/Modal/Modal.tsx
@@ -72,6 +72,8 @@ export interface ModalProps extends React.HTMLProps<HTMLDivElement>, OUIAProps {
   variant?: 'small' | 'medium' | 'large' | 'default';
   /** Default width of the modal. */
   width?: number | string;
+  /** Maximum width of the modal. */
+  maxWidth?: number | string;
   /** Value to overwrite the randomly generated data-ouia-component-id.*/
   ouiaId?: number | string;
   /** Set the value of data-ouia-safe. Only set to true when the component is in a static state, i.e. no animations are occurring. At all other times, this value must be false. */

--- a/packages/react-core/src/components/Modal/ModalContent.tsx
+++ b/packages/react-core/src/components/Modal/ModalContent.tsx
@@ -185,8 +185,10 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
       {...getOUIAProps(ModalContent.displayName, ouiaId, ouiaSafe)}
       style={
         {
-          ...(width && { '--pf-v5-c-modal-box--Width': width }),
-          ...(maxWidth && { '--pf-v5-c-modal-box--MaxWidth': maxWidth })
+          ...(width && { '--pf-v5-c-modal-box--Width': typeof width !== 'number' ? width : `${width}px` }),
+          ...(maxWidth && {
+            '--pf-v5-c-modal-box--MaxWidth': typeof maxWidth !== 'number' ? maxWidth : `${maxWidth}px`
+          })
         } as React.CSSProperties
       }
     >

--- a/packages/react-core/src/components/Modal/ModalContent.tsx
+++ b/packages/react-core/src/components/Modal/ModalContent.tsx
@@ -79,6 +79,8 @@ export interface ModalContentProps extends OUIAProps {
   variant?: 'small' | 'medium' | 'large' | 'default';
   /** Default width of the modal. */
   width?: number | string;
+  /** Maximum width of the modal. */
+  maxWidth?: number | string;
   /** Value to overwrite the randomly generated data-ouia-component-id.*/
   ouiaId?: number | string;
   /** Set the value of data-ouia-safe. Only set to true when the component is in a static state, i.e. no animations are occurring. At all other times, this value must be false. */
@@ -107,7 +109,8 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
   variant = 'default',
   position,
   positionOffset,
-  width = -1,
+  width,
+  maxWidth,
   boxId,
   labelId,
   descriptorId,
@@ -152,7 +155,6 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
       {children}
     </ModalBoxBody>
   );
-  const boxStyle = width === -1 ? {} : { width };
   const ariaLabelledbyFormatted = (): null | string => {
     if (ariaLabelledby === null) {
       return null;
@@ -173,7 +175,6 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
   const modalBox = (
     <ModalBox
       id={boxId}
-      style={boxStyle}
       className={css(className, isVariantIcon(titleIconVariant) && modalStyles.modifiers[titleIconVariant])}
       variant={variant}
       position={position}
@@ -182,6 +183,12 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
       aria-labelledby={ariaLabelledbyFormatted()}
       aria-describedby={ariaDescribedby || (hasNoBodyWrapper ? null : descriptorId)}
       {...getOUIAProps(ModalContent.displayName, ouiaId, ouiaSafe)}
+      style={
+        {
+          ...(width && { '--pf-v5-c-modal-box--Width': width }),
+          ...(maxWidth && { '--pf-v5-c-modal-box--MaxWidth': maxWidth })
+        } as React.CSSProperties
+      }
     >
       {showClose && <ModalBoxCloseButton onClose={(event) => onClose(event)} ouiaId={ouiaId} />}
       {modalBoxHeader}

--- a/packages/react-integration/cypress/integration/wizarddeprecated.spec.ts
+++ b/packages/react-integration/cypress/integration/wizarddeprecated.spec.ts
@@ -6,7 +6,7 @@ describe('Wizard Deprecated Demo Test', () => {
   it('Verify wizard in modal launches in a dialog and has a custom width', () => {
     cy.get('#launchWiz').click();
     cy.get('#modalWizId.pf-v5-c-wizard').should('exist');
-    cy.get('.pf-v5-c-modal-box').should('have.attr', 'style', 'width: 710px;');
+    cy.get('.pf-v5-c-modal-box').should('have.attr', 'style', '--pf-v5-c-modal-box--Width: 710px;');
     cy.focused().click();
   });
 

--- a/packages/react-integration/cypress/integration/wizarddeprecated.spec.ts
+++ b/packages/react-integration/cypress/integration/wizarddeprecated.spec.ts
@@ -6,7 +6,7 @@ describe('Wizard Deprecated Demo Test', () => {
   it('Verify wizard in modal launches in a dialog and has a custom width', () => {
     cy.get('#launchWiz').click();
     cy.get('#modalWizId.pf-v5-c-wizard').should('exist');
-    cy.get('.pf-v5-c-modal-box').should('have.attr', 'style', '--pf-v5-c-modal-box--Width: 710px;');
+    cy.get('.pf-v5-c-modal-box').should('have.attr', 'style', '--pf-v5-c-modal-box--Width:710px;');
     cy.focused().click();
   });
 


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #8351

Adds `maxWidth` property. 
Updates `width` and `maxWidth` to be set via css variables instead of directly as a style property.
