### PR TITLE
feat(charts): add RTL legend support

### DIFF
--- a/packages/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/react-charts/src/components/Chart/Chart.tsx
@@ -541,14 +541,14 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
     theme,
     ...(legendDirection === 'rtl' && {
       dataComponent: legendComponent.props.dataComponent ? (
-        React.cloneElement(legendComponent.props.dataComponent, { transform: 'translate(40)' })
+        React.cloneElement(legendComponent.props.dataComponent, { transform: `translate(${legendXOffset})` })
       ) : (
         <ChartPoint transform={`translate(${legendXOffset})`} />
       )
     }),
     ...(legendDirection === 'rtl' && {
       labelComponent: legendComponent.props.labelComponent ? (
-        React.cloneElement(legendComponent.props.labelComponent, { direction: 'rtl', dx: '10' })
+        React.cloneElement(legendComponent.props.labelComponent, { direction: 'rtl', dx: legendXOffset - 30 })
       ) : (
         <ChartLabel direction="rtl" dx={legendXOffset - 30} />
       )

--- a/packages/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/react-charts/src/components/Chart/Chart.tsx
@@ -26,7 +26,7 @@ import { ChartCommonStyles } from '../ChartTheme/ChartStyles';
 import { ChartThemeDefinition } from '../ChartTheme/ChartTheme';
 import { getClassName } from '../ChartUtils/chart-helpers';
 import { getLabelTextSize } from '../ChartUtils/chart-label';
-import { getComputedLegend, getLegendItemsExtraHeight } from '../ChartUtils/chart-legend';
+import { getComputedLegend, getLegendItemsExtraHeight, getLegendMaxTextWidth } from '../ChartUtils/chart-legend';
 import { getPaddingForSide } from '../ChartUtils/chart-padding';
 import { getPatternDefs, mergePatternData, useDefaultPatternProps } from '../ChartUtils/chart-patterns';
 import { getChartTheme } from '../ChartUtils/chart-theme-types';
@@ -529,6 +529,11 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
     ...(labelComponent && { labelComponent }) // Override label component props
   });
 
+  let legendXOffset = 0;
+  if (legendDirection === 'rtl') {
+    legendXOffset = getLegendMaxTextWidth(legendData, theme);
+  }
+
   const legend = React.cloneElement(legendComponent, {
     data: legendData,
     ...(name && { name: `${name}-${(legendComponent as any).type.displayName}` }),
@@ -538,14 +543,14 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
       dataComponent: legendComponent.props.dataComponent ? (
         React.cloneElement(legendComponent.props.dataComponent, { transform: 'translate(40)' })
       ) : (
-        <ChartPoint transform="translate(40)" />
+        <ChartPoint transform={`translate(${legendXOffset})`} />
       )
     }),
     ...(legendDirection === 'rtl' && {
       labelComponent: legendComponent.props.labelComponent ? (
         React.cloneElement(legendComponent.props.labelComponent, { direction: 'rtl', dx: '10' })
       ) : (
-        <ChartLabel direction="rtl" dx="10" />
+        <ChartLabel direction="rtl" dx={legendXOffset - 30} />
       )
     }),
     ...legendComponent.props

--- a/packages/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/react-charts/src/components/Chart/Chart.tsx
@@ -534,8 +534,20 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
     ...(name && { name: `${name}-${(legendComponent as any).type.displayName}` }),
     orientation: legendOrientation,
     theme,
-    ...(legendDirection === 'rtl' && { dataComponent: <ChartPoint transform="translate(40)" /> }),
-    ...(legendDirection === 'rtl' && { labelComponent: <ChartLabel direction="rtl" dx="10" /> }),
+    ...(legendDirection === 'rtl' && {
+      dataComponent: legendComponent.props.dataComponent ? (
+        React.cloneElement(legendComponent.props.dataComponent, { transform: 'translate(40)' })
+      ) : (
+        <ChartPoint transform="translate(40)" />
+      )
+    }),
+    ...(legendDirection === 'rtl' && {
+      labelComponent: legendComponent.props.labelComponent ? (
+        React.cloneElement(legendComponent.props.labelComponent, { direction: 'rtl', dx: '10' })
+      ) : (
+        <ChartLabel direction="rtl" dx="10" />
+      )
+    }),
     ...legendComponent.props
   });
 

--- a/packages/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/react-charts/src/components/Chart/Chart.tsx
@@ -31,6 +31,8 @@ import { getPaddingForSide } from '../ChartUtils/chart-padding';
 import { getPatternDefs, mergePatternData, useDefaultPatternProps } from '../ChartUtils/chart-patterns';
 import { getChartTheme } from '../ChartUtils/chart-theme-types';
 import { useEffect } from 'react';
