### PR TITLE
fix(Number Input): Fixed the readOnly not being applied when no onchange passed

### DIFF
--- a/packages/react-core/src/components/NumberInput/NumberInput.tsx
+++ b/packages/react-core/src/components/NumberInput/NumberInput.tsx
@@ -139,7 +139,7 @@ export const NumberInput: React.FunctionComponent<NumberInputProps> = ({
             {...(isDisabled && { isDisabled })}
             {...(onChange && { onChange: (event, _value) => onChange(event) })}
             onBlur={handleBlur}
-            {...(!onChange && { isReadOnly: true })}
+            {...(!onChange && { readOnlyVariant: "default" })}
             onKeyDown={keyDownHandler}
             validated={validated}
           />

--- a/packages/react-core/src/components/NumberInput/__tests__/NumberInput.test.tsx
+++ b/packages/react-core/src/components/NumberInput/__tests__/NumberInput.test.tsx
@@ -231,4 +231,17 @@ describe('numberInput', () => {
 
     expect(consoleSpy).not.toHaveBeenCalled();
   });
+
+  test('input is read only if onChange not passed ', () => {
+    render(<NumberInput inputAriaLabel="readonly input" value={5}/>);
+    const input = screen.getByLabelText('readonly input');
+    expect(input).toHaveAttribute('readOnly');
+  });
+
+  test('input is not read only if onChange passed ', () => {
+    const onChangeMock = jest.fn();
+    render(<NumberInput inputAriaLabel="not readonly input" value={5} onChange={onChangeMock}/>);
+    const input = screen.getByLabelText('not readonly input');
+    expect(input).not.toHaveAttribute('readOnly');
+  });
 });

--- a/packages/react-core/src/components/NumberInput/__tests__/__snapshots__/NumberInput.test.tsx.snap
+++ b/packages/react-core/src/components/NumberInput/__tests__/__snapshots__/NumberInput.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`numberInput disables lower threshold 1`] = `
         class="pf-v5-c-input-group__item"
       >
         <div
-          class="pf-v5-c-form-control"
+          class="pf-v5-c-form-control pf-m-readonly"
         >
           <input
             aria-invalid="false"
@@ -52,6 +52,7 @@ exports[`numberInput disables lower threshold 1`] = `
             data-ouia-component-id="OUIA-Generated-TextInputBase-7"
             data-ouia-component-type="PF5/TextInput"
             data-ouia-safe="true"
+            readonly=""
             type="number"
             value="0"
           />
@@ -136,7 +137,7 @@ exports[`numberInput disables upper threshold 1`] = `
         class="pf-v5-c-input-group__item"
       >
         <div
-          class="pf-v5-c-form-control"
+          class="pf-v5-c-form-control pf-m-readonly"
         >
           <input
             aria-invalid="false"
@@ -144,6 +145,7 @@ exports[`numberInput disables upper threshold 1`] = `
             data-ouia-component-id="OUIA-Generated-TextInputBase-8"
             data-ouia-component-type="PF5/TextInput"
             data-ouia-safe="true"
+            readonly=""
             type="number"
             value="100"
           />
@@ -230,7 +232,7 @@ exports[`numberInput passes button props successfully 1`] = `
         class="pf-v5-c-input-group__item"
       >
         <div
-          class="pf-v5-c-form-control"
+          class="pf-v5-c-form-control pf-m-readonly"
         >
           <input
             aria-invalid="false"
@@ -238,6 +240,7 @@ exports[`numberInput passes button props successfully 1`] = `
             data-ouia-component-id="OUIA-Generated-TextInputBase-13"
             data-ouia-component-type="PF5/TextInput"
             data-ouia-safe="true"
+            readonly=""
             type="number"
             value="5"
           />
@@ -417,7 +420,7 @@ exports[`numberInput renders custom width 1`] = `
         class="pf-v5-c-input-group__item"
       >
         <div
-          class="pf-v5-c-form-control"
+          class="pf-v5-c-form-control pf-m-readonly"
         >
           <input
             aria-invalid="false"
@@ -425,6 +428,7 @@ exports[`numberInput renders custom width 1`] = `
             data-ouia-component-id="OUIA-Generated-TextInputBase-11"
             data-ouia-component-type="PF5/TextInput"
             data-ouia-safe="true"
+            readonly=""
             type="number"
             value="5"
           />
@@ -510,7 +514,7 @@ exports[`numberInput renders defaults & extra props 1`] = `
         class="pf-v5-c-input-group__item"
       >
         <div
-          class="pf-v5-c-form-control"
+          class="pf-v5-c-form-control pf-m-readonly"
         >
           <input
             aria-invalid="false"
@@ -518,6 +522,7 @@ exports[`numberInput renders defaults & extra props 1`] = `
             data-ouia-component-id="OUIA-Generated-TextInputBase-1"
             data-ouia-component-type="PF5/TextInput"
             data-ouia-safe="true"
