### PR TITLE
fix: promote former next components out of beta

### DIFF
--- a/packages/react-core/src/components/DualListSelector/examples/DualListSelector.md
+++ b/packages/react-core/src/components/DualListSelector/examples/DualListSelector.md
@@ -13,7 +13,6 @@ propComponents:
     'DualListSelectorTree',
     'DualListSelectorTreeItemData'
   ]
-beta: true
 ---
 
 import AngleDoubleLeftIcon from '@patternfly/react-icons/dist/esm/icons/angle-double-left-icon';

--- a/packages/react-core/src/components/Modal/examples/Modal.md
+++ b/packages/react-core/src/components/Modal/examples/Modal.md
@@ -4,7 +4,6 @@ section: components
 cssPrefix: pf-v5-c-modal-box
 propComponents: ['Modal', 'ModalBody', 'ModalHeader', 'ModalFooter']
 ouia: true
-beta: true
 ---
 
 import WarningTriangleIcon from '@patternfly/react-icons/dist/esm/icons/warning-triangle-icon';

--- a/packages/react-drag-drop/src/components/DragDrop/examples/DragDrop.md
+++ b/packages/react-drag-drop/src/components/DragDrop/examples/DragDrop.md
@@ -4,7 +4,6 @@ section: components
 cssPrefix: pf-c-drag-drop
 propComponents: ['DragDropSort', 'DraggableObject']
 hideNavItem: true
-beta: true
 ---
 
 Note: This drag and drop implementation lives in its own package at [@patternfly/react-drag-drop](https://www.npmjs.com/package/@patternfly/react-drag-drop)!

--- a/packages/react-drag-drop/src/components/DragDrop/examples/DragDropDemos.md
+++ b/packages/react-drag-drop/src/components/DragDrop/examples/DragDropDemos.md
@@ -3,7 +3,6 @@ id: Drag and drop
 section: components
 source: react-demos
 propComponents: ['DragDropSort', 'DraggableObject']
-beta: true
 ---
 
 Note: This drag and drop implementation lives in its own package at [@patternfly/react-drag-drop](https://www.npmjs.com/package/@patternfly/react-drag-drop)!


### PR DESCRIPTION
Closes: https://github.com/patternfly/patternfly-react/issues/10827

Updates docs for

- DualListSelector
- Modal
- DragDrop