### PR TITLE
fix(CodeEditor): hide button and link when read-only

### DIFF
--- a/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
@@ -526,18 +526,20 @@ class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState> {
                   headingLevel="h4"
                 />
                 <EmptyStateBody>{emptyStateBody}</EmptyStateBody>
-                <EmptyStateFooter>
-                  <EmptyStateActions>
-                    <Button variant="primary" onClick={open}>
-                      {emptyStateButton}
-                    </Button>
-                  </EmptyStateActions>
-                  <EmptyStateActions>
-                    <Button variant="link" onClick={this.toggleEmptyState}>
-                      {emptyStateLink}
-                    </Button>
-                  </EmptyStateActions>
-                </EmptyStateFooter>
+                {!isReadOnly && (
+                  <EmptyStateFooter>
+                    <EmptyStateActions>
+                      <Button variant="primary" onClick={open}>
+                        {emptyStateButton}
+                      </Button>
+                    </EmptyStateActions>
+                    <EmptyStateActions>
+                      <Button variant="link" onClick={this.toggleEmptyState}>
+                        {emptyStateLink}
+                      </Button>
+                    </EmptyStateActions>
+                  </EmptyStateFooter>
+                )}
               </EmptyState>
             ) : (
               <EmptyState variant={EmptyStateVariant.sm}>
@@ -546,13 +548,15 @@ class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState> {
                   icon={<EmptyStateIcon icon={CodeIcon} />}
                   headingLevel="h4"
                 />
-                <EmptyStateFooter>
-                  <EmptyStateActions>
-                    <Button variant="primary" onClick={this.toggleEmptyState}>
-                      {emptyStateLink}
-                    </Button>
-                  </EmptyStateActions>
-                </EmptyStateFooter>
+                {!isReadOnly && (
+                  <EmptyStateFooter>
+                    <EmptyStateActions>
+                      <Button variant="primary" onClick={this.toggleEmptyState}>
+                        {emptyStateLink}
+                      </Button>
+                    </EmptyStateActions>
+                  </EmptyStateFooter>
+                )}
               </EmptyState>
             ));
 

--- a/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditorBasic.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditorBasic.tsx
@@ -23,8 +23,6 @@ export const CodeEditorBasic: React.FunctionComponent = () => {
   };
 
   const onEditorDidMount = (editor, monaco) => {
-    // eslint-disable-next-line no-console
-    console.log(editor.getValue());
     editor.layout();
     editor.focus();
     monaco.editor.getModels()[0].updateOptions({ tabSize: 5 });

--- a/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditorShortcutMainHeader.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditorShortcutMainHeader.tsx
@@ -4,8 +4,6 @@ import { Grid, GridItem, Chip } from '@patternfly/react-core';
 
 export const CodeEditorShortcutMainHeader: React.FunctionComponent = () => {
   const onEditorDidMount = (editor, monaco) => {
-    // eslint-disable-next-line no-console
-    console.log(editor.getValue());
     editor.layout();
     editor.focus();
     monaco.editor.getModels()[0].updateOptions({ tabSize: 5 });

--- a/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditorSizeToFit.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditorSizeToFit.tsx
@@ -3,8 +3,6 @@ import { CodeEditor, Language } from '@patternfly/react-code-editor';
 
 export const CodeEditorSizeToFit: React.FunctionComponent = () => {
   const onEditorDidMount = (editor, monaco) => {
-    // eslint-disable-next-line no-console
-    console.log(editor.getValue());
     editor.layout();
     editor.focus();
     monaco.editor.getModels()[0].updateOptions({ tabSize: 5 });


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #9537 

Added code to conditionally remove the footer (Browse btn and Start from scratch link) when it's a read-only code editor. Also removed some leftover console.logs that were being sent on mounts in order to clean up the console on load.

To test, pass isReadOnly to the code editor in the Code Editor with Actions example and verify that the button and link are no longer present.

Note that there is an exception thrown on load of the code editor examples - this was pre-existing and is fixed by a separate PR: https://github.com/patternfly/patternfly-react/pull/9665