### PR TITLE
chore(deps): update v6 core deps

### DIFF
--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -54,7 +54,7 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.0.0-alpha.12",
+    "@patternfly/patternfly": "6.0.0-alpha.19",
     "@rollup/plugin-commonjs": "^25.0.0",
     "@rollup/plugin-node-resolve": "^15.0.2",
     "@rollup/plugin-replace": "^5.0.2",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -54,7 +54,7 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.0.0-alpha.19",
+    "@patternfly/patternfly": "6.0.0-alpha.28",
     "@rollup/plugin-commonjs": "^25.0.0",
     "@rollup/plugin-node-resolve": "^15.0.2",
     "@rollup/plugin-replace": "^5.0.2",

--- a/packages/react-core/src/components/ExpandableSection/ExpandableSection.tsx
+++ b/packages/react-core/src/components/ExpandableSection/ExpandableSection.tsx
@@ -244,7 +244,7 @@ class ExpandableSection extends React.Component<ExpandableSectionProps, Expandab
             <AngleRightIcon aria-hidden />
           </span>
         )}
-        <span className={css(styles.expandableSectionToggleText)}>{toggleContent || computedToggleText}</span>
+        <span className={css(`${styles.expandableSection}__toggle-text`)}>{toggleContent || computedToggleText}</span>
       </button>
     );
 
@@ -254,7 +254,6 @@ class ExpandableSection extends React.Component<ExpandableSectionProps, Expandab
           styles.expandableSection,
           propOrStateIsExpanded && styles.modifiers.expanded,
           isActive && styles.modifiers.active,
-          isDetached && styles.modifiers.detached,
           displaySize === 'lg' && styles.modifiers.displayLg,
           isWidthLimited && styles.modifiers.limitWidth,
           isIndented && styles.modifiers.indented,

--- a/packages/react-core/src/components/ExpandableSection/ExpandableSectionToggle.tsx
+++ b/packages/react-core/src/components/ExpandableSection/ExpandableSectionToggle.tsx
@@ -45,7 +45,6 @@ export const ExpandableSectionToggle: React.FunctionComponent<ExpandableSectionT
     className={css(
       styles.expandableSection,
       isExpanded && styles.modifiers.expanded,
-      styles.modifiers.detached,
       hasTruncatedContent && styles.modifiers.truncate,
       className
     )}
@@ -69,7 +68,7 @@ export const ExpandableSectionToggle: React.FunctionComponent<ExpandableSectionT
           <AngleRightIcon aria-hidden />
         </span>
       )}
-      <span className={css(styles.expandableSectionToggleText)}>{children}</span>
+      <span className={css(`${styles.expandableSection}__toggle-text`)}>{children}</span>
     </button>
   </div>
 );

--- a/packages/react-core/src/components/ExpandableSection/__tests__/__snapshots__/ExpandableSection.test.tsx.snap
+++ b/packages/react-core/src/components/ExpandableSection/__tests__/__snapshots__/ExpandableSection.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Detached ExpandableSection renders successfully 1`] = `
 <DocumentFragment>
   <div
-    class="pf-v5-c-expandable-section pf-m-expanded pf-m-detached"
+    class="pf-v5-c-expandable-section pf-m-expanded"
   >
     <div
       aria-labelledby="toggle-id"
