### PR TITLE
chore: core version bump

### DIFF
--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -54,7 +54,7 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.0.0-alpha.84",
+    "@patternfly/patternfly": "6.0.0-alpha.90",
     "@rollup/plugin-commonjs": "^25.0.0",
     "@rollup/plugin-node-resolve": "^15.0.2",
     "@rollup/plugin-replace": "^5.0.2",

--- a/packages/react-core/src/components/LoginPage/LoginMainFooterLinksItem.tsx
+++ b/packages/react-core/src/components/LoginPage/LoginMainFooterLinksItem.tsx
@@ -30,12 +30,7 @@ export const LoginMainFooterLinksItem: React.FunctionComponent<LoginMainFooterLi
 
   return (
     <li className={css(styles.loginMainFooterLinksItem, className)} {...props}>
-      <LinkComponent
-        className={css(styles.loginMainFooterLinksItemLink)}
-        href={href}
-        target={target}
-        {...linkComponentProps}
-      >
+      <LinkComponent href={href} target={target} {...linkComponentProps}>
         {children}
       </LinkComponent>
     </li>

--- a/packages/react-core/src/components/LoginPage/__tests__/__snapshots__/LoginMainFooterLinksItem.test.tsx.snap
+++ b/packages/react-core/src/components/LoginPage/__tests__/__snapshots__/LoginMainFooterLinksItem.test.tsx.snap
@@ -6,7 +6,6 @@ exports[`LoginMainFooterLinksItem className is added to the root element 1`] = `
     class="pf-v5-c-login__main-footer-links-item extra-class"
   >
     <a
-      class="pf-v5-c-login__main-footer-links-item-link"
       href=""
     />
   </li>
@@ -19,7 +18,6 @@ exports[`LoginMainFooterLinksItem renders with PatternFly Core styles 1`] = `
     class="pf-v5-c-login__main-footer-links-item"
   >
     <a
-      class="pf-v5-c-login__main-footer-links-item-link"
       href="#"
       target=""
     />
@@ -33,7 +31,6 @@ exports[`LoginMainFooterLinksItem with custom node 1`] = `
     class="pf-v5-c-login__main-footer-links-item"
   >
     <a
-      class="pf-v5-c-login__main-footer-links-item-link"
       href=""
     >
       <div>

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -23,7 +23,7 @@
     "test:a11y": "patternfly-a11y --config patternfly-a11y.config"
   },
   "dependencies": {
-    "@patternfly/patternfly": "6.0.0-alpha.84",
+    "@patternfly/patternfly": "6.0.0-alpha.90",
     "@patternfly/react-charts": "^8.0.0-alpha.12",
     "@patternfly/react-code-editor": "^6.0.0-alpha.34",
     "@patternfly/react-core": "^6.0.0-alpha.34",

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -33,7 +33,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.14.0",
     "@fortawesome/free-regular-svg-icons": "^5.14.0",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
-    "@patternfly/patternfly": "6.0.0-alpha.84",
+    "@patternfly/patternfly": "6.0.0-alpha.90",
     "fs-extra": "^11.1.1",
     "glob": "^7.1.2",
     "rimraf": "^2.6.2",

--- a/packages/react-styles/package.json
+++ b/packages/react-styles/package.json
@@ -19,7 +19,7 @@
     "clean": "rimraf dist css"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.0.0-alpha.84",
+    "@patternfly/patternfly": "6.0.0-alpha.90",
     "camel-case": "^3.0.0",
     "css": "^2.2.3",
     "fs-extra": "^11.1.1",

--- a/packages/react-tokens/package.json
+++ b/packages/react-tokens/package.json
@@ -29,7 +29,7 @@
     "clean": "rimraf dist"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.0.0-alpha.84",
+    "@patternfly/patternfly": "6.0.0-alpha.90",
     "css": "^2.2.3",
     "fs-extra": "^11.1.1",
     "glob": "^7.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3988,10 +3988,10 @@
     puppeteer-cluster "^0.23.0"
     xmldoc "^1.1.2"
 
-"@patternfly/patternfly@6.0.0-alpha.84":
-  version "6.0.0-alpha.84"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-6.0.0-alpha.84.tgz#e6d6317eb6c72441c2ea4f14ee0695cac953fbd1"
-  integrity sha512-iL6BTOCk/yzE5jAfIxp4n2qLTUv9qs650sl6XA9tAYCNAq7djfMmOmJA4+YuQZtlRYz7iToReaVK7HuRXLOnTg==
+"@patternfly/patternfly@6.0.0-alpha.90":
+  version "6.0.0-alpha.90"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-6.0.0-alpha.90.tgz#43410df3f3c040bc9c6a296f2056d173663020e9"
+  integrity sha512-sxVIAH/91HobwG2gzuH5AFCMYnqFIMcb4wNjydmZdFo47oXLPx8/XqdCS9/qMtJtVQqI+RAAZy/Q/3v3wsSZOQ==
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"


### PR DESCRIPTION
Updates react's core version to `6.0.0-alpha.90`

Removes `loginMainFooterLinksItemLink` from `LoginMainFooterLinksItem` as that was removed in core https://github.com/patternfly/patternfly/pull/6328