### PR TITLE
Bug - v5 preview testing - chart legend tooltip spacing

### DIFF
--- a/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipContent.tsx
+++ b/packages/react-charts/src/components/ChartLegendTooltip/ChartLegendTooltipContent.tsx
@@ -266,6 +266,7 @@ export const ChartLegendTooltipContent: React.FunctionComponent<ChartLegendToolt
   const minLegendDimensions = getLegendTooltipSize({
     legendData: [{ name: '' }],
     legendProps,
+    minSpacing: 0,
     theme
   });
 

--- a/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
+++ b/packages/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
@@ -353,13 +353,13 @@ class EmbeddedHtml extends React.Component {
           containerComponent={
             <CursorVoronoiContainer
               cursorDimension="x"
-              labels={({ datum }) => `${datum.y}`}
+              labels={({ datum }) => `${datum.y !== null ? datum.y : 'no data'}`}
               labelComponent={
                 <ChartCursorTooltip
                   centerOffset={{x: ({ center, flyoutWidth, width, offset = flyoutWidth / 2 + 10 }) => width > center.x + flyoutWidth + 10 ? offset : -offset}}
                   flyout={<ChartCursorFlyout />}
                   flyoutHeight={110}
-                  flyoutWidth={125}
+                  flyoutWidth={({ datum }) => datum.y === null ? 160 : 125 }
                   labelComponent={<HtmlLegendContent legendData={legendData} title={(datum) => datum.x} />}
                 />
               }
@@ -390,7 +390,8 @@ class EmbeddedHtml extends React.Component {
                 { name: 'Cats', x: '2015', y: 3 },
                 { name: 'Cats', x: '2016', y: 4 },
                 { name: 'Cats', x: '2017', y: 8 },
-                { name: 'Cats', x: '2018', y: 6 }
+                { name: 'Cats', x: '2018', y: 6 },
+                { name: 'Cats', x: '2019', y: null }
               ]}
               interpolation="monotoneX"
             />

--- a/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
@@ -23,6 +23,7 @@ interface ChartLegendTooltipFlyoutInterface {
   legendData: any;
   legendOrientation?: 'horizontal' | 'vertical';
   legendProps?: any;
+  minSpacing?: number;
   text?: StringOrNumberOrCallback | string[] | number[];
   theme: ChartThemeDefinition;
 }
@@ -122,6 +123,7 @@ export const getLegendTooltipSize = ({
   legendData,
   legendOrientation = 'vertical',
   legendProps,
+  minSpacing = 1,
   text = '',
   theme
 }: ChartLegendTooltipFlyoutInterface) => {
@@ -146,10 +148,7 @@ export const getLegendTooltipSize = ({
   });
 
   // Set length to ensure minimum spacing between label and value
-  let maxLength = maxDataLength + maxTextLength;
-  if (maxDataLength < 20 && maxLength < 30) {
-    maxLength += 2;
-  }
+  const maxLength = maxDataLength + maxTextLength + minSpacing;
 
   // Get spacing to help align legend labels and text values
   const spacer = 'x';


### PR DESCRIPTION
Ensures chart legend tooltips have a minimum spacing between its label and value. Verified with Cost Management and the HCS UI.

Closes https://github.com/patternfly/patternfly-react/issues/9314

**Cost Management UI**
![Screenshot 2023-06-29 at 6 35 42 PM](https://github.com/patternfly/patternfly-react/assets/17481322/a4c3bf53-97b9-49cb-b845-f83e088cbb6e)

**HCS UI**
![Screenshot 2023-06-29 at 6 44 58 PM](https://github.com/patternfly/patternfly-react/assets/17481322/64a1c95a-76f5-493f-9804-68502354bbf5)
