### PR TITLE
fix(SelectDeprecated): use textinput component for typeahead

### DIFF
--- a/packages/react-core/src/deprecated/components/Select/Select.tsx
+++ b/packages/react-core/src/deprecated/components/Select/Select.tsx
@@ -1383,7 +1383,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
               <div className={css(styles.selectToggleWrapper)}>
                 {toggleIcon && <span className={css(styles.selectToggleIcon)}>{toggleIcon}</span>}
                 <TextInput 
-                    className={css(formStyles.formControl, styles.selectToggleTypeahead)}
+                    className={css(styles.selectToggleTypeahead)}
                     aria-activedescendant={typeaheadActiveChild && typeaheadActiveChild.id}
                     id={`${selectToggleId}-select-typeahead`}
                     aria-label={typeAheadAriaLabel}
@@ -1410,7 +1410,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
                 {toggleIcon && <span className={css(styles.selectToggleIcon)}>{toggleIcon}</span>}
                 {selections && Array.isArray(selections) && selections.length > 0 && selectedChips}
                 <TextInput 
-                    className={css(formStyles.formControl, styles.selectToggleTypeahead)}
+                    className={css(styles.selectToggleTypeahead)}
                     aria-activedescendant={typeaheadActiveChild && typeaheadActiveChild.id}
                     id={`${selectToggleId}-select-multi-typeahead-typeahead`}
                     aria-label={typeAheadAriaLabel}

--- a/packages/react-core/src/deprecated/components/Select/Select.tsx
+++ b/packages/react-core/src/deprecated/components/Select/Select.tsx
@@ -1400,26 +1400,6 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
                     isDisabled={isDisabled}
                     ref={this.inputRef}
                 />
-                {/* <div className={css(formStyles.formControl, styles.selectToggleTypeahead)}>
-                  <input
-                    aria-activedescendant={typeaheadActiveChild && typeaheadActiveChild.id}
-                    id={`${selectToggleId}-select-typeahead`}
-                    aria-label={typeAheadAriaLabel}
-                    {...(typeAheadAriaDescribedby && { 'aria-describedby': typeAheadAriaDescribedby })}
-                    placeholder={placeholderText as string}
-                    value={
-                      typeaheadInputValue !== null
-                        ? typeaheadInputValue
-                        : this.getDisplay(selections[0] as string, 'text') || ''
-                    }
-                    type="text"
-                    onClick={this.onClick}
-                    onChange={this.onChange}
-                    autoComplete={inputAutoComplete}
-                    disabled={isDisabled}
-                    ref={this.inputRef}
-                  />
-                </div> */}
               </div>
               {hasOnClear && (selections[0] || typeaheadInputValue) && clearBtn}
             </React.Fragment>

--- a/packages/react-core/src/deprecated/components/Select/Select.tsx
+++ b/packages/react-core/src/deprecated/components/Select/Select.tsx
@@ -37,6 +37,7 @@ import { Popper } from '../../../helpers/Popper/Popper';
 import { createRenderableFavorites, extendItemsWithFavorite } from '../../../helpers/favorites';
 import { ValidatedOptions } from '../../../helpers/constants';
 import { findTabbableElements } from '../../../helpers/util';
+import { TextInput } from '../../../components/TextInput';
 
 // seed for the aria-labelledby ID
 let currentId = 0;
@@ -1381,7 +1382,25 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
             <React.Fragment>
               <div className={css(styles.selectToggleWrapper)}>
                 {toggleIcon && <span className={css(styles.selectToggleIcon)}>{toggleIcon}</span>}
-                <div className={css(formStyles.formControl, styles.selectToggleTypeahead)}>
+                <TextInput 
+                    className={css(formStyles.formControl, styles.selectToggleTypeahead)}
+                    aria-activedescendant={typeaheadActiveChild && typeaheadActiveChild.id}
+                    id={`${selectToggleId}-select-typeahead`}
+                    aria-label={typeAheadAriaLabel}
+                    {...(typeAheadAriaDescribedby && { 'aria-describedby': typeAheadAriaDescribedby })}
+                    placeholder={placeholderText as string}
+                    value={
+                      typeaheadInputValue !== null
+                        ? typeaheadInputValue
+                        : this.getDisplay(selections[0] as string, 'text') || ''
+                    }
+                    onChange={(event) => this.onChange(event as React.ChangeEvent<HTMLInputElement>)}
+                    onClick={this.onClick}
+                    autoComplete={inputAutoComplete}
+                    isDisabled={isDisabled}
+                    ref={this.inputRef}
+                />
+                {/* <div className={css(formStyles.formControl, styles.selectToggleTypeahead)}>
                   <input
                     aria-activedescendant={typeaheadActiveChild && typeaheadActiveChild.id}
                     id={`${selectToggleId}-select-typeahead`}
@@ -1400,7 +1419,7 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
                     disabled={isDisabled}
                     ref={this.inputRef}
                   />
-                </div>
+                </div> */}
               </div>
               {hasOnClear && (selections[0] || typeaheadInputValue) && clearBtn}
             </React.Fragment>
