### PR TITLE
chore(CI): updated lerna to not publish private packages

### DIFF
--- a/.github/release.sh
+++ b/.github/release.sh
@@ -17,7 +17,7 @@ echo "Doing a release..."
 LOG=$(git log --format="%s" -1 | grep -Poe "#\d+")
 PR_NUM=${LOG:1}
 
-yarn run lerna publish --conventional-commits --conventional-prerelease --dist-tag=prerelease --yes 2>&1 | tee lerna-output.txt
+yarn run lerna publish --conventional-commits --conventional-prerelease --dist-tag=prerelease --yes --no-private 2>&1 | tee lerna-output.txt
 
 # use lerna command below for dry run
 # yarn run lerna version --conventional-commits --conventional-prerelease --yes --no-git-tag-version --no-push

--- a/packages/react-integration/package.json
+++ b/packages/react-integration/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@patternfly/react-integration",
-  "private": true,
   "version": "5.1.1-prerelease.0",
   "description": "Integration testing for PF5 using demo applications",
   "main": "lib/index.js",
@@ -19,6 +18,9 @@
     "url": "https://github.com/patternfly/patternfly-react/issues"
   },
   "homepage": "https://github.com/patternfly/patternfly-react#readme",
+  "publishConfig": {
+    "access": "restricted"
+  },
   "scripts": {
     "build:integration:report": "cd results && junit-merge * && node ../scripts/junit2html.js",
     "clean": "rimraf cypress/videos cypress/screenshots",


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #9505 

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:

Another attempt to resolve the error currently causing our prereleases to fail the release process. This time by updating lerna to run with the --no-private flag.

As part of that I updated react-integration from private to just a restricted publishConfig so that lerna will continue to bump it but the package will (I believe) remain not publicly available.