### PR TITLE
feat(TypeaheadSelect) Add creation options to TypeaheadSelect

### DIFF
--- a/packages/react-templates/src/components/Select/examples/TypeaheadSelectDemo.tsx
+++ b/packages/react-templates/src/components/Select/examples/TypeaheadSelectDemo.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { TypeaheadSelect, TypeaheadSelectOption } from '@patternfly/react-templates';
+import { Checkbox } from '@patternfly/react-core';
 
 const Options = [
   { content: 'Alabama', value: 'option1' },
@@ -13,10 +14,13 @@ const Options = [
 /* eslint-disable no-console */
 export const SelectTypeaheadDemo: React.FunctionComponent = () => {
   const [selected, setSelected] = React.useState<string | undefined>();
+  const [options, setOptions] = React.useState(Options);
+  const [isCreatable, setIsCreatable] = React.useState<boolean>(false);
+  const [isCreateOptionOnTop, setIsCreateOptionOnTop] = React.useState<boolean>(false);
 
   const initialOptions = React.useMemo<TypeaheadSelectOption[]>(
-    () => Options.map((o) => ({ ...o, selected: o.value === selected })),
-    [selected]
+    () => options.map((o) => ({ ...o, selected: o.value === selected })),
+    [options, selected]
   );
 
   React.useEffect(() => {
@@ -24,12 +28,38 @@ export const SelectTypeaheadDemo: React.FunctionComponent = () => {
   }, [selected]);
 
   return (
-    <TypeaheadSelect
-      initialOptions={initialOptions}
-      placeholder="Select a state"
-      noOptionsFoundMessage={(filter) => `No state was found for "${filter}"`}
-      onClearSelection={() => setSelected(undefined)}
-      onSelect={(_ev, selection) => setSelected(String(selection))}
-    />
+    <>
+      <TypeaheadSelect
+        initialOptions={initialOptions}
+        placeholder="Select a state"
+        noOptionsFoundMessage={(filter) => `No state was found for "${filter}"`}
+        onClearSelection={() => setSelected(undefined)}
+        onSelect={(_ev, selection) => {
+          if (!options.find((o) => o.content === selection)) {
+            setOptions([...options, { content: String(selection), value: String(selection) }]);
+          }
+          setSelected(String(selection));
+        }}
+        isCreatable={isCreatable}
+        isCreateOptionOnTop={isCreateOptionOnTop}
+      />
+      <Checkbox
+        className="pf-u-mt-sm"
+        label="isCreatable"
+        isChecked={isCreatable}
+        onChange={(_event, checked) => setIsCreatable(checked)}
+        aria-label="toggle creatable checkbox"
+        id="toggle-creatable-typeahead"
+        name="toggle-creatable-typeahead"
+      />
+      <Checkbox
+        label="isCreateOptionOnTop"
+        isChecked={isCreateOptionOnTop}
+        onChange={(_event, checked) => setIsCreateOptionOnTop(checked)}
+        aria-label="toggle createOptionOnTop checkbox"
+        id="toggle-create-option-on-top-typeahead"
+        name="toggle-create-option-on-top-typeahead"
+      />
+    </>
   );
 };


### PR DESCRIPTION
**What**:
Closes #10798

**Description**:
Adds options to allow creation of new items from the `@patternfly/react-templates` TypeaheadSelect component.