### PR TITLE
feat(ActionList): consumed Penta updates

### DIFF
--- a/packages/react-core/src/components/ActionList/ActionList.tsx
+++ b/packages/react-core/src/components/ActionList/ActionList.tsx
@@ -14,7 +14,7 @@ export interface ActionListProps extends React.HTMLProps<HTMLDivElement> {
 export const ActionList: React.FunctionComponent<ActionListProps> = ({
   children,
   isIconList,
-  className = '',
+  className,
   ...props
 }: ActionListProps) => (
   <div className={css(styles.actionList, isIconList && styles.modifiers.icons, className)} {...props}>

--- a/packages/react-core/src/components/ActionList/ActionListGroup.tsx
+++ b/packages/react-core/src/components/ActionList/ActionListGroup.tsx
@@ -7,14 +7,17 @@ export interface ActionListGroupProps extends React.HTMLProps<HTMLDivElement> {
   children?: React.ReactNode;
   /** Additional classes added to the action list group */
   className?: string;
+  /** Flag indicating the action list group contains multiple icons and item padding should be removed */
+  isIconGroup?: boolean;
 }
 
 export const ActionListGroup: React.FunctionComponent<ActionListGroupProps> = ({
   children,
-  className = '',
+  className,
+  isIconGroup,
   ...props
 }: ActionListGroupProps) => (
-  <div className={css(styles.actionListGroup, className)} {...props}>
+  <div className={css(styles.actionListGroup, isIconGroup && styles.modifiers.icons, className)} {...props}>
     {children}
   </div>
 );

--- a/packages/react-core/src/components/ActionList/ActionListItem.tsx
+++ b/packages/react-core/src/components/ActionList/ActionListItem.tsx
@@ -11,7 +11,7 @@ export interface ActionListItemProps extends React.HTMLProps<HTMLDivElement> {
 
 export const ActionListItem: React.FunctionComponent<ActionListItemProps> = ({
   children,
-  className = '',
+  className,
   ...props
 }: ActionListItemProps) => (
   <div className={css(`${styles.actionList}__item`, className)} {...props}>

--- a/packages/react-core/src/components/ActionList/__tests__/ActionListGroup.test.tsx
+++ b/packages/react-core/src/components/ActionList/__tests__/ActionListGroup.test.tsx
@@ -14,10 +14,16 @@ test('Renders children', () => {
   expect(screen.getByText('Test')).toBeVisible();
 });
 
-test(`Renders with class ${styles.actionListGroup}`, () => {
+test(`Renders with only class ${styles.actionListGroup} by default`, () => {
   render(<ActionListGroup>Test</ActionListGroup>);
 
-  expect(screen.getByText('Test')).toHaveClass(styles.actionListGroup);
+  expect(screen.getByText('Test')).toHaveClass(styles.actionListGroup, { exact: true });
+});
+
+test(`Renders with class ${styles.modifiers.icons} when isIconGroup is true`, () => {
+  render(<ActionListGroup isIconGroup>Test</ActionListGroup>);
+
+  expect(screen.getByText('Test')).toHaveClass(styles.modifiers.icons);
 });
 
 test('Renders with custom class names provided via prop', () => {

--- a/packages/react-core/src/components/ActionList/examples/ActionListSingleGroup.tsx
+++ b/packages/react-core/src/components/ActionList/examples/ActionListSingleGroup.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   ActionList,
+  ActionListGroup,
   ActionListItem,
   Button,
   Dropdown,
@@ -46,50 +47,54 @@ export const ActionListSingleGroup: React.FunctionComponent = () => {
   return (
     <React.Fragment>
       <ActionList>
-        <ActionListItem>
-          <Button variant="primary" id="single-group-next-button">
-            Next
-          </Button>
-        </ActionListItem>
-        <ActionListItem>
-          <Button variant="secondary" id="single-group-back-button">
-            Back
-          </Button>
-        </ActionListItem>
+        <ActionListGroup>
+          <ActionListItem>
+            <Button variant="primary" id="single-group-next-button">
+              Next
+            </Button>
+          </ActionListItem>
+          <ActionListItem>
+            <Button variant="secondary" id="single-group-back-button">
+              Back
+            </Button>
+          </ActionListItem>
+        </ActionListGroup>
       </ActionList>
       <br />
       With kebab
       <ActionList>
-        <ActionListItem>
-          <Button variant="primary" id="single-group-next-button2">
-            Next
-          </Button>
-        </ActionListItem>
-        <ActionListItem>
-          <Button variant="secondary" id="single-group-back-button2">
-            Back
-          </Button>
-        </ActionListItem>
-        <ActionListItem>
-          <Dropdown
-            onSelect={onSelect}
-            toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-              <MenuToggle
-                ref={toggleRef}
-                onClick={onToggle}
-                variant="plain"
-                isExpanded={isOpen}
-                aria-label="Action list single group kebab"
-              >
-                <EllipsisVIcon />
-              </MenuToggle>
-            )}
-            isOpen={isOpen}
-            onOpenChange={(isOpen: boolean) => setIsOpen(isOpen)}
-          >
-            <DropdownList>{dropdownItems}</DropdownList>
-          </Dropdown>
-        </ActionListItem>
+        <ActionListGroup>
+          <ActionListItem>
+            <Button variant="primary" id="single-group-next-button2">
+              Next
+            </Button>
+          </ActionListItem>
+          <ActionListItem>
+            <Button variant="secondary" id="single-group-back-button2">
+              Back
+            </Button>
+          </ActionListItem>
+          <ActionListItem>
+            <Dropdown
+              onSelect={onSelect}
+              toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                <MenuToggle
+                  ref={toggleRef}
+                  onClick={onToggle}
+                  variant="plain"
+                  isExpanded={isOpen}
+                  aria-label="Action list single group kebab"
+                >
+                  <EllipsisVIcon />
+                </MenuToggle>
+              )}
+              isOpen={isOpen}
+              onOpenChange={(isOpen: boolean) => setIsOpen(isOpen)}
+            >
+              <DropdownList>{dropdownItems}</DropdownList>
+            </Dropdown>
+          </ActionListItem>
+        </ActionListGroup>
       </ActionList>
     </React.Fragment>
   );

--- a/packages/react-core/src/components/ActionList/examples/ActionListWithCancelButton.tsx
+++ b/packages/react-core/src/components/ActionList/examples/ActionListWithCancelButton.tsx
@@ -5,16 +5,18 @@ export const ActionListWithCancelButton: React.FunctionComponent = () => (
   <React.Fragment>
     In modals, forms, data lists
     <ActionList>
-      <ActionListItem>
-        <Button variant="primary" id="with-cancel-save-button">
-          Save
-        </Button>
-      </ActionListItem>
-      <ActionListItem>
-        <Button variant="link" id="with-cancel-cancel-button">
-          Cancel
-        </Button>
-      </ActionListItem>
+      <ActionListGroup>
+        <ActionListItem>
+          <Button variant="primary" id="with-cancel-save-button">
+            Save
+          </Button>
+        </ActionListItem>
+        <ActionListItem>
+          <Button variant="link" id="with-cancel-cancel-button">
+            Cancel
+          </Button>
+        </ActionListItem>
+      </ActionListGroup>
     </ActionList>
     <br />
     In wizards

--- a/packages/react-core/src/components/ActionList/examples/ActionListWithIcons.tsx
+++ b/packages/react-core/src/components/ActionList/examples/ActionListWithIcons.tsx
@@ -1,19 +1,50 @@
 import React from 'react';
-import { ActionList, ActionListItem, Button } from '@patternfly/react-core';
+import { ActionList, ActionListGroup, ActionListItem, Button } from '@patternfly/react-core';
 import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
 import CheckIcon from '@patternfly/react-icons/dist/esm/icons/check-icon';
 
 export const ActionListWithIcons: React.FunctionComponent = () => (
-  <ActionList isIconList>
-    <ActionListItem>
-      <Button variant="plain" id="with-icons-times-button" aria-label="times icon button">
-        <TimesIcon />
-      </Button>
-    </ActionListItem>
-    <ActionListItem>
-      <Button variant="plain" id="with-icons-check-button" aria-label="check icon button">
-        <CheckIcon />
-      </Button>
-    </ActionListItem>
-  </ActionList>
+  <>
+    <h4>With list icons wrapper</h4>
+    <ActionList isIconList>
+      <ActionListItem>
+        <Button variant="plain" id="with-icons-times-button" aria-label="times icon button">
+          <TimesIcon />
+        </Button>
+      </ActionListItem>
+      <ActionListItem>
+        <Button variant="plain" id="with-icons-check-button" aria-label="check icon button">
+          <CheckIcon />
+        </Button>
+      </ActionListItem>
+    </ActionList>
+    <br />
+    <h4>With group icons wrapper</h4>
+    <ActionList>
+      <ActionListGroup isIconGroup>
+        <ActionListItem>
+          <Button variant="plain" id="with-icons-times-button" aria-label="times icon button">
+            <TimesIcon />
+          </Button>
+        </ActionListItem>
+        <ActionListItem>
+          <Button variant="plain" id="with-icons-check-button" aria-label="check icon button">
+            <CheckIcon />
+          </Button>
+        </ActionListItem>
+      </ActionListGroup>
+      <ActionListGroup isIconGroup>
+        <ActionListItem>
+          <Button variant="plain" id="with-icons-times-button" aria-label="times icon button">
+            <TimesIcon />
+          </Button>
+        </ActionListItem>
+        <ActionListItem>
+          <Button variant="plain" id="with-icons-check-button" aria-label="check icon button">
+            <CheckIcon />
+          </Button>
+        </ActionListItem>
+      </ActionListGroup>
+    </ActionList>
+  </>
 );

--- a/packages/react-core/src/components/ActionList/examples/ActionListWithIcons.tsx
+++ b/packages/react-core/src/components/ActionList/examples/ActionListWithIcons.tsx
@@ -23,24 +23,24 @@ export const ActionListWithIcons: React.FunctionComponent = () => (
     <ActionList>
       <ActionListGroup isIconGroup>
         <ActionListItem>
-          <Button variant="plain" id="with-icons-times-button" aria-label="times icon button">
+          <Button variant="plain" id="with-icons-list-times-button" aria-label="times icon button">
             <TimesIcon />
           </Button>
         </ActionListItem>
         <ActionListItem>
-          <Button variant="plain" id="with-icons-check-button" aria-label="check icon button">
+          <Button variant="plain" id="with-icons-list-check-button" aria-label="check icon button">
             <CheckIcon />
           </Button>
         </ActionListItem>
       </ActionListGroup>
       <ActionListGroup isIconGroup>
         <ActionListItem>
-          <Button variant="plain" id="with-icons-times-button" aria-label="times icon button">
+          <Button variant="plain" id="with-icons-group-times-button" aria-label="times icon button">
             <TimesIcon />
           </Button>
         </ActionListItem>
         <ActionListItem>
-          <Button variant="plain" id="with-icons-check-button" aria-label="check icon button">
+          <Button variant="plain" id="with-icons-group-check-button" aria-label="check icon button">
             <CheckIcon />
           </Button>
         </ActionListItem>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Towards #9677

Couple questions:

- For the "Action list with cancel button" example, should the "Cancel" button be in the same group as "Next" and "Back" buttons (how it is in Core), or should it be separate visually and structurally (how it is in this PR)? EDIT: update core example to use separate groups
- For the "Action list with icons" example, is it intended that that is the only time ActionListItem component should not be wrapped in an ActionListGroup? Or should we be consistent about always needing the ActionListGroup wrapping ActionListItem components? EDIT:~Open core issue to update pf-m-icons styling on pf-v5-c-action-list to also update group column-gap var (column-gap on action list should remain the same)~ PR opened by Matt - https://github.com/patternfly/patternfly/pull/6263

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
