### PR TITLE
fix(Wizard): allow dynamic step update

### DIFF
--- a/packages/react-core/src/components/Wizard/Wizard.tsx
+++ b/packages/react-core/src/components/Wizard/Wizard.tsx
@@ -91,6 +91,11 @@ export const Wizard = ({
     }
   }, [startIndex]);
 
+  // When children change, active step index should reset
+  React.useEffect(() => {
+    setActiveStepIndex(startIndex);
+  }, [children, startIndex]);
+
   const focusMainContentElement = () =>
     setTimeout(() => {
       wrapperRef?.current?.focus && wrapperRef.current.focus();

--- a/packages/react-core/src/components/Wizard/WizardContext.tsx
+++ b/packages/react-core/src/components/Wizard/WizardContext.tsx
@@ -74,6 +74,11 @@ export const WizardContextProvider: React.FunctionComponent<WizardContextProvide
   const [currentSteps, setCurrentSteps] = React.useState<WizardStepType[]>(initialSteps);
   const [currentFooter, setCurrentFooter] = React.useState<WizardFooterType>();
 
+  // Callback to update steps if they change after initial render
+  React.useEffect(() => {
+    setCurrentSteps(initialSteps);
+  }, [initialSteps]);
+
   // Combined initial and current state steps
   const steps = React.useMemo(
     () =>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #9752

Adds two useEffect blocks to update steps when the initial children change, and reset the active step index when the children change.

This [codesandbox](https://codesandbox.io/s/competent-fire-dd3vgr?file=/index.tsx) from the issue can be pasted into one of our Wizard examples to verify the fix.