### PR TITLE
feat(MenuToggle): replace custom styles with text modifier

### DIFF
--- a/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
+++ b/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
@@ -201,13 +201,12 @@ class MenuToggleBase extends React.Component<MenuToggleProps, MenuToggleState> {
         >
           {splitButtonOptions?.items}
           <button
-            className={css(styles.menuToggleButton)}
+            className={css(styles.menuToggleButton, children && styles.modifiers.text)}
             type="button"
             aria-expanded={isExpanded}
             aria-label={ariaLabel}
             disabled={isDisabled}
             onClick={onClick}
-            {...(children && { style: { display: 'flex', paddingLeft: 'var(--pf-v5-global--spacer--sm)' } })}
             {...otherProps}
             {...ouiaProps}
           >


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #10774 (for v5)

Replaces custom styling with new `pf-m-text` modifier.