### PR TITLE
chore(ci): cancel release workflow if new release is triggered

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   ci:
     name: CI


### PR DESCRIPTION
Cancels the release workflow if a new commit is pushed that could create failures if the workflows start competing for Git tags needed for release. This uses the [`concurrency`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-concurrency-and-the-default-behavior) feature in GitHub actions to automatically cancel any runs before the last.