+import { ChartLabel } from '../ChartLabel/ChartLabel';
+import { ChartPoint } from '../ChartPoint/ChartPoint';
 
 /**
  * Chart is a wrapper component that reconciles the domain for all its children, controls the layout of the chart,
@@ -283,7 +285,11 @@ export interface ChartProps extends VictoryChartProps {
    * Note: When adding a legend, padding may need to be adjusted in order to accommodate the extra legend. In some
    * cases, the legend may not be visible until enough padding is applied.
    */
-  legendPosition?: 'bottom' | 'bottom-left' | 'right';
+  legendPosition?: 'bottom' | 'bottom-left' | 'bottom-right' | 'left' | 'right';
+  /**
+   * Text direction of the legend labels.
+   */
+  legendDirection?: 'ltr' | 'rtl';
   /**
    * The maxDomain prop defines a maximum domain value for a chart. This prop is useful in situations where the maximum
    * domain of a chart is static, while the minimum value depends on data or other variable information. If the domain
@@ -471,6 +477,7 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
   legendComponent = <ChartLegend />,
   legendData,
   legendPosition = ChartCommonStyles.legend.position,
+  legendDirection = 'ltr',
   name,
   padding,
   patternScale,
@@ -527,6 +534,8 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
     ...(name && { name: `${name}-${(legendComponent as any).type.displayName}` }),
     orientation: legendOrientation,
     theme,
+    ...(legendDirection === 'rtl' && { dataComponent: <ChartPoint transform="translate(40)" /> }),
+    ...(legendDirection === 'rtl' && { labelComponent: <ChartLabel direction="rtl" dx="10" /> }),
     ...legendComponent.props
   });
 
@@ -553,6 +562,9 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
     } else if (legendPosition === 'bottom-left') {
       dy += xAxisLabelHeight + legendTitleHeight;
       dx = -10;
+    } else if (legendPosition === 'bottom-right') {
+      dy += xAxisLabelHeight + legendTitleHeight;
+      dx = 10;
     }
 
     // Adjust legend position when axis is hidden

--- a/packages/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/react-charts/src/components/Chart/Chart.tsx
@@ -285,9 +285,9 @@ export interface ChartProps extends VictoryChartProps {
    * Note: When adding a legend, padding may need to be adjusted in order to accommodate the extra legend. In some
    * cases, the legend may not be visible until enough padding is applied.
    */
