### PR TITLE
fix(Popper): fixed flicker when opening popper content

### DIFF
--- a/packages/react-core/src/components/DataList/__tests__/__snapshots__/DataList.test.tsx.snap
+++ b/packages/react-core/src/components/DataList/__tests__/__snapshots__/DataList.test.tsx.snap
@@ -164,7 +164,7 @@ exports[`DataList DataListAction dropdown 1`] = `
         data-ouia-component-id="OUIA-Generated-Dropdown-1"
         data-ouia-component-type="PF5/Dropdown"
         data-ouia-safe="true"
-        style="position: absolute; left: 0px; top: 0px; z-index: 9999;"
+        style="position: absolute; left: 0px; top: 0px; z-index: 9999; opacity: 0; transition: opacity 0ms cubic-bezier(.54, 1.5, .38, 1.11);"
       >
         <div
           class="pf-v5-c-menu__content"

--- a/packages/react-core/src/components/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react-core/src/components/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -59,9 +59,12 @@ exports[`With popover opened 1`] = `
       aria-describedby="popover-unique_id_mock-body"
       aria-label=""
       aria-modal="true"
-      class="pf-v5-c-popover pf-m-no-padding pf-m-width-auto pf-m-top"
+      class="pf-v5-c-popover pf-m-no-padding pf-m-width-auto pf-m-bottom"
+      data-popper-escaped="true"
+      data-popper-placement="bottom"
+      data-popper-reference-hidden="true"
       role="dialog"
-      style="opacity: 1; transition: opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11); position: absolute; left: 0px; top: 0px; z-index: 9999;"
+      style="position: absolute; left: 0px; top: 0px; z-index: 9999; opacity: 1; transition: opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11); min-width: auto; transform: translate(0px, 25px);"
     >
       <div
         class="pf-v5-c-popover__arrow"
@@ -130,7 +133,7 @@ exports[`With popover opened 1`] = `
                       <span
                         class="pf-v5-c-menu-toggle__text"
                       >
-                        December
+                        July
                       </span>
                       <span
                         class="pf-v5-c-menu-toggle__controls"
@@ -172,7 +175,7 @@ exports[`With popover opened 1`] = `
                         data-ouia-component-type="PF5/TextInput"
                         data-ouia-safe="true"
                         type="number"
-                        value="1969"
+                        value="2023"
                       />
                     </div>
                   </div>
@@ -328,7 +331,67 @@ exports[`With popover opened 1`] = `
                     class="pf-v5-c-calendar-month__dates-cell pf-m-adjacent-month"
                   >
                     <button
-                      aria-label="30 November 1969"
+                      aria-label="25 June 2023"
+                      class="pf-v5-c-calendar-month__date"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      25
+                    </button>
+                  </td>
+                  <td
+                    class="pf-v5-c-calendar-month__dates-cell pf-m-adjacent-month"
+                  >
+                    <button
+                      aria-label="26 June 2023"
+                      class="pf-v5-c-calendar-month__date"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      26
+                    </button>
+                  </td>
+                  <td
+                    class="pf-v5-c-calendar-month__dates-cell pf-m-adjacent-month"
+                  >
+                    <button
+                      aria-label="27 June 2023"
+                      class="pf-v5-c-calendar-month__date"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      27
+                    </button>
+                  </td>
+                  <td
+                    class="pf-v5-c-calendar-month__dates-cell pf-m-adjacent-month"
+                  >
+                    <button
+                      aria-label="28 June 2023"
+                      class="pf-v5-c-calendar-month__date"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      28
+                    </button>
+                  </td>
+                  <td
+                    class="pf-v5-c-calendar-month__dates-cell pf-m-adjacent-month"
+                  >
+                    <button
+                      aria-label="29 June 2023"
+                      class="pf-v5-c-calendar-month__date"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      29
+                    </button>
+                  </td>
+                  <td
+                    class="pf-v5-c-calendar-month__dates-cell pf-m-adjacent-month"
+                  >
+                    <button
+                      aria-label="30 June 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -340,7 +403,7 @@ exports[`With popover opened 1`] = `
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="1 December 1969"
+                      aria-label="1 July 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -348,11 +411,15 @@ exports[`With popover opened 1`] = `
                       1
                     </button>
                   </td>
+                </tr>
+                <tr
+                  class="pf-v5-c-calendar-month__dates-row"
+                >
                   <td
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="2 December 1969"
+                      aria-label="2 July 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -364,7 +431,7 @@ exports[`With popover opened 1`] = `
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="3 December 1969"
+                      aria-label="3 July 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -376,7 +443,7 @@ exports[`With popover opened 1`] = `
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="4 December 1969"
+                      aria-label="4 July 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -388,7 +455,7 @@ exports[`With popover opened 1`] = `
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="5 December 1969"
+                      aria-label="5 July 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -397,26 +464,22 @@ exports[`With popover opened 1`] = `
                     </button>
                   </td>
                   <td
