### PR TITLE
fix(ci): prevent V8 crashes during build

### DIFF
--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -59,3 +59,7 @@ runs:
       if: inputs.skip-build != 'true' && steps.cache-build.outputs.cache-hit != 'true'
       shell: bash
       run: yarn build && yarn build:umd
+      env:
+        # Disable V8 compile cache to hard crashes in Node.js. This can likely be removed once upgraded to the next LTS version (version 22).
+        # See: https://github.com/nodejs/node/issues/51555
+        DISABLE_V8_COMPILE_CACHE: 1


### PR DESCRIPTION
Fixes an issue where the CI will sometimes break due to a Node.js crash that seems related to the way V8 handles the compile cache (https://github.com/nodejs/node/issues/51555). The problem seems to be mitigated by disabling the compile cache for now, and is likely resolved by upgrading to a new LTS version in the future.

This issue seems to only occur on CI, as I was not able to reproduce it locally with the same version of Node.js, and this is likely related to the specific way the GitHub actions runners are set up. So I believe this will not impact local development.