### PR TITLE
bug(ci): fix broken release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,14 @@ jobs:
     steps:
       - name: Check out project
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Needs to be an admin token to get around branch protection.
+          token: ${{ secrets.GH_TOKEN_REDALLEN }}
+
+      # Fetches all tags from 'origin' and updates local tags, only fetches the latest commit.
+      - name: Fetch tags
+        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
       - name: Set up and build project
         uses: ./.github/actions/setup-project


### PR DESCRIPTION
Fixes the release job that is currently broken on `main`, I was a bit too optimistic in my code removal. This restores the token passed into `action/checkout` and also fetches all the tags from Git, as was done previously. I have no way of testing this on short notice, but I am fairly confident this should fix the issue.