-                    class="pf-v5-c-calendar-month__dates-cell"
+                    class="pf-v5-c-calendar-month__dates-cell pf-m-current"
                   >
                     <button
-                      aria-label="6 December 1969"
+                      aria-label="6 July 2023"
                       class="pf-v5-c-calendar-month__date"
-                      tabindex="-1"
+                      tabindex="0"
                       type="button"
                     >
                       6
                     </button>
                   </td>
-                </tr>
-                <tr
-                  class="pf-v5-c-calendar-month__dates-row"
-                >
                   <td
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="7 December 1969"
+                      aria-label="7 July 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -428,7 +491,7 @@ exports[`With popover opened 1`] = `
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="8 December 1969"
+                      aria-label="8 July 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -436,11 +499,15 @@ exports[`With popover opened 1`] = `
                       8
                     </button>
                   </td>
+                </tr>
+                <tr
+                  class="pf-v5-c-calendar-month__dates-row"
+                >
                   <td
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="9 December 1969"
+                      aria-label="9 July 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -452,7 +519,7 @@ exports[`With popover opened 1`] = `
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="10 December 1969"
+                      aria-label="10 July 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -464,7 +531,7 @@ exports[`With popover opened 1`] = `
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="11 December 1969"
+                      aria-label="11 July 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -476,7 +543,7 @@ exports[`With popover opened 1`] = `
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="12 December 1969"
+                      aria-label="12 July 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -488,7 +555,7 @@ exports[`With popover opened 1`] = `
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="13 December 1969"
+                      aria-label="13 July 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -496,15 +563,11 @@ exports[`With popover opened 1`] = `
                       13
                     </button>
                   </td>
-                </tr>
-                <tr
-                  class="pf-v5-c-calendar-month__dates-row"
-                >
                   <td
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="14 December 1969"
+                      aria-label="14 July 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -516,7 +579,7 @@ exports[`With popover opened 1`] = `
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="15 December 1969"
+                      aria-label="15 July 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -524,11 +587,15 @@ exports[`With popover opened 1`] = `
                       15
                     </button>
                   </td>
+                </tr>
+                <tr
+                  class="pf-v5-c-calendar-month__dates-row"
+                >
                   <td
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="16 December 1969"
+                      aria-label="16 July 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -540,7 +607,7 @@ exports[`With popover opened 1`] = `
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="17 December 1969"
+                      aria-label="17 July 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -552,7 +619,7 @@ exports[`With popover opened 1`] = `
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="18 December 1969"
+                      aria-label="18 July 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -564,7 +631,7 @@ exports[`With popover opened 1`] = `
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="19 December 1969"
+                      aria-label="19 July 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -576,7 +643,7 @@ exports[`With popover opened 1`] = `
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="20 December 1969"
+                      aria-label="20 July 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -584,15 +651,11 @@ exports[`With popover opened 1`] = `
                       20
                     </button>
                   </td>
-                </tr>
-                <tr
-                  class="pf-v5-c-calendar-month__dates-row"
-                >
                   <td
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="21 December 1969"
+                      aria-label="21 July 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -604,7 +667,7 @@ exports[`With popover opened 1`] = `
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="22 December 1969"
+                      aria-label="22 July 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -612,11 +675,15 @@ exports[`With popover opened 1`] = `
                       22
                     </button>
                   </td>
+                </tr>
+                <tr
+                  class="pf-v5-c-calendar-month__dates-row"
+                >
                   <td
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="23 December 1969"
+                      aria-label="23 July 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -628,7 +695,7 @@ exports[`With popover opened 1`] = `
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="24 December 1969"
+                      aria-label="24 July 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -640,7 +707,7 @@ exports[`With popover opened 1`] = `
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="25 December 1969"
+                      aria-label="25 July 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -652,7 +719,7 @@ exports[`With popover opened 1`] = `
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="26 December 1969"
+                      aria-label="26 July 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -664,7 +731,7 @@ exports[`With popover opened 1`] = `
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="27 December 1969"
+                      aria-label="27 July 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -672,15 +739,11 @@ exports[`With popover opened 1`] = `
                       27
                     </button>
                   </td>
-                </tr>
-                <tr
-                  class="pf-v5-c-calendar-month__dates-row"
-                >
                   <td
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="28 December 1969"
+                      aria-label="28 July 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -692,7 +755,7 @@ exports[`With popover opened 1`] = `
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="29 December 1969"
+                      aria-label="29 July 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -700,11 +763,15 @@ exports[`With popover opened 1`] = `
                       29
                     </button>
                   </td>
