### PR TITLE
chore: enable default configuration for Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,91 +1,14 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
-  "enabledManagers": ["npm"],
   "packageRules": [
     {
-      "packagePatterns": ["*"],
-      "excludePackagePatterns": [
-        "@babel/*",
-        "@octokit/rest",
-        "@patternfly/patternfly",
-        "@patternfly/patternfly-a11y",
-        "@patternfly/documentation-framework",
-        "@rollup/*",
-        "@testing-library/jest-dom",
-        "@testing-library/user-event",
-        "@types/jest",
-        "@types/react",
-        "@types/react-dom",
-        "@typescript-eslint/eslint-plugin",
-        "@typescript-eslint/parser",
-        "eslint",
-        "eslint-plugin-prettier",
-        "eslint-plugin-react",
-        "fs-extra",
-        "lint-staged",
-        "mutation-observer",
-        "plop",
-        "prettier",
-        "react-dropzone",
-        "rollup",
-        "rollup-plugin-scss",
-        "rollup-plugin-terser",
-        "surge",
-        "ts-patch"
+      "matchUpdateTypes": [
+        "major"
       ],
       "enabled": false
-    },
-    {
-      "groupName": "devDependencies",
-      "matchDatasources": ["npm"],
-      "automerge": true,
-      "matchPackagePatterns": [
-        "@babel/*",
-        "@octokit/rest",
-        "@patternfly/patternfly-a11y",
-        "@patternfly/documentation-framework",
-        "@rollup/*",
-        "@testing-library/jest-dom",
-        "@testing-library/react-hooks",
-        "@testing-library/user-event",
-        "@types/jest",
-        "@types/react",
-        "@types/react-dom",
-        "@typescript-eslint/eslint-plugin",
-        "@typescript-eslint/parser",
-        "eslint",
-        "eslint-plugin-prettier",
-        "eslint-plugin-react",
-        "focus-trap",
-        "fs-extra",
-        "lint-staged",
-        "mutation-observer",
-        "plop",
-        "prettier",
-        "react-dropzone",
-        "rollup",
-        "rollup-plugin-scss",
-        "rollup-plugin-terser",
-        "surge",
-        "ts-patch"
-      ]
-    },
-    {
-      "matchDatasources": ["npm"],
-      "matchPackageNames": [
-        "focus-trap",
-        "react-dropzone"
-      ]
-    },
-    {
-      "matchDatasources": ["npm"],
-      "matchPackageNames": [
-        "@patternfly/patternfly"
-      ],
-      "automerge": true,
-      "followTag": "prerelease"
     }
   ]
 }


### PR DESCRIPTION
Changes the Renovate configuration to extend the [recommended preset](https://docs.renovatebot.com/presets-config/#configrecommended), and configures it to exclude major upgrades (for now).

The reason for this is that a lot of minor and patch upgrades being skipped because they are getting bunched up into big PRs that fail the CI (see #9970, #9970). The recommended preset will instead create a separate PR for each dependency, increasing the chances of a successful merge that doesn't hold up other updates.

To avoid queuing up too many PRs the limit of the recommended config is set to a [maximum of 10 branches](https://docs.renovatebot.com/configuration-options/#branchconcurrentlimit) at any given time (CVEs excluded), this can be seen in action on [my fork](https://github.com/jonkoops/patternfly-react/pulls/app%2Frenovate).