-  legendPosition?: 'bottom' | 'bottom-left' | 'bottom-right' | 'left' | 'right';
+  legendPosition?: 'bottom' | 'bottom-left' | 'right';
   /**
-   * Text direction of the legend labels.
+   * @beta Text direction of the legend labels.
    */
   legendDirection?: 'ltr' | 'rtl';
   /**
@@ -574,9 +574,6 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
     } else if (legendPosition === 'bottom-left') {
       dy += xAxisLabelHeight + legendTitleHeight;
       dx = -10;
-    } else if (legendPosition === 'bottom-right') {
-      dy += xAxisLabelHeight + legendTitleHeight;
-      dx = 10;
     }
 
     // Adjust legend position when axis is hidden

--- a/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
@@ -677,8 +677,20 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
     orientation: legendOrientation,
     position: legendPosition,
     theme,
-    ...(legendDirection === 'rtl' && { dataComponent: <ChartPoint transform="translate(40)" /> }),
-    ...(legendDirection === 'rtl' && { labelComponent: <ChartLabel direction="rtl" dx="10" /> }),
+    ...(legendDirection === 'rtl' && {
+      dataComponent: legendComponent.props.dataComponent ? (
+        React.cloneElement(legendComponent.props.dataComponent, { transform: 'translate(40)' })
+      ) : (
+        <ChartPoint transform="translate(40)" />
+      )
+    }),
+    ...(legendDirection === 'rtl' && {
+      labelComponent: legendComponent.props.labelComponent ? (
+        React.cloneElement(legendComponent.props.labelComponent, { direction: 'rtl', dx: '10' })
+      ) : (
+        <ChartLabel direction="rtl" dx="10" />
+      )
+    }),
     ...legendComponent.props
   });
 

--- a/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
@@ -17,7 +17,7 @@ import { ChartLegend } from '../ChartLegend/ChartLegend';
 import { ChartThemeDefinition } from '../ChartTheme/ChartTheme';
 import { ChartTooltip } from '../ChartTooltip/ChartTooltip';
 import { ChartBulletStyles } from '../ChartTheme/ChartStyles';
-import { getComputedLegend, getLegendItemsExtraHeight } from '../ChartUtils/chart-legend';
+import { getComputedLegend, getLegendItemsExtraHeight, getLegendMaxTextWidth } from '../ChartUtils/chart-legend';
 import { ChartBulletComparativeErrorMeasure } from './ChartBulletComparativeErrorMeasure';
 import { ChartBulletComparativeMeasure } from './ChartBulletComparativeMeasure';
 import { ChartBulletComparativeWarningMeasure } from './ChartBulletComparativeWarningMeasure';
@@ -663,6 +663,20 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
     ...comparativeZeroMeasureComponent.props
   });
 
+  let legendXOffset = 0;
+  if (legendDirection === 'rtl') {
+    legendXOffset = getLegendMaxTextWidth(
+      [
+        ...(primaryDotMeasureLegendData ? primaryDotMeasureLegendData : []),
+        ...(primarySegmentedMeasureLegendData ? primarySegmentedMeasureLegendData : []),
+        ...(comparativeWarningMeasureLegendData ? comparativeWarningMeasureLegendData : []),
+        ...(comparativeErrorMeasureLegendData ? comparativeErrorMeasureLegendData : []),
+        ...(qualitativeRangeLegendData ? qualitativeRangeLegendData : [])
+      ],
+      theme
+    );
+  }
+
   // Legend
   const legend = React.cloneElement(legendComponent, {
     data: [
@@ -681,14 +695,14 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
       dataComponent: legendComponent.props.dataComponent ? (
         React.cloneElement(legendComponent.props.dataComponent, { transform: 'translate(40)' })
       ) : (
-        <ChartPoint transform="translate(40)" />
+        <ChartPoint transform={`translate(${legendXOffset})`} />
       )
     }),
     ...(legendDirection === 'rtl' && {
       labelComponent: legendComponent.props.labelComponent ? (
         React.cloneElement(legendComponent.props.labelComponent, { direction: 'rtl', dx: '10' })
       ) : (
-        <ChartLabel direction="rtl" dx="10" />
+        <ChartLabel direction="rtl" dx={legendXOffset - 30} />
       )
     }),
     ...legendComponent.props

--- a/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
@@ -253,9 +253,9 @@ export interface ChartBulletProps {
    * Note: When adding a legend, padding may need to be adjusted in order to accommodate the extra legend. In some
    * cases, the legend may not be visible until enough padding is applied.
    */
-  legendPosition?: 'bottom' | 'bottom-left' | 'bottom-right' | 'left' | 'right';
+  legendPosition?: 'bottom' | 'bottom-left' | 'right';
   /**
-   * Text direction of the legend labels.
+   * @beta Text direction of the legend labels.
    */
   legendDirection?: 'ltr' | 'rtl';
   /**
@@ -799,15 +799,6 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
         dy = -defaultPadding.bottom;
       }
       dx = -10;
-    } else if (legendPosition === 'bottom-right') {
-      if (horizontal) {
-        dy = defaultPadding.top * 0.5 + (defaultPadding.bottom * 0.5 - defaultPadding.bottom) - 25;
-      } else if (title) {
-        dy = -defaultPadding.bottom + 60;
-      } else {
-        dy = -defaultPadding.bottom;
-      }
-      dx = 10;
     }
 
     return getComputedLegend({

--- a/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
@@ -693,14 +693,14 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
     theme,
     ...(legendDirection === 'rtl' && {
       dataComponent: legendComponent.props.dataComponent ? (
-        React.cloneElement(legendComponent.props.dataComponent, { transform: 'translate(40)' })
+        React.cloneElement(legendComponent.props.dataComponent, { transform: `translate(${legendXOffset})` })
       ) : (
         <ChartPoint transform={`translate(${legendXOffset})`} />
       )
     }),
     ...(legendDirection === 'rtl' && {
       labelComponent: legendComponent.props.labelComponent ? (
-        React.cloneElement(legendComponent.props.labelComponent, { direction: 'rtl', dx: '10' })
+        React.cloneElement(legendComponent.props.labelComponent, { direction: 'rtl', dx: legendXOffset - 30 })
       ) : (
         <ChartLabel direction="rtl" dx={legendXOffset - 30} />
       )

--- a/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
+++ b/packages/react-charts/src/components/ChartBullet/ChartBullet.tsx
@@ -29,6 +29,8 @@ import { getBulletDomain } from './utils/chart-bullet-domain';
 import { getBulletThemeWithLegendColorScale } from './utils/chart-bullet-theme';
 import { getPaddingForSide } from '../ChartUtils/chart-padding';
 import { useEffect } from 'react';
+import { ChartPoint } from '../ChartPoint/ChartPoint';
+import { ChartLabel } from '../ChartLabel/ChartLabel';
 
 /**
  * ChartBullet renders a dataset as a bullet chart.
@@ -251,7 +253,11 @@ export interface ChartBulletProps {
    * Note: When adding a legend, padding may need to be adjusted in order to accommodate the extra legend. In some
    * cases, the legend may not be visible until enough padding is applied.
    */
