### PR TITLE
fix(DragDropSort): fix positioning of DragOverlay

### DIFF
--- a/packages/react-drag-drop/src/next/components/DragDrop/DragDropSort.tsx
+++ b/packages/react-drag-drop/src/next/components/DragDrop/DragDropSort.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import { css } from '@patternfly/react-styles';
 import {
   DndContext,
@@ -22,6 +23,7 @@ import { Draggable } from './Draggable';
 import { DraggableDataListItem } from './DraggableDataListItem';
 import { DraggableDualListSelectorListItem } from './DraggableDualListSelectorListItem';
 import styles from '@patternfly/react-styles/css/components/DragDrop/drag-drop';
+import { canUseDOM } from '@patternfly/react-core';
 
 export type DragDropSortDragEndEvent = DragEndEvent;
 export type DragDropSortDragStartEvent = DragStartEvent;
@@ -135,6 +137,8 @@ export const DragDropSort: React.FunctionComponent<DragDropSortProps> = ({
     );
   };
 
+  const dragOverlay = <DragOverlay>{activeId && getDragOverlay()}</DragOverlay>;
+
   const renderedChildren = (
     <SortableContext items={itemIds} strategy={verticalListSortingStrategy} id="droppable">
       {items.map((item: DraggableObject) => {
@@ -159,7 +163,7 @@ export const DragDropSort: React.FunctionComponent<DragDropSortProps> = ({
             );
         }
       })}
-      <DragOverlay>{activeId && getDragOverlay()}</DragOverlay>
+      {canUseDOM ? ReactDOM.createPortal(dragOverlay, document.getElementById('root')) : dragOverlay}
     </SortableContext>
   );
 

--- a/packages/react-drag-drop/src/next/components/DragDrop/__tests__/DragDrop.test.tsx
+++ b/packages/react-drag-drop/src/next/components/DragDrop/__tests__/DragDrop.test.tsx
@@ -2,6 +2,11 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { DragDropSort } from '../';
 
+jest.mock('react-dom', () => ({
+  ...jest.requireActual('react-dom'),
+  createPortal: jest.fn((node) => node)
+}));
+
 test('renders some divs', () => {
   const { asFragment } = render(
     <div className="pf-c-droppable pf-m-dragging">


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #10090

Change was done based on this [comment](https://github.com/clauderic/dnd-kit/issues/464#issuecomment-1008316262) from the author of the `dnd-kit` package.

I assume that a div with `id="root"` will always be present in a React app, which I don't know if it is 100% true.

We should also do this change for V6 once DragDrop is removed from the `next` folder.
