### PR TITLE
fix(charts): tooltip whitespace is not preserved for Safari

### DIFF
--- a/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
@@ -157,7 +157,7 @@ export const getLegendTooltipSize = ({
   // Get spacing to help align legend labels and text values
   const spacer = 'x';
   const getSpacing = (legendLabel: string, textLabel: string) => {
-    let spacing = '';
+    let spacing = '\u00A0';
     if (maxLength === 0) {
       return spacing;
     }


### PR DESCRIPTION
Preserve tooltip whitespace for Safari

Closes https://github.com/patternfly/patternfly-react/issues/10354

![Screenshot 2024-05-13 at 10 50 01 AM](https://github.com/patternfly/patternfly-react/assets/17481322/2a46d569-a437-4618-90aa-f0336370fda4)