-  legendPosition?: 'bottom' | 'bottom-left' | 'right';
+  legendPosition?: 'bottom' | 'bottom-left' | 'bottom-right' | 'left' | 'right';
+  /**
+   * Text direction of the legend labels.
+   */
+  legendDirection?: 'ltr' | 'rtl';
   /**
    * The maxDomain prop defines a maximum domain value for a chart. This prop is useful in situations where the maximum
    * domain of a chart is static, while the minimum value depends on data or other variable information. If the domain
@@ -509,6 +515,7 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
   legendComponent = <ChartLegend />,
   legendItemsPerRow,
   legendPosition = 'bottom',
+  legendDirection = 'ltr',
   maxDomain,
   minDomain,
   name,
@@ -670,6 +677,8 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
     orientation: legendOrientation,
     position: legendPosition,
     theme,
+    ...(legendDirection === 'rtl' && { dataComponent: <ChartPoint transform="translate(40)" /> }),
+    ...(legendDirection === 'rtl' && { labelComponent: <ChartLabel direction="rtl" dx="10" /> }),
     ...legendComponent.props
   });
 
@@ -778,6 +787,15 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
         dy = -defaultPadding.bottom;
       }
       dx = -10;
+    } else if (legendPosition === 'bottom-right') {
+      if (horizontal) {
+        dy = defaultPadding.top * 0.5 + (defaultPadding.bottom * 0.5 - defaultPadding.bottom) - 25;
+      } else if (title) {
+        dy = -defaultPadding.bottom + 60;
+      } else {
+        dy = -defaultPadding.bottom;
+      }
+      dx = 10;
     }
 
     return getComputedLegend({

--- a/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -344,9 +344,9 @@ export interface ChartDonutProps extends ChartPieProps {
    * Note: When adding a legend, padding may need to be adjusted in order to accommodate the extra legend. In some
    * cases, the legend may not be visible until enough padding is applied.
    */
-  legendPosition?: 'bottom' | 'right' | 'left';
+  legendPosition?: 'bottom' | 'right';
   /**
-   * Text direction of the legend labels.
+   * @beta Text direction of the legend labels.
    */
   legendDirection?: 'ltr' | 'rtl';
   /**

--- a/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -344,7 +344,11 @@ export interface ChartDonutProps extends ChartPieProps {
    * Note: When adding a legend, padding may need to be adjusted in order to accommodate the extra legend. In some
    * cases, the legend may not be visible until enough padding is applied.
    */
-  legendPosition?: 'bottom' | 'right';
+  legendPosition?: 'bottom' | 'right' | 'left';
+  /**
+   * Text direction of the legend labels.
+   */
+  legendDirection?: 'ltr' | 'rtl';
   /**
    * The name prop is typically used to reference a component instance when defining shared events. However, this
    * optional prop may also be applied to child elements as an ID prefix. This is a workaround to ensure Victory
@@ -573,6 +577,7 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
   containerComponent = <ChartContainer />,
   innerRadius,
   legendPosition = ChartCommonStyles.legend.position,
+  legendDirection = 'ltr',
   name,
   padAngle,
   padding,
@@ -698,6 +703,7 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
       innerRadius={chartInnerRadius > 0 ? chartInnerRadius : 0}
       key="pf-chart-donut-pie"
       legendPosition={legendPosition}
+      legendDirection={legendDirection}
       name={name}
       padAngle={padAngle !== undefined ? padAngle : getPadAngle}
       padding={padding}

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
@@ -336,7 +336,11 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    * Note: When adding a legend, padding may need to be adjusted in order to accommodate the extra legend. In some
    * cases, the legend may not be visible until enough padding is applied.
    */