+                </tr>
+                <tr
+                  class="pf-v5-c-calendar-month__dates-row"
+                >
                   <td
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="30 December 1969"
+                      aria-label="30 July 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -716,9 +783,9 @@ exports[`With popover opened 1`] = `
                     class="pf-v5-c-calendar-month__dates-cell"
                   >
                     <button
-                      aria-label="31 December 1969"
+                      aria-label="31 July 2023"
                       class="pf-v5-c-calendar-month__date"
-                      tabindex="0"
+                      tabindex="-1"
                       type="button"
                     >
                       31
@@ -728,7 +795,7 @@ exports[`With popover opened 1`] = `
                     class="pf-v5-c-calendar-month__dates-cell pf-m-adjacent-month"
                   >
                     <button
-                      aria-label="1 January 1970"
+                      aria-label="1 August 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -740,7 +807,7 @@ exports[`With popover opened 1`] = `
                     class="pf-v5-c-calendar-month__dates-cell pf-m-adjacent-month"
                   >
                     <button
-                      aria-label="2 January 1970"
+                      aria-label="2 August 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
@@ -752,12 +819,36 @@ exports[`With popover opened 1`] = `
                     class="pf-v5-c-calendar-month__dates-cell pf-m-adjacent-month"
                   >
                     <button
-                      aria-label="3 January 1970"
+                      aria-label="3 August 2023"
                       class="pf-v5-c-calendar-month__date"
                       tabindex="-1"
                       type="button"
                     >
                       3
+                    </button>
+                  </td>
+                  <td
+                    class="pf-v5-c-calendar-month__dates-cell pf-m-adjacent-month"
+                  >
+                    <button
+                      aria-label="4 August 2023"
+                      class="pf-v5-c-calendar-month__date"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      4
+                    </button>
+                  </td>
+                  <td
+                    class="pf-v5-c-calendar-month__dates-cell pf-m-adjacent-month"
+                  >
+                    <button
+                      aria-label="5 August 2023"
+                      class="pf-v5-c-calendar-month__date"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      5
                     </button>
                   </td>
                 </tr>

--- a/packages/react-core/src/components/Nav/__tests__/__snapshots__/Nav.test.tsx.snap
+++ b/packages/react-core/src/components/Nav/__tests__/__snapshots__/Nav.test.tsx.snap
@@ -1096,7 +1096,7 @@ exports[`Nav Nav List with flyout 1`] = `
       data-popper-escaped="true"
       data-popper-placement="right-start"
       data-popper-reference-hidden="true"
-      style="position: absolute; left: 0px; top: 0px; z-index: 9999; min-width: 0px; transform: translate(0px, 0px);"
+      style="position: absolute; left: 0px; top: 0px; z-index: 9999; opacity: 0; transition: opacity 0ms cubic-bezier(.54, 1.5, .38, 1.11); min-width: 0px; transform: translate(0px, 0px);"
     >
       <div>
         Flyout test

--- a/packages/react-core/src/components/Popover/Popover.tsx
+++ b/packages/react-core/src/components/Popover/Popover.tsx
@@ -14,7 +14,7 @@ import popoverMaxWidth from '@patternfly/react-tokens/dist/esm/c_popover_MaxWidt
 import popoverMinWidth from '@patternfly/react-tokens/dist/esm/c_popover_MinWidth';
 import { ReactElement } from 'react';
 import { FocusTrap } from '../../helpers';
