### PR TITLE
chore(CI): Update stale action to not close things

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-name: Close stale issues and PRs
+name: Mark stale issues and PRs
 on:
   schedule:
     - cron: 37 11 * * *
@@ -9,9 +9,9 @@ jobs:
       - uses: actions/stale@v9
         with:
           days-before-stale: 60
-          days-before-close: 14
+          days-before-close: -1
           exempt-issue-labels: accessibility,breaking change :boom:,security,pinned
-          stale-issue-label: wontfix
+          stale-issue-label: stale
           stale-issue-message: This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs.
           stale-pr-message: This PR has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs.
           close-issue-message: 'This issue has been closed because it has not had activity since being marked as stale.'

--- a/.github/workflows/triage-stale-issues.yml
+++ b/.github/workflows/triage-stale-issues.yml
@@ -1,0 +1,18 @@
+name: Move stale issues back to triage
+on:
+  issues:
+    types:
+      - labeled
+jobs:
+  update-status:
+    if: github.event.label.name == 'stale'
+    runs-on: ubuntu-latest
+    steps:
+        - uses: github/update-project-action@v3
+          with:
+            github_token: ${{ secrets.GH_PROJECTS }}
+            organization: patternfly
+            project_number: 7
+            content_id: ${{ github.event.client_payload.command.resource.id }}
+            field: Status
+            value: Needs triage


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Towards #10525 

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:

What I know this PR should do (assuming the stale actions docs are accurate):
- Change the stale label to `stale` instead of `wontfix`
- Stop PRs and issues from being closed due to being stale

What I think it should also do (this wasn't supported by stale action so I had to DIY it):
- Update the status back to `Needs triage` in the project board so that it can be re-prioritized