### PR TITLE
fix(CalendarMonth): does not skip a month on arrow click

### DIFF
--- a/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
+++ b/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
@@ -213,14 +213,8 @@ export const CalendarMonth = ({
 
   const changeYear = (newYear: number) => changeMonth(focusedDate.getMonth(), newYear);
 
-  const changeMonth = (newMonth: number, newYear?: number) => {
-    const year = newYear ?? focusedDate.getFullYear();
-    const daysInNewMonth = new Date(year, (newMonth + 1) % 12, 0).getDate(); // Setting day 0 of the next month returns the last day of current month
-    const desiredDay = initialDate.getDate();
-    const day = desiredDay <= daysInNewMonth ? desiredDay : daysInNewMonth;
-
-    return new Date(year, newMonth, day);
-  };
+  const changeMonth = (newMonth: number, newYear?: number) =>
+    new Date(newYear ?? focusedDate.getFullYear(), newMonth, 1);
 
   const addMonth = (toAdd: -1 | 1) => {
     let newMonth = focusedDate.getMonth() + toAdd;
@@ -332,6 +326,7 @@ export const CalendarMonth = ({
                   setFocusedDate(newDate);
                   setHoveredDate(newDate);
                   setShouldFocus(false);
+                  focusRef.current.blur(); // will unfocus a date when changing year via up/down arrows
                   onMonthChange(ev, newDate);
                 }}
               />

--- a/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
+++ b/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
@@ -154,12 +154,12 @@ export const CalendarMonth = ({
   const [isSelectOpen, setIsSelectOpen] = React.useState(false);
 
   const getInitialDate = () => {
-    const initDate = new Date(dateProp);
-    if (isValidDate(initDate)) {
-      return initDate;
-    } else {
-      return isValidDate(rangeStart) ? rangeStart : today;
+    if (dateProp && isValidDate(dateProp)) {
+      return dateProp;
+    } else if (rangeStart && isValidDate(rangeStart)) {
+      return rangeStart;
     }
+    return today;
   };
   const initialDate = getInitialDate();
   const [focusedDate, setFocusedDate] = React.useState(initialDate);
@@ -188,7 +188,7 @@ export const CalendarMonth = ({
   const onMonthClick = (ev: React.MouseEvent, newDate: Date) => {
     setFocusedDate(newDate);
     setHoveredDate(newDate);
-    setShouldFocus(false);
+    setShouldFocus(true);
     onMonthChange(ev, newDate);
   };
 
@@ -211,43 +211,31 @@ export const CalendarMonth = ({
     }
   };
 
-  const changeMonth = (month: number) => {
-    const newDate = new Date(focusedDate);
-    const desiredDay = newDate.getDate();
-    const monthDays = new Date(newDate.getFullYear(), (month + 1) % 12, 0).getDate(); // Setting day 0 of the next month returns the last day of current month
+  const changeYear = (newYear: number) => changeMonth(focusedDate.getMonth(), newYear);
 
-    if (monthDays < desiredDay) {
-      newDate.setDate(monthDays);
-    }
+  const changeMonth = (newMonth: number, newYear?: number) => {
+    const year = newYear ?? focusedDate.getFullYear();
+    const daysInNewMonth = new Date(year, (newMonth + 1) % 12, 0).getDate(); // Setting day 0 of the next month returns the last day of current month
+    const desiredDay = initialDate.getDate();
+    const day = desiredDay <= daysInNewMonth ? desiredDay : daysInNewMonth;
 
-    newDate.setMonth(month);
-
-    if (initialDate.getDate() > desiredDay && monthDays > desiredDay) {
-      newDate.setDate(initialDate.getDate());
-    }
-
-    return newDate;
+    return new Date(year, newMonth, day);
   };
 
   const addMonth = (toAdd: -1 | 1) => {
-    let newMonth = new Date(focusedDate).getMonth() + toAdd;
+    let newMonth = focusedDate.getMonth() + toAdd;
+    let newYear = focusedDate.getFullYear();
+
     if (newMonth === -1) {
       newMonth = 11;
+      newYear--;
     } else if (newMonth === 12) {
       newMonth = 0;
+      newYear++;
     }
-    const newDate = changeMonth(newMonth);
-    if (toAdd === 1 && newMonth === 0) {
-      newDate.setFullYear(newDate.getFullYear() + 1);
-    }
-    if (toAdd === -1 && newMonth === 11) {
-      newDate.setFullYear(newDate.getFullYear() - 1);
-    }
-    return newDate;
-  };
 
-  const yearHasFebruary29th = (year: number) => new Date(year, 1, 29).getMonth() === 1;
-  const dateIsFebruary29th = (date: Date) => date.getMonth() === 1 && date.getDate() === 29;
+    return changeMonth(newMonth, newYear);
+  };
 
   const prevMonth = addMonth(-1);
   const nextMonth = addMonth(1);
@@ -317,7 +305,7 @@ export const CalendarMonth = ({
                     const newDate = changeMonth(Number(monthNum as string));
                     setFocusedDate(newDate);
                     setHoveredDate(newDate);
-                    setShouldFocus(false);
+                    setShouldFocus(true);
                     onMonthChange(ev, newDate);
                   }, 0);
                 }}
@@ -340,19 +328,10 @@ export const CalendarMonth = ({
                 type="number"
                 value={yearFormatted}
                 onChange={(ev: React.FormEvent<HTMLInputElement>, year: string) => {
-                  const newDate = new Date(focusedDate);
-                  if (dateIsFebruary29th(newDate) && !yearHasFebruary29th(+year)) {
-                    newDate.setDate(28);
-                    newDate.setMonth(1);
-                  }
-                  if (dateIsFebruary29th(initialDate) && yearHasFebruary29th(+year)) {
-                    newDate.setFullYear(+year);
-                    newDate.setDate(29);
-                  }
-                  newDate.setFullYear(+year);
+                  const newDate = changeYear(Number(year));
                   setFocusedDate(newDate);
                   setHoveredDate(newDate);
-                  setShouldFocus(false);
+                  setShouldFocus(true);
                   onMonthChange(ev, newDate);
                 }}
               />

--- a/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
+++ b/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
@@ -326,7 +326,7 @@ export const CalendarMonth = ({
                   setFocusedDate(newDate);
                   setHoveredDate(newDate);
                   setShouldFocus(false);
-                  focusRef.current.blur(); // will unfocus a date when changing year via up/down arrows
+                  focusRef.current?.blur(); // will unfocus a date when changing year via up/down arrows
                   onMonthChange(ev, newDate);
                 }}
               />

--- a/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
+++ b/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
@@ -188,7 +188,7 @@ export const CalendarMonth = ({
   const onMonthClick = (ev: React.MouseEvent, newDate: Date) => {
     setFocusedDate(newDate);
     setHoveredDate(newDate);
-    setShouldFocus(true);
+    setShouldFocus(false);
     onMonthChange(ev, newDate);
   };
 
@@ -305,7 +305,7 @@ export const CalendarMonth = ({
                     const newDate = changeMonth(Number(monthNum as string));
                     setFocusedDate(newDate);
                     setHoveredDate(newDate);
-                    setShouldFocus(true);
+                    setShouldFocus(false);
                     onMonthChange(ev, newDate);
                   }, 0);
                 }}
@@ -331,7 +331,7 @@ export const CalendarMonth = ({
                   const newDate = changeYear(Number(year));
                   setFocusedDate(newDate);
                   setHoveredDate(newDate);
-                  setShouldFocus(true);
+                  setShouldFocus(false);
                   onMonthChange(ev, newDate);
                 }}
               />

--- a/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
+++ b/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
@@ -154,9 +154,10 @@ export const CalendarMonth = ({
   const [isSelectOpen, setIsSelectOpen] = React.useState(false);
 
   const getInitialDate = () => {
-    if (dateProp && isValidDate(dateProp)) {
+    if (isValidDate(dateProp)) {
       return dateProp;
-    } else if (rangeStart && isValidDate(rangeStart)) {
+    }
+    if (isValidDate(rangeStart)) {
       return rangeStart;
     }
     return today;

--- a/packages/react-core/src/helpers/datetimeUtils.ts
+++ b/packages/react-core/src/helpers/datetimeUtils.ts
@@ -1,4 +1,4 @@
 /**
  * @param {Date} date - A date to check the validity of
  */
-export const isValidDate = (date: Date) => Boolean(date && !isNaN(date as any));
+export const isValidDate = (date?: Date) => Boolean(date && !isNaN(date as any));


### PR DESCRIPTION
**What**: Closes #9700

The bug was related to incorrect setting of `initialDate`, if `dateProp` was null, `new Date(null)` returns a valid date: 1 st Jan 1970, but in countries with UTC minus it returns 31 Dec 1969, then if the initial day is 31 it was causing issues in `changeMonth` function, which is now also refactored and fixed.

Other changes made:
* `changeMonth` refactoring (as we are not focusing dates on month change, `changeMonth` was simplified to always return the first day of the month)
* change year functionality refactoring
* unfocusing date, when changing year by clicking on small arrows
