### PR TITLE
chore: update breadcrumb dropdown item arrow to work in RTL

### DIFF
--- a/packages/react-core/src/components/Breadcrumb/examples/BreadcrumbDropdown.tsx
+++ b/packages/react-core/src/components/Breadcrumb/examples/BreadcrumbDropdown.tsx
@@ -7,19 +7,42 @@ import {
   Dropdown,
   DropdownList,
   DropdownItem,
+  Icon,
   MenuToggle,
   MenuToggleElement
 } from '@patternfly/react-core';
+import AngleLeftIcon from '@patternfly/react-icons/dist/esm/icons/angle-left-icon';
 import CaretDownIcon from '@patternfly/react-icons/dist/esm/icons/caret-down-icon';
 
 const dropdownItems = [
-  <DropdownItem direction="up" key="edit">
+  <DropdownItem
+    icon={
+      <Icon shouldMirrorRTL>
+        <AngleLeftIcon />
+      </Icon>
+    }
+    key="edit"
+  >
     Edit
   </DropdownItem>,
-  <DropdownItem direction="up" key="action">
+  <DropdownItem
+    icon={
+      <Icon shouldMirrorRTL>
+        <AngleLeftIcon />
+      </Icon>
+    }
+    key="action"
+  >
     Deployment
   </DropdownItem>,
-  <DropdownItem direction="up" key="apps">
+  <DropdownItem
+    icon={
+      <Icon shouldMirrorRTL>
+        <AngleLeftIcon />
+      </Icon>
+    }
+    key="apps"
+  >
     Applications
   </DropdownItem>
 ];

--- a/packages/react-core/src/components/Breadcrumb/examples/BreadcrumbDropdown.tsx
+++ b/packages/react-core/src/components/Breadcrumb/examples/BreadcrumbDropdown.tsx
@@ -10,17 +10,16 @@ import {
   MenuToggle,
   MenuToggleElement
 } from '@patternfly/react-core';
-import AngleLeftIcon from '@patternfly/react-icons/dist/esm/icons/angle-left-icon';
 import CaretDownIcon from '@patternfly/react-icons/dist/esm/icons/caret-down-icon';
 
 const dropdownItems = [
-  <DropdownItem icon={<AngleLeftIcon />} key="edit">
+  <DropdownItem direction="up" key="edit">
     Edit
   </DropdownItem>,
-  <DropdownItem icon={<AngleLeftIcon />} key="action">
+  <DropdownItem direction="up" key="action">
     Deployment
   </DropdownItem>,
-  <DropdownItem icon={<AngleLeftIcon />} key="apps">
+  <DropdownItem direction="up" key="apps">
     Applications
   </DropdownItem>
 ];