-  legendPosition?: 'bottom' | 'right';
+  legendPosition?: 'bottom' | 'right' | 'left';
+  /**
+   * Text direction of the legend labels.
+   */
+  legendDirection?: 'ltr' | 'rtl';
   /**
    * The labelRadius prop defines the radius of the arc that will be used for positioning each slice label.
    * If this prop is not set, the label radius will default to the radius of the pie + label padding.
@@ -589,6 +593,7 @@ export const ChartDonutUtilization: React.FunctionComponent<ChartDonutUtilizatio
   invert = false,
   isStatic = true,
   legendPosition = ChartCommonStyles.legend.position,
+  legendDirection = 'ltr',
   padding,
   standalone = true,
   themeColor,
@@ -679,6 +684,7 @@ export const ChartDonutUtilization: React.FunctionComponent<ChartDonutUtilizatio
       height={height}
       key="pf-chart-donut-utilization"
       legendPosition={legendPosition}
+      legendDirection={legendDirection}
       padding={padding}
       standalone={false}
       theme={getThresholdTheme()}

--- a/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
+++ b/packages/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
@@ -336,9 +336,9 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    * Note: When adding a legend, padding may need to be adjusted in order to accommodate the extra legend. In some
    * cases, the legend may not be visible until enough padding is applied.
    */
-  legendPosition?: 'bottom' | 'right' | 'left';
+  legendPosition?: 'bottom' | 'right';
   /**
-   * Text direction of the legend labels.
+   * @beta Text direction of the legend labels.
    */
   legendDirection?: 'ltr' | 'rtl';
   /**

--- a/packages/react-charts/src/components/ChartPie/ChartPie.tsx
+++ b/packages/react-charts/src/components/ChartPie/ChartPie.tsx
@@ -588,8 +588,20 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
     key: 'pf-chart-pie-legend',
     orientation: legendOrientation,
     theme,
-    ...(legendDirection === 'rtl' && { dataComponent: <ChartPoint transform="translate(80)" /> }),
-    ...(legendDirection === 'rtl' && { labelComponent: <ChartLabel direction="rtl" dx="50" /> }),
+    ...(legendDirection === 'rtl' && {
+      dataComponent: legendComponent.props.dataComponent ? (
+        React.cloneElement(legendComponent.props.dataComponent, { transform: 'translate(80)' })
+      ) : (
+        <ChartPoint transform="translate(80)" />
+      )
+    }),
+    ...(legendDirection === 'rtl' && {
+      labelComponent: legendComponent.props.labelComponent ? (
+        React.cloneElement(legendComponent.props.labelComponent, { direction: 'rtl', dx: '50' })
+      ) : (
+        <ChartLabel direction="rtl" dx="50" />
+      )
+    }),
     ...legendComponent.props
   });
 

--- a/packages/react-charts/src/components/ChartPie/ChartPie.tsx
+++ b/packages/react-charts/src/components/ChartPie/ChartPie.tsx
@@ -28,7 +28,7 @@ import { ChartLegend } from '../ChartLegend/ChartLegend';
 import { ChartCommonStyles } from '../ChartTheme/ChartStyles';
 import { ChartThemeDefinition } from '../ChartTheme/ChartTheme';
 import { ChartTooltip } from '../ChartTooltip/ChartTooltip';
-import { getComputedLegend, getLegendItemsExtraHeight } from '../ChartUtils/chart-legend';
+import { getComputedLegend, getLegendItemsExtraHeight, getLegendMaxTextWidth } from '../ChartUtils/chart-legend';
 import { getPaddingForSide } from '../ChartUtils/chart-padding';
 import { getPatternDefs, useDefaultPatternProps } from '../ChartUtils/chart-patterns';
 import { getTheme } from '../ChartUtils/chart-theme';
@@ -581,6 +581,11 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
     />
   );
 
+  let legendXOffset = 0;
+  if (legendDirection === 'rtl') {
+    legendXOffset = getLegendMaxTextWidth(legendData, theme);
+  }
+
   const legend = React.cloneElement(legendComponent, {
     colorScale,
     data: legendData,
@@ -592,14 +597,14 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
       dataComponent: legendComponent.props.dataComponent ? (
         React.cloneElement(legendComponent.props.dataComponent, { transform: 'translate(80)' })
       ) : (
-        <ChartPoint transform="translate(80)" />
+        <ChartPoint transform={`translate(${legendXOffset})`} />
       )
     }),
     ...(legendDirection === 'rtl' && {
       labelComponent: legendComponent.props.labelComponent ? (
         React.cloneElement(legendComponent.props.labelComponent, { direction: 'rtl', dx: '50' })
       ) : (
-        <ChartLabel direction="rtl" dx="50" />
+        <ChartLabel direction="rtl" dx={legendXOffset - 30} />
       )
     }),
     ...legendComponent.props

--- a/packages/react-charts/src/components/ChartPie/ChartPie.tsx
+++ b/packages/react-charts/src/components/ChartPie/ChartPie.tsx
@@ -33,6 +33,8 @@ import { getPaddingForSide } from '../ChartUtils/chart-padding';
 import { getPatternDefs, useDefaultPatternProps } from '../ChartUtils/chart-patterns';
 import { getTheme } from '../ChartUtils/chart-theme';
 import { useEffect } from 'react';
+import { ChartPoint } from '../ChartPoint/ChartPoint';
+import { ChartLabel } from '../ChartLabel/ChartLabel';
 
 /**
  * ChartPie renders a dataset as a pie chart.
@@ -332,7 +334,11 @@ export interface ChartPieProps extends VictoryPieProps {
    * Note: When adding a legend, padding may need to be adjusted in order to accommodate the extra legend. In some
    * cases, the legend may not be visible until enough padding is applied.
    */
