### PR TITLE
feat(MultiTypeaheadSelect): Add MultiTypeaheadSelect to react-templates

### DIFF
--- a/packages/react-templates/src/components/Select/MultiTypeaheadSelect.tsx
+++ b/packages/react-templates/src/components/Select/MultiTypeaheadSelect.tsx
@@ -144,7 +144,7 @@ export const MultiTypeaheadSelectBase: React.FunctionComponent<MultiTypeaheadSel
     _event: React.MouseEvent<Element, MouseEvent> | React.KeyboardEvent<HTMLInputElement> | undefined,
     option: string | number
   ) => {
-    const selections = selected.includes(option) ? selected.filter((o) => option === o) : [...selected, option];
+    const selections = selected.includes(option) ? selected.filter((o) => option !== o) : [...selected, option];
 
     onSelectionChange && onSelectionChange(_event, selections);
     setSelected(selections);

--- a/packages/react-templates/src/components/Select/MultiTypeaheadSelect.tsx
+++ b/packages/react-templates/src/components/Select/MultiTypeaheadSelect.tsx
@@ -1,0 +1,348 @@
+import React from 'react';
+import {
+  Select,
+  SelectOption,
+  SelectList,
+  SelectOptionProps,
+  MenuToggle,
+  MenuToggleElement,
+  TextInputGroup,
+  TextInputGroupMain,
+  TextInputGroupUtilities,
+  Button,
+  MenuToggleProps,
+  SelectProps,
+  ChipGroup,
+  Chip
+} from '@patternfly/react-core';
+import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+
+export interface MultiTypeaheadSelectOption extends Omit<SelectOptionProps, 'content'> {
+  /** Content of the select option. */
+  content: string | number;
+  /** Value of the select option. */
+  value: string | number;
+}
+
+export interface MultiTypeaheadSelectProps extends Omit<SelectProps, 'toggle' | 'onSelect'> {
+  /** @hide Forwarded ref */
+  innerRef?: React.Ref<any>;
+  /** Initial options of the select. */
+  initialOptions: MultiTypeaheadSelectOption[];
+  /** Callback triggered on selection. */
+  onSelectionChange?: (
+    _event: React.MouseEvent<Element, MouseEvent> | React.KeyboardEvent<HTMLInputElement>,
+    selections: (string | number)[]
+  ) => void;
+  /** Callback triggered when the select opens or closes. */
+  onToggle?: (nextIsOpen: boolean) => void;
+  /** Callback triggered when the text in the input field changes. */
+  onInputChange?: (newValue: string) => void;
+  /** Placeholder text for the select input. */
+  placeholder?: string;
+  /** Message to display when no options match the filter. */
+  noOptionsFoundMessage?: string | ((filter: string) => string);
+  /** Flag indicating the select should be disabled. */
+  isDisabled?: boolean;
+  /** Width of the toggle. */
+  toggleWidth?: string;
+  /** Additional props passed to the toggle. */
+  toggleProps?: MenuToggleProps;
+}
+
+export const MultiTypeaheadSelectBase: React.FunctionComponent<MultiTypeaheadSelectProps> = ({
+  innerRef,
+  initialOptions,
+  onSelectionChange,
+  onToggle,
+  onInputChange,
+  placeholder = 'Select an option',
+  noOptionsFoundMessage = (filter) => `No results found for "${filter}"`,
+  isDisabled,
+  toggleWidth,
+  toggleProps,
+  ...props
+}: MultiTypeaheadSelectProps) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [selected, setSelected] = React.useState<(string | number)[]>(
+    (initialOptions?.filter((o) => o.selected) ?? []).map((o) => o.value)
+  );
+  const [inputValue, setInputValue] = React.useState<string>();
+  const [selectOptions, setSelectOptions] = React.useState<MultiTypeaheadSelectOption[]>(initialOptions);
+  const [focusedItemIndex, setFocusedItemIndex] = React.useState<number | null>(null);
+  const [activeItemId, setActiveItemId] = React.useState<string | null>(null);
+  const textInputRef = React.useRef<HTMLInputElement>();
+
+  const NO_RESULTS = 'no results';
+
+  const openMenu = () => {
+    onToggle && onToggle(true);
+    setIsOpen(true);
+  };
+
+  React.useEffect(() => {
+    let newSelectOptions: MultiTypeaheadSelectOption[] = initialOptions;
+
+    // Filter menu items based on the text input value when one exists
+    if (inputValue) {
+      newSelectOptions = initialOptions.filter((option) =>
+        String(option.content).toLowerCase().includes(inputValue.toLowerCase())
+      );
+
+      // When no options are found after filtering, display 'No results found'
+      if (!newSelectOptions.length) {
+        newSelectOptions = [
+          {
+            isAriaDisabled: true,
+            content:
+              typeof noOptionsFoundMessage === 'string' ? noOptionsFoundMessage : noOptionsFoundMessage(inputValue),
+            value: NO_RESULTS
+          }
+        ];
+      }
+
+      // Open the menu when the input value changes and the new value is not empty
+      openMenu();
+    }
+
+    setSelectOptions(newSelectOptions);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inputValue, initialOptions]);
+
+  React.useEffect(
+    () => setSelected((initialOptions?.filter((o) => o.selected) ?? []).map((o) => o.value)),
+    [initialOptions]
+  );
+
+  const setActiveAndFocusedItem = (itemIndex: number) => {
+    setFocusedItemIndex(itemIndex);
+    const focusedItem = selectOptions[itemIndex];
+    setActiveItemId(focusedItem.value as string);
+  };
+
+  const resetActiveAndFocusedItem = () => {
+    setFocusedItemIndex(null);
+    setActiveItemId(null);
+  };
+
+  const closeMenu = () => {
+    onToggle && onToggle(false);
+    setIsOpen(false);
+    resetActiveAndFocusedItem();
+    setInputValue('');
+  };
+
+  const onInputClick = () => {
+    if (!isOpen) {
+      openMenu();
+    } else if (!inputValue) {
+      closeMenu();
+    }
+  };
+
+  const selectOption = (
+    _event: React.MouseEvent<Element, MouseEvent> | React.KeyboardEvent<HTMLInputElement> | undefined,
+    option: string | number
+  ) => {
+    const selections = selected.includes(option) ? selected.filter((o) => option === o) : [...selected, option];
+
+    onSelectionChange && onSelectionChange(_event, selections);
+    setSelected(selections);
+  };
+
+  const clearOption = (
+    _event: React.MouseEvent<Element, MouseEvent> | React.KeyboardEvent<HTMLInputElement> | undefined,
+    option: string | number
+  ) => {
+    const selections = selected.filter((o) => option !== o);
+    onSelectionChange && onSelectionChange(_event, selections);
+    setSelected(selections);
+  };
+
+  const _onSelect = (_event: React.MouseEvent<Element, MouseEvent> | undefined, value: string | number | undefined) => {
+    if (value && value !== NO_RESULTS) {
+      selectOption(_event, value);
+    }
+  };
+
+  const onTextInputChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => {
+    setInputValue(value);
+    onInputChange && onInputChange(value);
+
+    resetActiveAndFocusedItem();
+  };
+
+  const handleMenuArrowKeys = (key: string) => {
+    let indexToFocus = 0;
+
+    if (!isOpen) {
+      openMenu();
+    }
+
+    if (selectOptions.every((option) => option.isDisabled)) {
+      return;
+    }
+
+    if (key === 'ArrowUp') {
+      // When no index is set or at the first index, focus to the last, otherwise decrement focus index
+      if (focusedItemIndex === null || focusedItemIndex === 0) {
+        indexToFocus = selectOptions.length - 1;
+      } else {
+        indexToFocus = focusedItemIndex - 1;
+      }
+
+      // Skip disabled options
+      while (selectOptions[indexToFocus].isDisabled) {
+        indexToFocus--;
+        if (indexToFocus === -1) {
+          indexToFocus = selectOptions.length - 1;
+        }
+      }
+    }
+
+    if (key === 'ArrowDown') {
+      // When no index is set or at the last index, focus to the first, otherwise increment focus index
+      if (focusedItemIndex === null || focusedItemIndex === selectOptions.length - 1) {
+        indexToFocus = 0;
+      } else {
+        indexToFocus = focusedItemIndex + 1;
+      }
+
+      // Skip disabled options
+      while (selectOptions[indexToFocus].isDisabled) {
+        indexToFocus++;
+        if (indexToFocus === selectOptions.length) {
+          indexToFocus = 0;
+        }
+      }
+    }
+
+    setActiveAndFocusedItem(indexToFocus);
+  };
+
+  const onInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    const focusedItem = focusedItemIndex !== null ? selectOptions[focusedItemIndex] : null;
+
+    switch (event.key) {
+      case 'Enter':
+        if (isOpen && focusedItem && focusedItem.value !== NO_RESULTS && !focusedItem.isAriaDisabled) {
+          selectOption(event, focusedItem?.value);
+        }
+
+        if (!isOpen) {
+          onToggle && onToggle(true);
+          setIsOpen(true);
+        }
+
+        break;
+      case 'ArrowUp':
+      case 'ArrowDown':
+        event.preventDefault();
+        handleMenuArrowKeys(event.key);
+        break;
+    }
+  };
+
+  const onToggleClick = () => {
+    onToggle && onToggle(!isOpen);
+    setIsOpen(!isOpen);
+    textInputRef?.current?.focus();
+  };
+
+  const onClearButtonClick = (ev: React.MouseEvent) => {
+    setSelected([]);
+    onInputChange && onInputChange('');
+    resetActiveAndFocusedItem();
+    textInputRef?.current?.focus();
+    onSelectionChange && onSelectionChange(ev, []);
+  };
+
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      ref={toggleRef}
+      variant="typeahead"
+      aria-label="Multi select Typeahead menu toggle"
+      onClick={onToggleClick}
+      isExpanded={isOpen}
+      isDisabled={isDisabled}
+      isFullWidth
+      style={
+        {
+          width: toggleWidth
+        } as React.CSSProperties
+      }
+      {...toggleProps}
+    >
+      <TextInputGroup isPlain>
+        <TextInputGroupMain
+          value={inputValue}
+          onClick={onInputClick}
+          onChange={onTextInputChange}
+          onKeyDown={onInputKeyDown}
+          autoComplete="off"
+          innerRef={textInputRef}
+          placeholder={placeholder}
+          {...(activeItemId && { 'aria-activedescendant': activeItemId })}
+          role="combobox"
+          isExpanded={isOpen}
+          aria-controls="select-typeahead-listbox"
+        >
+          <ChipGroup aria-label="Current selections">
+            {selected.map((selection, index) => (
+              <Chip
+                key={index}
+                datatest-id={`${selection}-chip`}
+                onClick={(ev) => {
+                  ev.stopPropagation();
+                  clearOption(ev, selection);
+                }}
+              >
+                {initialOptions.find((o) => o.value === selection)?.content}
+              </Chip>
+            ))}
+          </ChipGroup>
+        </TextInputGroupMain>
+        <TextInputGroupUtilities {...(selected.length === 0 ? { style: { display: 'none' } } : {})}>
+          <Button variant="plain" onClick={onClearButtonClick} aria-label="Clear input value">
+            <TimesIcon aria-hidden />
+          </Button>
+        </TextInputGroupUtilities>
+      </TextInputGroup>
+    </MenuToggle>
+  );
+
+  return (
+    <Select
+      isOpen={isOpen}
+      selected={selected}
+      onSelect={_onSelect}
+      onOpenChange={(isOpen) => {
+        !isOpen && closeMenu();
+      }}
+      toggle={toggle}
+      shouldFocusFirstItemOnOpen={false}
+      ref={innerRef}
+      {...props}
+    >
+      <SelectList>
+        {selectOptions.map((option, index) => {
+          const { content, value, ...props } = option;
+
+          return (
+            <SelectOption key={value} value={value} isFocused={focusedItemIndex === index} {...props}>
+              {content}
+            </SelectOption>
+          );
+        })}
+      </SelectList>
+    </Select>
+  );
+};
+
+MultiTypeaheadSelectBase.displayName = 'MultiTypeaheadSelectBase';
+
+export const MultiTypeaheadSelect = React.forwardRef((props: MultiTypeaheadSelectProps, ref: React.Ref<any>) => (
+  <MultiTypeaheadSelectBase {...props} innerRef={ref} />
+));
+
+MultiTypeaheadSelect.displayName = 'MultiTypeaheadSelect';

