### PR TITLE
chore: Replace `lodash/uniqueId` with `getUniqueId()`

### DIFF
--- a/packages/react-charts/package.json
+++ b/packages/react-charts/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/patternfly/patternfly-react#readme",
   "dependencies": {
+    "@patternfly/react-core": "^5.2.0-prerelease.41",
     "@patternfly/react-styles": "^5.2.0-prerelease.6",
     "@patternfly/react-tokens": "^5.2.0-prerelease.7",
     "hoist-non-react-statics": "^3.3.0",

--- a/packages/react-charts/src/components/ChartUtils/chart-patterns.tsx
+++ b/packages/react-charts/src/components/ChartUtils/chart-patterns.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import uniqueId from 'lodash/uniqueId';
+import { getUniqueId } from '@patternfly/react-core';
 
 interface PatternPropsInterface {
   children?: any;
@@ -217,7 +217,7 @@ const patterns: any = [
  * Helper function to return a pattern ID
  * @private
  */
-const getPatternId = () => uniqueId('pf-pattern');
+const getPatternId = () => getUniqueId('pf-pattern');
 
 /**
  * Helper function to return pattern defs ID


### PR DESCRIPTION
Replaces all usage of `lodash/uniqueId` with [`getUniqueId()`](https://github.com/patternfly/patternfly-react/blob/19ddee701efb222b931b83c531987405860d604f/packages/react-core/src/helpers/util.ts#L14-L17), reducing the dependency on Lodash as a whole.

Works towards closing #9942