### PR TITLE
feat(TreeView): onCollapse callback

### DIFF
--- a/packages/react-core/src/components/TreeView/TreeView.tsx
+++ b/packages/react-core/src/components/TreeView/TreeView.tsx
@@ -76,6 +76,8 @@ export interface TreeViewProps {
   onCheck?: (event: React.ChangeEvent<HTMLInputElement>, item: TreeViewDataItem, parentItem: TreeViewDataItem) => void;
   /** Callback for item selection. */
   onSelect?: (event: React.MouseEvent, item: TreeViewDataItem, parentItem: TreeViewDataItem) => void;
+  /** Callback for toggling a node with children. */
+  onCollapse?: (event: React.MouseEvent, item: TreeViewDataItem, parentItem: TreeViewDataItem) => void;
   /** Internal. Parent item of a tree view list item. */
   parentItem?: TreeViewDataItem;
   /** Toolbar to display above the tree view. */
@@ -104,6 +106,7 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
   parentItem,
   onSelect,
   onCheck,
+  onCollapse,
   toolbar,
   activeItems,
   compareItems = (item, itemToCheck) => item.id === itemToCheck.id,
@@ -113,7 +116,7 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
 }: TreeViewProps) => {
   const treeViewList = (
     <TreeViewList isNested={isNested} toolbar={toolbar}>
-      {data.map(item => (
+      {data.map((item) => (
         <TreeViewListItem
           key={item.id?.toString() || item.name?.toString()}
           name={item.name}
@@ -124,6 +127,7 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
           defaultExpanded={item.defaultExpanded !== undefined ? item.defaultExpanded : defaultAllExpanded}
           onSelect={onSelect}
           onCheck={onCheck}
+          onCollapse={onCollapse}
           hasCheckbox={item.hasCheckbox !== undefined ? item.hasCheckbox : hasCheckboxes}
           checkProps={item.checkProps}
           hasBadge={item.hasBadge !== undefined ? item.hasBadge : hasBadges}
@@ -153,6 +157,7 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
                 defaultAllExpanded={defaultAllExpanded}
                 onSelect={onSelect}
                 onCheck={onCheck}
+                onCollapse={onCollapse}
                 activeItems={activeItems}
                 icon={icon}
                 expandedIcon={expandedIcon}

--- a/packages/react-core/src/components/TreeView/TreeView.tsx
+++ b/packages/react-core/src/components/TreeView/TreeView.tsx
@@ -76,7 +76,9 @@ export interface TreeViewProps {
   onCheck?: (event: React.ChangeEvent<HTMLInputElement>, item: TreeViewDataItem, parentItem: TreeViewDataItem) => void;
   /** Callback for item selection. */
   onSelect?: (event: React.MouseEvent, item: TreeViewDataItem, parentItem: TreeViewDataItem) => void;
-  /** Callback for toggling a node with children. */
+  /** Callback for expanding a node with children. */
+  onExpand?: (event: React.MouseEvent, item: TreeViewDataItem, parentItem: TreeViewDataItem) => void;
+  /** Callback for collapsing a node with children. */
   onCollapse?: (event: React.MouseEvent, item: TreeViewDataItem, parentItem: TreeViewDataItem) => void;
   /** Internal. Parent item of a tree view list item. */
   parentItem?: TreeViewDataItem;
@@ -106,6 +108,7 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
   parentItem,
   onSelect,
   onCheck,
+  onExpand,
   onCollapse,
   toolbar,
   activeItems,
@@ -127,6 +130,7 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
           defaultExpanded={item.defaultExpanded !== undefined ? item.defaultExpanded : defaultAllExpanded}
           onSelect={onSelect}
           onCheck={onCheck}
+          onExpand={onExpand}
           onCollapse={onCollapse}
           hasCheckbox={item.hasCheckbox !== undefined ? item.hasCheckbox : hasCheckboxes}
           checkProps={item.checkProps}
@@ -157,6 +161,7 @@ export const TreeView: React.FunctionComponent<TreeViewProps> = ({
                 defaultAllExpanded={defaultAllExpanded}
                 onSelect={onSelect}
                 onCheck={onCheck}
+                onExpand={onExpand}
                 onCollapse={onCollapse}
                 activeItems={activeItems}
                 icon={icon}

--- a/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
+++ b/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
@@ -55,6 +55,8 @@ export interface TreeViewListItemProps {
    * from toggling.
    */
   onSelect?: (event: React.MouseEvent, item: TreeViewDataItem, parent: TreeViewDataItem) => void;
+  /** Callback for toggling a node with children. */
+  onCollapse?: (event: React.MouseEvent, item: TreeViewDataItem, parentItem: TreeViewDataItem) => void;
   /** Parent item of tree view item. */
   parentItem?: TreeViewDataItem;
   /** Title of a tree view item. */
@@ -74,6 +76,7 @@ const TreeViewListItemBase: React.FunctionComponent<TreeViewListItemProps> = ({
   defaultExpanded = false,
   children = null,
   onSelect,
+  onCollapse,
   onCheck,
   hasCheckbox = false,
   checkProps = {
@@ -117,6 +120,7 @@ const TreeViewListItemBase: React.FunctionComponent<TreeViewListItemProps> = ({
       className={css(styles.treeViewNodeToggle)}
       onClick={(evt: React.MouseEvent) => {
         if (isSelectable || hasCheckbox) {
+          onCollapse && onCollapse(evt, itemData, parentItem);
           setIsExpanded(!internalIsExpanded);
         }
         if (isSelectable) {
@@ -135,9 +139,9 @@ const TreeViewListItemBase: React.FunctionComponent<TreeViewListItemProps> = ({
     <span className={css(styles.treeViewNodeCheck)}>
       <input
         type="checkbox"
-        onChange={evt => onCheck && onCheck(evt, itemData, parentItem)}
-        onClick={evt => evt.stopPropagation()}
-        ref={elem => elem && (elem.indeterminate = checkProps.checked === null)}
+        onChange={(evt) => onCheck && onCheck(evt, itemData, parentItem)}
+        onClick={(evt) => evt.stopPropagation()}
+        ref={(elem) => elem && (elem.indeterminate = checkProps.checked === null)}
         {...checkProps}
         checked={checkProps.checked === null ? false : checkProps.checked}
         id={randomId}
@@ -192,7 +196,7 @@ const TreeViewListItemBase: React.FunctionComponent<TreeViewListItemProps> = ({
     >
       <div className={css(styles.treeViewContent)}>
         <GenerateId prefix={isSelectable ? 'selectable-id' : 'checkbox-id'}>
-          {randomId => (
+          {(randomId) => (
             <Component
               className={css(
                 styles.treeViewNode,
@@ -200,7 +204,7 @@ const TreeViewListItemBase: React.FunctionComponent<TreeViewListItemProps> = ({
                 (!children || isSelectable) &&
                   activeItems &&
                   activeItems.length > 0 &&
-                  activeItems.some(item => compareItems && item && compareItems(item, itemData))
+                  activeItems.some((item) => compareItems && item && compareItems(item, itemData))
                   ? styles.modifiers.current
                   : ''
               )}
@@ -208,6 +212,7 @@ const TreeViewListItemBase: React.FunctionComponent<TreeViewListItemProps> = ({
                 if (!hasCheckbox) {
                   onSelect && onSelect(evt, itemData, parentItem);
                   if (!isSelectable && children && evt.isDefaultPrevented() !== true) {
+                    onCollapse && onCollapse(evt, itemData, parentItem);
                     setIsExpanded(!internalIsExpanded);
                   }
                 }
@@ -241,13 +246,13 @@ export const TreeViewListItem = React.memo(TreeViewListItemBase, (prevProps, nex
     prevProps.activeItems &&
     prevProps.activeItems.length > 0 &&
     prevProps.activeItems.some(
-      item => prevProps.compareItems && item && prevProps.compareItems(item, prevProps.itemData)
+      (item) => prevProps.compareItems && item && prevProps.compareItems(item, prevProps.itemData)
     );
   const nextIncludes =
     nextProps.activeItems &&
     nextProps.activeItems.length > 0 &&
     nextProps.activeItems.some(
-      item => nextProps.compareItems && item && nextProps.compareItems(item, nextProps.itemData)
+      (item) => nextProps.compareItems && item && nextProps.compareItems(item, nextProps.itemData)
     );
 
   if (prevIncludes || nextIncludes) {
@@ -262,6 +267,7 @@ export const TreeViewListItem = React.memo(TreeViewListItemBase, (prevProps, nex
     prevProps.defaultExpanded !== nextProps.defaultExpanded ||
     prevProps.onSelect !== nextProps.onSelect ||
     prevProps.onCheck !== nextProps.onCheck ||
+    prevProps.onCollapse !== nextProps.onCollapse ||
     prevProps.hasCheckbox !== nextProps.hasCheckbox ||
     prevProps.checkProps !== nextProps.checkProps ||
     prevProps.hasBadge !== nextProps.hasBadge ||

--- a/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
+++ b/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
@@ -55,7 +55,9 @@ export interface TreeViewListItemProps {
    * from toggling.
    */
   onSelect?: (event: React.MouseEvent, item: TreeViewDataItem, parent: TreeViewDataItem) => void;
-  /** Callback for toggling a node with children. */
+  /** Callback for expanding a node with children. */
+  onExpand?: (event: React.MouseEvent, item: TreeViewDataItem, parentItem: TreeViewDataItem) => void;
+  /** Callback for collapsing a node with children. */
   onCollapse?: (event: React.MouseEvent, item: TreeViewDataItem, parentItem: TreeViewDataItem) => void;
   /** Parent item of tree view item. */
   parentItem?: TreeViewDataItem;
@@ -76,6 +78,7 @@ const TreeViewListItemBase: React.FunctionComponent<TreeViewListItemProps> = ({
   defaultExpanded = false,
   children = null,
   onSelect,
+  onExpand,
   onCollapse,
   onCheck,
   hasCheckbox = false,
@@ -120,7 +123,11 @@ const TreeViewListItemBase: React.FunctionComponent<TreeViewListItemProps> = ({
       className={css(styles.treeViewNodeToggle)}
       onClick={(evt: React.MouseEvent) => {
         if (isSelectable || hasCheckbox) {
-          onCollapse && onCollapse(evt, itemData, parentItem);
+          if (internalIsExpanded) {
+            onCollapse && onCollapse(evt, itemData, parentItem);
+          } else {
+            onExpand && onExpand(evt, itemData, parentItem);
+          }
           setIsExpanded(!internalIsExpanded);
         }
         if (isSelectable) {
@@ -212,7 +219,11 @@ const TreeViewListItemBase: React.FunctionComponent<TreeViewListItemProps> = ({
                 if (!hasCheckbox) {
                   onSelect && onSelect(evt, itemData, parentItem);
                   if (!isSelectable && children && evt.isDefaultPrevented() !== true) {
-                    onCollapse && onCollapse(evt, itemData, parentItem);
+                    if (internalIsExpanded) {
+                      onCollapse && onCollapse(evt, itemData, parentItem);
+                    } else {
+                      onExpand && onExpand(evt, itemData, parentItem);
+                    }
                     setIsExpanded(!internalIsExpanded);
                   }
                 }
@@ -267,6 +278,7 @@ export const TreeViewListItem = React.memo(TreeViewListItemBase, (prevProps, nex
     prevProps.defaultExpanded !== nextProps.defaultExpanded ||
     prevProps.onSelect !== nextProps.onSelect ||
     prevProps.onCheck !== nextProps.onCheck ||
+    prevProps.onExpand !== nextProps.onExpand ||
     prevProps.onCollapse !== nextProps.onCollapse ||
     prevProps.hasCheckbox !== nextProps.hasCheckbox ||
     prevProps.checkProps !== nextProps.checkProps ||

--- a/packages/react-core/src/components/TreeView/__tests__/TreeView.test.tsx
+++ b/packages/react-core/src/components/TreeView/__tests__/TreeView.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { TreeView } from '../TreeView';
 import { Button } from '@patternfly/react-core';
 import { FolderIcon, FolderOpenIcon } from '@patternfly/react-icons';
@@ -146,6 +146,37 @@ describe('tree view', () => {
   test('renders basic successfully', () => {
     const { asFragment } = render(<TreeView data={options} onSelect={jest.fn()} />);
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  test('calls onExpand and onCollapse appropriately', () => {
+    const onExpand = jest.fn();
+    const onCollapse = jest.fn();
+    const { asFragment } = render(
+      <TreeView data={options} onSelect={jest.fn()} onExpand={onExpand} onCollapse={onCollapse} />
+    );
+    expect(onExpand).not.toHaveBeenCalled();
+    expect(onCollapse).not.toHaveBeenCalled();
+    expect(screen.queryByText('Application 3')).toBeNull();
+    expect(screen.getByText('Cost Management')).toBeInTheDocument();
+    fireEvent(
+      screen.getByText('Cost Management'),
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true
+      })
+    );
+    expect(onExpand).toHaveBeenCalled();
+    expect(onCollapse).not.toHaveBeenCalled();
+    expect(screen.getByText('Application 3')).toBeInTheDocument();
+    fireEvent(
+      screen.getByText('Cost Management'),
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true
+      })
+    );
+    expect(onCollapse).toHaveBeenCalled();
+    expect(screen.queryByText('Application 3')).toBeNull();
   });
 
   test('renders active successfully', () => {

--- a/packages/react-core/src/components/TreeView/__tests__/__snapshots__/TreeView.test.tsx.snap
+++ b/packages/react-core/src/components/TreeView/__tests__/__snapshots__/TreeView.test.tsx.snap
@@ -1905,14 +1905,14 @@ exports[`tree view renders checkboxes successfully 1`] = `
         >
           <label
             class="pf-v5-c-tree-view__node pf-m-selectable"
-            for="checkbox-id18"
-            id="label-checkbox-id18"
+            for="checkbox-id25"
+            id="label-checkbox-id25"
           >
             <span
               class="pf-v5-c-tree-view__node-container"
             >
               <button
-                aria-labelledby="label-checkbox-id18"
+                aria-labelledby="label-checkbox-id25"
                 class="pf-v5-c-tree-view__node-toggle"
                 tabindex="0"
               >
@@ -1938,7 +1938,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
                 class="pf-v5-c-tree-view__node-check"
               >
                 <input
-                  id="checkbox-id18"
+                  id="checkbox-id25"
                   tabindex="0"
                   type="checkbox"
                 />
@@ -1966,14 +1966,14 @@ exports[`tree view renders checkboxes successfully 1`] = `
             >
               <label
                 class="pf-v5-c-tree-view__node pf-m-selectable"
-                for="checkbox-id19"
-                id="label-checkbox-id19"
+                for="checkbox-id26"
+                id="label-checkbox-id26"
               >
                 <span
                   class="pf-v5-c-tree-view__node-container"
                 >
                   <button
-                    aria-labelledby="label-checkbox-id19"
+                    aria-labelledby="label-checkbox-id26"
                     class="pf-v5-c-tree-view__node-toggle"
                     tabindex="-1"
                   >
@@ -1999,7 +1999,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
                     class="pf-v5-c-tree-view__node-check"
                   >
                     <input
-                      id="checkbox-id19"
+                      id="checkbox-id26"
                       tabindex="-1"
                       type="checkbox"
                     />
@@ -2024,14 +2024,14 @@ exports[`tree view renders checkboxes successfully 1`] = `
             >
               <label
                 class="pf-v5-c-tree-view__node pf-m-selectable"
-                for="checkbox-id20"
-                id="label-checkbox-id20"
+                for="checkbox-id27"
+                id="label-checkbox-id27"
               >
                 <span
                   class="pf-v5-c-tree-view__node-container"
                 >
                   <button
-                    aria-labelledby="label-checkbox-id20"
+                    aria-labelledby="label-checkbox-id27"
                     class="pf-v5-c-tree-view__node-toggle"
                     tabindex="-1"
                   >
@@ -2057,7 +2057,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
                     class="pf-v5-c-tree-view__node-check"
                   >
                     <input
-                      id="checkbox-id20"
+                      id="checkbox-id27"
                       tabindex="-1"
                       type="checkbox"
                     />
@@ -2084,14 +2084,14 @@ exports[`tree view renders checkboxes successfully 1`] = `
         >
           <label
             class="pf-v5-c-tree-view__node pf-m-selectable"
-            for="checkbox-id21"
-            id="label-checkbox-id21"
+            for="checkbox-id28"
+            id="label-checkbox-id28"
           >
             <span
               class="pf-v5-c-tree-view__node-container"
             >
               <button
-                aria-labelledby="label-checkbox-id21"
+                aria-labelledby="label-checkbox-id28"
                 class="pf-v5-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -2117,7 +2117,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
                 class="pf-v5-c-tree-view__node-check"
               >
                 <input
-                  id="checkbox-id21"
+                  id="checkbox-id28"
                   tabindex="-1"
                   type="checkbox"
                 />
@@ -2142,14 +2142,14 @@ exports[`tree view renders checkboxes successfully 1`] = `
         >
           <label
             class="pf-v5-c-tree-view__node pf-m-selectable"
-            for="checkbox-id22"
-            id="label-checkbox-id22"
+            for="checkbox-id29"
+            id="label-checkbox-id29"
           >
             <span
               class="pf-v5-c-tree-view__node-container"
             >
               <button
-                aria-labelledby="label-checkbox-id22"
+                aria-labelledby="label-checkbox-id29"
                 class="pf-v5-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -2175,7 +2175,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
                 class="pf-v5-c-tree-view__node-check"
               >
                 <input
-                  id="checkbox-id22"
+                  id="checkbox-id29"
                   tabindex="-1"
                   type="checkbox"
                 />
@@ -2200,14 +2200,14 @@ exports[`tree view renders checkboxes successfully 1`] = `
         >
           <label
             class="pf-v5-c-tree-view__node pf-m-selectable"
-            for="checkbox-id23"
-            id="label-checkbox-id23"
+            for="checkbox-id30"
+            id="label-checkbox-id30"
           >
             <span
               class="pf-v5-c-tree-view__node-container"
             >
               <button
-                aria-labelledby="label-checkbox-id23"
+                aria-labelledby="label-checkbox-id30"
                 class="pf-v5-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -2233,7 +2233,7 @@ exports[`tree view renders checkboxes successfully 1`] = `
                 class="pf-v5-c-tree-view__node-check"
               >
                 <input
-                  id="checkbox-id23"
+                  id="checkbox-id30"
                   tabindex="-1"
                   type="checkbox"
                 />
@@ -2672,15 +2672,15 @@ exports[`tree view renders individual flag options successfully 1`] = `
         >
           <label
             class="pf-v5-c-tree-view__node pf-m-selectable"
-            for="checkbox-id36"
-            id="label-checkbox-id36"
+            for="checkbox-id43"
+            id="label-checkbox-id43"
             tabindex="0"
           >
             <span
               class="pf-v5-c-tree-view__node-container"
             >
               <button
-                aria-labelledby="label-checkbox-id36"
+                aria-labelledby="label-checkbox-id43"
                 class="pf-v5-c-tree-view__node-toggle"
                 tabindex="-1"
               >
@@ -2706,7 +2706,7 @@ exports[`tree view renders individual flag options successfully 1`] = `
                 class="pf-v5-c-tree-view__node-check"
               >
                 <input
-                  id="checkbox-id36"
+                  id="checkbox-id43"
                   tabindex="-1"
                   type="checkbox"
                 />


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #9361

Adds `onCollapse` callback to `TreeView`. This callback is triggered when a node that has children is clicked.

Does `onCollapse` make the most sense for the name, or would `onToggle` be a better fit?
