### PR TITLE
feat(misc, TextContent): update core version & text content updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,7 @@
     "surge": "^0.23.1",
     "ts-node": "^10.9.1",
     "ts-patch": "^2.1.0",
-    "typescript": "^4.7.4",
-    "ts-node": "^10.9.1"
+    "typescript": "^4.7.4"
   },
   "scripts": {
     "build": "yarn clean && yarn build:generate && yarn build:esm && yarn build:cjs && yarn build:subpaths && yarn build:single:packages",

--- a/packages/react-charts/src/components/Chart/__snapshots__/Chart.test.tsx.snap
+++ b/packages/react-charts/src/components/Chart/__snapshots__/Chart.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`Chart 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
+          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
           vector-effect="non-scaling-stroke"
           x1="50"
           x2="400"
@@ -32,7 +32,7 @@ exports[`Chart 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="120"
             x2="120"
@@ -49,7 +49,7 @@ exports[`Chart 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="120"
             >
@@ -63,7 +63,7 @@ exports[`Chart 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="190"
             x2="190"
@@ -80,7 +80,7 @@ exports[`Chart 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="190"
             >
@@ -94,7 +94,7 @@ exports[`Chart 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="260"
             x2="260"
@@ -111,7 +111,7 @@ exports[`Chart 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="260"
             >
@@ -125,7 +125,7 @@ exports[`Chart 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="330"
             x2="330"
@@ -142,7 +142,7 @@ exports[`Chart 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="330"
             >
@@ -156,7 +156,7 @@ exports[`Chart 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="400"
             x2="400"
@@ -173,7 +173,7 @@ exports[`Chart 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="400"
             >
@@ -188,7 +188,7 @@ exports[`Chart 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
+          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
           vector-effect="non-scaling-stroke"
           x1="50"
           x2="50"
@@ -201,7 +201,7 @@ exports[`Chart 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -218,7 +218,7 @@ exports[`Chart 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -232,7 +232,7 @@ exports[`Chart 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -249,7 +249,7 @@ exports[`Chart 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -263,7 +263,7 @@ exports[`Chart 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -280,7 +280,7 @@ exports[`Chart 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -294,7 +294,7 @@ exports[`Chart 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -311,7 +311,7 @@ exports[`Chart 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -325,7 +325,7 @@ exports[`Chart 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -342,7 +342,7 @@ exports[`Chart 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -385,7 +385,7 @@ exports[`Chart 2`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
+          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
           vector-effect="non-scaling-stroke"
           x1="50"
           x2="400"
@@ -398,7 +398,7 @@ exports[`Chart 2`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="120"
             x2="120"
@@ -415,7 +415,7 @@ exports[`Chart 2`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="120"
             >
@@ -429,7 +429,7 @@ exports[`Chart 2`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="190"
             x2="190"
@@ -446,7 +446,7 @@ exports[`Chart 2`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="190"
             >
@@ -460,7 +460,7 @@ exports[`Chart 2`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="260"
             x2="260"
@@ -477,7 +477,7 @@ exports[`Chart 2`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="260"
             >
@@ -491,7 +491,7 @@ exports[`Chart 2`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="330"
             x2="330"
@@ -508,7 +508,7 @@ exports[`Chart 2`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="330"
             >
@@ -522,7 +522,7 @@ exports[`Chart 2`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="400"
             x2="400"
@@ -539,7 +539,7 @@ exports[`Chart 2`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="400"
             >
@@ -554,7 +554,7 @@ exports[`Chart 2`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
+          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
           vector-effect="non-scaling-stroke"
           x1="50"
           x2="50"
@@ -567,7 +567,7 @@ exports[`Chart 2`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -584,7 +584,7 @@ exports[`Chart 2`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -598,7 +598,7 @@ exports[`Chart 2`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -615,7 +615,7 @@ exports[`Chart 2`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -629,7 +629,7 @@ exports[`Chart 2`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -646,7 +646,7 @@ exports[`Chart 2`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -660,7 +660,7 @@ exports[`Chart 2`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -677,7 +677,7 @@ exports[`Chart 2`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -691,7 +691,7 @@ exports[`Chart 2`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -708,7 +708,7 @@ exports[`Chart 2`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -791,7 +791,7 @@ exports[`renders axis and component children 1`] = `
             d="M50,127.77777777777779L83.33333333333334,138.88888888888886L116.66666666666667,72.22222222222223L150,105.55555555555557"
             role="presentation"
             shape-rendering="auto"
-            style="fill: none; stroke: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7); pointer-events: stroke; width: 3px; opacity: 1; stroke-width: 2;"
+            style="fill: none; stroke: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9); pointer-events: stroke; width: 3px; opacity: 1; stroke-width: 2;"
           />
         </g>
         <g
@@ -815,7 +815,7 @@ exports[`renders axis and component children 1`] = `
             d="M50,116.66666666666669L83.33333333333334,105.55555555555557L116.66666666666667,50L150,94.44444444444443"
             role="presentation"
             shape-rendering="auto"
-            style="fill: none; stroke: var(--pf-v6-chart-theme--blue--ColorScale--300, #002f5d); pointer-events: stroke; width: 3px; opacity: 1; stroke-width: 2;"
+            style="fill: none; stroke: var(--pf-v6-chart-theme--blue--ColorScale--300, #036); pointer-events: stroke; width: 3px; opacity: 1; stroke-width: 2;"
           />
         </g>
         <g
@@ -839,7 +839,7 @@ exports[`renders axis and component children 1`] = `
             d="M50,116.66666666666669L83.33333333333334,116.66666666666669L116.66666666666667,61.111111111111114L150,72.22222222222223"
             role="presentation"
             shape-rendering="auto"
-            style="fill: none; stroke: var(--pf-v6-chart-theme--blue--ColorScale--400, #519de9); pointer-events: stroke; width: 3px; opacity: 1; stroke-width: 2;"
+            style="fill: none; stroke: var(--pf-v6-chart-theme--blue--ColorScale--400, #4394e5); pointer-events: stroke; width: 3px; opacity: 1; stroke-width: 2;"
           />
         </g>
       </g>
@@ -849,7 +849,7 @@ exports[`renders axis and component children 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
+          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
           vector-effect="non-scaling-stroke"
           x1="50"
           x2="150"
@@ -862,7 +862,7 @@ exports[`renders axis and component children 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="50"
@@ -879,7 +879,7 @@ exports[`renders axis and component children 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="50"
             >
@@ -893,7 +893,7 @@ exports[`renders axis and component children 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="66.66666666666667"
             x2="66.66666666666667"
@@ -910,7 +910,7 @@ exports[`renders axis and component children 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="66.66666666666667"
             >
@@ -924,7 +924,7 @@ exports[`renders axis and component children 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="83.33333333333334"
             x2="83.33333333333334"
@@ -941,7 +941,7 @@ exports[`renders axis and component children 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="83.33333333333334"
             >
@@ -955,7 +955,7 @@ exports[`renders axis and component children 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="100"
             x2="100"
@@ -972,7 +972,7 @@ exports[`renders axis and component children 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="100"
             >
@@ -986,7 +986,7 @@ exports[`renders axis and component children 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="116.66666666666667"
             x2="116.66666666666667"
@@ -1003,7 +1003,7 @@ exports[`renders axis and component children 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="116.66666666666667"
             >
@@ -1017,7 +1017,7 @@ exports[`renders axis and component children 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="133.33333333333334"
             x2="133.33333333333334"
@@ -1034,7 +1034,7 @@ exports[`renders axis and component children 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="133.33333333333334"
             >
@@ -1048,7 +1048,7 @@ exports[`renders axis and component children 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="150"
             x2="150"
@@ -1065,7 +1065,7 @@ exports[`renders axis and component children 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="150"
             >
@@ -1080,7 +1080,7 @@ exports[`renders axis and component children 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
+          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
           vector-effect="non-scaling-stroke"
           x1="50"
           x2="50"
@@ -1093,7 +1093,7 @@ exports[`renders axis and component children 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -1110,7 +1110,7 @@ exports[`renders axis and component children 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -1124,7 +1124,7 @@ exports[`renders axis and component children 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -1141,7 +1141,7 @@ exports[`renders axis and component children 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -1155,7 +1155,7 @@ exports[`renders axis and component children 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -1172,7 +1172,7 @@ exports[`renders axis and component children 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -1186,7 +1186,7 @@ exports[`renders axis and component children 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -1203,7 +1203,7 @@ exports[`renders axis and component children 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >

--- a/packages/react-charts/src/components/ChartAxis/__snapshots__/ChartAxis.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartAxis/__snapshots__/ChartAxis.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`ChartAxis 1`] = `
       <line
         role="presentation"
         shape-rendering="auto"
-        style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
+        style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
         vector-effect="non-scaling-stroke"
         x1="50"
         x2="400"
@@ -29,7 +29,7 @@ exports[`ChartAxis 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+          style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
           vector-effect="non-scaling-stroke"
           x1="50"
           x2="50"
@@ -46,7 +46,7 @@ exports[`ChartAxis 1`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
+            style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: middle;"
             text-anchor="middle"
             x="50"
           >
@@ -60,7 +60,7 @@ exports[`ChartAxis 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+          style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
           vector-effect="non-scaling-stroke"
           x1="120"
           x2="120"
@@ -77,7 +77,7 @@ exports[`ChartAxis 1`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
+            style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: middle;"
             text-anchor="middle"
             x="120"
           >
@@ -91,7 +91,7 @@ exports[`ChartAxis 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+          style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
           vector-effect="non-scaling-stroke"
           x1="190"
           x2="190"
@@ -108,7 +108,7 @@ exports[`ChartAxis 1`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
+            style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: middle;"
             text-anchor="middle"
             x="190"
           >
@@ -122,7 +122,7 @@ exports[`ChartAxis 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+          style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
           vector-effect="non-scaling-stroke"
           x1="260"
           x2="260"
@@ -139,7 +139,7 @@ exports[`ChartAxis 1`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
+            style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: middle;"
             text-anchor="middle"
             x="260"
           >
@@ -153,7 +153,7 @@ exports[`ChartAxis 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+          style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
           vector-effect="non-scaling-stroke"
           x1="330"
           x2="330"
@@ -170,7 +170,7 @@ exports[`ChartAxis 1`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
+            style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: middle;"
             text-anchor="middle"
             x="330"
           >
@@ -184,7 +184,7 @@ exports[`ChartAxis 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+          style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
           vector-effect="non-scaling-stroke"
           x1="400"
           x2="400"
@@ -201,7 +201,7 @@ exports[`ChartAxis 1`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
+            style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: middle;"
             text-anchor="middle"
             x="400"
           >
@@ -240,7 +240,7 @@ exports[`ChartAxis 2`] = `
       <line
         role="presentation"
         shape-rendering="auto"
-        style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
+        style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
         vector-effect="non-scaling-stroke"
         x1="50"
         x2="400"
@@ -253,7 +253,7 @@ exports[`ChartAxis 2`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+          style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
           vector-effect="non-scaling-stroke"
           x1="50"
           x2="50"
@@ -270,7 +270,7 @@ exports[`ChartAxis 2`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
+            style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: middle;"
             text-anchor="middle"
             x="50"
           >
@@ -284,7 +284,7 @@ exports[`ChartAxis 2`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+          style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
           vector-effect="non-scaling-stroke"
           x1="120"
           x2="120"
@@ -301,7 +301,7 @@ exports[`ChartAxis 2`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
+            style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: middle;"
             text-anchor="middle"
             x="120"
           >
@@ -315,7 +315,7 @@ exports[`ChartAxis 2`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+          style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
           vector-effect="non-scaling-stroke"
           x1="190"
           x2="190"
@@ -332,7 +332,7 @@ exports[`ChartAxis 2`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
+            style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: middle;"
             text-anchor="middle"
             x="190"
           >
@@ -346,7 +346,7 @@ exports[`ChartAxis 2`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+          style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
           vector-effect="non-scaling-stroke"
           x1="260"
           x2="260"
@@ -363,7 +363,7 @@ exports[`ChartAxis 2`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
+            style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: middle;"
             text-anchor="middle"
             x="260"
           >
@@ -377,7 +377,7 @@ exports[`ChartAxis 2`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+          style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
           vector-effect="non-scaling-stroke"
           x1="330"
           x2="330"
@@ -394,7 +394,7 @@ exports[`ChartAxis 2`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
+            style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: middle;"
             text-anchor="middle"
             x="330"
           >
@@ -408,7 +408,7 @@ exports[`ChartAxis 2`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+          style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
           vector-effect="non-scaling-stroke"
           x1="400"
           x2="400"
@@ -425,7 +425,7 @@ exports[`ChartAxis 2`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
+            style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: middle;"
             text-anchor="middle"
             x="400"
           >
@@ -507,7 +507,7 @@ exports[`renders component data 1`] = `
             d="M80,137.5L128.33333333333331,150L176.66666666666666,75L224.99999999999997,112.5"
             role="presentation"
             shape-rendering="auto"
-            style="fill: none; stroke: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7); pointer-events: stroke; width: 6px; opacity: 1; stroke-width: 2;"
+            style="fill: none; stroke: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9); pointer-events: stroke; width: 6px; opacity: 1; stroke-width: 2;"
           />
         </g>
         <g
@@ -531,7 +531,7 @@ exports[`renders component data 1`] = `
             d="M80,125L128.33333333333331,112.5L176.66666666666666,50L224.99999999999997,100"
             role="presentation"
             shape-rendering="auto"
-            style="fill: none; stroke: var(--pf-v6-chart-theme--blue--ColorScale--300, #002f5d); pointer-events: stroke; width: 6px; opacity: 1; stroke-width: 2;"
+            style="fill: none; stroke: var(--pf-v6-chart-theme--blue--ColorScale--300, #036); pointer-events: stroke; width: 6px; opacity: 1; stroke-width: 2;"
           />
         </g>
         <g
@@ -555,7 +555,7 @@ exports[`renders component data 1`] = `
             d="M80,125L128.33333333333331,125L176.66666666666666,62.5L224.99999999999997,75"
             role="presentation"
             shape-rendering="auto"
-            style="fill: none; stroke: var(--pf-v6-chart-theme--blue--ColorScale--400, #519de9); pointer-events: stroke; width: 6px; opacity: 1; stroke-width: 2;"
+            style="fill: none; stroke: var(--pf-v6-chart-theme--blue--ColorScale--400, #4394e5); pointer-events: stroke; width: 6px; opacity: 1; stroke-width: 2;"
           />
         </g>
       </g>
@@ -565,7 +565,7 @@ exports[`renders component data 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
+          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
           vector-effect="non-scaling-stroke"
           x1="50"
           x2="250"
@@ -578,7 +578,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="128.33333333333331"
             x2="128.33333333333331"
@@ -595,7 +595,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: middle;"
               text-anchor="middle"
               x="128.33333333333331"
             >
@@ -609,7 +609,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="176.66666666666666"
             x2="176.66666666666666"
@@ -626,7 +626,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: middle;"
               text-anchor="middle"
               x="176.66666666666666"
             >
@@ -640,7 +640,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="224.99999999999997"
             x2="224.99999999999997"
@@ -657,7 +657,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: middle;"
               text-anchor="middle"
               x="224.99999999999997"
             >
@@ -672,7 +672,7 @@ exports[`renders component data 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
+          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
           vector-effect="non-scaling-stroke"
           x1="50"
           x2="50"
@@ -685,7 +685,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -702,7 +702,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: end;"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: end;"
               text-anchor="end"
               x="35"
             >
@@ -716,7 +716,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -733,7 +733,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: end;"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: end;"
               text-anchor="end"
               x="35"
             >
@@ -747,7 +747,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -764,7 +764,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: end;"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: end;"
               text-anchor="end"
               x="35"
             >

--- a/packages/react-charts/src/components/ChartBar/__snapshots__/ChartBar.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartBar/__snapshots__/ChartBar.test.tsx.snap
@@ -278,7 +278,7 @@ A 0 0 0 0 1, 79.5, 150
             index="0"
             role="presentation"
             shape-rendering="auto"
-            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7); stroke: var(--pf-v6-chart-bar--data--stroke, none); width: 6px; padding: 8px; stroke-width: 0;"
+            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9); stroke: var(--pf-v6-chart-bar--data--stroke, none); width: 6px; padding: 8px; stroke-width: 0;"
           />
           <path
             d="M 117.83333333333331, 150 
@@ -293,7 +293,7 @@ A 0 0 0 0 1, 127.83333333333331, 150
             index="1"
             role="presentation"
             shape-rendering="auto"
-            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7); stroke: var(--pf-v6-chart-bar--data--stroke, none); width: 6px; padding: 8px; stroke-width: 0;"
+            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9); stroke: var(--pf-v6-chart-bar--data--stroke, none); width: 6px; padding: 8px; stroke-width: 0;"
           />
           <path
             d="M 166.16666666666666, 150 
@@ -308,7 +308,7 @@ A 0 0 0 0 1, 176.16666666666666, 150
             index="2"
             role="presentation"
             shape-rendering="auto"
-            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7); stroke: var(--pf-v6-chart-bar--data--stroke, none); width: 6px; padding: 8px; stroke-width: 0;"
+            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9); stroke: var(--pf-v6-chart-bar--data--stroke, none); width: 6px; padding: 8px; stroke-width: 0;"
           />
           <path
             d="M 214.49999999999997, 150 
@@ -323,7 +323,7 @@ A 0 0 0 0 1, 224.49999999999997, 150
             index="3"
             role="presentation"
             shape-rendering="auto"
-            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7); stroke: var(--pf-v6-chart-bar--data--stroke, none); width: 6px; padding: 8px; stroke-width: 0;"
+            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9); stroke: var(--pf-v6-chart-bar--data--stroke, none); width: 6px; padding: 8px; stroke-width: 0;"
           />
         </g>
         <g
@@ -342,7 +342,7 @@ A 0 0 0 0 1, 90.5, 150
             index="0"
             role="presentation"
             shape-rendering="auto"
-            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #002f5d); stroke: var(--pf-v6-chart-bar--data--stroke, none); width: 6px; padding: 8px; stroke-width: 0;"
+            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #036); stroke: var(--pf-v6-chart-bar--data--stroke, none); width: 6px; padding: 8px; stroke-width: 0;"
           />
           <path
             d="M 128.83333333333331, 150 
@@ -357,7 +357,7 @@ A 0 0 0 0 1, 138.83333333333331, 150
             index="1"
             role="presentation"
             shape-rendering="auto"
-            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #002f5d); stroke: var(--pf-v6-chart-bar--data--stroke, none); width: 6px; padding: 8px; stroke-width: 0;"
+            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #036); stroke: var(--pf-v6-chart-bar--data--stroke, none); width: 6px; padding: 8px; stroke-width: 0;"
           />
           <path
             d="M 177.16666666666666, 150 
@@ -372,7 +372,7 @@ A 0 0 0 0 1, 187.16666666666666, 150
             index="2"
             role="presentation"
             shape-rendering="auto"
-            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #002f5d); stroke: var(--pf-v6-chart-bar--data--stroke, none); width: 6px; padding: 8px; stroke-width: 0;"
+            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #036); stroke: var(--pf-v6-chart-bar--data--stroke, none); width: 6px; padding: 8px; stroke-width: 0;"
           />
           <path
             d="M 225.5, 150 
@@ -387,7 +387,7 @@ A 0 0 0 0 1, 235.5, 150
             index="3"
             role="presentation"
             shape-rendering="auto"
-            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #002f5d); stroke: var(--pf-v6-chart-bar--data--stroke, none); width: 6px; padding: 8px; stroke-width: 0;"
+            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #036); stroke: var(--pf-v6-chart-bar--data--stroke, none); width: 6px; padding: 8px; stroke-width: 0;"
           />
         </g>
         <g
@@ -406,7 +406,7 @@ A 0 0 0 0 1, 101.49999999999999, 150
             index="0"
             role="presentation"
             shape-rendering="auto"
-            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #519de9); stroke: var(--pf-v6-chart-bar--data--stroke, none); width: 6px; padding: 8px; stroke-width: 0;"
+            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #4394e5); stroke: var(--pf-v6-chart-bar--data--stroke, none); width: 6px; padding: 8px; stroke-width: 0;"
           />
           <path
             d="M 139.83333333333331, 150 
@@ -421,7 +421,7 @@ A 0 0 0 0 1, 149.83333333333331, 150
             index="1"
             role="presentation"
             shape-rendering="auto"
-            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #519de9); stroke: var(--pf-v6-chart-bar--data--stroke, none); width: 6px; padding: 8px; stroke-width: 0;"
+            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #4394e5); stroke: var(--pf-v6-chart-bar--data--stroke, none); width: 6px; padding: 8px; stroke-width: 0;"
           />
           <path
             d="M 188.16666666666666, 150 
@@ -436,7 +436,7 @@ A 0 0 0 0 1, 198.16666666666666, 150
             index="2"
             role="presentation"
             shape-rendering="auto"
-            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #519de9); stroke: var(--pf-v6-chart-bar--data--stroke, none); width: 6px; padding: 8px; stroke-width: 0;"
+            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #4394e5); stroke: var(--pf-v6-chart-bar--data--stroke, none); width: 6px; padding: 8px; stroke-width: 0;"
           />
           <path
             d="M 236.5, 150 
@@ -451,7 +451,7 @@ A 0 0 0 0 1, 246.5, 150
             index="3"
             role="presentation"
             shape-rendering="auto"
-            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #519de9); stroke: var(--pf-v6-chart-bar--data--stroke, none); width: 6px; padding: 8px; stroke-width: 0;"
+            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #4394e5); stroke: var(--pf-v6-chart-bar--data--stroke, none); width: 6px; padding: 8px; stroke-width: 0;"
           />
         </g>
       </g>
@@ -461,7 +461,7 @@ A 0 0 0 0 1, 246.5, 150
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
+          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
           vector-effect="non-scaling-stroke"
           x1="50"
           x2="250"
@@ -474,7 +474,7 @@ A 0 0 0 0 1, 246.5, 150
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="80"
             x2="80"
@@ -491,7 +491,7 @@ A 0 0 0 0 1, 246.5, 150
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="80"
             >
@@ -505,7 +505,7 @@ A 0 0 0 0 1, 246.5, 150
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="128.33333333333331"
             x2="128.33333333333331"
@@ -522,7 +522,7 @@ A 0 0 0 0 1, 246.5, 150
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="128.33333333333331"
             >
@@ -536,7 +536,7 @@ A 0 0 0 0 1, 246.5, 150
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="176.66666666666666"
             x2="176.66666666666666"
@@ -553,7 +553,7 @@ A 0 0 0 0 1, 246.5, 150
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="176.66666666666666"
             >
@@ -567,7 +567,7 @@ A 0 0 0 0 1, 246.5, 150
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="224.99999999999997"
             x2="224.99999999999997"
@@ -584,7 +584,7 @@ A 0 0 0 0 1, 246.5, 150
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="224.99999999999997"
             >
@@ -599,7 +599,7 @@ A 0 0 0 0 1, 246.5, 150
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
+          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
           vector-effect="non-scaling-stroke"
           x1="50"
           x2="50"
@@ -612,7 +612,7 @@ A 0 0 0 0 1, 246.5, 150
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -629,7 +629,7 @@ A 0 0 0 0 1, 246.5, 150
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -643,7 +643,7 @@ A 0 0 0 0 1, 246.5, 150
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -660,7 +660,7 @@ A 0 0 0 0 1, 246.5, 150
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -674,7 +674,7 @@ A 0 0 0 0 1, 246.5, 150
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -691,7 +691,7 @@ A 0 0 0 0 1, 246.5, 150
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -705,7 +705,7 @@ A 0 0 0 0 1, 246.5, 150
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -722,7 +722,7 @@ A 0 0 0 0 1, 246.5, 150
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >

--- a/packages/react-charts/src/components/ChartBoxPlot/__snapshots__/ChartBoxPlot.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartBoxPlot/__snapshots__/ChartBoxPlot.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`ChartBar 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="50"
@@ -70,7 +70,7 @@ exports[`ChartBar 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="40"
             x2="60"
@@ -82,7 +82,7 @@ exports[`ChartBar 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="400"
             x2="400"
@@ -92,7 +92,7 @@ exports[`ChartBar 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="390"
             x2="410"
@@ -104,7 +104,7 @@ exports[`ChartBar 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="50"
@@ -114,7 +114,7 @@ exports[`ChartBar 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="40"
             x2="60"
@@ -126,7 +126,7 @@ exports[`ChartBar 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="400"
             x2="400"
@@ -136,7 +136,7 @@ exports[`ChartBar 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="390"
             x2="410"
@@ -147,7 +147,7 @@ exports[`ChartBar 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-boxplot--median--stroke--Color, #151515); padding: 8px; stroke-width: 1;"
+          style="stroke: var(--pf-v6-chart-boxplot--median--stroke--Color, #1f1f1f); padding: 8px; stroke-width: 1;"
           vector-effect="non-scaling-stroke"
           x1="40"
           x2="60"
@@ -157,7 +157,7 @@ exports[`ChartBar 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-boxplot--median--stroke--Color, #151515); padding: 8px; stroke-width: 1;"
+          style="stroke: var(--pf-v6-chart-boxplot--median--stroke--Color, #1f1f1f); padding: 8px; stroke-width: 1;"
           vector-effect="non-scaling-stroke"
           x1="390"
           x2="410"
@@ -240,7 +240,7 @@ exports[`ChartBar 2`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="50"
@@ -250,7 +250,7 @@ exports[`ChartBar 2`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="40"
             x2="60"
@@ -262,7 +262,7 @@ exports[`ChartBar 2`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="400"
             x2="400"
@@ -272,7 +272,7 @@ exports[`ChartBar 2`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="390"
             x2="410"
@@ -284,7 +284,7 @@ exports[`ChartBar 2`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="50"
@@ -294,7 +294,7 @@ exports[`ChartBar 2`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="40"
             x2="60"
@@ -306,7 +306,7 @@ exports[`ChartBar 2`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="400"
             x2="400"
@@ -316,7 +316,7 @@ exports[`ChartBar 2`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="390"
             x2="410"
@@ -327,7 +327,7 @@ exports[`ChartBar 2`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-boxplot--median--stroke--Color, #151515); padding: 8px; stroke-width: 1;"
+          style="stroke: var(--pf-v6-chart-boxplot--median--stroke--Color, #1f1f1f); padding: 8px; stroke-width: 1;"
           vector-effect="non-scaling-stroke"
           x1="40"
           x2="60"
@@ -337,7 +337,7 @@ exports[`ChartBar 2`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-boxplot--median--stroke--Color, #151515); padding: 8px; stroke-width: 1;"
+          style="stroke: var(--pf-v6-chart-boxplot--median--stroke--Color, #1f1f1f); padding: 8px; stroke-width: 1;"
           vector-effect="non-scaling-stroke"
           x1="390"
           x2="410"
@@ -460,7 +460,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="80"
             x2="80"
@@ -470,7 +470,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="70"
             x2="90"
@@ -482,7 +482,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="128.33333333333331"
             x2="128.33333333333331"
@@ -492,7 +492,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="118.33333333333331"
             x2="138.33333333333331"
@@ -504,7 +504,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="176.66666666666666"
             x2="176.66666666666666"
@@ -514,7 +514,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="166.66666666666666"
             x2="186.66666666666666"
@@ -526,7 +526,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="224.99999999999997"
             x2="224.99999999999997"
@@ -536,7 +536,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--max--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="214.99999999999997"
             x2="234.99999999999997"
@@ -548,7 +548,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="80"
             x2="80"
@@ -558,7 +558,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="70"
             x2="90"
@@ -570,7 +570,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="128.33333333333331"
             x2="128.33333333333331"
@@ -580,7 +580,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="118.33333333333331"
             x2="138.33333333333331"
@@ -592,7 +592,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="176.66666666666666"
             x2="176.66666666666666"
@@ -602,7 +602,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="166.66666666666666"
             x2="186.66666666666666"
@@ -614,7 +614,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="224.99999999999997"
             x2="224.99999999999997"
@@ -624,7 +624,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #151515); stroke-width: 1;"
+            style="padding: 8px; stroke: var(--pf-v6-chart-boxplot--min--stroke--Color, #1f1f1f); stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="214.99999999999997"
             x2="234.99999999999997"
@@ -635,7 +635,7 @@ exports[`renders component data 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-boxplot--median--stroke--Color, #151515); padding: 8px; stroke-width: 1;"
+          style="stroke: var(--pf-v6-chart-boxplot--median--stroke--Color, #1f1f1f); padding: 8px; stroke-width: 1;"
           vector-effect="non-scaling-stroke"
           x1="70"
           x2="90"
@@ -645,7 +645,7 @@ exports[`renders component data 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-boxplot--median--stroke--Color, #151515); padding: 8px; stroke-width: 1;"
+          style="stroke: var(--pf-v6-chart-boxplot--median--stroke--Color, #1f1f1f); padding: 8px; stroke-width: 1;"
           vector-effect="non-scaling-stroke"
           x1="118.33333333333331"
           x2="138.33333333333331"
@@ -655,7 +655,7 @@ exports[`renders component data 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-boxplot--median--stroke--Color, #151515); padding: 8px; stroke-width: 1;"
+          style="stroke: var(--pf-v6-chart-boxplot--median--stroke--Color, #1f1f1f); padding: 8px; stroke-width: 1;"
           vector-effect="non-scaling-stroke"
           x1="166.66666666666666"
           x2="186.66666666666666"
@@ -665,7 +665,7 @@ exports[`renders component data 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-boxplot--median--stroke--Color, #151515); padding: 8px; stroke-width: 1;"
+          style="stroke: var(--pf-v6-chart-boxplot--median--stroke--Color, #1f1f1f); padding: 8px; stroke-width: 1;"
           vector-effect="non-scaling-stroke"
           x1="214.99999999999997"
           x2="234.99999999999997"
@@ -679,7 +679,7 @@ exports[`renders component data 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
+          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
           vector-effect="non-scaling-stroke"
           x1="50"
           x2="250"
@@ -692,7 +692,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="80"
             x2="80"
@@ -709,7 +709,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="80"
             >
@@ -723,7 +723,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="128.33333333333331"
             x2="128.33333333333331"
@@ -740,7 +740,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="128.33333333333331"
             >
@@ -754,7 +754,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="176.66666666666666"
             x2="176.66666666666666"
@@ -771,7 +771,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="176.66666666666666"
             >
@@ -785,7 +785,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="224.99999999999997"
             x2="224.99999999999997"
@@ -802,7 +802,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="224.99999999999997"
             >
@@ -817,7 +817,7 @@ exports[`renders component data 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
+          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
           vector-effect="non-scaling-stroke"
           x1="50"
           x2="50"
@@ -830,7 +830,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -847,7 +847,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -861,7 +861,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -878,7 +878,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -892,7 +892,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -909,7 +909,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -923,7 +923,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -940,7 +940,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -954,7 +954,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -971,7 +971,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >

--- a/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBullet.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBullet.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`ChartBulletQualitativeRange 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
+          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
           vector-effect="non-scaling-stroke"
           x1="50"
           x2="400"
@@ -32,7 +32,7 @@ exports[`ChartBulletQualitativeRange 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="225"
             x2="225"
@@ -49,7 +49,7 @@ exports[`ChartBulletQualitativeRange 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: middle;"
               text-anchor="middle"
               x="225"
             >
@@ -104,7 +104,7 @@ exports[`ChartBulletQualitativeRange 2`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
+          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
           vector-effect="non-scaling-stroke"
           x1="50"
           x2="400"
@@ -117,7 +117,7 @@ exports[`ChartBulletQualitativeRange 2`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="225"
             x2="225"
@@ -134,7 +134,7 @@ exports[`ChartBulletQualitativeRange 2`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: middle;"
               text-anchor="middle"
               x="225"
             >
@@ -201,7 +201,7 @@ exports[`renders component data 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
+          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
           vector-effect="non-scaling-stroke"
           x1="50"
           x2="400"
@@ -214,7 +214,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="50"
@@ -231,7 +231,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: middle;"
               text-anchor="middle"
               x="50"
             >
@@ -245,7 +245,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="400"
             x2="400"
@@ -262,7 +262,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: middle;"
               text-anchor="middle"
               x="400"
             >
@@ -276,7 +276,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="137.5"
             x2="137.5"
@@ -293,7 +293,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: middle;"
               text-anchor="middle"
               x="137.5"
             >
@@ -307,7 +307,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="225"
             x2="225"
@@ -324,7 +324,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: middle;"
               text-anchor="middle"
               x="225"
             >
@@ -338,7 +338,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="312.5"
             x2="312.5"
@@ -355,7 +355,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: middle;"
               text-anchor="middle"
               x="312.5"
             >
@@ -380,7 +380,7 @@ A 0 0 0 0 1, 312.5, 85
           index="0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-bullet--qualitative-range--ColorScale--200, #d2d2d2); stroke: var(--pf-v6-chart-bar--data--stroke, none); padding: 8px; stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-bullet--qualitative-range--ColorScale--200, #92c5f9); stroke: var(--pf-v6-chart-bar--data--stroke, none); padding: 8px; stroke-width: 0;"
         />
       </g>
       <g
@@ -399,7 +399,7 @@ A 0 0 0 0 1, 225, 85
           index="0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-bullet--qualitative-range--ColorScale--100, #f0f0f0); stroke: var(--pf-v6-chart-bar--data--stroke, none); padding: 8px; stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-bullet--qualitative-range--ColorScale--100, #92c5f9); stroke: var(--pf-v6-chart-bar--data--stroke, none); padding: 8px; stroke-width: 0;"
         />
       </g>
       <g
@@ -437,7 +437,7 @@ A 0 0 0 0 1, 358, 85
           index="0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-bullet--comparative-measure--warning--Fill--Color, #ec7a08); stroke: var(--pf-v6-chart-bullet--comparative-measure--warning--stroke--Color, #ec7a08); padding: 8px; stroke-width: 2;"
+          style="fill: var(--pf-v6-chart-bullet--comparative-measure--warning--Fill--Color, #f5921b); stroke: var(--pf-v6-chart-bullet--comparative-measure--warning--stroke--Color, #f5921b); padding: 8px; stroke-width: 2;"
         />
       </g>
       <g>

--- a/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletComparativeErrorMeasure.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletComparativeErrorMeasure.test.tsx.snap
@@ -83,7 +83,7 @@ A 0 0 0 0 1, 225, 104.8
           index="0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-bullet--comparative-measure--error--Fill--Color, #c9190b); stroke: var(--pf-v6-chart-bullet--comparative-measure--error--stroke--Color, #c9190b); padding: 8px; stroke-width: 2;"
+          style="fill: var(--pf-v6-chart-bullet--comparative-measure--error--Fill--Color, #b1380b); stroke: var(--pf-v6-chart-bullet--comparative-measure--error--stroke--Color, #b1380b); padding: 8px; stroke-width: 1;"
         />
       </g>
     </svg>

--- a/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletComparativeMeasure.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletComparativeMeasure.test.tsx.snap
@@ -83,7 +83,7 @@ A 0 0 0 0 1, 225, 104.8
           index="0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-bullet--comparative-measure--Fill--Color, #4f5255); stroke: var(--pf-v6-chart-bullet--comparative-measure--stroke--Color, #4f5255); padding: 8px; stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-bullet--comparative-measure--Fill--Color, #383838); stroke: var(--pf-v6-chart-bullet--comparative-measure--stroke--Color, #383838); padding: 8px; stroke-width: 1;"
         />
       </g>
     </svg>

--- a/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletComparativeWarningMeasure.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletComparativeWarningMeasure.test.tsx.snap
@@ -83,7 +83,7 @@ A 0 0 0 0 1, 225, 104.8
           index="0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-bullet--comparative-measure--warning--Fill--Color, #ec7a08); stroke: var(--pf-v6-chart-bullet--comparative-measure--warning--stroke--Color, #ec7a08); padding: 8px; stroke-width: 2;"
+          style="fill: var(--pf-v6-chart-bullet--comparative-measure--warning--Fill--Color, #f5921b); stroke: var(--pf-v6-chart-bullet--comparative-measure--warning--stroke--Color, #f5921b); padding: 8px; stroke-width: 2;"
         />
       </g>
     </svg>

--- a/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletGroupTitle.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletGroupTitle.test.tsx.snap
@@ -72,12 +72,12 @@ exports[`renders component data 1`] = `
         dx="0"
         id="test2"
         x="225"
-        y="48.675000000000004"
+        y="49.150000000000006"
       >
         <tspan
           dx="0"
           dy="0"
-          style="fill: var(--pf-v6-chart-bullet--label--grouptitle--Fill, #151515); font-size: 24px; text-anchor: middle; font-family: var(--pf-v6-chart-global--FontFamily, \\"RedHatText\\", helvetica, arial, sans-serif); letter-spacing: var(--pf-v6-chart-global--letter-spacing, normal); stroke: transparent;"
+          style="fill: var(--pf-v6-chart-bullet--label--grouptitle--Fill, #1f1f1f); font-size: 22px; text-anchor: middle; font-family: var(--pf-v6-chart-global--FontFamily, redhattextvf, redhattext, helvetica, arial, sans-serif); letter-spacing: var(--pf-v6-chart-global--letter-spacing, normal); stroke: transparent;"
           text-anchor="middle"
           x="225"
         >
@@ -85,8 +85,8 @@ exports[`renders component data 1`] = `
         </tspan>
         <tspan
           dx="0"
-          dy="13.5"
-          style="fill: var(--pf-v6-chart-bullet--label--subtitle--Fill, #b8bbbe); font-size: 14px; text-anchor: middle; font-family: var(--pf-v6-chart-global--FontFamily, \\"RedHatText\\", helvetica, arial, sans-serif); letter-spacing: var(--pf-v6-chart-global--letter-spacing, normal); stroke: transparent;"
+          dy="13.6"
+          style="fill: var(--pf-v6-chart-bullet--label--subtitle--Fill, #a3a3a3); font-size: 14px; text-anchor: middle; font-family: var(--pf-v6-chart-global--FontFamily, redhattextvf, redhattext, helvetica, arial, sans-serif); letter-spacing: var(--pf-v6-chart-global--letter-spacing, normal); stroke: transparent;"
           text-anchor="middle"
           x="225"
         >
@@ -94,7 +94,7 @@ exports[`renders component data 1`] = `
         </tspan>
       </text>
       <line
-        style="fill: var(--pf-v6-chart-bullet--group-title--divider--Fill--Color, #f0f0f0); opacity: 1; stroke: var(--pf-v6-chart-bullet--group-title--divider--stroke--Color, #f0f0f0); stroke-width: 2;"
+        style="fill: var(--pf-v6-chart-bullet--group-title--divider--Fill--Color, #c7c7c7); opacity: 1; stroke: var(--pf-v6-chart-bullet--group-title--divider--stroke--Color, #c7c7c7); stroke-width: 2;"
         vector-effect="non-scaling-stroke"
         x1="0"
         x2="450"

--- a/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletPrimarySegmentedMeasure.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletPrimarySegmentedMeasure.test.tsx.snap
@@ -83,7 +83,7 @@ A 0 0 0 0 1, 399.99999999976666, 94.3
           index="0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #002f5d); stroke: var(--pf-v6-chart-bar--data--stroke, none); padding: 8px; stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #036); stroke: var(--pf-v6-chart-bar--data--stroke, none); padding: 8px; stroke-width: 0;"
         />
       </g>
       <g
@@ -102,7 +102,7 @@ A 0 0 0 0 1, 399.9999999995882, 94.3
           index="0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7); stroke: var(--pf-v6-chart-bar--data--stroke, none); padding: 8px; stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9); stroke: var(--pf-v6-chart-bar--data--stroke, none); padding: 8px; stroke-width: 0;"
         />
       </g>
       <g

--- a/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletQualitativeRange.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletQualitativeRange.test.tsx.snap
@@ -83,7 +83,7 @@ A 0 0 0 0 1, 399.99999999976666, 104.8
           index="0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-bullet--qualitative-range--ColorScale--300, #b8bbbe); stroke: var(--pf-v6-chart-bar--data--stroke, none); padding: 8px; stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-bullet--qualitative-range--ColorScale--300, #92c5f9); stroke: var(--pf-v6-chart-bar--data--stroke, none); padding: 8px; stroke-width: 0;"
         />
       </g>
       <g
@@ -102,7 +102,7 @@ A 0 0 0 0 1, 399.9999999995882, 104.8
           index="0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-bullet--qualitative-range--ColorScale--200, #d2d2d2); stroke: var(--pf-v6-chart-bar--data--stroke, none); padding: 8px; stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-bullet--qualitative-range--ColorScale--200, #92c5f9); stroke: var(--pf-v6-chart-bar--data--stroke, none); padding: 8px; stroke-width: 0;"
         />
       </g>
       <g
@@ -121,7 +121,7 @@ A 0 0 0 0 1, 399.9999999993, 104.8
           index="0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-bullet--qualitative-range--ColorScale--100, #f0f0f0); stroke: var(--pf-v6-chart-bar--data--stroke, none); padding: 8px; stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-bullet--qualitative-range--ColorScale--100, #92c5f9); stroke: var(--pf-v6-chart-bar--data--stroke, none); padding: 8px; stroke-width: 0;"
         />
       </g>
     </svg>

--- a/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletTitle.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletTitle.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`renders component data 1`] = `
         <tspan
           dx="0"
           dy="0"
-          style="fill: var(--pf-v6-chart-bullet--label--title--Fill, #151515); font-size: 18px; text-anchor: end; font-family: var(--pf-v6-chart-global--FontFamily, \\"RedHatText\\", helvetica, arial, sans-serif); letter-spacing: var(--pf-v6-chart-global--letter-spacing, normal); stroke: transparent;"
+          style="fill: var(--pf-v6-chart-bullet--label--title--Fill, #1f1f1f); font-size: 18px; text-anchor: end; font-family: var(--pf-v6-chart-global--FontFamily, redhattextvf, redhattext, helvetica, arial, sans-serif); letter-spacing: var(--pf-v6-chart-global--letter-spacing, normal); stroke: transparent;"
           text-anchor="end"
           x="36"
         >
@@ -86,7 +86,7 @@ exports[`renders component data 1`] = `
         <tspan
           dx="0"
           dy="13.8"
-          style="fill: var(--pf-v6-chart-bullet--label--subtitle--Fill, #b8bbbe); font-size: 14px; text-anchor: end; font-family: var(--pf-v6-chart-global--FontFamily, \\"RedHatText\\", helvetica, arial, sans-serif); letter-spacing: var(--pf-v6-chart-global--letter-spacing, normal); stroke: transparent;"
+          style="fill: var(--pf-v6-chart-bullet--label--subtitle--Fill, #a3a3a3); font-size: 14px; text-anchor: end; font-family: var(--pf-v6-chart-global--FontFamily, redhattextvf, redhattext, helvetica, arial, sans-serif); letter-spacing: var(--pf-v6-chart-global--letter-spacing, normal); stroke: transparent;"
           text-anchor="end"
           x="36"
         >

--- a/packages/react-charts/src/components/ChartContainer/__snapshots__/ChartContainer.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartContainer/__snapshots__/ChartContainer.test.tsx.snap
@@ -86,7 +86,7 @@ exports[`renders container via ChartLegend 1`] = `
       z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7);"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9);"
         />
         <text
           direction="inherit"
@@ -98,7 +98,7 @@ exports[`renders container via ChartLegend 1`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 2px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #151515);"
+            style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 2px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #1f1f1f);"
             text-anchor="start"
             x="2"
           >
@@ -115,7 +115,7 @@ exports[`renders container via ChartLegend 1`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #151515);"
+            style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #1f1f1f);"
             text-anchor="start"
             x="30.8"
           >
@@ -132,7 +132,7 @@ exports[`renders container via ChartLegend 1`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #151515);"
+            style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #1f1f1f);"
             text-anchor="start"
             x="70.39999999999999"
           >

--- a/packages/react-charts/src/components/ChartCursorContainer/__snapshots__/ChartCursorContainer.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartCursorContainer/__snapshots__/ChartCursorContainer.test.tsx.snap
@@ -104,7 +104,7 @@ exports[`renders container via ChartGroup 1`] = `
           d="M50,135.71428571428572L75,121.42857142857142L100,92.85714285714286L125,78.57142857142857L150,78.57142857142857L150,150L125,150L100,150L75,150L50,150Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7); width: 6px; fill-opacity: 0.3; stroke-width: 2; stroke: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7);"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9); width: 6px; fill-opacity: 0.3; stroke-width: 2; stroke: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9);"
         />
       </g>
     </svg>

--- a/packages/react-charts/src/components/ChartCursorTooltip/__snapshots__/ChartCursorFlyout.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartCursorTooltip/__snapshots__/ChartCursorFlyout.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`allows tooltip via container component 1`] = `
           d="M50,135.71428571428572L75,121.42857142857142L100,92.85714285714286L125,78.57142857142857L150,78.57142857142857L150,150L125,150L100,150L75,150L50,150Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7); width: 6px; fill-opacity: 0.3; stroke-width: 2; stroke: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7);"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9); width: 6px; fill-opacity: 0.3; stroke-width: 2; stroke: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9);"
         />
       </g>
     </svg>

--- a/packages/react-charts/src/components/ChartCursorTooltip/__snapshots__/ChartCursorTooltip.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartCursorTooltip/__snapshots__/ChartCursorTooltip.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`allows tooltip via container component 1`] = `
           d="M50,135.71428571428572L75,121.42857142857142L100,92.85714285714286L125,78.57142857142857L150,78.57142857142857L150,150L125,150L100,150L75,150L50,150Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7); width: 6px; fill-opacity: 0.3; stroke-width: 2; stroke: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7);"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9); width: 6px; fill-opacity: 0.3; stroke-width: 2; stroke: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9);"
         />
       </g>
     </svg>

--- a/packages/react-charts/src/components/ChartDonut/__snapshots__/ChartDonut.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartDonut/__snapshots__/ChartDonut.test.tsx.snap
@@ -25,28 +25,28 @@ exports[`ChartDonut 1`] = `
           d="M61.91722684939433,-72.05037834238375A95,95,0,0,1,82.82584189723372,46.52827005181304L75.03101670275841,42.027925627496636A86,86,0,0,0,56.13169557884936,-65.15545066564565Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
           transform="translate(115, 115)"
         />
         <path
           d="M81.70758480762967,48.46514814693137A95,95,0,0,1,-81.70758480762966,48.465148146931405L-73.91275961315432,43.96480372261502A86,86,0,0,0,73.91275961315435,43.96480372261497Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #002f5d); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #036); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
           transform="translate(115, 115)"
         />
         <path
           d="M-82.82584189723369,46.528270051813095A95,95,0,0,1,-93.74443803302738,-15.394165708861626L-84.88048987244326,-13.831212492549462A86,86,0,0,0,-75.0310167027584,42.02792562749668Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #519de9); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #4394e5); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
           transform="translate(115, 115)"
         />
         <path
           d="M-93.35607142148164,-17.596702212267488A95,95,0,0,1,-1.118257089604104,-94.99341819874444L-1.1182570896040813,-85.99272935011163A86,86,0,0,0,-84.49212326089753,-16.033748995955364Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--500, #004b95); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--500, #004d99); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
           transform="translate(115, 115)"
         />
       </g>
@@ -90,28 +90,28 @@ exports[`ChartDonut 2`] = `
           d="M61.91722684939433,-72.05037834238375A95,95,0,0,1,82.82584189723372,46.52827005181304L75.03101670275841,42.027925627496636A86,86,0,0,0,56.13169557884936,-65.15545066564565Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
           transform="translate(115, 115)"
         />
         <path
           d="M81.70758480762967,48.46514814693137A95,95,0,0,1,-81.70758480762966,48.465148146931405L-73.91275961315432,43.96480372261502A86,86,0,0,0,73.91275961315435,43.96480372261497Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #002f5d); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #036); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
           transform="translate(115, 115)"
         />
         <path
           d="M-82.82584189723369,46.528270051813095A95,95,0,0,1,-93.74443803302738,-15.394165708861626L-84.88048987244326,-13.831212492549462A86,86,0,0,0,-75.0310167027584,42.02792562749668Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #519de9); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #4394e5); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
           transform="translate(115, 115)"
         />
         <path
           d="M-93.35607142148164,-17.596702212267488A95,95,0,0,1,-1.118257089604104,-94.99341819874444L-1.1182570896040813,-85.99272935011163A86,86,0,0,0,-84.49212326089753,-16.033748995955364Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--500, #004b95); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--500, #004d99); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
           transform="translate(115, 115)"
         />
       </g>
@@ -155,14 +155,14 @@ exports[`renders component data 1`] = `
           d="M64.16830759493514,47.77476635632862A80,80,0,1,1,-47.774766356328655,-64.16830759493511L-42.48429331491433,-56.886596149992364A71,71,0,1,0,56.88659614999237,42.48429331491432Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
           transform="translate(100, 100)"
         />
         <path
           d="M-46.26447237139682,-65.26560040477878A80,80,0,0,1,-0.9334130156924101,-79.99455444055012L-0.9334130156923751,-70.99386410206263A71,71,0,0,0,-40.97399932998255,-57.98388895983599Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #002f5d); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #036); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
           transform="translate(100, 100)"
         />
       </g>

--- a/packages/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutThreshold.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutThreshold.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`ChartDonutThreshold 1`] = `
           d="M5.8170722959499274e-15,-95L5.2659812363336185e-15,-86Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-donut--threshold--first--Color, #f0f0f0); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-donut--threshold--first--Color, #e0e0e0); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
           transform="translate(115, 115)"
         />
       </g>
@@ -55,7 +55,7 @@ exports[`ChartDonutThreshold 2`] = `
           d="M5.8170722959499274e-15,-95L5.2659812363336185e-15,-86Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-donut--threshold--first--Color, #f0f0f0); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-donut--threshold--first--Color, #e0e0e0); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
           transform="translate(115, 115)"
         />
       </g>
@@ -92,28 +92,28 @@ exports[`renders component data 1`] = `
           d="M0.9334130156923648,-79.99455444055012A80,80,0,0,1,46.26447237139683,-65.26560040477877L40.97399932998254,-57.983888959835994A71,71,0,0,0,0.9334130156923663,-70.99386410206263Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-donut--threshold--first--Color, #f0f0f0); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-donut--threshold--first--Color, #e0e0e0); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
           transform="translate(100, 100)"
         />
         <path
           d="M47.77476635632862,-64.16830759493513A80,80,0,0,1,65.26560040477878,46.26447237139683L57.983888959835994,40.97399932998254A71,71,0,0,0,42.484293314914325,-56.886596149992364Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-donut--threshold--second--Color, #d2d2d2); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-donut--threshold--second--Color, #c7c7c7); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
           transform="translate(100, 100)"
         />
         <path
           d="M64.16830759493514,47.77476635632862A80,80,0,0,1,-23.831948248612967,76.36778275343231L-21.050581972913932,67.80761755585895A71,71,0,0,0,56.88659614999237,42.48429331491432Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-donut--threshold--third--Color, #b8bbbe); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-donut--threshold--third--Color, #a3a3a3); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
           transform="translate(100, 100)"
         />
         <path
           d="M-25.607405310550824,75.7909017841929A80,80,0,0,1,-0.9334130156924101,-79.99455444055012L-0.9334130156923751,-70.99386410206263A71,71,0,0,0,-22.826039034851792,67.23073658661953Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #519de9); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #4394e5); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
           transform="translate(100, 100)"
         />
       </g>

--- a/packages/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutUtilization.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutUtilization.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`ChartDonutUtilization 1`] = `
           d="M5.8170722959499274e-15,-95A95,95,0,1,1,-5.8170722959499274e-15,95A95,95,0,1,1,5.8170722959499274e-15,-95M6.058540038520991e-14,-86A86,86,0,1,0,-6.058540038520991e-14,86A86,86,0,1,0,6.058540038520991e-14,-86Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-donut--threshold--first--Color, #f0f0f0); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-donut--threshold--first--Color, #e0e0e0); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
           transform="translate(115, 115)"
         />
       </g>
@@ -69,7 +69,7 @@ exports[`ChartDonutUtilization 2`] = `
           d="M5.8170722959499274e-15,-95A95,95,0,1,1,-5.8170722959499274e-15,95A95,95,0,1,1,5.8170722959499274e-15,-95M6.058540038520991e-14,-86A86,86,0,1,0,-6.058540038520991e-14,86A86,86,0,1,0,6.058540038520991e-14,-86Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-donut--threshold--first--Color, #f0f0f0); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-donut--threshold--first--Color, #e0e0e0); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
           transform="translate(115, 115)"
         />
       </g>
@@ -113,7 +113,7 @@ exports[`renders component data 1`] = `
           d="M64.16830759493514,47.77476635632862A80,80,0,1,1,-0.9334130156924101,-79.99455444055012L-0.9334130156923751,-70.99386410206263A71,71,0,1,0,56.88659614999237,42.48429331491432Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-donut--threshold--first--Color, #f0f0f0); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-donut--threshold--first--Color, #e0e0e0); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
           transform="translate(100, 100)"
         />
       </g>

--- a/packages/react-charts/src/components/ChartGroup/__snapshots__/ChartGroup.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartGroup/__snapshots__/ChartGroup.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`renders container children 1`] = `
           d="M50,135.71428571428572L75,121.42857142857142L100,92.85714285714286L125,78.57142857142857L150,78.57142857142857L150,150L125,150L100,150L75,150L50,150Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7); width: 6px; fill-opacity: 0.3; stroke-width: 2; stroke: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7);"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9); width: 6px; fill-opacity: 0.3; stroke-width: 2; stroke: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9);"
         />
       </g>
     </svg>

--- a/packages/react-charts/src/components/ChartLabel/__snapshots__/ChartLabel.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartLabel/__snapshots__/ChartLabel.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`renders component text 1`] = `
     <tspan
       dx="0"
       dy="0"
-      style="fill: var(--pf-v6-chart-global--label--Fill, #151515); font-family: var(--pf-v6-chart-global--FontFamily, \\"RedHatText\\", helvetica, arial, sans-serif); font-size: 14px; letter-spacing: var(--pf-v6-chart-global--letter-spacing, normal); stroke: transparent;"
+      style="fill: var(--pf-v6-chart-global--label--Fill, #1f1f1f); font-family: var(--pf-v6-chart-global--FontFamily, redhattextvf, redhattext, helvetica, arial, sans-serif); font-size: 14px; letter-spacing: var(--pf-v6-chart-global--letter-spacing, normal); stroke: transparent;"
       text-anchor="start"
       x="0"
     >

--- a/packages/react-charts/src/components/ChartLegend/__snapshots__/ChartLegend.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartLegend/__snapshots__/ChartLegend.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`ChartLegend 1`] = `
       z"
         role="presentation"
         shape-rendering="auto"
-        style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7);"
+        style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9);"
       />
       <text
         direction="inherit"
@@ -53,7 +53,7 @@ exports[`ChartLegend 1`] = `
         <tspan
           dx="0"
           dy="0"
-          style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #151515);"
+          style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #1f1f1f);"
           text-anchor="start"
           x="30.8"
         >
@@ -70,7 +70,7 @@ exports[`ChartLegend 1`] = `
         <tspan
           dx="0"
           dy="0"
-          style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #151515);"
+          style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #1f1f1f);"
           text-anchor="start"
           x="70.39999999999999"
         >
@@ -133,7 +133,7 @@ exports[`ChartLegend 2`] = `
       z"
         role="presentation"
         shape-rendering="auto"
-        style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7);"
+        style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9);"
       />
       <text
         direction="inherit"
@@ -145,7 +145,7 @@ exports[`ChartLegend 2`] = `
         <tspan
           dx="0"
           dy="0"
-          style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #151515);"
+          style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #1f1f1f);"
           text-anchor="start"
           x="30.8"
         >
@@ -162,7 +162,7 @@ exports[`ChartLegend 2`] = `
         <tspan
           dx="0"
           dy="0"
-          style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #151515);"
+          style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #1f1f1f);"
           text-anchor="start"
           x="70.39999999999999"
         >
@@ -225,7 +225,7 @@ exports[`renders component data 1`] = `
       z"
         role="presentation"
         shape-rendering="auto"
-        style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7);"
+        style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9);"
       />
       <text
         direction="inherit"
@@ -237,7 +237,7 @@ exports[`renders component data 1`] = `
         <tspan
           dx="0"
           dy="0"
-          style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 2px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #151515);"
+          style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 2px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #1f1f1f);"
           text-anchor="start"
           x="2"
         >
@@ -254,7 +254,7 @@ exports[`renders component data 1`] = `
         <tspan
           dx="0"
           dy="0"
-          style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #151515);"
+          style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #1f1f1f);"
           text-anchor="start"
           x="30.8"
         >
@@ -271,7 +271,7 @@ exports[`renders component data 1`] = `
         <tspan
           dx="0"
           dy="0"
-          style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #151515);"
+          style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #1f1f1f);"
           text-anchor="start"
           x="70.39999999999999"
         >

--- a/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltip.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltip.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`allows tooltip via container component 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
+          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
           vector-effect="non-scaling-stroke"
           x1="50"
           x2="400"
@@ -42,7 +42,7 @@ exports[`allows tooltip via container component 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="50"
@@ -59,7 +59,7 @@ exports[`allows tooltip via container component 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: middle;"
               text-anchor="middle"
               x="50"
             >
@@ -73,7 +73,7 @@ exports[`allows tooltip via container component 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="166.66666666666666"
             x2="166.66666666666666"
@@ -90,7 +90,7 @@ exports[`allows tooltip via container component 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: middle;"
               text-anchor="middle"
               x="166.66666666666666"
             >
@@ -104,7 +104,7 @@ exports[`allows tooltip via container component 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="283.3333333333333"
             x2="283.3333333333333"
@@ -121,7 +121,7 @@ exports[`allows tooltip via container component 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: middle;"
               text-anchor="middle"
               x="283.3333333333333"
             >
@@ -135,7 +135,7 @@ exports[`allows tooltip via container component 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="400"
             x2="400"
@@ -152,7 +152,7 @@ exports[`allows tooltip via container component 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: middle;"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: middle;"
               text-anchor="middle"
               x="400"
             >
@@ -167,7 +167,7 @@ exports[`allows tooltip via container component 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
+          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
           vector-effect="non-scaling-stroke"
           x1="50"
           x2="50"
@@ -180,7 +180,7 @@ exports[`allows tooltip via container component 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--grid--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--grid--Fill, none); pointer-events: painted; stroke-linecap: round; stroke-linejoin: round;"
+            style="stroke: var(--pf-v6-chart-axis--grid--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--grid--Fill, none); pointer-events: painted; stroke-linecap: round; stroke-linejoin: round;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="400"
@@ -190,7 +190,7 @@ exports[`allows tooltip via container component 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -207,7 +207,7 @@ exports[`allows tooltip via container component 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: end;"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: end;"
               text-anchor="end"
               x="35"
             >
@@ -221,7 +221,7 @@ exports[`allows tooltip via container component 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--grid--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--grid--Fill, none); pointer-events: painted; stroke-linecap: round; stroke-linejoin: round;"
+            style="stroke: var(--pf-v6-chart-axis--grid--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--grid--Fill, none); pointer-events: painted; stroke-linecap: round; stroke-linejoin: round;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="400"
@@ -231,7 +231,7 @@ exports[`allows tooltip via container component 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -248,7 +248,7 @@ exports[`allows tooltip via container component 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: end;"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: end;"
               text-anchor="end"
               x="35"
             >
@@ -262,7 +262,7 @@ exports[`allows tooltip via container component 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--grid--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--grid--Fill, none); pointer-events: painted; stroke-linecap: round; stroke-linejoin: round;"
+            style="stroke: var(--pf-v6-chart-axis--grid--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--grid--Fill, none); pointer-events: painted; stroke-linecap: round; stroke-linejoin: round;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="400"
@@ -272,7 +272,7 @@ exports[`allows tooltip via container component 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -289,7 +289,7 @@ exports[`allows tooltip via container component 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255); text-anchor: end;"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838); text-anchor: end;"
               text-anchor="end"
               x="35"
             >
@@ -320,7 +320,7 @@ exports[`allows tooltip via container component 1`] = `
             d="M50,185L166.66666666666666,170L283.3333333333333,125L400,155"
             role="presentation"
             shape-rendering="auto"
-            style="fill: none; stroke: var(--pf-v6-chart-theme--green--ColorScale--100, #4cb140); pointer-events: stroke; width: 11px; opacity: 1; stroke-width: 2;"
+            style="fill: none; stroke: var(--pf-v6-chart-theme--green--ColorScale--100, #63993d); pointer-events: stroke; width: 11px; opacity: 1; stroke-width: 2;"
           />
         </g>
         <g
@@ -344,7 +344,7 @@ exports[`allows tooltip via container component 1`] = `
             d="M50,170L166.66666666666666,185L283.3333333333333,95L400,140"
             role="presentation"
             shape-rendering="auto"
-            style="fill: none; stroke: var(--pf-v6-chart-theme--green--ColorScale--200, #bde2b9); pointer-events: stroke; stroke-dasharray: 3,3; width: 11px; opacity: 1; stroke-width: 2;"
+            style="fill: none; stroke: var(--pf-v6-chart-theme--green--ColorScale--200, #afdc8f); pointer-events: stroke; stroke-dasharray: 3,3; width: 11px; opacity: 1; stroke-width: 2;"
           />
         </g>
         <g
@@ -368,7 +368,7 @@ exports[`allows tooltip via container component 1`] = `
             d="M50,155L166.66666666666666,140L283.3333333333333,65L400,125"
             role="presentation"
             shape-rendering="auto"
-            style="fill: none; stroke: var(--pf-v6-chart-theme--green--ColorScale--300, #23511e); pointer-events: stroke; width: 11px; opacity: 1; stroke-width: 2;"
+            style="fill: none; stroke: var(--pf-v6-chart-theme--green--ColorScale--300, #204d00); pointer-events: stroke; width: 11px; opacity: 1; stroke-width: 2;"
           />
         </g>
         <g
@@ -392,7 +392,7 @@ exports[`allows tooltip via container component 1`] = `
             d="M50,155ZM283.3333333333333,80L400,95"
             role="presentation"
             shape-rendering="auto"
-            style="fill: none; stroke: var(--pf-v6-chart-theme--green--ColorScale--400, #7cc674); pointer-events: stroke; width: 11px; opacity: 1; stroke-width: 2;"
+            style="fill: none; stroke: var(--pf-v6-chart-theme--green--ColorScale--400, #87bb62); pointer-events: stroke; width: 11px; opacity: 1; stroke-width: 2;"
           />
         </g>
       </g>
@@ -415,7 +415,7 @@ exports[`allows tooltip via container component 1`] = `
       z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--green--ColorScale--100, #4cb140);"
+          style="fill: var(--pf-v6-chart-theme--green--ColorScale--100, #63993d);"
         />
         <path
           d="M 193.44, 248.156
@@ -435,7 +435,7 @@ exports[`allows tooltip via container component 1`] = `
       z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--green--ColorScale--200, #bde2b9);"
+          style="fill: var(--pf-v6-chart-theme--green--ColorScale--200, #afdc8f);"
         />
         <path
           d="M 234.32799999999997, 250.872
@@ -445,7 +445,7 @@ exports[`allows tooltip via container component 1`] = `
       z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--green--ColorScale--300, #23511e);"
+          style="fill: var(--pf-v6-chart-theme--green--ColorScale--300, #204d00);"
         />
         <path
           d="M 273.928, 250.872
@@ -455,7 +455,7 @@ exports[`allows tooltip via container component 1`] = `
       z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--green--ColorScale--400, #7cc674);"
+          style="fill: var(--pf-v6-chart-theme--green--ColorScale--400, #87bb62);"
         />
         <text
           direction="inherit"
@@ -467,7 +467,7 @@ exports[`allows tooltip via container component 1`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #151515);"
+            style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #1f1f1f);"
             text-anchor="start"
             x="176.8"
           >
@@ -484,7 +484,7 @@ exports[`allows tooltip via container component 1`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #151515);"
+            style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #1f1f1f);"
             text-anchor="start"
             x="216.4"
           >
@@ -501,7 +501,7 @@ exports[`allows tooltip via container component 1`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #151515);"
+            style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #1f1f1f);"
             text-anchor="start"
             x="256"
           >
@@ -518,7 +518,7 @@ exports[`allows tooltip via container component 1`] = `
           <tspan
             dx="0"
             dy="0"
-            style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #151515);"
+            style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #1f1f1f);"
             text-anchor="start"
             x="295.6"
           >

--- a/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltipLabel.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartLegendTooltip/__snapshots__/ChartLegendTooltipLabel.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`renders component text 1`] = `
     <tspan
       dx="0"
       dy="0"
-      style="fill: var(--pf-v6-chart-voronoi--labels--Fill, #f0f0f0); text-anchor: start; font-family: var(--pf-v6-chart-global--FontFamily, \\"RedHatText\\", helvetica, arial, sans-serif); font-size: 14px; letter-spacing: var(--pf-v6-chart-global--letter-spacing, normal); stroke: transparent;"
+      style="fill: var(--pf-v6-chart-voronoi--labels--Fill, #e0e0e0); text-anchor: start; font-family: var(--pf-v6-chart-global--FontFamily, redhattextvf, redhattext, helvetica, arial, sans-serif); font-size: 14px; letter-spacing: var(--pf-v6-chart-global--letter-spacing, normal); stroke: transparent;"
       text-anchor="start"
       x="0"
     >
@@ -33,7 +33,7 @@ exports[`renders component text 1`] = `
     <tspan
       dx="0"
       dy="0"
-      style="fill: var(--pf-v6-chart-voronoi--labels--Fill, #f0f0f0); text-anchor: end; font-family: var(--pf-v6-chart-global--FontFamily, \\"RedHatText\\", helvetica, arial, sans-serif); font-size: 14px; letter-spacing: var(--pf-v6-chart-global--letter-spacing, normal); stroke: transparent;"
+      style="fill: var(--pf-v6-chart-voronoi--labels--Fill, #e0e0e0); text-anchor: end; font-family: var(--pf-v6-chart-global--FontFamily, redhattextvf, redhattext, helvetica, arial, sans-serif); font-size: 14px; letter-spacing: var(--pf-v6-chart-global--letter-spacing, normal); stroke: transparent;"
       text-anchor="end"
       x="NaN"
     >

--- a/packages/react-charts/src/components/ChartLine/__snapshots__/ChartLine.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartLine/__snapshots__/ChartLine.test.tsx.snap
@@ -163,7 +163,7 @@ exports[`renders component data 1`] = `
             d="M50,127.77777777777779L83.33333333333334,138.88888888888886L116.66666666666667,72.22222222222223L150,105.55555555555557"
             role="presentation"
             shape-rendering="auto"
-            style="fill: none; stroke: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7); pointer-events: stroke; width: 3px; opacity: 1; stroke-width: 2;"
+            style="fill: none; stroke: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9); pointer-events: stroke; width: 3px; opacity: 1; stroke-width: 2;"
           />
         </g>
         <g
@@ -187,7 +187,7 @@ exports[`renders component data 1`] = `
             d="M50,116.66666666666669L83.33333333333334,105.55555555555557L116.66666666666667,50L150,94.44444444444443"
             role="presentation"
             shape-rendering="auto"
-            style="fill: none; stroke: var(--pf-v6-chart-theme--blue--ColorScale--300, #002f5d); pointer-events: stroke; width: 3px; opacity: 1; stroke-width: 2;"
+            style="fill: none; stroke: var(--pf-v6-chart-theme--blue--ColorScale--300, #036); pointer-events: stroke; width: 3px; opacity: 1; stroke-width: 2;"
           />
         </g>
         <g
@@ -211,7 +211,7 @@ exports[`renders component data 1`] = `
             d="M50,116.66666666666669L83.33333333333334,116.66666666666669L116.66666666666667,61.111111111111114L150,72.22222222222223"
             role="presentation"
             shape-rendering="auto"
-            style="fill: none; stroke: var(--pf-v6-chart-theme--blue--ColorScale--400, #519de9); pointer-events: stroke; width: 3px; opacity: 1; stroke-width: 2;"
+            style="fill: none; stroke: var(--pf-v6-chart-theme--blue--ColorScale--400, #4394e5); pointer-events: stroke; width: 3px; opacity: 1; stroke-width: 2;"
           />
         </g>
       </g>
@@ -221,7 +221,7 @@ exports[`renders component data 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
+          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
           vector-effect="non-scaling-stroke"
           x1="50"
           x2="150"
@@ -234,7 +234,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="50"
@@ -251,7 +251,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="50"
             >
@@ -265,7 +265,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="66.66666666666667"
             x2="66.66666666666667"
@@ -282,7 +282,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="66.66666666666667"
             >
@@ -296,7 +296,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="83.33333333333334"
             x2="83.33333333333334"
@@ -313,7 +313,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="83.33333333333334"
             >
@@ -327,7 +327,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="100"
             x2="100"
@@ -344,7 +344,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="100"
             >
@@ -358,7 +358,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="116.66666666666667"
             x2="116.66666666666667"
@@ -375,7 +375,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="116.66666666666667"
             >
@@ -389,7 +389,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="133.33333333333334"
             x2="133.33333333333334"
@@ -406,7 +406,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="133.33333333333334"
             >
@@ -420,7 +420,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="150"
             x2="150"
@@ -437,7 +437,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="150"
             >
@@ -452,7 +452,7 @@ exports[`renders component data 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
+          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
           vector-effect="non-scaling-stroke"
           x1="50"
           x2="50"
@@ -465,7 +465,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -482,7 +482,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -496,7 +496,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -513,7 +513,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -527,7 +527,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -544,7 +544,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -558,7 +558,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -575,7 +575,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >

--- a/packages/react-charts/src/components/ChartPie/__snapshots__/ChartPie.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartPie/__snapshots__/ChartPie.test.tsx.snap
@@ -25,28 +25,28 @@ exports[`ChartPie 1`] = `
           d="M61.06482292022124,-72.7742220963029A95,95,0,0,1,82.27241335952168,47.499999999999986L0,0Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
           transform="translate(115, 115)"
         />
         <path
           d="M82.27241335952168,47.499999999999986A95,95,0,0,1,-82.27241335952165,47.50000000000003L0,0Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #002f5d); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #036); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
           transform="translate(115, 115)"
         />
         <path
           d="M-82.27241335952165,47.50000000000003A95,95,0,0,1,-93.55673653615978,-16.496576878358354L0,0Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #519de9); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #4394e5); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
           transform="translate(115, 115)"
         />
         <path
           d="M-93.55673653615978,-16.496576878358354A95,95,0,0,1,-1.745121688784978e-14,-95L0,0Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--500, #004b95); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--500, #004d99); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
           transform="translate(115, 115)"
         />
       </g>
@@ -90,28 +90,28 @@ exports[`ChartPie 2`] = `
           d="M61.06482292022124,-72.7742220963029A95,95,0,0,1,82.27241335952168,47.499999999999986L0,0Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
           transform="translate(115, 115)"
         />
         <path
           d="M82.27241335952168,47.499999999999986A95,95,0,0,1,-82.27241335952165,47.50000000000003L0,0Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #002f5d); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #036); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
           transform="translate(115, 115)"
         />
         <path
           d="M-82.27241335952165,47.50000000000003A95,95,0,0,1,-93.55673653615978,-16.496576878358354L0,0Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #519de9); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #4394e5); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
           transform="translate(115, 115)"
         />
         <path
           d="M-93.55673653615978,-16.496576878358354A95,95,0,0,1,-1.745121688784978e-14,-95L0,0Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--500, #004b95); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--500, #004d99); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
           transform="translate(115, 115)"
         />
       </g>
@@ -155,14 +155,14 @@ exports[`renders component data 1`] = `
           d="M64.7213595499958,47.022820183397855A80,80,0,1,1,-47.02282018339786,-64.72135954999578L0,0Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
           transform="translate(100, 100)"
         />
         <path
           d="M-47.02282018339786,-64.72135954999578A80,80,0,0,1,-1.4695761589768237e-14,-80L0,0Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #002f5d); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #036); padding: 8px; stroke: var(--pf-v6-chart-pie--data--stroke--Color, transparent); stroke-width: 1;"
           transform="translate(100, 100)"
         />
       </g>

--- a/packages/react-charts/src/components/ChartPoint/__snapshots__/ChartPoint.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartPoint/__snapshots__/ChartPoint.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`ChartPoint 1`] = `
       z"
         role="presentation"
         shape-rendering="auto"
-        style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7);"
+        style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9);"
       />
       <text
         direction="inherit"
@@ -53,7 +53,7 @@ exports[`ChartPoint 1`] = `
         <tspan
           dx="0"
           dy="0"
-          style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #151515);"
+          style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #1f1f1f);"
           text-anchor="start"
           x="30.8"
         >
@@ -70,7 +70,7 @@ exports[`ChartPoint 1`] = `
         <tspan
           dx="0"
           dy="0"
-          style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #151515);"
+          style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #1f1f1f);"
           text-anchor="start"
           x="70.39999999999999"
         >
@@ -133,7 +133,7 @@ exports[`ChartPoint 2`] = `
       z"
         role="presentation"
         shape-rendering="auto"
-        style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7);"
+        style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9);"
       />
       <text
         direction="inherit"
@@ -145,7 +145,7 @@ exports[`ChartPoint 2`] = `
         <tspan
           dx="0"
           dy="0"
-          style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #151515);"
+          style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #1f1f1f);"
           text-anchor="start"
           x="30.8"
         >
@@ -162,7 +162,7 @@ exports[`ChartPoint 2`] = `
         <tspan
           dx="0"
           dy="0"
-          style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #151515);"
+          style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #1f1f1f);"
           text-anchor="start"
           x="70.39999999999999"
         >
@@ -235,7 +235,7 @@ exports[`renders component data 1`] = `
       z"
         role="presentation"
         shape-rendering="auto"
-        style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7);"
+        style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9);"
       />
       <text
         direction="inherit"
@@ -247,7 +247,7 @@ exports[`renders component data 1`] = `
         <tspan
           dx="0"
           dy="0"
-          style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 2px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #151515);"
+          style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 2px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #1f1f1f);"
           text-anchor="start"
           x="2"
         >
@@ -264,7 +264,7 @@ exports[`renders component data 1`] = `
         <tspan
           dx="0"
           dy="0"
-          style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #151515);"
+          style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #1f1f1f);"
           text-anchor="start"
           x="30.8"
         >
@@ -281,7 +281,7 @@ exports[`renders component data 1`] = `
         <tspan
           dx="0"
           dy="0"
-          style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #151515);"
+          style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-global--label--Fill, #1f1f1f);"
           text-anchor="start"
           x="70.39999999999999"
         >

--- a/packages/react-charts/src/components/ChartScatter/__snapshots__/ChartScatter.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartScatter/__snapshots__/ChartScatter.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 57, 246
@@ -30,7 +30,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 64, 242
@@ -39,7 +39,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 71, 238
@@ -48,7 +48,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 78, 234
@@ -57,7 +57,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 85, 230
@@ -66,7 +66,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 92, 226
@@ -75,7 +75,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 99, 222
@@ -84,7 +84,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 106, 218
@@ -93,7 +93,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 113, 214.00000000000003
@@ -102,7 +102,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 120, 210
@@ -111,7 +111,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 127, 206
@@ -120,7 +120,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 134, 202
@@ -129,7 +129,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 141, 198
@@ -138,7 +138,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 148, 194
@@ -147,7 +147,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 155, 190
@@ -156,7 +156,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 162, 185.99999999999997
@@ -165,7 +165,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 169, 181.99999999999997
@@ -174,7 +174,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 176, 178
@@ -183,7 +183,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 183, 174
@@ -192,7 +192,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 190, 170
@@ -201,7 +201,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 197, 166.00000000000003
@@ -210,7 +210,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 204, 162
@@ -219,7 +219,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 211, 158
@@ -228,7 +228,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 218, 154
@@ -237,7 +237,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 225, 150
@@ -246,7 +246,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 232, 146
@@ -255,7 +255,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 239, 142
@@ -264,7 +264,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 246.00000000000003, 138
@@ -273,7 +273,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 252.99999999999997, 134
@@ -282,7 +282,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 260, 130
@@ -291,7 +291,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 267, 126
@@ -300,7 +300,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 274, 122
@@ -309,7 +309,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 281, 117.99999999999999
@@ -318,7 +318,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 288, 113.99999999999999
@@ -327,7 +327,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 295, 109.99999999999999
@@ -336,7 +336,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 302, 106
@@ -345,7 +345,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 309, 102
@@ -354,7 +354,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 316, 98
@@ -363,7 +363,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 323, 94
@@ -372,7 +372,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 330, 89.99999999999999
@@ -381,7 +381,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 337, 85.99999999999999
@@ -390,7 +390,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 344, 82
@@ -399,7 +399,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 351, 78
@@ -408,7 +408,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 358, 74
@@ -417,7 +417,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 365, 70
@@ -426,7 +426,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 372, 65.99999999999999
@@ -435,7 +435,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 379, 61.999999999999986
@@ -444,7 +444,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 386, 58.00000000000001
@@ -453,7 +453,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 393, 54.00000000000001
@@ -462,7 +462,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 400, 50
@@ -471,7 +471,7 @@ exports[`ChartScatter 1`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
       </g>
     </svg>
@@ -510,7 +510,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 57, 246
@@ -519,7 +519,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 64, 242
@@ -528,7 +528,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 71, 238
@@ -537,7 +537,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 78, 234
@@ -546,7 +546,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 85, 230
@@ -555,7 +555,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 92, 226
@@ -564,7 +564,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 99, 222
@@ -573,7 +573,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 106, 218
@@ -582,7 +582,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 113, 214.00000000000003
@@ -591,7 +591,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 120, 210
@@ -600,7 +600,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 127, 206
@@ -609,7 +609,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 134, 202
@@ -618,7 +618,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 141, 198
@@ -627,7 +627,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 148, 194
@@ -636,7 +636,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 155, 190
@@ -645,7 +645,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 162, 185.99999999999997
@@ -654,7 +654,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 169, 181.99999999999997
@@ -663,7 +663,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 176, 178
@@ -672,7 +672,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 183, 174
@@ -681,7 +681,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 190, 170
@@ -690,7 +690,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 197, 166.00000000000003
@@ -699,7 +699,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 204, 162
@@ -708,7 +708,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 211, 158
@@ -717,7 +717,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 218, 154
@@ -726,7 +726,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 225, 150
@@ -735,7 +735,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 232, 146
@@ -744,7 +744,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 239, 142
@@ -753,7 +753,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 246.00000000000003, 138
@@ -762,7 +762,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 252.99999999999997, 134
@@ -771,7 +771,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 260, 130
@@ -780,7 +780,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 267, 126
@@ -789,7 +789,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 274, 122
@@ -798,7 +798,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 281, 117.99999999999999
@@ -807,7 +807,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 288, 113.99999999999999
@@ -816,7 +816,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 295, 109.99999999999999
@@ -825,7 +825,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 302, 106
@@ -834,7 +834,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 309, 102
@@ -843,7 +843,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 316, 98
@@ -852,7 +852,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 323, 94
@@ -861,7 +861,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 330, 89.99999999999999
@@ -870,7 +870,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 337, 85.99999999999999
@@ -879,7 +879,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 344, 82
@@ -888,7 +888,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 351, 78
@@ -897,7 +897,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 358, 74
@@ -906,7 +906,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 365, 70
@@ -915,7 +915,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 372, 65.99999999999999
@@ -924,7 +924,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 379, 61.999999999999986
@@ -933,7 +933,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 386, 58.00000000000001
@@ -942,7 +942,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 393, 54.00000000000001
@@ -951,7 +951,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
         <path
           d="M 400, 50
@@ -960,7 +960,7 @@ exports[`ChartScatter 2`] = `
       a 3, 3 0 1,0 -6,0"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-scatter--data--Fill, #151515); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+          style="fill: var(--pf-v6-chart-scatter--data--Fill, #1f1f1f); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
         />
       </g>
     </svg>
@@ -1038,7 +1038,7 @@ exports[`renders component data 1`] = `
       a 3, 3 0 1,0 -6,0"
             role="presentation"
             shape-rendering="auto"
-            style="width: 3px; fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+            style="width: 3px; fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
           />
           <path
             d="M 83.33333333333334, 107.14285714285714
@@ -1047,7 +1047,7 @@ exports[`renders component data 1`] = `
       a 3, 3 0 1,0 -6,0"
             role="presentation"
             shape-rendering="auto"
-            style="width: 3px; fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+            style="width: 3px; fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
           />
           <path
             d="M 100, 92.85714285714286
@@ -1056,7 +1056,7 @@ exports[`renders component data 1`] = `
       a 3, 3 0 1,0 -6,0"
             role="presentation"
             shape-rendering="auto"
-            style="width: 3px; fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+            style="width: 3px; fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
           />
           <path
             d="M 116.66666666666667, 78.57142857142857
@@ -1065,7 +1065,7 @@ exports[`renders component data 1`] = `
       a 3, 3 0 1,0 -6,0"
             role="presentation"
             shape-rendering="auto"
-            style="width: 3px; fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+            style="width: 3px; fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
           />
         </g>
         <g>
@@ -1076,7 +1076,7 @@ exports[`renders component data 1`] = `
       a 3, 3 0 1,0 -6,0"
             role="presentation"
             shape-rendering="auto"
-            style="width: 3px; fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #002f5d); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+            style="width: 3px; fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #036); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
           />
           <path
             d="M 100, 92.85714285714286
@@ -1085,7 +1085,7 @@ exports[`renders component data 1`] = `
       a 3, 3 0 1,0 -6,0"
             role="presentation"
             shape-rendering="auto"
-            style="width: 3px; fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #002f5d); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+            style="width: 3px; fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #036); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
           />
           <path
             d="M 116.66666666666667, 78.57142857142857
@@ -1094,7 +1094,7 @@ exports[`renders component data 1`] = `
       a 3, 3 0 1,0 -6,0"
             role="presentation"
             shape-rendering="auto"
-            style="width: 3px; fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #002f5d); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+            style="width: 3px; fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #036); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
           />
           <path
             d="M 133.33333333333334, 64.28571428571429
@@ -1103,7 +1103,7 @@ exports[`renders component data 1`] = `
       a 3, 3 0 1,0 -6,0"
             role="presentation"
             shape-rendering="auto"
-            style="width: 3px; fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #002f5d); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+            style="width: 3px; fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #036); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
           />
         </g>
         <g>
@@ -1114,7 +1114,7 @@ exports[`renders component data 1`] = `
       a 3, 3 0 1,0 -6,0"
             role="presentation"
             shape-rendering="auto"
-            style="width: 3px; fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #519de9); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+            style="width: 3px; fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #4394e5); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
           />
           <path
             d="M 116.66666666666667, 78.57142857142857
@@ -1123,7 +1123,7 @@ exports[`renders component data 1`] = `
       a 3, 3 0 1,0 -6,0"
             role="presentation"
             shape-rendering="auto"
-            style="width: 3px; fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #519de9); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+            style="width: 3px; fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #4394e5); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
           />
           <path
             d="M 133.33333333333334, 64.28571428571429
@@ -1132,7 +1132,7 @@ exports[`renders component data 1`] = `
       a 3, 3 0 1,0 -6,0"
             role="presentation"
             shape-rendering="auto"
-            style="width: 3px; fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #519de9); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+            style="width: 3px; fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #4394e5); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
           />
           <path
             d="M 150, 50
@@ -1141,7 +1141,7 @@ exports[`renders component data 1`] = `
       a 3, 3 0 1,0 -6,0"
             role="presentation"
             shape-rendering="auto"
-            style="width: 3px; fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #519de9); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
+            style="width: 3px; fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #4394e5); opacity: 1; stroke: var(--pf-v6-chart-scatter--data--stroke--Color, transparent); stroke-width: 0;"
           />
         </g>
       </g>
@@ -1151,7 +1151,7 @@ exports[`renders component data 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
+          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
           vector-effect="non-scaling-stroke"
           x1="50"
           x2="150"
@@ -1164,7 +1164,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="50"
@@ -1181,7 +1181,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="50"
             >
@@ -1195,7 +1195,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="66.66666666666667"
             x2="66.66666666666667"
@@ -1212,7 +1212,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="66.66666666666667"
             >
@@ -1226,7 +1226,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="83.33333333333334"
             x2="83.33333333333334"
@@ -1243,7 +1243,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="83.33333333333334"
             >
@@ -1257,7 +1257,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="100"
             x2="100"
@@ -1274,7 +1274,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="100"
             >
@@ -1288,7 +1288,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="116.66666666666667"
             x2="116.66666666666667"
@@ -1305,7 +1305,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="116.66666666666667"
             >
@@ -1319,7 +1319,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="133.33333333333334"
             x2="133.33333333333334"
@@ -1336,7 +1336,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="133.33333333333334"
             >
@@ -1350,7 +1350,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="150"
             x2="150"
@@ -1367,7 +1367,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="150"
             >
@@ -1382,7 +1382,7 @@ exports[`renders component data 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
+          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
           vector-effect="non-scaling-stroke"
           x1="50"
           x2="50"
@@ -1395,7 +1395,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -1412,7 +1412,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -1426,7 +1426,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -1443,7 +1443,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -1457,7 +1457,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -1474,7 +1474,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -1488,7 +1488,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -1505,7 +1505,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -1519,7 +1519,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -1536,7 +1536,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -1550,7 +1550,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -1567,7 +1567,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -1581,7 +1581,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -1598,7 +1598,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >

--- a/packages/react-charts/src/components/ChartStack/__snapshots__/ChartStack.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartStack/__snapshots__/ChartStack.test.tsx.snap
@@ -84,7 +84,7 @@ A 0 0 0 0 1, 85, 125.86206896551724
             index="0"
             role="presentation"
             shape-rendering="auto"
-            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #519de9); stroke: var(--pf-v6-chart-bar--data--stroke, none); stroke-width: 1; padding: 8px;"
+            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #4394e5); stroke: var(--pf-v6-chart-bar--data--stroke, none); stroke-width: 1; padding: 8px;"
           />
           <path
             d="M 123.33333333333331, 125.86206896551724 
@@ -99,7 +99,7 @@ A 0 0 0 0 1, 133.33333333333331, 125.86206896551724
             index="1"
             role="presentation"
             shape-rendering="auto"
-            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #519de9); stroke: var(--pf-v6-chart-bar--data--stroke, none); stroke-width: 1; padding: 8px;"
+            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #4394e5); stroke: var(--pf-v6-chart-bar--data--stroke, none); stroke-width: 1; padding: 8px;"
           />
           <path
             d="M 171.66666666666666, 77.58620689655172 
@@ -114,7 +114,7 @@ A 0 0 0 0 1, 181.66666666666666, 77.58620689655172
             index="2"
             role="presentation"
             shape-rendering="auto"
-            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #519de9); stroke: var(--pf-v6-chart-bar--data--stroke, none); stroke-width: 1; padding: 8px;"
+            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #4394e5); stroke: var(--pf-v6-chart-bar--data--stroke, none); stroke-width: 1; padding: 8px;"
           />
           <path
             d="M 219.99999999999997, 101.72413793103448 
@@ -129,7 +129,7 @@ A 0 0 0 0 1, 229.99999999999997, 101.72413793103448
             index="3"
             role="presentation"
             shape-rendering="auto"
-            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #519de9); stroke: var(--pf-v6-chart-bar--data--stroke, none); stroke-width: 1; padding: 8px;"
+            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--400, #4394e5); stroke: var(--pf-v6-chart-bar--data--stroke, none); stroke-width: 1; padding: 8px;"
           />
         </g>
         <g
@@ -148,7 +148,7 @@ A 0 0 0 0 1, 85, 139.6551724137931
             index="0"
             role="presentation"
             shape-rendering="auto"
-            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #002f5d); stroke: var(--pf-v6-chart-bar--data--stroke, none); stroke-width: 1; padding: 8px;"
+            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #036); stroke: var(--pf-v6-chart-bar--data--stroke, none); stroke-width: 1; padding: 8px;"
           />
           <path
             d="M 123.33333333333331, 139.6551724137931 
@@ -163,7 +163,7 @@ A 0 0 0 0 1, 133.33333333333331, 139.6551724137931
             index="1"
             role="presentation"
             shape-rendering="auto"
-            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #002f5d); stroke: var(--pf-v6-chart-bar--data--stroke, none); stroke-width: 1; padding: 8px;"
+            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #036); stroke: var(--pf-v6-chart-bar--data--stroke, none); stroke-width: 1; padding: 8px;"
           />
           <path
             d="M 171.66666666666666, 108.62068965517243 
@@ -178,7 +178,7 @@ A 0 0 0 0 1, 181.66666666666666, 108.62068965517243
             index="2"
             role="presentation"
             shape-rendering="auto"
-            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #002f5d); stroke: var(--pf-v6-chart-bar--data--stroke, none); stroke-width: 1; padding: 8px;"
+            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #036); stroke: var(--pf-v6-chart-bar--data--stroke, none); stroke-width: 1; padding: 8px;"
           />
           <path
             d="M 219.99999999999997, 125.86206896551724 
@@ -193,7 +193,7 @@ A 0 0 0 0 1, 229.99999999999997, 125.86206896551724
             index="3"
             role="presentation"
             shape-rendering="auto"
-            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #002f5d); stroke: var(--pf-v6-chart-bar--data--stroke, none); stroke-width: 1; padding: 8px;"
+            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--300, #036); stroke: var(--pf-v6-chart-bar--data--stroke, none); stroke-width: 1; padding: 8px;"
           />
         </g>
         <g
@@ -212,7 +212,7 @@ A 0 0 0 0 1, 85, 146.55172413793105
             index="0"
             role="presentation"
             shape-rendering="auto"
-            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7); stroke: var(--pf-v6-chart-bar--data--stroke, none); stroke-width: 1; padding: 8px;"
+            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9); stroke: var(--pf-v6-chart-bar--data--stroke, none); stroke-width: 1; padding: 8px;"
           />
           <path
             d="M 123.33333333333331, 143.10344827586206 
@@ -227,7 +227,7 @@ A 0 0 0 0 1, 133.33333333333331, 143.10344827586206
             index="1"
             role="presentation"
             shape-rendering="auto"
-            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7); stroke: var(--pf-v6-chart-bar--data--stroke, none); stroke-width: 1; padding: 8px;"
+            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9); stroke: var(--pf-v6-chart-bar--data--stroke, none); stroke-width: 1; padding: 8px;"
           />
           <path
             d="M 171.66666666666666, 132.75862068965517 
@@ -242,7 +242,7 @@ A 0 0 0 0 1, 181.66666666666666, 132.75862068965517
             index="2"
             role="presentation"
             shape-rendering="auto"
-            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7); stroke: var(--pf-v6-chart-bar--data--stroke, none); stroke-width: 1; padding: 8px;"
+            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9); stroke: var(--pf-v6-chart-bar--data--stroke, none); stroke-width: 1; padding: 8px;"
           />
           <path
             d="M 219.99999999999997, 139.6551724137931 
@@ -257,7 +257,7 @@ A 0 0 0 0 1, 229.99999999999997, 139.6551724137931
             index="3"
             role="presentation"
             shape-rendering="auto"
-            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7); stroke: var(--pf-v6-chart-bar--data--stroke, none); stroke-width: 1; padding: 8px;"
+            style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9); stroke: var(--pf-v6-chart-bar--data--stroke, none); stroke-width: 1; padding: 8px;"
           />
         </g>
         <g
@@ -331,7 +331,7 @@ A 0 0 0 0 1, 229.99999999999997, 150
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
+          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
           vector-effect="non-scaling-stroke"
           x1="50"
           x2="250"
@@ -344,7 +344,7 @@ A 0 0 0 0 1, 229.99999999999997, 150
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="80"
             x2="80"
@@ -361,7 +361,7 @@ A 0 0 0 0 1, 229.99999999999997, 150
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="80"
             >
@@ -375,7 +375,7 @@ A 0 0 0 0 1, 229.99999999999997, 150
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="128.33333333333331"
             x2="128.33333333333331"
@@ -392,7 +392,7 @@ A 0 0 0 0 1, 229.99999999999997, 150
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="128.33333333333331"
             >
@@ -406,7 +406,7 @@ A 0 0 0 0 1, 229.99999999999997, 150
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="176.66666666666666"
             x2="176.66666666666666"
@@ -423,7 +423,7 @@ A 0 0 0 0 1, 229.99999999999997, 150
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="176.66666666666666"
             >
@@ -437,7 +437,7 @@ A 0 0 0 0 1, 229.99999999999997, 150
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="224.99999999999997"
             x2="224.99999999999997"
@@ -454,7 +454,7 @@ A 0 0 0 0 1, 229.99999999999997, 150
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="224.99999999999997"
             >
@@ -469,7 +469,7 @@ A 0 0 0 0 1, 229.99999999999997, 150
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
+          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
           vector-effect="non-scaling-stroke"
           x1="50"
           x2="50"
@@ -482,7 +482,7 @@ A 0 0 0 0 1, 229.99999999999997, 150
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -499,7 +499,7 @@ A 0 0 0 0 1, 229.99999999999997, 150
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -513,7 +513,7 @@ A 0 0 0 0 1, 229.99999999999997, 150
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -530,7 +530,7 @@ A 0 0 0 0 1, 229.99999999999997, 150
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -544,7 +544,7 @@ A 0 0 0 0 1, 229.99999999999997, 150
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -561,7 +561,7 @@ A 0 0 0 0 1, 229.99999999999997, 150
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -575,7 +575,7 @@ A 0 0 0 0 1, 229.99999999999997, 150
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -592,7 +592,7 @@ A 0 0 0 0 1, 229.99999999999997, 150
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -606,7 +606,7 @@ A 0 0 0 0 1, 229.99999999999997, 150
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -623,7 +623,7 @@ A 0 0 0 0 1, 229.99999999999997, 150
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >

--- a/packages/react-charts/src/components/ChartTheme/styles/box-plot-tooltip-styles.ts
+++ b/packages/react-charts/src/components/ChartTheme/styles/box-plot-tooltip-styles.ts
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import global_FontWeight_bold from '@patternfly/react-tokens/dist/esm/global_FontWeight_bold';
+import global_font_weight_heading_bold from '@patternfly/react-tokens/dist/esm/global_font_weight_heading_bold';
 import chart_voronoi_labels_Fill from '@patternfly/react-tokens/dist/esm/chart_voronoi_labels_Fill';
 
 /**
@@ -12,6 +12,6 @@ export const BoxPlotTooltipStyles = {
   },
   label: {
     fill: chart_voronoi_labels_Fill.var,
-    fontWeight: global_FontWeight_bold.value
+    fontWeight: global_font_weight_heading_bold.value
   } as any
 };

--- a/packages/react-charts/src/components/ChartTheme/styles/legend-tooltip-styles.ts
+++ b/packages/react-charts/src/components/ChartTheme/styles/legend-tooltip-styles.ts
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import global_FontWeight_bold from '@patternfly/react-tokens/dist/esm/global_FontWeight_bold';
+import global_font_weight_heading_bold from '@patternfly/react-tokens/dist/esm/global_font_weight_heading_bold';
 import chart_voronoi_labels_Fill from '@patternfly/react-tokens/dist/esm/chart_voronoi_labels_Fill';
 
 /**
@@ -12,6 +12,6 @@ export const LegendTooltipStyles = {
   },
   label: {
     fill: chart_voronoi_labels_Fill.var,
-    fontWeight: global_FontWeight_bold.value
+    fontWeight: global_font_weight_heading_bold.value
   } as any
 };

--- a/packages/react-charts/src/components/ChartThreshold/__snapshots__/ChartThreshold.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartThreshold/__snapshots__/ChartThreshold.test.tsx.snap
@@ -149,7 +149,7 @@ exports[`renders component data 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
+          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
           vector-effect="non-scaling-stroke"
           x1="50"
           x2="150"
@@ -162,7 +162,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="70"
             x2="70"
@@ -179,7 +179,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="70"
             >
@@ -193,7 +193,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="90"
             x2="90"
@@ -210,7 +210,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="90"
             >
@@ -224,7 +224,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="110"
             x2="110"
@@ -241,7 +241,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="110"
             >
@@ -255,7 +255,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="130"
             x2="130"
@@ -272,7 +272,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="130"
             >
@@ -286,7 +286,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="150"
             x2="150"
@@ -303,7 +303,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="middle"
               x="150"
             >
@@ -318,7 +318,7 @@ exports[`renders component data 1`] = `
         <line
           role="presentation"
           shape-rendering="auto"
-          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
+          style="stroke: var(--pf-v6-chart-axis--axis--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--axis--Fill, transparent); stroke-width: 1; stroke-linecap: round; stroke-linejoin: round;"
           vector-effect="non-scaling-stroke"
           x1="50"
           x2="50"
@@ -331,7 +331,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -348,7 +348,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -362,7 +362,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -379,7 +379,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -393,7 +393,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -410,7 +410,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -424,7 +424,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -441,7 +441,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -455,7 +455,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -472,7 +472,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >
@@ -486,7 +486,7 @@ exports[`renders component data 1`] = `
           <line
             role="presentation"
             shape-rendering="auto"
-            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #d2d2d2); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
+            style="stroke: var(--pf-v6-chart-axis--tick--stroke--Color, #c7c7c7); fill: var(--pf-v6-chart-axis--tick--Fill, transparent); size: 5px; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1;"
             vector-effect="non-scaling-stroke"
             x1="50"
             x2="45"
@@ -503,7 +503,7 @@ exports[`renders component data 1`] = `
             <tspan
               dx="0"
               dy="0"
-              style="font-family: \\"RedHatText\\",helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #4f5255);"
+              style="font-family: redhattextvf,redhattext,helvetica,arial,sans-serif; font-size: 14px; letter-spacing: normal; padding: 10px; stroke: var(--pf-v6-chart-global--label--stroke, transparent); fill: var(--pf-v6-chart-axis--tick-label--Fill, #383838);"
               text-anchor="end"
               x="35"
             >

--- a/packages/react-charts/src/components/ChartTooltip/__snapshots__/ChartTooltip.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartTooltip/__snapshots__/ChartTooltip.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`allows tooltip via container component 1`] = `
           d="M50,135.71428571428572L75,121.42857142857142L100,92.85714285714286L125,78.57142857142857L150,78.57142857142857L150,150L125,150L100,150L75,150L50,150Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7); width: 6px; fill-opacity: 0.3; stroke-width: 2; stroke: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7);"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9); width: 6px; fill-opacity: 0.3; stroke-width: 2; stroke: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9);"
         />
       </g>
     </svg>

--- a/packages/react-charts/src/components/ChartVoronoiContainer/__snapshots__/ChartVoronoContainer.test.tsx.snap
+++ b/packages/react-charts/src/components/ChartVoronoiContainer/__snapshots__/ChartVoronoContainer.test.tsx.snap
@@ -104,7 +104,7 @@ exports[`renders container via ChartGroup 1`] = `
           d="M50,135.71428571428572L75,121.42857142857142L100,92.85714285714286L125,78.57142857142857L150,78.57142857142857L150,150L125,150L100,150L75,150L50,150Z"
           role="presentation"
           shape-rendering="auto"
-          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7); width: 6px; fill-opacity: 0.3; stroke-width: 2; stroke: var(--pf-v6-chart-theme--blue--ColorScale--200, #8bc1f7);"
+          style="fill: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9); width: 6px; fill-opacity: 0.3; stroke-width: 2; stroke: var(--pf-v6-chart-theme--blue--ColorScale--200, #92c5f9);"
         />
       </g>
     </svg>

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -55,7 +55,7 @@
     "tslib": "^2.5.0"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.0.0-alpha.117",
+    "@patternfly/patternfly": "6.0.0-alpha.135",
     "@rollup/plugin-commonjs": "^25.0.0",
     "@rollup/plugin-node-resolve": "^15.0.2",
     "@rollup/plugin-replace": "^5.0.2",

--- a/packages/react-core/src/components/Menu/Menu.tsx
+++ b/packages/react-core/src/components/Menu/Menu.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/Menu/menu';
 import breadcrumbStyles from '@patternfly/react-styles/css/components/Breadcrumb/breadcrumb';
-import dropdownStyles from '@patternfly/react-styles/css/components/Dropdown/dropdown';
 import { css } from '@patternfly/react-styles';
 import { getOUIAProps, OUIAProps, getDefaultOUIAId } from '../../helpers';
 import { MenuContext } from './MenuContext';
@@ -193,9 +192,7 @@ class MenuBase extends React.Component<MenuProps, MenuState> {
 
     const parentMenu = this.activeMenu;
     const key = event.key;
-    const isFromBreadcrumb =
-      activeElement.classList.contains(breadcrumbStyles.breadcrumbLink) ||
-      activeElement.classList.contains(dropdownStyles.dropdownToggle);
+    const isFromBreadcrumb = activeElement.classList.contains(breadcrumbStyles.breadcrumbLink);
 
     if (key === ' ' || key === 'Enter') {
       event.preventDefault();
@@ -313,7 +310,6 @@ class MenuBase extends React.Component<MenuProps, MenuState> {
             noHorizontalArrowHandling={
               document.activeElement &&
               (document.activeElement.classList.contains(breadcrumbStyles.breadcrumbLink) ||
-                document.activeElement.classList.contains(dropdownStyles.dropdownToggle) ||
                 document.activeElement.tagName === 'INPUT')
             }
             noEnterHandling

--- a/packages/react-core/src/components/NotificationDrawer/NotificationDrawerHeader.tsx
+++ b/packages/react-core/src/components/NotificationDrawer/NotificationDrawerHeader.tsx
@@ -3,8 +3,6 @@ import * as React from 'react';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/NotificationDrawer/notification-drawer';
 import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
-
-import { Text, TextVariants } from '../Text';
 import { Button, ButtonVariant } from '../Button';
 
 export interface NotificationDrawerHeaderProps extends React.HTMLProps<HTMLDivElement> {
@@ -38,9 +36,7 @@ export const NotificationDrawerHeader: React.FunctionComponent<NotificationDrawe
   ...props
 }: NotificationDrawerHeaderProps) => (
   <div {...props} className={css(styles.notificationDrawerHeader, className)}>
-    <Text component={TextVariants.h1} className={css(styles.notificationDrawerHeaderTitle)}>
-      {title}
-    </Text>
+    <h1 className={css(styles.notificationDrawerHeaderTitle)}>{title}</h1>
     {(customText !== undefined || count !== undefined) && (
       <span className={css(styles.notificationDrawerHeaderStatus)} aria-live="polite">
         {customText || `${count} ${unreadText}`}

--- a/packages/react-core/src/components/NotificationDrawer/__tests__/__snapshots__/NotificationDrawerHeader.test.tsx.snap
+++ b/packages/react-core/src/components/NotificationDrawer/__tests__/__snapshots__/NotificationDrawerHeader.test.tsx.snap
@@ -6,11 +6,7 @@ exports[`NotificationDrawerHeader drawer header with count applied 1`] = `
     class="pf-v6-c-notification-drawer__header"
   >
     <h1
-      class="pf-v6-c-content--h1 pf-v6-c-notification-drawer__header-title"
-      data-ouia-component-id="OUIA-Generated-Text-3"
-      data-ouia-component-type="PF6/Text"
-      data-ouia-safe="true"
-      data-pf-content="true"
+      class="pf-v6-c-notification-drawer__header-title"
     >
       Notifications
     </h1>
@@ -30,11 +26,7 @@ exports[`NotificationDrawerHeader drawer header with custom unread text applied 
     class="pf-v6-c-notification-drawer__header"
   >
     <h1
-      class="pf-v6-c-content--h1 pf-v6-c-notification-drawer__header-title"
-      data-ouia-component-id="OUIA-Generated-Text-5"
-      data-ouia-component-type="PF6/Text"
-      data-ouia-safe="true"
-      data-pf-content="true"
+      class="pf-v6-c-notification-drawer__header-title"
     >
       Notifications
     </h1>
@@ -54,11 +46,7 @@ exports[`NotificationDrawerHeader drawer header with title applied 1`] = `
     class="pf-v6-c-notification-drawer__header"
   >
     <h1
-      class="pf-v6-c-content--h1 pf-v6-c-notification-drawer__header-title"
-      data-ouia-component-id="OUIA-Generated-Text-4"
-      data-ouia-component-type="PF6/Text"
-      data-ouia-safe="true"
-      data-pf-content="true"
+      class="pf-v6-c-notification-drawer__header-title"
     >
       Some Title
     </h1>
@@ -72,11 +60,7 @@ exports[`NotificationDrawerHeader renders with PatternFly Core styles 1`] = `
     class="pf-v6-c-notification-drawer__header"
   >
     <h1
-      class="pf-v6-c-content--h1 pf-v6-c-notification-drawer__header-title"
-      data-ouia-component-id="OUIA-Generated-Text-1"
-      data-ouia-component-type="PF6/Text"
-      data-ouia-safe="true"
-      data-pf-content="true"
+      class="pf-v6-c-notification-drawer__header-title"
     >
       Notifications
     </h1>

--- a/packages/react-core/src/components/NotificationDrawer/__tests__/__snapshots__/NotificationDrawerHeader.test.tsx.snap
+++ b/packages/react-core/src/components/NotificationDrawer/__tests__/__snapshots__/NotificationDrawerHeader.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`NotificationDrawerHeader drawer header with count applied 1`] = `
     class="pf-v6-c-notification-drawer__header"
   >
     <h1
-      class="pf-v6-c-notification-drawer__header-title"
+      class="pf-v6-c-content--h1 pf-v6-c-notification-drawer__header-title"
       data-ouia-component-id="OUIA-Generated-Text-3"
       data-ouia-component-type="PF6/Text"
       data-ouia-safe="true"
@@ -30,7 +30,7 @@ exports[`NotificationDrawerHeader drawer header with custom unread text applied 
     class="pf-v6-c-notification-drawer__header"
   >
     <h1
-      class="pf-v6-c-notification-drawer__header-title"
+      class="pf-v6-c-content--h1 pf-v6-c-notification-drawer__header-title"
       data-ouia-component-id="OUIA-Generated-Text-5"
       data-ouia-component-type="PF6/Text"
       data-ouia-safe="true"
@@ -54,7 +54,7 @@ exports[`NotificationDrawerHeader drawer header with title applied 1`] = `
     class="pf-v6-c-notification-drawer__header"
   >
     <h1
-      class="pf-v6-c-notification-drawer__header-title"
+      class="pf-v6-c-content--h1 pf-v6-c-notification-drawer__header-title"
       data-ouia-component-id="OUIA-Generated-Text-4"
       data-ouia-component-type="PF6/Text"
       data-ouia-safe="true"
@@ -72,7 +72,7 @@ exports[`NotificationDrawerHeader renders with PatternFly Core styles 1`] = `
     class="pf-v6-c-notification-drawer__header"
   >
     <h1
-      class="pf-v6-c-notification-drawer__header-title"
+      class="pf-v6-c-content--h1 pf-v6-c-notification-drawer__header-title"
       data-ouia-component-id="OUIA-Generated-Text-1"
       data-ouia-component-type="PF6/Text"
       data-ouia-safe="true"

--- a/packages/react-core/src/components/Skeleton/examples/Skeleton.md
+++ b/packages/react-core/src/components/Skeleton/examples/Skeleton.md
@@ -5,37 +5,42 @@ cssPrefix: pf-v5-c-skeleton
 propComponents: ['Skeleton']
 ---
 
-import global_FontSize_4xl from '@patternfly/react-tokens/dist/esm/global_FontSize_4xl';
-import global_FontSize_3xl from '@patternfly/react-tokens/dist/esm/global_FontSize_3xl';
-import global_FontSize_2xl from '@patternfly/react-tokens/dist/esm/global_FontSize_2xl';
-import global_FontSize_xl from '@patternfly/react-tokens/dist/esm/global_FontSize_xl';
-import global_FontSize_lg from '@patternfly/react-tokens/dist/esm/global_FontSize_lg';
-import global_FontSize_md from '@patternfly/react-tokens/dist/esm/global_FontSize_md';
-import global_FontSize_sm from '@patternfly/react-tokens/dist/esm/global_FontSize_sm';
+import global_font_size_4xl from '@patternfly/react-tokens/dist/esm/global_font_size_4xl';
+import global_font_size_3xl from '@patternfly/react-tokens/dist/esm/global_font_size_3xl';
+import global_font_size_2xl from '@patternfly/react-tokens/dist/esm/global_font_size_2xl';
+import global_font_size_xl from '@patternfly/react-tokens/dist/esm/global_font_size_xl';
+import global_font_size_lg from '@patternfly/react-tokens/dist/esm/global_font_size_lg';
+import global_font_size_md from '@patternfly/react-tokens/dist/esm/global_font_size_md';
+import global_font_size_sm from '@patternfly/react-tokens/dist/esm/global_font_size_sm';
 
 ## Examples
 
 ### Default
 
 ```ts file="./SkeletonDefault.tsx"
+
 ```
 
 ### Percentage widths
 
 ```ts file="./SkeletonPercentageWidth.tsx"
+
 ```
 
 ### Percentage heights
 
 ```ts file="./SkeletonPercentageHeight.tsx"
+
 ```
 
 ### Text modifiers
 
 ```ts file="./SkeletonText.tsx"
+
 ```
 
 ### Shapes
 
 ```ts file="./SkeletonShapes.tsx"
+
 ```

--- a/packages/react-core/src/components/Skeleton/examples/SkeletonText.tsx
+++ b/packages/react-core/src/components/Skeleton/examples/SkeletonText.tsx
@@ -1,35 +1,35 @@
 import React from 'react';
 import { Skeleton } from '@patternfly/react-core';
 /* eslint-disable camelcase */
-import global_FontSize_4xl from '@patternfly/react-tokens/dist/esm/global_FontSize_4xl';
-import global_FontSize_3xl from '@patternfly/react-tokens/dist/esm/global_FontSize_3xl';
-import global_FontSize_2xl from '@patternfly/react-tokens/dist/esm/global_FontSize_2xl';
-import global_FontSize_xl from '@patternfly/react-tokens/dist/esm/global_FontSize_xl';
-import global_FontSize_lg from '@patternfly/react-tokens/dist/esm/global_FontSize_lg';
-import global_FontSize_md from '@patternfly/react-tokens/dist/esm/global_FontSize_md';
-import global_FontSize_sm from '@patternfly/react-tokens/dist/esm/global_FontSize_sm';
+import global_font_size_4xl from '@patternfly/react-tokens/dist/esm/global_font_size_4xl';
+import global_font_size_3xl from '@patternfly/react-tokens/dist/esm/global_font_size_3xl';
+import global_font_size_2xl from '@patternfly/react-tokens/dist/esm/global_font_size_2xl';
+import global_font_size_xl from '@patternfly/react-tokens/dist/esm/global_font_size_xl';
+import global_font_size_lg from '@patternfly/react-tokens/dist/esm/global_font_size_lg';
+import global_font_size_md from '@patternfly/react-tokens/dist/esm/global_font_size_md';
+import global_font_size_sm from '@patternfly/react-tokens/dist/esm/global_font_size_sm';
 
 export const SkeletonText: React.FunctionComponent = () => (
   <React.Fragment>
-    {global_FontSize_4xl.name}
+    {global_font_size_4xl.name}
     <Skeleton fontSize="4xl" screenreaderText="Loading font size 4xl" />
     <br />
-    {global_FontSize_3xl.name}
+    {global_font_size_3xl.name}
     <Skeleton fontSize="3xl" screenreaderText="Loading font size 3xl" />
     <br />
-    {global_FontSize_2xl.name}
+    {global_font_size_2xl.name}
     <Skeleton fontSize="2xl" screenreaderText="Loading font size 2xl" />
     <br />
-    {global_FontSize_xl.name}
+    {global_font_size_xl.name}
     <Skeleton fontSize="xl" screenreaderText="Loading font size xl" />
     <br />
-    {global_FontSize_lg.name}
+    {global_font_size_lg.name}
     <Skeleton fontSize="lg" screenreaderText="Loading font size lg" />
     <br />
-    {global_FontSize_md.name}
+    {global_font_size_md.name}
     <Skeleton fontSize="md" screenreaderText="Loading font size md" />
     <br />
-    {global_FontSize_sm.name}
+    {global_font_size_sm.name}
     <Skeleton fontSize="sm" screenreaderText="Loading font size sm" />
   </React.Fragment>
 );

--- a/packages/react-core/src/components/Slider/SliderStep.tsx
+++ b/packages/react-core/src/components/Slider/SliderStep.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/Slider/slider';
 import { css } from '@patternfly/react-styles';
-import sliderStepLeft from '@patternfly/react-tokens/dist/esm/c_slider__step_Left';
+import sliderStepInsetInlineStart from '@patternfly/react-tokens/dist/esm/c_slider__step_InsetInlineStart';
 
 export interface SliderStepProps extends Omit<React.HTMLProps<HTMLDivElement>, 'label'> {
   /** Additional classes added to the slider step. */
@@ -27,7 +27,9 @@ export const SliderStep: React.FunctionComponent<SliderStepProps> = ({
   isActive = false,
   ...props
 }: SliderStepProps) => {
-  const style = { [sliderStepLeft.name]: `${value ? value : sliderStepLeft.value}%` } as React.CSSProperties;
+  const style = {
+    [sliderStepInsetInlineStart.name]: `${value ? value : sliderStepInsetInlineStart.value}%`
+  } as React.CSSProperties;
   return (
     <div className={css(styles.sliderStep, isActive && styles.modifiers.active, className)} style={style} {...props}>
       {!isTickHidden && <div className={css(styles.sliderStepTick)} />}

--- a/packages/react-core/src/components/Slider/_tests_/__snapshots__/Slider.test.tsx.snap
+++ b/packages/react-core/src/components/Slider/_tests_/__snapshots__/Slider.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`slider renders continuous slider 1`] = `
       >
         <div
           class="pf-v6-c-slider__step pf-m-active"
-          style="--pf-v6-c-slider__step--Left: 0%;"
+          style="--pf-v6-c-slider__step--InsetInlineStart: 0%;"
         >
           <div
             class="pf-v6-c-slider__step-label"
@@ -32,7 +32,7 @@ exports[`slider renders continuous slider 1`] = `
         </div>
         <div
           class="pf-v6-c-slider__step"
-          style="--pf-v6-c-slider__step--Left: 100%;"
+          style="--pf-v6-c-slider__step--InsetInlineStart: 100%;"
         >
           <div
             class="pf-v6-c-slider__step-label"
@@ -96,7 +96,7 @@ exports[`slider renders continuous slider with custom steps 1`] = `
       >
         <div
           class="pf-v6-c-slider__step pf-m-active"
-          style="--pf-v6-c-slider__step--Left: 0%;"
+          style="--pf-v6-c-slider__step--InsetInlineStart: 0%;"
         >
           <div
             class="pf-v6-c-slider__step-tick"
@@ -109,7 +109,7 @@ exports[`slider renders continuous slider with custom steps 1`] = `
         </div>
         <div
           class="pf-v6-c-slider__step"
-          style="--pf-v6-c-slider__step--Left: 100%;"
+          style="--pf-v6-c-slider__step--InsetInlineStart: 100%;"
         >
           <div
             class="pf-v6-c-slider__step-tick"
@@ -159,7 +159,7 @@ exports[`slider renders disabled slider 1`] = `
       >
         <div
           class="pf-v6-c-slider__step pf-m-active"
-          style="--pf-v6-c-slider__step--Left: 0%;"
+          style="--pf-v6-c-slider__step--InsetInlineStart: 0%;"
         >
           <div
             class="pf-v6-c-slider__step-label"
@@ -169,7 +169,7 @@ exports[`slider renders disabled slider 1`] = `
         </div>
         <div
           class="pf-v6-c-slider__step"
-          style="--pf-v6-c-slider__step--Left: 100%;"
+          style="--pf-v6-c-slider__step--InsetInlineStart: 100%;"
         >
           <div
             class="pf-v6-c-slider__step-label"
@@ -216,7 +216,7 @@ exports[`slider renders discrete slider 1`] = `
       >
         <div
           class="pf-v6-c-slider__step pf-m-active"
-          style="--pf-v6-c-slider__step--Left: 0%;"
+          style="--pf-v6-c-slider__step--InsetInlineStart: 0%;"
         >
           <div
             class="pf-v6-c-slider__step-label"
@@ -226,7 +226,7 @@ exports[`slider renders discrete slider 1`] = `
         </div>
         <div
           class="pf-v6-c-slider__step"
-          style="--pf-v6-c-slider__step--Left: 100%;"
+          style="--pf-v6-c-slider__step--InsetInlineStart: 100%;"
         >
           <div
             class="pf-v6-c-slider__step-label"
@@ -290,7 +290,7 @@ exports[`slider renders discrete slider with custom steps 1`] = `
       >
         <div
           class="pf-v6-c-slider__step pf-m-active"
-          style="--pf-v6-c-slider__step--Left: 0%;"
+          style="--pf-v6-c-slider__step--InsetInlineStart: 0%;"
         >
           <div
             class="pf-v6-c-slider__step-tick"
@@ -303,7 +303,7 @@ exports[`slider renders discrete slider with custom steps 1`] = `
         </div>
         <div
           class="pf-v6-c-slider__step pf-m-active"
-          style="--pf-v6-c-slider__step--Left: 25%;"
+          style="--pf-v6-c-slider__step--InsetInlineStart: 25%;"
         >
           <div
             class="pf-v6-c-slider__step-tick"
@@ -311,7 +311,7 @@ exports[`slider renders discrete slider with custom steps 1`] = `
         </div>
         <div
           class="pf-v6-c-slider__step pf-m-active"
-          style="--pf-v6-c-slider__step--Left: 50%;"
+          style="--pf-v6-c-slider__step--InsetInlineStart: 50%;"
         >
           <div
             class="pf-v6-c-slider__step-tick"
@@ -324,7 +324,7 @@ exports[`slider renders discrete slider with custom steps 1`] = `
         </div>
         <div
           class="pf-v6-c-slider__step"
-          style="--pf-v6-c-slider__step--Left: 75%;"
+          style="--pf-v6-c-slider__step--InsetInlineStart: 75%;"
         >
           <div
             class="pf-v6-c-slider__step-tick"
@@ -332,7 +332,7 @@ exports[`slider renders discrete slider with custom steps 1`] = `
         </div>
         <div
           class="pf-v6-c-slider__step"
-          style="--pf-v6-c-slider__step--Left: 100%;"
+          style="--pf-v6-c-slider__step--InsetInlineStart: 100%;"
         >
           <div
             class="pf-v6-c-slider__step-tick"
@@ -382,7 +382,7 @@ exports[`slider renders slider with input 1`] = `
       >
         <div
           class="pf-v6-c-slider__step pf-m-active"
-          style="--pf-v6-c-slider__step--Left: 0%;"
+          style="--pf-v6-c-slider__step--InsetInlineStart: 0%;"
         >
           <div
             class="pf-v6-c-slider__step-label"
@@ -392,7 +392,7 @@ exports[`slider renders slider with input 1`] = `
         </div>
         <div
           class="pf-v6-c-slider__step"
-          style="--pf-v6-c-slider__step--Left: 100%;"
+          style="--pf-v6-c-slider__step--InsetInlineStart: 100%;"
         >
           <div
             class="pf-v6-c-slider__step-label"
@@ -473,7 +473,7 @@ exports[`slider renders slider with input above thumb 1`] = `
       >
         <div
           class="pf-v6-c-slider__step pf-m-active"
-          style="--pf-v6-c-slider__step--Left: 0%;"
+          style="--pf-v6-c-slider__step--InsetInlineStart: 0%;"
         >
           <div
             class="pf-v6-c-slider__step-label"
@@ -483,7 +483,7 @@ exports[`slider renders slider with input above thumb 1`] = `
         </div>
         <div
           class="pf-v6-c-slider__step"
-          style="--pf-v6-c-slider__step--Left: 100%;"
+          style="--pf-v6-c-slider__step--InsetInlineStart: 100%;"
         >
           <div
             class="pf-v6-c-slider__step-label"
@@ -577,7 +577,7 @@ exports[`slider renders slider with input actions 1`] = `
       >
         <div
           class="pf-v6-c-slider__step pf-m-active"
-          style="--pf-v6-c-slider__step--Left: 0%;"
+          style="--pf-v6-c-slider__step--InsetInlineStart: 0%;"
         >
           <div
             class="pf-v6-c-slider__step-label"
@@ -587,7 +587,7 @@ exports[`slider renders slider with input actions 1`] = `
         </div>
         <div
           class="pf-v6-c-slider__step"
-          style="--pf-v6-c-slider__step--Left: 100%;"
+          style="--pf-v6-c-slider__step--InsetInlineStart: 100%;"
         >
           <div
             class="pf-v6-c-slider__step-label"
@@ -647,7 +647,7 @@ exports[`slider renders slider with tooltip on thumb 1`] = `
       >
         <div
           class="pf-v6-c-slider__step pf-m-active"
-          style="--pf-v6-c-slider__step--Left: 0%;"
+          style="--pf-v6-c-slider__step--InsetInlineStart: 0%;"
         >
           <div
             class="pf-v6-c-slider__step-label"
@@ -657,7 +657,7 @@ exports[`slider renders slider with tooltip on thumb 1`] = `
         </div>
         <div
           class="pf-v6-c-slider__step"
-          style="--pf-v6-c-slider__step--Left: 100%;"
+          style="--pf-v6-c-slider__step--InsetInlineStart: 100%;"
         >
           <div
             class="pf-v6-c-slider__step-label"

--- a/packages/react-core/src/components/Text/Text.tsx
+++ b/packages/react-core/src/components/Text/Text.tsx
@@ -32,6 +32,20 @@ export interface TextProps extends React.HTMLProps<HTMLElement>, OUIAProps {
   ouiaSafe?: boolean;
 }
 
+const componentStyles = {
+  h1: styles.contentH1,
+  h2: styles.contentH2,
+  h3: styles.contentH3,
+  h4: styles.contentH4,
+  h5: styles.contentH5,
+  h6: styles.contentH6,
+  p: styles.contentP,
+  a: styles.contentA,
+  small: styles.contentSmall,
+  blockquote: styles.contentBlockquote,
+  pre: styles.contentPre
+};
+
 export const Text: React.FunctionComponent<TextProps> = ({
   children = null,
   className = '',
@@ -49,7 +63,11 @@ export const Text: React.FunctionComponent<TextProps> = ({
       {...ouiaProps}
       {...props}
       data-pf-content
-      className={css(isVisitedLink && component === TextVariants.a && styles.modifiers.visited, className)}
+      className={css(
+        isVisitedLink && component === TextVariants.a && styles.modifiers.visited,
+        componentStyles[component],
+        className
+      )}
     >
       {children}
     </Component>

--- a/packages/react-core/src/components/Text/TextList.tsx
+++ b/packages/react-core/src/components/Text/TextList.tsx
@@ -8,6 +8,12 @@ export enum TextListVariants {
   dl = 'dl'
 }
 
+const componentStyles = {
+  ul: styles.contentUl,
+  ol: styles.contentOl,
+  dl: styles.contentDl
+};
+
 export interface TextListProps extends React.HTMLProps<HTMLElement> {
   /** Content rendered within the TextList */
   children?: React.ReactNode;
@@ -29,7 +35,7 @@ export const TextList: React.FunctionComponent<TextListProps> = ({
   const Component: any = component;
 
   return (
-    <Component {...props} className={css(isPlain && styles.modifiers.plain, className)}>
+    <Component {...props} className={css(isPlain && styles.modifiers.plain, componentStyles[component], className)}>
       {children}
     </Component>
   );

--- a/packages/react-core/src/components/Text/TextListItem.tsx
+++ b/packages/react-core/src/components/Text/TextListItem.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import styles from '@patternfly/react-styles/css/components/Content/content';
 import { css } from '@patternfly/react-styles';
 
 export enum TextListItemVariants {
@@ -6,6 +7,12 @@ export enum TextListItemVariants {
   dt = 'dt',
   dd = 'dd'
 }
+
+const componentStyles = {
+  li: styles.contentLi,
+  dt: styles.contentDt,
+  dd: styles.contentDd
+};
 
 export interface TextListItemProps extends React.HTMLProps<HTMLElement> {
   /** Content rendered within the TextListItem */
@@ -25,7 +32,7 @@ export const TextListItem: React.FunctionComponent<TextListItemProps> = ({
   const Component: any = component;
 
   return (
-    <Component {...props} className={css(className)}>
+    <Component {...props} className={css(componentStyles[component], className)}>
       {children}
     </Component>
   );

--- a/packages/react-core/src/components/Text/__tests__/Generated/__snapshots__/TextList.test.tsx.snap
+++ b/packages/react-core/src/components/Text/__tests__/Generated/__snapshots__/TextList.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`TextList should match snapshot (auto-generated) 1`] = `
 <DocumentFragment>
   <ul
-    class="''"
+    class="pf-v6-c-content--ul ''"
   >
     ReactNode
   </ul>

--- a/packages/react-core/src/components/Text/__tests__/Generated/__snapshots__/TextListItem.test.tsx.snap
+++ b/packages/react-core/src/components/Text/__tests__/Generated/__snapshots__/TextListItem.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`TextListItem should match snapshot (auto-generated) 1`] = `
 <DocumentFragment>
   <li
-    class="''"
+    class="pf-v6-c-content--li ''"
   >
     ReactNode
   </li>

--- a/packages/react-core/src/components/Text/__tests__/Text.test.tsx
+++ b/packages/react-core/src/components/Text/__tests__/Text.test.tsx
@@ -16,11 +16,6 @@ test('Renders children', () => {
   expect(screen.getByText('Test')).toBeVisible();
 });
 
-test('Renders without class name by default', () => {
-  render(<Text>Test</Text>);
-  expect(screen.getByText('Test')).not.toHaveClass();
-});
-
 test('Renders with custom class name when className prop is provided', () => {
   render(<Text className="custom-class">Test</Text>);
   expect(screen.getByText('Test')).toHaveClass('custom-class');

--- a/packages/react-core/src/components/Text/__tests__/TextList.test.tsx
+++ b/packages/react-core/src/components/Text/__tests__/TextList.test.tsx
@@ -16,11 +16,6 @@ test('Renders children', () => {
   expect(screen.getByText('Test')).toBeVisible();
 });
 
-test('Renders without class name by default', () => {
-  render(<TextList>Test</TextList>);
-  expect(screen.getByText('Test')).not.toHaveClass();
-});
-
 test('Renders with custom class name when className prop is provided', () => {
   render(<TextList className="custom-class">Test</TextList>);
   expect(screen.getByText('Test')).toHaveClass('custom-class');

--- a/packages/react-core/src/components/Text/__tests__/TextListItem.test.tsx
+++ b/packages/react-core/src/components/Text/__tests__/TextListItem.test.tsx
@@ -16,11 +16,6 @@ test('Renders children', () => {
   expect(screen.getByText('Test')).toBeVisible();
 });
 
-test('Renders without class name by default', () => {
-  render(<TextListItem>Test</TextListItem>);
-  expect(screen.getByText('Test')).not.toHaveClass();
-});
-
 test('Renders with custom class name when className prop is provided', () => {
   render(<TextListItem className="custom-class">Test</TextListItem>);
   expect(screen.getByText('Test')).toHaveClass('custom-class');

--- a/packages/react-core/src/components/Text/__tests__/__snapshots__/Text.test.tsx.snap
+++ b/packages/react-core/src/components/Text/__tests__/__snapshots__/Text.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Matches the snapshot 1`] = `
 <DocumentFragment>
   <p
-    class=""
+    class="pf-v6-c-content--p"
     data-ouia-component-id="ouia-id"
     data-ouia-component-type="PF6/Text"
     data-ouia-safe="true"

--- a/packages/react-core/src/components/Text/__tests__/__snapshots__/TextList.test.tsx.snap
+++ b/packages/react-core/src/components/Text/__tests__/__snapshots__/TextList.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Matches the snapshot 1`] = `
 <DocumentFragment>
   <ul
-    class=""
+    class="pf-v6-c-content--ul"
   >
     Test
   </ul>

--- a/packages/react-core/src/components/Text/__tests__/__snapshots__/TextListItem.test.tsx.snap
+++ b/packages/react-core/src/components/Text/__tests__/__snapshots__/TextListItem.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Matches the snapshot 1`] = `
 <DocumentFragment>
   <li
-    class=""
+    class="pf-v6-c-content--li"
   >
     Test
   </li>

--- a/packages/react-core/src/components/Text/examples/Text.md
+++ b/packages/react-core/src/components/Text/examples/Text.md
@@ -25,8 +25,6 @@ For example, rather than nesting the `<List>` and `<Title>` components within `<
 
 ```
 
-Text components such as Text, TextList, TextListItem need to be placed within a TextContent
-
 ### Unordered list
 
 ```ts file="./TextUnorderedList.tsx"
@@ -48,6 +46,14 @@ Text components such as Text, TextList, TextListItem need to be placed within a 
 ### Description list
 
 ```ts file="./TextDescriptionList.tsx"
+
+```
+
+Text components such as Text, TextList, TextListItem can be placed within a TextContent to provide styling for html elements, and additional styling options applied to the children.
+
+### Wrapped in TextContent
+
+```ts file="./TextContentWrapped.tsx"
 
 ```
 

--- a/packages/react-core/src/components/Text/examples/Text.md
+++ b/packages/react-core/src/components/Text/examples/Text.md
@@ -5,7 +5,7 @@ cssPrefix: pf-v5-c-content
 propComponents: ['TextContent', 'Text', 'TextList', 'TextListItem']
 ---
 
-The `<Text>` component provides simple, built-in styling for putting common blocks of HTML elements together. It establishes the block of content and styling within it for the elements listed in the `component` property(`h1` through `h6`, `p`, `a`, `small`, `blockquote`, and `pre`), as well as the text component suite `<TextList>`, and `<TextListItem>`. `TextContent` may be used as a container for the text components, but nesting them inside `TextContent` is not required.
+The `<Text>` component provides simple, built-in styling for putting common blocks of HTML elements together. It establishes the block of content and styling within it for the elements listed in the `component` property(`h1` through `h6`, `p`, `a`, `small`, `blockquote`, and `pre`), as well as the text component suite `<TextList>`, and `<TextListItem>`. `TextContent` may be used as a container for the text components, but nesting them inside `<TextContent>` is not required.
 
 You cannot nest other components within `<Text>`, and doing so can cause styling overrides or other conflicts. Instead, you can use the `<Text>` component's properties to achieve the same results.
 

--- a/packages/react-core/src/components/Text/examples/Text.md
+++ b/packages/react-core/src/components/Text/examples/Text.md
@@ -5,7 +5,7 @@ cssPrefix: pf-v5-c-content
 propComponents: ['TextContent', 'Text', 'TextList', 'TextListItem']
 ---
 
-The `<Text>` component provides simple, built-in styling for putting common blocks of HTML elements together. It establishes the block of content and styling within it for the elements listed in the `component` property(`h1` through `h6`, `p`, `a`, `small`, `blockquote`, and `pre`), as well as the text component suite (`<TextContent>`, `<TextList>`, and `<TextListItem>`).
+The `<Text>` component provides simple, built-in styling for putting common blocks of HTML elements together. It establishes the block of content and styling within it for the elements listed in the `component` property(`h1` through `h6`, `p`, `a`, `small`, `blockquote`, and `pre`), as well as the text component suite `<TextList>`, and `<TextListItem>`. `TextContent` may be used as a container for the text components, but nesting them inside `TextContent` is not required.
 
 You cannot nest other components within `<Text>`, and doing so can cause styling overrides or other conflicts. Instead, you can use the `<Text>` component's properties to achieve the same results.
 

--- a/packages/react-core/src/components/Text/examples/TextBody.tsx
+++ b/packages/react-core/src/components/Text/examples/TextBody.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { TextContent, Text, TextVariants } from '@patternfly/react-core';
+import { Text, TextVariants } from '@patternfly/react-core';
 
 export const TextBody: React.FunctionComponent = () => (
-  <TextContent>
+  <>
     <Text component={TextVariants.p}>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla accumsan, metus ultrices eleifend gravida, nulla
       nunc varius lectus, nec rutrum justo nibh eu lectus. Ut vulputate semper dui. Fusce erat odio, sollicitudin vel
@@ -20,5 +20,5 @@ export const TextBody: React.FunctionComponent = () => (
       turpis.
     </Text>
     <Text component={TextVariants.small}>Sometimes you need small text to display things like date created</Text>
-  </TextContent>
+  </>
 );

--- a/packages/react-core/src/components/Text/examples/TextContentWrapped.tsx
+++ b/packages/react-core/src/components/Text/examples/TextContentWrapped.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { TextContent, Text, TextVariants } from '@patternfly/react-core';
+
+export const TextContentWrapped: React.FunctionComponent = () => (
+  <TextContent>
+    <Text component={TextVariants.p}>
+      Text with a component of type "p" still renders the same when wrapped with a TextContent.
+    </Text>
+    <p>If located within a wrapping TextContent, html elements are styled as well!</p>
+  </TextContent>
+);

--- a/packages/react-core/src/components/Text/examples/TextDescriptionList.tsx
+++ b/packages/react-core/src/components/Text/examples/TextDescriptionList.tsx
@@ -1,17 +1,15 @@
 import React from 'react';
-import { TextContent, TextList, TextListVariants, TextListItem, TextListItemVariants } from '@patternfly/react-core';
+import { TextList, TextListVariants, TextListItem, TextListItemVariants } from '@patternfly/react-core';
 
 export const TextDescriptionList: React.FunctionComponent = () => (
-  <TextContent>
-    <TextList component={TextListVariants.dl}>
-      <TextListItem component={TextListItemVariants.dt}>Web</TextListItem>
-      <TextListItem component={TextListItemVariants.dd}>
-        The part of the Internet that contains websites and web pages
-      </TextListItem>
-      <TextListItem component={TextListItemVariants.dt}>HTML</TextListItem>
-      <TextListItem component={TextListItemVariants.dd}>A markup language for creating web pages</TextListItem>
-      <TextListItem component={TextListItemVariants.dt}>CSS</TextListItem>
-      <TextListItem component={TextListItemVariants.dd}>A technology to make HTML look better</TextListItem>
-    </TextList>
-  </TextContent>
+  <TextList component={TextListVariants.dl}>
+    <TextListItem component={TextListItemVariants.dt}>Web</TextListItem>
+    <TextListItem component={TextListItemVariants.dd}>
+      The part of the Internet that contains websites and web pages
+    </TextListItem>
+    <TextListItem component={TextListItemVariants.dt}>HTML</TextListItem>
+    <TextListItem component={TextListItemVariants.dd}>A markup language for creating web pages</TextListItem>
+    <TextListItem component={TextListItemVariants.dt}>CSS</TextListItem>
+    <TextListItem component={TextListItemVariants.dd}>A technology to make HTML look better</TextListItem>
+  </TextList>
 );

--- a/packages/react-core/src/components/Text/examples/TextHeadings.tsx
+++ b/packages/react-core/src/components/Text/examples/TextHeadings.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import { TextContent, Text, TextVariants } from '@patternfly/react-core';
+import { Text, TextVariants } from '@patternfly/react-core';
 
 export const TextHeadings: React.FunctionComponent = () => (
-  <TextContent>
+  <>
     <Text component={TextVariants.h1}>Hello World</Text>
     <Text component={TextVariants.h2}>Second level</Text>
     <Text component={TextVariants.h3}>Third level</Text>
     <Text component={TextVariants.h4}>Fourth level</Text>
     <Text component={TextVariants.h5}>Fifth level</Text>
     <Text component={TextVariants.h6}>Sixth level</Text>
-  </TextContent>
+  </>
 );

--- a/packages/react-core/src/components/Text/examples/TextOrderedList.tsx
+++ b/packages/react-core/src/components/Text/examples/TextOrderedList.tsx
@@ -1,16 +1,14 @@
 import React from 'react';
-import { TextContent, TextList, TextListVariants, TextListItem } from '@patternfly/react-core';
+import { TextList, TextListVariants, TextListItem } from '@patternfly/react-core';
 
 export const TextOrderedList: React.FunctionComponent = () => (
-  <TextContent>
-    <TextList component={TextListVariants.ol}>
-      <TextListItem>Donec blandit a lorem id convallis.</TextListItem>
-      <TextListItem>Cras gravida arcu at diam gravida gravida.</TextListItem>
-      <TextListItem>Integer in volutpat libero.</TextListItem>
-      <TextListItem>Donec a diam tellus.</TextListItem>
-      <TextListItem>Aenean nec tortor orci.</TextListItem>
-      <TextListItem>Quisque aliquam cursus urna, non bibendum massa viverra eget.</TextListItem>
-      <TextListItem>Vivamus maximus ultricies pulvinar.</TextListItem>
-    </TextList>
-  </TextContent>
+  <TextList component={TextListVariants.ol}>
+    <TextListItem>Donec blandit a lorem id convallis.</TextListItem>
+    <TextListItem>Cras gravida arcu at diam gravida gravida.</TextListItem>
+    <TextListItem>Integer in volutpat libero.</TextListItem>
+    <TextListItem>Donec a diam tellus.</TextListItem>
+    <TextListItem>Aenean nec tortor orci.</TextListItem>
+    <TextListItem>Quisque aliquam cursus urna, non bibendum massa viverra eget.</TextListItem>
+    <TextListItem>Vivamus maximus ultricies pulvinar.</TextListItem>
+  </TextList>
 );

--- a/packages/react-core/src/components/Text/examples/TextPlainList.tsx
+++ b/packages/react-core/src/components/Text/examples/TextPlainList.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Text, TextVariants, TextContent, TextList, TextListVariants, TextListItem } from '@patternfly/react-core';
+import { Text, TextVariants, TextList, TextListVariants, TextListItem } from '@patternfly/react-core';
 
 export const TextPlainList: React.FunctionComponent = () => (
-  <TextContent>
+  <>
     <Text component={TextVariants.h3}>Plain unordered list</Text>
     <TextList isPlain>
       <TextListItem>In fermentum leo eu lectus mollis, quis dictum mi aliquet.</TextListItem>
@@ -20,5 +20,5 @@ export const TextPlainList: React.FunctionComponent = () => (
       <TextListItem>Quisque aliquam cursus urna, non bibendum massa viverra eget.</TextListItem>
       <TextListItem>Vivamus maximus ultricies pulvinar.</TextListItem>
     </TextList>
-  </TextContent>
+  </>
 );

--- a/packages/react-core/src/components/Text/examples/TextUnorderedList.tsx
+++ b/packages/react-core/src/components/Text/examples/TextUnorderedList.tsx
@@ -1,19 +1,17 @@
 import React from 'react';
-import { TextContent, TextList, TextListItem } from '@patternfly/react-core';
+import { TextList, TextListItem } from '@patternfly/react-core';
 
 export const TextUnorderedList: React.FunctionComponent = () => (
-  <TextContent>
-    <TextList>
-      <TextListItem>In fermentum leo eu lectus mollis, quis dictum mi aliquet.</TextListItem>
-      <TextListItem>Morbi eu nulla lobortis, lobortis est in, fringilla felis.</TextListItem>
-      <TextListItem>
-        Aliquam nec felis in sapien venenatis viverra fermentum nec lectus.
-        <TextList>
-          <TextListItem>In fermentum leo eu lectus mollis, quis dictum mi aliquet.</TextListItem>
-          <TextListItem>Morbi eu nulla lobortis, lobortis est in, fringilla felis.</TextListItem>
-        </TextList>
-      </TextListItem>
-      <TextListItem>Ut non enim metus.</TextListItem>
-    </TextList>
-  </TextContent>
+  <TextList>
+    <TextListItem>In fermentum leo eu lectus mollis, quis dictum mi aliquet.</TextListItem>
+    <TextListItem>Morbi eu nulla lobortis, lobortis est in, fringilla felis.</TextListItem>
+    <TextListItem>
+      Aliquam nec felis in sapien venenatis viverra fermentum nec lectus.
+      <TextList>
+        <TextListItem>In fermentum leo eu lectus mollis, quis dictum mi aliquet.</TextListItem>
+        <TextListItem>Morbi eu nulla lobortis, lobortis est in, fringilla felis.</TextListItem>
+      </TextList>
+    </TextListItem>
+    <TextListItem>Ut non enim metus.</TextListItem>
+  </TextList>
 );

--- a/packages/react-core/src/components/Toolbar/ToolbarItem.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarItem.tsx
@@ -80,7 +80,8 @@ export const ToolbarItem: React.FunctionComponent<ToolbarItemProps> = ({
         <div
           className={css(
             styles.toolbarItem,
-            variant && styles.modifiers[toCamel(variant) as 'pagination' | 'label' | 'chipGroup'],
+            variant && styles.modifiers[toCamel(variant) as 'pagination' | 'label'],
+            variant === ToolbarItemVariant['chip-group'] && styles.modifiers.labelGroup,
             isAllExpanded && styles.modifiers.expanded,
             isOverflowContainer && styles.modifiers.overflowContainer,
             formatBreakpointMods(visibility, styles, '', getBreakpoint(width)),

--- a/packages/react-core/src/components/Toolbar/__tests__/__snapshots__/Toolbar.test.tsx.snap
+++ b/packages/react-core/src/components/Toolbar/__tests__/__snapshots__/Toolbar.test.tsx.snap
@@ -100,7 +100,7 @@ exports[`Toolbar should render with custom chip content 1`] = `
         hidden=""
       >
         <div
-          class="pf-v6-c-toolbar__item pf-m-chip-group"
+          class="pf-v6-c-toolbar__item pf-m-label-group"
         >
           <div
             class="pf-v6-c-label-group pf-m-category"

--- a/packages/react-core/src/components/Wizard/WizardFooter.tsx
+++ b/packages/react-core/src/components/Wizard/WizardFooter.tsx
@@ -5,7 +5,7 @@ import styles from '@patternfly/react-styles/css/components/Wizard/wizard';
 
 import { Button, ButtonVariant } from '../Button';
 import { isCustomWizardFooter, WizardFooterButtonProps, WizardStepType } from './types';
-
+import { ActionList, ActionListGroup, ActionListItem } from '../ActionList';
 /**
  * Hosts the standard structure of a footer with ties to the active step so that text for buttons can vary from step to step.
  */
@@ -74,29 +74,38 @@ const InternalWizardFooter = ({
   cancelButtonProps
 }: Omit<WizardFooterProps, 'activeStep'>) => (
   <WizardFooterWrapper>
-    {!isBackHidden && (
-      <Button variant={ButtonVariant.secondary} onClick={onBack} isDisabled={isBackDisabled} {...backButtonProps}>
-        {backButtonText}
-      </Button>
-    )}
+    <ActionList>
+      <ActionListGroup>
+        {!isBackHidden && (
+          <ActionListItem>
+            <Button variant={ButtonVariant.secondary} onClick={onBack} isDisabled={isBackDisabled} {...backButtonProps}>
+              {backButtonText}
+            </Button>
+          </ActionListItem>
+        )}
+        <ActionListItem>
+          <Button
+            variant={ButtonVariant.primary}
+            type="submit"
+            onClick={onNext}
+            isDisabled={isNextDisabled}
+            {...nextButtonProps}
+          >
+            {nextButtonText}
+          </Button>
+        </ActionListItem>
 
-    <Button
-      variant={ButtonVariant.primary}
-      type="submit"
-      onClick={onNext}
-      isDisabled={isNextDisabled}
-      {...nextButtonProps}
-    >
-      {nextButtonText}
-    </Button>
-
-    {!isCancelHidden && (
-      <div className={styles.wizardFooterCancel}>
-        <Button variant={ButtonVariant.link} onClick={onClose} {...cancelButtonProps}>
-          {cancelButtonText}
-        </Button>
-      </div>
-    )}
+        {!isCancelHidden && (
+          <ActionListGroup>
+            <ActionListItem>
+              <Button variant={ButtonVariant.link} onClick={onClose} {...cancelButtonProps}>
+                {cancelButtonText}
+              </Button>
+            </ActionListItem>
+          </ActionListGroup>
+        )}
+      </ActionListGroup>
+    </ActionList>
   </WizardFooterWrapper>
 );
 

--- a/packages/react-core/src/components/Wizard/WizardFooter.tsx
+++ b/packages/react-core/src/components/Wizard/WizardFooter.tsx
@@ -94,17 +94,16 @@ const InternalWizardFooter = ({
             {nextButtonText}
           </Button>
         </ActionListItem>
-
-        {!isCancelHidden && (
-          <ActionListGroup>
-            <ActionListItem>
-              <Button variant={ButtonVariant.link} onClick={onClose} {...cancelButtonProps}>
-                {cancelButtonText}
-              </Button>
-            </ActionListItem>
-          </ActionListGroup>
-        )}
       </ActionListGroup>
+      {!isCancelHidden && (
+        <ActionListGroup>
+          <ActionListItem>
+            <Button variant={ButtonVariant.link} onClick={onClose} {...cancelButtonProps}>
+              {cancelButtonText}
+            </Button>
+          </ActionListItem>
+        </ActionListGroup>
+      )}
     </ActionList>
   </WizardFooterWrapper>
 );

--- a/packages/react-core/src/components/Wizard/WizardNavItem.tsx
+++ b/packages/react-core/src/components/Wizard/WizardNavItem.tsx
@@ -7,8 +7,6 @@ import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclam
 
 import { OUIAProps, useOUIAProps } from '../../helpers';
 import { WizardNavItemStatus } from './types';
-import globalSpacerSm from '@patternfly/react-tokens/dist/esm/global_spacer_sm';
-import globalDangerColor100 from '@patternfly/react-tokens/dist/esm/global_danger_color_100';
 
 export interface WizardNavItemProps extends OUIAProps {
   /** Can nest a WizardNav component for substeps */
@@ -105,7 +103,8 @@ export const WizardNavItem = ({
         className={css(
           styles.wizardNavLink,
           isCurrent && styles.modifiers.current,
-          isDisabled && styles.modifiers.disabled
+          isDisabled && styles.modifiers.disabled,
+          status === WizardNavItemStatus.Error && styles.modifiers.danger
         )}
         aria-disabled={isDisabled ? true : null}
         aria-current={isCurrent && !children ? 'step' : false}
@@ -113,26 +112,25 @@ export const WizardNavItem = ({
         {...(ariaLabel && { 'aria-label': ariaLabel })}
         {...ouiaProps}
       >
-        {isExpandable ? (
-          <>
-            <span className={css(styles.wizardNavLinkText)}>{content}</span>
-            <span className={css(styles.wizardNavLinkToggle)}>
-              <span className={css(styles.wizardNavLinkToggleIcon)}>
-                <AngleRightIcon aria-label={`${isCurrent ? 'Collapse' : 'Expand'} step icon`} />
-              </span>
-            </span>
-          </>
-        ) : (
-          <>
-            {content}
-            {/* TODO, patternfly/patternfly#5142 */}
-            {status === WizardNavItemStatus.Error && (
-              <span style={{ marginLeft: globalSpacerSm.var }}>
-                <ExclamationCircleIcon color={globalDangerColor100.var} />
-              </span>
-            )}
-          </>
+        {status === WizardNavItemStatus.Error && (
+          <span className={css(styles.wizardNavLinkStatusIcon)}>
+            <ExclamationCircleIcon />
+          </span>
         )}
+        <span className={css(styles.wizardNavLinkMain)}>
+          {isExpandable ? (
+            <>
+              <span className={css(styles.wizardNavLinkText)}>{content}</span>
+              <span className={css(styles.wizardNavLinkToggle)}>
+                <span className={css(styles.wizardNavLinkToggleIcon)}>
+                  <AngleRightIcon aria-label={`${isCurrent ? 'Collapse' : 'Expand'} step icon`} />
+                </span>
+              </span>
+            </>
+          ) : (
+            <>{content}</>
+          )}
+        </span>
       </NavItemComponent>
       {children}
     </li>

--- a/packages/react-core/src/components/Wizard/WizardToggle.tsx
+++ b/packages/react-core/src/components/Wizard/WizardToggle.tsx
@@ -94,7 +94,7 @@ export const WizardToggle = ({
         <span className={css(styles.wizardToggleList)}>
           <span className={css(styles.wizardToggleListItem, isActiveStepStatus === 'error' && styles.modifiers.danger)}>
             {isActiveStepStatus === 'error' ? (
-              <span className={css(styles.wizardNavLinkStatusIcon)}>
+              <span className={css(styles.wizardToggleStatusIcon)}>
                 <ExclamationCircleIcon />
               </span>
             ) : (

--- a/packages/react-core/src/components/Wizard/WizardToggle.tsx
+++ b/packages/react-core/src/components/Wizard/WizardToggle.tsx
@@ -31,8 +31,6 @@ export interface WizardToggleProps {
   isNavExpanded?: boolean;
   /** Callback to expand or collapse the dropdown navigation */
   toggleNavExpanded?: (event: React.MouseEvent<HTMLButtonElement> | KeyboardEvent) => void;
-  /** Used to determine the icon displayed next to content. Default has no icon. */
-  status?: 'default' | 'error';
 }
 
 export const WizardToggle = ({
@@ -42,13 +40,13 @@ export const WizardToggle = ({
   nav,
   isNavExpanded,
   toggleNavExpanded,
-  status = 'default',
   'aria-label': ariaLabel = 'Wizard toggle'
 }: WizardToggleProps) => {
   const isActiveSubStep = isWizardSubStep(activeStep);
   const parentStep = isActiveSubStep && steps.find((step) => step.id === activeStep.parentId);
   const nonSubSteps = steps.filter((step) => !isWizardSubStep(step));
   const wizardToggleIndex = nonSubSteps.indexOf(parentStep || activeStep) + 1;
+  const isActiveStepStatus = activeStep.status;
 
   const handleKeyClicks = React.useCallback(
     (event: KeyboardEvent): void => {
@@ -94,8 +92,8 @@ export const WizardToggle = ({
         aria-expanded={isNavExpanded}
       >
         <span className={css(styles.wizardToggleList)}>
-          <span className={css(styles.wizardToggleListItem, status === 'error' && styles.modifiers.danger)}>
-            {status === 'error' ? (
+          <span className={css(styles.wizardToggleListItem, isActiveStepStatus === 'error' && styles.modifiers.danger)}>
+            {isActiveStepStatus === 'error' ? (
               <span className={css(styles.wizardNavLinkStatusIcon)}>
                 <ExclamationCircleIcon />
               </span>

--- a/packages/react-core/src/components/Wizard/WizardToggle.tsx
+++ b/packages/react-core/src/components/Wizard/WizardToggle.tsx
@@ -4,6 +4,7 @@ import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Wizard/wizard';
 import AngleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-right-icon';
 import CaretDownIcon from '@patternfly/react-icons/dist/esm/icons/caret-down-icon';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 
 import { KeyTypes } from '../../helpers/constants';
 import { WizardStepType, isWizardSubStep } from './types';
@@ -30,6 +31,8 @@ export interface WizardToggleProps {
   isNavExpanded?: boolean;
   /** Callback to expand or collapse the dropdown navigation */
   toggleNavExpanded?: (event: React.MouseEvent<HTMLButtonElement> | KeyboardEvent) => void;
+  /** Used to determine the icon displayed next to content. Default has no icon. */
+  status?: 'default' | 'error';
 }
 
 export const WizardToggle = ({
@@ -39,6 +42,7 @@ export const WizardToggle = ({
   nav,
   isNavExpanded,
   toggleNavExpanded,
+  status = 'default',
   'aria-label': ariaLabel = 'Wizard toggle'
 }: WizardToggleProps) => {
   const isActiveSubStep = isWizardSubStep(activeStep);
@@ -90,8 +94,14 @@ export const WizardToggle = ({
         aria-expanded={isNavExpanded}
       >
         <span className={css(styles.wizardToggleList)}>
-          <span className={css(styles.wizardToggleListItem)}>
-            <span className={css(styles.wizardToggleNum)}>{wizardToggleIndex}</span>{' '}
+          <span className={css(styles.wizardToggleListItem, status === 'error' && styles.modifiers.danger)}>
+            {status === 'error' ? (
+              <span className={css(styles.wizardNavLinkStatusIcon)}>
+                <ExclamationCircleIcon />
+              </span>
+            ) : (
+              <span className={css(styles.wizardToggleNum)}>{wizardToggleIndex}</span>
+            )}{' '}
             {parentStep?.name || activeStep?.name}
             {isActiveSubStep && <AngleRightIcon className={css(styles.wizardToggleSeparator)} aria-hidden="true" />}
           </span>

--- a/packages/react-core/src/demos/CardDemos.md
+++ b/packages/react-core/src/demos/CardDemos.md
@@ -7,7 +7,7 @@ import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-ico
 import InfoCircleIcon from '@patternfly/react-icons/dist/js/icons/info-circle-icon';
 import ArrowRightIcon from '@patternfly/react-icons/dist/js/icons/arrow-right-icon';
 import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
-import { CheckCircleIcon, ExclamationCircleIcon, ExclamationTriangleIcon, TimesCircleIcon, BellIcon } from '@patternfly/react-icons';
+import { CheckCircleIcon, ExclamationCircleIcon, ExclamationTriangleIcon, BellIcon } from '@patternfly/react-icons';
 import { Table, Thead, Tbody, Tr, Th, Td, ExpandableRowContent } from '@patternfly/react-table';
 import { Chart, ChartAxis, ChartGroup, ChartVoronoiContainer, ChartStack, ChartBar, ChartTooltip, ChartDonutThreshold, ChartDonutUtilization, ChartArea, ChartContainer, ChartLabel } from '@patternfly/react-charts';
 import chart_color_gold_100 from '@patternfly/react-tokens/dist/esm/chart_color_gold_100';
@@ -15,8 +15,6 @@ import chart_color_gold_300 from '@patternfly/react-tokens/dist/esm/chart_color_
 import chart_color_orange_300 from '@patternfly/react-tokens/dist/esm/chart_color_orange_300';
 import chart_color_red_100 from '@patternfly/react-tokens/dist/esm/chart_color_red_100';
 import l_gallery_GridTemplateColumns_min from '@patternfly/react-tokens/dist/esm/l_gallery_GridTemplateColumns_min';
-import global_color_status_success_default from '@patternfly/react-tokens/dist/esm/global_color_status_success_default';
-import global_color_status_danger_default from '@patternfly/react-tokens/dist/esm/global_color_status_danger_default';
 import global_text_color_subtle from '@patternfly/react-tokens/dist/esm/global_text_color_subtle';
 import flex from '@patternfly/react-styles/css/utilities/Flex/flex';
 import text from '@patternfly/react-styles/css/utilities/Text/text';

--- a/packages/react-core/src/demos/CardDemos.md
+++ b/packages/react-core/src/demos/CardDemos.md
@@ -15,10 +15,10 @@ import chart_color_gold_300 from '@patternfly/react-tokens/dist/esm/chart_color_
 import chart_color_orange_300 from '@patternfly/react-tokens/dist/esm/chart_color_orange_300';
 import chart_color_red_100 from '@patternfly/react-tokens/dist/esm/chart_color_red_100';
 import l_gallery_GridTemplateColumns_min from '@patternfly/react-tokens/dist/esm/l_gallery_GridTemplateColumns_min';
-import global_success_color_100 from '@patternfly/react-tokens/dist/esm/global_success_color_100';
-import global_warning_color_100 from '@patternfly/react-tokens/dist/esm/global_warning_color_100';
-import global_danger_color_100 from '@patternfly/react-tokens/dist/esm/global_danger_color_100';
-import global_Color_200 from '@patternfly/react-tokens/dist/esm/global_Color_200';
+import global_color_status_success_default from '@patternfly/react-tokens/dist/esm/global_color_status_success_default';
+import global_color_status_warning_default from '@patternfly/react-tokens/dist/esm/global_color_status_warning_default';
+import global_color_status_danger_default from '@patternfly/react-tokens/dist/esm/global_color_status_danger_default';
+import global_color_brand_200 from '@patternfly/react-tokens/dist/esm/global_color_brand_200';
 import flex from '@patternfly/react-styles/css/utilities/Flex/flex';
 import text from '@patternfly/react-styles/css/utilities/Text/text';
 import sizing from '@patternfly/react-styles/css/utilities/Sizing/sizing';

--- a/packages/react-core/src/demos/CardDemos.md
+++ b/packages/react-core/src/demos/CardDemos.md
@@ -16,9 +16,8 @@ import chart_color_orange_300 from '@patternfly/react-tokens/dist/esm/chart_colo
 import chart_color_red_100 from '@patternfly/react-tokens/dist/esm/chart_color_red_100';
 import l_gallery_GridTemplateColumns_min from '@patternfly/react-tokens/dist/esm/l_gallery_GridTemplateColumns_min';
 import global_color_status_success_default from '@patternfly/react-tokens/dist/esm/global_color_status_success_default';
-import global_color_status_warning_default from '@patternfly/react-tokens/dist/esm/global_color_status_warning_default';
 import global_color_status_danger_default from '@patternfly/react-tokens/dist/esm/global_color_status_danger_default';
-import global_color_brand_200 from '@patternfly/react-tokens/dist/esm/global_color_brand_200';
+import global_text_color_subtle from '@patternfly/react-tokens/dist/esm/global_text_color_subtle';
 import flex from '@patternfly/react-styles/css/utilities/Flex/flex';
 import text from '@patternfly/react-styles/css/utilities/Text/text';
 import sizing from '@patternfly/react-styles/css/utilities/Sizing/sizing';

--- a/packages/react-core/src/demos/examples/Card/CardAggregateStatus.tsx
+++ b/packages/react-core/src/demos/examples/Card/CardAggregateStatus.tsx
@@ -16,7 +16,6 @@ import {
 import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
-import TimesCircleIcon from '@patternfly/react-icons/dist/js/icons/times-circle-icon';
 import l_gallery_GridTemplateColumns_min from '@patternfly/react-tokens/dist/esm/l_gallery_GridTemplateColumns_min';
 
 interface ContentType {
@@ -72,7 +71,7 @@ const cardData: CardData = {
         {
           icon: (
             <Icon status="danger">
-              <TimesCircleIcon />
+              <ExclamationCircleIcon />
             </Icon>
           )
         }
@@ -87,7 +86,7 @@ const cardData: CardData = {
         {
           icon: (
             <Icon status="success">
-              <ExclamationCircleIcon />
+              <CheckCircleIcon />
             </Icon>
           ),
           count: 2
@@ -116,8 +115,8 @@ const cardData: CardData = {
         },
         {
           icon: (
-            <Icon status="success">
-              <TimesCircleIcon />
+            <Icon status="danger">
+              <ExclamationCircleIcon />
             </Icon>
           ),
           count: 12
@@ -139,7 +138,7 @@ const cardData: CardData = {
         {
           icon: (
             <Icon status="danger">
-              <TimesCircleIcon />
+              <ExclamationCircleIcon />
             </Icon>
           ),
           count: 7
@@ -155,7 +154,7 @@ const cardData: CardData = {
         {
           icon: (
             <Icon status="danger">
-              <TimesCircleIcon />
+              <ExclamationCircleIcon />
             </Icon>
           ),
           status: '2 errors',
@@ -212,7 +211,7 @@ const cardData: CardData = {
         {
           icon: (
             <Icon status="danger">
-              <TimesCircleIcon />
+              <ExclamationCircleIcon />
             </Icon>
           ),
           status: '1 error',

--- a/packages/react-core/src/demos/examples/Card/CardAggregateStatus.tsx
+++ b/packages/react-core/src/demos/examples/Card/CardAggregateStatus.tsx
@@ -10,15 +10,13 @@ import {
   Gallery,
   Grid,
   GridItem,
-  Stack
+  Stack,
+  Icon
 } from '@patternfly/react-core';
 import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 import TimesCircleIcon from '@patternfly/react-icons/dist/js/icons/times-circle-icon';
-import global_color_status_success_default from '@patternfly/react-tokens/dist/esm/global_color_status_success_default';
-import global_color_status_warning_default from '@patternfly/react-tokens/dist/esm/global_color_status_warning_default';
-import global_color_status_danger_default from '@patternfly/react-tokens/dist/esm/global_color_status_danger_default';
 import l_gallery_GridTemplateColumns_min from '@patternfly/react-tokens/dist/esm/l_gallery_GridTemplateColumns_min';
 
 interface ContentType {
@@ -46,7 +44,11 @@ const cardData: CardData = {
       title: '5 Clusters',
       content: [
         {
-          icon: <CheckCircleIcon color={global_color_status_success_default.var} />
+          icon: (
+            <Icon status="success">
+              <CheckCircleIcon />
+            </Icon>
+          )
         }
       ],
       layout: 'icon'
@@ -55,7 +57,11 @@ const cardData: CardData = {
       title: '15 Clusters',
       content: [
         {
-          icon: <ExclamationTriangleIcon color={global_color_status_warning_default.var} />
+          icon: (
+            <Icon status="warning">
+              <ExclamationTriangleIcon />
+            </Icon>
+          )
         }
       ],
       layout: 'icon'
@@ -64,7 +70,11 @@ const cardData: CardData = {
       title: '3 Clusters',
       content: [
         {
-          icon: <TimesCircleIcon color={global_color_status_danger_default.var} />
+          icon: (
+            <Icon status="danger">
+              <TimesCircleIcon />
+            </Icon>
+          )
         }
       ],
       layout: 'icon'
@@ -75,11 +85,19 @@ const cardData: CardData = {
       title: '10 Hosts',
       content: [
         {
-          icon: <ExclamationCircleIcon color={global_color_status_success_default.var} />,
+          icon: (
+            <Icon status="success">
+              <ExclamationCircleIcon />
+            </Icon>
+          ),
           count: 2
         },
         {
-          icon: <ExclamationTriangleIcon color={global_color_status_warning_default.var} />,
+          icon: (
+            <Icon status="warning">
+              <ExclamationTriangleIcon />
+            </Icon>
+          ),
           count: 1
         }
       ],
@@ -89,11 +107,19 @@ const cardData: CardData = {
       title: '50 Hosts',
       content: [
         {
-          icon: <CheckCircleIcon color={global_color_status_success_default.var} />,
+          icon: (
+            <Icon status="success">
+              <CheckCircleIcon />
+            </Icon>
+          ),
           count: 5
         },
         {
-          icon: <TimesCircleIcon color={global_color_status_danger_default.var} />,
+          icon: (
+            <Icon status="success">
+              <TimesCircleIcon />
+            </Icon>
+          ),
           count: 12
         }
       ],
@@ -103,11 +129,19 @@ const cardData: CardData = {
       title: '12 Hosts',
       content: [
         {
-          icon: <ExclamationTriangleIcon color={global_color_status_warning_default.var} />,
+          icon: (
+            <Icon status="warning">
+              <ExclamationTriangleIcon />
+            </Icon>
+          ),
           count: 3
         },
         {
-          icon: <TimesCircleIcon color={global_color_status_danger_default.var} />,
+          icon: (
+            <Icon status="danger">
+              <TimesCircleIcon />
+            </Icon>
+          ),
           count: 7
         }
       ],
@@ -119,12 +153,20 @@ const cardData: CardData = {
       title: '13 Hosts',
       content: [
         {
-          icon: <TimesCircleIcon color={global_color_status_danger_default.var} />,
+          icon: (
+            <Icon status="danger">
+              <TimesCircleIcon />
+            </Icon>
+          ),
           status: '2 errors',
           subtitle: 'subtitle'
         },
         {
-          icon: <ExclamationTriangleIcon color={global_color_status_warning_default.var} />,
+          icon: (
+            <Icon status="warning">
+              <ExclamationTriangleIcon />
+            </Icon>
+          ),
           status: '1 warning',
           subtitle: 'subtitle'
         }
@@ -135,12 +177,20 @@ const cardData: CardData = {
       title: '3 Hosts',
       content: [
         {
-          icon: <CheckCircleIcon color={global_color_status_success_default.var} />,
+          icon: (
+            <Icon status="success">
+              <CheckCircleIcon />
+            </Icon>
+          ),
           status: '2 successes',
           subtitle: 'subtitle'
         },
         {
-          icon: <ExclamationTriangleIcon color={global_color_status_warning_default.var} />,
+          icon: (
+            <Icon status="warning">
+              <ExclamationTriangleIcon />
+            </Icon>
+          ),
           status: '3 warnings',
           subtitle: 'subtitle'
         }
@@ -151,12 +201,20 @@ const cardData: CardData = {
       title: '50 Hosts',
       content: [
         {
-          icon: <ExclamationTriangleIcon color={global_color_status_warning_default.var} />,
+          icon: (
+            <Icon status="warning">
+              <ExclamationTriangleIcon />
+            </Icon>
+          ),
           status: '7 warnings',
           subtitle: 'subtitle'
         },
         {
-          icon: <TimesCircleIcon color={global_color_status_danger_default.var} />,
+          icon: (
+            <Icon status="danger">
+              <TimesCircleIcon />
+            </Icon>
+          ),
           status: '1 error',
           subtitle: 'subtitle'
         }

--- a/packages/react-core/src/demos/examples/Card/CardAggregateStatus.tsx
+++ b/packages/react-core/src/demos/examples/Card/CardAggregateStatus.tsx
@@ -16,9 +16,9 @@ import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 import TimesCircleIcon from '@patternfly/react-icons/dist/js/icons/times-circle-icon';
-import global_success_color_100 from '@patternfly/react-tokens/dist/esm/global_success_color_100';
-import global_warning_color_100 from '@patternfly/react-tokens/dist/esm/global_warning_color_100';
-import global_danger_color_100 from '@patternfly/react-tokens/dist/esm/global_danger_color_100';
+import global_color_status_success_default from '@patternfly/react-tokens/dist/esm/global_color_status_success_default';
+import global_color_status_warning_default from '@patternfly/react-tokens/dist/esm/global_color_status_warning_default';
+import global_color_status_danger_default from '@patternfly/react-tokens/dist/esm/global_color_status_danger_default';
 import l_gallery_GridTemplateColumns_min from '@patternfly/react-tokens/dist/esm/l_gallery_GridTemplateColumns_min';
 
 interface ContentType {
@@ -46,7 +46,7 @@ const cardData: CardData = {
       title: '5 Clusters',
       content: [
         {
-          icon: <CheckCircleIcon color={global_success_color_100.var} />
+          icon: <CheckCircleIcon color={global_color_status_success_default.var} />
         }
       ],
       layout: 'icon'
@@ -55,7 +55,7 @@ const cardData: CardData = {
       title: '15 Clusters',
       content: [
         {
-          icon: <ExclamationTriangleIcon color={global_warning_color_100.var} />
+          icon: <ExclamationTriangleIcon color={global_color_status_warning_default.var} />
         }
       ],
       layout: 'icon'
@@ -64,7 +64,7 @@ const cardData: CardData = {
       title: '3 Clusters',
       content: [
         {
-          icon: <TimesCircleIcon color={global_danger_color_100.var} />
+          icon: <TimesCircleIcon color={global_color_status_danger_default.var} />
         }
       ],
       layout: 'icon'
@@ -75,11 +75,11 @@ const cardData: CardData = {
       title: '10 Hosts',
       content: [
         {
-          icon: <ExclamationCircleIcon color={global_success_color_100.var} />,
+          icon: <ExclamationCircleIcon color={global_color_status_success_default.var} />,
           count: 2
         },
         {
-          icon: <ExclamationTriangleIcon color={global_warning_color_100.var} />,
+          icon: <ExclamationTriangleIcon color={global_color_status_warning_default.var} />,
           count: 1
         }
       ],
@@ -89,11 +89,11 @@ const cardData: CardData = {
       title: '50 Hosts',
       content: [
         {
-          icon: <CheckCircleIcon color={global_success_color_100.var} />,
+          icon: <CheckCircleIcon color={global_color_status_success_default.var} />,
           count: 5
         },
         {
-          icon: <TimesCircleIcon color={global_danger_color_100.var} />,
+          icon: <TimesCircleIcon color={global_color_status_danger_default.var} />,
           count: 12
         }
       ],
@@ -103,11 +103,11 @@ const cardData: CardData = {
       title: '12 Hosts',
       content: [
         {
-          icon: <ExclamationTriangleIcon color={global_warning_color_100.var} />,
+          icon: <ExclamationTriangleIcon color={global_color_status_warning_default.var} />,
           count: 3
         },
         {
-          icon: <TimesCircleIcon color={global_danger_color_100.var} />,
+          icon: <TimesCircleIcon color={global_color_status_danger_default.var} />,
           count: 7
         }
       ],
@@ -119,12 +119,12 @@ const cardData: CardData = {
       title: '13 Hosts',
       content: [
         {
-          icon: <TimesCircleIcon color={global_danger_color_100.var} />,
+          icon: <TimesCircleIcon color={global_color_status_danger_default.var} />,
           status: '2 errors',
           subtitle: 'subtitle'
         },
         {
-          icon: <ExclamationTriangleIcon color={global_warning_color_100.var} />,
+          icon: <ExclamationTriangleIcon color={global_color_status_warning_default.var} />,
           status: '1 warning',
           subtitle: 'subtitle'
         }
@@ -135,12 +135,12 @@ const cardData: CardData = {
       title: '3 Hosts',
       content: [
         {
-          icon: <CheckCircleIcon color={global_success_color_100.var} />,
+          icon: <CheckCircleIcon color={global_color_status_success_default.var} />,
           status: '2 successes',
           subtitle: 'subtitle'
         },
         {
-          icon: <ExclamationTriangleIcon color={global_warning_color_100.var} />,
+          icon: <ExclamationTriangleIcon color={global_color_status_warning_default.var} />,
           status: '3 warnings',
           subtitle: 'subtitle'
         }
@@ -151,12 +151,12 @@ const cardData: CardData = {
       title: '50 Hosts',
       content: [
         {
-          icon: <ExclamationTriangleIcon color={global_warning_color_100.var} />,
+          icon: <ExclamationTriangleIcon color={global_color_status_warning_default.var} />,
           status: '7 warnings',
           subtitle: 'subtitle'
         },
         {
-          icon: <TimesCircleIcon color={global_danger_color_100.var} />,
+          icon: <TimesCircleIcon color={global_color_status_danger_default.var} />,
           status: '1 error',
           subtitle: 'subtitle'
         }

--- a/packages/react-core/src/demos/examples/Card/CardStatus.tsx
+++ b/packages/react-core/src/demos/examples/Card/CardStatus.tsx
@@ -28,7 +28,7 @@ import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclama
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 import global_color_status_success_default from '@patternfly/react-tokens/dist/esm/global_color_status_success_default';
 import global_color_status_danger_default from '@patternfly/react-tokens/dist/esm/global_color_status_danger_default';
-import global_color_brand_200 from '@patternfly/react-tokens/dist/esm/global_color_brand_200';
+import global_text_color_subtle from '@patternfly/react-tokens/dist/esm/global_text_color_subtle';
 
 export const CardStatus: React.FunctionComponent = () => {
   const [drawerExpanded, setDrawerExpanded] = React.useState(false);
@@ -171,7 +171,7 @@ export const CardStatus: React.FunctionComponent = () => {
                 <a href="#">Operators</a>
               </FlexItem>
               <FlexItem>
-                <span style={{ color: global_color_brand_200.var }}>1 degraded</span>
+                <span style={{ color: global_text_color_subtle.var }}>1 degraded</span>
               </FlexItem>
             </Flex>
           </Flex>
@@ -186,7 +186,7 @@ export const CardStatus: React.FunctionComponent = () => {
                 <a href="#">Image Vulnerabilities</a>
               </FlexItem>
               <FlexItem>
-                <span style={{ color: global_color_brand_200.var }}>0 vulnerabilities</span>
+                <span style={{ color: global_text_color_subtle.var }}>0 vulnerabilities</span>
               </FlexItem>
             </Flex>
           </Flex>

--- a/packages/react-core/src/demos/examples/Card/CardStatus.tsx
+++ b/packages/react-core/src/demos/examples/Card/CardStatus.tsx
@@ -26,9 +26,9 @@ import BellIcon from '@patternfly/react-icons/dist/js/icons/bell-icon';
 import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
-import global_success_color_100 from '@patternfly/react-tokens/dist/esm/global_success_color_100';
-import global_danger_color_100 from '@patternfly/react-tokens/dist/esm/global_danger_color_100';
-import global_Color_200 from '@patternfly/react-tokens/dist/esm/global_Color_200';
+import global_color_status_success_default from '@patternfly/react-tokens/dist/esm/global_color_status_success_default';
+import global_color_status_danger_default from '@patternfly/react-tokens/dist/esm/global_color_status_danger_default';
+import global_color_brand_200 from '@patternfly/react-tokens/dist/esm/global_color_brand_200';
 
 export const CardStatus: React.FunctionComponent = () => {
   const [drawerExpanded, setDrawerExpanded] = React.useState(false);
@@ -140,7 +140,7 @@ export const CardStatus: React.FunctionComponent = () => {
         <GridItem>
           <Flex spaceItems={{ default: 'spaceItemsSm' }}>
             <FlexItem>
-              <CheckCircleIcon color={global_success_color_100.var} />
+              <CheckCircleIcon color={global_color_status_success_default.var} />
             </FlexItem>
             <FlexItem>
               <span>Cluster</span>
@@ -150,7 +150,7 @@ export const CardStatus: React.FunctionComponent = () => {
         <GridItem>
           <Flex spaceItems={{ default: 'spaceItemsSm' }}>
             <FlexItem>
-              <ExclamationCircleIcon color={global_danger_color_100.var} />
+              <ExclamationCircleIcon color={global_color_status_danger_default.var} />
             </FlexItem>
             <FlexItem>
               <Popover headerContent="Control Panel Status" bodyContent={popoverBodyContent} minWidth="400px">
@@ -164,14 +164,14 @@ export const CardStatus: React.FunctionComponent = () => {
         <GridItem>
           <Flex spaceItems={{ default: 'spaceItemsSm' }}>
             <FlexItem>
-              <ExclamationCircleIcon color={global_danger_color_100.var} />
+              <ExclamationCircleIcon color={global_color_status_danger_default.var} />
             </FlexItem>
             <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsNone' }}>
               <FlexItem>
                 <a href="#">Operators</a>
               </FlexItem>
               <FlexItem>
-                <span style={{ color: global_Color_200.var }}>1 degraded</span>
+                <span style={{ color: global_color_brand_200.var }}>1 degraded</span>
               </FlexItem>
             </Flex>
           </Flex>
@@ -179,14 +179,14 @@ export const CardStatus: React.FunctionComponent = () => {
         <GridItem>
           <Flex spaceItems={{ default: 'spaceItemsSm' }}>
             <FlexItem>
-              <CheckCircleIcon color={global_success_color_100.var} />
+              <CheckCircleIcon color={global_color_status_success_default.var} />
             </FlexItem>
             <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsNone' }}>
               <FlexItem>
                 <a href="#">Image Vulnerabilities</a>
               </FlexItem>
               <FlexItem>
-                <span style={{ color: global_Color_200.var }}>0 vulnerabilities</span>
+                <span style={{ color: global_color_brand_200.var }}>0 vulnerabilities</span>
               </FlexItem>
             </Flex>
           </Flex>

--- a/packages/react-core/src/demos/examples/Card/CardStatus.tsx
+++ b/packages/react-core/src/demos/examples/Card/CardStatus.tsx
@@ -19,15 +19,14 @@ import {
   NotificationDrawerListItemBody,
   NotificationDrawerListItemHeader,
   Popover,
-  Title
+  Title,
+  Icon
 } from '@patternfly/react-core';
 import { Table, Thead, Tbody, Tr, Th, Td, ExpandableRowContent } from '@patternfly/react-table';
 import BellIcon from '@patternfly/react-icons/dist/js/icons/bell-icon';
 import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
-import global_color_status_success_default from '@patternfly/react-tokens/dist/esm/global_color_status_success_default';
-import global_color_status_danger_default from '@patternfly/react-tokens/dist/esm/global_color_status_danger_default';
 import global_text_color_subtle from '@patternfly/react-tokens/dist/esm/global_text_color_subtle';
 
 export const CardStatus: React.FunctionComponent = () => {
@@ -140,7 +139,9 @@ export const CardStatus: React.FunctionComponent = () => {
         <GridItem>
           <Flex spaceItems={{ default: 'spaceItemsSm' }}>
             <FlexItem>
-              <CheckCircleIcon color={global_color_status_success_default.var} />
+              <Icon status="success">
+                <CheckCircleIcon />
+              </Icon>
             </FlexItem>
             <FlexItem>
               <span>Cluster</span>
@@ -150,7 +151,9 @@ export const CardStatus: React.FunctionComponent = () => {
         <GridItem>
           <Flex spaceItems={{ default: 'spaceItemsSm' }}>
             <FlexItem>
-              <ExclamationCircleIcon color={global_color_status_danger_default.var} />
+              <Icon status="danger">
+                <ExclamationCircleIcon />
+              </Icon>
             </FlexItem>
             <FlexItem>
               <Popover headerContent="Control Panel Status" bodyContent={popoverBodyContent} minWidth="400px">
@@ -164,7 +167,9 @@ export const CardStatus: React.FunctionComponent = () => {
         <GridItem>
           <Flex spaceItems={{ default: 'spaceItemsSm' }}>
             <FlexItem>
-              <ExclamationCircleIcon color={global_color_status_danger_default.var} />
+              <Icon status="danger">
+                <ExclamationCircleIcon />
+              </Icon>
             </FlexItem>
             <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsNone' }}>
               <FlexItem>
@@ -179,7 +184,9 @@ export const CardStatus: React.FunctionComponent = () => {
         <GridItem>
           <Flex spaceItems={{ default: 'spaceItemsSm' }}>
             <FlexItem>
-              <CheckCircleIcon color={global_color_status_success_default.var} />
+              <Icon status="success">
+                <CheckCircleIcon />
+              </Icon>
             </FlexItem>
             <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsNone' }}>
               <FlexItem>

--- a/packages/react-core/src/deprecated/components/Wizard/WizardFooterInternal.tsx
+++ b/packages/react-core/src/deprecated/components/Wizard/WizardFooterInternal.tsx
@@ -3,7 +3,7 @@ import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Wizard/wizard';
 import { Button, ButtonVariant } from '../../../components/Button';
 import { WizardStep } from './Wizard';
-
+import { ActionList, ActionListGroup, ActionListItem } from '../../../components/ActionList';
 export interface WizardFooterInternalProps {
   onNext: any;
   onBack: any;
@@ -28,21 +28,29 @@ export const WizardFooterInternal: React.FunctionComponent<WizardFooterInternalP
   cancelButtonText
 }: WizardFooterInternalProps) => (
   <footer className={css(styles.wizardFooter)}>
-    {!activeStep.hideBackButton && (
-      <Button variant={ButtonVariant.secondary} onClick={onBack} isDisabled={firstStep}>
-        {backButtonText}
-      </Button>
-    )}
-    <Button variant={ButtonVariant.primary} type="submit" onClick={onNext} isDisabled={!isValid}>
-      {nextButtonText}
-    </Button>
-    {!activeStep.hideCancelButton && (
-      <div className={styles.wizardFooterCancel}>
-        <Button variant={ButtonVariant.link} onClick={onClose}>
-          {cancelButtonText}
-        </Button>
-      </div>
-    )}
+    <ActionList>
+      <ActionListGroup>
+        {!activeStep.hideBackButton && (
+          <ActionListItem>
+            <Button variant={ButtonVariant.secondary} onClick={onBack} isDisabled={firstStep}>
+              {backButtonText}
+            </Button>
+          </ActionListItem>
+        )}
+        <ActionListItem>
+          <Button variant={ButtonVariant.primary} type="submit" onClick={onNext} isDisabled={!isValid}>
+            {nextButtonText}
+          </Button>
+        </ActionListItem>
+      </ActionListGroup>
+      {!activeStep.hideCancelButton && (
+        <ActionListItem>
+          <Button variant={ButtonVariant.link} onClick={onClose}>
+            {cancelButtonText}
+          </Button>
+        </ActionListItem>
+      )}
+    </ActionList>
   </footer>
 );
 WizardFooterInternal.displayName = 'WizardFooterInternal';

--- a/packages/react-core/src/deprecated/components/Wizard/WizardFooterInternal.tsx
+++ b/packages/react-core/src/deprecated/components/Wizard/WizardFooterInternal.tsx
@@ -44,11 +44,13 @@ export const WizardFooterInternal: React.FunctionComponent<WizardFooterInternalP
         </ActionListItem>
       </ActionListGroup>
       {!activeStep.hideCancelButton && (
-        <ActionListItem>
-          <Button variant={ButtonVariant.link} onClick={onClose}>
-            {cancelButtonText}
-          </Button>
-        </ActionListItem>
+        <ActionListGroup>
+          <ActionListItem>
+            <Button variant={ButtonVariant.link} onClick={onClose}>
+              {cancelButtonText}
+            </Button>
+          </ActionListItem>
+        </ActionListGroup>
       )}
     </ActionList>
   </footer>

--- a/packages/react-core/src/deprecated/components/Wizard/__tests__/Generated/__snapshots__/WizardFooterInternal.test.tsx.snap
+++ b/packages/react-core/src/deprecated/components/Wizard/__tests__/Generated/__snapshots__/WizardFooterInternal.test.tsx.snap
@@ -5,46 +5,62 @@ exports[`WizardFooterInternal should match snapshot (auto-generated) 1`] = `
   <footer
     class="pf-v6-c-wizard__footer"
   >
-    <button
-      aria-disabled="false"
-      class="pf-v6-c-button pf-m-secondary"
-      data-ouia-component-id="OUIA-Generated-Button-secondary-1"
-      data-ouia-component-type="PF6/Button"
-      data-ouia-safe="true"
-      disabled=""
-      type="button"
-    >
-      <div>
-        ReactNode
-      </div>
-    </button>
-    <button
-      aria-disabled="false"
-      class="pf-v6-c-button pf-m-primary"
-      data-ouia-component-id="OUIA-Generated-Button-primary-1"
-      data-ouia-component-type="PF6/Button"
-      data-ouia-safe="true"
-      type="submit"
-    >
-      <div>
-        ReactNode
-      </div>
-    </button>
     <div
-      class="pf-v6-c-wizard__footer-cancel"
+      class="pf-v6-c-action-list"
     >
-      <button
-        aria-disabled="false"
-        class="pf-v6-c-button pf-m-link"
-        data-ouia-component-id="OUIA-Generated-Button-link-1"
-        data-ouia-component-type="PF6/Button"
-        data-ouia-safe="true"
-        type="button"
+      <div
+        class="pf-v6-c-action-list__group"
       >
-        <div>
-          ReactNode
+        <div
+          class="pf-v6-c-action-list__item"
+        >
+          <button
+            aria-disabled="false"
+            class="pf-v6-c-button pf-m-secondary"
+            data-ouia-component-id="OUIA-Generated-Button-secondary-1"
+            data-ouia-component-type="PF6/Button"
+            data-ouia-safe="true"
+            disabled=""
+            type="button"
+          >
+            <div>
+              ReactNode
+            </div>
+          </button>
         </div>
-      </button>
+        <div
+          class="pf-v6-c-action-list__item"
+        >
+          <button
+            aria-disabled="false"
+            class="pf-v6-c-button pf-m-primary"
+            data-ouia-component-id="OUIA-Generated-Button-primary-1"
+            data-ouia-component-type="PF6/Button"
+            data-ouia-safe="true"
+            type="submit"
+          >
+            <div>
+              ReactNode
+            </div>
+          </button>
+        </div>
+      </div>
+      <div
+        class="pf-v6-c-action-list__item"
+      >
+        <button
+          aria-disabled="false"
+          class="pf-v6-c-button pf-m-link"
+          data-ouia-component-id="OUIA-Generated-Button-link-1"
+          data-ouia-component-type="PF6/Button"
+          data-ouia-safe="true"
+          type="button"
+        >
+          <div>
+            ReactNode
+          </div>
+        </button>
+      </div>
     </div>
   </footer>
 </DocumentFragment>

--- a/packages/react-core/src/deprecated/components/Wizard/__tests__/Generated/__snapshots__/WizardFooterInternal.test.tsx.snap
+++ b/packages/react-core/src/deprecated/components/Wizard/__tests__/Generated/__snapshots__/WizardFooterInternal.test.tsx.snap
@@ -46,20 +46,24 @@ exports[`WizardFooterInternal should match snapshot (auto-generated) 1`] = `
         </div>
       </div>
       <div
-        class="pf-v6-c-action-list__item"
+        class="pf-v6-c-action-list__group"
       >
-        <button
-          aria-disabled="false"
-          class="pf-v6-c-button pf-m-link"
-          data-ouia-component-id="OUIA-Generated-Button-link-1"
-          data-ouia-component-type="PF6/Button"
-          data-ouia-safe="true"
-          type="button"
+        <div
+          class="pf-v6-c-action-list__item"
         >
-          <div>
-            ReactNode
-          </div>
-        </button>
+          <button
+            aria-disabled="false"
+            class="pf-v6-c-button pf-m-link"
+            data-ouia-component-id="OUIA-Generated-Button-link-1"
+            data-ouia-component-type="PF6/Button"
+            data-ouia-safe="true"
+            type="button"
+          >
+            <div>
+              ReactNode
+            </div>
+          </button>
+        </div>
       </div>
     </div>
   </footer>

--- a/packages/react-core/src/deprecated/components/Wizard/__tests__/__snapshots__/Wizard.test.tsx.snap
+++ b/packages/react-core/src/deprecated/components/Wizard/__tests__/__snapshots__/Wizard.test.tsx.snap
@@ -275,18 +275,22 @@ exports[`Wizard Expandable Nav Wizard should match snapshot 1`] = `
             </div>
           </div>
           <div
-            class="pf-v6-c-action-list__item"
+            class="pf-v6-c-action-list__group"
           >
-            <button
-              aria-disabled="false"
-              class="pf-v6-c-button pf-m-link"
-              data-ouia-component-id="OUIA-Generated-Button-link-2"
-              data-ouia-component-type="PF6/Button"
-              data-ouia-safe="true"
-              type="button"
+            <div
+              class="pf-v6-c-action-list__item"
             >
-              Cancel
-            </button>
+              <button
+                aria-disabled="false"
+                class="pf-v6-c-button pf-m-link"
+                data-ouia-component-id="OUIA-Generated-Button-link-2"
+                data-ouia-component-type="PF6/Button"
+                data-ouia-safe="true"
+                type="button"
+              >
+                Cancel
+              </button>
+            </div>
           </div>
         </div>
       </footer>
@@ -550,18 +554,22 @@ exports[`Wizard Wizard should match snapshot 1`] = `
             </div>
           </div>
           <div
-            class="pf-v6-c-action-list__item"
+            class="pf-v6-c-action-list__group"
           >
-            <button
-              aria-disabled="false"
-              class="pf-v6-c-button pf-m-link"
-              data-ouia-component-id="OUIA-Generated-Button-link-1"
-              data-ouia-component-type="PF6/Button"
-              data-ouia-safe="true"
-              type="button"
+            <div
+              class="pf-v6-c-action-list__item"
             >
-              Cancel
-            </button>
+              <button
+                aria-disabled="false"
+                class="pf-v6-c-button pf-m-link"
+                data-ouia-component-id="OUIA-Generated-Button-link-1"
+                data-ouia-component-type="PF6/Button"
+                data-ouia-safe="true"
+                type="button"
+              >
+                Cancel
+              </button>
+            </div>
           </div>
         </div>
       </footer>
@@ -697,18 +705,22 @@ exports[`Wizard bare wiz 1`] = `
             </div>
           </div>
           <div
-            class="pf-v6-c-action-list__item"
+            class="pf-v6-c-action-list__group"
           >
-            <button
-              aria-disabled="false"
-              class="pf-v6-c-button pf-m-link"
-              data-ouia-component-id="OUIA-Generated-Button-link-3"
-              data-ouia-component-type="PF6/Button"
-              data-ouia-safe="true"
-              type="button"
+            <div
+              class="pf-v6-c-action-list__item"
             >
-              Cancel
-            </button>
+              <button
+                aria-disabled="false"
+                class="pf-v6-c-button pf-m-link"
+                data-ouia-component-id="OUIA-Generated-Button-link-3"
+                data-ouia-component-type="PF6/Button"
+                data-ouia-safe="true"
+                type="button"
+              >
+                Cancel
+              </button>
+            </div>
           </div>
         </div>
       </footer>

--- a/packages/react-core/src/deprecated/components/Wizard/__tests__/__snapshots__/Wizard.test.tsx.snap
+++ b/packages/react-core/src/deprecated/components/Wizard/__tests__/__snapshots__/Wizard.test.tsx.snap
@@ -238,40 +238,56 @@ exports[`Wizard Expandable Nav Wizard should match snapshot 1`] = `
       <footer
         class="pf-v6-c-wizard__footer"
       >
-        <button
-          aria-disabled="false"
-          class="pf-v6-c-button pf-m-secondary"
-          data-ouia-component-id="OUIA-Generated-Button-secondary-2"
-          data-ouia-component-type="PF6/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          Back
-        </button>
-        <button
-          aria-disabled="false"
-          class="pf-v6-c-button pf-m-primary"
-          data-ouia-component-id="OUIA-Generated-Button-primary-2"
-          data-ouia-component-type="PF6/Button"
-          data-ouia-safe="true"
-          type="submit"
-        >
-          Next
-        </button>
         <div
-          class="pf-v6-c-wizard__footer-cancel"
+          class="pf-v6-c-action-list"
         >
-          <button
-            aria-disabled="false"
-            class="pf-v6-c-button pf-m-link"
-            data-ouia-component-id="OUIA-Generated-Button-link-2"
-            data-ouia-component-type="PF6/Button"
-            data-ouia-safe="true"
-            type="button"
+          <div
+            class="pf-v6-c-action-list__group"
           >
-            Cancel
-          </button>
+            <div
+              class="pf-v6-c-action-list__item"
+            >
+              <button
+                aria-disabled="false"
+                class="pf-v6-c-button pf-m-secondary"
+                data-ouia-component-id="OUIA-Generated-Button-secondary-2"
+                data-ouia-component-type="PF6/Button"
+                data-ouia-safe="true"
+                disabled=""
+                type="button"
+              >
+                Back
+              </button>
+            </div>
+            <div
+              class="pf-v6-c-action-list__item"
+            >
+              <button
+                aria-disabled="false"
+                class="pf-v6-c-button pf-m-primary"
+                data-ouia-component-id="OUIA-Generated-Button-primary-2"
+                data-ouia-component-type="PF6/Button"
+                data-ouia-safe="true"
+                type="submit"
+              >
+                Next
+              </button>
+            </div>
+          </div>
+          <div
+            class="pf-v6-c-action-list__item"
+          >
+            <button
+              aria-disabled="false"
+              class="pf-v6-c-button pf-m-link"
+              data-ouia-component-id="OUIA-Generated-Button-link-2"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              type="button"
+            >
+              Cancel
+            </button>
+          </div>
         </div>
       </footer>
     </div>
@@ -497,40 +513,56 @@ exports[`Wizard Wizard should match snapshot 1`] = `
       <footer
         class="pf-v6-c-wizard__footer"
       >
-        <button
-          aria-disabled="false"
-          class="pf-v6-c-button pf-m-secondary"
-          data-ouia-component-id="OUIA-Generated-Button-secondary-1"
-          data-ouia-component-type="PF6/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          Back
-        </button>
-        <button
-          aria-disabled="false"
-          class="pf-v6-c-button pf-m-primary"
-          data-ouia-component-id="OUIA-Generated-Button-primary-1"
-          data-ouia-component-type="PF6/Button"
-          data-ouia-safe="true"
-          type="submit"
-        >
-          Next
-        </button>
         <div
-          class="pf-v6-c-wizard__footer-cancel"
+          class="pf-v6-c-action-list"
         >
-          <button
-            aria-disabled="false"
-            class="pf-v6-c-button pf-m-link"
-            data-ouia-component-id="OUIA-Generated-Button-link-1"
-            data-ouia-component-type="PF6/Button"
-            data-ouia-safe="true"
-            type="button"
+          <div
+            class="pf-v6-c-action-list__group"
           >
-            Cancel
-          </button>
+            <div
+              class="pf-v6-c-action-list__item"
+            >
+              <button
+                aria-disabled="false"
+                class="pf-v6-c-button pf-m-secondary"
+                data-ouia-component-id="OUIA-Generated-Button-secondary-1"
+                data-ouia-component-type="PF6/Button"
+                data-ouia-safe="true"
+                disabled=""
+                type="button"
+              >
+                Back
+              </button>
+            </div>
+            <div
+              class="pf-v6-c-action-list__item"
+            >
+              <button
+                aria-disabled="false"
+                class="pf-v6-c-button pf-m-primary"
+                data-ouia-component-id="OUIA-Generated-Button-primary-1"
+                data-ouia-component-type="PF6/Button"
+                data-ouia-safe="true"
+                type="submit"
+              >
+                Next
+              </button>
+            </div>
+          </div>
+          <div
+            class="pf-v6-c-action-list__item"
+          >
+            <button
+              aria-disabled="false"
+              class="pf-v6-c-button pf-m-link"
+              data-ouia-component-id="OUIA-Generated-Button-link-1"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              type="button"
+            >
+              Cancel
+            </button>
+          </div>
         </div>
       </footer>
     </div>
@@ -628,40 +660,56 @@ exports[`Wizard bare wiz 1`] = `
       <footer
         class="pf-v6-c-wizard__footer"
       >
-        <button
-          aria-disabled="false"
-          class="pf-v6-c-button pf-m-secondary"
-          data-ouia-component-id="OUIA-Generated-Button-secondary-3"
-          data-ouia-component-type="PF6/Button"
-          data-ouia-safe="true"
-          disabled=""
-          type="button"
-        >
-          Back
-        </button>
-        <button
-          aria-disabled="false"
-          class="pf-v6-c-button pf-m-primary"
-          data-ouia-component-id="OUIA-Generated-Button-primary-3"
-          data-ouia-component-type="PF6/Button"
-          data-ouia-safe="true"
-          type="submit"
-        >
-          Next
-        </button>
         <div
-          class="pf-v6-c-wizard__footer-cancel"
+          class="pf-v6-c-action-list"
         >
-          <button
-            aria-disabled="false"
-            class="pf-v6-c-button pf-m-link"
-            data-ouia-component-id="OUIA-Generated-Button-link-3"
-            data-ouia-component-type="PF6/Button"
-            data-ouia-safe="true"
-            type="button"
+          <div
+            class="pf-v6-c-action-list__group"
           >
-            Cancel
-          </button>
+            <div
+              class="pf-v6-c-action-list__item"
+            >
+              <button
+                aria-disabled="false"
+                class="pf-v6-c-button pf-m-secondary"
+                data-ouia-component-id="OUIA-Generated-Button-secondary-3"
+                data-ouia-component-type="PF6/Button"
+                data-ouia-safe="true"
+                disabled=""
+                type="button"
+              >
+                Back
+              </button>
+            </div>
+            <div
+              class="pf-v6-c-action-list__item"
+            >
+              <button
+                aria-disabled="false"
+                class="pf-v6-c-button pf-m-primary"
+                data-ouia-component-id="OUIA-Generated-Button-primary-3"
+                data-ouia-component-type="PF6/Button"
+                data-ouia-safe="true"
+                type="submit"
+              >
+                Next
+              </button>
+            </div>
+          </div>
+          <div
+            class="pf-v6-c-action-list__item"
+          >
+            <button
+              aria-disabled="false"
+              class="pf-v6-c-button pf-m-link"
+              data-ouia-component-id="OUIA-Generated-Button-link-3"
+              data-ouia-component-type="PF6/Button"
+              data-ouia-safe="true"
+              type="button"
+            >
+              Cancel
+            </button>
+          </div>
         </div>
       </footer>
     </div>

--- a/packages/react-core/src/helpers/constants.ts
+++ b/packages/react-core/src/helpers/constants.ts
@@ -4,11 +4,11 @@ import globalBreakpointLg from '@patternfly/react-tokens/dist/esm/global_breakpo
 import globalBreakpointXl from '@patternfly/react-tokens/dist/esm/global_breakpoint_xl';
 import globalBreakpoint2xl from '@patternfly/react-tokens/dist/esm/global_breakpoint_2xl';
 
-import globalHeightBreakpointSm from '@patternfly/react-tokens/dist/esm/global_height_breakpoint_sm';
-import globalHeightBreakpointMd from '@patternfly/react-tokens/dist/esm/global_height_breakpoint_md';
-import globalHeightBreakpointLg from '@patternfly/react-tokens/dist/esm/global_height_breakpoint_lg';
-import globalHeightBreakpointXl from '@patternfly/react-tokens/dist/esm/global_height_breakpoint_xl';
-import globalHeightBreakpoint2xl from '@patternfly/react-tokens/dist/esm/global_height_breakpoint_2xl';
+import globalHeightBreakpointSm from '@patternfly/react-tokens/dist/esm/global_breakpoint_height_sm';
+import globalHeightBreakpointMd from '@patternfly/react-tokens/dist/esm/global_breakpoint_height_md';
+import globalHeightBreakpointLg from '@patternfly/react-tokens/dist/esm/global_breakpoint_height_lg';
+import globalHeightBreakpointXl from '@patternfly/react-tokens/dist/esm/global_breakpoint_height_xl';
+import globalHeightBreakpoint2xl from '@patternfly/react-tokens/dist/esm/global_breakpoint_height_2xl';
 
 import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -35,7 +35,7 @@
     "@patternfly/react-tokens": "^6.0.0-alpha.20"
   },
   "devDependencies": {
-    "@patternfly/documentation-framework": "^6.0.0-alpha.21",
+    "@patternfly/documentation-framework": "^6.0.0-alpha.28",
     "@patternfly/patternfly-a11y": "4.3.1",
     "rimraf": "^2.6.3",
     "shx": "^0.3.4"

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -23,7 +23,7 @@
     "test:a11y": "patternfly-a11y --config patternfly-a11y.config"
   },
   "dependencies": {
-    "@patternfly/patternfly": "6.0.0-alpha.117",
+    "@patternfly/patternfly": "6.0.0-alpha.135",
     "@patternfly/react-charts": "^8.0.0-alpha.20",
     "@patternfly/react-code-editor": "^6.0.0-alpha.57",
     "@patternfly/react-core": "^6.0.0-alpha.57",

--- a/packages/react-docs/patternfly-docs/pages/icons.js
+++ b/packages/react-docs/patternfly-docs/pages/icons.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Tooltip, Text, Grid, GridItem, PageSection } from '@patternfly/react-core';
 import spacerMd from '@patternfly/react-tokens/dist/esm/global_spacer_md';
-import labelFontSize from '@patternfly/react-tokens/dist/esm/global_FontSize_sm';
+import labelFontSize from '@patternfly/react-tokens/dist/esm/global_font_size_sm';
 import * as IconsModule from '@patternfly/react-icons/dist/esm';
 
 const iconsPage = () => {

--- a/packages/react-docs/patternfly-docs/patternfly-docs.css.js
+++ b/packages/react-docs/patternfly-docs/patternfly-docs.css.js
@@ -19,6 +19,3 @@ import '@patternfly/patternfly/patternfly-addons.css';
 
 // Charts
 import '@patternfly/patternfly/patternfly-charts.css';
-
-// Dark theme
-import '@patternfly/patternfly/patternfly-charts-theme-dark.css';

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -33,7 +33,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.14.0",
     "@fortawesome/free-regular-svg-icons": "^5.14.0",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
-    "@patternfly/patternfly": "6.0.0-alpha.117",
+    "@patternfly/patternfly": "6.0.0-alpha.135",
     "fs-extra": "^11.1.1",
     "glob": "^7.1.2",
     "rimraf": "^2.6.2",

--- a/packages/react-integration/cypress/integration/drawer.spec.ts
+++ b/packages/react-integration/cypress/integration/drawer.spec.ts
@@ -44,7 +44,7 @@ describe('Drawer Demo Test', () => {
     $drawerPanel.should('have.class', 'pf-m-width-50-on-lg');
     $drawerPanel.should('have.class', 'pf-m-width-33-on-xl');
     $drawerPanel.should('have.class', 'pf-m-width-25-on-2xl');
-    $drawerPanel.should('have.css', 'flex-basis', 'max(0% + 24px, min(0% + 300px, 100% + 0px))');
+    $drawerPanel.should('have.css', 'flex-basis', 'max(24px, min(300px, 100%))');
     // Medium viewport
     cy.viewport(800, 660);
     cy.get('#basic-drawer .pf-v6-c-drawer__panel').should(
@@ -61,11 +61,7 @@ describe('Drawer Demo Test', () => {
     );
     // 2Xl viewport
     cy.viewport(1450, 660);
-    cy.get('#basic-drawer .pf-v6-c-drawer__panel').should(
-      'have.css',
-      'flex-basis',
-      'max(0% + 24px, min(0% + 300px, 100% + 0px))'
-    );
+    cy.get('#basic-drawer .pf-v6-c-drawer__panel').should('have.css', 'flex-basis', 'max(24px, min(300px, 100%))');
   });
 
   it('Verify that focus gets sent to drawer', () => {

--- a/packages/react-integration/cypress/integration/drawer.spec.ts
+++ b/packages/react-integration/cypress/integration/drawer.spec.ts
@@ -44,7 +44,7 @@ describe('Drawer Demo Test', () => {
     $drawerPanel.should('have.class', 'pf-m-width-50-on-lg');
     $drawerPanel.should('have.class', 'pf-m-width-33-on-xl');
     $drawerPanel.should('have.class', 'pf-m-width-25-on-2xl');
-    $drawerPanel.should('have.css', 'flex-basis', 'max(24px, min(300px, 100%))');
+    $drawerPanel.should('have.css', 'flex-basis', 'max(0% + 24px, min(0% + 300px, 100% + 0px))');
     // Medium viewport
     cy.viewport(800, 660);
     cy.get('#basic-drawer .pf-v6-c-drawer__panel').should(
@@ -61,7 +61,11 @@ describe('Drawer Demo Test', () => {
     );
     // 2Xl viewport
     cy.viewport(1450, 660);
-    cy.get('#basic-drawer .pf-v6-c-drawer__panel').should('have.css', 'flex-basis', 'max(24px, min(300px, 100%))');
+    cy.get('#basic-drawer .pf-v6-c-drawer__panel').should(
+      'have.css',
+      'flex-basis',
+      'max(0% + 24px, min(0% + 300px, 100% + 0px))'
+    );
   });
 
   it('Verify that focus gets sent to drawer', () => {

--- a/packages/react-integration/cypress/integration/wizarddeprecated.spec.ts
+++ b/packages/react-integration/cypress/integration/wizarddeprecated.spec.ts
@@ -6,7 +6,7 @@ describe('Wizard Deprecated Demo Test', () => {
   it('Verify wizard in modal launches in a dialog and has a custom width', () => {
     cy.get('#launchWiz').click();
     cy.get('#modalWizId.pf-v6-c-wizard').should('exist');
-    cy.get('.pf-v6-c-modal-box').should('have.attr', 'style', '--pf-v6-c-modal-box--Width: 710px;');
+    cy.get('.pf-v6-c-modal-box').should('have.attr', 'style', '--pf-v6-c-modal-box--Width:710px;');
     cy.focused().click();
   });
 

--- a/packages/react-integration/cypress/integration/wizarddeprecated.spec.ts
+++ b/packages/react-integration/cypress/integration/wizarddeprecated.spec.ts
@@ -6,7 +6,7 @@ describe('Wizard Deprecated Demo Test', () => {
   it('Verify wizard in modal launches in a dialog and has a custom width', () => {
     cy.get('#launchWiz').click();
     cy.get('#modalWizId.pf-v6-c-wizard').should('exist');
-    cy.get('.pf-v6-c-modal-box').should('have.attr', 'style', '--pf-v6-c-modal-box--Width:710px;');
+    cy.get('.pf-v6-c-modal-box').should('have.attr', 'style', '--pf-v6-c-modal-box--Width: 710px;');
     cy.focused().click();
   });
 

--- a/packages/react-integration/demo-app-ts/src/components/demos/DataListDemo/DataListDraggableDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DataListDemo/DataListDraggableDemo.tsx
@@ -6,11 +6,9 @@ import {
   DataListItemRow,
   DataListControl,
   DataListDragButton,
-  DataListItemCells,
-  DragDrop,
-  Draggable,
-  Droppable
+  DataListItemCells
 } from '@patternfly/react-core';
+import { DragDrop, Draggable, Droppable } from '@patternfly/react-core/deprecated';
 
 interface ItemType {
   id: string;
@@ -110,3 +108,4 @@ class DataListDraggableDemo extends React.Component {
 }
 
 DataListDraggableDemo.displayName = 'DataListDraggableDemo';
+export { DataListDraggableDemo };

--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableComposableDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableComposableDemo.tsx
@@ -29,7 +29,7 @@ import CodeBranchIcon from '@patternfly/react-icons/dist/esm/icons/code-branch-i
 import CodeIcon from '@patternfly/react-icons/dist/esm/icons/code-icon';
 import CubeIcon from '@patternfly/react-icons/dist/esm/icons/cube-icon';
 /* eslint-disable camelcase */
-import global_primary_color_100 from '@patternfly/react-tokens/dist/esm/global_primary_color_100';
+import global_color_brand_default from '@patternfly/react-tokens/dist/esm/global_color_brand_default';
 
 export const TableComposableDemo = () => {
   const ComposableTableBasic = () => {
@@ -143,7 +143,7 @@ export const TableComposableDemo = () => {
           {rows.map((row, rowIndex) => {
             const isOddRow = (rowIndex + 1) % 2;
             const customStyle = {
-              borderLeft: `3px solid ${global_primary_color_100.var}`
+              borderLeft: `3px solid ${global_color_brand_default.var}`
             };
             return (
               <Tr

--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableRowWrapperDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableRowWrapperDemo.tsx
@@ -5,7 +5,7 @@ import { Table, TableHeader, TableBody, TableProps } from '@patternfly/react-tab
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 /* eslint-disable camelcase */
-import global_primary_color_100 from '@patternfly/react-tokens/dist/esm/global_primary_color_100';
+import global_color_brand_default from '@patternfly/react-tokens/dist/esm/global_color_brand_default';
 
 interface ITableRowWrapperDemoState {
   rows: IRow[];
@@ -35,7 +35,7 @@ export class TableRowWrapperDemo extends Component<TableProps, ITableRowWrapperD
       const isExpanded = rest.row ? rest.row.isExpanded : false;
       const isOddRow = (rowProps.rowIndex + 1) % 2;
       const customStyle = {
-        borderLeft: `3px solid ${global_primary_color_100.var}`
+        borderLeft: `3px solid ${global_color_brand_default.var}`
       };
       return (
         <tr

--- a/packages/react-integration/demo-app-ts/src/index.tsx
+++ b/packages/react-integration/demo-app-ts/src/index.tsx
@@ -3,7 +3,6 @@ import React, { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App';
-import '@patternfly/patternfly/patternfly-theme-dark.css';
 
 const container = document.getElementById('root');
 const root = createRoot(container);

--- a/packages/react-styles/package.json
+++ b/packages/react-styles/package.json
@@ -19,7 +19,7 @@
     "clean": "rimraf dist css"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.0.0-alpha.117",
+    "@patternfly/patternfly": "6.0.0-alpha.135",
     "camel-case": "^3.0.0",
     "css": "^2.2.3",
     "fs-extra": "^11.1.1",

--- a/packages/react-table/src/components/Table/Td.tsx
+++ b/packages/react-table/src/components/Table/Td.tsx
@@ -30,8 +30,8 @@ import {
   TdTreeRowType
 } from './base/types';
 import cssStickyCellMinWidth from '@patternfly/react-tokens/dist/esm/c_table__sticky_cell_MinWidth';
-import cssStickyCellLeft from '@patternfly/react-tokens/dist/esm/c_table__sticky_cell_Left';
-import cssStickyCellRight from '@patternfly/react-tokens/dist/esm/c_table__sticky_cell_Right';
+import cssStickyCellInlineStart from '@patternfly/react-tokens/dist/esm/c_table__sticky_cell_InsetInlineStart';
+import cssStickyCellInlineEnd from '@patternfly/react-tokens/dist/esm/c_table__sticky_cell_InsetInlineEnd';
 
 export interface TdProps extends BaseCellProps, Omit<React.HTMLProps<HTMLTableDataCellElement>, 'onSelect' | 'width'> {
   /**
@@ -294,8 +294,8 @@ const TdBase: React.FunctionComponent<TdProps> = ({
       {...(isStickyColumn && {
         style: {
           [cssStickyCellMinWidth.name]: stickyMinWidth ? stickyMinWidth : undefined,
-          [cssStickyCellLeft.name]: stickyLeftOffset ? stickyLeftOffset : 0,
-          [cssStickyCellRight.name]: stickyRightOffset ? stickyRightOffset : 0,
+          [cssStickyCellInlineStart.name]: stickyLeftOffset ? stickyLeftOffset : 0,
+          [cssStickyCellInlineEnd.name]: stickyRightOffset ? stickyRightOffset : 0,
           ...props.style
         } as React.CSSProperties
       })}

--- a/packages/react-table/src/components/Table/Th.tsx
+++ b/packages/react-table/src/components/Table/Th.tsx
@@ -10,8 +10,8 @@ import { Tooltip, TooltipProps } from '@patternfly/react-core/dist/esm/component
 import { BaseCellProps } from './Table';
 import { IFormatterValueType, IColumn } from './TableTypes';
 import cssStickyCellMinWidth from '@patternfly/react-tokens/dist/esm/c_table__sticky_cell_MinWidth';
-import cssStickyCellLeft from '@patternfly/react-tokens/dist/esm/c_table__sticky_cell_Left';
-import cssStickyCellRight from '@patternfly/react-tokens/dist/esm/c_table__sticky_cell_Right';
+import cssStickyCellInlineStart from '@patternfly/react-tokens/dist/esm/c_table__sticky_cell_InsetInlineStart';
+import cssStickyCellInlineEnd from '@patternfly/react-tokens/dist/esm/c_table__sticky_cell_InsetInlineEnd';
 
 export interface ThProps
   extends BaseCellProps,
@@ -224,8 +224,8 @@ const ThBase: React.FunctionComponent<ThProps> = ({
       {...(isStickyColumn && {
         style: {
           [cssStickyCellMinWidth.name]: stickyMinWidth ? stickyMinWidth : undefined,
-          [cssStickyCellLeft.name]: stickyLeftOffset ? stickyLeftOffset : 0,
-          [cssStickyCellRight.name]: stickyRightOffset ? stickyRightOffset : 0,
+          [cssStickyCellInlineStart.name]: stickyLeftOffset ? stickyLeftOffset : 0,
+          [cssStickyCellInlineEnd.name]: stickyRightOffset ? stickyRightOffset : 0,
           ...props.style
         } as React.CSSProperties
       })}

--- a/packages/react-table/src/components/Table/examples/Table.md
+++ b/packages/react-table/src/components/Table/examples/Table.md
@@ -56,7 +56,7 @@ import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import textStyles from '@patternfly/react-styles/css/utilities/Text/text';
-import global_background_color_200 from '@patternfly/react-tokens/dist/esm/global_background_color_200';
+import global_background_color_secondary_default from '@patternfly/react-tokens/dist/esm/global_background_color_secondary_default';
 
 ## Table examples
 

--- a/packages/react-table/src/components/Table/examples/Table.md
+++ b/packages/react-table/src/components/Table/examples/Table.md
@@ -56,7 +56,7 @@ import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import textStyles from '@patternfly/react-styles/css/utilities/Text/text';
-import global_BackgroundColor_150 from '@patternfly/react-tokens/dist/esm/global_BackgroundColor_150';
+import global_background_color_200 from '@patternfly/react-tokens/dist/esm/global_background_color_200';
 
 ## Table examples
 
@@ -71,6 +71,7 @@ Some general notes:
 ### Basic
 
 ```ts file="TableBasic.tsx"
+
 ```
 
 ### Custom row wrapper, header tooltips & popovers
@@ -82,6 +83,7 @@ Some general notes:
 To add a header tooltip or popover to `Th`, pass a `ThInfoType` object via the `info` prop.
 
 ```ts file="TableMisc.tsx"
+
 ```
 
 ### Sortable & wrapping headers
@@ -103,6 +105,7 @@ type OnSort = (
 The built in display for sorting is not fully responsive, as the column headers will be displayed per row when the screen size is small. To see a full page demo of a responsive sortable table, utilizing a toolbar item to control sorting for small screens, view the `Sortable - responsive` demo in the `React demos` tab.
 
 ```ts file="TableSortable.tsx"
+
 ```
 
 ### Sortable - custom control
@@ -110,6 +113,7 @@ The built in display for sorting is not fully responsive, as the column headers 
 Sorting a table may also be controlled manually with a toolbar control. To see a full page demo of a responsive table, view the `Sortable - responsive` demo in the `React demos` tab.
 
 ```ts file="TableSortableCustom.tsx"
+
 ```
 
 ### Selectable with checkbox
@@ -140,6 +144,7 @@ type OnSelect = (
 checking checkboxes will check intermediate rows' checkboxes.
 
 ```ts file="TableSelectable.tsx"
+
 ```
 
 ### Selectable radio input
@@ -147,6 +152,7 @@ checking checkboxes will check intermediate rows' checkboxes.
 Similarly to the selectable example above, the radio buttons use the first column. The first header cell is empty, and each body row's first cell has radio button props.
 
 ```ts file="TableSelectableRadio.tsx"
+
 ```
 
 ### Row click handler, clickable rows
@@ -154,6 +160,7 @@ Similarly to the selectable example above, the radio buttons use the first colum
 This selectable rows feature is intended for use when a table is used to present a list of objects in a Primary-detail view.
 
 ```ts file="TableClickable.tsx"
+
 ```
 
 ### Actions
@@ -165,6 +172,7 @@ To make a cell an action cell, render an `ActionsColumn` component inside a row'
 If actions menus are getting clipped by other items on the page, such as sticky columns or rows, the `ActionsColumn` can be passed a `menuAppendTo` prop to adjust where the actions menu is appended.
 
 ```ts file="TableActions.tsx"
+
 ```
 
 ### Actions Overflow
@@ -172,6 +180,7 @@ If actions menus are getting clipped by other items on the page, such as sticky 
 Useing an `OverflowMenu` in the actions column, allowing the actions to condense into a dropdown if necessary for space.
 
 ```ts file="TableActionsOverflow.tsx"
+
 ```
 
 ### Expandable
@@ -197,6 +206,7 @@ type OnCollapse = (
 Note: Table column widths will respond automatically when toggling expanded rows. To retain column widths between expanded and collapsed states, column header and/or data cell widths must be set.
 
 ```ts file="TableExpandable.tsx"
+
 ```
 
 ### Compound expandable
@@ -221,16 +231,19 @@ export type OnExpand = (
 ```
 
 ```ts file="TableCompoundExpandable.tsx"
+
 ```
 
 ### Cell width, breakpoint modifiers
 
 ```ts file="TableCellWidth.tsx"
+
 ```
 
 ### Controlling text
 
 ```ts file="TableControllingText.tsx"
+
 ```
 
 ### Modifiers with table text
@@ -238,11 +251,13 @@ export type OnExpand = (
 If the "wrapModifier" property is set to "truncate", it's needed to ensure that the corresponding tooltip can be opened using both keyboard and screen reader. Since this particular Td element is generic and doesn't have any predefined decorators, the focus management required to trigger the tooltip needs to be handled manually by defining and manipulating the requisite props.
 
 ```ts file="TableTextModifiers.tsx"
+
 ```
 
 ### Empty state
 
 ```ts file="TableEmptyState.tsx"
+
 ```
 
 ### Favoritable (implemented with sortable)
@@ -265,6 +280,7 @@ type OnFavorite = (
 To make a favoritable column sortable, pass a `ThSortType` object to the favoritable column's `Th` with `isFavorites` set to true.
 
 ```ts file="TableFavoritable.tsx"
+
 ```
 
 ### Tree table
@@ -298,6 +314,7 @@ aria-posinset, and aria-setsize as violations. This is an intentional choice at 
 the voice over technologies will recognize the flat table structure as a tree.
 
 ```ts file="TableTree.tsx"
+
 ```
 
 ### Flat tree table with no inset
@@ -305,6 +322,7 @@ the voice over technologies will recognize the flat table structure as a tree.
 To remove the inset used to leave space for the expand/collapse toggle in a flat tree table, use the `hasNoInset` prop on the `Table` component.
 
 ```ts file="TableTreeNoInset.tsx"
+
 ```
 
 ### Draggable row table
@@ -318,6 +336,7 @@ To make a row draggable:
 5. The draggable `Td` in each row needs a `TdDraggableType` object passed to its `draggable` prop.
 
 ```ts isBeta file="TableDraggable.tsx"
+
 ```
 
 ### Sticky table modifiers
@@ -334,7 +353,7 @@ There are a few ways this can be handled:
 
 ### Sticky column
 
-To make a column sticky, wrap `Table` with `InnerScrollContainer` and add the following properties to the `Th` or `Td` that should be sticky: 
+To make a column sticky, wrap `Table` with `InnerScrollContainer` and add the following properties to the `Th` or `Td` that should be sticky:
 
 - `isStickyColumn`
 - `hasRightBorder` for a left-aligned sticky column, or `hasLeftBorder` for a right-aligned sticky column.
@@ -342,6 +361,7 @@ To make a column sticky, wrap `Table` with `InnerScrollContainer` and add the fo
 To prevent the default text wrapping behavior and allow horizontal scrolling, all `Th` or `Td` cells should also have the `modifier="nowrap"` property. To set the minimum width of the sticky column, use the `stickyMinWidth` property. For multiple sticky columns, use the `stickyLeftOffset` and `stickyRightOffset` properties for additional left or right sticky columns.
 
 ```ts file="TableStickyColumn.tsx"
+
 ```
 
 ### Multiple left-aligned sticky columns
@@ -351,11 +371,12 @@ To make multiple left-aligned columns sticky:
 - wrap `Table` with `InnerScrollContainer`
 - add `isStickyColumn` to all columns that should be sticky
 - add `hasRightBorder` to the rightmost sticky column
-- add `stickyLeftOffset` to each sticky column with a value that equals the combined width - set by `stickyMindWidth` - of the previous sticky columns. The leftmost sticky column should have a value of `0`, which is the default of this property. 
+- add `stickyLeftOffset` to each sticky column with a value that equals the combined width - set by `stickyMindWidth` - of the previous sticky columns. The leftmost sticky column should have a value of `0`, which is the default of this property.
 
 To prevent the default text wrapping behavior and allow horizontal scrolling, all `Th` or `Td` cells should also have the `modifier="nowrap"` property.
 
 ```ts file="TableMultipleStickyColumns.tsx"
+
 ```
 
 ### Multiple right-aligned sticky columns
@@ -365,11 +386,12 @@ To make multiple right-aligned columns sticky:
 - wrap `Table` with `InnerScrollContainer`
 - add `isStickyColumn` to all columns that should be sticky
 - add `hasLeftBorder` to the leftmost sticky column
-- add `stickyRightOffset` to each sticky column with a value that equals the combined width - set by `stickyMindWidth` - of the next sticky columns. The rightmost sticky column should have a value of `0`, which is the default of this property. 
+- add `stickyRightOffset` to each sticky column with a value that equals the combined width - set by `stickyMindWidth` - of the next sticky columns. The rightmost sticky column should have a value of `0`, which is the default of this property.
 
 To prevent the default text wrapping behavior and allow horizontal scrolling, all `Th` or `Td` cells should also have the `modifier="nowrap"` property.
 
 ```ts file="TableRightStickyColumn.tsx"
+
 ```
 
 ### Sticky columns and header
@@ -377,6 +399,7 @@ To prevent the default text wrapping behavior and allow horizontal scrolling, al
 To maintain proper sticky behavior across sticky columns and header, `Table` must be wrapped with `OuterScrollContainer` and `InnerScrollContainer`.
 
 ```ts file="TableStickyColumnsAndHeader.tsx"
+
 ```
 
 ### Nested column headers
@@ -393,21 +416,25 @@ The first `Tr` represents the top level of columns, and each must pass either `r
 The second `Tr` represents the second level of sub columns. The `Th` in this row each should pass `isSubHeader`, and the last sub column of a column should also pass `hasRightBorder`.
 
 ```ts file="TableNestedHeaders.tsx"
+
 ```
 
 ### Nested column headers and expandable rows
 
 ```ts file="TableNestedExpandable.tsx"
+
 ```
 
 ### Expandable with nested table
 
 ```ts file="TableNestedTableExpandable.tsx"
+
 ```
 
 ### Nested sticky header
 
 ```ts file="TableNestedStickyHeader.tsx"
+
 ```
 
 ### Striped
@@ -415,6 +442,7 @@ The second `Tr` represents the second level of sub columns. The `Th` in this row
 To apply striping to a basic table, add the `isStriped` property to `Table`.
 
 ```ts file="TableStriped.tsx"
+
 ```
 
 ### Striped expandable
@@ -422,6 +450,7 @@ To apply striping to a basic table, add the `isStriped` property to `Table`.
 To apply striping to an expandable table, add the `isStriped` and `isExpandable` properties to `Table`.
 
 ```ts file="TableStripedExpandable.tsx"
+
 ```
 
 ### Striped multiple tobdy
@@ -429,6 +458,7 @@ To apply striping to an expandable table, add the `isStriped` and `isExpandable`
 When there are multiple `Tbody` components within a table, a more granular application of striping may be controlled by adding either the `isEvenStriped` or `isOddStriped` properties to `Tbody`. These properties will stripe even or odd rows within that `Tbody` respectively.
 
 ```ts file="TableStripedMultipleTbody.tsx"
+
 ```
 
 ### Striped tr
@@ -436,4 +466,5 @@ When there are multiple `Tbody` components within a table, a more granular appli
 To manually control striping, add the `isStriped` property to each desired `Tr`. This replaces adding the `isStriped` property to `Table`.
 
 ```ts file="TableStripedTr.tsx"
+
 ```

--- a/packages/react-table/src/components/Table/examples/TableMisc.tsx
+++ b/packages/react-table/src/components/Table/examples/TableMisc.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 /* eslint-disable camelcase */
-import global_BackgroundColor_150 from '@patternfly/react-tokens/dist/esm/global_BackgroundColor_150';
+import global_background_color_200 from '@patternfly/react-tokens/dist/esm/global_background_color_200';
 
 interface Repository {
   name: string;
@@ -67,7 +67,7 @@ export const TableMisc: React.FunctionComponent = () => {
         {repositories.map((repo, rowIndex) => {
           const isOddRow = (rowIndex + 1) % 2;
           const customStyle = {
-            backgroundColor: global_BackgroundColor_150.var
+            backgroundColor: global_background_color_200.var
           };
           // Some arbitrary logic to demonstrate that cell styles can be based on anything
           const nameColSpan = repo.branches === null && repo.prs === null ? 3 : 1;

--- a/packages/react-table/src/components/Table/examples/TableMisc.tsx
+++ b/packages/react-table/src/components/Table/examples/TableMisc.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 /* eslint-disable camelcase */
-import global_background_color_200 from '@patternfly/react-tokens/dist/esm/global_background_color_200';
+import global_background_color_secondary_default from '@patternfly/react-tokens/dist/esm/global_background_color_secondary_default';
 
 interface Repository {
   name: string;
@@ -67,7 +67,7 @@ export const TableMisc: React.FunctionComponent = () => {
         {repositories.map((repo, rowIndex) => {
           const isOddRow = (rowIndex + 1) % 2;
           const customStyle = {
-            backgroundColor: global_background_color_200.var
+            backgroundColor: global_background_color_secondary_default.var
           };
           // Some arbitrary logic to demonstrate that cell styles can be based on anything
           const nameColSpan = repo.branches === null && repo.prs === null ? 3 : 1;

--- a/packages/react-table/src/components/Table/utils/transformers.test.tsx
+++ b/packages/react-table/src/components/Table/utils/transformers.test.tsx
@@ -30,7 +30,7 @@ import {
 } from '../TableTypes';
 import { css } from '@patternfly/react-styles';
 import tableStyles from '@patternfly/react-styles/css/components/Table/table';
-import dropdownStyles from '@patternfly/react-styles/css/components/Dropdown/dropdown';
+import menuStyles from '@patternfly/react-styles/css/components/Menu/menu';
 
 const testCellActions = async ({
   actions,
@@ -76,9 +76,7 @@ const testCellActions = async ({
     await user.click(screen.getAllByRole('button')[0]);
     await waitFor(() =>
       // eslint-disable-next-line testing-library/no-container
-      expect(container.querySelectorAll(`.${dropdownStyles.dropdownMenu} li button`)).toHaveLength(
-        expectDisabled ? 0 : 1
-      )
+      expect(container.querySelectorAll(`.${menuStyles.menu} li button`)).toHaveLength(expectDisabled ? 0 : 1)
     );
   }
 };

--- a/packages/react-table/src/demos/Table.md
+++ b/packages/react-table/src/demos/Table.md
@@ -57,7 +57,6 @@ import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclam
 import CogIcon from '@patternfly/react-icons/dist/esm/icons/cog-icon';
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 import QuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/question-circle-icon';
-import globalDangerColor200 from '@patternfly/react-tokens/dist/esm/global_danger_color_200';
 import AngleDownIcon from '@patternfly/react-icons/dist/esm/icons/angle-down-icon';
 import AngleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-right-icon';
 import BarsIcon from '@patternfly/react-icons/dist/esm/icons/bars-icon';

--- a/packages/react-table/src/demos/examples/TableEmptyStateError.tsx
+++ b/packages/react-table/src/demos/examples/TableEmptyStateError.tsx
@@ -11,7 +11,6 @@ import {
   PageSection
 } from '@patternfly/react-core';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
-import globalDangerColor200 from '@patternfly/react-tokens/dist/esm/global_danger_color_200';
 import { DashboardWrapper } from '@patternfly/react-table/dist/esm/demos/DashboardWrapper';
 
 export const TableEmptyStateError: React.FunctionComponent = () => (
@@ -32,10 +31,10 @@ export const TableEmptyStateError: React.FunctionComponent = () => (
             <Tr>
               <Td colSpan={8}>
                 <Bullseye>
-                  <EmptyState variant={EmptyStateVariant.sm}>
+                  <EmptyState variant={EmptyStateVariant.sm} titleText="">
                     <EmptyStateHeader
                       titleText="Unable to connect"
-                      icon={<EmptyStateIcon icon={ExclamationCircleIcon} color={globalDangerColor200.value} />}
+                      icon={<EmptyStateIcon icon={ExclamationCircleIcon} />}
                       headingLevel="h2"
                     />
                     <EmptyStateBody>

--- a/packages/react-table/src/deprecated/components/Table/examples/LegacyTableMisc.tsx
+++ b/packages/react-table/src/deprecated/components/Table/examples/LegacyTableMisc.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Table, TableHeader, TableBody, TableProps } from '@patternfly/react-table/deprecated';
 import { css } from '@patternfly/react-styles';
 /* eslint-disable camelcase */
-import global_primary_color_100 from '@patternfly/react-tokens/dist/esm/global_primary_color_100';
+import global_color_brand_default from '@patternfly/react-tokens/dist/esm/global_color_brand_default';
 
 interface Repository {
   name: string;
@@ -32,7 +32,7 @@ export const LegacyTableMisc: React.FunctionComponent = () => {
   const customRowWrapper: TableProps['rowWrapper'] = ({ trRef, className, rowProps, row: _row }) => {
     const isOddRow = rowProps ? !!((rowProps.rowIndex + 1) % 2) : true;
     const customStyle = {
-      borderLeft: `3px solid ${global_primary_color_100.var}`
+      borderLeft: `3px solid ${global_color_brand_default.var}`
     };
     return (
       <tr

--- a/packages/react-table/src/deprecated/components/Table/examples/Table.md
+++ b/packages/react-table/src/deprecated/components/Table/examples/Table.md
@@ -22,18 +22,17 @@ import FolderIcon from '@patternfly/react-icons/dist/esm/icons/folder-icon';
 import FolderOpenIcon from '@patternfly/react-icons/dist/esm/icons/folder-open-icon';
 import SortAmountDownIcon from '@patternfly/react-icons/dist/esm/icons/sort-amount-down-icon';
 import { SelectOption as SelectOptionDeprecated } from '@patternfly/react-core/deprecated';
-import { 
-  Select as NewSelect,
-  SelectGroup as NewSelectGroup,
-  SelectList  as NewSelectList,
-  SelectOption as NewSelectOption,
+import {
+Select as NewSelect,
+SelectGroup as NewSelectGroup,
+SelectList as NewSelectList,
+SelectOption as NewSelectOption,
 } from '@patternfly/react-core/dist/esm/components/Select';
-
 
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-import global_primary_color_100 from '@patternfly/react-tokens/dist/esm/global_primary_color_100';
+import global_color_brand_default from '@patternfly/react-tokens/dist/esm/global_color_brand_default';
 
 ## Table Columns
 
@@ -122,6 +121,7 @@ interface IRowCell {
 ### Basic
 
 ```ts file="LegacyTableBasic.tsx"
+
 ```
 
 ### Custom row wrapper
@@ -152,6 +152,7 @@ interface RowWrapperProps {
 ```
 
 ```ts file="LegacyTableMisc.tsx"
+
 ```
 
 ### Sortable & wrapping column headers
@@ -169,6 +170,7 @@ Note: If you want to add a tooltip/popover to a sortable header, in the `transfo
 The built in display for sorting is not fully responsive, as the column headers will be displayed per row when the screen size is small. The example below showcases how sorting may have a custom control display that can be used for small screen sizes.
 
 ```ts file="LegacyTableSortable.tsx"
+
 ```
 
 ### Sortable - custom control
@@ -176,6 +178,7 @@ The built in display for sorting is not fully responsive, as the column headers 
 Sorting a table may also be controlled with a toolbar. This toolbar item may also be hidden at large screen sizes and only displayed when the screen size is small to support responsive tables.
 
 ```ts file="LegacyTableSortableCustom.tsx"
+
 ```
 
 ### Selectable with checkbox
@@ -196,6 +199,7 @@ of using `td` elements, the cells in that column use `th` elements.
 checking checkboxes will check intermediate rows' checkboxes.
 
 ```ts file="LegacyTableSelectable.tsx"
+
 ```
 
 ### Selectable radio input
@@ -206,6 +210,7 @@ To enable row radio selection, set the `onSelect` callback prop on the Table, an
 To disable selection for a row, set `disableSelection: true` on the row definition.
 
 ```ts file="LegacyTableSelectableRadio.tsx"
+
 ```
 
 ### Clickable rows, selectable rows, and header cell tooltips/popovers
@@ -213,6 +218,7 @@ To disable selection for a row, set `disableSelection: true` on the row definiti
 This selectable rows feature is intended for use when a table is used to present a list of objects in a Primary-detail view.
 
 ```ts file="LegacyTableClickable.tsx"
+
 ```
 
 ### Actions and first cell in body rows as th
@@ -222,6 +228,7 @@ To use actions you can either specify an array of actions and pass that into the
 If actions menus are getting clipped by other items on the page, such as sticky columns or rows, the `Table` can be passed a `actionsMenuAppendTo` prop to adjust where the actions menu is appended.
 
 ```ts file="LegacyTableActions.tsx"
+
 ```
 
 ### Expandable
@@ -232,6 +239,7 @@ The parent row can have an `isOpen` field for managing the expanded state of the
 Also, pass an `onCollapse` event handler via the prop on the Table
 
 ```ts file="LegacyTableExpandable.tsx"
+
 ```
 
 ### Compound expandable
@@ -248,26 +256,31 @@ To build a compound expandable table:
 4. An `onExpand` event handler prop should be passed to the Table.
 
 ```ts file="LegacyTableCompoundExpandable.tsx"
+
 ```
 
 ### With width and breakpoint visibility modifiers
 
 ```ts file="LegacyTableCellWidth.tsx"
+
 ```
 
 ### Controlling text
 
 ```ts file="LegacyTableControllingText.tsx"
+
 ```
 
 ### Modifiers with table text
 
 ```ts file="LegacyTableTextModifiers.tsx"
+
 ```
 
 ### Empty state
 
 ```ts file="LegacyTableEmptyState.tsx"
+
 ```
 
 ### Editable rows
@@ -330,13 +343,13 @@ class EditableRowsTable extends React.Component {
       ],
       rows: [
         {
-          rowEditBtnAriaLabel: idx => `Edit row ${idx}`,
-          rowSaveBtnAriaLabel: idx => `Save edits for row ${idx}`,
-          rowCancelBtnAriaLabel: idx => `Cancel edits for row ${idx}`,
+          rowEditBtnAriaLabel: (idx) => `Edit row ${idx}`,
+          rowSaveBtnAriaLabel: (idx) => `Save edits for row ${idx}`,
+          rowCancelBtnAriaLabel: (idx) => `Cancel edits for row ${idx}`,
           rowEditValidationRules: [
             {
               name: 'required',
-              validator: value => value.trim() !== '',
+              validator: (value) => value.trim() !== '',
               errorText: 'This field is required'
             }
           ],
@@ -537,22 +550,22 @@ class EditableRowsTable extends React.Component {
           rowEditValidationRules: [
             {
               name: 'required',
-              validator: value => value.trim() !== '',
+              validator: (value) => value.trim() !== '',
               errorText: 'This field is required'
             },
             {
               name: 'notFoo',
-              validator: value => value.trim().toLowerCase() !== 'foo',
+              validator: (value) => value.trim().toLowerCase() !== 'foo',
               errorText: 'Value cannot be "foo"'
             },
             {
               name: 'minLength',
-              validator: value => value.trim().length >= 7,
+              validator: (value) => value.trim().length >= 7,
               errorText: 'Value must be at least 7 characters'
             },
             {
               name: 'notXyz',
-              validator: value => value.trim().toLowerCase() !== 'xyz',
+              validator: (value) => value.trim().toLowerCase() !== 'xyz',
               errorText: 'Value cannot be xyz'
             }
           ],
@@ -703,7 +716,7 @@ class EditableRowsTable extends React.Component {
             if (!newSelected.includes(newValue)) {
               newSelected.push(newValue);
             } else {
-              newSelected = newSelected.filter(el => el !== newValue);
+              newSelected = newSelected.filter((el) => el !== newValue);
             }
             newSelectOpen = true;
             break;
@@ -734,7 +747,7 @@ class EditableRowsTable extends React.Component {
     };
 
     this.onToggle = (isOpen, rowIndex, cellIndex) => {
-      console.log("isOpen", isOpen);
+      console.log('isOpen', isOpen);
       let newRows = Array.from(this.state.rows);
       newRows[rowIndex].cells[cellIndex].props.isSelectOpen = isOpen;
       this.setState({
@@ -774,6 +787,7 @@ When you also pass a sort callback through the `onSort` prop, favorites sorting 
 If you want to exclude favorites from sorting, set `canSortFavorites={false}` on the Table.
 
 ```ts file="LegacyTableFavoritable.tsx"
+
 ```
 
 ### Tree table
@@ -803,6 +817,7 @@ aria-posinset, and aria-setsize as violations. This is an intentional choice at 
 the voice over technologies will recognize the flat table structure as a tree.
 
 ```ts file="LegacyTableTree.tsx"
+
 ```
 
 ### Striped
@@ -810,6 +825,7 @@ the voice over technologies will recognize the flat table structure as a tree.
 To apply striping to a basic table, add the `isStriped` property to `Table`.
 
 ```ts file="LegacyTableStriped.tsx"
+
 ```
 
 ### Striped expandable
@@ -817,6 +833,7 @@ To apply striping to a basic table, add the `isStriped` property to `Table`.
 To apply striping to an expandable table, add the `isStriped` and `isExpandable` properties to `Table`.
 
 ```ts file="LegacyTableStripedExpandable.tsx"
+
 ```
 
 ### Striped custom tr
@@ -824,4 +841,5 @@ To apply striping to an expandable table, add the `isStriped` and `isExpandable`
 To manually control striping, use a custom row wrapper that applies the `pf-m-striped` css class for each desired row.
 
 ```ts file="LegacyTableStripedCustomTr.tsx"
+
 ```

--- a/packages/react-table/src/deprecated/components/Table/examples/Table.md
+++ b/packages/react-table/src/deprecated/components/Table/examples/Table.md
@@ -21,7 +21,6 @@ import LeafIcon from '@patternfly/react-icons/dist/esm/icons/leaf-icon';
 import FolderIcon from '@patternfly/react-icons/dist/esm/icons/folder-icon';
 import FolderOpenIcon from '@patternfly/react-icons/dist/esm/icons/folder-open-icon';
 import SortAmountDownIcon from '@patternfly/react-icons/dist/esm/icons/sort-amount-down-icon';
-import { SelectOption as SelectOptionDeprecated } from '@patternfly/react-core/deprecated';
 import {
 Select as NewSelect,
 SelectGroup as NewSelectGroup,
@@ -316,7 +315,6 @@ Example:
 
 ```js
 import React from 'react';
-import { SelectOption as SelectOptionDeprecated } from '@patternfly/react-core/deprecated';
 import {
   Table,
   TableHeader,
@@ -326,7 +324,8 @@ import {
   validateCellEdits,
   applyCellEdits,
   EditableTextCell,
-  EditableSelectInputCell
+  EditableSelectInputCell,
+  SelectOption
 } from '@patternfly/react-table';
 
 class EditableRowsTable extends React.Component {
@@ -413,12 +412,9 @@ class EditableRowsTable extends React.Component {
                   onSelect={this.onSelect}
                   isOpen={props.isSelectOpen}
                   options={props.options.map((option, index) => (
-                    <SelectOptionDeprecated
-                      key={index}
-                      value={option.value}
-                      id={'uniqueIdRow1Cell4Option' + index}
-                      isPlaceholder={option.isPlaceholder}
-                    />
+                    <SelectOption key={index} value={option.value} id={'uniqueIdRow1Cell4Option' + index}>
+                      {option.value}
+                    </SelectOption>
                   ))}
                   onToggle={(event, isOpen) => {
                     this.onToggle(isOpen, rowIndex, cellIndex);
@@ -432,7 +428,6 @@ class EditableRowsTable extends React.Component {
                 isSelectOpen: props.isSelectOpen || false,
                 selected: props.selected || ['Option 1'],
                 options: [
-                  { value: 'Placeholder...', isPlaceholder: true },
                   { value: 'Option 1' },
                   { value: 'Option 2' },
                   { value: 'Option 3' },
@@ -510,12 +505,9 @@ class EditableRowsTable extends React.Component {
                   isOpen={props.isSelectOpen}
                   options={props.options.map((option, index) => {
                     return (
-                      <SelectOptionDeprecated
-                        key={index}
-                        value={option.value}
-                        id={'uniqueIdRow2Cell4Option' + index}
-                        isPlaceholder={option.isPlaceholder}
-                      />
+                      <SelectOption key={index} value={option.value} id={'uniqueIdRow2Cell4Option' + index}>
+                        {option.value}
+                      </SelectOption>
                     );
                   })}
                   onToggle={(event, isOpen) => {
@@ -630,12 +622,9 @@ class EditableRowsTable extends React.Component {
                   clearSelection={this.clearSelection}
                   isOpen={props.isSelectOpen}
                   options={props.options.map((option, index) => (
-                    <SelectOptionDeprecated
-                      key={index}
-                      value={option.value}
-                      id={'uniqueIdRow3Cell4Option' + index}
-                      isPlaceholder={option.isPlaceholder}
-                    />
+                    <SelectOption key={index} value={option.value} id={'uniqueIdRow3Cell4Option' + index}>
+                      {option.value}
+                    </SelectOption>
                   ))}
                   onToggle={(event, isOpen) => {
                     this.onToggle(isOpen, rowIndex, cellIndex);

--- a/packages/react-tokens/README.md
+++ b/packages/react-tokens/README.md
@@ -1,6 +1,6 @@
 # @patternfly/react-tokens
 
-## Installation 
+## Installation
 
 ```bash
 yarn add @patternfly/react-tokens
@@ -32,11 +32,11 @@ import global_BackgroundColor_100 from '@patternfly/react-tokens/dist/esm/global
 - `var`: The property name wrapped in `var()`.
 
 ```js
-import global_BackgroundColor_100 from '@patternfly/react-tokens/dist/esm/global_-background-color_100';
+import global_BackgroundColor_100 from '@patternfly/react-tokens/dist/esm/global_background_color_100';
 
-global_BackgroundColor_100.name === '--pf-v5-global--BackgroundColor--100'; // true
+global_BackgroundColor_100.name === '--pf-t--global--background--color--100'; // true
 global_BackgroundColor_100.value === '#fff'; // true
-global_BackgroundColor_100.var === 'var(--pf-v5-global--BackgroundColor--100)'; // true
+global_BackgroundColor_100.var === 'var(--pf-t--global--background--color--100)'; // true
 ```
 
 [token-page]: https://react-staging.patternfly.org/developer-resources/global-css-variables

--- a/packages/react-tokens/README.md
+++ b/packages/react-tokens/README.md
@@ -32,11 +32,11 @@ import global_BackgroundColor_100 from '@patternfly/react-tokens/dist/esm/global
 - `var`: The property name wrapped in `var()`.
 
 ```js
-import global_BackgroundColor_100 from '@patternfly/react-tokens/dist/esm/global_background_color_100';
+import global_background_color_primary_default from '@patternfly/react-tokens/dist/esm/global_background_color_primary_default';
 
-global_BackgroundColor_100.name === '--pf-t--global--background--color--100'; // true
-global_BackgroundColor_100.value === '#fff'; // true
-global_BackgroundColor_100.var === 'var(--pf-t--global--background--color--100)'; // true
+global_background_color_primary_default.name === '--pf-t--global--background--color--primary--default'; // true
+global_background_color_primary_default.value === '#fff'; // true
+global_background_color_primary_default.var === 'var(--pf-t--global--background--color--primary--default)'; // true
 ```
 
 [token-page]: https://react-staging.patternfly.org/developer-resources/global-css-variables

--- a/packages/react-tokens/README.md
+++ b/packages/react-tokens/README.md
@@ -22,7 +22,7 @@ All Tokens and their corresponding values can be viewed on the
 ## Examples
 
 ```js
-import global_BackgroundColor_100 from '@patternfly/react-tokens/dist/esm/global_-background-color_100';
+import global_background_color_primary_default from '@patternfly/react-tokens/dist/esm/global_background_color_primary_default';
 ```
 
 #### Each token as three properties

--- a/packages/react-tokens/package.json
+++ b/packages/react-tokens/package.json
@@ -29,7 +29,7 @@
     "clean": "rimraf dist"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.0.0-alpha.117",
+    "@patternfly/patternfly": "6.0.0-alpha.135",
     "css": "^2.2.3",
     "fs-extra": "^11.1.1",
     "glob": "^7.1.2",

--- a/packages/react-tokens/tests/react-tokens.test.js
+++ b/packages/react-tokens/tests/react-tokens.test.js
@@ -2,6 +2,6 @@ const reactTokens = require('@patternfly/react-tokens');
 
 // Test importing CJS tokens
 test('CJS token', () => {
-  const { global_palette_green_500: green } = reactTokens;
-  expect(green.value).toBeTruthy();
+  const { color_black: black } = reactTokens;
+  expect(black.value).toBeTruthy();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2827,10 +2827,10 @@
     node-addon-api "^3.2.1"
     node-gyp-build "^4.3.0"
 
-"@patternfly/ast-helpers@^1.4.0-alpha.10":
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/@patternfly/ast-helpers/-/ast-helpers-1.10.1.tgz#b1f048ade6471a5faab51c543bc1e33c68070720"
-  integrity sha512-afWVFF2o8ZWE0+fHX/oxTOG0m9OfECWbz8wHOuvhrReHoTTnqCvpNXEyHSBFa+hsUa1fSj076HYyIDyUhybOdA==
+"@patternfly/ast-helpers@^1.4.0-alpha.17":
+  version "1.15.5"
+  resolved "https://registry.yarnpkg.com/@patternfly/ast-helpers/-/ast-helpers-1.15.5.tgz#f2a81db1f9b36f014384773024e6ed2447562d87"
+  integrity sha512-WZGCLfi50JGl/dr0JqRCsVwndf8AQb8py8EhZaC8FX3DfVDZ5KnfshtrlcKcPX/AuHIAQNAW01wL8SNAb5oeuw==
   dependencies:
     acorn "^8.4.1"
     acorn-class-fields "^1.0.0"
@@ -2838,16 +2838,16 @@
     acorn-static-class-features "^1.0.0"
     astring "^1.7.5"
 
-"@patternfly/documentation-framework@^6.0.0-alpha.21":
-  version "6.0.0-alpha.21"
-  resolved "https://registry.yarnpkg.com/@patternfly/documentation-framework/-/documentation-framework-6.0.0-alpha.21.tgz#8632d12980a450362d11313291b51f4e247b53aa"
-  integrity sha512-j95ACCMvlv0XkKcHP6OadOeKqWOsRspId3jfNuU2UlGrcOVSPZa/ldaxNKZGaUKtJkmxN7LdcslJHH+hKs7+lg==
+"@patternfly/documentation-framework@^6.0.0-alpha.28":
+  version "6.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/@patternfly/documentation-framework/-/documentation-framework-6.0.0-alpha.28.tgz#1f10fd2a164a4fd4d549ca3e3bde83dcb0f6135e"
+  integrity sha512-YPvUQrWYXTdCIMU7EX4IeuWJh3px2Sm1H4geLyRiZZfdp14bn2FB5kC3d2MJlaC06KGLu5ynU1gh8bMmjxGQaQ==
   dependencies:
     "@babel/core" "^7.24.3"
     "@babel/preset-env" "^7.24.3"
     "@babel/preset-react" "^7.24.1"
     "@mdx-js/util" "1.6.16"
-    "@patternfly/ast-helpers" "^1.4.0-alpha.10"
+    "@patternfly/ast-helpers" "^1.4.0-alpha.17"
     "@reach/router" "npm:@gatsbyjs/reach-router@1.3.9"
     autoprefixer "9.8.6"
     babel-loader "^9.1.3"
@@ -2894,7 +2894,7 @@
     style-to-object "0.3.0"
     to-vfile "6.1.0"
     typedoc "0.23.0"
-    typescript "4.3.5"
+    typescript "4.7.4"
     unified "9.1.0"
     unist-util-remove "2.0.0"
     unist-util-visit "2.0.3"
@@ -18290,20 +18290,15 @@ typedoc@0.23.0:
     minimatch "^5.1.0"
     shiki "^0.10.1"
 
-typescript@4.3.5:
-  version "4.3.5"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+typescript@4.7.4, typescript@^4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 "typescript@>=3 < 6":
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
   integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
-
-typescript@^4.7.4:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 typical@^2.6.0, typical@^2.6.1:
   version "2.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2920,10 +2920,10 @@
     puppeteer-cluster "^0.23.0"
     xmldoc "^1.1.2"
 
-"@patternfly/patternfly@6.0.0-alpha.117":
-  version "6.0.0-alpha.117"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-6.0.0-alpha.117.tgz#ae62a787f99085acfecb4422fd1c08cace2fd23a"
-  integrity sha512-AqN09ur+jQXqtu7mf1UD7YmFa9fsbeb3tuyMwxut7P9QW4dvdTkHhFC9zv5eaJ5v7M03vvKKtxteVwPLaDn2zA==
+"@patternfly/patternfly@6.0.0-alpha.135":
+  version "6.0.0-alpha.135"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-6.0.0-alpha.135.tgz#c085ec494b9afba978b971388b78c6923d82d9e0"
+  integrity sha512-e3w5Yh8UWWaIjOvaSCHjZeewK94P0AJtAodf/KweXZET9OyEsDXFb4RhWI5f28HYRbzR6cyRkR+YZY2KYQq0Wg==
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #10314, #10262, #10335

- Updated core version to `alpha.135`
- Updated generateTokens, removing old, unused files it was pulling in to map vars
- Updated Text component suite to use default content classes (#10262)
- Updated Wizard to not use danger token directly & structure update (#10335)
- Added blurb to docs about Text changes
- Removed dropdown styles usage from Menu
- Updated Charts font weight token `global_FontWeight_bold` to `global_font_weight_heading_bold`
- Updated Slider inset token `c_slider__step_Left` to `c_slider__step_InsetInlineStart`
- Updated Td/Th inset tokens `c_table__sticky_cell_Left` and `c_table__sticky_cell_Right` to `c_table__sticky_cell_InsetInlineStart` and `c_table__sticky_cell_InsetInlineEnd`
- Updated Toolbar chip group class (variant prop still uses `chip-group`, but maps to `pf-m-label-group` now)
- Updated Wizard Footer to use ActionList (also for deprecated)
- Updated global height breakpoint token names
- Updated snapshots
- Fixed integration tests
- Updated Table integration demo token `global_primary_color_100` to `global_color_brand_default`
- Fixed Table transformers test referencing dropdown styles to menu styles
- Fixed react-token test, updated old token to new token