-  legendPosition?: 'bottom' | 'right';
+  legendPosition?: 'bottom' | 'right' | 'left';
+  /**
+   * Text direction of the legend labels.
+   */
+  legendDirection?: 'ltr' | 'rtl';
   /**
    * The name prop is typically used to reference a component instance when defining shared events. However, this
    * optional prop may also be applied to child elements as an ID prefix. This is a workaround to ensure Victory
@@ -498,16 +504,15 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
   legendComponent = <ChartLegend />,
   legendData,
   legendPosition = ChartCommonStyles.legend.position,
+  legendDirection = 'ltr',
   name,
   patternScale,
   patternUnshiftIndex,
-
   padding,
   radius,
   standalone = true,
   style,
   themeColor,
-
   // destructure last
   theme = getTheme(themeColor),
   labelComponent = allowTooltip ? (
@@ -583,6 +588,8 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
     key: 'pf-chart-pie-legend',
     orientation: legendOrientation,
     theme,
+    ...(legendDirection === 'rtl' && { dataComponent: <ChartPoint transform="translate(80)" /> }),
+    ...(legendDirection === 'rtl' && { labelComponent: <ChartLabel direction="rtl" dx="50" /> }),
     ...legendComponent.props
   });
 

--- a/packages/react-charts/src/components/ChartPie/ChartPie.tsx
+++ b/packages/react-charts/src/components/ChartPie/ChartPie.tsx
@@ -595,14 +595,14 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
     theme,
     ...(legendDirection === 'rtl' && {
       dataComponent: legendComponent.props.dataComponent ? (
-        React.cloneElement(legendComponent.props.dataComponent, { transform: 'translate(80)' })
+        React.cloneElement(legendComponent.props.dataComponent, { transform: `translate(${legendXOffset})` })
       ) : (
         <ChartPoint transform={`translate(${legendXOffset})`} />
       )
     }),
     ...(legendDirection === 'rtl' && {
       labelComponent: legendComponent.props.labelComponent ? (
-        React.cloneElement(legendComponent.props.labelComponent, { direction: 'rtl', dx: '50' })
+        React.cloneElement(legendComponent.props.labelComponent, { direction: 'rtl', dx: legendXOffset - 30 })
       ) : (
         <ChartLabel direction="rtl" dx={legendXOffset - 30} />
       )

--- a/packages/react-charts/src/components/ChartPie/ChartPie.tsx
+++ b/packages/react-charts/src/components/ChartPie/ChartPie.tsx
@@ -334,9 +334,9 @@ export interface ChartPieProps extends VictoryPieProps {
    * Note: When adding a legend, padding may need to be adjusted in order to accommodate the extra legend. In some
    * cases, the legend may not be visible until enough padding is applied.
    */
