### PR TITLE
fix(Popper): check for undefined

### DIFF
--- a/packages/react-core/src/helpers/Popper/Popper.tsx
+++ b/packages/react-core/src/helpers/Popper/Popper.tsx
@@ -449,7 +449,7 @@ export const Popper: React.FunctionComponent<PopperProps> = ({
   React.useEffect(() => {
     // currentPopperContent = {tooltip children} || {dropdown children}
     const currentPopperContent =
-      popper?.props?.children[1]?.props?.children || popper?.props?.children?.props?.children;
+      popper?.props?.children?.[1]?.props?.children || popper?.props?.children?.props?.children;
     setPopperContent(currentPopperContent);
 
     if (currentPopperContent && popperContent && currentPopperContent !== popperContent) {


### PR DESCRIPTION
**What**: Closes #9936

@nicolethoen I guess this should fix the error, when I try to reproduce the bug in patternfly runtime, I get the `children is undefined` error right away from the docs build, so I cannot reproduce the bug properly

<img width="395" alt="Screenshot 2024-02-14 at 10 31 18" src="https://github.com/patternfly/patternfly-react/assets/84135613/813864ae-edf1-415e-b231-75400e5bb60d">
