### PR TITLE
fix(charts): export getThemeColors

### DIFF
--- a/packages/react-charts/src/components/ChartUtils/chart-theme.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-theme.ts
@@ -36,9 +36,9 @@ export const getTheme = (themeColor: string): ChartThemeDefinition => {
 
 /**
  * Returns theme colors
- * @private use getTheme
+ * @public
  */
-const getThemeColors = (themeColor: string) => {
+export const getThemeColors = (themeColor: string) => {
   switch (themeColor) {
     case ChartThemeColor.blue:
       return BlueColorTheme;

--- a/packages/react-charts/src/components/index.ts
+++ b/packages/react-charts/src/components/index.ts
@@ -37,4 +37,4 @@ export * from './ChartVoronoiContainer/ChartVoronoiContainer';
 
 export { createContainer } from './ChartUtils/chart-container';
 export { getInteractiveLegendEvents, getInteractiveLegendItemStyles } from './ChartUtils/chart-interactive-legend';
-export { getCustomTheme, getTheme } from './ChartUtils/chart-theme';
+export { getCustomTheme, getTheme, getThemeColors } from './ChartUtils/chart-theme';


### PR DESCRIPTION
Exporting our `getThemeColors` util. This will eliminate any need to import unsupported theme color references (e.g., for building custom components).

Example: `getThemeColors(ChartThemeColor.multiUnordered)`