### PR TITLE
fix(Chip): prevented duplicate ID being applied

### DIFF
--- a/packages/react-core/src/components/Chip/Chip.tsx
+++ b/packages/react-core/src/components/Chip/Chip.tsx
@@ -149,6 +149,8 @@ class Chip extends React.Component<ChipProps, ChipState> {
       isOverflowChip,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       tooltipPosition,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      id: idProp,
       component,
       ouiaId,
       textMaxWidth,

--- a/packages/react-core/src/components/Chip/__tests__/__snapshots__/Chip.test.tsx.snap
+++ b/packages/react-core/src/components/Chip/__tests__/__snapshots__/Chip.test.tsx.snap
@@ -7,7 +7,6 @@ exports[`Matches snapshot 1`] = `
     data-ouia-component-id="snapshot-test"
     data-ouia-component-type="PF5/Chip"
     data-ouia-safe="true"
-    id="snapshot-test"
   >
     <span
       class="pf-v5-c-chip__content"

--- a/packages/react-integration/cypress/integration/chip.spec.ts
+++ b/packages/react-integration/cypress/integration/chip.spec.ts
@@ -4,7 +4,7 @@ describe('Chip Group Demo Test', () => {
   });
 
   it('Verify tooltipPosition is passed to Tooltip', () => {
-    cy.get('#longName-chip').focus();
+    cy.get('.pf-v5-c-chip').focus();
     cy.get('.pf-v5-c-tooltip').should('have.class', 'pf-m-bottom');
   });
 });


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #9764

Prior to https://github.com/patternfly/patternfly-react/pull/8383, the original logic was that the `id` prop would be applied to the chip text for a non-overflow chip, so this is just preserving that original functionality. We could alternatively have the `id` prop spread to the outer Chip element and only apply a randomId to the chip text (or suffix the passed in `id` with "chip-text-[random number]" or something).


<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
