### PR TITLE
Fix crash in menu

### DIFF
--- a/packages/react-core/src/components/Menu/Menu.tsx
+++ b/packages/react-core/src/components/Menu/Menu.tsx
@@ -156,20 +156,22 @@ class MenuBase extends React.Component<MenuProps, MenuState> {
       this.setState({ transitionMoveTarget: null });
     } else {
       const nextMenu = current.querySelector('#' + this.props.activeMenu) || current || null;
-      const nextMenuChildren = Array.from(nextMenu.getElementsByTagName('UL')[0].children);
+      const nextMenuLists = nextMenu.getElementsByTagName('UL');
+      if (nextMenuLists.length > 0) {
+        const nextMenuChildren = Array.from(nextMenuLists[0].children);
 
-      if (!this.state.currentDrilldownMenuId || nextMenu.id !== this.state.currentDrilldownMenuId) {
-        this.setState({ currentDrilldownMenuId: nextMenu.id });
-      } else {
-        // if the drilldown transition ends on the same menu, do not focus the first item
-        return;
+        if (!this.state.currentDrilldownMenuId || nextMenu.id !== this.state.currentDrilldownMenuId) {
+          this.setState({ currentDrilldownMenuId: nextMenu.id });
+        } else {
+          // if the drilldown transition ends on the same menu, do not focus the first item
+          return;
+        }
+        const nextTarget = nextMenuChildren.filter(
+          (el) => !(el.classList.contains('pf-m-disabled') || el.classList.contains(styles.divider))
+        )[0].firstChild;
+        (nextTarget as HTMLElement).focus();
+        (nextTarget as HTMLElement).tabIndex = 0;
       }
-      const nextTarget = nextMenuChildren.filter(
-        (el) => !(el.classList.contains('pf-m-disabled') || el.classList.contains(styles.divider))
-      )[0].firstChild;
-
-      (nextTarget as HTMLElement).focus();
-      (nextTarget as HTMLElement).tabIndex = 0;
     }
   };
 


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Fixes crash in menu when access the first element in array without checking that the array is not empty.

This was run into when using a menu that shows asynchronously loaded items.
Upon reset some logic goes wrong in the PF component and tries to reference an array item that is not there and crashes.

There are a bunch of places in the code that reference the first array item without properly checking for it to exist.
While this only fixes the one that we are currently running into, once fixed, we may run into more.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
