### PR TITLE
fix: limit depth of Yarn workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,8 @@
   },
   "workspaces": {
     "packages": [
-      "packages/**"
+      "packages/*",
+      "packages/react-integration/demo-app-ts"
     ]
   }
 }


### PR DESCRIPTION
Limits the depth of the Yarn workspaces to one level to prevent `package.json` files in the distribution from being picked up.