@@ -1410,8 +1429,8 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
               <div className={css(styles.selectToggleWrapper)}>
                 {toggleIcon && <span className={css(styles.selectToggleIcon)}>{toggleIcon}</span>}
                 {selections && Array.isArray(selections) && selections.length > 0 && selectedChips}
-                <div className={css(formStyles.formControl, styles.selectToggleTypeahead)}>
-                  <input
+                <TextInput 
+                    className={css(formStyles.formControl, styles.selectToggleTypeahead)}
                     aria-activedescendant={typeaheadActiveChild && typeaheadActiveChild.id}
                     id={`${selectToggleId}-select-multi-typeahead-typeahead`}
                     aria-label={typeAheadAriaLabel}
@@ -1419,14 +1438,12 @@ export class Select extends React.Component<SelectProps & OUIAProps, SelectState
                     {...(typeAheadAriaDescribedby && { 'aria-describedby': typeAheadAriaDescribedby })}
                     placeholder={placeholderText as string}
                     value={typeaheadInputValue !== null ? typeaheadInputValue : ''}
-                    type="text"
-                    onChange={this.onChange}
+                    onChange={(event) => this.onChange(event as React.ChangeEvent<HTMLInputElement>)}
                     onClick={this.onClick}
                     autoComplete={inputAutoComplete}
-                    disabled={isDisabled}
+                    isDisabled={isDisabled}
                     ref={this.inputRef}
-                  />
-                </div>
+                />
               </div>
               {hasOnClear && ((selections && selections.length > 0) || typeaheadInputValue) && clearBtn}
             </React.Fragment>

--- a/packages/react-core/src/deprecated/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/packages/react-core/src/deprecated/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
@@ -1667,7 +1667,7 @@ exports[`typeahead multi select renders closed successfully 1`] = `
         class="pf-v5-c-select__toggle-wrapper"
       >
         <div
-          class="pf-v5-c-form-control pf-v5-c-form-control pf-v5-c-select__toggle-typeahead"
+          class="pf-v5-c-form-control pf-v5-c-select__toggle-typeahead"
         >
           <input
             aria-invalid="false"
@@ -1727,7 +1727,7 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
         class="pf-v5-c-select__toggle-wrapper"
       >
         <div
-          class="pf-v5-c-form-control pf-v5-c-form-control pf-v5-c-select__toggle-typeahead"
+          class="pf-v5-c-form-control pf-v5-c-select__toggle-typeahead"
         >
           <input
             aria-invalid="false"
@@ -1963,7 +1963,7 @@ exports[`typeahead multi select renders selected successfully 1`] = `
           </div>
         </div>
         <div
-          class="pf-v5-c-form-control pf-v5-c-form-control pf-v5-c-select__toggle-typeahead"
+          class="pf-v5-c-form-control pf-v5-c-select__toggle-typeahead"
         >
           <input
             aria-invalid="false"
@@ -2117,7 +2117,7 @@ exports[`typeahead select renders closed successfully 1`] = `
         class="pf-v5-c-select__toggle-wrapper"
       >
         <div
-          class="pf-v5-c-form-control pf-v5-c-form-control pf-v5-c-select__toggle-typeahead"
+          class="pf-v5-c-form-control pf-v5-c-select__toggle-typeahead"
         >
           <input
             aria-invalid="false"
@@ -2177,7 +2177,7 @@ exports[`typeahead select renders expanded successfully 1`] = `
         class="pf-v5-c-select__toggle-wrapper"
       >
         <div
-          class="pf-v5-c-form-control pf-v5-c-form-control pf-v5-c-select__toggle-typeahead"
+          class="pf-v5-c-form-control pf-v5-c-select__toggle-typeahead"
         >
           <input
             aria-invalid="false"
@@ -2295,7 +2295,7 @@ exports[`typeahead select renders selected successfully 1`] = `
         class="pf-v5-c-select__toggle-wrapper"
       >
         <div
-          class="pf-v5-c-form-control pf-v5-c-form-control pf-v5-c-select__toggle-typeahead"
+          class="pf-v5-c-form-control pf-v5-c-select__toggle-typeahead"
         >
           <input
             aria-invalid="false"

--- a/packages/react-core/src/deprecated/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/packages/react-core/src/deprecated/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
@@ -1667,12 +1667,15 @@ exports[`typeahead multi select renders closed successfully 1`] = `
         class="pf-v5-c-select__toggle-wrapper"
       >
         <div
