### PR TITLE
docs(Page): add example showing different type prop variants

### DIFF
--- a/packages/react-core/src/components/Page/examples/Page.md
+++ b/packages/react-core/src/components/Page/examples/Page.md
@@ -106,6 +106,14 @@ To remove padding at specific breakpoints, pass in 'noPadding' at those breakpoi
 
 ```
 
+### Main section variations
+
+This example shows all types of page sections.
+
+```ts file="./PageMainSectionVariations.tsx"
+
+```
+
 ### Group section
 
 To group page content sections, add 1 or more `<PageGroup>` components to a `<Page>`.

--- a/packages/react-core/src/components/Page/examples/PageMainSectionVariations.tsx
+++ b/packages/react-core/src/components/Page/examples/PageMainSectionVariations.tsx
@@ -24,7 +24,7 @@ export const PageMainSectionPadding: React.FunctionComponent = () => {
   };
 
   const headerToolbar = (
-    <Toolbar id="main-padding-toolbar">
+    <Toolbar id="main-variations-toolbar">
       <ToolbarContent>
         <ToolbarItem>header-tools</ToolbarItem>
       </ToolbarContent>
@@ -39,7 +39,7 @@ export const PageMainSectionPadding: React.FunctionComponent = () => {
           aria-label="Global navigation"
           isSidebarOpen={isSidebarOpen}
           onSidebarToggle={onSidebarToggle}
-          id="main-padding-nav-toggle"
+          id="main-variations-nav-toggle"
         >
           <BarsIcon />
         </PageToggleButton>
@@ -54,7 +54,7 @@ export const PageMainSectionPadding: React.FunctionComponent = () => {
   );
 
   const sidebar = (
-    <PageSidebar isSidebarOpen={isSidebarOpen} id="main-padding-sidebar">
+    <PageSidebar isSidebarOpen={isSidebarOpen} id="main-variations-sidebar">
       <PageSidebarBody>Navigation</PageSidebarBody>
     </PageSidebar>
   );

--- a/packages/react-core/src/components/Page/examples/PageMainSectionVariations.tsx
+++ b/packages/react-core/src/components/Page/examples/PageMainSectionVariations.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import {
+  Page,
+  Masthead,
+  MastheadToggle,
+  MastheadMain,
+  MastheadBrand,
+  MastheadContent,
+  PageSidebar,
+  PageSidebarBody,
+  PageSection,
+  PageToggleButton,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem
+} from '@patternfly/react-core';
+import BarsIcon from '@patternfly/react-icons/dist/esm/icons/bars-icon';
+
+export const PageMainSectionPadding: React.FunctionComponent = () => {
+  const [isSidebarOpen, setIsSidebarOpen] = React.useState(true);
+
+  const onSidebarToggle = () => {
+    setIsSidebarOpen(!isSidebarOpen);
+  };
+
+  const headerToolbar = (
+    <Toolbar id="main-padding-toolbar">
+      <ToolbarContent>
+        <ToolbarItem>header-tools</ToolbarItem>
+      </ToolbarContent>
+    </Toolbar>
+  );
+
+  const header = (
+    <Masthead>
+      <MastheadToggle>
+        <PageToggleButton
+          variant="plain"
+          aria-label="Global navigation"
+          isSidebarOpen={isSidebarOpen}
+          onSidebarToggle={onSidebarToggle}
+          id="main-padding-nav-toggle"
+        >
+          <BarsIcon />
+        </PageToggleButton>
+      </MastheadToggle>
+      <MastheadMain>
+        <MastheadBrand href="https://patternfly.org" target="_blank">
+          Logo
+        </MastheadBrand>
+      </MastheadMain>
+      <MastheadContent>{headerToolbar}</MastheadContent>
+    </Masthead>
+  );
+
+  const sidebar = (
+    <PageSidebar isSidebarOpen={isSidebarOpen} id="main-padding-sidebar">
+      <PageSidebarBody>Navigation</PageSidebarBody>
+    </PageSidebar>
+  );
+
+  return (
+    <Page header={header} sidebar={sidebar}>
+      <PageSection type="subnav">
+        Section with <code>type="subnav"</code> for horizontal subnav navigation
+      </PageSection>
+      <PageSection type="nav">
+        Section with <code>type="nav"</code> for tertiary navigation
+      </PageSection>
+      <PageSection type="tabs">
+        Section with <code>type="tabs"</code> for tabs
+      </PageSection>
+      <PageSection type="breadcrumb">
+        Section with <code>type="breadcrumb"</code> for breadcrumbs
+      </PageSection>
+      <PageSection>
+        Section without <code>type</code> prop or <code>type="default"</code> for main sections
+      </PageSection>
+      <PageSection type="wizard">
+        Section with <code>type="wizard"</code> for wizards
+      </PageSection>
+    </Page>
+  );
+};

--- a/packages/react-core/src/components/Page/examples/page.css
+++ b/packages/react-core/src/components/Page/examples/page.css
@@ -1,3 +1,4 @@
-.pf-v5-c-page__sidebar-body {
+.pf-v5-c-page__sidebar-body,
+.pf-v5-c-page__main-subnav {
   color: var(--pf-v5-global--Color--light-100);
 }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #9868

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
- `Section with type="nav" for tertiary navigation`: the `tertiary` navigation was removed in V6, we should rename it in the upcoming React example for V6 and the Core V6 example too - but what is the `type="nav"` used for in V6 if not tertiary navigation?