### PR TITLE
fix(Chip): update tooltip vis when chip updates

### DIFF
--- a/packages/react-core/src/components/Chip/Chip.tsx
+++ b/packages/react-core/src/components/Chip/Chip.tsx
@@ -81,6 +81,15 @@ class Chip extends React.Component<ChipProps, ChipState> {
     });
   }
 
+  componentDidUpdate(_prevProps: ChipProps, prevState: ChipState) {
+    const nextIsTooltipVisible = this.span.current && this.span.current.offsetWidth < this.span.current.scrollWidth;
+    if (prevState.isTooltipVisible !== nextIsTooltipVisible) {
+      this.setState({
+        isTooltipVisible: nextIsTooltipVisible
+      });
+    }
+  }
+
   setChipStyle = () => ({
     [cssChipTextMaxWidth.name]: this.props.textMaxWidth
   });

--- a/packages/react-core/src/components/Chip/Chip.tsx
+++ b/packages/react-core/src/components/Chip/Chip.tsx
@@ -82,7 +82,9 @@ class Chip extends React.Component<ChipProps, ChipState> {
   }
 
   componentDidUpdate(_prevProps: ChipProps, prevState: ChipState) {
-    const nextIsTooltipVisible = this.span.current && this.span.current.offsetWidth < this.span.current.scrollWidth;
+    const nextIsTooltipVisible = Boolean(
+      this.span.current && this.span.current.offsetWidth < this.span.current.scrollWidth
+    );
     if (prevState.isTooltipVisible !== nextIsTooltipVisible) {
       this.setState({
         isTooltipVisible: nextIsTooltipVisible


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #9690 

Adds logic for `Chip` to update its internal `isTooltipVisible` prop when chip updates.

Can be tested by going to `ExpandableSection` examples and adding the following as a child (before this PR, the long chip text would not trigger its tooltip). 
`<ChipGroup className="pf-u-mb-lg">
            <Chip id="1">
              Very long text which. The tooltip will show because the chip is
              initially rendered visible.
            </Chip>
</ChipGroup>`
