### PR TITLE
fix(popper): update trigger element when content changes

### DIFF
--- a/packages/react-core/src/helpers/Popper/Popper.tsx
+++ b/packages/react-core/src/helpers/Popper/Popper.tsx
@@ -289,7 +289,7 @@ export const Popper: React.FunctionComponent<PopperProps> = ({
         setRefElement(triggerRef());
       }
     }
-  }, [triggerRef]);
+  }, [triggerRef, trigger]);
   React.useEffect(() => {
     // When the popperRef is defined or the popper visibility changes, ensure the popper element is up to date
     if (popperRef) {


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #9698

Fix to update popper's internal trigger element when the given `trigger` changes and `triggerRef` remains the same (in the case of the trigger content updating or changing).

Verified testing locally with the issue's [codesandbox](https://codesandbox.io/s/amazing-firefly-lqd5kj?file=/index.tsx:123-2730). The code should be copied into the surge to check this PR, as we don't currently have an example of a dynamically updating toggle. 
