### PR TITLE
Consume core Penta updates: Form controls, checkbox, radio

### DIFF
--- a/packages/react-core/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react-core/src/components/Checkbox/Checkbox.tsx
@@ -16,8 +16,6 @@ export interface CheckboxProps
   inputClassName?: string;
   /** Flag to indicate whether the checkbox wrapper element is a <label> element for the checkbox input. Will not apply if a component prop (with a value other than a "label") is specified. */
   isLabelWrapped?: boolean;
-  /** Flag to show if the checkbox label is shown before the checkbox input. */
-  isLabelBeforeButton?: boolean;
   /** Flag to show if the checkbox selection is valid or invalid. */
   isValid?: boolean;
   /** Flag to show if the checkbox is disabled. */
@@ -31,6 +29,8 @@ export interface CheckboxProps
   onChange?: (event: React.FormEvent<HTMLInputElement>, checked: boolean) => void;
   /** Label text of the checkbox. */
   label?: React.ReactNode;
+  /** Sets the position of the label. Defaults to 'end' (after the checkbox input). */
+  labelPosition?: 'start' | 'end';
   /** Id of the checkbox. */
   id: string;
   /** Aria-label of the checkbox. */
@@ -85,7 +85,7 @@ class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
       inputClassName,
       onChange,
       isLabelWrapped,
-      isLabelBeforeButton,
+      labelPosition = 'end',
       isValid,
       isDisabled,
       isRequired,
@@ -156,7 +156,7 @@ class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
         className={css(styles.check, !label && styles.modifiers.standalone, className)}
         htmlFor={wrapWithLabel ? props.id : undefined}
       >
