### PR TITLE
Bump core lts alphas

### DIFF
--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -54,7 +54,7 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.0.0-alpha.63",
+    "@patternfly/patternfly": "6.0.0-alpha.65",
     "@rollup/plugin-commonjs": "^25.0.0",
     "@rollup/plugin-node-resolve": "^15.0.2",
     "@rollup/plugin-replace": "^5.0.2",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -54,7 +54,7 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.0.0-alpha.65",
+    "@patternfly/patternfly": "6.0.0-alpha.66",
     "@rollup/plugin-commonjs": "^25.0.0",
     "@rollup/plugin-node-resolve": "^15.0.2",
     "@rollup/plugin-replace": "^5.0.2",

--- a/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadStatusItem.tsx
+++ b/packages/react-core/src/components/MultipleFileUpload/MultipleFileUploadStatusItem.tsx
@@ -165,7 +165,8 @@ export const MultipleFileUploadStatusItem: React.FunctionComponent<MultipleFileU
           helperText={progressHelperText}
         />
       </div>
-      <div className={styles.multipleFileUploadStatusItemClose}>
+      {/* TODO: Update with issue #9997.  Removed class "styles.multipleFileUploadStatusItemClose" that no longer exists */}
+      <div>
         <Button variant="plain" aria-label={buttonAriaLabel} onClick={onClearClick}>
           <TimesCircleIcon />
         </Button>

--- a/packages/react-core/src/components/MultipleFileUpload/__tests__/__snapshots__/MultipleFileUploadStatusItem.test.tsx.snap
+++ b/packages/react-core/src/components/MultipleFileUpload/__tests__/__snapshots__/MultipleFileUploadStatusItem.test.tsx.snap
@@ -85,9 +85,7 @@ exports[`MultipleFileUploadStatusItem renders custom aria labels 1`] = `
         </div>
       </div>
     </div>
-    <div
-      class="pf-v5-c-multiple-file-upload__status-item-close"
-    >
+    <div>
       <button
         aria-disabled="false"
         aria-label="buttonAriaLabel"
@@ -198,9 +196,7 @@ exports[`MultipleFileUploadStatusItem renders custom class names 1`] = `
         </div>
       </div>
     </div>
-    <div
-      class="pf-v5-c-multiple-file-upload__status-item-close"
-    >
+    <div>
       <button
         aria-disabled="false"
         aria-label="Remove from list"
