### PR TITLE
docs(menu-toggle): Adds docs for split button examples.

### DIFF
--- a/packages/react-core/src/components/MenuToggle/examples/MenuToggle.md
+++ b/packages/react-core/src/components/MenuToggle/examples/MenuToggle.md
@@ -193,7 +193,7 @@ import { MenuToggle } from '@patternfly/react-core';
 </React.Fragment>
 ```
 
-### Split button toggle with checkbox
+### Split toggle with checkbox
 
 To add a checkbox (or other action/control) to a menu toggle, use a split button. 
 
@@ -207,7 +207,7 @@ Variant styling can be applied to split button toggles to adjust their appearanc
 
 ```
 
-### Split button toggle with checkbox and text label
+### Split toggle with labeled checkbox
 
 To add a text label to a split button toggle, pass `children` to the `<MenuToggle>` component.
 
@@ -215,7 +215,7 @@ To add a text label to a split button toggle, pass `children` to the `<MenuToggl
 
 ```
 
-### Split button toggle with checkbox and clickable text label  
+### Split toggle with checkbox and toggle text label
 
 You can allow users to select a toggle checkbox by clicking either the checkbox or the text label.
 
@@ -225,7 +225,7 @@ To do so, pass `children` to the `<MenuToggleCheckbox>` component. When the menu
 
 ```
 
-### Split button toggle with action
+### Split toggle with action
 
 To add an action to a split button, pass `variant='action'` into `splitButtonOptions` and add a `<MenuToggleAction>` to the `items` property of `splitButtonOptions`.
 

--- a/packages/react-core/src/components/MenuToggle/examples/MenuToggle.md
+++ b/packages/react-core/src/components/MenuToggle/examples/MenuToggle.md
@@ -195,7 +195,9 @@ import { MenuToggle } from '@patternfly/react-core';
 
 ### Split button toggle with checkbox
 
-To add an action button or other control to a menu toggle, use a split button. A `<MenuToggle>` can be rendered as a split button by adding a `splitButtonOptions` object. Elements to be displayed before the toggle button must be included in the `items` property of `splitButtonOptions`.
+To add a checkbox (or other action/control) to a menu toggle, use a split button. 
+
+A `<MenuToggle>` can be rendered as a split button by adding a `splitButtonOptions` object. Elements to be displayed before the toggle button must be included in the `items` property of `splitButtonOptions`.
 
 The following example shows a split button with a `<MenuToggleCheckbox>`.
 
@@ -205,21 +207,21 @@ Variant styling can be applied to split button toggles to adjust their appearanc
 
 ```
 
-### Split button toggle with checkbox label
+### Split button toggle with checkbox and text label
 
-To display text in a split button menu toggle, add a label to the `items` property of `splitButtonOptions`.
+To add a text label to a split button toggle, pass `children` to the `<MenuToggle>` component.
 
-```ts file='MenuToggleSplitButtonCheckboxWithText.tsx'
+```ts file='MenuToggleSplitButtonCheckboxWithToggleText.tsx'
 
 ```
 
-### Split button toggle with checkbox and toggle button text
+### Split button toggle with checkbox and clickable text label  
 
-For split button toggles that should still contain text which will trigger the toggle's `onClick`, pass `children` to the `MenuToggle`.
+You can allow users to select a toggle checkbox by clicking either the checkbox or the text label.
 
-The following example shows a split button with a `<MenuToggleCheckbox>` and toggle button text.
+To do so, pass `children` to the `<MenuToggleCheckbox>` component. When the menu toggle text is clicked, the checkbox's `onChange` callback will be triggered.
 
-```ts file='MenuToggleSplitButtonCheckboxWithToggleText.tsx'
+```ts file='MenuToggleSplitButtonCheckboxWithText.tsx'
 
 ```
 


### PR DESCRIPTION
Closes #10258 