### PR TITLE
chore(Wizard): updated integration tests to avoid PR failures

### DIFF
--- a/packages/react-integration/cypress/integration/wizard.spec.ts
+++ b/packages/react-integration/cypress/integration/wizard.spec.ts
@@ -3,22 +3,25 @@ describe('Wizard Demo Test', () => {
     cy.visit('http://localhost:3000/wizard-demo-nav-link');
   });
 
+  it('Verify in page wizard displays on page render', () => {
+    cy.get('#inPageWizId.pf-v5-c-wizard').should('exist');
+  });
+
   it('Verify wizard in modal launches in a dialog and has a custom width', () => {
     cy.get('#launchWiz').click();
     cy.get('#modalWizId.pf-v5-c-wizard').should('exist');
     cy.get('#modalWizId.pf-v5-c-wizard').should('have.attr', 'style', 'width: 710px;');
-    cy.focused().click();
+    cy.get('#modalWizId .pf-v5-c-wizard__close > button').click();
   });
 
   it('Verify wizard in modal sends focus to the new content', () => {
     cy.get('#launchWiz').click();
     cy.get('#modalWizId.pf-v5-c-wizard').should('exist');
-    cy.focused().should('have.class', 'pf-v5-c-button');
-    cy.focused().click();
-  });
-
-  it('Verify in page wizard displays on page render', () => {
-    cy.get('#inPageWizId.pf-v5-c-wizard').should('exist');
+    cy.get('#modalWizId .pf-v5-c-wizard__close > button')
+      .should('have.focus')
+      .then(($closeButton) => {
+        cy.wrap($closeButton).click();
+      });
   });
 
   it('Verify in-page wizard step content is focusable and has role only if content overflows', () => {
@@ -26,26 +29,37 @@ describe('Wizard Demo Test', () => {
     cy.get('#inPageWizWithOverflow .pf-v5-c-wizard__main').should('not.have.attr', 'role');
     cy.get('#inPageWizWithOverflow .pf-v5-c-wizard__main').click();
     cy.get('#inPageWizWithOverflow .pf-v5-c-wizard__main').should('not.have.focus');
-    cy.get('#inPageWizWithOverflow button.pf-v5-c-wizard__nav-link').last().click();
+    cy.get('#inPageWizWithOverflow #inPage-overflow-step-2.pf-v5-c-wizard__nav-link').click();
     cy.get('#inPageWizWithOverflow .pf-v5-c-wizard__main').should('have.attr', 'tabindex');
     cy.get('#inPageWizWithOverflow .pf-v5-c-wizard__main').should('have.attr', 'role').and('eq', 'region');
     cy.get('#inPageWizWithOverflow .pf-v5-c-wizard__main').click();
     cy.get('#inPageWizWithOverflow .pf-v5-c-wizard__main').should('have.focus');
   });
 
-  it('Verify modal wizard step content with main element is focusable only if content overflows', () => {
+  it('Verify modal wizard step content is focusable only if content overflows', () => {
     cy.get('#launchWizOverflow').click();
     cy.get('#inModalWizWithOverflow.pf-v5-c-wizard').should('exist');
     cy.get('#inModalWizWithOverflow .pf-v5-c-wizard__main').should('not.have.attr', 'tabindex');
     cy.get('#inModalWizWithOverflow .pf-v5-c-wizard__main').should('not.have.attr', 'role');
     cy.get('#inModalWizWithOverflow .pf-v5-c-wizard__main').click();
     cy.get('#inModalWizWithOverflow .pf-v5-c-wizard__main').should('not.have.focus');
-    cy.get('#inModalWizWithOverflow button.pf-v5-c-wizard__nav-link').last().click();
+    cy.get('#inModalWizWithOverflow #modal-overflow-step-2.pf-v5-c-wizard__nav-link').click();
     cy.get('#inModalWizWithOverflow main.pf-v5-c-wizard__main').should('exist');
     cy.get('#inModalWizWithOverflow main.pf-v5-c-wizard__main').should('have.attr', 'tabindex');
-    // When WizardBody component is not a div, it should not have a role applied
-    cy.get('#inModalWizWithOverflow main.pf-v5-c-wizard__main').should('not.have.attr', 'role');
     cy.get('#inModalWizWithOverflow main.pf-v5-c-wizard__main').click();
     cy.get('#inModalWizWithOverflow main.pf-v5-c-wizard__main').should('have.focus');
+    cy.get('#inModalWizWithOverflow .pf-v5-c-wizard__close > button').click();
+  });
+
+  it('Verify modal wizard roles are applied correctly', () => {
+    cy.get('#launchWizOverflow').click();
+    cy.get('#inModalWizWithOverflow .pf-v5-c-wizard__main').should('not.have.attr', 'role');
+    cy.get('#inModalWizWithOverflow #modal-overflow-step-2.pf-v5-c-wizard__nav-link').click();
+    // When WizardBody component is not a div, it should not have a role applied
+    cy.get('#inModalWizWithOverflow main.pf-v5-c-wizard__main').should('not.have.attr', 'role');
+    cy.get('#inModalWizWithOverflow #modal-overflow-step-3.pf-v5-c-wizard__nav-link').click();
+    // When WizardBody component **is** a div, it should have role="region"
+    cy.get('#inModalWizWithOverflow div.pf-v5-c-wizard__main').should('have.attr', 'role').and('eq', 'region');
+    cy.get('#inModalWizWithOverflow .pf-v5-c-wizard__close > button').click();
   });
 });

--- a/packages/react-integration/demo-app-ts/src/components/demos/WizardDemo/WizardDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/WizardDemo/WizardDemo.tsx
@@ -8,7 +8,7 @@ interface WizardDemoState {
   isOpenWithRole: boolean;
 }
 
-export class WizardDemo extends React.Component<React.HTMLProps<HTMLDivElement>, WizardDemoState> {
+class WizardDemo extends React.Component<React.HTMLProps<HTMLDivElement>, WizardDemoState> {
   static displayName = 'WizardDemo';
   state = {
     isOpen: false,
@@ -72,6 +72,8 @@ export class WizardDemo extends React.Component<React.HTMLProps<HTMLDivElement>,
             </WizardStep>
           </Wizard>
         </Modal>
+        <br />
+        <br />
         <Wizard id="inPageWizId" height={500}>
           <WizardStep name="A" id="wizard-step-a">
             <p>Step 1</p>
@@ -95,6 +97,8 @@ export class WizardDemo extends React.Component<React.HTMLProps<HTMLDivElement>,
             <p>Step 5</p>
           </WizardStep>
         </Wizard>
+        <br />
+        <br />
         <Wizard id="inPageWizWithAnchorsId" height={500}>
           <WizardStep
             name={
@@ -130,16 +134,20 @@ export class WizardDemo extends React.Component<React.HTMLProps<HTMLDivElement>,
             <p>Step 3</p>
           </WizardStep>
         </Wizard>
+        <br />
+        <br />
         <Wizard id="inPageWizWithOverflow" height={500}>
-          <WizardStep name="Step without overflow" id="wizard-overflow-without">
+          <WizardStep id="inPage-overflow-step-1" name="Step without overflow">
             <p>Step 1</p>
           </WizardStep>
-          <WizardStep name="Step with overflow" id="wizard-overflow-with">
+          <WizardStep id="inPage-overflow-step-2" name="Step with overflow">
             <div style={{ height: '800px' }}>
               <p>Step 2</p>
             </div>
           </WizardStep>
         </Wizard>
+        <br />
+        <br />
         <Button id="launchWizOverflow" variant="primary" onClick={this.handleRoleWizardToggle}>
           Show Modal with Overflow
         </Button>
@@ -157,10 +165,106 @@ export class WizardDemo extends React.Component<React.HTMLProps<HTMLDivElement>,
               />
             }
           >
-            <WizardStep body={{ component: 'main' }} name="Step without overflow" id="wizard-overflow-without">
+            <WizardStep id="modal-overflow-step-1" body={{ component: 'main' }} name="Step without overflow">
               <p>Step 1</p>
             </WizardStep>
-            <WizardStep body={{ component: 'main' }} name="Step with overflow" id="wizard-overflow-with">
+            <WizardStep id="modal-overflow-step-2" body={{ component: 'main' }} name="Step with overflow">
+              <div style={{ height: '200px' }}>
+                <>
+                  <p>
+                    The content of this step overflows and creates a scrollbar, which causes a tabindex of "0", a role
+                    of "region", and an aria-label or aria-labelledby to be applied.
+                  </p>
+                  <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer bibendum in neque nec pharetra.
+                    Duis lacinia vel sapien ut imperdiet. Nunc ultrices mollis dictum. Duis tempus, massa nec tincidunt
+                    tempor, enim ex porttitor odio, eu facilisis dolor tortor id sapien. Etiam sit amet molestie lacus.
+                    Nulla facilisi. Duis eget finibus ipsum. Quisque dictum enim sed sodales porta. Curabitur eget orci
+                    eu risus posuere pulvinar id nec turpis. Morbi mattis orci vel posuere tincidunt. Fusce bibendum et
+                    libero a auctor.
+                  </p>
+                  <p>
+                    Proin elementum commodo sodales. Quisque eget libero mattis, ornare augue at, egestas nisi. Mauris
+                    ultrices orci fringilla pretium mattis. Aliquam erat volutpat. Sed pharetra condimentum dui, nec
+                    bibendum ante. Vestibulum sollicitudin, sem accumsan pharetra molestie, purus turpis lacinia lorem,
+                    commodo sodales quam lectus a urna. Nam gravida, felis a lacinia varius, ex ipsum ultrices orci, non
+                    egestas diam velit in mi. Ut sit amet commodo orci. Duis sed diam odio. Duis mi metus, dignissim in
+                    odio nec, ornare aliquet libero. Sed luctus elit nibh. Quisque et felis diam. Integer ac metus
+                    dolor.
+                  </p>
+                </>
+                <>
+                  <p>
+                    The content of this step overflows and creates a scrollbar, which causes a tabindex of "0", a role
+                    of "region", and an aria-label or aria-labelledby to be applied.
+                  </p>
+                  <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer bibendum in neque nec pharetra.
+                    Duis lacinia vel sapien ut imperdiet. Nunc ultrices mollis dictum. Duis tempus, massa nec tincidunt
+                    tempor, enim ex porttitor odio, eu facilisis dolor tortor id sapien. Etiam sit amet molestie lacus.
+                    Nulla facilisi. Duis eget finibus ipsum. Quisque dictum enim sed sodales porta. Curabitur eget orci
+                    eu risus posuere pulvinar id nec turpis. Morbi mattis orci vel posuere tincidunt. Fusce bibendum et
+                    libero a auctor.
+                  </p>
+                  <p>
+                    Proin elementum commodo sodales. Quisque eget libero mattis, ornare augue at, egestas nisi. Mauris
+                    ultrices orci fringilla pretium mattis. Aliquam erat volutpat. Sed pharetra condimentum dui, nec
+                    bibendum ante. Vestibulum sollicitudin, sem accumsan pharetra molestie, purus turpis lacinia lorem,
+                    commodo sodales quam lectus a urna. Nam gravida, felis a lacinia varius, ex ipsum ultrices orci, non
+                    egestas diam velit in mi. Ut sit amet commodo orci. Duis sed diam odio. Duis mi metus, dignissim in
+                    odio nec, ornare aliquet libero. Sed luctus elit nibh. Quisque et felis diam. Integer ac metus
+                    dolor.
+                  </p>
+                </>
+                <>
+                  <p>
+                    The content of this step overflows and creates a scrollbar, which causes a tabindex of "0", a role
+                    of "region", and an aria-label or aria-labelledby to be applied.
+                  </p>
+                  <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer bibendum in neque nec pharetra.
+                    Duis lacinia vel sapien ut imperdiet. Nunc ultrices mollis dictum. Duis tempus, massa nec tincidunt
+                    tempor, enim ex porttitor odio, eu facilisis dolor tortor id sapien. Etiam sit amet molestie lacus.
+                    Nulla facilisi. Duis eget finibus ipsum. Quisque dictum enim sed sodales porta. Curabitur eget orci
+                    eu risus posuere pulvinar id nec turpis. Morbi mattis orci vel posuere tincidunt. Fusce bibendum et
+                    libero a auctor.
+                  </p>
+                  <p>
+                    Proin elementum commodo sodales. Quisque eget libero mattis, ornare augue at, egestas nisi. Mauris
+                    ultrices orci fringilla pretium mattis. Aliquam erat volutpat. Sed pharetra condimentum dui, nec
+                    bibendum ante. Vestibulum sollicitudin, sem accumsan pharetra molestie, purus turpis lacinia lorem,
+                    commodo sodales quam lectus a urna. Nam gravida, felis a lacinia varius, ex ipsum ultrices orci, non
+                    egestas diam velit in mi. Ut sit amet commodo orci. Duis sed diam odio. Duis mi metus, dignissim in
+                    odio nec, ornare aliquet libero. Sed luctus elit nibh. Quisque et felis diam. Integer ac metus
+                    dolor.
+                  </p>
+                </>
+                <>
+                  <p>
+                    The content of this step overflows and creates a scrollbar, which causes a tabindex of "0", a role
+                    of "region", and an aria-label or aria-labelledby to be applied.
+                  </p>
+                  <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer bibendum in neque nec pharetra.
+                    Duis lacinia vel sapien ut imperdiet. Nunc ultrices mollis dictum. Duis tempus, massa nec tincidunt
+                    tempor, enim ex porttitor odio, eu facilisis dolor tortor id sapien. Etiam sit amet molestie lacus.
+                    Nulla facilisi. Duis eget finibus ipsum. Quisque dictum enim sed sodales porta. Curabitur eget orci
+                    eu risus posuere pulvinar id nec turpis. Morbi mattis orci vel posuere tincidunt. Fusce bibendum et
+                    libero a auctor.
+                  </p>
+                  <p>
+                    Proin elementum commodo sodales. Quisque eget libero mattis, ornare augue at, egestas nisi. Mauris
+                    ultrices orci fringilla pretium mattis. Aliquam erat volutpat. Sed pharetra condimentum dui, nec
+                    bibendum ante. Vestibulum sollicitudin, sem accumsan pharetra molestie, purus turpis lacinia lorem,
+                    commodo sodales quam lectus a urna. Nam gravida, felis a lacinia varius, ex ipsum ultrices orci, non
+                    egestas diam velit in mi. Ut sit amet commodo orci. Duis sed diam odio. Duis mi metus, dignissim in
+                    odio nec, ornare aliquet libero. Sed luctus elit nibh. Quisque et felis diam. Integer ac metus
+                    dolor.
+                  </p>
+                </>
+              </div>
+            </WizardStep>
+            <WizardStep id="modal-overflow-step-3" body={{ component: 'div' }} name="Div step with overflow">
               <div style={{ height: '200px' }}>
                 <>
                   <p>
@@ -262,3 +366,5 @@ export class WizardDemo extends React.Component<React.HTMLProps<HTMLDivElement>,
     );
   }
 }
+
+export { WizardDemo };


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #9724

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
Also tried looking at the demos that are failing a11y in some PRs lately, looks like it's caused by:

- the plain button that should only be visible at certain viewport widths having an `aria-controls` of an ID that doesn't exist yet
- possibly the `aria-controls` and the respective `id` (when rendered) being updated due to the internal incrementing of the `currentId` suffix within ToolbarContent