### PR TITLE
fix(InputGroup): don't add aria-describedby automatically

### DIFF
--- a/packages/react-core/src/components/InputGroup/InputGroup.tsx
+++ b/packages/react-core/src/components/InputGroup/InputGroup.tsx
@@ -1,9 +1,6 @@
 import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/InputGroup/input-group';
 import { css } from '@patternfly/react-styles';
-import { FormSelect } from '../FormSelect';
-import { TextArea } from '../TextArea';
-import { TextInput } from '../TextInput';
 
 export interface InputGroupProps extends React.HTMLProps<HTMLDivElement> {
   /** Additional classes added to the input group. */
@@ -20,61 +17,12 @@ export const InputGroupBase: React.FunctionComponent<InputGroupProps> = ({
   innerRef,
   ...props
 }: InputGroupProps) => {
-  const getIdItem = () => {
-    const getChildId = (_children: any) =>
-      React.Children.toArray(_children).find(
-        (_child: any) => !formCtrls.includes(_child?.type?.displayName) && _child?.props?.id
-      );
-    let childId = getChildId(children);
-    if (childId) {
-      return childId;
-    }
-    React.Children.toArray(children).find((child: any) => {
-      const _childId = getChildId(child.props.children);
-      if (_childId) {
-        childId = _childId;
-        return true;
-      }
-    });
-    return childId;
-  };
-  const formCtrls = [FormSelect, TextArea, TextInput].map((comp) => comp.displayName);
-  const idItem = getIdItem() as React.ReactElement<{ id: string }>;
   const ref = React.useRef(null);
   const inputGroupRef = innerRef || ref;
 
-  const childrenWithId = React.Children.map(children, (child: any) => {
-    if (child?.type.displayName === 'InputGroupItem') {
-      const newChildren = React.Children.map(child.props.children, (_child) => {
-        if (!_child.props) {
-          return _child;
-        }
-        if (_child.props['aria-describedby']) {
-          return _child;
-        }
-        if (!formCtrls.includes(_child.type.displayName)) {
-          return _child;
-        }
-        return React.cloneElement(_child, {
-          'aria-describedby': _child.props['aria-describedby'] === '' ? undefined : idItem?.props?.id
-        });
-      });
-      return React.cloneElement(child, {}, newChildren);
-    }
-
-    if (child?.props['aria-describedby']) {
-      return child;
-    }
-    if (!formCtrls.includes(child?.type.displayName)) {
-      return child;
-    }
-    return React.cloneElement(child, {
-      'aria-describedby': child.props['aria-describedby'] === '' ? undefined : idItem?.props?.id
-    });
-  });
   return (
     <div ref={inputGroupRef} className={css(styles.inputGroup, className)} {...props}>
-      {idItem ? childrenWithId : children}
+      {children}
     </div>
   );
 };

--- a/packages/react-core/src/components/InputGroup/__tests__/InputGroup.test.tsx
+++ b/packages/react-core/src/components/InputGroup/__tests__/InputGroup.test.tsx
@@ -8,59 +8,22 @@ import { Button } from '../../Button';
 import { TextInput } from '../../TextInput';
 
 describe('InputGroup', () => {
-  test('add aria-describedby to form-control if one of the non form-controls has id', () => {
-    // In this test, TextInput is a form-control component and Button is not.
-    // If Button has an id props, this should be used in aria-describedby.
+  // Regression test for https://github.com/patternfly/patternfly-react/issues/9667
+  test('wont add aria-describedby automatically to form-control', () => {
     render(
       <InputGroup>
         <InputGroupItem>
-          <TextInput value="some data" aria-label="some text" />
+          <TextInput aria-label="User password" />
         </InputGroupItem>
         <InputGroupItem>
-          <Button variant="primary" id="button-id">
-            hello
+          <Button variant="control" id="show-password-toggler">
+            Show
           </Button>
         </InputGroupItem>
       </InputGroup>
     );
-    expect(screen.getByLabelText('some text')).toHaveAttribute('aria-describedby', 'button-id');
-  });
 
-  test('wont add aria-describedby to form-control if describedby is empty string', () => {
-    // In this test, TextInput is a form-control component and Button is not.
-    // If Button has an id props, this should be used in aria-describedby, but this
-    // example has an empty aria-describedby to prevent that from happening.
-    render(
-      <InputGroup>
-        <InputGroupItem>
-          <TextInput value="some data" aria-describedby="" aria-label="some text" />
-        </InputGroupItem>
-        <InputGroupItem>
-          <Button id="button-id">
-            hello
-          </Button>
-        </InputGroupItem>
-      </InputGroup>
-    );
-    expect(screen.getByLabelText('some text')).not.toHaveAttribute('aria-describedby');
-  });
-
-  test('wont override aria-describedby in form-control if describedby has value', () => {
-    // In this test, TextInput is a form-control component and Button is not.
-    // If Button has an id props, this should be used in aria-describedby, but this
-    // example has a predefined aria-describedby to prevent that from happening
-    render(
-      <InputGroup>
-        <InputGroupItem>
-          <TextInput value="some data" aria-describedby="myself" aria-label="some text" />
-        </InputGroupItem>
-        <InputGroupItem>
-          <Button id="button-id">
-            hello
-          </Button>
-        </InputGroupItem>
-      </InputGroup>
-    );
-    expect(screen.getByLabelText('some text')).toHaveAttribute('aria-describedby', 'myself');
+    const formControl = screen.getByLabelText("User password");
+    expect(formControl).not.toHaveAttribute("aria-describedby");
   });
 });

--- a/packages/react-core/src/components/NumberInput/__tests__/NumberInput.test.tsx
+++ b/packages/react-core/src/components/NumberInput/__tests__/NumberInput.test.tsx
@@ -69,7 +69,6 @@ describe('numberInput', () => {
       <NumberInput
         value={5}
         onMinus={jest.fn()}
-        inputProps={{ 'aria-describedby': '' }}
         minusBtnProps={{ id: 'minus-id' }}
         onPlus={jest.fn()}
         plusBtnProps={{ id: 'plus-id' }}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #9667 

This contribution complete one of the two tasks mentioned by @thatblindgeye at https://github.com/orgs/patternfly/discussions/5954#discussioncomment-7103093

>  Ideally what we'd want to do is:
>
>    * Remove the automated application of the aria-describedby attribute, and have it simply be something passed by the consumer when applicable like most/all of our other components
>    * Possibly provide an example showcasing when an aria-describedby would make sense

Hope it helps.