-        {isLabelBeforeButton ? (
+        {labelPosition === 'start' ? (
           <>
             {labelRendered}
             {inputRendered}

--- a/packages/react-core/src/components/Checkbox/__tests__/Checkbox.test.tsx
+++ b/packages/react-core/src/components/Checkbox/__tests__/Checkbox.test.tsx
@@ -263,8 +263,8 @@ test('Renders with span element around the inner label text if component is set 
   expect(screen.getByText(labelText).tagName).toBe('SPAN');
 });
 
-test('Renders label before checkbox input if isLabelBeforeButton is provided', () => {
-  render(<Checkbox id="test-id" isLabelBeforeButton label={'test checkbox label'} />);
+test('Renders label before checkbox input if labelPosition is "start"', () => {
+  render(<Checkbox id="test-id" labelPosition="start" label={'test checkbox label'} />);
 
   const wrapper = screen.getByRole('checkbox').parentElement!;
 

--- a/packages/react-core/src/components/Form/FormFieldGroupHeader.tsx
+++ b/packages/react-core/src/components/Form/FormFieldGroupHeader.tsx
@@ -5,7 +5,7 @@ import { css } from '@patternfly/react-styles';
 export interface FormFieldGroupHeaderTitleTextObject {
   /** Title text. */
   text: React.ReactNode;
-  /** The applied to the title div for accessibility */
+  /** The id applied to the title div for accessibility */
   id: string;
 }
 

--- a/packages/react-core/src/components/Form/FormFieldGroupHeader.tsx
+++ b/packages/react-core/src/components/Form/FormFieldGroupHeader.tsx
@@ -2,15 +2,12 @@ import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/Form/form';
 import { css } from '@patternfly/react-styles';
 
-// typo - rename to FormFieldGroupHeaderTitleTextObject during breaking change release
-export interface FormFiledGroupHeaderTitleTextObject {
+export interface FormFieldGroupHeaderTitleTextObject {
   /** Title text. */
   text: React.ReactNode;
   /** The applied to the title div for accessibility */
   id: string;
 }
-
-export interface FormFieldGroupHeaderTitleTextObject extends FormFiledGroupHeaderTitleTextObject {}
 
 export interface FormFieldGroupHeaderProps extends React.HTMLProps<HTMLDivElement> {
   /** Additional classes added to the section */

--- a/packages/react-core/src/components/Form/FormGroup.tsx
+++ b/packages/react-core/src/components/Form/FormGroup.tsx
@@ -13,8 +13,8 @@ export interface FormGroupProps extends Omit<React.HTMLProps<HTMLDivElement>, 'l
   label?: React.ReactNode;
   /** Additional label information displayed after the label. */
   labelInfo?: React.ReactNode;
-  /** Sets an icon for the label. We recommend using FormGroupLabelHelp element as a help icon button. For providing additional context, host element for Popover  */
-  labelIcon?: React.ReactElement;
+  /** A help button for the label. We recommend using FormGroupLabelHelp element as a help icon button. The help button should be wrapped or linked to our popover component. */
+  labelHelp?: React.ReactElement;
   /** Sets the FormGroup required. */
   isRequired?: boolean;
   /** Sets the FormGroup isInline. */
@@ -38,7 +38,7 @@ export const FormGroup: React.FunctionComponent<FormGroupProps> = ({
   className = '',
   label,
   labelInfo,
-  labelIcon,
+  labelHelp,
   isRequired = false,
   isInline = false,
   hasNoPaddingTop = false,
@@ -62,7 +62,7 @@ export const FormGroup: React.FunctionComponent<FormGroupProps> = ({
         )}
       </LabelComponent>
       <>&nbsp;&nbsp;</>
-      {React.isValidElement(labelIcon) && <span className={styles.formGroupLabelHelp}>{labelIcon}</span>}
+      {React.isValidElement(labelHelp) && <span className={styles.formGroupLabelHelp}>{labelHelp}</span>}
     </>
   );
 

--- a/packages/react-core/src/components/Form/FormGroup.tsx
+++ b/packages/react-core/src/components/Form/FormGroup.tsx
@@ -51,7 +51,7 @@ export const FormGroup: React.FunctionComponent<FormGroupProps> = ({
   const LabelComponent = isGroupOrRadioGroup ? 'span' : 'label';
 
   const labelContent = (
-    <React.Fragment>
+    <>
       <LabelComponent className={css(styles.formLabel)} {...(!isGroupOrRadioGroup && { htmlFor: fieldId })}>
         <span className={css(styles.formLabelText)}>{label}</span>
         {isRequired && (
@@ -60,9 +60,10 @@ export const FormGroup: React.FunctionComponent<FormGroupProps> = ({
             {ASTERISK}
           </span>
         )}
-      </LabelComponent>{' '}
-      {React.isValidElement(labelIcon) && labelIcon}
-    </React.Fragment>
+      </LabelComponent>
+      <>&nbsp;&nbsp;</>
+      {React.isValidElement(labelIcon) && <span className={styles.formGroupLabelHelp}>{labelIcon}</span>}
+    </>
   );
 
   return (

--- a/packages/react-core/src/components/Form/FormGroup.tsx
+++ b/packages/react-core/src/components/Form/FormGroup.tsx
@@ -13,7 +13,7 @@ export interface FormGroupProps extends Omit<React.HTMLProps<HTMLDivElement>, 'l
   label?: React.ReactNode;
   /** Additional label information displayed after the label. */
   labelInfo?: React.ReactNode;
-  /** Sets an icon for the label. For providing additional context. Host element for Popover  */
+  /** Sets an icon for the label. We recommend using FormGroupLabelHelp element as a help icon button. For providing additional context, host element for Popover  */
   labelIcon?: React.ReactElement;
   /** Sets the FormGroup required. */
   isRequired?: boolean;

--- a/packages/react-core/src/components/Form/FormGroupLabelHelp.tsx
+++ b/packages/react-core/src/components/Form/FormGroupLabelHelp.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Button, ButtonProps } from '../Button';
+import QuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/question-circle-icon';
+
+export const FormGroupLabelHelp: React.FunctionComponent<ButtonProps> = (props: ButtonProps) => (
+  <Button isInline variant="plain" hasNoPadding {...props}>
+    <QuestionCircleIcon />
+  </Button>
+);
+FormGroupLabelHelp.displayName = 'FormGroupLabelHelp';

--- a/packages/react-core/src/components/Form/FormGroupLabelHelp.tsx
+++ b/packages/react-core/src/components/Form/FormGroupLabelHelp.tsx
@@ -2,8 +2,22 @@ import React from 'react';
 import { Button, ButtonProps } from '../Button';
 import QuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/question-circle-icon';
 
-export const FormGroupLabelHelp: React.FunctionComponent<ButtonProps> = (props: ButtonProps) => (
-  <Button isInline variant="plain" hasNoPadding {...props}>
+/** A help button to be passed to the FormGroup's labelHelp property. This should be wrapped or linked
+ * to our Popover component.
+ */
+export interface FormGroupLabelHelpProps extends ButtonProps {
+  /** Adds an accessible name for the help button. */
+  'aria-label': string;
+  /** Additional classes added to the help button. */
+  className?: string;
+}
+
+export const FormGroupLabelHelp: React.FunctionComponent<FormGroupLabelHelpProps> = ({
+  'aria-label': ariaLabel,
+  className,
+  ...props
+}) => (
+  <Button aria-label={ariaLabel} className={className} variant="plain" hasNoPadding {...props}>
     <QuestionCircleIcon />
   </Button>
 );

--- a/packages/react-core/src/components/Form/__tests__/__snapshots__/FormGroup.test.tsx.snap
+++ b/packages/react-core/src/components/Form/__tests__/__snapshots__/FormGroup.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`FormGroup should render correctly when label is not a string with Child
           </div>
         </span>
       </label>
-       
+        
     </div>
     <div
       class="pf-v6-c-form__group-control"
@@ -55,7 +55,7 @@ exports[`FormGroup should render default form group variant 1`] = `
           label
         </span>
       </label>
-       
+        
     </div>
     <div
       class="pf-v6-c-form__group-control"
@@ -88,7 +88,7 @@ exports[`FormGroup should render form group variant with node label 1`] = `
           </h1>
         </span>
       </label>
-       
+        
     </div>
     <div
       class="pf-v6-c-form__group-control"
@@ -125,7 +125,7 @@ exports[`FormGroup should render form group variant with required label 1`] = `
            *
         </span>
       </label>
-       
+        
     </div>
     <div
       class="pf-v6-c-form__group-control"
@@ -177,7 +177,7 @@ exports[`FormGroup should render form group with additonal label info 1`] = `
             </h1>
           </span>
         </label>
-         
+          
       </div>
       <div
         class="pf-v6-c-form__group-label-info"
@@ -218,7 +218,7 @@ exports[`FormGroup should render horizontal form group variant 1`] = `
             label
           </span>
         </label>
-         
+          
       </div>
       <div
         class="pf-v6-c-form__group-control"
@@ -254,7 +254,7 @@ exports[`FormGroup should render stacked horizontal form group variant 1`] = `
             label
           </span>
         </label>
-         
+          
       </div>
       <div
         class="pf-v6-c-form__group-control pf-m-stack"

--- a/packages/react-core/src/components/Form/examples/Form.md
+++ b/packages/react-core/src/components/Form/examples/Form.md
@@ -8,6 +8,7 @@ propComponents:
     'ActionGroup',
     'Form',
     'FormGroup',
+    'FormGroupLabelHelp',
     'FormSection',
     'FormHelperText',
     'FormFieldGroup',
@@ -21,23 +22,6 @@ propComponents:
   ]
 ---
 
-import {
-Button,
-Form,
-FormGroup,
-FormGroupLabelHelp,
-Popover,
-TextInput,
-TextArea,
-FormSelect,
-FormHelperText,
-FormFieldGroup,
-FormFieldGroupHeader,
-FormFieldGroupExpandable,
-Checkbox,
-ActionGroup,
-Radio
-} from '@patternfly/react-core';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 import TrashIcon from '@patternfly/react-icons/dist/esm/icons/trash-icon';

--- a/packages/react-core/src/components/Form/examples/Form.md
+++ b/packages/react-core/src/components/Form/examples/Form.md
@@ -25,6 +25,7 @@ import {
 Button,
 Form,
 FormGroup,
+FormGroupLabelHelp,
 Popover,
 TextInput,
 TextArea,

--- a/packages/react-core/src/components/Form/examples/FormBasic.tsx
+++ b/packages/react-core/src/components/Form/examples/FormBasic.tsx
@@ -10,10 +10,9 @@ import {
   Radio,
   HelperText,
   HelperTextItem,
-  FormHelperText
+  FormHelperText,
+  FormGroupLabelHelp
 } from '@patternfly/react-core';
-import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
-import styles from '@patternfly/react-styles/css/components/Form/form';
 
 export const FormBasic: React.FunctionComponent = () => {
   const [name, setName] = React.useState('');
@@ -64,15 +63,7 @@ export const FormBasic: React.FunctionComponent = () => {
               </div>
             }
           >
-            <button
-              type="button"
-              aria-label="More info for name field"
-              onClick={(e) => e.preventDefault()}
-              aria-describedby="simple-form-name-01"
-              className={styles.formGroupLabelHelp}
-            >
-              <HelpIcon />
-            </button>
+            <FormGroupLabelHelp aria-label="More info for name field" aria-describedby="simple-form-name-01" />
           </Popover>
         }
         isRequired

--- a/packages/react-core/src/components/Form/examples/FormBasic.tsx
+++ b/packages/react-core/src/components/Form/examples/FormBasic.tsx
@@ -35,7 +35,7 @@ export const FormBasic: React.FunctionComponent = () => {
     <Form>
       <FormGroup
         label="Full name"
-        labelIcon={
+        labelHelp={
           <Popover
             headerContent={
               <div>
@@ -63,7 +63,7 @@ export const FormBasic: React.FunctionComponent = () => {
               </div>
             }
           >
-            <FormGroupLabelHelp aria-label="More info for name field" aria-describedby="simple-form-name-01" />
+            <FormGroupLabelHelp aria-label="More info for name field" />
           </Popover>
         }
         isRequired

--- a/packages/react-core/src/components/Form/examples/FormGroupLabelInfo.tsx
+++ b/packages/react-core/src/components/Form/examples/FormGroupLabelInfo.tsx
@@ -50,7 +50,7 @@ export const FormGroupLabelInfo: React.FunctionComponent = () => {
               </div>
             }
           >
-            <FormGroupLabelHelp aria-label="More info for name field" aria-describedby="form-group-label-info" />
+            <FormGroupLabelHelp aria-label="More info for name field" />
           </Popover>
         }
         isRequired

--- a/packages/react-core/src/components/Form/examples/FormGroupLabelInfo.tsx
+++ b/packages/react-core/src/components/Form/examples/FormGroupLabelInfo.tsx
@@ -22,7 +22,7 @@ export const FormGroupLabelInfo: React.FunctionComponent = () => {
       <FormGroup
         label="Full name"
         labelInfo="Additional label info"
-        labelIcon={
+        labelHelp={
           <Popover
             headerContent={
               <div>

--- a/packages/react-core/src/components/Form/examples/FormGroupLabelInfo.tsx
+++ b/packages/react-core/src/components/Form/examples/FormGroupLabelInfo.tsx
@@ -6,10 +6,9 @@ import {
   Popover,
   HelperText,
   HelperTextItem,
-  FormHelperText
+  FormHelperText,
+  FormGroupLabelHelp
 } from '@patternfly/react-core';
-import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
-import styles from '@patternfly/react-styles/css/components/Form/form';
 
 export const FormGroupLabelInfo: React.FunctionComponent = () => {
   const [name, setName] = React.useState('');
@@ -51,15 +50,7 @@ export const FormGroupLabelInfo: React.FunctionComponent = () => {
               </div>
             }
           >
-            <button
-              type="button"
-              aria-label="More info for name field"
-              onClick={(e) => e.preventDefault()}
-              aria-describedby="form-group-label-info"
-              className={styles.formGroupLabelHelp}
-            >
-              <HelpIcon />
-            </button>
+            <FormGroupLabelHelp aria-label="More info for name field" aria-describedby="form-group-label-info" />
           </Popover>
         }
         isRequired

--- a/packages/react-core/src/components/Form/examples/FormLimitWidth.tsx
+++ b/packages/react-core/src/components/Form/examples/FormLimitWidth.tsx
@@ -10,10 +10,9 @@ import {
   Radio,
   HelperText,
   HelperTextItem,
-  FormHelperText
+  FormHelperText,
+  FormGroupLabelHelp
 } from '@patternfly/react-core';
-import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
-import styles from '@patternfly/react-styles/css/components/Form/form';
 
 export const FormLimitWidth: React.FunctionComponent = () => {
   const [name, setName] = React.useState('');
@@ -64,15 +63,7 @@ export const FormLimitWidth: React.FunctionComponent = () => {
               </div>
             }
           >
-            <button
-              type="button"
-              aria-label="More info for name field"
-              onClick={(e) => e.preventDefault()}
-              aria-describedby="simple-form-name-02"
-              className={styles.formGroupLabelHelp}
-            >
-              <HelpIcon />
-            </button>
+            <FormGroupLabelHelp aria-label="More info for name field" aria-describedby="simple-form-name-02" />
           </Popover>
         }
         isRequired

--- a/packages/react-core/src/components/Form/examples/FormLimitWidth.tsx
+++ b/packages/react-core/src/components/Form/examples/FormLimitWidth.tsx
@@ -35,7 +35,7 @@ export const FormLimitWidth: React.FunctionComponent = () => {
     <Form isWidthLimited>
       <FormGroup
         label="Full name"
-        labelIcon={
+        labelHelp={
           <Popover
             headerContent={
               <div>
@@ -63,7 +63,7 @@ export const FormLimitWidth: React.FunctionComponent = () => {
               </div>
             }
           >
-            <FormGroupLabelHelp aria-label="More info for name field" aria-describedby="simple-form-name-02" />
+            <FormGroupLabelHelp aria-label="More info for name field" />
           </Popover>
         }
         isRequired

--- a/packages/react-core/src/components/Form/index.ts
+++ b/packages/react-core/src/components/Form/index.ts
@@ -5,6 +5,7 @@ export * from './FormFieldGroup';
 export * from './FormFieldGroupExpandable';
 export * from './FormFieldGroupHeader';
 export * from './FormGroup';
+export * from './FormGroupLabelHelp';
 export * from './FormHelperText';
 export * from './FormSection';
 export * from './FormContext';

--- a/packages/react-core/src/components/LoginPage/__tests__/__snapshots__/LoginForm.test.tsx.snap
+++ b/packages/react-core/src/components/LoginPage/__tests__/__snapshots__/LoginForm.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`LoginForm LoginForm with rememberMeLabel 1`] = `
              *
           </span>
         </label>
-         
+          
       </div>
       <div
         class="pf-v6-c-form__group-control"
@@ -72,7 +72,7 @@ exports[`LoginForm LoginForm with rememberMeLabel 1`] = `
              *
           </span>
         </label>
-         
+          
       </div>
       <div
         class="pf-v6-c-form__group-control"
@@ -175,7 +175,7 @@ exports[`LoginForm LoginForm with show password 1`] = `
              *
           </span>
         </label>
-         
+          
       </div>
       <div
         class="pf-v6-c-form__group-control"
@@ -219,7 +219,7 @@ exports[`LoginForm LoginForm with show password 1`] = `
              *
           </span>
         </label>
-         
+          
       </div>
       <div
         class="pf-v6-c-form__group-control"
@@ -330,7 +330,7 @@ exports[`LoginForm should render Login form 1`] = `
              *
           </span>
         </label>
-         
+          
       </div>
       <div
         class="pf-v6-c-form__group-control"
@@ -374,7 +374,7 @@ exports[`LoginForm should render Login form 1`] = `
              *
           </span>
         </label>
-         
+          
       </div>
       <div
         class="pf-v6-c-form__group-control"

--- a/packages/react-core/src/components/Modal/examples/ModalWithForm.tsx
+++ b/packages/react-core/src/components/Modal/examples/ModalWithForm.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
-import { Modal, ModalVariant, Button, Form, FormGroup, Popover, TextInput } from '@patternfly/react-core';
-import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
-import formStyles from '@patternfly/react-styles/css/components/Form/form';
+import {
+  Modal,
+  ModalVariant,
+  Button,
+  Form,
+  FormGroup,
+  FormGroupLabelHelp,
+  Popover,
+  TextInput
+} from '@patternfly/react-core';
 
 export const ModalWithForm: React.FunctionComponent = () => {
   const [isModalOpen, setModalOpen] = React.useState(false);
@@ -47,7 +54,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
         <Form id="modal-with-form-form">
           <FormGroup
             label="Name"
-            labelIcon={
+            labelHelp={
               <Popover
                 headerContent={
                   <div>
@@ -75,15 +82,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
                   </div>
                 }
               >
-                <button
-                  type="button"
-                  aria-label="More info for name field"
-                  onClick={(e) => e.preventDefault()}
-                  aria-describedby="modal-with-form-form-name"
-                  className={formStyles.formGroupLabelHelp}
-                >
-                  <HelpIcon />
-                </button>
+                <FormGroupLabelHelp aria-label="More info for name field" />
               </Popover>
             }
             isRequired
@@ -100,7 +99,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
           </FormGroup>
           <FormGroup
             label="E-mail"
-            labelIcon={
+            labelHelp={
               <Popover
                 headerContent={
                   <div>
@@ -124,15 +123,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
                   </div>
                 }
               >
-                <button
-                  type="button"
-                  aria-label="More info for e-mail field"
-                  onClick={(e) => e.preventDefault()}
-                  aria-describedby="modal-with-form-form-email"
-                  className={formStyles.formGroupLabelHelp}
-                >
-                  <HelpIcon />
-                </button>
+                <FormGroupLabelHelp aria-label="More info for e-mail field" />
               </Popover>
             }
             isRequired
@@ -149,7 +140,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
           </FormGroup>
           <FormGroup
             label="Address"
-            labelIcon={
+            labelHelp={
               <Popover
                 headerContent={
                   <div>
@@ -172,15 +163,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
                   </div>
                 }
               >
-                <button
-                  type="button"
-                  aria-label="More info for address field"
-                  onClick={(e) => e.preventDefault()}
-                  aria-describedby="modal-with-form-form-address"
-                  className={formStyles.formGroupLabelHelp}
-                >
-                  <HelpIcon />
-                </button>
+                <FormGroupLabelHelp aria-label="More info for address field" />
               </Popover>
             }
             isRequired

--- a/packages/react-core/src/components/Radio/Radio.tsx
+++ b/packages/react-core/src/components/Radio/Radio.tsx
@@ -17,8 +17,6 @@ export interface RadioProps
   id: string;
   /** Flag to indicate whether the radio wrapper element is a native label element for the radio input. Will not apply if a component prop (with a value other than a "label") is specified. */
   isLabelWrapped?: boolean;
-  /** Flag to show if the radio label is shown before the radio input. */
-  isLabelBeforeButton?: boolean;
   /** Flag to show if the radio is checked. */
   checked?: boolean;
   /** Flag to show if the radio is checked. */
@@ -29,6 +27,8 @@ export interface RadioProps
   isValid?: boolean;
   /** Label text of the radio. */
   label?: React.ReactNode;
+  /** Sets the position of the label. Defaults to 'end' (after the radio input). */
+  labelPosition?: 'start' | 'end';
   /** Name for group of radios */
   name: string;
   /** A callback for when the radio selection changes. */
@@ -79,7 +79,7 @@ class Radio extends React.Component<RadioProps, { ouiaStateId: string }> {
       inputClassName,
       defaultChecked,
       isLabelWrapped,
-      isLabelBeforeButton,
+      labelPosition = 'end',
       isChecked,
       isDisabled,
       isValid,
@@ -132,7 +132,7 @@ class Radio extends React.Component<RadioProps, { ouiaStateId: string }> {
         className={css(styles.radio, !label && styles.modifiers.standalone, className)}
         htmlFor={wrapWithLabel ? props.id : undefined}
       >
-        {isLabelBeforeButton ? (
+        {labelPosition === 'start' ? (
           <>
             {labelRendered}
             {inputRendered}

--- a/packages/react-core/src/components/Radio/__tests__/Radio.test.tsx
+++ b/packages/react-core/src/components/Radio/__tests__/Radio.test.tsx
@@ -25,9 +25,9 @@ describe('Radio', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test('isLabelBeforeButton', () => {
+  test('labelPosition is "start"', () => {
     const { asFragment } = render(
-      <Radio id="check" isLabelBeforeButton label="Radio label" aria-label="check" name="check" />
+      <Radio id="check" labelPosition="start" label="Radio label" aria-label="check" name="check" />
     );
     expect(asFragment()).toMatchSnapshot();
   });
@@ -133,8 +133,8 @@ describe('Radio', () => {
     expect(screen.getByText(labelText).tagName).toBe('SPAN');
   });
 
-  test('Renders label before radio input if isLabelBeforeButton is provided', () => {
-    render(<Radio id="test-id" name="check" isLabelBeforeButton label={'test radio label'} />);
+  test('Renders label before radio input if labelPosition is "start"', () => {
+    render(<Radio id="test-id" name="check" labelPosition="start" label={'test radio label'} />);
 
     const wrapper = screen.getByRole('radio').parentElement!;
 

--- a/packages/react-core/src/components/Radio/__tests__/__snapshots__/Radio.test.tsx.snap
+++ b/packages/react-core/src/components/Radio/__tests__/__snapshots__/Radio.test.tsx.snap
@@ -42,31 +42,6 @@ exports[`Radio isDisabled 1`] = `
 </DocumentFragment>
 `;
 
-exports[`Radio isLabelBeforeButton 1`] = `
-<DocumentFragment>
-  <div
-    class="pf-v6-c-radio"
-  >
-    <label
-      class="pf-v6-c-radio__label"
-      for="check"
-    >
-      Radio label
-    </label>
-    <input
-      aria-invalid="false"
-      class="pf-v6-c-radio__input"
-      data-ouia-component-id="OUIA-Generated-Radio-4"
-      data-ouia-component-type="PF5/Radio"
-      data-ouia-safe="true"
-      id="check"
-      name="check"
-      type="radio"
-    />
-  </div>
-</DocumentFragment>
-`;
-
 exports[`Radio isLabelWrapped 1`] = `
 <DocumentFragment>
   <label
@@ -170,6 +145,31 @@ exports[`Radio label is string 1`] = `
     >
       Label
     </label>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Radio labelPosition is "start" 1`] = `
+<DocumentFragment>
+  <div
+    class="pf-v5-c-radio"
+  >
+    <label
+      class="pf-v5-c-radio__label"
+      for="check"
+    >
+      Radio label
+    </label>
+    <input
+      aria-invalid="false"
+      class="pf-v5-c-radio__input"
+      data-ouia-component-id="OUIA-Generated-Radio-4"
+      data-ouia-component-type="PF5/Radio"
+      data-ouia-safe="true"
+      id="check"
+      name="check"
+      type="radio"
+    />
   </div>
 </DocumentFragment>
 `;

--- a/packages/react-core/src/components/Radio/__tests__/__snapshots__/Radio.test.tsx.snap
+++ b/packages/react-core/src/components/Radio/__tests__/__snapshots__/Radio.test.tsx.snap
@@ -152,17 +152,17 @@ exports[`Radio label is string 1`] = `
 exports[`Radio labelPosition is "start" 1`] = `
 <DocumentFragment>
   <div
-    class="pf-v5-c-radio"
+    class="pf-v6-c-radio"
   >
     <label
-      class="pf-v5-c-radio__label"
+      class="pf-v6-c-radio__label"
       for="check"
     >
       Radio label
     </label>
     <input
       aria-invalid="false"
-      class="pf-v5-c-radio__input"
+      class="pf-v6-c-radio__input"
       data-ouia-component-id="OUIA-Generated-Radio-4"
       data-ouia-component-type="PF5/Radio"
       data-ouia-safe="true"

--- a/packages/react-core/src/components/Radio/examples/RadioReversed.tsx
+++ b/packages/react-core/src/components/Radio/examples/RadioReversed.tsx
@@ -2,5 +2,5 @@ import React from 'react';
 import { Radio } from '@patternfly/react-core';
 
 export const RadioReversed: React.FunctionComponent = () => (
-  <Radio isLabelBeforeButton label="Reversed radio example" id="radio-reversed" name="radio-3" />
+  <Radio labelPosition="start" label="Reversed radio example" id="radio-reversed" name="radio-3" />
 );

--- a/packages/react-core/src/components/SearchInput/__tests__/__snapshots__/SearchInput.test.tsx.snap
+++ b/packages/react-core/src/components/SearchInput/__tests__/__snapshots__/SearchInput.test.tsx.snap
@@ -306,7 +306,7 @@ exports[`SearchInput advanced search with custom attributes 1`] = `
                       Username
                     </span>
                   </label>
-                   
+                    
                 </div>
                 <div
                   class="pf-v6-c-form__group-control"
@@ -339,7 +339,7 @@ exports[`SearchInput advanced search with custom attributes 1`] = `
                       First name
                     </span>
                   </label>
-                   
+                    
                 </div>
                 <div
                   class="pf-v6-c-form__group-control"
@@ -372,7 +372,7 @@ exports[`SearchInput advanced search with custom attributes 1`] = `
                       Has words
                     </span>
                   </label>
-                   
+                    
                 </div>
                 <div
                   class="pf-v6-c-form__group-control"

--- a/packages/react-core/src/demos/examples/PasswordStrength/PasswordStrengthDemo.tsx
+++ b/packages/react-core/src/demos/examples/PasswordStrength/PasswordStrengthDemo.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import {
   Form,
   FormGroup,
+  FormGroupLabelHelp,
   FormHelperText,
   HelperText,
   Popover,
   HelperTextItem,
   TextInput
 } from '@patternfly/react-core';
-import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
 import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
@@ -91,15 +91,7 @@ export const PasswordStrengthDemo: React.FunctionComponent = () => {
 
   const iconPopover = (
     <Popover headerContent={<div>Password Requirements</div>} bodyContent={<div>Password rules</div>}>
-      <button
-        type="button"
-        aria-label="More info for name field"
-        onClick={(e) => e.preventDefault()}
-        aria-describedby="password-field"
-        className="pf-v6-c-form__group-label-help"
-      >
-        <HelpIcon />
-      </button>
+      <FormGroupLabelHelp aria-label="More info for name field" />
     </Popover>
   );
 
@@ -115,7 +107,7 @@ export const PasswordStrengthDemo: React.FunctionComponent = () => {
     <Form>
       <FormGroup
         label="Password"
-        labelIcon={iconPopover}
+        labelHelp={iconPopover}
         isRequired
         fieldId="password-field"
         {...(ruleLength === 'success' &&

--- a/packages/react-core/src/next/components/Modal/examples/ModalWithForm.tsx
+++ b/packages/react-core/src/next/components/Modal/examples/ModalWithForm.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
-import { Button, Form, FormGroup, Popover, TextInput } from '@patternfly/react-core';
+import { Button, Form, FormGroup, FormGroupLabelHelp, Popover, TextInput } from '@patternfly/react-core';
 import { Modal, ModalBody, ModalFooter, ModalHeader, ModalVariant } from '@patternfly/react-core/next';
-import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
-import formStyles from '@patternfly/react-styles/css/components/Form/form';
 
 export const ModalWithForm: React.FunctionComponent = () => {
   const [isModalOpen, setModalOpen] = React.useState(false);
@@ -47,7 +45,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
           <Form id="modal-with-form-form">
             <FormGroup
               label="Name"
-              labelIcon={
+              labelHelp={
                 <Popover
                   headerContent={
                     <div>
@@ -75,15 +73,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
                     </div>
                   }
                 >
-                  <button
-                    type="button"
-                    aria-label="More info for name field"
-                    onClick={(e) => e.preventDefault()}
-                    aria-describedby="modal-with-form-form-name"
-                    className={formStyles.formGroupLabelHelp}
-                  >
-                    <HelpIcon />
-                  </button>
+                  <FormGroupLabelHelp aria-label="More info for name field" />
                 </Popover>
               }
               isRequired
@@ -100,7 +90,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
             </FormGroup>
             <FormGroup
               label="E-mail"
-              labelIcon={
+              labelHelp={
                 <Popover
                   headerContent={
                     <div>
@@ -124,15 +114,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
                     </div>
                   }
                 >
-                  <button
-                    type="button"
-                    aria-label="More info for e-mail field"
-                    onClick={(e) => e.preventDefault()}
-                    aria-describedby="modal-with-form-form-email"
-                    className={formStyles.formGroupLabelHelp}
-                  >
-                    <HelpIcon />
-                  </button>
+                  <FormGroupLabelHelp aria-label="More info for e-mail field" />
                 </Popover>
               }
               isRequired
@@ -149,7 +131,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
             </FormGroup>
             <FormGroup
               label="Address"
-              labelIcon={
+              labelHelp={
                 <Popover
                   headerContent={
                     <div>
@@ -172,15 +154,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
                     </div>
                   }
                 >
-                  <button
-                    type="button"
-                    aria-label="More info for address field"
-                    onClick={(e) => e.preventDefault()}
-                    aria-describedby="modal-with-form-form-address"
-                    className={formStyles.formGroupLabelHelp}
-                  >
-                    <HelpIcon />
-                  </button>
+                  <FormGroupLabelHelp aria-label="More info for address field" />
                 </Popover>
               }
               isRequired

--- a/packages/react-integration/demo-app-ts/src/components/demos/FormDemo/FormDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/FormDemo/FormDemo.tsx
@@ -3,6 +3,7 @@ import {
   Divider,
   Form,
   FormGroup,
+  FormGroupLabelHelp,
   FormProps,
   FormSection,
   TextInput,
@@ -15,8 +16,6 @@ import {
 } from '@patternfly/react-core';
 import { Select, SelectOption, SelectOptionObject, SelectVariant } from '@patternfly/react-core/deprecated';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
-import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
-import styles from '@patternfly/react-styles/css/components/Form/form';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
 export interface FormState {
@@ -113,7 +112,7 @@ export class FormDemo extends Component<FormProps, FormState> {
             id="form-group-age"
             label="Age"
             labelInfo="Age info"
-            labelIcon={
+            labelHelp={
               <Popover
                 headerContent={<div>The age of a person</div>}
                 bodyContent={
@@ -123,15 +122,7 @@ export class FormDemo extends Component<FormProps, FormState> {
                   </div>
                 }
               >
-                <button
-                  id="helper-text-target"
-                  aria-label="More info for name field"
-                  onClick={(e) => e.preventDefault()}
-                  aria-describedby="simple-form-name"
-                  className={styles.formGroupLabelHelp}
-                >
-                  <HelpIcon />
-                </button>
+                <FormGroupLabelHelp aria-label="More info for name field" />
               </Popover>
             }
             type="number"


### PR DESCRIPTION
**What**: Closes #9931, closes #10055

Things done:
- introduced `FormGroupLabelHelp` component to make using `labelIcon` prop simple
- added some spaces next to label in **FormGroup** to look similar to core

Breaking changes done:
- renamed `labelIcon` prop in **FormGroup** to `labelHelp`
- renamed `isLabelBeforeButton` prop in **Checkbox/Radio** to `labelPosition?: 'start' | 'end'`

Todo:
- update examples of **Checkbox** to show `isLabelWrapped` and `labelPosition="start"` (issue: https://github.com/patternfly/patternfly-react/issues/10085)
- (add Form control examples in React too)