### PR TITLE
fix(code-editor): force element that wraps editor to be LTR

### DIFF
--- a/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
@@ -625,7 +625,7 @@ class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState> {
           );
 
           const editor = (
-            <div className={css(styles.codeEditorCode)} ref={this.wrapperRef} tabIndex={0}>
+            <div className={css(styles.codeEditorCode)} ref={this.wrapperRef} tabIndex={0} dir="ltr">
               <MonacoEditor
                 height={height}
                 width={width}

--- a/packages/react-code-editor/src/components/CodeEditor/__test__/__snapshots__/CodeEditor.test.tsx.snap
+++ b/packages/react-code-editor/src/components/CodeEditor/__test__/__snapshots__/CodeEditor.test.tsx.snap
@@ -138,6 +138,7 @@ exports[`CodeEditor matches snapshot with all props 1`] = `
         />
         <div
           class="pf-v5-c-code-editor__code"
+          dir="ltr"
           tabindex="0"
         >
           <div
@@ -376,6 +377,7 @@ exports[`CodeEditor matches snapshot without props 1`] = `
     >
       <div
         class="pf-v5-c-code-editor__code"
+        dir="ltr"
         tabindex="0"
       >
         <div


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-react/issues/9625