### PR TITLE
feat(FormGroupLabelHelp): update markup to match core

### DIFF
--- a/packages/react-core/src/components/Button/examples/ButtonInlineSpanLink.tsx
+++ b/packages/react-core/src/components/Button/examples/ButtonInlineSpanLink.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { Button } from '@patternfly/react-core';
+import { Button, KeyTypes } from '@patternfly/react-core';
 
 const handleKeydown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
   const { key } = event;
-  const isEnterKey: boolean = key === 'Enter';
-  const isEnterOrSpaceKey: boolean = isEnterKey || key === 'Space';
+  const isEnterKey: boolean = key === KeyTypes.Enter;
+  const isEnterOrSpaceKey: boolean = isEnterKey || key === KeyTypes.Space;
 
   if (isEnterOrSpaceKey) {
     event.preventDefault();

--- a/packages/react-core/src/components/Form/FormGroupLabelHelp.tsx
+++ b/packages/react-core/src/components/Form/FormGroupLabelHelp.tsx
@@ -16,9 +16,29 @@ export const FormGroupLabelHelp: React.FunctionComponent<FormGroupLabelHelpProps
   'aria-label': ariaLabel,
   className,
   ...props
-}) => (
-  <Button aria-label={ariaLabel} className={className} variant="plain" hasNoPadding {...props}>
-    <QuestionCircleIcon />
-  </Button>
-);
+}) => {
+  const buttonRef = React.useRef(null);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLSpanElement>) => {
+    if (event.key === 'Enter' && buttonRef.current) {
+      buttonRef.current.click();
+    }
+  };
+
+  return (
+    <Button
+      component="span"
+      isInline
+      ref={buttonRef}
+      onKeyDown={handleKeyDown}
+      aria-label={ariaLabel}
+      className={className}
+      variant="plain"
+      hasNoPadding
+      {...props}
+    >
+      <QuestionCircleIcon />
+    </Button>
+  );
+};
 FormGroupLabelHelp.displayName = 'FormGroupLabelHelp';

--- a/packages/react-core/src/components/Form/FormGroupLabelHelp.tsx
+++ b/packages/react-core/src/components/Form/FormGroupLabelHelp.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Button, ButtonProps } from '../Button';
 import QuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/question-circle-icon';
+import { KeyTypes } from '../../helpers/constants';
 
 /** A help button to be passed to the FormGroup's labelHelp property. This should be wrapped or linked
  * to our Popover component.
@@ -27,7 +28,7 @@ const FormGroupLabelHelpBase: React.FunctionComponent<FormGroupLabelHelpProps> =
     typeof ref === 'object' && ref !== null && 'current' in ref && ref.current !== undefined;
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLSpanElement>) => {
-    if (event.key === 'Enter' && isMutableRef(buttonRef) && buttonRef.current) {
+    if ([KeyTypes.Space, KeyTypes.Enter].includes(event.key) && isMutableRef(buttonRef) && buttonRef.current) {
       buttonRef.current.click();
     }
   };

--- a/packages/react-core/src/components/Form/FormGroupLabelHelp.tsx
+++ b/packages/react-core/src/components/Form/FormGroupLabelHelp.tsx
@@ -29,6 +29,7 @@ const FormGroupLabelHelpBase: React.FunctionComponent<FormGroupLabelHelpProps> =
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLSpanElement>) => {
     if ([KeyTypes.Space, KeyTypes.Enter].includes(event.key) && isMutableRef(buttonRef) && buttonRef.current) {
+      event.preventDefault();
       buttonRef.current.click();
     }
   };

--- a/packages/react-core/src/components/Form/FormGroupLabelHelp.tsx
+++ b/packages/react-core/src/components/Form/FormGroupLabelHelp.tsx
@@ -10,17 +10,24 @@ export interface FormGroupLabelHelpProps extends ButtonProps {
   'aria-label': string;
   /** Additional classes added to the help button. */
   className?: string;
+  /** @hide Forwarded ref */
+  innerRef?: React.Ref<HTMLSpanElement>;
 }
 