--- a/packages/react-core/src/components/Menu/examples/MenuWithDrilldownBreadcrumbs.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuWithDrilldownBreadcrumbs.tsx
@@ -21,7 +21,6 @@ import {
 import StorageDomainIcon from '@patternfly/react-icons/dist/esm/icons/storage-domain-icon';
 import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
 import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
-import AngleLeftIcon from '@patternfly/react-icons/dist/esm/icons/angle-left-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import CaretDownIcon from '@patternfly/react-icons/dist/esm/icons/caret-down-icon';
 
@@ -129,7 +128,7 @@ export const MenuWithDrilldownBreadcrumbs: React.FunctionComponent = () => {
           <DropdownList>
             <DropdownItem
               key="dropdown-start"
-              icon={<AngleLeftIcon />}
+              direction="up"
               onClick={(event: any) =>
                 drillOut(event, 'breadcrumbs-drilldownMenuStart', 'group:app_grouping_start', startRolloutBreadcrumb)
               }
@@ -169,7 +168,7 @@ export const MenuWithDrilldownBreadcrumbs: React.FunctionComponent = () => {
           <DropdownList>
             <DropdownItem
               key="dropdown-start"
-              icon={<AngleLeftIcon />}
+              direction="up"
               onClick={(event: any) =>
                 drillOut(event, 'breadcrumbs-drilldownMenuStart', 'group:labels_start', startRolloutBreadcrumb)
               }
@@ -221,7 +220,7 @@ export const MenuWithDrilldownBreadcrumbs: React.FunctionComponent = () => {
           <DropdownList>
             <DropdownItem
               key="dropdown-pause"
-              icon={<AngleLeftIcon />}
+              direction="up"
               onClick={(event: any) =>
                 drillOut(event, 'breadcrumbs-drilldownMenuPause', 'group:app_grouping', pauseRolloutsBreadcrumb)
               }
@@ -266,7 +265,7 @@ export const MenuWithDrilldownBreadcrumbs: React.FunctionComponent = () => {
           <DropdownList>
             <DropdownItem
               key="dropdown-pause"
-              icon={<AngleLeftIcon />}
+              direction="up"
               onClick={(event: any) =>
                 drillOut(event, 'breadcrumbs-drilldownMenuPause', 'group:labels', pauseRolloutsBreadcrumb)
               }

--- a/packages/react-core/src/components/Menu/examples/MenuWithDrilldownBreadcrumbs.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuWithDrilldownBreadcrumbs.tsx
@@ -1,26 +1,28 @@
 import React from 'react';
 import {
-  Menu,
-  MenuContent,
-  MenuList,
-  MenuItem,
+  Badge,
+  Breadcrumb,
+  BreadcrumbHeading,
+  BreadcrumbItem,
+  Checkbox,
   Divider,
   DrilldownMenu,
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbHeading,
-  MenuBreadcrumb,
-  Checkbox,
   Dropdown,
-  DropdownList,
   DropdownItem,
+  DropdownList,
+  Icon,
+  Menu,
+  MenuBreadcrumb,
+  MenuContent,
+  MenuItem,
+  MenuList,
   MenuToggle,
-  MenuToggleElement,
-  Badge
+  MenuToggleElement
 } from '@patternfly/react-core';
 import StorageDomainIcon from '@patternfly/react-icons/dist/esm/icons/storage-domain-icon';
 import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-icon';
 import LayerGroupIcon from '@patternfly/react-icons/dist/esm/icons/layer-group-icon';
+import AngleLeftIcon from '@patternfly/react-icons/dist/esm/icons/angle-left-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 import CaretDownIcon from '@patternfly/react-icons/dist/esm/icons/caret-down-icon';
 
@@ -128,7 +130,11 @@ export const MenuWithDrilldownBreadcrumbs: React.FunctionComponent = () => {
           <DropdownList>
             <DropdownItem
               key="dropdown-start"
-              direction="up"
+              icon={
+                <Icon shouldMirrorRTL>
+                  <AngleLeftIcon />
+                </Icon>
+              }
               onClick={(event: any) =>
                 drillOut(event, 'breadcrumbs-drilldownMenuStart', 'group:app_grouping_start', startRolloutBreadcrumb)
               }
@@ -168,7 +174,11 @@ export const MenuWithDrilldownBreadcrumbs: React.FunctionComponent = () => {
           <DropdownList>
             <DropdownItem
               key="dropdown-start"
-              direction="up"
+              icon={
+                <Icon shouldMirrorRTL>
+                  <AngleLeftIcon />
+                </Icon>
+              }
               onClick={(event: any) =>
                 drillOut(event, 'breadcrumbs-drilldownMenuStart', 'group:labels_start', startRolloutBreadcrumb)
               }
@@ -220,7 +230,11 @@ export const MenuWithDrilldownBreadcrumbs: React.FunctionComponent = () => {
           <DropdownList>
             <DropdownItem
               key="dropdown-pause"
-              direction="up"
+              icon={
+                <Icon shouldMirrorRTL>
+                  <AngleLeftIcon />
+                </Icon>
+              }
               onClick={(event: any) =>
                 drillOut(event, 'breadcrumbs-drilldownMenuPause', 'group:app_grouping', pauseRolloutsBreadcrumb)
               }
@@ -265,7 +279,11 @@ export const MenuWithDrilldownBreadcrumbs: React.FunctionComponent = () => {
           <DropdownList>
             <DropdownItem
               key="dropdown-pause"
-              direction="up"
+              icon={
+                <Icon shouldMirrorRTL>
+                  <AngleLeftIcon />
+                </Icon>
+              }
               onClick={(event: any) =>
                 drillOut(event, 'breadcrumbs-drilldownMenuPause', 'group:labels', pauseRolloutsBreadcrumb)
               }


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-react/issues/9587

This may not be a great way to do this, but these are basically drillup items in the breadcrumb menus.