### PR TITLE
fix Search Input - composable advanced search demo

### DIFF
--- a/packages/react-core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-core/src/components/DatePicker/DatePicker.tsx
@@ -272,7 +272,7 @@ const DatePickerBase = (
       >
         <div className={styles.datePickerInput} ref={triggerRef}>
           <InputGroup>
-            <InputGroupItem isFill>
+            <InputGroupItem>
               <TextInput
                 isDisabled={isDisabled}
                 isRequired={requiredDateOptions?.isRequired}

--- a/packages/react-core/src/components/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react-core/src/components/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`With popover opened 1`] = `
         class="pf-v5-c-input-group"
       >
         <div
-          class="pf-v5-c-input-group__item pf-m-fill"
+          class="pf-v5-c-input-group__item"
         >
           <span
             class="pf-v5-c-form-control"
@@ -787,7 +787,7 @@ exports[`disabled date picker 1`] = `
         class="pf-v5-c-input-group"
       >
         <div
-          class="pf-v5-c-input-group__item pf-m-fill"
+          class="pf-v5-c-input-group__item"
         >
           <span
             class="pf-v5-c-form-control pf-m-disabled"

--- a/packages/react-core/src/demos/SearchInput/SearchInput.md
+++ b/packages/react-core/src/demos/SearchInput/SearchInput.md
@@ -492,7 +492,7 @@ AdvancedComposableSearchInput = () => {
                       id="datePicker"
                       style={{ width: '100%' }}
                       value={date}
-                      onChange={setDate}
+                      onChange={(_e, newValue) => setDate(newValue)}
                       appendTo={() => document.querySelector('#datePicker')}
                     />
                   </FormGroup>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #9442
1. selecting a date would crash the page because of incorrect variables passed to `onChange`
2. DatePicker should not have used `isFill` since it will always use the `--pf-v5-c-date-picker__input--c-form-control--Width` width. Previously the width was ignored because input had `flex: 2;` but that css was removed in a input-group refactor