-export const FormGroupLabelHelp: React.FunctionComponent<FormGroupLabelHelpProps> = ({
+const FormGroupLabelHelpBase: React.FunctionComponent<FormGroupLabelHelpProps> = ({
   'aria-label': ariaLabel,
   className,
+  innerRef,
   ...props
 }) => {
-  const buttonRef = React.useRef(null);
+  const ref = React.useRef<HTMLSpanElement>(null);
+  const buttonRef = innerRef || ref;
+
+  const isMutableRef = (ref: React.Ref<HTMLSpanElement>): ref is React.MutableRefObject<HTMLSpanElement> =>
+    typeof ref === 'object' && ref !== null && 'current' in ref && ref.current !== undefined;
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLSpanElement>) => {
-    if (event.key === 'Enter' && buttonRef.current) {
+    if (event.key === 'Enter' && isMutableRef(buttonRef) && buttonRef.current) {
       buttonRef.current.click();
     }
   };
@@ -41,4 +48,9 @@ export const FormGroupLabelHelp: React.FunctionComponent<FormGroupLabelHelpProps
     </Button>
   );
 };
+
+export const FormGroupLabelHelp = React.forwardRef((props: FormGroupLabelHelpProps, ref: React.Ref<any>) => (
+  <FormGroupLabelHelpBase innerRef={ref} {...props} />
+));
+
 FormGroupLabelHelp.displayName = 'FormGroupLabelHelp';

--- a/packages/react-core/src/components/Form/examples/FormBasic.tsx
+++ b/packages/react-core/src/components/Form/examples/FormBasic.tsx
@@ -18,6 +18,7 @@ export const FormBasic: React.FunctionComponent = () => {
   const [name, setName] = React.useState('');
   const [email, setEmail] = React.useState('');
   const [phone, setPhone] = React.useState('');
+  const labelHelpRef = React.useRef(null);
 
   const handleNameChange = (_event, name: string) => {
     setName(name);
@@ -37,6 +38,7 @@ export const FormBasic: React.FunctionComponent = () => {
         label="Full name"
         labelHelp={
           <Popover
+            triggerRef={labelHelpRef}
             headerContent={
               <div>
                 The{' '}
@@ -63,7 +65,7 @@ export const FormBasic: React.FunctionComponent = () => {
               </div>
             }
           >
-            <FormGroupLabelHelp aria-label="More info for name field" />
+            <FormGroupLabelHelp ref={labelHelpRef} aria-label="More info for name field" />
           </Popover>
         }
         isRequired

--- a/packages/react-core/src/components/Form/examples/FormGroupLabelInfo.tsx
+++ b/packages/react-core/src/components/Form/examples/FormGroupLabelInfo.tsx
@@ -12,6 +12,7 @@ import {
 
 export const FormGroupLabelInfo: React.FunctionComponent = () => {
   const [name, setName] = React.useState('');
+  const labelHelpRef = React.useRef(null);
 
   const handleNameChange = (_event, name: string) => {
     setName(name);
@@ -24,6 +25,7 @@ export const FormGroupLabelInfo: React.FunctionComponent = () => {
         labelInfo="Additional label info"
         labelHelp={
           <Popover
+            triggerRef={labelHelpRef}
             headerContent={
               <div>
                 The{' '}
@@ -50,7 +52,7 @@ export const FormGroupLabelInfo: React.FunctionComponent = () => {
               </div>
             }
           >
-            <FormGroupLabelHelp aria-label="More info for name field" />
+            <FormGroupLabelHelp ref={labelHelpRef} aria-label="More info for name field" />
           </Popover>
         }
         isRequired

--- a/packages/react-core/src/components/Form/examples/FormLimitWidth.tsx
+++ b/packages/react-core/src/components/Form/examples/FormLimitWidth.tsx
@@ -18,6 +18,7 @@ export const FormLimitWidth: React.FunctionComponent = () => {
   const [name, setName] = React.useState('');
   const [email, setEmail] = React.useState('');
   const [phone, setPhone] = React.useState('');
+  const labelHelpRef = React.useRef(null);
 
   const handleNameChange = (_event, name: string) => {
     setName(name);
@@ -37,6 +38,7 @@ export const FormLimitWidth: React.FunctionComponent = () => {
         label="Full name"
         labelHelp={
           <Popover
+            triggerRef={labelHelpRef}
             headerContent={
               <div>
                 The{' '}
@@ -63,7 +65,7 @@ export const FormLimitWidth: React.FunctionComponent = () => {
               </div>
             }
           >
-            <FormGroupLabelHelp aria-label="More info for name field" />
+            <FormGroupLabelHelp ref={labelHelpRef} aria-label="More info for name field" />
           </Popover>
         }
         isRequired

--- a/packages/react-core/src/components/Modal/examples/ModalWithForm.tsx
+++ b/packages/react-core/src/components/Modal/examples/ModalWithForm.tsx
@@ -15,6 +15,9 @@ export const ModalWithForm: React.FunctionComponent = () => {
   const [nameValue, setNameValue] = React.useState('');
   const [emailValue, setEmailValue] = React.useState('');
   const [addressValue, setAddressValue] = React.useState('');
+  const nameLabelHelpRef = React.useRef(null);
+  const emailLabelHelpRef = React.useRef(null);
+  const addressLabelHelpRef = React.useRef(null);
 
   const handleModalToggle = (_event: KeyboardEvent | React.MouseEvent) => {
     setModalOpen(!isModalOpen);
@@ -56,6 +59,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
             label="Name"
             labelHelp={
               <Popover
+                triggerRef={nameLabelHelpRef}
                 headerContent={
                   <div>
                     The
@@ -82,7 +86,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
                   </div>
                 }
               >
-                <FormGroupLabelHelp aria-label="More info for name field" />
+                <FormGroupLabelHelp ref={nameLabelHelpRef} aria-label="More info for name field" />
               </Popover>
             }
             isRequired
@@ -101,6 +105,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
             label="E-mail"
             labelHelp={
               <Popover
+                triggerRef={emailLabelHelpRef}
                 headerContent={
                   <div>
                     The
@@ -123,7 +128,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
                   </div>
                 }
               >
-                <FormGroupLabelHelp aria-label="More info for e-mail field" />
+                <FormGroupLabelHelp ref={emailLabelHelpRef} aria-label="More info for e-mail field" />
               </Popover>
             }
             isRequired
@@ -142,6 +147,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
             label="Address"
             labelHelp={
               <Popover
+                triggerRef={addressLabelHelpRef}
                 headerContent={
                   <div>
                     The
@@ -163,7 +169,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
                   </div>
                 }
               >
-                <FormGroupLabelHelp aria-label="More info for address field" />
+                <FormGroupLabelHelp ref={addressLabelHelpRef} aria-label="More info for address field" />
               </Popover>
             }
             isRequired

--- a/packages/react-core/src/demos/SearchInput/SearchInput.md
+++ b/packages/react-core/src/demos/SearchInput/SearchInput.md
@@ -128,9 +128,9 @@ SearchAutocomplete = () => {
         event.preventDefault(); // by default, the up and down arrow keys scroll the window
         // the tab, enter, and space keys will close the menu, and the tab key will move browser
         // focus forward one element (by default)
-      } else if (event.key === 'Tab' || event.key === 'Enter' || event.key === 'Space') {
+      } else if (event.key === 'Tab' || event.key === 'Enter' || event.key === ' ') {
         setIsAutocompleteOpen(false);
-        if (event.key === 'Enter' || event.key === 'Space') {
+        if (event.key === 'Enter' || event.key === ' ') {
           event.preventDefault();
         }
       }

--- a/packages/react-core/src/demos/examples/PasswordStrength/PasswordStrengthDemo.tsx
+++ b/packages/react-core/src/demos/examples/PasswordStrength/PasswordStrengthDemo.tsx
@@ -89,9 +89,15 @@ export const PasswordStrengthDemo: React.FunctionComponent = () => {
     }
   };
 
+  const labelHelpRef = React.useRef(null);
+
   const iconPopover = (
-    <Popover headerContent={<div>Password Requirements</div>} bodyContent={<div>Password rules</div>}>
-      <FormGroupLabelHelp aria-label="More info for name field" />
+    <Popover
+      triggerRef={labelHelpRef}
+      headerContent={<div>Password Requirements</div>}
+      bodyContent={<div>Password rules</div>}
+    >
+      <FormGroupLabelHelp ref={labelHelpRef} aria-label="More info for name field" />
     </Popover>
   );
 

--- a/packages/react-core/src/next/components/Modal/examples/ModalWithForm.tsx
+++ b/packages/react-core/src/next/components/Modal/examples/ModalWithForm.tsx
@@ -7,6 +7,9 @@ export const ModalWithForm: React.FunctionComponent = () => {
   const [nameValue, setNameValue] = React.useState('');
   const [emailValue, setEmailValue] = React.useState('');
   const [addressValue, setAddressValue] = React.useState('');
+  const nameLabelHelpRef = React.useRef(null);
+  const emailLabelHelpRef = React.useRef(null);
+  const addressLabelHelpRef = React.useRef(null);
 
   const handleModalToggle = (_event: KeyboardEvent | React.MouseEvent) => {
     setModalOpen(!isModalOpen);
@@ -47,6 +50,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
               label="Name"
               labelHelp={
                 <Popover
+                  triggerRef={nameLabelHelpRef}
                   headerContent={
                     <div>
                       The
@@ -73,7 +77,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
                     </div>
                   }
                 >
-                  <FormGroupLabelHelp aria-label="More info for name field" />
+                  <FormGroupLabelHelp ref={nameLabelHelpRef} aria-label="More info for name field" />
                 </Popover>
               }
               isRequired
@@ -92,6 +96,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
               label="E-mail"
               labelHelp={
                 <Popover
+                  triggerRef={emailLabelHelpRef}
                   headerContent={
                     <div>
                       The
@@ -114,7 +119,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
                     </div>
                   }
                 >
-                  <FormGroupLabelHelp aria-label="More info for e-mail field" />
+                  <FormGroupLabelHelp ref={emailLabelHelpRef} aria-label="More info for e-mail field" />
                 </Popover>
               }
               isRequired
@@ -133,6 +138,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
               label="Address"
               labelHelp={
                 <Popover
+                  triggerRef={addressLabelHelpRef}
                   headerContent={
                     <div>
                       The
@@ -154,7 +160,7 @@ export const ModalWithForm: React.FunctionComponent = () => {
                     </div>
                   }
                 >
-                  <FormGroupLabelHelp aria-label="More info for address field" />
+                  <FormGroupLabelHelp ref={addressLabelHelpRef} aria-label="More info for address field" />
                 </Popover>
               }
               isRequired

--- a/packages/react-integration/demo-app-ts/src/components/demos/FormDemo/FormDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/FormDemo/FormDemo.tsx
@@ -43,6 +43,9 @@ export class FormDemo extends Component<FormProps, FormState> {
 
     this.handleCheckboxChange = this.handleCheckboxChange.bind(this);
   }
+
+  labelHelpRef: React.RefObject<HTMLSpanElement> = React.createRef();
+
   handleTextInputChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => {
     this.setState({ value, isValid: /^\d+$/.test(value) });
   };
@@ -114,6 +117,7 @@ export class FormDemo extends Component<FormProps, FormState> {
             labelInfo="Age info"
             labelHelp={
               <Popover
+                triggerRef={this.labelHelpRef}
                 headerContent={<div>The age of a person</div>}
                 bodyContent={
                   <div>
@@ -122,7 +126,7 @@ export class FormDemo extends Component<FormProps, FormState> {
                   </div>
                 }
               >
-                <FormGroupLabelHelp aria-label="More info for name field" />
+                <FormGroupLabelHelp ref={this.labelHelpRef} aria-label="More info for name field" />
               </Popover>
             }
             type="number"

--- a/packages/react-table/src/components/Table/Table.tsx
+++ b/packages/react-table/src/components/Table/Table.tsx
@@ -5,7 +5,7 @@ import stylesTreeView from '@patternfly/react-styles/css/components/Table/table-
 import { css } from '@patternfly/react-styles';
 import { toCamel } from './utils';
 import { IVisibility } from './utils/decorators/classNames';
-import { useOUIAProps, OUIAProps, handleArrows, setTabIndex } from '@patternfly/react-core';
+import { useOUIAProps, OUIAProps, handleArrows, setTabIndex, KeyTypes } from '@patternfly/react-core';
 import { TableGridBreakpoint, TableVariant } from './TableTypes';
 
 export interface BaseCellProps {
@@ -169,7 +169,7 @@ const TableBase: React.FunctionComponent<TableProps> = ({
     const rows = (Array.from(tableRef.current.querySelectorAll('tbody tr')) as Element[]).filter(
       (el) => !el.classList.contains('pf-m-disabled') && !(el as HTMLElement).hidden
     );
-    if (key === 'Space' || key === 'Enter') {
+    if (key === KeyTypes.Space || key === KeyTypes.Enter) {
       (activeElement as HTMLElement).click();
       event.preventDefault();
     }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #10158

I am not sure if the last two commits are necessary. I did them so the `<div style="display: contents;">` is not present in the markup and there is no better way to hide it from Popover than by passing both the `children` and the `triggerRef` prop to Popover.

