### PR TITLE
fix(Draggable): dont disable droppable on false ondrag

### DIFF
--- a/packages/react-core/src/components/DragDrop/Draggable.tsx
+++ b/packages/react-core/src/components/DragDrop/Draggable.tsx
@@ -265,6 +265,7 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
 
     if (!onDrag({ droppableId, index })) {
       // Consumer disallowed drag
+      droppableItems.forEach((item) => resetDroppableItem(item));
       return;
     }
 


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #9645 

Can test with

`<DragDrop onDrop={onDrop} onDrag={(i) =>  !(i.index == 0 && i.droppableId == 'items1')}>` 

on line 82 of https://patternfly-react-pr-9646.surge.sh/components/drag-and-drop#multiple-lists

It won't let you move the first option in the first list, but also will not disable stuff