@@ -15,7 +15,7 @@ exports[`Detached ExpandableSection renders successfully 1`] = `
     </div>
   </div>
   <div
-    class="pf-v5-c-expandable-section pf-m-expanded pf-m-detached"
+    class="pf-v5-c-expandable-section pf-m-expanded"
   >
     <button
       aria-controls="content-id"

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -23,7 +23,7 @@
     "test:a11y": "patternfly-a11y --config patternfly-a11y.config"
   },
   "dependencies": {
-    "@patternfly/patternfly": "6.0.0-alpha.12",
+    "@patternfly/patternfly": "6.0.0-alpha.19",
     "@patternfly/react-charts": "^8.0.0-alpha.2",
     "@patternfly/react-code-editor": "^6.0.0-alpha.2",
     "@patternfly/react-core": "^6.0.0-alpha.2",

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -23,7 +23,7 @@
     "test:a11y": "patternfly-a11y --config patternfly-a11y.config"
   },
   "dependencies": {
-    "@patternfly/patternfly": "6.0.0-alpha.19",
+    "@patternfly/patternfly": "6.0.0-alpha.28",
     "@patternfly/react-charts": "^8.0.0-alpha.2",
     "@patternfly/react-code-editor": "^6.0.0-alpha.2",
     "@patternfly/react-core": "^6.0.0-alpha.2",

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -33,7 +33,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.14.0",
     "@fortawesome/free-regular-svg-icons": "^5.14.0",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
-    "@patternfly/patternfly": "6.0.0-alpha.19",
+    "@patternfly/patternfly": "6.0.0-alpha.28",
     "fs-extra": "^11.1.1",
     "glob": "^7.1.2",
     "rimraf": "^2.6.2",

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -33,7 +33,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.14.0",
     "@fortawesome/free-regular-svg-icons": "^5.14.0",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
-    "@patternfly/patternfly": "6.0.0-alpha.12",
+    "@patternfly/patternfly": "6.0.0-alpha.19",
     "fs-extra": "^11.1.1",
     "glob": "^7.1.2",
     "rimraf": "^2.6.2",

--- a/packages/react-integration/cypress/integration/expandablesection.spec.ts
+++ b/packages/react-integration/cypress/integration/expandablesection.spec.ts
@@ -19,7 +19,8 @@ describe('Expandable Demo Test', () => {
     cy.get('.pf-v5-c-expandable-section__toggle').find('span').should('contain', 'Show Less');
   });
 
-  it('Verify detached expandable', () => {
+  // disabled this test because pf-m-detached was removed from core.
+  xit('Verify detached expandable', () => {
     cy.get('#detached').should('have.class', 'pf-m-detached');
     cy.get('#detached-section').should('have.class', 'pf-m-detached');
     cy.get('#detached button').click();

--- a/packages/react-styles/package.json
+++ b/packages/react-styles/package.json
@@ -19,7 +19,7 @@
     "clean": "rimraf dist css"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.0.0-alpha.19",
+    "@patternfly/patternfly": "6.0.0-alpha.28",
     "camel-case": "^3.0.0",
     "css": "^2.2.3",
     "fs-extra": "^11.1.1",

--- a/packages/react-styles/package.json
+++ b/packages/react-styles/package.json
@@ -19,7 +19,7 @@
     "clean": "rimraf dist css"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.0.0-alpha.12",
+    "@patternfly/patternfly": "6.0.0-alpha.19",
     "camel-case": "^3.0.0",
     "css": "^2.2.3",
     "fs-extra": "^11.1.1",

--- a/packages/react-tokens/package.json
+++ b/packages/react-tokens/package.json
@@ -29,7 +29,7 @@
     "clean": "rimraf dist"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.0.0-alpha.12",
+    "@patternfly/patternfly": "6.0.0-alpha.19",
     "css": "^2.2.3",
     "fs-extra": "^11.1.1",
     "glob": "^7.1.2",

--- a/packages/react-tokens/package.json
+++ b/packages/react-tokens/package.json
@@ -29,7 +29,7 @@
     "clean": "rimraf dist"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.0.0-alpha.19",
+    "@patternfly/patternfly": "6.0.0-alpha.28",
     "css": "^2.2.3",
     "fs-extra": "^11.1.1",
     "glob": "^7.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3925,10 +3925,10 @@
     puppeteer-cluster "^0.23.0"
     xmldoc "^1.1.2"
 
-"@patternfly/patternfly@6.0.0-alpha.19":
-  version "6.0.0-alpha.19"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-6.0.0-alpha.19.tgz#0dfc68628997a08b2f3b13f05302d65024a85c3b"
-  integrity sha512-v7LUfyKrWJN929i5+OsItypUUcKLnJegWPJYrNSBumZXaUEFQkrMRwH4zN+RzbvuoqEXdYqJ/6hlh8QM5FIbjw==
+"@patternfly/patternfly@6.0.0-alpha.28":
+  version "6.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-6.0.0-alpha.28.tgz#5c3d0b0b1c712d8f2b9bcc05d3b6545f8f46a9ce"
+  integrity sha512-10vNDFHjtSRIfTbAnZqed2jbhXA6K4o9ijT8lGrxiSTq4qxRHNcTnNoV9oX328wvvdao052xv6HDYwvgwlvBiA==
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3925,10 +3925,10 @@
     puppeteer-cluster "^0.23.0"
     xmldoc "^1.1.2"
 
-"@patternfly/patternfly@6.0.0-alpha.12":
-  version "6.0.0-alpha.12"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-6.0.0-alpha.12.tgz#99ac69ae0a41b43cf1a78a109facae935001f2d1"
-  integrity sha512-8oUTBLXmdzVidxWvkXS2fCUYi4vmbgDBCdFmur8i4T4ssa+qH+0NZLN4kCPfVkgNY7RVcL6ISs1GIP6du6UacQ==
+"@patternfly/patternfly@6.0.0-alpha.19":
+  version "6.0.0-alpha.19"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-6.0.0-alpha.19.tgz#0dfc68628997a08b2f3b13f05302d65024a85c3b"
+  integrity sha512-v7LUfyKrWJN929i5+OsItypUUcKLnJegWPJYrNSBumZXaUEFQkrMRwH4zN+RzbvuoqEXdYqJ/6hlh8QM5FIbjw==
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #9835

Towards: #9850 

- Converted `pf-v5-c-expandable-section__toggle-text` to placholder class
- removed `pf-m-detached` modifier