### PR TITLE
feat(Icon): add new icon sizes for penta

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,7 +14,9 @@ module.exports = {
     '^.+\\.svg$': 'jest-transform-stub'
   },
   setupFilesAfterEnv: ['<rootDir>/packages/testSetup.ts'],
-  transformIgnorePatterns: ['node_modules/(?!@patternfly|@novnc|@popperjs|lodash|monaco-editor|react-monaco-editor)'],
+  transformIgnorePatterns: [
+    'node_modules/(?!@patternfly|@novnc|@popperjs|lodash|monaco-editor|react-monaco-editor|case-anything)'
+  ],
   testPathIgnorePatterns: ['<rootDir>/packages/react-integration/'],
   coveragePathIgnorePatterns: ['/dist/'],
   moduleNameMapper: {

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -66,7 +66,8 @@
     "rollup-plugin-scss": "^4.0.0",
     "rollup-plugin-svg": "2.0.0",
     "rollup-plugin-terser": "^7.0.2",
-    "typescript": "^4.7.4"
+    "typescript": "^4.7.4",
+    "case-anything": "^2.1.13"
   },
   "peerDependencies": {
     "react": "^17 || ^18",

--- a/packages/react-core/src/components/Icon/Icon.tsx
+++ b/packages/react-core/src/components/Icon/Icon.tsx
@@ -3,6 +3,23 @@ import styles from '@patternfly/react-styles/css/components/Icon/icon';
 import { css } from '@patternfly/react-styles';
 import { Spinner } from '../Spinner';
 
+export type IconSize =
+  | 'sm'
+  | 'md'
+  | 'lg'
+  | 'xl'
+  | '2xl'
+  | '3xl'
+  | 'headingSm'
+  | 'headingMd'
+  | 'headingLg'
+  | 'headingXl'
+  | 'heading_2xl'
+  | 'heading_3xl'
+  | 'bodySm'
+  | 'bodyDefault'
+  | 'bodyLg';
+
 export interface IconComponentProps extends Omit<React.HTMLProps<HTMLSpanElement>, 'size'> {
   /** Icon content */
   children?: React.ReactNode;
@@ -11,11 +28,11 @@ export interface IconComponentProps extends Omit<React.HTMLProps<HTMLSpanElement
   /** Additional classes applied to the icon container */
   className?: string;
   /** Size of the icon component container and icon. */
-  size?: 'sm' | 'md' | 'lg' | 'xl';
+  size?: IconSize;
   /** Size of icon. Overrides the icon size set by the size property. */
-  iconSize?: 'sm' | 'md' | 'lg' | 'xl';
+  iconSize?: IconSize;
   /** Size of progress icon. Overrides the icon size set by the size property. */
-  progressIconSize?: 'sm' | 'md' | 'lg' | 'xl';
+  progressIconSize?: IconSize;
   /** Status color of the icon */
   status?: 'custom' | 'info' | 'success' | 'warning' | 'danger';
   /** Indicates the icon is inline and should inherit the text font size and color. Overriden by size and iconSize properties. */

--- a/packages/react-core/src/components/Icon/__tests__/Icon.test.tsx
+++ b/packages/react-core/src/components/Icon/__tests__/Icon.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
-import { Icon } from '../Icon';
+import { kebabCase } from 'case-anything';
+import { Icon, IconSize } from '../Icon';
 import CheckIcon from '@patternfly/react-icons/dist/esm/icons/check-icon';
 import styles from '@patternfly/react-styles/css/components/Icon/icon';
 
@@ -41,16 +42,34 @@ test('sets additional custom class successfully', () => {
   expect(iconContainer).toHaveClass('test');
 });
 
-Object.values(['sm', 'md', 'lg', 'xl']).forEach((size) => {
+Object.values([
+  'sm',
+  'md',
+  'lg',
+  'xl',
+  '2xl',
+  '3xl',
+  'headingSm',
+  'headingMd',
+  'headingLg',
+  'headingXl',
+  'heading_2xl',
+  'heading_3xl',
+  'bodySm',
+  'bodyDefault',
+  'bodyLg'
+]).forEach((size) => {
   test(`sets icon size modifier successfully - ${size}`, () => {
     render(
-      <Icon iconSize={size as 'sm' | 'md' | 'lg' | 'xl'} title={`content-${size}-icon`}>
+      <Icon iconSize={size as IconSize} title={`content-${size}-icon`}>
         <CheckIcon />
       </Icon>
     );
     const iconContainer = screen.getByTitle(`content-${size}-icon`).querySelector(`.${styles.iconContent}`);
 
-    expect(iconContainer).toHaveClass(`pf-m-${size}`);
+    const formattedSize = kebabCase(size).replace(/(\d)(-)/, '$1');
+
+    expect(iconContainer).toHaveClass(`pf-m-${formattedSize}`);
   });
 });
 
@@ -64,16 +83,34 @@ test('check icon without iconSize', () => {
   expect(Array.from(iconContainer?.classList || []).some((c) => /pf-m-*/.test(c))); // Check no modifier classes have been added
 });
 
-Object.values(['sm', 'md', 'lg', 'xl']).forEach((size) => {
+Object.values([
+  'sm',
+  'md',
+  'lg',
+  'xl',
+  '2xl',
+  '3xl',
+  'headingSm',
+  'headingMd',
+  'headingLg',
+  'headingXl',
+  'heading_2xl',
+  'heading_3xl',
+  'bodySm',
+  'bodyDefault',
+  'bodyLg'
+]).forEach((size) => {
   test(`sets progress icon size modifier successfully - ${size}`, () => {
     render(
-      <Icon isInProgress progressIconSize={size as 'sm' | 'md' | 'lg' | 'xl'} title={`progress-content-${size}-icon`}>
+      <Icon isInProgress progressIconSize={size as IconSize} title={`progress-content-${size}-icon`}>
         <CheckIcon />
       </Icon>
     );
     const iconContainer = screen.getByTitle(`progress-content-${size}-icon`).querySelector(`.${styles.iconProgress}`);
 
-    expect(iconContainer).toHaveClass(`pf-m-${size}`);
+    const formattedSize = kebabCase(size).replace(/(\d)(-)/, '$1');
+
+    expect(iconContainer).toHaveClass(`pf-m-${formattedSize}`);
   });
 });
 
@@ -87,16 +124,34 @@ test('check icon without progress icon size', () => {
   expect(Array.from(iconContainer?.classList || []).some((c) => /pf-m-*/.test(c))); // Check no modifier classes have been added
 });
 
-Object.values(['sm', 'md', 'lg', 'xl']).forEach((size) => {
+Object.values([
+  'sm',
+  'md',
+  'lg',
+  'xl',
+  '2xl',
+  '3xl',
+  'headingSm',
+  'headingMd',
+  'headingLg',
+  'headingXl',
+  'heading_2xl',
+  'heading_3xl',
+  'bodySm',
+  'bodyDefault',
+  'bodyLg'
+]).forEach((size) => {
   test(`sets size modifier successfully - ${size}`, () => {
     render(
-      <Icon size={size as 'sm' | 'md' | 'lg' | 'xl'} title={`${size}-icon`}>
+      <Icon size={size as IconSize} title={`${size}-icon`}>
         <CheckIcon />
       </Icon>
     );
     const iconContainer = screen.getByTitle(`${size}-icon`);
 
-    expect(iconContainer).toHaveClass(`pf-m-${size}`);
+    const formattedSize = kebabCase(size).replace(/(\d)(-)/, '$1');
+
+    expect(iconContainer).toHaveClass(`pf-m-${formattedSize}`);
   });
 });
 

--- a/packages/react-core/src/components/Icon/__tests__/Icon.test.tsx
+++ b/packages/react-core/src/components/Icon/__tests__/Icon.test.tsx
@@ -71,35 +71,7 @@ Object.values([
 
     expect(iconContainer).toHaveClass(`pf-m-${formattedSize}`);
   });
-});
 
-test('check icon without iconSize', () => {
-  render(
-    <Icon title="no-icon-size">
-      <CheckIcon />
-    </Icon>
-  );
-  const iconContainer = screen.getByTitle('no-icon-size').querySelector(`.${styles.iconContent}`);
-  expect(Array.from(iconContainer?.classList || []).some((c) => /pf-m-*/.test(c))); // Check no modifier classes have been added
-});
-
-Object.values([
-  'sm',
-  'md',
-  'lg',
-  'xl',
-  '2xl',
-  '3xl',
-  'headingSm',
-  'headingMd',
-  'headingLg',
-  'headingXl',
-  'heading_2xl',
-  'heading_3xl',
-  'bodySm',
-  'bodyDefault',
-  'bodyLg'
-]).forEach((size) => {
   test(`sets progress icon size modifier successfully - ${size}`, () => {
     render(
       <Icon isInProgress progressIconSize={size as IconSize} title={`progress-content-${size}-icon`}>
@@ -112,35 +84,7 @@ Object.values([
 
     expect(iconContainer).toHaveClass(`pf-m-${formattedSize}`);
   });
-});
 
-test('check icon without progress icon size', () => {
-  render(
-    <Icon title="no-progress-icon-size">
-      <CheckIcon />
-    </Icon>
-  );
-  const iconContainer = screen.getByTitle('no-progress-icon-size').querySelector(`.${styles.iconProgress}`);
-  expect(Array.from(iconContainer?.classList || []).some((c) => /pf-m-*/.test(c))); // Check no modifier classes have been added
-});
-
-Object.values([
-  'sm',
-  'md',
-  'lg',
-  'xl',
-  '2xl',
-  '3xl',
-  'headingSm',
-  'headingMd',
-  'headingLg',
-  'headingXl',
-  'heading_2xl',
-  'heading_3xl',
-  'bodySm',
-  'bodyDefault',
-  'bodyLg'
-]).forEach((size) => {
   test(`sets size modifier successfully - ${size}`, () => {
     render(
       <Icon size={size as IconSize} title={`${size}-icon`}>
@@ -153,6 +97,26 @@ Object.values([
 
     expect(iconContainer).toHaveClass(`pf-m-${formattedSize}`);
   });
+});
+
+test('check icon without iconSize', () => {
+  render(
+    <Icon title="no-icon-size">
+      <CheckIcon />
+    </Icon>
+  );
+  const iconContainer = screen.getByTitle('no-icon-size').querySelector(`.${styles.iconContent}`);
+  expect(Array.from(iconContainer?.classList || []).some((c) => /pf-m-*/.test(c))); // Check no modifier classes have been added
+});
+
+test('check icon without progress icon size', () => {
+  render(
+    <Icon title="no-progress-icon-size">
+      <CheckIcon />
+    </Icon>
+  );
+  const iconContainer = screen.getByTitle('no-progress-icon-size').querySelector(`.${styles.iconProgress}`);
+  expect(Array.from(iconContainer?.classList || []).some((c) => /pf-m-*/.test(c))); // Check no modifier classes have been added
 });
 
 test('check icon without size', () => {

--- a/packages/react-core/src/components/Icon/examples/BodyIconSizes.tsx
+++ b/packages/react-core/src/components/Icon/examples/BodyIconSizes.tsx
@@ -2,18 +2,15 @@ import React from 'react';
 import { Icon } from '@patternfly/react-core';
 import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 
-export const IconSizes: React.FunctionComponent = () => (
+export const BodyIconSizes: React.FunctionComponent = () => (
   <React.Fragment>
-    <Icon size="sm">
+    <Icon size="bodySm">
       <PlusCircleIcon />
     </Icon>
-    <Icon size="md">
+    <Icon size="bodyDefault">
       <PlusCircleIcon />
     </Icon>
-    <Icon size="lg">
-      <PlusCircleIcon />
-    </Icon>
-    <Icon size="xl">
+    <Icon size="bodyLg">
       <PlusCircleIcon />
     </Icon>
   </React.Fragment>

--- a/packages/react-core/src/components/Icon/examples/HeadingIconSizes.tsx
+++ b/packages/react-core/src/components/Icon/examples/HeadingIconSizes.tsx
@@ -2,18 +2,24 @@ import React from 'react';
 import { Icon } from '@patternfly/react-core';
 import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 
-export const IconContentSizes: React.FunctionComponent = () => (
+export const HeadingIconSizes: React.FunctionComponent = () => (
   <React.Fragment>
-    <Icon size="3xl" iconSize="lg">
+    <Icon size="headingSm">
       <PlusCircleIcon />
     </Icon>
-    <Icon size="3xl" iconSize="xl">
+    <Icon size="headingMd">
       <PlusCircleIcon />
     </Icon>
-    <Icon size="3xl" iconSize="2xl">
+    <Icon size="headingLg">
       <PlusCircleIcon />
     </Icon>
-    <Icon size="3xl">
+    <Icon size="headingXl">
+      <PlusCircleIcon />
+    </Icon>
+    <Icon size="heading_2xl">
+      <PlusCircleIcon />
+    </Icon>
+    <Icon size="heading_3xl">
       <PlusCircleIcon />
     </Icon>
   </React.Fragment>

--- a/packages/react-core/src/components/Icon/examples/Icon.md
+++ b/packages/react-core/src/components/Icon/examples/Icon.md
@@ -23,9 +23,25 @@ import BellIcon from '@patternfly/react-icons/dist/esm/icons/bell-icon';
 ```ts file="IconBasic.tsx"
 ```
 
-### Sizes
+### Standalone icon sizes
 
-```ts file="IconSizes.tsx"
+These are the standard options for sizing icons.
+
+```ts file="StandaloneIconSizes.tsx"
+```
+
+### Body sizes
+
+These size options are meant to make icons match the size of body text.
+
+```ts file="BodyIconSizes.tsx"
+```
+
+### Heading sizes
+
+These size options are meant to make icons match the size of heading text.
+
+```ts file="HeadingIconSizes.tsx"
 ```
 
 ### Status colors

--- a/packages/react-core/src/components/Icon/examples/StandaloneIconSizes.tsx
+++ b/packages/react-core/src/components/Icon/examples/StandaloneIconSizes.tsx
@@ -2,15 +2,21 @@ import React from 'react';
 import { Icon } from '@patternfly/react-core';
 import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 
-export const IconContentSizes: React.FunctionComponent = () => (
+export const StandaloneIconSizes: React.FunctionComponent = () => (
   <React.Fragment>
-    <Icon size="3xl" iconSize="lg">
+    <Icon size="sm">
       <PlusCircleIcon />
     </Icon>
-    <Icon size="3xl" iconSize="xl">
+    <Icon size="md">
       <PlusCircleIcon />
     </Icon>
-    <Icon size="3xl" iconSize="2xl">
+    <Icon size="lg">
+      <PlusCircleIcon />
+    </Icon>
+    <Icon size="xl">
+      <PlusCircleIcon />
+    </Icon>
+    <Icon size="2xl">
       <PlusCircleIcon />
     </Icon>
     <Icon size="3xl">

--- a/yarn.lock
+++ b/yarn.lock
@@ -6851,6 +6851,11 @@ capture-stack-trace@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz"
 
+case-anything@^2.1.13:
+  version "2.1.13"
+  resolved "https://registry.yarnpkg.com/case-anything/-/case-anything-2.1.13.tgz#0cdc16278cb29a7fcdeb072400da3f342ba329e9"
+  integrity sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==
+
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #9988

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:

I added the `case-anything` package to handle changing case (i.e. cameCase to kebab-case) for us, needed it for converting prop values to class names in the updated Icon tests.

Convenience link: https://patternfly-react-pr-10030.surge.sh/components/icon/