### PR TITLE
[v4] Fix package.json link for code editor required peer deps

### DIFF
--- a/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditor.md
+++ b/packages/react-code-editor/src/components/CodeEditor/examples/CodeEditor.md
@@ -5,7 +5,7 @@ cssPrefix: pf-c-code-editor
 propComponents: ['CodeEditor', 'CodeEditorControl', 'Popover']
 ---
 
-Note: Code editor lives in its own package at [@patternfly/react-code-editor](https://www.npmjs.com/package/@patternfly/react-code-editor) and has [**required peer deps**](https://github.com/patternfly/patternfly-react/blob/main/packages/react-code-editor/package.json).
+Note: Code editor lives in its own package at [@patternfly/react-code-editor](https://www.npmjs.com/package/@patternfly/react-code-editor) and has [**required peer deps**](https://github.com/patternfly/patternfly-react/blob/v4/packages/react-code-editor/package.json).
 
 import { CodeEditor, CodeEditorControl, Language } from '@patternfly/react-code-editor';
 import PlayIcon from '@patternfly/react-icons/dist/esm/icons/play-icon';


### PR DESCRIPTION
This link is pointing to latest react-code-editor (v5) but it should point to v4

<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #9813 

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: Not that I know of
