### PR TITLE
fix(DatePicker/CalendarMonth): better range styling when some dates are disabled

### DIFF
--- a/packages/react-core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-core/src/components/DatePicker/DatePicker.tsx
@@ -236,7 +236,12 @@ const DatePickerBase = (
   );
   const focusSelectorForUnselectedDate = createFocusSelectorString(calendarMonthStyles.modifiers.current);
 
-  const getElementToFocus = () => {
+  /**
+   * Returns a CSS selector for a date button element which will receive initial focus after opening calendar popover.
+   * In case of a range picker it returns the end date, if it is selected, start date otherwise.
+   * In case of a normal datepicker it returns the selected date, if present, today otherwise.
+   */
+  const getElementSelectorToFocus = () => {
     if (isValidDate(valueDate) && isValidDate(rangeStart)) {
       return focusSelectorForSelectedEndRangeDate;
     }
@@ -249,7 +254,7 @@ const DatePickerBase = (
   return (
     <div className={css(styles.datePicker, className)} ref={datePickerWrapperRef} style={style} {...props}>
       <Popover
-        elementToFocus={getElementToFocus()}
+        elementToFocus={getElementSelectorToFocus()}
         position="bottom"
         bodyContent={
           <CalendarMonth

--- a/packages/react-core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-core/src/components/DatePicker/DatePicker.tsx
@@ -231,12 +231,25 @@ const DatePickerBase = (
   const createFocusSelectorString = (modifierClass: string) =>
     `.${calendarMonthStyles.calendarMonthDatesCell}.${modifierClass} .${calendarMonthStyles.calendarMonthDate}`;
   const focusSelectorForSelectedDate = createFocusSelectorString(calendarMonthStyles.modifiers.selected);
+  const focusSelectorForSelectedEndRangeDate = createFocusSelectorString(
+    `${calendarMonthStyles.modifiers.selected}.${calendarMonthStyles.modifiers.endRange}`
+  );
   const focusSelectorForUnselectedDate = createFocusSelectorString(calendarMonthStyles.modifiers.current);
+
+  const getElementToFocus = () => {
+    if (isValidDate(valueDate) && isValidDate(rangeStart)) {
+      return focusSelectorForSelectedEndRangeDate;
+    }
+    if (isValidDate(valueDate) || isValidDate(rangeStart)) {
+      return focusSelectorForSelectedDate;
+    }
+    return focusSelectorForUnselectedDate;
+  };
 
   return (
     <div className={css(styles.datePicker, className)} ref={datePickerWrapperRef} style={style} {...props}>
       <Popover
-        elementToFocus={isValidDate(valueDate) ? focusSelectorForSelectedDate : focusSelectorForUnselectedDate}
+        elementToFocus={getElementToFocus()}
         position="bottom"
         bodyContent={
           <CalendarMonth


### PR DESCRIPTION
Closes #9933

- shows styling on a range even if some of the dates of the range (including `rangeStart`) may be disabled with the `validators` prop
- tries to autofocus the `dateProp` first (rangeEnd) over rangeStart. If no dateProp is given, tries to autofocus the `rangeStart` over today

Related to discussion on the working session - I decided **not** to attempt to find a closest focusable date, neither to add the prop to customize which month should be open. It might be useful only in rare use case like having a validator that disables large amount of dates (and it could complicate things more than be useful). - but let me know if it is something we might want to add