### PR TITLE
chore(deps): replace `camel-case` with `camelcase`

### DIFF
--- a/packages/react-styles/package.json
+++ b/packages/react-styles/package.json
@@ -14,12 +14,12 @@
     "access": "public"
   },
   "scripts": {
-    "generate": "rimraf css && node scripts/writeClassMaps.js && node scripts/copyStyles.js",
+    "generate": "rimraf css && node scripts/writeClassMaps.mjs && node scripts/copyStyles.mjs",
     "clean": "rimraf dist css"
   },
   "devDependencies": {
     "@patternfly/patternfly": "5.4.0-prerelease.3",
-    "camel-case": "^3.0.0",
+    "camelcase": "^8.0.0",
     "css": "^2.2.4",
     "fs-extra": "^11.2.0",
     "jsdom": "^15.2.1"

--- a/packages/react-styles/scripts/copyStyles.js
+++ b/packages/react-styles/scripts/copyStyles.js
@@ -1,7 +1,0 @@
-const { copySync } = require('fs-extra');
-const { resolve, dirname, join } = require('path');
-
-const toDir = resolve(__dirname, '../css');
-const fromDir = dirname(require.resolve('@patternfly/patternfly/package.json'));
-
-copySync(join(fromDir, 'assets/images'), join(toDir, 'assets/images'));

--- a/packages/react-styles/scripts/copyStyles.mjs
+++ b/packages/react-styles/scripts/copyStyles.mjs
@@ -1,0 +1,8 @@
+import { copySync } from 'fs-extra/esm';
+import path from 'node:path';
+import url from 'node:url';
+
+const toDir = path.resolve(import.meta.dirname, '../css');
+const fromDir = path.dirname(url.fileURLToPath(import.meta.resolve('@patternfly/patternfly/package.json')));
+
+copySync(path.join(fromDir, 'assets/images'), path.join(toDir, 'assets/images'));

--- a/packages/react-styles/scripts/generateClassMaps.mjs
+++ b/packages/react-styles/scripts/generateClassMaps.mjs
@@ -1,7 +1,8 @@
-const path = require('path');
-const fs = require('fs-extra');
-const { glob } = require('glob');
-const camelcase = require('camel-case');
+import camelCase from 'camelcase';
+import { glob } from 'glob';
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
 
 /**
  * @param {string} cssString - CSS string
@@ -14,7 +15,7 @@ function getCSSClasses(cssString) {
  * @param {string} className - Class name
  */
 function formatClassName(className) {
-  return camelcase(className.replace(/pf-(v5-)?((c|l|m|u|is|has)-)?/g, ''));
+  return camelCase(className.replace(/pf-(v5-)?((c|l|m|u|is|has)-)?/g, ''));
 }
 
 /**
@@ -53,8 +54,8 @@ function getClassMaps(cssString) {
 /**
  * @returns {any} Map of file names to classMaps
  */
-function generateClassMaps() {
-  const pfStylesDir = path.dirname(require.resolve('@patternfly/patternfly/patternfly.css'));
+export function generateClassMaps() {
+  const pfStylesDir = path.dirname(url.fileURLToPath(import.meta.resolve('@patternfly/patternfly/patternfly.css')));
 
   const patternflyCSSFiles = glob.sync('**/*.css', {
     cwd: pfStylesDir,
@@ -73,7 +74,3 @@ function generateClassMaps() {
 
   return res;
 }
-
-module.exports = {
-  generateClassMaps
-};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3270,7 +3270,7 @@ __metadata:
   resolution: "@patternfly/react-styles@workspace:packages/react-styles"
   dependencies:
     "@patternfly/patternfly": "npm:5.4.0-prerelease.3"
-    camel-case: "npm:^3.0.0"
+    camelcase: "npm:^8.0.0"
     css: "npm:^2.2.4"
     fs-extra: "npm:^11.2.0"
     jsdom: "npm:^15.2.1"
@@ -6483,16 +6483,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"camel-case@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "camel-case@npm:3.0.0"
-  dependencies:
-    no-case: "npm:^2.2.0"
-    upper-case: "npm:^1.1.1"
-  checksum: 10c0/491c6bbf986b9d8355e12cca6beb719b44c2fe96e8526c09958a1b4e0dbb081a82ea59c13b5a6ccf9158ce5979cbe56a8a10d7322bfeed2d84725c6b89d8f934
-  languageName: node
-  linkType: hard
-
 "camel-case@npm:^4.1.2":
   version: 4.1.2
   resolution: "camel-case@npm:4.1.2"
@@ -6539,6 +6529,13 @@ __metadata:
   version: 6.3.0
   resolution: "camelcase@npm:6.3.0"
   checksum: 10c0/0d701658219bd3116d12da3eab31acddb3f9440790c0792e0d398f0a520a6a4058018e546862b6fba89d7ae990efaeb97da71e1913e9ebf5a8b5621a3d55c710
+  languageName: node
+  linkType: hard
+
+"camelcase@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "camelcase@npm:8.0.0"
+  checksum: 10c0/56c5fe072f0523c9908cdaac21d4a3b3fb0f608fb2e9ba90a60e792b95dd3bb3d1f3523873ab17d86d146e94171305f73ef619e2f538bd759675bc4a14b4bff3
   languageName: node
   linkType: hard
 
@@ -14350,13 +14347,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lower-case@npm:^1.1.1":
-  version: 1.1.4
-  resolution: "lower-case@npm:1.1.4"
-  checksum: 10c0/2153ae5490d655a63addc8e7d2f848c6c94803b342ed2d177f75e8073e9fbb50a733d1432c82e1cb8425fa6eae14b2877bf5bbdcb93ab93bb982fb5c3962c57b
-  languageName: node
-  linkType: hard
-
 "lower-case@npm:^2.0.2":
   version: 2.0.2
   resolution: "lower-case@npm:2.0.2"
@@ -15336,15 +15326,6 @@ __metadata:
   version: 0.1.4
   resolution: "netrc@npm:0.1.4"
   checksum: 10c0/899319db24c69c127771eaf24b74c3d68011c2736009ce6d75d4b1028e7ea3ac278e6af992602b937f364298fbefb7c74aaa749fa837e67b77a085430e19207c
-  languageName: node
-  linkType: hard
-
-"no-case@npm:^2.2.0":
-  version: 2.3.2
-  resolution: "no-case@npm:2.3.2"
-  dependencies:
-    lower-case: "npm:^1.1.1"
-  checksum: 10c0/63f306e83c18efa0bb37f1c23a25baf4ccf5ebaec70b482fa04d4c5bf8bbb8bcc9a8fbcd818af828ab69f2b602153daf81ec26e448b2bda2d704b8d0c7eec8fa
   languageName: node
   linkType: hard
 
@@ -21093,13 +21074,6 @@ __metadata:
   dependencies:
     tslib: "npm:^2.0.3"
   checksum: 10c0/ccad6a0b143310ebfba2b5841f30bef71246297385f1329c022c902b2b5fc5aee009faf1ac9da5ab3ba7f615b88f5dc1cd80461b18a8f38cb1d4c3eb92538ea9
-  languageName: node
-  linkType: hard
-
-"upper-case@npm:^1.1.1":
-  version: 1.1.3
-  resolution: "upper-case@npm:1.1.3"
-  checksum: 10c0/3e4d3a90519915bb591db84d72610392518806d8287b8f7541d87642d30388f42b2def1ed2f687e5792ee025e8f7e17d3a0dcbd5b3b59e306ceb1f3b8121ef54
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Replaces [`camel-case`](https://www.npmjs.com/package/camel-case) (which is deprecated) with [`camelcase`](https://www.npmjs.com/package/camelcase), and converts all the `react-styles` scripts to ESM.