-  legendPosition?: 'bottom' | 'right' | 'left';
+  legendPosition?: 'bottom' | 'right';
   /**
-   * Text direction of the legend labels.
+   * @beta Text direction of the legend labels.
    */
   legendDirection?: 'ltr' | 'rtl';
   /**

--- a/packages/react-charts/src/components/ChartUtils/chart-label.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-label.ts
@@ -20,7 +20,7 @@ interface ChartPieLabelInterface {
   dy?: number; // Horizontal shift from the y coordinate
   height: number; // Chart height
   labelPosition?: 'bottom' | 'center' | 'right'; // Position of label
-  legendPosition?: 'bottom' | 'right' | 'left'; // Position of legend
+  legendPosition?: 'bottom' | 'right'; // Position of legend
   padding: any; // Chart padding
   width: number; // Chart width
 }
@@ -77,7 +77,6 @@ export const getPieLabelX = ({
           return origin.x + ChartCommonStyles.label.margin + dx + radius;
         case 'right':
           return origin.x + ChartCommonStyles.label.margin + dx;
-        case 'left':
         default:
           return dx;
       }

--- a/packages/react-charts/src/components/ChartUtils/chart-label.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-label.ts
@@ -20,7 +20,7 @@ interface ChartPieLabelInterface {
   dy?: number; // Horizontal shift from the y coordinate
   height: number; // Chart height
   labelPosition?: 'bottom' | 'center' | 'right'; // Position of label
-  legendPosition?: 'bottom' | 'right'; // Position of legend
+  legendPosition?: 'bottom' | 'right' | 'left'; // Position of legend
   padding: any; // Chart padding
   width: number; // Chart width
 }
@@ -77,6 +77,7 @@ export const getPieLabelX = ({
           return origin.x + ChartCommonStyles.label.margin + dx + radius;
         case 'right':
           return origin.x + ChartCommonStyles.label.margin + dx;
+        case 'left':
         default:
           return dx;
       }

--- a/packages/react-charts/src/components/ChartUtils/chart-legend.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-legend.ts
@@ -18,7 +18,7 @@ interface ChartLegendInterface {
   orientation?: 'horizontal' | 'vertical'; // Orientation of legend
   padding: PaddingProps; // Chart padding
   patternScale?: string[]; // Legend symbol patterns
-  position: 'bottom' | 'bottom-left' | 'bottom-right' | 'left' | 'right'; // The legend position
+  position: 'bottom' | 'bottom-left' | 'right'; // The legend position
   theme: ChartThemeDefinition; // The theme that will be applied to the chart
   width: number; // Overall width of SVG
 }
@@ -37,7 +37,7 @@ interface ChartLegendPositionInterface {
   height?: number; // Overall height of SVG
   legendData: any[]; // The legend data used to determine width
   legendOrientation: 'horizontal' | 'vertical'; // Orientation of legend
-  legendPosition: 'bottom' | 'bottom-left' | 'bottom-right' | 'left' | 'right'; // Position of legend
+  legendPosition: 'bottom' | 'bottom-left' | 'right'; // Position of legend
   legendProps: any; // The legend props used to determine width
   padding?: PaddingProps; // Chart padding
   theme: ChartThemeDefinition; // The theme that will be applied to the chart

--- a/packages/react-charts/src/components/ChartUtils/chart-legend.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-legend.ts
@@ -18,7 +18,7 @@ interface ChartLegendInterface {
   orientation?: 'horizontal' | 'vertical'; // Orientation of legend
   padding: PaddingProps; // Chart padding
   patternScale?: string[]; // Legend symbol patterns
-  position: 'bottom' | 'bottom-left' | 'right'; // The legend position
+  position: 'bottom' | 'bottom-left' | 'bottom-right' | 'left' | 'right'; // The legend position
   theme: ChartThemeDefinition; // The theme that will be applied to the chart
   width: number; // Overall width of SVG
 }
@@ -37,7 +37,7 @@ interface ChartLegendPositionInterface {
   height?: number; // Overall height of SVG
   legendData: any[]; // The legend data used to determine width
   legendOrientation: 'horizontal' | 'vertical'; // Orientation of legend
-  legendPosition: 'bottom' | 'bottom-left' | 'right'; // Position of legend
+  legendPosition: 'bottom' | 'bottom-left' | 'bottom-right' | 'left' | 'right'; // Position of legend
   legendProps: any; // The legend props used to determine width
   padding?: PaddingProps; // Chart padding
   theme: ChartThemeDefinition; // The theme that will be applied to the chart
@@ -311,6 +311,7 @@ const getBulletLegendY = ({
   switch (legendPosition) {
     case 'bottom':
     case 'bottom-left':
+    case 'bottom-right':
       return chartSize.height + ChartCommonStyles.legend.margin + dy;
     case 'right': {
       // Legend height with padding
@@ -356,12 +357,15 @@ const getChartLegendX = ({
   });
 
   switch (legendPosition) {
+    case 'bottom-right':
+      return width - legendDimensions.width - right + dx;
     case 'bottom':
       return width > legendDimensions.width ? Math.round((width - legendDimensions.width) / 2) + dx : dx;
     case 'bottom-left':
       return left + dx;
     case 'right':
       return chartSize.width + ChartCommonStyles.legend.margin + left + dx;
+    case 'left':
     default:
       return dx;
   }
@@ -391,7 +395,9 @@ const getChartLegendY = ({
   switch (legendPosition) {
     case 'bottom':
     case 'bottom-left':
+    case 'bottom-right':
       return chartSize.height + ChartCommonStyles.legend.margin * 2 + top + dy;
+    case 'left':
     case 'right': {
       // Legend height with padding
       const legendDimensions = getLegendDimensions({
@@ -438,6 +444,7 @@ const getPieLegendX = ({
       return width > legendDimensions.width ? Math.round((width - legendDimensions.width) / 2) + dx : dx;
     case 'right':
       return origin.x + ChartCommonStyles.label.margin + dx + radius;
+    case 'left':
     default:
       return dx;
   }
@@ -464,6 +471,7 @@ const getPieLegendY = ({
   switch (legendPosition) {
     case 'bottom':
       return origin.y + ChartCommonStyles.legend.margin + radius + dy;
+    case 'left':
     case 'right': {
       // Legend height with padding
       const legendDimensions = getLegendDimensions({

--- a/packages/react-charts/src/components/ChartUtils/chart-legend.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-legend.ts
@@ -311,7 +311,6 @@ const getBulletLegendY = ({
   switch (legendPosition) {
     case 'bottom':
     case 'bottom-left':
-    case 'bottom-right':
       return chartSize.height + ChartCommonStyles.legend.margin + dy;
     case 'right': {
       // Legend height with padding
@@ -357,15 +356,12 @@ const getChartLegendX = ({
   });
 
   switch (legendPosition) {
-    case 'bottom-right':
-      return width - legendDimensions.width - right + dx;
     case 'bottom':
       return width > legendDimensions.width ? Math.round((width - legendDimensions.width) / 2) + dx : dx;
     case 'bottom-left':
       return left + dx;
     case 'right':
       return chartSize.width + ChartCommonStyles.legend.margin + left + dx;
-    case 'left':
     default:
       return dx;
   }
@@ -395,9 +391,7 @@ const getChartLegendY = ({
   switch (legendPosition) {
     case 'bottom':
     case 'bottom-left':
-    case 'bottom-right':
       return chartSize.height + ChartCommonStyles.legend.margin * 2 + top + dy;
-    case 'left':
     case 'right': {
       // Legend height with padding
       const legendDimensions = getLegendDimensions({
@@ -444,7 +438,6 @@ const getPieLegendX = ({
       return width > legendDimensions.width ? Math.round((width - legendDimensions.width) / 2) + dx : dx;
     case 'right':
       return origin.x + ChartCommonStyles.label.margin + dx + radius;
-    case 'left':
     default:
       return dx;
   }
@@ -471,7 +464,6 @@ const getPieLegendY = ({
   switch (legendPosition) {
     case 'bottom':
       return origin.y + ChartCommonStyles.legend.margin + radius + dy;
-    case 'left':
     case 'right': {
       // Legend height with padding
       const legendDimensions = getLegendDimensions({

--- a/packages/react-charts/src/components/ChartUtils/chart-legend.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-legend.ts
@@ -4,6 +4,7 @@ import { VictoryLegend } from 'victory-legend';
 import { ChartLegendProps } from '../ChartLegend/ChartLegend';
 import { ChartCommonStyles } from '../ChartTheme/ChartStyles';
 import { ChartThemeDefinition } from '../ChartTheme/ChartTheme';
+import { getLabelTextSize } from '../ChartUtils/chart-label';
 import { getPieOrigin } from './chart-origin';
 import * as React from 'react';
 
@@ -48,6 +49,22 @@ interface ChartLegendTextMaxSizeInterface {
   legendData: any[]; // The legend data used to determine width
   theme: ChartThemeDefinition; // The theme that will be applied to the chart
 }
+
+/**
+ * Returns the max text length in a legend data set to calculate the x offset for right aligned legends.
+ * @private
+ */
+
+export const getLegendMaxTextWidth = (legendData: any[], theme: ChartThemeDefinition) => {
+  let legendXOffset = 0;
+  legendData.map((data: any) => {
+    const labelWidth = getLabelTextSize({ text: data.name, theme }).width;
+    if (labelWidth > legendXOffset) {
+      legendXOffset = labelWidth;
+    }
+  });
+  return legendXOffset;
+};
 
 /**
  * Returns a legend which has been positioned per the given chart properties


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #9541

Adds the `legendDirection` property to specify RTL/LTR, and adds `left` and `bottom-right` as valid values for `legendPosition`.

The values for the transform and offset passed to the `ChartLabel` and `ChartPoint` were what ended up working/looking visually correct (basically swapping the legend icon and text positions locally). I'm unsure why `ChartPie` needed a slightly different offset - with 40/10 a left-aligned RTL legend was disappearing off the container regardless of the left padding on the pie chart. 

It should be possible get a RTL legend with the current implementation but that would require manual legend creation. To summarize - to fully enable RTL in charts, a user would need to pass `invertAxis` to the `ChartAxis`, and pass both `legendDirection` and a reasonable `legendPosition` to the `Chart`/`PieChart`/etc, and update the chart padding as required.