-          class="pf-v5-c-form-control pf-v5-c-select__toggle-typeahead"
+          class="pf-v5-c-form-control pf-v5-c-form-control pf-v5-c-select__toggle-typeahead"
         >
           <input
             aria-invalid="false"
             aria-label=""
             autocomplete="off"
+            data-ouia-component-id="OUIA-Generated-TextInputBase-6"
+            data-ouia-component-type="PF5/TextInput"
+            data-ouia-safe="true"
             id="typeahead-multi-select-closed-select-multi-typeahead-typeahead"
             placeholder=""
             type="text"
@@ -1724,12 +1727,15 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
         class="pf-v5-c-select__toggle-wrapper"
       >
         <div
-          class="pf-v5-c-form-control pf-v5-c-select__toggle-typeahead"
+          class="pf-v5-c-form-control pf-v5-c-form-control pf-v5-c-select__toggle-typeahead"
         >
           <input
             aria-invalid="false"
             aria-label=""
             autocomplete="off"
+            data-ouia-component-id="OUIA-Generated-TextInputBase-7"
+            data-ouia-component-type="PF5/TextInput"
+            data-ouia-safe="true"
             id="pf-select-toggle-id-19-select-multi-typeahead-typeahead"
             placeholder=""
             type="text"
@@ -1957,12 +1963,15 @@ exports[`typeahead multi select renders selected successfully 1`] = `
           </div>
         </div>
         <div
-          class="pf-v5-c-form-control pf-v5-c-select__toggle-typeahead"
+          class="pf-v5-c-form-control pf-v5-c-form-control pf-v5-c-select__toggle-typeahead"
         >
           <input
             aria-invalid="false"
             aria-label=""
             autocomplete="off"
+            data-ouia-component-id="OUIA-Generated-TextInputBase-8"
+            data-ouia-component-type="PF5/TextInput"
+            data-ouia-safe="true"
             id="typeahead-multi-select-selected-select-multi-typeahead-typeahead"
             placeholder=""
             type="text"
@@ -2108,11 +2117,15 @@ exports[`typeahead select renders closed successfully 1`] = `
         class="pf-v5-c-select__toggle-wrapper"
       >
         <div
-          class="pf-v5-c-form-control pf-v5-c-select__toggle-typeahead"
+          class="pf-v5-c-form-control pf-v5-c-form-control pf-v5-c-select__toggle-typeahead"
         >
           <input
+            aria-invalid="false"
             aria-label=""
             autocomplete="off"
+            data-ouia-component-id="OUIA-Generated-TextInputBase-2"
+            data-ouia-component-type="PF5/TextInput"
+            data-ouia-safe="true"
             id="typeahead-select-closed-select-typeahead"
             placeholder=""
             type="text"
@@ -2164,11 +2177,15 @@ exports[`typeahead select renders expanded successfully 1`] = `
         class="pf-v5-c-select__toggle-wrapper"
       >
         <div
-          class="pf-v5-c-form-control pf-v5-c-select__toggle-typeahead"
+          class="pf-v5-c-form-control pf-v5-c-form-control pf-v5-c-select__toggle-typeahead"
         >
           <input
+            aria-invalid="false"
             aria-label=""
             autocomplete="off"
+            data-ouia-component-id="OUIA-Generated-TextInputBase-3"
+            data-ouia-component-type="PF5/TextInput"
+            data-ouia-safe="true"
             id="pf-select-toggle-id-9-select-typeahead"
             placeholder=""
             type="text"
@@ -2278,11 +2295,15 @@ exports[`typeahead select renders selected successfully 1`] = `
         class="pf-v5-c-select__toggle-wrapper"
       >
         <div
-          class="pf-v5-c-form-control pf-v5-c-select__toggle-typeahead"
+          class="pf-v5-c-form-control pf-v5-c-form-control pf-v5-c-select__toggle-typeahead"
         >
           <input
+            aria-invalid="false"
             aria-label=""
             autocomplete="off"
+            data-ouia-component-id="OUIA-Generated-TextInputBase-4"
+            data-ouia-component-type="PF5/TextInput"
+            data-ouia-safe="true"
             id="pf-select-toggle-id-10-select-typeahead"
             placeholder=""
             type="text"


### PR DESCRIPTION
Closes patternfly/patternfly-react#9324 
