### PR TITLE
refactor(ToggleGroup)

### DIFF
--- a/packages/react-core/src/components/ToggleGroup/ToggleGroupItem.tsx
+++ b/packages/react-core/src/components/ToggleGroup/ToggleGroupItem.tsx
@@ -28,9 +28,9 @@ export const ToggleGroupItem: React.FunctionComponent<ToggleGroupItemProps> = ({
   className,
   isDisabled = false,
   isSelected = false,
-  'aria-label': ariaLabel = '',
+  'aria-label': ariaLabel,
   onChange = () => {},
-  buttonId = '',
+  buttonId,
   ...props
 }: ToggleGroupItemProps) => {
   const handleChange = (event: any): void => {
@@ -49,12 +49,12 @@ export const ToggleGroupItem: React.FunctionComponent<ToggleGroupItemProps> = ({
         className={css(styles.toggleGroupButton, isSelected && styles.modifiers.selected)}
         aria-pressed={isSelected}
         onClick={handleChange}
-        {...(ariaLabel && { 'aria-label': ariaLabel })}
-        {...(isDisabled && { disabled: true })}
-        {...(buttonId && { id: buttonId })}
+        aria-label={ariaLabel}
+        disabled={isDisabled}
+        id={buttonId}
       >
-        {icon ? <ToggleGroupItemElement variant={ToggleGroupItemVariant.icon}>{icon}</ToggleGroupItemElement> : null}
-        {text ? <ToggleGroupItemElement variant={ToggleGroupItemVariant.text}>{text}</ToggleGroupItemElement> : null}
+        {icon && <ToggleGroupItemElement variant={ToggleGroupItemVariant.icon}>{icon}</ToggleGroupItemElement>}
+        {text && <ToggleGroupItemElement variant={ToggleGroupItemVariant.text}>{text}</ToggleGroupItemElement>}
       </button>
     </div>
   );

--- a/packages/react-core/src/components/ToggleGroup/examples/ToggleGroupDefaultMultiple.tsx
+++ b/packages/react-core/src/components/ToggleGroup/examples/ToggleGroupDefaultMultiple.tsx
@@ -17,9 +17,6 @@ export const ToggleGroupDefaultMultiple: React.FunctionComponent = () => {
   return (
     <Stack hasGutter>
       <StackItem>
-        <Button onClick={disableAllClick}>{disableAll ? 'Enable back' : 'Disable all'}</Button>
-      </StackItem>
-      <StackItem>
         <ToggleGroup areAllGroupsDisabled={disableAll} aria-label="Default with multiple selectable">
           <ToggleGroupItem
             text="Option 1"
@@ -37,6 +34,9 @@ export const ToggleGroupDefaultMultiple: React.FunctionComponent = () => {
           />
           <ToggleGroupItem text="Option 3" key={2} isDisabled />
         </ToggleGroup>
+      </StackItem>
+      <StackItem>
+        <Button onClick={disableAllClick}>{disableAll ? 'Enable back' : 'Disable all'}</Button>
       </StackItem>
     </Stack>
   );


### PR DESCRIPTION
**What**: Closes #9982

No token update was necessary.

- updated 1 example to show toggle group at the top
- refactoring

**QUESTION**: in HTML examples https://pf6.patternfly.org/components/toggle-group#icon-and-text there is also a variant with icon **_after_** text. 

<img width="294" alt="Screenshot 2024-01-18 at 11 48 08" src="https://github.com/patternfly/patternfly-react/assets/84135613/03f98301-8927-4c82-96e0-d59ef11cb349">

We currently don't support that in React - is it something we want? 

(I checked design guidelines and none of the examples shows the icon after text)
