### PR TITLE
Added undefined to table sortBy function as it expects number | undefined

### DIFF
--- a/packages/react-core/src/components/Switch/Switch.tsx
+++ b/packages/react-core/src/components/Switch/Switch.tsx
@@ -127,7 +127,9 @@ class Switch extends React.Component<SwitchProps & OUIAProps, { ouiaStateId: str
         ) : (
           <span className={css(styles.switchToggle)}>
             <div className={css(styles.switchToggleIcon)} aria-hidden="true">
-              <CheckIcon />
+              {hasCheckIcon && (
+                <CheckIcon />
+              )}
             </div>
           </span>
         )}

--- a/packages/react-table/src/components/Table/examples/TableFavoritable.tsx
+++ b/packages/react-table/src/components/Table/examples/TableFavoritable.tsx
@@ -73,8 +73,8 @@ export const TableFavoritable: React.FunctionComponent = () => {
   const getSortParams = (columnIndex: number): ThProps['sort'] => ({
     isFavorites: columnIndex === 0, // Not just statically true in case we add sorting on other columns later
     sortBy: {
-      index: activeSortIndex,
-      direction: activeSortDirection
+      index: activeSortIndex ?? undefined,
+      direction: activeSortDirection ?? undefined
     },
     onSort: (_event, index, direction) => {
       setActiveSortIndex(index);

--- a/packages/react-table/src/components/Table/examples/TableMultipleStickyColumns.tsx
+++ b/packages/react-table/src/components/Table/examples/TableMultipleStickyColumns.tsx
@@ -76,8 +76,8 @@ export const TableMultipleStickyColumns: React.FunctionComponent = () => {
 
   const getSortParams = (columnIndex: number): ThProps['sort'] => ({
     sortBy: {
-      index: activeSortIndex,
-      direction: activeSortDirection
+      index: activeSortIndex ?? undefined,
+      direction: activeSortDirection ?? undefined
     },
     onSort: (_event, index, direction) => {
       setActiveSortIndex(index);

--- a/packages/react-table/src/components/Table/examples/TableNestedHeaders.tsx
+++ b/packages/react-table/src/components/Table/examples/TableNestedHeaders.tsx
@@ -103,8 +103,8 @@ export const TableNestedHeaders: React.FunctionComponent = () => {
 
   const getSortParams = (columnIndex: number): ThProps['sort'] => ({
     sortBy: {
-      index: activeSortIndex,
-      direction: activeSortDirection
+      index: activeSortIndex ?? undefined,
+      direction: activeSortDirection ?? undefined
     },
     onSort: (_event, index, direction) => {
       setActiveSortIndex(index);

--- a/packages/react-table/src/components/Table/examples/TableRightStickyColumn.tsx
+++ b/packages/react-table/src/components/Table/examples/TableRightStickyColumn.tsx
@@ -75,8 +75,8 @@ export const ComposableTableRightStickyColumn: React.FunctionComponent = () => {
 
   const getSortParams = (columnIndex: number): ThProps['sort'] => ({
     sortBy: {
-      index: activeSortIndex,
-      direction: activeSortDirection
+      index: activeSortIndex ?? undefined,
+      direction: activeSortDirection ?? undefined
     },
     onSort: (_event, index, direction) => {
       setActiveSortIndex(index);

--- a/packages/react-table/src/components/Table/examples/TableSortable.tsx
+++ b/packages/react-table/src/components/Table/examples/TableSortable.tsx
@@ -66,8 +66,8 @@ export const TableSortable: React.FunctionComponent = () => {
 
   const getSortParams = (columnIndex: number): ThProps['sort'] => ({
     sortBy: {
-      index: activeSortIndex,
-      direction: activeSortDirection,
+      index: activeSortIndex ?? undefined,
+      direction: activeSortDirection ?? undefined,
       defaultDirection: 'asc' // starting sort direction when first sorting a column. Defaults to 'asc'
     },
     onSort: (_event, index, direction) => {

--- a/packages/react-table/src/components/Table/examples/TableSortableCustom.tsx
+++ b/packages/react-table/src/components/Table/examples/TableSortableCustom.tsx
@@ -83,8 +83,8 @@ export const TableSortableCustom: React.FunctionComponent = () => {
 
   const getSortParams = (columnIndex: number): ThProps['sort'] => ({
     sortBy: {
-      index: activeSortIndex,
-      direction: activeSortDirection
+      index: activeSortIndex ?? undefined,
+      direction: activeSortDirection ?? undefined
     },
     onSort: (_event, index, direction) => {
       setActiveSortIndex(index);

--- a/packages/react-table/src/components/Table/examples/TableStickyColumn.tsx
+++ b/packages/react-table/src/components/Table/examples/TableStickyColumn.tsx
@@ -75,8 +75,8 @@ export const TableStickyColumn: React.FunctionComponent = () => {
 
   const getSortParams = (columnIndex: number): ThProps['sort'] => ({
     sortBy: {
-      index: activeSortIndex,
-      direction: activeSortDirection
+      index: activeSortIndex ?? undefined,
+      direction: activeSortDirection ?? undefined
     },
     onSort: (_event, index, direction) => {
       setActiveSortIndex(index);

--- a/packages/react-table/src/deprecated/components/Table/examples/LegacyTableFavoritable.tsx
+++ b/packages/react-table/src/deprecated/components/Table/examples/LegacyTableFavoritable.tsx
@@ -143,8 +143,8 @@ export const LegacyTableFavoritable: React.FunctionComponent = () => {
           setActiveSortDirection(direction);
         }}
         sortBy={{
-          index: activeSortIndex,
-          direction: activeSortDirection
+          index: activeSortIndex ?? undefined,
+          direction: activeSortDirection ?? undefined
         }}
         aria-label="Favoritable Table"
         cells={columns}

--- a/packages/react-table/src/deprecated/components/Table/examples/LegacyTableSortable.tsx
+++ b/packages/react-table/src/deprecated/components/Table/examples/LegacyTableSortable.tsx
@@ -94,8 +94,8 @@ export const LegacyTableSortable: React.FunctionComponent = () => {
     <Table
       aria-label="Sortable Table"
       sortBy={{
-        index: activeSortIndex,
-        direction: activeSortDirection,
+        index: activeSortIndex ?? undefined,
+        direction: activeSortDirection ?? undefined,
         defaultDirection: 'asc' // starting sort direction when first sorting a column. Defaults to 'asc'
       }}
       onSort={(_event, index, direction) => {

--- a/packages/react-table/src/deprecated/components/Table/examples/LegacyTableSortableCustom.tsx
+++ b/packages/react-table/src/deprecated/components/Table/examples/LegacyTableSortableCustom.tsx
@@ -168,8 +168,8 @@ export const LegacyTableSortableCustom: React.FunctionComponent = () => {
       <Table
         aria-label="Sortable Table with Custom Toolbar"
         sortBy={{
-          index: activeSortIndex,
-          direction: activeSortDirection
+          index: activeSortIndex ?? undefined,
+          direction: activeSortDirection ?? undefined
         }}
         onSort={(_event, index, direction) => {
           setActiveSortIndex(index);


### PR DESCRIPTION
In many table examples `activeSortIndex` and `activeSortDirection` are defined as `number | null`
But `ThSortType.sortBy: ISortBy` expects `number | undefined` and we get error `Type 'null' is not assignable to type 'number | undefined'`

so to resolve that error made changes :
```
index: activeSortIndex ?? undefined,
direction: activeSortDirection ?? undefined
```

more info at https://patternfly.slack.com/archives/C4FM977N0/p1703294961208719?thread_ts=1703237597.944969&cid=C4FM977N0