-import { Popper, getOpacityTransition } from '../../helpers/Popper/Popper';
+import { Popper } from '../../helpers/Popper/Popper';
 import { getUniqueId } from '../../helpers/util';
 
 export enum PopoverPosition {
@@ -273,11 +273,7 @@ export const Popover: React.FunctionComponent<PopoverProps> = ({
   const uniqueId = id || getUniqueId();
   const triggerManually = isVisible !== null;
   const [visible, setVisible] = React.useState(false);
-  const [opacity, setOpacity] = React.useState(0);
   const [focusTrapActive, setFocusTrapActive] = React.useState(Boolean(propWithFocusTrap));
-  const transitionTimerRef = React.useRef(null);
-  const showTimerRef = React.useRef(null);
-  const hideTimerRef = React.useRef(null);
   const popoverRef = React.useRef(null);
 
   React.useEffect(() => {
@@ -294,34 +290,15 @@ export const Popover: React.FunctionComponent<PopoverProps> = ({
   }, [isVisible, triggerManually]);
   const show = (event?: MouseEvent | KeyboardEvent, withFocusTrap?: boolean) => {
     event && onShow(event);
-
-    if (transitionTimerRef.current) {
-      clearTimeout(transitionTimerRef.current);
-    }
-    if (hideTimerRef.current) {
-      clearTimeout(hideTimerRef.current);
-    }
-    showTimerRef.current = setTimeout(() => {
-      setVisible(true);
-      setOpacity(1);
-      propWithFocusTrap !== false && withFocusTrap && setFocusTrapActive(true);
-      onShown();
-    }, 0);
+    setVisible(true);
+    propWithFocusTrap !== false && withFocusTrap && setFocusTrapActive(true);
   };
+
   const hide = (event?: MouseEvent | KeyboardEvent) => {
     event && onHide(event);
-    if (showTimerRef.current) {
-      clearTimeout(showTimerRef.current);
-    }
-    hideTimerRef.current = setTimeout(() => {
-      setVisible(false);
-      setOpacity(0);
-      setFocusTrapActive(false);
-      transitionTimerRef.current = setTimeout(() => {
-        onHidden();
-      }, animationDuration);
-    }, 0);
+    setVisible(false);
   };
+
   const positionModifiers = {
     top: styles.modifiers.top,
     bottom: styles.modifiers.bottom,
@@ -426,9 +403,7 @@ export const Popover: React.FunctionComponent<PopoverProps> = ({
       onMouseDown={onContentMouseDown}
       style={{
         minWidth: hasCustomMinWidth ? minWidth : null,
-        maxWidth: hasCustomMaxWidth ? maxWidth : null,
-        opacity,
-        transition: getOpacityTransition(animationDuration)
+        maxWidth: hasCustomMaxWidth ? maxWidth : null
       }}
       {...rest}
     >
@@ -477,6 +452,9 @@ export const Popover: React.FunctionComponent<PopoverProps> = ({
         enableFlip={enableFlip}
         zIndex={zIndex}
         flipBehavior={flipBehavior}
+        animationDuration={animationDuration}
+        onHidden={onHidden}
+        onShown={onShown}
       />
     </PopoverContext.Provider>
   );

--- a/packages/react-core/src/components/SearchInput/__tests__/__snapshots__/SearchInput.test.tsx.snap
+++ b/packages/react-core/src/components/SearchInput/__tests__/__snapshots__/SearchInput.test.tsx.snap
@@ -130,6 +130,13 @@ exports[`SearchInput advanced search 1`] = `
         </button>
       </div>
     </div>
+    <div
+      class=""
+      data-popper-escaped="true"
+      data-popper-placement="bottom-start"
+      data-popper-reference-hidden="true"
+      style="position: absolute; left: 0px; top: 0px; z-index: 9999; opacity: 1; transition: opacity 0ms cubic-bezier(.54, 1.5, .38, 1.11); min-width: 0px; transform: translate(0px, 0px);"
+    />
   </div>
 </DocumentFragment>
 `;
@@ -270,7 +277,7 @@ exports[`SearchInput advanced search with custom attributes 1`] = `
       data-popper-escaped="true"
       data-popper-placement="bottom-start"
       data-popper-reference-hidden="true"
-      style="position: absolute; top: 0px; left: 0px; transform: translate(0px, 0px); min-width: 0px; z-index: 9999;"
+      style="position: absolute; top: 0px; left: 0px; transform: translate(0px, 0px); min-width: 0px; z-index: 9999; opacity: 1; transition: opacity 0ms cubic-bezier(.54, 1.5, .38, 1.11);"
     >
       <div
         class="pf-v5-c-panel pf-m-raised"
@@ -599,6 +606,13 @@ exports[`SearchInput renders search input in strict mode 1`] = `
         </button>
       </div>
     </div>
+    <div
+      class=""
+      data-popper-escaped="true"
+      data-popper-placement="bottom-start"
+      data-popper-reference-hidden="true"
+      style="position: absolute; left: 0px; top: 0px; z-index: 9999; opacity: 1; transition: opacity 0ms cubic-bezier(.54, 1.5, .38, 1.11); min-width: 0px; transform: translate(0px, 0px);"
+    />
   </div>
 </DocumentFragment>
 `;

--- a/packages/react-core/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-core/src/components/Tooltip/Tooltip.tsx
@@ -7,7 +7,7 @@ import { TooltipArrow } from './TooltipArrow';
 import { KeyTypes } from '../../helpers/constants';
 import tooltipMaxWidth from '@patternfly/react-tokens/dist/esm/c_tooltip_MaxWidth';
 import { ReactElement } from 'react';
-import { Popper, getOpacityTransition } from '../../helpers/Popper/Popper';
+import { Popper } from '../../helpers/Popper/Popper';
 
 export enum TooltipPosition {
   auto = 'auto',
@@ -174,29 +174,7 @@ export const Tooltip: React.FunctionComponent<TooltipProps> = ({
   const triggerOnClick = trigger.includes('click');
   const triggerManually = trigger === 'manual';
   const [visible, setVisible] = React.useState(false);
-  const [opacity, setOpacity] = React.useState(0);
-  const transitionTimerRef = React.useRef(null);
-  const showTimerRef = React.useRef(null);
-  const hideTimerRef = React.useRef(null);
   const popperRef = React.createRef<HTMLDivElement>();
-
-  const prevExitDelayRef = React.useRef<number>();
-
-  const clearTimeouts = (timeoutRefs: React.RefObject<any>[]) => {
-    timeoutRefs.forEach((ref) => {
-      if (ref.current) {
-        clearTimeout(ref.current);
-      }
-    });
-  };
-
-  // Cancel all timers on unmount
-  React.useEffect(
-    () => () => {
-      clearTimeouts([transitionTimerRef, hideTimerRef, showTimerRef]);
-    },
-    []
-  );
 
   const onDocumentKeyDown = (event: KeyboardEvent) => {
     if (!triggerManually) {
@@ -222,36 +200,11 @@ export const Tooltip: React.FunctionComponent<TooltipProps> = ({
     }
   }, [isVisible]);
 
-  React.useEffect(() => {
-    if (prevExitDelayRef.current < exitDelay) {
-      clearTimeouts([transitionTimerRef, hideTimerRef]);
-      hideTimerRef.current = setTimeout(() => {
-        setOpacity(0);
-        transitionTimerRef.current = setTimeout(() => {
-          setVisible(false);
-          onTooltipHidden();
-        }, animationDuration);
-      }, exitDelay);
-    }
-    prevExitDelayRef.current = exitDelay;
-  }, [exitDelay]);
-
   const show = () => {
-    clearTimeouts([transitionTimerRef, hideTimerRef]);
-    showTimerRef.current = setTimeout(() => {
-      setVisible(true);
-      setOpacity(1);
-    }, entryDelay);
+    setVisible(true);
   };
   const hide = () => {
-    clearTimeouts([showTimerRef]);
-    hideTimerRef.current = setTimeout(() => {
-      setOpacity(0);
-      transitionTimerRef.current = setTimeout(() => {
-        setVisible(false);
-        onTooltipHidden();
-      }, animationDuration);
-    }, exitDelay);
+    setVisible(false);
   };
   const positionModifiers = {
     top: styles.modifiers.top,
@@ -275,9 +228,7 @@ export const Tooltip: React.FunctionComponent<TooltipProps> = ({
       role="tooltip"
       id={id}
       style={{
-        maxWidth: hasCustomMaxWidth ? maxWidth : null,
-        opacity,
-        transition: getOpacityTransition(animationDuration)
+        maxWidth: hasCustomMaxWidth ? maxWidth : null
       }}
       ref={popperRef}
       {...rest}
@@ -342,6 +293,10 @@ export const Tooltip: React.FunctionComponent<TooltipProps> = ({
       enableFlip={enableFlip}
       zIndex={zIndex}
       flipBehavior={flipBehavior}
+      animationDuration={animationDuration}
+      entryDelay={entryDelay}
+      exitDelay={exitDelay}
+      onHidden={onTooltipHidden}
     />
   );
 };

--- a/packages/react-core/src/helpers/__mocks__/util.ts
+++ b/packages/react-core/src/helpers/__mocks__/util.ts
@@ -1,1 +1,3 @@
 export const getUniqueId = () => 'unique_id_mock';
+
+export const clearTimeouts = () => {};

--- a/packages/react-core/src/helpers/util.ts
+++ b/packages/react-core/src/helpers/util.ts
@@ -519,3 +519,14 @@ export const preventedEvents = (events: string[]) =>
     }),
     {}
   );
+
+/**
+ * @param {React.RefObject<any>[]} timeoutRefs - Timeout refs to clear
+ */
+export const clearTimeouts = (timeoutRefs: React.RefObject<any>[]) => {
+  timeoutRefs.forEach((ref) => {
+    if (ref.current) {
+      clearTimeout(ref.current);
+    }
+  });
+};


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #9119 

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:

Essentially this fixes the flicker by having the opacity change that makes the Popper content visible to users happen after Popper has initially rendered and figured out where it should be placed.

In accomplishing that goal I moved the largely identical opacity change logic in Tooltip/Popover directly into Popper.