### PR TITLE
chore(ci): configure Renovate to bump package versions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "rangeStrategy": "bump",
   "packageRules": [
     {
       "matchUpdateTypes": [


### PR DESCRIPTION
Configures Renovate to [bump](https://docs.renovatebot.com/configuration-options/#rangestrategy) the versions in the package file, instead of only the lockfile, which helps keeps the versions consistent between them.