### PR TITLE
fix(fileupload): use default readonly text input instead of plain

### DIFF
--- a/packages/react-core/src/components/FileUpload/FileUploadField.tsx
+++ b/packages/react-core/src/components/FileUpload/FileUploadField.tsx
@@ -132,7 +132,7 @@ export const FileUploadField: React.FunctionComponent<FileUploadFieldProps> = ({
         <InputGroup>
           <InputGroupItem isFill>
             <TextInput
-              readOnlyVariant="plain" // Always read-only regardless of isReadOnly prop (which is just for the TextArea)
+              readOnlyVariant="default" // Always read-only regardless of isReadOnly prop (which is just for the TextArea)
               isDisabled={isDisabled}
               id={`${id}-filename`}
               name={`${id}-filename`}

--- a/packages/react-core/src/components/FileUpload/__tests__/__snapshots__/FileUpload.test.tsx.snap
+++ b/packages/react-core/src/components/FileUpload/__tests__/__snapshots__/FileUpload.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`simple fileupload 1`] = `
           class="pf-v5-c-input-group__item pf-m-fill"
         >
           <span
-            class="pf-v5-c-form-control pf-m-readonly pf-m-plain"
+            class="pf-v5-c-form-control pf-m-readonly"
           >
             <input
               aria-describedby="simple-text-file-browse-button"

--- a/packages/react-core/src/components/FileUpload/__tests__/__snapshots__/FileUploadField.test.tsx.snap
+++ b/packages/react-core/src/components/FileUpload/__tests__/__snapshots__/FileUploadField.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`simple fileuploadfield 1`] = `
           class="pf-v5-c-input-group__item pf-m-fill"
         >
           <span
-            class="pf-v5-c-form-control pf-m-readonly pf-m-plain"
+            class="pf-v5-c-form-control pf-m-readonly"
           >
             <input
               aria-describedby="custom-file-upload-browse-button"


### PR DESCRIPTION
Fixes https://github.com/patternfly/patternfly-react/issues/9386