@@ -313,9 +309,7 @@ exports[`MultipleFileUploadStatusItem renders custom file name/size/icon/progres
         </div>
       </div>
     </div>
-    <div
-      class="pf-v5-c-multiple-file-upload__status-item-close"
-    >
+    <div>
       <button
         aria-disabled="false"
         aria-label="Remove from list"
@@ -428,9 +422,7 @@ exports[`MultipleFileUploadStatusItem renders custom function progressAriaLiveMe
         </div>
       </div>
     </div>
-    <div
-      class="pf-v5-c-multiple-file-upload__status-item-close"
-    >
+    <div>
       <button
         aria-disabled="false"
         aria-label="Remove from list"
@@ -560,9 +552,7 @@ exports[`MultipleFileUploadStatusItem renders custom progress value/variant when
         </div>
       </div>
     </div>
-    <div
-      class="pf-v5-c-multiple-file-upload__status-item-close"
-    >
+    <div>
       <button
         aria-disabled="false"
         aria-label="Remove from list"
@@ -675,9 +665,7 @@ exports[`MultipleFileUploadStatusItem renders expected values from a passed file
         </div>
       </div>
     </div>
-    <div
-      class="pf-v5-c-multiple-file-upload__status-item-close"
-    >
+    <div>
       <button
         aria-disabled="false"
         aria-label="Remove from list"
@@ -788,9 +776,7 @@ exports[`MultipleFileUploadStatusItem renders with expected class names 1`] = `
         </div>
       </div>
     </div>
-    <div
-      class="pf-v5-c-multiple-file-upload__status-item-close"
-    >
+    <div>
       <button
         aria-disabled="false"
         aria-label="Remove from list"
@@ -903,9 +889,7 @@ exports[`MultipleFileUploadStatusItem rendersdefault progressAriaLiveMessage whe
         </div>
       </div>
     </div>
-    <div
-      class="pf-v5-c-multiple-file-upload__status-item-close"
-    >
+    <div>
       <button
         aria-disabled="false"
         aria-label="Remove from list"

--- a/packages/react-core/src/components/Toolbar/ToolbarChipGroupContent.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarChipGroupContent.tsx
@@ -74,7 +74,8 @@ class ToolbarChipGroupContent extends React.Component<ToolbarChipGroupContentPro
       <div
         className={css(
           styles.toolbarContent,
-          !isHidden && !collapseListedFilters && styles.modifiers.chipContainer,
+          // TODO: Update with issue issue #9677
+          // !isHidden && !collapseListedFilters && styles.modifiers.chipContainer,
           isHidden && styles.modifiers.hidden,
           className
         )}

--- a/packages/react-core/src/components/Toolbar/ToolbarExpandableContent.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarExpandableContent.tsx
@@ -61,7 +61,8 @@ class ToolbarExpandableContent extends React.Component<ToolbarExpandableContentP
       >
         <ToolbarGroup>{children}</ToolbarGroup>
         {numberOfFilters > 0 && (
-          <ToolbarGroup className={styles.modifiers.chipContainer}>
+          // TODO: Update with issue issue #9677. Removed 'chipContainer' modifier
+          <ToolbarGroup>
             <ToolbarGroup ref={chipContainerRef} />
             {showClearFiltersButton && !customChipGroupContent && (
               <ToolbarItem>

--- a/packages/react-core/src/components/Toolbar/ToolbarGroup.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarGroup.tsx
@@ -82,7 +82,8 @@ class ToolbarGroupWithRef extends React.Component<ToolbarGroupProps> {
           <div
             className={css(
               styles.toolbarGroup,
-              variant && styles.modifiers[toCamel(variant) as 'filterGroup' | 'iconButtonGroup' | 'buttonGroup'],
+              // TODO: Update with issue #9677.  Removed "buttonGroup" modifier
+              variant && styles.modifiers[toCamel(variant) as 'filterGroup' | 'iconButtonGroup'],
               formatBreakpointMods(visibility, styles, '', getBreakpoint(width)),
               formatBreakpointMods(align, styles, '', getBreakpoint(width)),
               formatBreakpointMods(spacer, styles, '', getBreakpoint(width)),

--- a/packages/react-core/src/components/Toolbar/ToolbarItem.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarItem.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/Toolbar/toolbar';
 import { css } from '@patternfly/react-styles';
-import cssWidth from '@patternfly/react-tokens/dist/esm/c_toolbar__item_Width';
+// TODO: Update with issue #9677
+// import cssWidth from '@patternfly/react-tokens/dist/esm/c_toolbar__item_Width';
 
 import { formatBreakpointMods, toCamel } from '../../helpers/util';
 import { Divider } from '../Divider';
@@ -84,7 +85,8 @@ export const ToolbarItem: React.FunctionComponent<ToolbarItemProps> = ({
   variant,
   visibility,
   spacer,
-  widths,
+  // TODO: Update with issue #9677
+  // widths,
   align,
   alignSelf,
   alignItems,
@@ -95,16 +97,17 @@ export const ToolbarItem: React.FunctionComponent<ToolbarItemProps> = ({
   ...props
 }: ToolbarItemProps) => {
   if (variant === ToolbarItemVariant.separator) {
-    return <Divider className={css(styles.modifiers.vertical, className)} {...props} />;
+    return <Divider className={css(className)} orientation={{ default: 'vertical' }} {...props} />;
   }
 
-  const widthStyles: any = {};
-  if (widths) {
-    Object.entries(widths || {}).map(
-      ([breakpoint, value]) =>
-        (widthStyles[`${cssWidth.name}${breakpoint !== 'default' ? `-on-${breakpoint}` : ''}`] = value)
-    );
-  }
+  // TODO: Update with issue #9677
+  // const widthStyles: any = {};
+  // if (widths) {
+  //   Object.entries(widths || {}).map(
+  //     ([breakpoint, value]) =>
+  //       (widthStyles[`${cssWidth.name}${breakpoint !== 'default' ? `-on-${breakpoint}` : ''}`] = value)
+  //   );
+  // }
 
   return (
     <PageContext.Consumer>
@@ -113,15 +116,8 @@ export const ToolbarItem: React.FunctionComponent<ToolbarItemProps> = ({
           className={css(
             styles.toolbarItem,
             variant &&
-              styles.modifiers[
-                toCamel(variant) as
-                  | 'bulkSelect'
-                  | 'overflowMenu'
-                  | 'pagination'
-                  | 'searchFilter'
-                  | 'label'
-                  | 'chipGroup'
-              ],
+              // TODO: Update with issue #9677.  Removed "bulkSleect", "overflowMenu" and "searchFilter" modifiers
+              styles.modifiers[toCamel(variant) as 'pagination' | 'label' | 'chipGroup'],
             isAllExpanded && styles.modifiers.expanded,
             isOverflowContainer && styles.modifiers.overflowContainer,
             formatBreakpointMods(visibility, styles, '', getBreakpoint(width)),
@@ -138,7 +134,8 @@ export const ToolbarItem: React.FunctionComponent<ToolbarItemProps> = ({
           {...(variant === 'label' && { 'aria-hidden': true })}
           id={id}
           {...props}
-          {...(widths && { style: { ...widthStyles, ...props.style } as React.CSSProperties })}
+          // TODO: Update with issue #9677
+          // {...(widths && { style: { ...widthStyles, ...props.style } as React.CSSProperties })}
         >
           {children}
         </div>

--- a/packages/react-core/src/components/Toolbar/ToolbarToggleGroup.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarToggleGroup.tsx
@@ -162,8 +162,8 @@ class ToolbarToggleGroup extends React.Component<ToolbarToggleGroupProps> {
                         className={css(
                           styles.toolbarGroup,
                           styles.modifiers.toggleGroup,
-                          variant &&
-                            styles.modifiers[toCamel(variant) as 'filterGroup' | 'iconButtonGroup' | 'buttonGroup'],
+                          // TODO: Update with issue #9677.  Removed "buttonGroup" modifier
+                          variant && styles.modifiers[toCamel(variant) as 'filterGroup' | 'iconButtonGroup'],
                           formatBreakpointMods(breakpointMod, styles, '', getBreakpoint(width)),
                           formatBreakpointMods(visibility, styles, '', getBreakpoint(width)),
                           formatBreakpointMods(alignment, styles, '', getBreakpoint(width)),

--- a/packages/react-core/src/components/Toolbar/__tests__/__snapshots__/ToolbarItem.test.tsx.snap
+++ b/packages/react-core/src/components/Toolbar/__tests__/__snapshots__/ToolbarItem.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`ToolbarItem should map width breakpoints 1`] = `
 <DocumentFragment>
   <div
     class="pf-v5-c-toolbar__item"
-    style="--pf-v5-c-toolbar__item--Width: 100px; --pf-v5-c-toolbar__item--Width-on-sm: 80px; --pf-v5-c-toolbar__item--Width-on-md: 150px; --pf-v5-c-toolbar__item--Width-on-lg: 200px; --pf-v5-c-toolbar__item--Width-on-xl: 250px; --pf-v5-c-toolbar__item--Width-on-2xl: 300px;"
+    widths="[object Object]"
   >
     Test
   </div>

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -23,7 +23,7 @@
     "test:a11y": "patternfly-a11y --config patternfly-a11y.config"
   },
   "dependencies": {
-    "@patternfly/patternfly": "6.0.0-alpha.63",
+    "@patternfly/patternfly": "6.0.0-alpha.66",
     "@patternfly/react-charts": "^8.0.0-alpha.8",
     "@patternfly/react-code-editor": "^6.0.0-alpha.17",
     "@patternfly/react-core": "^6.0.0-alpha.17",

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -33,7 +33,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.14.0",
     "@fortawesome/free-regular-svg-icons": "^5.14.0",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
-    "@patternfly/patternfly": "6.0.0-alpha.65",
+    "@patternfly/patternfly": "6.0.0-alpha.66",
     "fs-extra": "^11.1.1",
     "glob": "^7.1.2",
     "rimraf": "^2.6.2",

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -33,7 +33,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.14.0",
     "@fortawesome/free-regular-svg-icons": "^5.14.0",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
-    "@patternfly/patternfly": "6.0.0-alpha.63",
+    "@patternfly/patternfly": "6.0.0-alpha.65",
     "fs-extra": "^11.1.1",
     "glob": "^7.1.2",
     "rimraf": "^2.6.2",

--- a/packages/react-styles/package.json
+++ b/packages/react-styles/package.json
@@ -19,7 +19,7 @@
     "clean": "rimraf dist css"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.0.0-alpha.63",
+    "@patternfly/patternfly": "6.0.0-alpha.65",
     "camel-case": "^3.0.0",
     "css": "^2.2.3",
     "fs-extra": "^11.1.1",

--- a/packages/react-styles/package.json
+++ b/packages/react-styles/package.json
@@ -19,7 +19,7 @@
     "clean": "rimraf dist css"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.0.0-alpha.65",
+    "@patternfly/patternfly": "6.0.0-alpha.66",
     "camel-case": "^3.0.0",
     "css": "^2.2.3",
     "fs-extra": "^11.1.1",

--- a/packages/react-tokens/package.json
+++ b/packages/react-tokens/package.json
@@ -29,7 +29,7 @@
     "clean": "rimraf dist"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.0.0-alpha.63",
+    "@patternfly/patternfly": "6.0.0-alpha.65",
     "css": "^2.2.3",
     "fs-extra": "^11.1.1",
     "glob": "^7.1.2",

--- a/packages/react-tokens/package.json
+++ b/packages/react-tokens/package.json
@@ -29,7 +29,7 @@
     "clean": "rimraf dist"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.0.0-alpha.65",
+    "@patternfly/patternfly": "6.0.0-alpha.66",
     "css": "^2.2.3",
     "fs-extra": "^11.1.1",
     "glob": "^7.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3975,10 +3975,10 @@
     puppeteer-cluster "^0.23.0"
     xmldoc "^1.1.2"
 
-"@patternfly/patternfly@6.0.0-alpha.65":
-  version "6.0.0-alpha.65"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-6.0.0-alpha.65.tgz#5efb8518215e44c571d94e9c1b90e790be708103"
-  integrity sha512-cA2WZrWUdpOEEErei8MiYGq6GaecyhWnFDwm54N02uUs4YscnmcY4GQlCQCPDYQrkghLAhFA64MCs99kRuUcJw==
+"@patternfly/patternfly@6.0.0-alpha.66":
+  version "6.0.0-alpha.66"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-6.0.0-alpha.66.tgz#e06e003a128050eb9b27e1d37ec9ebf61f663f24"
+  integrity sha512-pUKNGcKKyKwc9xb/ZQS27juxxRCewdji/Mvd6UQuLJxtiEIY/pRavNW7lDa3k4qqbD90tlWnsfSct4WRSwpRsg==
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3975,10 +3975,10 @@
     puppeteer-cluster "^0.23.0"
     xmldoc "^1.1.2"
 
-"@patternfly/patternfly@6.0.0-alpha.63":
-  version "6.0.0-alpha.63"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-6.0.0-alpha.63.tgz#8342777ebc70be8ebc9c5e18be3bc9818d70044d"
-  integrity sha512-RlgJcurd4lvqH98uZx+hrj+AY5gq5MRyXtSo/M6fEdW0LREi2xhHv4XeXD+f2npWk9VKTLzUl2AcxwzKMG4p/Q==
+"@patternfly/patternfly@6.0.0-alpha.65":
+  version "6.0.0-alpha.65"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-6.0.0-alpha.65.tgz#5efb8518215e44c571d94e9c1b90e790be708103"
+  integrity sha512-cA2WZrWUdpOEEErei8MiYGq6GaecyhWnFDwm54N02uUs4YscnmcY4GQlCQCPDYQrkghLAhFA64MCs99kRuUcJw==
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #10018

Additional core bump PR

Towards: #9997, #9677

- Multifile upload (#9997): 
   - Removed class "styles.multipleFileUploadStatusItemClose" that no longer exists
- Toolbar (#9677):
   - removed application of `pf-m-chip-container` modifier on toolbar group in ToolbarExpandableContent.tsx
   -  removed application of `pf-m-buttonGroup` modifier on toolbar group in 
   - removed import of `@patternfly/react-tokens/dist/esm/c_toolbar__item_Width` since it no longer exists. also comment out `widths` prop application since it depends on the token.
   - Removed `bulkSelect`, `overflowMenu`, `searchFilter` modifier applications on toolbar item
   