### PR TITLE
Popover FocusTrap returnFocusOnDeactivate prop dependent on withFocusTrap prop #9866

### DIFF
--- a/packages/react-core/src/components/Popover/Popover.tsx
+++ b/packages/react-core/src/components/Popover/Popover.tsx
@@ -415,7 +415,7 @@ export const Popover: React.FunctionComponent<PopoverProps> = ({
       ref={popoverRef}
       active={focusTrapActive}
       focusTrapOptions={{
-        returnFocusOnDeactivate: true,
+        returnFocusOnDeactivate: propWithFocusTrap !== false,
         clickOutsideDeactivates: true,
         // FocusTrap's initialFocus can accept false as a value to prevent initial focus.
         // We want to prevent this in case false is ever passed in.


### PR DESCRIPTION
Do not return focus on deactivate if `withFocusTrap` prop is false

<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #9863

