### PR TITLE
feat(Tabs): consumed Penta updates

### DIFF
--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -54,7 +54,7 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.0.0-alpha.66",
+    "@patternfly/patternfly": "6.0.0-alpha.69",
     "@rollup/plugin-commonjs": "^25.0.0",
     "@rollup/plugin-node-resolve": "^15.0.2",
     "@rollup/plugin-replace": "^5.0.2",

--- a/packages/react-core/src/components/Tabs/TabContent.tsx
+++ b/packages/react-core/src/components/Tabs/TabContent.tsx
@@ -27,10 +27,10 @@ export interface TabContentProps extends Omit<React.HTMLProps<HTMLElement>, 'ref
   ouiaSafe?: boolean;
 }
 
-// TODO: Update with issue #9909
-// const variantStyle = {
-//   default: ''
-// };
+const variantStyle = {
+  default: '',
+  secondary: styles.modifiers.secondary
+};
 
 const TabContentBase: React.FunctionComponent<TabContentProps> = ({
   id,
@@ -56,27 +56,30 @@ const TabContentBase: React.FunctionComponent<TabContentProps> = ({
 
     return (
       <TabsContextConsumer>
-        {({ variant }: TabsContextProps) => (
-          <section
-            ref={innerRef}
-            hidden={children ? null : child.props.eventKey !== activeKey}
-            // TODO: Update "variant" with issue #9909
-            className={
-              children
-                ? css(styles.tabContent, className, variant)
-                : css(styles.tabContent, child.props.className, variant)
-            }
-            id={children ? id : `pf-tab-section-${child.props.eventKey}-${id}`}
-            aria-label={ariaLabel}
-            aria-labelledby={labelledBy}
-            role="tabpanel"
-            tabIndex={0}
-            {...getOUIAProps('TabContent', ouiaId, ouiaSafe)}
-            {...props}
-          >
-            {children || child.props.children}
-          </section>
-        )}
+        {({ variant }: TabsContextProps) => {
+          const variantClass = variantStyle[variant];
+
+          return (
+            <section
+              ref={innerRef}
+              hidden={children ? null : child.props.eventKey !== activeKey}
+              className={
+                children
+                  ? css(styles.tabContent, className, variantClass)
+                  : css(styles.tabContent, child.props.className, variantClass)
+              }
+              id={children ? id : `pf-tab-section-${child.props.eventKey}-${id}`}
+              aria-label={ariaLabel}
+              aria-labelledby={labelledBy}
+              role="tabpanel"
+              tabIndex={0}
+              {...getOUIAProps('TabContent', ouiaId, ouiaSafe)}
+              {...props}
+            >
+              {children || child.props.children}
+            </section>
+          );
+        }}
       </TabsContextConsumer>
     );
   }

--- a/packages/react-core/src/components/Tabs/TabTitleIcon.tsx
+++ b/packages/react-core/src/components/Tabs/TabTitleIcon.tsx
@@ -14,7 +14,7 @@ export const TabTitleIcon: React.FunctionComponent<TabTitleIconProps> = ({
   className = '',
   ...props
 }: TabTitleIconProps) => (
-  <span className={css(styles.tabsItemIcon, className)} {...props}>
+  <span className={css(`${styles.tabs}__item-icon`, className)} {...props}>
     {children}
   </span>
 );

--- a/packages/react-core/src/components/Tabs/Tabs.tsx
+++ b/packages/react-core/src/components/Tabs/Tabs.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/Tabs/tabs';
-import buttonStyles from '@patternfly/react-styles/css/components/Button/button';
 import { css } from '@patternfly/react-styles';
 import { PickOptional } from '../../helpers/typeUtils';
 import AngleLeftIcon from '@patternfly/react-icons/dist/esm/icons/angle-left-icon';
@@ -38,7 +37,7 @@ export interface TabsProps extends Omit<React.HTMLProps<HTMLElement | HTMLDivEle
   /** Additional classes added to the tabs */
   className?: string;
   /** Tabs background color variant */
-  variant?: 'default';
+  variant?: 'default' | 'secondary';
   /** The index of the active tab */
   activeKey?: number | string;
   /** The index of the default active tab. Set this for uncontrolled Tabs */
@@ -55,8 +54,8 @@ export interface TabsProps extends Omit<React.HTMLProps<HTMLElement | HTMLDivEle
   id?: string;
   /** Enables the filled tab list layout */
   isFilled?: boolean;
-  /** Enables secondary tab styling */
-  isSecondary?: boolean;
+  /** Enables subtab tab styling */
+  isSubtab?: boolean;
   /** Enables box styling to the tab component */
   isBox?: boolean;
   /** Enables vertical tab styling */
@@ -119,7 +118,7 @@ export interface TabsProps extends Omit<React.HTMLProps<HTMLElement | HTMLDivEle
 
 const variantStyle = {
   default: '',
-  light300: styles.modifiers.colorSchemeLight_300
+  secondary: styles.modifiers.secondary
 };
 
 interface TabsState {
@@ -177,7 +176,7 @@ class Tabs extends React.Component<TabsProps, TabsState> {
     activeKey: 0,
     onSelect: () => undefined as any,
     isFilled: false,
-    isSecondary: false,
+    isSubtab: false,
     isVertical: false,
     isBox: false,
     hasNoBorderBottom: false,
@@ -247,7 +246,6 @@ class Tabs extends React.Component<TabsProps, TabsState> {
       if (container && !this.props.isVertical && !isOverflowHorizontal) {
         // get first element and check if it is in view
         const overflowOnLeft = !isElementInView(container, container.firstChild as HTMLElement, false);
-
         // get last element and check if it is in view
         const overflowOnRight = !isElementInView(container, container.lastChild as HTMLElement, false);
 
@@ -392,7 +390,7 @@ class Tabs extends React.Component<TabsProps, TabsState> {
       defaultActiveKey,
       id,
       isFilled,
-      isSecondary,
+      isSubtab,
       isVertical,
       isBox,
       hasNoBorderBottom,
@@ -473,7 +471,7 @@ class Tabs extends React.Component<TabsProps, TabsState> {
           className={css(
             styles.tabs,
             isFilled && styles.modifiers.fill,
-            isSecondary && styles.modifiers.secondary,
+            isSubtab && styles.modifiers.subtab,
             isVertical && styles.modifiers.vertical,
             isVertical && expandable && formatBreakpointMods(expandable, styles),
             isVertical && expandable && isExpandedLocal && styles.modifiers.expanded,
@@ -518,33 +516,35 @@ class Tabs extends React.Component<TabsProps, TabsState> {
             </GenerateId>
           )}
           {renderScrollButtons && (
-            <button
-              type="button"
-              className={css(styles.tabsScrollButton, isSecondary && buttonStyles.modifiers.secondary)}
-              aria-label={backScrollAriaLabel || leftScrollAriaLabel}
-              onClick={this.scrollBack}
-              disabled={disableBackScrollButton}
-              aria-hidden={disableBackScrollButton}
-              ref={this.leftScrollButtonRef}
-            >
-              <AngleLeftIcon />
-            </button>
+            <div className={css(styles.tabsScrollButton)}>
+              <Button
+                aria-label={backScrollAriaLabel || leftScrollAriaLabel}
+                onClick={this.scrollBack}
+                isDisabled={disableBackScrollButton}
+                aria-hidden={disableBackScrollButton}
+                ref={this.leftScrollButtonRef}
+                variant="plain"
+              >
+                <AngleLeftIcon />
+              </Button>
+            </div>
           )}
           <ul className={css(styles.tabsList)} ref={this.tabList} onScroll={this.handleScrollButtons} role="tablist">
             {isOverflowHorizontal ? filteredChildrenWithoutOverflow : filteredChildren}
             {hasOverflowTab && <OverflowTab overflowingTabs={overflowingTabProps} {...overflowObjectProps} />}
           </ul>
           {renderScrollButtons && (
-            <button
-              type="button"
-              className={css(styles.tabsScrollButton, isSecondary && buttonStyles.modifiers.secondary)}
-              aria-label={forwardScrollAriaLabel || rightScrollAriaLabel}
-              onClick={this.scrollForward}
-              disabled={disableForwardScrollButton}
-              aria-hidden={disableForwardScrollButton}
-            >
-              <AngleRightIcon />
-            </button>
+            <div className={css(styles.tabsScrollButton)}>
+              <Button
+                aria-label={forwardScrollAriaLabel || rightScrollAriaLabel}
+                onClick={this.scrollForward}
+                isDisabled={disableForwardScrollButton}
+                aria-hidden={disableForwardScrollButton}
+                variant="plain"
+              >
+                <AngleRightIcon />
+              </Button>
+            </div>
           )}
           {onAdd !== undefined && (
             <span className={css(styles.tabsAdd)}>

--- a/packages/react-core/src/components/Tabs/TabsContext.ts
+++ b/packages/react-core/src/components/Tabs/TabsContext.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 export interface TabsContextProps {
-  variant: 'default' | 'light300';
+  variant: 'default' | 'secondary';
   mountOnEnter: boolean;
   unmountOnExit: boolean;
   localActiveKey: string | number;

--- a/packages/react-core/src/components/Tabs/__tests__/Generated/__snapshots__/TabContent.test.tsx.snap
+++ b/packages/react-core/src/components/Tabs/__tests__/Generated/__snapshots__/TabContent.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`TabContent should match snapshot (auto-generated) 1`] = `
 <DocumentFragment>
   <section
     aria-label="string"
-    class="pf-v5-c-tab-content string default"
+    class="pf-v5-c-tab-content string"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     id="string"

--- a/packages/react-core/src/components/Tabs/__tests__/Tabs.test.tsx
+++ b/packages/react-core/src/components/Tabs/__tests__/Tabs.test.tsx
@@ -251,19 +251,19 @@ test('should render filled tabs', () => {
   expect(asFragment()).toMatchSnapshot();
 });
 
-test('should render secondary tabs', () => {
+test('should render subtabs', () => {
   const { asFragment } = render(
     <Tabs id="primarieTabs">
       <Tab eventKey={0} title={<TabTitleText>"Tab item 1"</TabTitleText>}>
-        <Tabs isSecondary id="secondaryTabs">
-          <Tab id="secondary tab1" eventKey={10} title={<TabTitleText>"Secondary Tab item 1"</TabTitleText>}>
-            Secondary Tab 1 section
+        <Tabs isSubtab id="subtabs">
+          <Tab id="subtab1" eventKey={10} title={<TabTitleText>"Subtab item 1"</TabTitleText>}>
+            Subtab 1 section
           </Tab>
-          <Tab id="secondary tab2" eventKey={11} title={<TabTitleText>"Secondary Tab item 2"</TabTitleText>}>
-            Secondary Tab 2 section
+          <Tab id="subtab2" eventKey={11} title={<TabTitleText>"Subtab item 2"</TabTitleText>}>
+            Subtab 2 section
           </Tab>
-          <Tab id="secondary tab3" eventKey={12} title={<TabTitleText>"Secondary Tab item 3"</TabTitleText>}>
-            Secondary Tab 3 section
+          <Tab id="subtab3" eventKey={12} title={<TabTitleText>"Subtab item 3"</TabTitleText>}>
+            Subtab 3 section
           </Tab>
         </Tabs>
       </Tab>
@@ -338,9 +338,9 @@ test('should render tabs with separate content', () => {
   expect(asFragment()).toMatchSnapshot();
 });
 
-test('should render box tabs of light variant', () => {
+test('should render box tabs of secondary variant', () => {
   const { asFragment } = render(
-    <Tabs id="boxLightVariantTabs" isBox variant="light300">
+    <Tabs id="boxSecondaryVariantTabs" isBox variant="secondary">
       <Tab id="tab1" eventKey={0} title={<TabTitleText>"Tab item 1"</TabTitleText>}>
         Tab 1 section
       </Tab>
@@ -372,9 +372,9 @@ test('should render tabs with no bottom border', () => {
   expect(asFragment()).toMatchSnapshot();
 });
 
-test('should render secondary tabs with no bottom border when passed hasNoBorderBottom', () => {
+test('should render subtabs with no bottom border when passed hasNoBorderBottom', () => {
   render(
-    <Tabs isSecondary hasNoBorderBottom id="noBottomBorderTabs" aria-label="Secondary bottom border">
+    <Tabs isSubtab hasNoBorderBottom id="noBottomBorderTabs" aria-label="Subtab bottom border">
       <Tab id="tab1" eventKey={0} title={<TabTitleText>"Tab item 1"</TabTitleText>}>
         Tab 1 section
       </Tab>
@@ -387,14 +387,14 @@ test('should render secondary tabs with no bottom border when passed hasNoBorder
     </Tabs>
   );
 
-  const tabsContainer = screen.queryByLabelText('Secondary bottom border');
+  const tabsContainer = screen.queryByLabelText('Subtab bottom border');
 
   expect(tabsContainer).toHaveClass('pf-m-no-border-bottom');
 });
 
-test('should render secondary tabs with border bottom', () => {
+test('should render subtabs with border bottom', () => {
   render(
-    <Tabs isSecondary id="bottomBorderTabs" aria-label="Secondary bottom border">
+    <Tabs isSubtab id="bottomBorderTabs" aria-label="Subtab bottom border">
       <Tab id="tab1" eventKey={0} title={<TabTitleText>"Tab item 1"</TabTitleText>}>
         Tab 1 section
       </Tab>
@@ -407,7 +407,7 @@ test('should render secondary tabs with border bottom', () => {
     </Tabs>
   );
 
-  const tabsContainer = screen.queryByLabelText('Secondary bottom border');
+  const tabsContainer = screen.queryByLabelText('Subtab bottom border');
 
   expect(tabsContainer).not.toHaveClass('pf-m-no-border-bottom');
 });

--- a/packages/react-core/src/components/Tabs/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/react-core/src/components/Tabs/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -81,7 +81,7 @@ exports[`should render accessible tabs 1`] = `
   </nav>
   <section
     aria-labelledby="pf-tab-0-tab1"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     id="pf-tab-section-0-tab1"
@@ -92,7 +92,7 @@ exports[`should render accessible tabs 1`] = `
   </section>
   <section
     aria-labelledby="pf-tab-1-tab2"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     hidden=""
@@ -104,7 +104,7 @@ exports[`should render accessible tabs 1`] = `
   </section>
   <section
     aria-labelledby="pf-tab-2-tab3"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     hidden=""
@@ -227,7 +227,7 @@ exports[`should render box tabs 1`] = `
   </div>
   <section
     aria-labelledby="pf-tab-0-tab1"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     id="pf-tab-section-0-tab1"
@@ -238,7 +238,7 @@ exports[`should render box tabs 1`] = `
   </section>
   <section
     aria-labelledby="pf-tab-1-tab2"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     hidden=""
@@ -250,7 +250,7 @@ exports[`should render box tabs 1`] = `
   </section>
   <section
     aria-labelledby="pf-tab-2-tab3"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     hidden=""
@@ -262,7 +262,7 @@ exports[`should render box tabs 1`] = `
   </section>
   <section
     aria-labelledby="pf-tab-3-tab4"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     hidden=""
@@ -275,14 +275,14 @@ exports[`should render box tabs 1`] = `
 </DocumentFragment>
 `;
 
-exports[`should render box tabs of light variant 1`] = `
+exports[`should render box tabs of secondary variant 1`] = `
 <DocumentFragment>
   <div
-    class="pf-v5-c-tabs pf-m-box pf-m-color-scheme--light-300"
+    class="pf-v5-c-tabs pf-m-box pf-m-secondary"
     data-ouia-component-id="OUIA-Generated-Tabs-15"
     data-ouia-component-type="PF5/Tabs"
     data-ouia-safe="true"
-    id="boxLightVariantTabs"
+    id="boxSecondaryVariantTabs"
   >
     <ul
       class="pf-v5-c-tabs__list"
@@ -355,7 +355,7 @@ exports[`should render box tabs of light variant 1`] = `
   </div>
   <section
     aria-labelledby="pf-tab-0-tab1"
-    class="pf-v5-c-tab-content light300"
+    class="pf-v5-c-tab-content pf-m-secondary"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     id="pf-tab-section-0-tab1"
@@ -366,7 +366,7 @@ exports[`should render box tabs of light variant 1`] = `
   </section>
   <section
     aria-labelledby="pf-tab-1-tab2"
-    class="pf-v5-c-tab-content light300"
+    class="pf-v5-c-tab-content pf-m-secondary"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     hidden=""
@@ -378,7 +378,7 @@ exports[`should render box tabs of light variant 1`] = `
   </section>
   <section
     aria-labelledby="pf-tab-2-tab3"
-    class="pf-v5-c-tab-content light300"
+    class="pf-v5-c-tab-content pf-m-secondary"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     hidden=""
@@ -544,7 +544,7 @@ exports[`should render expandable vertical tabs 1`] = `
   </div>
   <section
     aria-labelledby="pf-tab-0-tab1"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     id="pf-tab-section-0-tab1"
@@ -555,7 +555,7 @@ exports[`should render expandable vertical tabs 1`] = `
   </section>
   <section
     aria-labelledby="pf-tab-1-tab2"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     hidden=""
@@ -567,7 +567,7 @@ exports[`should render expandable vertical tabs 1`] = `
   </section>
   <section
     aria-labelledby="pf-tab-2-tab3"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     hidden=""
@@ -579,7 +579,7 @@ exports[`should render expandable vertical tabs 1`] = `
   </section>
   <section
     aria-labelledby="pf-tab-3-tab4"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     hidden=""
@@ -672,7 +672,7 @@ exports[`should render filled tabs 1`] = `
   </div>
   <section
     aria-labelledby="pf-tab-0-tab1"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     id="pf-tab-section-0-tab1"
@@ -683,7 +683,7 @@ exports[`should render filled tabs 1`] = `
   </section>
   <section
     aria-labelledby="pf-tab-1-tab2"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     hidden=""
@@ -695,234 +695,7 @@ exports[`should render filled tabs 1`] = `
   </section>
   <section
     aria-labelledby="pf-tab-2-tab3"
-    class="pf-v5-c-tab-content default"
-    data-ouia-component-type="PF5/TabContent"
-    data-ouia-safe="true"
-    hidden=""
-    id="pf-tab-section-2-tab3"
-    role="tabpanel"
-    tabindex="0"
-  >
-    Tab 3 section
-  </section>
-</DocumentFragment>
-`;
-
-exports[`should render secondary tabs 1`] = `
-<DocumentFragment>
-  <div
-    class="pf-v5-c-tabs"
-    data-ouia-component-id="OUIA-Generated-Tabs-11"
-    data-ouia-component-type="PF5/Tabs"
-    data-ouia-safe="true"
-    id="primarieTabs"
-  >
-    <ul
-      class="pf-v5-c-tabs__list"
-      role="tablist"
-    >
-      <li
-        class="pf-v5-c-tabs__item pf-m-current"
-        role="presentation"
-      >
-        <button
-          aria-controls="pf-tab-section-0-primarieTabs"
-          aria-selected="true"
-          class="pf-v5-c-tabs__link"
-          data-ouia-component-type="PF5/TabButton"
-          data-ouia-safe="true"
-          id="pf-tab-0-primarieTabs"
-          role="tab"
-          type="button"
-        >
-          <span
-            class="pf-v5-c-tabs__item-text"
-          >
-            "Tab item 1"
-          </span>
-        </button>
-      </li>
-      <li
-        class="pf-v5-c-tabs__item"
-        role="presentation"
-      >
-        <button
-          aria-controls="pf-tab-section-1-tab2"
-          aria-selected="false"
-          class="pf-v5-c-tabs__link"
-          data-ouia-component-type="PF5/TabButton"
-          data-ouia-safe="true"
-          id="pf-tab-1-tab2"
-          role="tab"
-          type="button"
-        >
-          <span
-            class="pf-v5-c-tabs__item-text"
-          >
-            "Tab item 2"
-          </span>
-        </button>
-      </li>
-      <li
-        class="pf-v5-c-tabs__item"
-        role="presentation"
-      >
-        <button
-          aria-controls="pf-tab-section-2-tab3"
-          aria-selected="false"
-          class="pf-v5-c-tabs__link"
-          data-ouia-component-type="PF5/TabButton"
-          data-ouia-safe="true"
-          id="pf-tab-2-tab3"
-          role="tab"
-          type="button"
-        >
-          <span
-            class="pf-v5-c-tabs__item-text"
-          >
-            "Tab item 3"
-          </span>
-        </button>
-      </li>
-    </ul>
-  </div>
-  <section
-    aria-labelledby="pf-tab-0-primarieTabs"
-    class="pf-v5-c-tab-content default"
-    data-ouia-component-type="PF5/TabContent"
-    data-ouia-safe="true"
-    id="pf-tab-section-0-primarieTabs"
-    role="tabpanel"
-    tabindex="0"
-  >
-    <div
-      class="pf-v5-c-tabs pf-m-secondary"
-      data-ouia-component-id="OUIA-Generated-Tabs-12"
-      data-ouia-component-type="PF5/Tabs"
-      data-ouia-safe="true"
-      id="secondaryTabs"
-    >
-      <ul
-        class="pf-v5-c-tabs__list"
-        role="tablist"
-      >
-        <li
-          class="pf-v5-c-tabs__item"
-          role="presentation"
-        >
-          <button
-            aria-controls="pf-tab-section-10-secondary tab1"
-            aria-selected="false"
-            class="pf-v5-c-tabs__link"
-            data-ouia-component-type="PF5/TabButton"
-            data-ouia-safe="true"
-            id="pf-tab-10-secondary tab1"
-            role="tab"
-            type="button"
-          >
-            <span
-              class="pf-v5-c-tabs__item-text"
-            >
-              "Secondary Tab item 1"
-            </span>
-          </button>
-        </li>
-        <li
-          class="pf-v5-c-tabs__item"
-          role="presentation"
-        >
-          <button
-            aria-controls="pf-tab-section-11-secondary tab2"
-            aria-selected="false"
-            class="pf-v5-c-tabs__link"
-            data-ouia-component-type="PF5/TabButton"
-            data-ouia-safe="true"
-            id="pf-tab-11-secondary tab2"
-            role="tab"
-            type="button"
-          >
-            <span
-              class="pf-v5-c-tabs__item-text"
-            >
-              "Secondary Tab item 2"
-            </span>
-          </button>
-        </li>
-        <li
-          class="pf-v5-c-tabs__item"
-          role="presentation"
-        >
-          <button
-            aria-controls="pf-tab-section-12-secondary tab3"
-            aria-selected="false"
-            class="pf-v5-c-tabs__link"
-            data-ouia-component-type="PF5/TabButton"
-            data-ouia-safe="true"
-            id="pf-tab-12-secondary tab3"
-            role="tab"
-            type="button"
-          >
-            <span
-              class="pf-v5-c-tabs__item-text"
-            >
-              "Secondary Tab item 3"
-            </span>
-          </button>
-        </li>
-      </ul>
-    </div>
-    <section
-      aria-labelledby="pf-tab-10-secondary tab1"
-      class="pf-v5-c-tab-content default"
-      data-ouia-component-type="PF5/TabContent"
-      data-ouia-safe="true"
-      hidden=""
-      id="pf-tab-section-10-secondary tab1"
-      role="tabpanel"
-      tabindex="0"
-    >
-      Secondary Tab 1 section
-    </section>
-    <section
-      aria-labelledby="pf-tab-11-secondary tab2"
-      class="pf-v5-c-tab-content default"
-      data-ouia-component-type="PF5/TabContent"
-      data-ouia-safe="true"
-      hidden=""
-      id="pf-tab-section-11-secondary tab2"
-      role="tabpanel"
-      tabindex="0"
-    >
-      Secondary Tab 2 section
-    </section>
-    <section
-      aria-labelledby="pf-tab-12-secondary tab3"
-      class="pf-v5-c-tab-content default"
-      data-ouia-component-type="PF5/TabContent"
-      data-ouia-safe="true"
-      hidden=""
-      id="pf-tab-section-12-secondary tab3"
-      role="tabpanel"
-      tabindex="0"
-    >
-      Secondary Tab 3 section
-    </section>
-  </section>
-  <section
-    aria-labelledby="pf-tab-1-tab2"
-    class="pf-v5-c-tab-content default"
-    data-ouia-component-type="PF5/TabContent"
-    data-ouia-safe="true"
-    hidden=""
-    id="pf-tab-section-1-tab2"
-    role="tabpanel"
-    tabindex="0"
-  >
-    Tab 2 section
-  </section>
-  <section
-    aria-labelledby="pf-tab-2-tab3"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     hidden=""
@@ -1045,7 +818,7 @@ exports[`should render simple tabs 1`] = `
   </div>
   <section
     aria-labelledby="pf-tab-0-tab1"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     id="pf-tab-section-0-tab1"
@@ -1056,7 +829,7 @@ exports[`should render simple tabs 1`] = `
   </section>
   <section
     aria-labelledby="pf-tab-1-tab2"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     hidden=""
@@ -1068,7 +841,7 @@ exports[`should render simple tabs 1`] = `
   </section>
   <section
     aria-labelledby="pf-tab-2-tab3"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     hidden=""
@@ -1080,7 +853,7 @@ exports[`should render simple tabs 1`] = `
   </section>
   <section
     aria-labelledby="pf-tab-3-tab4"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     hidden=""
@@ -1089,6 +862,233 @@ exports[`should render simple tabs 1`] = `
     tabindex="0"
   >
     Tab 4 section
+  </section>
+</DocumentFragment>
+`;
+
+exports[`should render subtabs 1`] = `
+<DocumentFragment>
+  <div
+    class="pf-v5-c-tabs"
+    data-ouia-component-id="OUIA-Generated-Tabs-11"
+    data-ouia-component-type="PF5/Tabs"
+    data-ouia-safe="true"
+    id="primarieTabs"
+  >
+    <ul
+      class="pf-v5-c-tabs__list"
+      role="tablist"
+    >
+      <li
+        class="pf-v5-c-tabs__item pf-m-current"
+        role="presentation"
+      >
+        <button
+          aria-controls="pf-tab-section-0-primarieTabs"
+          aria-selected="true"
+          class="pf-v5-c-tabs__link"
+          data-ouia-component-type="PF5/TabButton"
+          data-ouia-safe="true"
+          id="pf-tab-0-primarieTabs"
+          role="tab"
+          type="button"
+        >
+          <span
+            class="pf-v5-c-tabs__item-text"
+          >
+            "Tab item 1"
+          </span>
+        </button>
+      </li>
+      <li
+        class="pf-v5-c-tabs__item"
+        role="presentation"
+      >
+        <button
+          aria-controls="pf-tab-section-1-tab2"
+          aria-selected="false"
+          class="pf-v5-c-tabs__link"
+          data-ouia-component-type="PF5/TabButton"
+          data-ouia-safe="true"
+          id="pf-tab-1-tab2"
+          role="tab"
+          type="button"
+        >
+          <span
+            class="pf-v5-c-tabs__item-text"
+          >
+            "Tab item 2"
+          </span>
+        </button>
+      </li>
+      <li
+        class="pf-v5-c-tabs__item"
+        role="presentation"
+      >
+        <button
+          aria-controls="pf-tab-section-2-tab3"
+          aria-selected="false"
+          class="pf-v5-c-tabs__link"
+          data-ouia-component-type="PF5/TabButton"
+          data-ouia-safe="true"
+          id="pf-tab-2-tab3"
+          role="tab"
+          type="button"
+        >
+          <span
+            class="pf-v5-c-tabs__item-text"
+          >
+            "Tab item 3"
+          </span>
+        </button>
+      </li>
+    </ul>
+  </div>
+  <section
+    aria-labelledby="pf-tab-0-primarieTabs"
+    class="pf-v5-c-tab-content"
+    data-ouia-component-type="PF5/TabContent"
+    data-ouia-safe="true"
+    id="pf-tab-section-0-primarieTabs"
+    role="tabpanel"
+    tabindex="0"
+  >
+    <div
+      class="pf-v5-c-tabs pf-m-subtab"
+      data-ouia-component-id="OUIA-Generated-Tabs-12"
+      data-ouia-component-type="PF5/Tabs"
+      data-ouia-safe="true"
+      id="subtabs"
+    >
+      <ul
+        class="pf-v5-c-tabs__list"
+        role="tablist"
+      >
+        <li
+          class="pf-v5-c-tabs__item"
+          role="presentation"
+        >
+          <button
+            aria-controls="pf-tab-section-10-subtab1"
+            aria-selected="false"
+            class="pf-v5-c-tabs__link"
+            data-ouia-component-type="PF5/TabButton"
+            data-ouia-safe="true"
+            id="pf-tab-10-subtab1"
+            role="tab"
+            type="button"
+          >
+            <span
+              class="pf-v5-c-tabs__item-text"
+            >
+              "Subtab item 1"
+            </span>
+          </button>
+        </li>
+        <li
+          class="pf-v5-c-tabs__item"
+          role="presentation"
+        >
+          <button
+            aria-controls="pf-tab-section-11-subtab2"
+            aria-selected="false"
+            class="pf-v5-c-tabs__link"
+            data-ouia-component-type="PF5/TabButton"
+            data-ouia-safe="true"
+            id="pf-tab-11-subtab2"
+            role="tab"
+            type="button"
+          >
+            <span
+              class="pf-v5-c-tabs__item-text"
+            >
+              "Subtab item 2"
+            </span>
+          </button>
+        </li>
+        <li
+          class="pf-v5-c-tabs__item"
+          role="presentation"
+        >
+          <button
+            aria-controls="pf-tab-section-12-subtab3"
+            aria-selected="false"
+            class="pf-v5-c-tabs__link"
+            data-ouia-component-type="PF5/TabButton"
+            data-ouia-safe="true"
+            id="pf-tab-12-subtab3"
+            role="tab"
+            type="button"
+          >
+            <span
+              class="pf-v5-c-tabs__item-text"
+            >
+              "Subtab item 3"
+            </span>
+          </button>
+        </li>
+      </ul>
+    </div>
+    <section
+      aria-labelledby="pf-tab-10-subtab1"
+      class="pf-v5-c-tab-content"
+      data-ouia-component-type="PF5/TabContent"
+      data-ouia-safe="true"
+      hidden=""
+      id="pf-tab-section-10-subtab1"
+      role="tabpanel"
+      tabindex="0"
+    >
+      Subtab 1 section
+    </section>
+    <section
+      aria-labelledby="pf-tab-11-subtab2"
+      class="pf-v5-c-tab-content"
+      data-ouia-component-type="PF5/TabContent"
+      data-ouia-safe="true"
+      hidden=""
+      id="pf-tab-section-11-subtab2"
+      role="tabpanel"
+      tabindex="0"
+    >
+      Subtab 2 section
+    </section>
+    <section
+      aria-labelledby="pf-tab-12-subtab3"
+      class="pf-v5-c-tab-content"
+      data-ouia-component-type="PF5/TabContent"
+      data-ouia-safe="true"
+      hidden=""
+      id="pf-tab-section-12-subtab3"
+      role="tabpanel"
+      tabindex="0"
+    >
+      Subtab 3 section
+    </section>
+  </section>
+  <section
+    aria-labelledby="pf-tab-1-tab2"
+    class="pf-v5-c-tab-content"
+    data-ouia-component-type="PF5/TabContent"
+    data-ouia-safe="true"
+    hidden=""
+    id="pf-tab-section-1-tab2"
+    role="tabpanel"
+    tabindex="0"
+  >
+    Tab 2 section
+  </section>
+  <section
+    aria-labelledby="pf-tab-2-tab3"
+    class="pf-v5-c-tab-content"
+    data-ouia-component-type="PF5/TabContent"
+    data-ouia-safe="true"
+    hidden=""
+    id="pf-tab-section-2-tab3"
+    role="tabpanel"
+    tabindex="0"
+  >
+    Tab 3 section
   </section>
 </DocumentFragment>
 `;
@@ -1173,7 +1173,7 @@ exports[`should render tabs with eventKey Strings 1`] = `
   </div>
   <section
     aria-labelledby="pf-tab-one-tab1"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     hidden=""
@@ -1185,7 +1185,7 @@ exports[`should render tabs with eventKey Strings 1`] = `
   </section>
   <section
     aria-labelledby="pf-tab-two-tab2"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     hidden=""
@@ -1197,7 +1197,7 @@ exports[`should render tabs with eventKey Strings 1`] = `
   </section>
   <section
     aria-labelledby="pf-tab-three-tab3"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     hidden=""
@@ -1290,7 +1290,7 @@ exports[`should render tabs with no bottom border 1`] = `
   </div>
   <section
     aria-labelledby="pf-tab-0-tab1"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     id="pf-tab-section-0-tab1"
@@ -1301,7 +1301,7 @@ exports[`should render tabs with no bottom border 1`] = `
   </section>
   <section
     aria-labelledby="pf-tab-1-tab2"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     hidden=""
@@ -1313,7 +1313,7 @@ exports[`should render tabs with no bottom border 1`] = `
   </section>
   <section
     aria-labelledby="pf-tab-2-tab3"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     hidden=""
@@ -1407,7 +1407,7 @@ exports[`should render tabs with separate content 1`] = `
   <div>
     <section
       aria-label="Tab item 1"
-      class="pf-v5-c-tab-content default"
+      class="pf-v5-c-tab-content"
       data-ouia-component-type="PF5/TabContent"
       data-ouia-safe="true"
       id="refTab1Section"
@@ -1418,7 +1418,7 @@ exports[`should render tabs with separate content 1`] = `
     </section>
     <section
       aria-label="Tab item 2"
-      class="pf-v5-c-tab-content default"
+      class="pf-v5-c-tab-content"
       data-ouia-component-type="PF5/TabContent"
       data-ouia-safe="true"
       hidden=""
@@ -1434,7 +1434,7 @@ exports[`should render tabs with separate content 1`] = `
     </section>
     <section
       aria-label="Tab item 3"
-      class="pf-v5-c-tab-content default"
+      class="pf-v5-c-tab-content"
       data-ouia-component-type="PF5/TabContent"
       data-ouia-safe="true"
       hidden=""
@@ -1561,7 +1561,7 @@ exports[`should render uncontrolled tabs 1`] = `
   </div>
   <section
     aria-labelledby="pf-tab-0-tab1"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     id="pf-tab-section-0-tab1"
@@ -1572,7 +1572,7 @@ exports[`should render uncontrolled tabs 1`] = `
   </section>
   <section
     aria-labelledby="pf-tab-1-tab2"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     hidden=""
@@ -1584,7 +1584,7 @@ exports[`should render uncontrolled tabs 1`] = `
   </section>
   <section
     aria-labelledby="pf-tab-2-tab3"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     hidden=""
@@ -1596,7 +1596,7 @@ exports[`should render uncontrolled tabs 1`] = `
   </section>
   <section
     aria-labelledby="pf-tab-3-tab4"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     hidden=""
@@ -1719,7 +1719,7 @@ exports[`should render vertical tabs 1`] = `
   </div>
   <section
     aria-labelledby="pf-tab-0-tab1"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     id="pf-tab-section-0-tab1"
@@ -1730,7 +1730,7 @@ exports[`should render vertical tabs 1`] = `
   </section>
   <section
     aria-labelledby="pf-tab-1-tab2"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     hidden=""
@@ -1742,7 +1742,7 @@ exports[`should render vertical tabs 1`] = `
   </section>
   <section
     aria-labelledby="pf-tab-2-tab3"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     hidden=""
@@ -1754,7 +1754,7 @@ exports[`should render vertical tabs 1`] = `
   </section>
   <section
     aria-labelledby="pf-tab-3-tab4"
-    class="pf-v5-c-tab-content default"
+    class="pf-v5-c-tab-content"
     data-ouia-component-type="PF5/TabContent"
     data-ouia-safe="true"
     hidden=""

--- a/packages/react-core/src/components/Tabs/examples/Tabs.md
+++ b/packages/react-core/src/components/Tabs/examples/Tabs.md
@@ -36,15 +36,13 @@ Tabs can be styled as 'default' or 'boxed':
 ```ts file="./TabsDefault.tsx"
 ```
 
-### Boxed light tabs
+### Boxed secondary tabs
 
-To change the background color of boxed tabs, use the `variant` property. 
+To change the background color of boxed tabs or the tab content, use the `variant` property. 
 
-The following example passes `variant={isTabsLightScheme ? 'light300' : 'default'}` into the `<Tabs>` component to style the tabs with a lighter color.
+Toggle the tab color by selecting the 'Tabs secondary variant' checkbox in the following example.
 
-Toggle the tab color by selecting the 'Tabs light variation' checkbox in the following example.
-
-```ts file="./TabsBoxLight.tsx"
+```ts file="./TabsBoxSecondary.tsx"
 ```
 
 ### Vertical tabs
@@ -132,11 +130,11 @@ To add an icon to a tab, pass a `<TabTitleIcon>` component that contains the ico
 ```ts file="./TabsIconAndText.tsx"
 ```
 
-### Secondary tabs
+### Subtabs
 
-Use secondary tabs as "sub tabs" or within other components, like modals. Secondary tabs have less visually prominent styling. 
+Use subtabs within other components, like modals. Subtabs have less visually prominent styling. 
 
-To apply secondary styling to tabs, use the `isSecondary` property. 
+To apply subtab styling to tabs, use the `isSubtab` property. 
 
 ```ts file="./TabsSubtabs.tsx"
 ```
@@ -157,11 +155,11 @@ Nav tabs should use the `href` property to link the tab to the URL of another pa
 ```ts file="./TabsNav.tsx"
 ```
 
-### Secondary tabs linked to nav elements
+### Subtabs linked to nav elements
 
-Secondary tabs can also link to nav elements. 
+Subtabs can also link to nav elements. 
 
-```ts file="./TabsNavSecondary.tsx"
+```ts file="./TabsNavSubtab.tsx"
 ```
 
 ### With separate content

--- a/packages/react-core/src/components/Tabs/examples/TabsBoxSecondary.tsx
+++ b/packages/react-core/src/components/Tabs/examples/TabsBoxSecondary.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Tabs, Tab, TabTitleText, Checkbox, Tooltip } from '@patternfly/react-core';
 
-export const TabsBoxLight: React.FunctionComponent = () => {
+export const TabsBoxSecondary: React.FunctionComponent = () => {
   const [activeTabKey, setActiveTabKey] = React.useState<string | number>(0);
-  const [isTabsLightScheme, setIsTabsLightScheme] = React.useState<boolean>(true);
+  const [isTabsBoxSecondary, setIsTabsBoxSecondary] = React.useState<boolean>(true);
   // Toggle currently active tab
   const handleTabClick = (
     event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent,
@@ -13,7 +13,7 @@ export const TabsBoxLight: React.FunctionComponent = () => {
   };
 
   const toggleScheme = (checked: boolean) => {
-    setIsTabsLightScheme(checked);
+    setIsTabsBoxSecondary(checked);
   };
 
   const tooltip = (
@@ -24,8 +24,7 @@ export const TabsBoxLight: React.FunctionComponent = () => {
       <Tabs
         activeKey={activeTabKey}
         onSelect={handleTabClick}
-        // TODO: Update variant value when "isTabsLightScheme" with issue #9909
-        variant={isTabsLightScheme ? 'default' : 'default'}
+        variant={isTabsBoxSecondary ? 'secondary' : 'default'}
         isBox
         aria-label="Tabs in the box light variation example"
         role="region"
@@ -51,12 +50,11 @@ export const TabsBoxLight: React.FunctionComponent = () => {
       </Tabs>
       <div style={{ marginTop: '20px' }}>
         <Checkbox
-          label="Tabs light variation"
-          isChecked={isTabsLightScheme}
+          label="Tabs secondary variant"
+          isChecked={isTabsBoxSecondary}
           onChange={(_event, checked) => toggleScheme(checked)}
-          aria-label="show light scheme variation checkbox"
-          id="toggle-scheme"
-          name="toggle-scheme"
+          id="toggle-tabs-variant"
+          name="toggle-tabs-variant"
         />
       </div>
     </div>

--- a/packages/react-core/src/components/Tabs/examples/TabsNavSubtab.tsx
+++ b/packages/react-core/src/components/Tabs/examples/TabsNavSubtab.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Tabs, Tab, TabsComponent, TabTitleText } from '@patternfly/react-core';
 
-export const TabsNavSecondary: React.FunctionComponent = () => {
+export const TabsNavSubtab: React.FunctionComponent = () => {
   const [activeTabKey1, setActiveTabKey1] = React.useState<string | number>(0);
   const [activeTabKey2, setActiveTabKey2] = React.useState<string | number>(0);
 
@@ -31,7 +31,7 @@ export const TabsNavSecondary: React.FunctionComponent = () => {
       <Tab eventKey={0} title={<TabTitleText>Users</TabTitleText>} href="#" aria-label="Subtabs with nav content users">
         <Tabs
           activeKey={activeTabKey2}
-          isSecondary
+          isSubtab
           onSelect={handleTabClickSecond}
           aria-label="Local secondary"
           component={TabsComponent.nav}

--- a/packages/react-core/src/components/Tabs/examples/TabsSubtabs.tsx
+++ b/packages/react-core/src/components/Tabs/examples/TabsSubtabs.tsx
@@ -14,7 +14,7 @@ export const TabsSubtabs: React.FunctionComponent = () => {
     setActiveTabKey1(tabIndex);
   };
 
-  // Toggle currently active secondary tab
+  // Toggle currently active subtab
   const handleTabClickSecond = (
     event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent,
     tabIndex: string | number
@@ -37,35 +37,35 @@ export const TabsSubtabs: React.FunctionComponent = () => {
       >
         <Tab eventKey={0} title={<TabTitleText>Users</TabTitleText>} aria-label="Tabs with subtabs content users">
           <Tabs
-            aria-label="secondary tabs for users"
+            aria-label="subtabs for users"
             role="region"
             activeKey={activeTabKey2}
-            isSecondary
+            isSubtab
             onSelect={handleTabClickSecond}
           >
-            <Tab eventKey={20} title={<TabTitleText>Secondary tab item 1</TabTitleText>}>
-              Secondary tab item 1 item section
+            <Tab eventKey={20} title={<TabTitleText>Subtab item 1</TabTitleText>}>
+              Subtab item 1 item section
             </Tab>
-            <Tab eventKey={21} title={<TabTitleText>Secondary tab item 2</TabTitleText>}>
-              Secondary tab item 2 section
+            <Tab eventKey={21} title={<TabTitleText>Subtab item 2</TabTitleText>}>
+              Subtab item 2 section
             </Tab>
-            <Tab eventKey={22} title={<TabTitleText>Secondary tab item 3</TabTitleText>}>
-              Secondary tab item 3 section
+            <Tab eventKey={22} title={<TabTitleText>Subtab item 3</TabTitleText>}>
+              Subtab item 3 section
             </Tab>
-            <Tab eventKey={23} title={<TabTitleText>Secondary tab item 4</TabTitleText>}>
-              Secondary tab item 4 section
+            <Tab eventKey={23} title={<TabTitleText>Subtab item 4</TabTitleText>}>
+              Subtab item 4 section
             </Tab>
-            <Tab eventKey={24} title={<TabTitleText>Secondary tab item 5</TabTitleText>}>
-              Secondary tab item 5 section
+            <Tab eventKey={24} title={<TabTitleText>Subtab item 5</TabTitleText>}>
+              Subtab item 5 section
             </Tab>
-            <Tab eventKey={25} title={<TabTitleText>Secondary tab item 6</TabTitleText>}>
-              Secondary tab item 6 section
+            <Tab eventKey={25} title={<TabTitleText>Subtab item 6</TabTitleText>}>
+              Subtab item 6 section
             </Tab>
-            <Tab eventKey={26} title={<TabTitleText>Secondary tab item 7</TabTitleText>}>
-              Secondary tab item 7 section
+            <Tab eventKey={26} title={<TabTitleText>Subtab item 7</TabTitleText>}>
+              Subtab item 7 section
             </Tab>
-            <Tab eventKey={27} title={<TabTitleText>Secondary tab item 8</TabTitleText>}>
-              Secondary tab item 8 section
+            <Tab eventKey={27} title={<TabTitleText>Subtab item 8</TabTitleText>}>
+              Subtab item 8 section
             </Tab>
           </Tabs>
         </Tab>
@@ -106,8 +106,8 @@ export const TabsSubtabs: React.FunctionComponent = () => {
           isChecked={isBox}
           onChange={(_event, checked) => toggleBox(checked)}
           aria-label="show box variation checkbox with sub tabs"
-          id="toggle-box-secondary"
-          name="toggle-box-secondary"
+          id="toggle-box-subtab"
+          name="toggle-box-subtab"
         />
       </div>
     </div>

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -23,7 +23,7 @@
     "test:a11y": "patternfly-a11y --config patternfly-a11y.config"
   },
   "dependencies": {
-    "@patternfly/patternfly": "6.0.0-alpha.66",
+    "@patternfly/patternfly": "6.0.0-alpha.69",
     "@patternfly/react-charts": "^8.0.0-alpha.10",
     "@patternfly/react-code-editor": "^6.0.0-alpha.20",
     "@patternfly/react-core": "^6.0.0-alpha.20",

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -33,7 +33,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.14.0",
     "@fortawesome/free-regular-svg-icons": "^5.14.0",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
-    "@patternfly/patternfly": "6.0.0-alpha.66",
+    "@patternfly/patternfly": "6.0.0-alpha.69",
     "fs-extra": "^11.1.1",
     "glob": "^7.1.2",
     "rimraf": "^2.6.2",

--- a/packages/react-integration/cypress/integration/tabs.spec.ts
+++ b/packages/react-integration/cypress/integration/tabs.spec.ts
@@ -55,8 +55,8 @@ describe('Tab Demo Test', () => {
     cy.get('#filledTabs.pf-m-fill').should('exist');
   });
 
-  it('Verify light variant box tabs', () => {
-    cy.get('#boxLightVariantTabs.pf-m-box.pf-m-color-scheme--light-300').should('exist');
+  it('Verify secondary variant box tabs', () => {
+    cy.get('#boxSecondaryVariantTabs.pf-m-box.pf-m-secondary').should('exist');
   });
 
   it('Verify className in tabs', () => {

--- a/packages/react-integration/cypress/integration/tabuncontrolleddemo.spec.ts
+++ b/packages/react-integration/cypress/integration/tabuncontrolleddemo.spec.ts
@@ -55,8 +55,8 @@ describe('Tab Uncontrolled Demo Test', () => {
     cy.get('#filledTabs.pf-m-fill').should('exist');
   });
 
-  it('Verify light variant box tabs', () => {
-    cy.get('#boxLightVariantTabs.pf-m-box.pf-m-color-scheme--light-300').should('exist');
+  it('Verify secondary variant box tabs', () => {
+    cy.get('#boxSecondaryVariantTabs.pf-m-box.pf-m-secondary').should('exist');
   });
 
   it('Verify className in tabs', () => {

--- a/packages/react-integration/demo-app-ts/src/components/demos/TabsDemo/TabsDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TabsDemo/TabsDemo.tsx
@@ -102,7 +102,7 @@ export class TabDemo extends Component {
             ref={this.contentRef1}
             aria-label="Tab item 1"
             // eslint-disable-next-line no-console
-            onAuxClick={event => console.log(event)}
+            onAuxClick={(event) => console.log(event)}
           >
             Tab 1 section
           </TabContent>
@@ -169,11 +169,11 @@ export class TabDemo extends Component {
           </Tab>
         </Tabs>
         <Tabs
-          id="boxLightVariantTabs"
+          id="boxSecondaryVariantTabs"
           activeKey={this.state.activeTabKey4}
           onSelect={this.handleTabClick4}
           isBox
-          variant="light300"
+          variant="secondary"
         >
           <Tab eventKey={0} title={<TabTitleText>Tab item 1</TabTitleText>}>
             Tab 1 section

--- a/packages/react-integration/demo-app-ts/src/components/demos/TabsDemo/TabsUncontrolledDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TabsDemo/TabsUncontrolledDemo.tsx
@@ -70,7 +70,7 @@ export class TabUncontrolledDemo extends Component {
             ref={this.contentRef1}
             aria-label="Tab item 1"
             // eslint-disable-next-line no-console
-            onAuxClick={event => console.log(event)}
+            onAuxClick={(event) => console.log(event)}
           >
             Tab 1 section
           </TabContent>
@@ -136,7 +136,7 @@ export class TabUncontrolledDemo extends Component {
             Tab 3 section
           </Tab>
         </Tabs>
-        <Tabs id="boxLightVariantTabs" defaultActiveKey={0} isBox variant="light300">
+        <Tabs id="boxSecondaryVariantTabs" defaultActiveKey={0} isBox variant="secondary">
           <Tab eventKey={0} title={<TabTitleText>Tab item 1</TabTitleText>}>
             Tab 1 section
           </Tab>

--- a/packages/react-styles/package.json
+++ b/packages/react-styles/package.json
@@ -19,7 +19,7 @@
     "clean": "rimraf dist css"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.0.0-alpha.66",
+    "@patternfly/patternfly": "6.0.0-alpha.69",
     "camel-case": "^3.0.0",
     "css": "^2.2.3",
     "fs-extra": "^11.1.1",

--- a/packages/react-tokens/package.json
+++ b/packages/react-tokens/package.json
@@ -29,7 +29,7 @@
     "clean": "rimraf dist"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.0.0-alpha.66",
+    "@patternfly/patternfly": "6.0.0-alpha.69",
     "css": "^2.2.3",
     "fs-extra": "^11.1.1",
     "glob": "^7.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3988,10 +3988,10 @@
     puppeteer-cluster "^0.23.0"
     xmldoc "^1.1.2"
 
-"@patternfly/patternfly@6.0.0-alpha.66":
-  version "6.0.0-alpha.66"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-6.0.0-alpha.66.tgz#e06e003a128050eb9b27e1d37ec9ebf61f663f24"
-  integrity sha512-pUKNGcKKyKwc9xb/ZQS27juxxRCewdji/Mvd6UQuLJxtiEIY/pRavNW7lDa3k4qqbD90tlWnsfSct4WRSwpRsg==
+"@patternfly/patternfly@6.0.0-alpha.69":
+  version "6.0.0-alpha.69"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-6.0.0-alpha.69.tgz#26a2c474048b54fb592de1c8b245cf365e335bd5"
+  integrity sha512-05Dj2EkaaCKR3OjkcZnIHZ9YMYibQxsFoj6n5PDI/tjwI2lSPsgr07N/cVe3pQFZ4l8cLnXROThOfdYXTVoxhQ==
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #10043, closes #9909

[Codemod for tabs](https://github.com/patternfly/pf-codemods/issues/555)
[Preview for tabs](https://patternfly-react-pr-10044.surge.sh/components/tabs)

As an FYI this PR suffers (may suffer depending on whether it affects you) the same visual bug mentioned in the original Core PR, which that will require a followup.

This also bumps the core alphas as they're needed for this update.

Per convo with design during one of the Penta meetings, it was decided that the `secondary` styling for TabContent should only be enabled when the Tabs component has both `pf-m-box` and `pf-m-secondary`, as the background colors of the current tab and the tab content will match as intended. Consumers can still use a non-box Tabs with secondary TabContent styling, though. If we'd want to restrict that a bit more we could consider removing the `isBox` prop and update the `variant` prop to accept default, box, and box-secondary values.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
