### PR TITLE
chore(charts): update chart's tooltip example

### DIFF
--- a/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
+++ b/packages/react-charts/src/components/ChartLegend/examples/ChartLegend.md
@@ -616,13 +616,13 @@ class TooltipPieChart extends React.Component {
     super(props);
     
     // Custom legend label component
-    // Note: Tooltip wraps children with a div tag, so we add a reference to ChartLabel instead
+    // Note: Tooltip wraps children with a div tag, so we use a reference to ChartLabel instead
     this.LegendLabel = ({datum, ...rest}) => {
       const ref = React.createRef();
       return (
         <g ref={ref}>
           <ChartLabel {...rest} />
-          <Tooltip content={datum.name} enableFlip reference={ref} />
+          <Tooltip content={datum.name} enableFlip triggerRef={ref} />
         </g>
       );
     }


### PR DESCRIPTION
The chart's tooltip example below no longer works. It appears the `reference` prop of `Tooltip` was renamed as `triggerRef` at some point prior to the v5 release.

https://www.patternfly.org/charts/legends/#legend-tooltips

closes: #9619 