+            readonly=""
             type="number"
             value="0"
           />
@@ -603,7 +608,7 @@ exports[`numberInput renders disabled 1`] = `
         class="pf-v5-c-input-group__item"
       >
         <div
-          class="pf-v5-c-form-control pf-m-disabled"
+          class="pf-v5-c-form-control pf-m-readonly pf-m-disabled"
         >
           <input
             aria-invalid="false"
@@ -612,6 +617,7 @@ exports[`numberInput renders disabled 1`] = `
             data-ouia-component-type="PF5/TextInput"
             data-ouia-safe="true"
             disabled=""
+            readonly=""
             type="number"
             value="90"
           />
@@ -697,7 +703,7 @@ exports[`numberInput renders error validated 1`] = `
         class="pf-v5-c-input-group__item"
       >
         <div
-          class="pf-v5-c-form-control pf-m-error"
+          class="pf-v5-c-form-control pf-m-readonly pf-m-error"
         >
           <input
             aria-invalid="true"
@@ -705,6 +711,7 @@ exports[`numberInput renders error validated 1`] = `
             data-ouia-component-id="OUIA-Generated-TextInputBase-3"
             data-ouia-component-type="PF5/TextInput"
             data-ouia-safe="true"
+            readonly=""
             type="number"
             value="0"
           />
@@ -810,7 +817,7 @@ exports[`numberInput renders success validated 1`] = `
         class="pf-v5-c-input-group__item"
       >
         <div
-          class="pf-v5-c-form-control pf-m-success"
+          class="pf-v5-c-form-control pf-m-readonly pf-m-success"
         >
           <input
             aria-invalid="false"
@@ -818,6 +825,7 @@ exports[`numberInput renders success validated 1`] = `
             data-ouia-component-id="OUIA-Generated-TextInputBase-2"
             data-ouia-component-type="PF5/TextInput"
             data-ouia-safe="true"
+            readonly=""
             type="number"
             value="0"
           />
@@ -928,7 +936,7 @@ exports[`numberInput renders unit & position 1`] = `
         class="pf-v5-c-input-group__item"
       >
         <div
-          class="pf-v5-c-form-control"
+          class="pf-v5-c-form-control pf-m-readonly"
         >
           <input
             aria-invalid="false"
@@ -936,6 +944,7 @@ exports[`numberInput renders unit & position 1`] = `
             data-ouia-component-id="OUIA-Generated-TextInputBase-10"
             data-ouia-component-type="PF5/TextInput"
             data-ouia-safe="true"
+            readonly=""
             type="number"
             value="5"
           />
@@ -1020,7 +1029,7 @@ exports[`numberInput renders unit 1`] = `
         class="pf-v5-c-input-group__item"
       >
         <div
-          class="pf-v5-c-form-control"
+          class="pf-v5-c-form-control pf-m-readonly"
         >
           <input
             aria-invalid="false"
@@ -1028,6 +1037,7 @@ exports[`numberInput renders unit 1`] = `
             data-ouia-component-id="OUIA-Generated-TextInputBase-9"
             data-ouia-component-type="PF5/TextInput"
             data-ouia-safe="true"
+            readonly=""
             type="number"
             value="5"
           />
@@ -1117,7 +1127,7 @@ exports[`numberInput renders value 1`] = `
         class="pf-v5-c-input-group__item"
       >
         <div
-          class="pf-v5-c-form-control"
+          class="pf-v5-c-form-control pf-m-readonly"
         >
           <input
             aria-invalid="false"
@@ -1125,6 +1135,7 @@ exports[`numberInput renders value 1`] = `
             data-ouia-component-id="OUIA-Generated-TextInputBase-5"
             data-ouia-component-type="PF5/TextInput"
             data-ouia-safe="true"
+            readonly=""
             type="number"
             value="90"
           />
@@ -1209,7 +1220,7 @@ exports[`numberInput renders warning validated 1`] = `
         class="pf-v5-c-input-group__item"
       >
         <div
-          class="pf-v5-c-form-control pf-m-warning"
+          class="pf-v5-c-form-control pf-m-readonly pf-m-warning"
         >
           <input
             aria-invalid="false"
@@ -1217,6 +1228,7 @@ exports[`numberInput renders warning validated 1`] = `
             data-ouia-component-id="OUIA-Generated-TextInputBase-4"
             data-ouia-component-type="PF5/TextInput"
             data-ouia-safe="true"
+            readonly=""
             type="number"
             value="0"
           />


### PR DESCRIPTION


<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #9311 

Fixed regression introduced when TextInput's deprecated `isReadonly` was removed. 