--- a/packages/react-templates/src/components/Select/__tests__/MultiTypeaheadSelect.test.tsx
+++ b/packages/react-templates/src/components/Select/__tests__/MultiTypeaheadSelect.test.tsx
@@ -1,0 +1,414 @@
+import * as React from 'react';
+import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MultiTypeaheadSelect } from '../MultiTypeaheadSelect';
+import styles from '@patternfly/react-styles/css/components/Menu/menu';
+
+const getToggle = () => screen.getByRole('button', { name: 'Multi select Typeahead menu toggle' });
+
+describe('MultiTypeaheadSelect', () => {
+  it('renders MultiTypeaheadSelect with options', async () => {
+    const initialOptions = [
+      { content: 'Option 1', value: 'option1' },
+      { content: 'Option 2', value: 'option2' },
+      { content: 'Option 3', value: 'option3' }
+    ];
+
+    const user = userEvent.setup();
+
+    render(<MultiTypeaheadSelect initialOptions={initialOptions} />);
+
+    const toggle = getToggle();
+
+    await user.click(toggle);
+
+    const option1 = screen.getByText('Option 1');
+    const option2 = screen.getByText('Option 2');
+    const option3 = screen.getByText('Option 3');
+
+    expect(option1).toBeInTheDocument();
+    expect(option2).toBeInTheDocument();
+    expect(option3).toBeInTheDocument();
+  });
+
+  it('selects options when clicked', async () => {
+    const initialOptions = [
+      { content: 'Option 1', value: 'option1' },
+      { content: 'Option 2', value: 'option2' },
+      { content: 'Option 3', value: 'option3' }
+    ];
+
+    const user = userEvent.setup();
+
+    render(<MultiTypeaheadSelect initialOptions={initialOptions} />);
+
+    const toggle = getToggle();
+
+    await user.click(toggle);
+
+    const option1 = screen.getByRole('option', { name: 'Option 1' });
+
+    expect(option1).not.toHaveClass(styles.modifiers.selected);
+
+    await user.click(option1);
+
+    expect(option1).toHaveClass(styles.modifiers.selected);
+  });
+
+  it('calls the onSelectionChange callback with the selected value when an option is selected', async () => {
+    const initialOptions = [
+      { content: 'Option 1', value: 'option1' },
+      { content: 'Option 2', value: 'option2' },
+      { content: 'Option 3', value: 'option3' }
+    ];
+
+    const user = userEvent.setup();
+    const onSelectionChangeMock = jest.fn();
+
+    render(<MultiTypeaheadSelect initialOptions={initialOptions} onSelect={onSelectionChangeMock} />);
+
+    const toggle = getToggle();
+
+    await user.click(toggle);
+
+    expect(onSelectionChangeMock).not.toHaveBeenCalled();
+
+    const option1 = screen.getByRole('option', { name: 'Option 1' });
+
+    await user.click(option1);
+
+    expect(onSelectionChangeMock).toHaveBeenCalledTimes(1);
+    expect(onSelectionChangeMock).toHaveBeenCalledWith(expect.anything(), 'option1');
+  });
+
+  it('deselects options when clear button is clicked', async () => {
+    const initialOptions = [
+      { content: 'Option 1', value: 'option1' },
+      { content: 'Option 2', value: 'option2' },
+      { content: 'Option 3', value: 'option3' }
+    ];
+
+    const user = userEvent.setup();
+
+    render(<MultiTypeaheadSelect initialOptions={initialOptions} />);
+
+    const toggle = getToggle();
+
+    await user.click(toggle);
+
+    const option1 = screen.getByRole('option', { name: 'Option 1' });
+    await user.click(option1);
+    expect(option1).toHaveClass(styles.modifiers.selected);
+
+    const input = screen.getByRole('combobox');
+
+    const clearButton = screen.getByRole('button', { name: 'Clear input value' });
+    await user.click(clearButton);
+
+    expect(input).toHaveValue('');
+
+    await user.click(toggle);
+    expect(screen.getByRole('option', { name: 'Option 1' })).not.toHaveClass(styles.modifiers.selected);
+  });
+
+  it('toggles the select menu when the toggle button is clicked', async () => {
+    const initialOptions = [
+      { content: 'Option 1', value: 'option1' },
+      { content: 'Option 2', value: 'option2' },
+      { content: 'Option 3', value: 'option3' }
+    ];
+
+    const user = userEvent.setup();
+
+    render(<MultiTypeaheadSelect initialOptions={initialOptions} />);
+
+    const toggle = getToggle();
+
+    await user.click(toggle);
+
+    const menu = screen.getByRole('listbox');
+    expect(menu).toBeInTheDocument();
+
+    await user.click(toggle);
+
+    await waitForElementToBeRemoved(menu);
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('calls the onToggle callback when the toggle is clicked', async () => {
+    const initialOptions = [
+      { content: 'Option 1', value: 'option1' },
+      { content: 'Option 2', value: 'option2' },
+      { content: 'Option 3', value: 'option3' }
+    ];
+
+    const user = userEvent.setup();
+    const onToggleMock = jest.fn();
+
+    render(<MultiTypeaheadSelect initialOptions={initialOptions} onToggle={onToggleMock} />);
+
+    const toggle = getToggle();
+
+    expect(onToggleMock).not.toHaveBeenCalled();
+
+    await user.click(toggle);
+
+    expect(onToggleMock).toHaveBeenCalledTimes(1);
+    expect(onToggleMock).toHaveBeenCalledWith(true);
+
+    await user.click(toggle);
+
+    expect(onToggleMock).toHaveBeenCalledTimes(2);
+    expect(onToggleMock).toHaveBeenCalledWith(false);
+  });
+
+  it('Passes toggleWidth', () => {
+    const initialOptions = [
+      { content: 'Option 1', value: 'option1' },
+      { content: 'Option 2', value: 'option2' },
+      { content: 'Option 3', value: 'option3' }
+    ];
+
+    render(<MultiTypeaheadSelect initialOptions={initialOptions} toggleWidth="500px" />);
+
+    const toggle = getToggle();
+    expect(toggle.parentElement).toHaveAttribute('style', 'width: 500px;');
+  });
+
+  it('Passes additional toggleProps', () => {
+    const initialOptions = [
+      { content: 'Option 1', value: 'option1' },
+      { content: 'Option 2', value: 'option2' },
+      { content: 'Option 3', value: 'option3' }
+    ];
+
+    render(<MultiTypeaheadSelect initialOptions={initialOptions} toggleProps={{ id: 'toggle' }} />);
+
+    const toggle = getToggle();
+    expect(toggle.parentElement).toHaveAttribute('id', 'toggle');
+  });
+
+  it('passes custom placeholder text', async () => {
+    const initialOptions = [
+      { content: 'Option 1', value: 'option1' },
+      { content: 'Option 2', value: 'option2' },
+      { content: 'Option 3', value: 'option3' }
+    ];
+
+    render(<MultiTypeaheadSelect initialOptions={initialOptions} placeholder="custom" />);
+
+    const input = screen.getByRole('combobox');
+
+    expect(input).toHaveAttribute('placeholder', 'custom');
+  });
+
+  it('displays noOptionsFoundMessage when filter returns no results', async () => {
+    const initialOptions = [
+      { content: 'Option 1', value: 'option1' },
+      { content: 'Option 2', value: 'option2' },
+      { content: 'Option 3', value: 'option3' }
+    ];
+    const user = userEvent.setup();
+
+    render(<MultiTypeaheadSelect initialOptions={initialOptions} />);
+
+    const toggle = getToggle();
+    const input = screen.getByRole('combobox');
+
+    expect(input).toHaveAttribute('placeholder', 'Select an option');
+
+    await user.click(toggle);
+
+    const option1 = screen.getByRole('option', { name: 'Option 1' });
+    const option2 = screen.getByRole('option', { name: 'Option 2' });
+    const option3 = screen.getByRole('option', { name: 'Option 3' });
+
+    expect(option1).toBeInTheDocument();
+    expect(option2).toBeInTheDocument();
+    expect(option3).toBeInTheDocument();
+
+    await user.type(input, '9');
+    expect(input).toHaveValue('9');
+
+    expect(option1).not.toBeInTheDocument();
+    expect(option2).not.toBeInTheDocument();
+    expect(option3).not.toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'No results found for "9"' })).toBeInTheDocument();
+  });
+
+  it('displays custom noOptionsFoundMessage', async () => {
+    const initialOptions = [
+      { content: 'Option 1', value: 'option1' },
+      { content: 'Option 2', value: 'option2' },
+      { content: 'Option 3', value: 'option3' }
+    ];
+    const user = userEvent.setup();
+
+    render(<MultiTypeaheadSelect initialOptions={initialOptions} noOptionsFoundMessage="custom" />);
+
+    const toggle = getToggle();
+    const input = screen.getByRole('combobox');
+
+    expect(input).toHaveAttribute('placeholder', 'Select an option');
+
+    await user.click(toggle);
+
+    const option1 = screen.getByRole('option', { name: 'Option 1' });
+    const option2 = screen.getByRole('option', { name: 'Option 2' });
+    const option3 = screen.getByRole('option', { name: 'Option 3' });
+
+    expect(option1).toBeInTheDocument();
+    expect(option2).toBeInTheDocument();
+    expect(option3).toBeInTheDocument();
+
+    await user.type(input, '9');
+    expect(input).toHaveValue('9');
+
+    expect(option1).not.toBeInTheDocument();
+    expect(option2).not.toBeInTheDocument();
+    expect(option3).not.toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'custom' })).toBeInTheDocument();
+  });
+
+  it('disables the select when isDisabled prop is true', async () => {
+    const initialOptions = [
+      { content: 'Option 1', value: 'option1' },
+      { content: 'Option 2', value: 'option2' },
+      { content: 'Option 3', value: 'option3' }
+    ];
+
+    const user = userEvent.setup();
+
+    render(<MultiTypeaheadSelect initialOptions={initialOptions} isDisabled={true} />);
+
+    const toggle = getToggle();
+
+    expect(toggle.parentElement).toHaveClass(styles.modifiers.disabled);
+
+    await user.click(toggle);
+
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('passes other SelectOption props to the SelectOption component', async () => {
+    const initialOptions = [{ content: 'Option 1', value: 'option1', isDisabled: true }];
+
+    const user = userEvent.setup();
+
+    render(<MultiTypeaheadSelect initialOptions={initialOptions} />);
+
+    const toggle = getToggle();
+
+    await user.click(toggle);
+
+    const option1 = screen.getByRole('option', { name: 'Option 1' });
+    expect(option1).toBeDisabled();
+  });
+
+  it('displays the option in chip when option is selected', async () => {
+    const initialOptions = [
+      { content: 'Option 1', value: 'option1' },
+      { content: 'Option 2', value: 'option2' },
+      { content: 'Option 3', value: 'option3' }
+    ];
+
+    const user = userEvent.setup();
+
+    render(<MultiTypeaheadSelect initialOptions={initialOptions} />);
+
+    const toggle = getToggle();
+    const input = screen.getByRole('combobox');
+
+    expect(input).toHaveAttribute('placeholder', 'Select an option');
+
+    await user.click(toggle);
+
+    const option1 = screen.getByRole('option', { name: 'Option 1' });
+
+    await user.click(option1);
+
+    await user.click(toggle);
+
+    // TODO: How to find the chips?
+
+    const clearButton = screen.getByRole('button', { name: 'Clear input value' });
+    await user.click(clearButton);
+
+    // TODO: How to find the chips?
+  });
+
+  it('typing in input filters options', async () => {
+    const initialOptions = [
+      { content: 'Option 1', value: 'option1' },
+      { content: 'Option 2', value: 'option2' },
+      { content: 'Option 3', value: 'option3' }
+    ];
+
+    const user = userEvent.setup();
+
+    render(<MultiTypeaheadSelect initialOptions={initialOptions} />);
+
+    const toggle = getToggle();
+    const input = screen.getByRole('combobox');
+
+    expect(input).toHaveAttribute('placeholder', 'Select an option');
+
+    await user.click(toggle);
+
+    const option1 = screen.getByRole('option', { name: 'Option 1' });
+    const option2 = screen.getByRole('option', { name: 'Option 2' });
+    const option3 = screen.getByRole('option', { name: 'Option 3' });
+
+    expect(option1).toBeInTheDocument();
+    expect(option2).toBeInTheDocument();
+    expect(option3).toBeInTheDocument();
+
+    await user.type(input, '1');
+    expect(input).toHaveValue('1');
+
+    expect(option1).toBeInTheDocument();
+    expect(option2).not.toBeInTheDocument();
+    expect(option3).not.toBeInTheDocument();
+  });
+
+  it('typing in input triggers onInputChange callback', async () => {
+    const initialOptions = [
+      { content: 'Option 1', value: 'option1' },
+      { content: 'Option 2', value: 'option2' },
+      { content: 'Option 3', value: 'option3' }
+    ];
+
+    const user = userEvent.setup();
+    const onInputChangeMock = jest.fn();
+
+    render(<MultiTypeaheadSelect initialOptions={initialOptions} onInputChange={onInputChangeMock} />);
+
+    const input = screen.getByRole('combobox');
+
+    expect(input).toHaveAttribute('placeholder', 'Select an option');
+
+    await user.type(input, '1');
+
+    expect(input).toHaveValue('1');
+    expect(onInputChangeMock).toHaveBeenCalledTimes(1);
+    expect(onInputChangeMock).toHaveBeenCalledWith('1');
+  });
+
+  it('Matches snapshot', async () => {
+    const initialOptions = [
+      { content: 'Option 1', value: 'option1' },
+      { content: 'Option 2', value: 'option2' },
+      { content: 'Option 3', value: 'option3' }
+    ];
+
+    const user = userEvent.setup();
+
+    const { asFragment } = render(<MultiTypeaheadSelect initialOptions={initialOptions} />);
+
+    const toggle = getToggle();
+    await user.click(toggle);
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/packages/react-templates/src/components/Select/__tests__/__snapshots__/MultiTypeaheadSelect.test.tsx.snap
+++ b/packages/react-templates/src/components/Select/__tests__/__snapshots__/MultiTypeaheadSelect.test.tsx.snap
@@ -1,0 +1,180 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MultiTypeaheadSelect Matches snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="pf-v5-c-menu-toggle pf-m-expanded pf-m-full-width pf-m-typeahead"
+  >
+    <div
+      class="pf-v5-c-text-input-group pf-m-plain"
+    >
+      <div
+        autocomplete="off"
+        class="pf-v5-c-text-input-group__main"
+      >
+        <span
+          class="pf-v5-c-text-input-group__text"
+        >
+          <input
+            aria-controls="select-typeahead-listbox"
+            aria-expanded="true"
+            aria-label="Type to filter"
+            class="pf-v5-c-text-input-group__text-input"
+            placeholder="Select an option"
+            role="combobox"
+            type="text"
+            value=""
+          />
+        </span>
+      </div>
+      <div
+        class="pf-v5-c-text-input-group__utilities"
+        style="display: none;"
+      >
+        <button
+          aria-disabled="false"
+          aria-label="Clear input value"
+          class="pf-v5-c-button pf-m-plain"
+          data-ouia-component-id="OUIA-Generated-Button-plain-20"
+          data-ouia-component-type="PF5/Button"
+          data-ouia-safe="true"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="pf-v5-svg"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 352 512"
+            width="1em"
+          >
+            <path
+              d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+    <button
+      aria-expanded="true"
+      aria-label="Multi select Typeahead menu toggle"
+      class="pf-v5-c-menu-toggle__button"
+      data-ouia-component-id="OUIA-Generated-MenuToggle-typeahead-17"
+      data-ouia-component-type="PF5/MenuToggle"
+      data-ouia-safe="true"
+      tabindex="-1"
+      type="button"
+    >
+      <span
+        class="pf-v5-c-menu-toggle__controls"
+      >
+        <span
+          class="pf-v5-c-menu-toggle__toggle-icon"
+        >
+          <svg
+            aria-hidden="true"
+            class="pf-v5-svg"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 320 512"
+            width="1em"
+          >
+            <path
+              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+            />
+          </svg>
+        </span>
+      </span>
+    </button>
+  </div>
+  <div
+    class="pf-v5-c-menu"
+    data-ouia-component-id="OUIA-Generated-Select-68"
+    data-ouia-component-type="PF5/Select"
+    data-ouia-safe="true"
+    data-popper-escaped="true"
+    data-popper-placement="bottom-start"
+    data-popper-reference-hidden="true"
+    style="position: absolute; left: 0px; top: 0px; z-index: 9999; opacity: 1; transition: opacity 0ms cubic-bezier(.54, 1.5, .38, 1.11); min-width: 0px; transform: translate(0px, 0px);"
+  >
+    <div
+      class="pf-v5-c-menu__content"
+    >
+      <ul
+        aria-multiselectable="false"
+        class="pf-v5-c-menu__list"
+        role="listbox"
+      >
+        <li
+          class="pf-v5-c-menu__list-item"
+          role="none"
+        >
+          <button
+            aria-selected="false"
+            class="pf-v5-c-menu__item"
+            role="option"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="pf-v5-c-menu__item-main"
+            >
+              <span
+                class="pf-v5-c-menu__item-text"
+              >
+                Option 1
+              </span>
+            </span>
+          </button>
+        </li>
+        <li
+          class="pf-v5-c-menu__list-item"
+          role="none"
+        >
+          <button
+            aria-selected="false"
+            class="pf-v5-c-menu__item"
+            role="option"
+            tabindex="-1"
+            type="button"
+          >
+            <span
+              class="pf-v5-c-menu__item-main"
+            >
+              <span
+                class="pf-v5-c-menu__item-text"
+              >
+                Option 2
+              </span>
+            </span>
+          </button>
+        </li>
+        <li
+          class="pf-v5-c-menu__list-item"
+          role="none"
+        >
+          <button
+            aria-selected="false"
+            class="pf-v5-c-menu__item"
+            role="option"
+            tabindex="-1"
+            type="button"
+          >
+            <span
+              class="pf-v5-c-menu__item-main"
+            >
+              <span
+                class="pf-v5-c-menu__item-text"
+              >
+                Option 3
+              </span>
+            </span>
+          </button>
+        </li>
+      </ul>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/packages/react-templates/src/components/Select/examples/MultiTypeaheadSelectDemo.tsx
+++ b/packages/react-templates/src/components/Select/examples/MultiTypeaheadSelectDemo.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { MultiTypeaheadSelect, MultiTypeaheadSelectOption } from '@patternfly/react-templates';
+
+const Options = [
+  { content: 'Alabama', value: 'option1' },
+  { content: 'Arizona', value: 'option2' },
+  { content: 'California', value: 'option3' },
+  { content: 'Florida', value: 'option4' },
+  { content: 'Massachusetts', value: 'option5' },
+  { content: 'Maine', value: 'option6' },
+  { content: 'New Jersey', value: 'option7' },
+  { content: 'New Mexico', value: 'option8' },
+  { content: 'New York', value: 'option9' },
+  { content: 'North Carolina', value: 'option10' }
+];
+
+type SelectionsType = (string | number)[];
+
+export const MultiSelectTypeaheadDemo: React.FunctionComponent = () => {
+  const [selected, setSelected] = React.useState<SelectionsType>(['option5']);
+
+  const initialOptions = React.useMemo<MultiTypeaheadSelectOption[]>(
+    () => Options.map((o) => ({ ...o, selected: selected.includes(o.value) })),
+    [selected]
+  );
+
+  return (
+    <MultiTypeaheadSelect
+      initialOptions={initialOptions}
+      placeholder="Select a state"
+      noOptionsFoundMessage={(filter) => `No state was found for "${filter}"`}
+      onSelectionChange={(_ev, selections) => setSelected(selections)}
+    />
+  );
+};

--- a/packages/react-templates/src/components/Select/examples/SelectTemplates.md
+++ b/packages/react-templates/src/components/Select/examples/SelectTemplates.md
@@ -12,7 +12,7 @@ Note: Templates live in their own package at [@patternfly/react-templates](https
 For custom use cases, please see the select component suite from [@patternfly/react-core](https://www.npmjs.com/package/@patternfly/react-core).
 
 import { Checkbox } from '@patternfly/react-core';
-import { SimpleSelect, CheckboxSelect, TypeaheadSelect } from '@patternfly/react-templates';
+import { SimpleSelect, CheckboxSelect, TypeaheadSelect, MultiTypeaheadSelect } from '@patternfly/react-templates';
 
 ## Select template examples
 
@@ -31,5 +31,11 @@ import { SimpleSelect, CheckboxSelect, TypeaheadSelect } from '@patternfly/react
 ### Typeahead
 
 ```ts file="TypeaheadSelectDemo.tsx"
+
+```
+
+### Multi-Typeahead
+
+```ts file="MultiTypeaheadSelectDemo.tsx"
 
 ```

--- a/packages/react-templates/src/components/Select/index.ts
+++ b/packages/react-templates/src/components/Select/index.ts
@@ -1,3 +1,4 @@
 export * from './SimpleSelect';
 export * from './CheckboxSelect';
 export * from './TypeaheadSelect';
+export * from './MultiTypeaheadSelect';


### PR DESCRIPTION
**What**:
Closes #10733 

**Description**:
Adds a `MultiTypeaheadSelect` component to the @patternfly/react-templates package and a demo of the component for the docs apge.