### PR TITLE
feat(Table): favoritable sortable header cell and example

### DIFF
--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableFavoritesDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableFavoritesDemo.tsx
@@ -68,7 +68,7 @@ export class TableFavoritesDemo extends Component<TableProps, TableState> {
     });
   }
 
-  onFavorite(_event: React.MouseEvent, isFavorited: boolean, rowId?: number) {
+  onFavorite(_event: React.MouseEvent, isFavorited: boolean, rowId: number) {
     this.setState({
       rows: this.state.rows.map((row, index) => {
         if (index === rowId) {

--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableFavoritesDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableFavoritesDemo.tsx
@@ -68,7 +68,7 @@ export class TableFavoritesDemo extends Component<TableProps, TableState> {
     });
   }
 
-  onFavorite(_event: React.MouseEvent, isFavorited: boolean, rowId: number) {
+  onFavorite(_event: React.MouseEvent, isFavorited: boolean, rowId?: number) {
     this.setState({
       rows: this.state.rows.map((row, index) => {
         if (index === rowId) {

--- a/packages/react-table/src/components/Table/SortColumn.tsx
+++ b/packages/react-table/src/components/Table/SortColumn.tsx
@@ -2,10 +2,13 @@ import * as React from 'react';
 import LongArrowAltUpIcon from '@patternfly/react-icons/dist/esm/icons/long-arrow-alt-up-icon';
 import LongArrowAltDownIcon from '@patternfly/react-icons/dist/esm/icons/long-arrow-alt-down-icon';
 import ArrowsAltVIcon from '@patternfly/react-icons/dist/esm/icons/arrows-alt-v-icon';
+import StarIcon from '@patternfly/react-icons/dist/esm/icons/star-icon';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 import { TableText } from './TableText';
+import { OnFavorite } from './TableTypes';
 import { TooltipProps } from '@patternfly/react-core/dist/esm/components/Tooltip';
+import { ActionList, ActionListItem, Button } from '@patternfly/react-core';
 
 export enum SortByDirection {
   asc = 'asc',
@@ -21,6 +24,8 @@ export interface SortColumnProps extends React.ButtonHTMLAttributes<HTMLButtonEl
   tooltip?: React.ReactNode;
   tooltipProps?: Omit<TooltipProps, 'content'>;
   tooltipHasDefaultBehavior?: boolean;
+  onFavorite?: OnFavorite;
+  favorited?: boolean;
 }
 
 export const SortColumn: React.FunctionComponent<SortColumnProps> = ({
@@ -33,6 +38,8 @@ export const SortColumn: React.FunctionComponent<SortColumnProps> = ({
   tooltip,
   tooltipProps,
   tooltipHasDefaultBehavior,
+  onFavorite,
+  favorited,
   ...props
 }: SortColumnProps) => {
   let SortedByIcon;
@@ -42,6 +49,34 @@ export const SortColumn: React.FunctionComponent<SortColumnProps> = ({
   } else {
     SortedByIcon = ArrowsAltVIcon;
   }
+
+  if (onFavorite) {
+    return (
+      <ActionList isIconList>
+        <ActionListItem>
+          <Button
+            variant="plain"
+            icon={<StarIcon />}
+            aria-label={favorited ? 'Unfavorite all' : 'Favorite all'}
+            onClick={(event) => onFavorite(event, !favorited)}
+          />
+        </ActionListItem>
+        <ActionListItem>
+          <Button
+            variant="plain"
+            icon={
+              <span className={css(styles.tableSortIndicator)}>
+                <SortedByIcon />
+              </span>
+            }
+            aria-label="Sort favorites"
+            onClick={(event) => onSort && onSort(event)}
+          />
+        </ActionListItem>
+      </ActionList>
+    );
+  }
+
   return (
     <button
       {...props}

--- a/packages/react-table/src/components/Table/SortColumn.tsx
+++ b/packages/react-table/src/components/Table/SortColumn.tsx
@@ -6,9 +6,9 @@ import StarIcon from '@patternfly/react-icons/dist/esm/icons/star-icon';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 import { TableText } from './TableText';
-import { OnFavorite } from './TableTypes';
 import { TooltipProps } from '@patternfly/react-core/dist/esm/components/Tooltip';
 import { ActionList, ActionListItem, Button } from '@patternfly/react-core';
+import { FavoriteButtonProps } from './base/types';
 
 export enum SortByDirection {
   asc = 'asc',
@@ -24,8 +24,7 @@ export interface SortColumnProps extends React.ButtonHTMLAttributes<HTMLButtonEl
   tooltip?: React.ReactNode;
   tooltipProps?: Omit<TooltipProps, 'content'>;
   tooltipHasDefaultBehavior?: boolean;
-  onFavorite?: OnFavorite;
-  favorited?: boolean;
+  favoriteButtonProps?: FavoriteButtonProps;
 }
 
 export const SortColumn: React.FunctionComponent<SortColumnProps> = ({
@@ -38,8 +37,7 @@ export const SortColumn: React.FunctionComponent<SortColumnProps> = ({
   tooltip,
   tooltipProps,
   tooltipHasDefaultBehavior,
-  onFavorite,
-  favorited,
+  favoriteButtonProps,
   ...props
 }: SortColumnProps) => {
   let SortedByIcon;
@@ -50,16 +48,11 @@ export const SortColumn: React.FunctionComponent<SortColumnProps> = ({
     SortedByIcon = ArrowsAltVIcon;
   }
 
-  if (onFavorite) {
+  if (favoriteButtonProps) {
     return (
       <ActionList isIconList>
         <ActionListItem>
-          <Button
-            variant="plain"
-            icon={<StarIcon />}
-            aria-label={favorited ? 'Unfavorite all' : 'Favorite all'}
-            onClick={(event) => onFavorite(event, !favorited)}
-          />
+          <Button variant="plain" icon={<StarIcon />} {...favoriteButtonProps} />
         </ActionListItem>
         <ActionListItem>
           <Button
@@ -69,8 +62,8 @@ export const SortColumn: React.FunctionComponent<SortColumnProps> = ({
                 <SortedByIcon />
               </span>
             }
-            aria-label="Sort favorites"
             onClick={(event) => onSort && onSort(event)}
+            {...props}
           />
         </ActionListItem>
       </ActionList>

--- a/packages/react-table/src/components/Table/TableTypes.tsx
+++ b/packages/react-table/src/components/Table/TableTypes.tsx
@@ -63,9 +63,9 @@ export type OnRowEdit = (
 export type OnFavorite = (
   event: React.MouseEvent,
   isFavorited: boolean,
-  rowIndex?: number,
-  rowData?: IRowData,
-  extraData?: IExtraData
+  rowIndex: number,
+  rowData: IRowData,
+  extraData: IExtraData
 ) => void;
 
 export type OnTreeRowCollapse = (event: any, rowIndex: number, title: React.ReactNode, rowData: IRowData) => void;
@@ -109,7 +109,7 @@ export interface IColumn {
     allRowsExpanded?: boolean;
     isHeaderSelectDisabled?: boolean;
     onFavorite?: OnFavorite;
-    favorited?: boolean;
+    favoriteButtonProps?: ButtonProps;
   };
 }
 

--- a/packages/react-table/src/components/Table/TableTypes.tsx
+++ b/packages/react-table/src/components/Table/TableTypes.tsx
@@ -63,9 +63,9 @@ export type OnRowEdit = (
 export type OnFavorite = (
   event: React.MouseEvent,
   isFavorited: boolean,
-  rowIndex: number,
-  rowData: IRowData,
-  extraData: IExtraData
+  rowIndex?: number,
+  rowData?: IRowData,
+  extraData?: IExtraData
 ) => void;
 
 export type OnTreeRowCollapse = (event: any, rowIndex: number, title: React.ReactNode, rowData: IRowData) => void;
@@ -109,6 +109,7 @@ export interface IColumn {
     allRowsExpanded?: boolean;
     isHeaderSelectDisabled?: boolean;
     onFavorite?: OnFavorite;
+    favorited?: boolean;
   };
 }
 

--- a/packages/react-table/src/components/Table/Th.tsx
+++ b/packages/react-table/src/components/Table/Th.tsx
@@ -102,6 +102,7 @@ const ThBase: React.FunctionComponent<ThProps> = ({
     );
   }
 
+  const [favorited, setFavorited] = React.useState(false);
   const [showTooltip, setShowTooltip] = React.useState(false);
   const [truncated, setTruncated] = React.useState(false);
   const cellRef = innerRef ? innerRef : React.createRef();
@@ -121,7 +122,12 @@ const ThBase: React.FunctionComponent<ThProps> = ({
         columnIndex: sort.columnIndex,
         sortBy: sort.sortBy,
         tooltip: tooltip as string,
-        tooltipProps
+        tooltipProps,
+        onFavorite: (event: React.MouseEvent, isFavorited: boolean) => {
+          setFavorited(isFavorited);
+          sort.onFavorite(event, isFavorited);
+        },
+        favorited
       })();
     } else {
       sortParams = sortable(children as IFormatterValueType, {
@@ -217,6 +223,7 @@ const ThBase: React.FunctionComponent<ThProps> = ({
         hasRightBorder && scrollStyles.modifiers.borderRight,
         hasLeftBorder && scrollStyles.modifiers.borderLeft,
         modifier && styles.modifiers[modifier as 'breakWord' | 'fitContent' | 'nowrap' | 'truncate' | 'wrap'],
+        favorited && styles.modifiers.favorited,
         mergedClassName
       )}
       {...mergedProps}

--- a/packages/react-table/src/components/Table/Th.tsx
+++ b/packages/react-table/src/components/Table/Th.tsx
@@ -113,17 +113,18 @@ const ThBase: React.FunctionComponent<ThProps> = ({
     }
     onMouseEnterProp(event);
   };
+
   let sortParams = null;
   if (sort) {
     if (sort.isFavorites) {
       sortParams = sortableFavorites({
-        onSort: sort?.onSort,
+        onSort: sort.onSort,
         columnIndex: sort.columnIndex,
         sortBy: sort.sortBy,
         tooltip: tooltip as string,
         tooltipProps,
-        onFavorite: (event: React.MouseEvent, isFavorited: boolean) => sort.onFavorite(event, isFavorited),
-        favorited: sort.favorited
+        ariaLabel: sort['aria-label'],
+        favoriteButtonProps: sort.favoriteButtonProps
       })();
     } else {
       sortParams = sortable(children as IFormatterValueType, {
@@ -139,6 +140,7 @@ const ThBase: React.FunctionComponent<ThProps> = ({
       });
     }
   }
+
   const selectParams = select
     ? selectable(children as IFormatterValueType, {
         rowData: {
@@ -219,7 +221,7 @@ const ThBase: React.FunctionComponent<ThProps> = ({
         hasRightBorder && scrollStyles.modifiers.borderRight,
         hasLeftBorder && scrollStyles.modifiers.borderLeft,
         modifier && styles.modifiers[modifier as 'breakWord' | 'fitContent' | 'nowrap' | 'truncate' | 'wrap'],
-        sort?.favorited && styles.modifiers.favorited,
+        sort?.favoriteButtonProps?.favorited && styles.modifiers.favorited,
         mergedClassName
       )}
       {...mergedProps}

--- a/packages/react-table/src/components/Table/Th.tsx
+++ b/packages/react-table/src/components/Table/Th.tsx
@@ -102,7 +102,6 @@ const ThBase: React.FunctionComponent<ThProps> = ({
     );
   }
 
-  const [favorited, setFavorited] = React.useState(false);
   const [showTooltip, setShowTooltip] = React.useState(false);
   const [truncated, setTruncated] = React.useState(false);
   const cellRef = innerRef ? innerRef : React.createRef();
@@ -123,11 +122,8 @@ const ThBase: React.FunctionComponent<ThProps> = ({
         sortBy: sort.sortBy,
         tooltip: tooltip as string,
         tooltipProps,
-        onFavorite: (event: React.MouseEvent, isFavorited: boolean) => {
-          setFavorited(isFavorited);
-          sort.onFavorite(event, isFavorited);
-        },
-        favorited
+        onFavorite: (event: React.MouseEvent, isFavorited: boolean) => sort.onFavorite(event, isFavorited),
+        favorited: sort.favorited
       })();
     } else {
       sortParams = sortable(children as IFormatterValueType, {
@@ -223,7 +219,7 @@ const ThBase: React.FunctionComponent<ThProps> = ({
         hasRightBorder && scrollStyles.modifiers.borderRight,
         hasLeftBorder && scrollStyles.modifiers.borderLeft,
         modifier && styles.modifiers[modifier as 'breakWord' | 'fitContent' | 'nowrap' | 'truncate' | 'wrap'],
-        favorited && styles.modifiers.favorited,
+        sort?.favorited && styles.modifiers.favorited,
         mergedClassName
       )}
       {...mergedProps}

--- a/packages/react-table/src/components/Table/base/types.tsx
+++ b/packages/react-table/src/components/Table/base/types.tsx
@@ -6,9 +6,7 @@
  */
 
 import * as React from 'react';
-import { TooltipProps } from '@patternfly/react-core/dist/esm/components/Tooltip';
-import { PopoverProps } from '@patternfly/react-core/dist/esm/components/Popover';
-import { SelectProps } from '@patternfly/react-core/dist/esm/components/Select';
+import { ButtonProps, PopoverProps, SelectProps, TooltipProps } from '@patternfly/react-core';
 import { Table } from '../Table';
 import { Thead } from '../Thead';
 import { Tbody } from '../Tbody';
@@ -156,6 +154,11 @@ export interface ThInfoType {
   className?: string;
 }
 
+export interface FavoriteButtonProps extends ButtonProps {
+  /** Flag if the button is favorited. */
+  favorited?: boolean;
+}
+
 export interface ThSortType {
   /** Wraps the content in a button and adds a sort icon - Click callback on the sortable cell */
   onSort?: OnSort;
@@ -163,12 +166,12 @@ export interface ThSortType {
   sortBy: ISortBy;
   /** The column index */
   columnIndex: number;
+  /** Adds accessible text to the sort button. */
+  'aria-label'?: string;
   /** True to make this a favoritable sorting cell */
   isFavorites?: boolean;
-  /** Click callback on the star icon button (only for favoritable cell). */
-  onFavorite?: OnFavorite;
-  /** Flag if the cell is favorited, only used for favoritable cells. */
-  favorited?: boolean;
+  /** Props for the favorite button (only for favoritable cell). */
+  favoriteButtonProps?: FavoriteButtonProps;
 }
 
 export interface ThSelectType {

--- a/packages/react-table/src/components/Table/base/types.tsx
+++ b/packages/react-table/src/components/Table/base/types.tsx
@@ -167,6 +167,8 @@ export interface ThSortType {
   isFavorites?: boolean;
   /** Click callback on the star icon button (only for favoritable cell). */
   onFavorite?: OnFavorite;
+  /** Flag if the cell is favorited, only used for favoritable cells. */
+  favorited?: boolean;
 }
 
 export interface ThSelectType {

--- a/packages/react-table/src/components/Table/base/types.tsx
+++ b/packages/react-table/src/components/Table/base/types.tsx
@@ -165,6 +165,8 @@ export interface ThSortType {
   columnIndex: number;
   /** True to make this a favoritable sorting cell */
   isFavorites?: boolean;
+  /** Click callback on the star icon button (only for favoritable cell). */
+  onFavorite?: OnFavorite;
 }
 
 export interface ThSelectType {

--- a/packages/react-table/src/components/Table/examples/TableFavoritable.tsx
+++ b/packages/react-table/src/components/Table/examples/TableFavoritable.tsx
@@ -42,6 +42,9 @@ export const TableFavoritable: React.FunctionComponent = () => {
     });
   const isRepoFavorited = (repo: Repository) => favoriteRepoNames.includes(repo.name);
 
+  // State of the header cell to favorite / unfavorite all rows
+  const [headerFavorited, setHeaderFavorited] = React.useState(false);
+
   // Since OnSort specifies sorted columns by index, we need sortable values for our object by column index.
   // In this example we only deal with booleans here because we only sort on the favorites column.
   // For more complex sorting, see Sortable.
@@ -80,9 +83,11 @@ export const TableFavoritable: React.FunctionComponent = () => {
       setActiveSortIndex(index);
       setActiveSortDirection(direction);
     },
-    onFavorite: (_event, isFavorited) => {
+    onFavorite: (_event, isFavorited: boolean) => {
       repositories.forEach((repo) => setRepoFavorited(repo, isFavorited));
+      setHeaderFavorited(isFavorited);
     },
+    favorited: headerFavorited,
     columnIndex
   });
 
@@ -104,7 +109,20 @@ export const TableFavoritable: React.FunctionComponent = () => {
             <Td
               favorites={{
                 isFavorited: isRepoFavorited(repo),
-                onFavorite: (_event, isFavoriting) => setRepoFavorited(repo, isFavoriting),
+                onFavorite: (_event, isFavoriting) => {
+                  setRepoFavorited(repo, isFavoriting);
+
+                  if (
+                    isFavoriting &&
+                    repositories.filter((r) => r !== repo).every((r) => favoriteRepoNames.includes(r.name))
+                  ) {
+                    setHeaderFavorited(true);
+                  }
+
+                  if (!isFavoriting && favoriteRepoNames.length === 1 && favoriteRepoNames.includes(repo.name)) {
+                    setHeaderFavorited(false);
+                  }
+                },
                 rowIndex
               }}
             />

--- a/packages/react-table/src/components/Table/examples/TableFavoritable.tsx
+++ b/packages/react-table/src/components/Table/examples/TableFavoritable.tsx
@@ -80,6 +80,9 @@ export const TableFavoritable: React.FunctionComponent = () => {
       setActiveSortIndex(index);
       setActiveSortDirection(direction);
     },
+    onFavorite: (_event, isFavorited) => {
+      repositories.forEach((repo) => setRepoFavorited(repo, isFavorited));
+    },
     columnIndex
   });
 

--- a/packages/react-table/src/components/Table/examples/TableFavoritable.tsx
+++ b/packages/react-table/src/components/Table/examples/TableFavoritable.tsx
@@ -28,10 +28,10 @@ export const TableFavoritable: React.FunctionComponent = () => {
   // Index of the currently sorted column
   // Note: if you intend to make columns reorderable, you may instead want to use a non-numeric key
   // as the identifier of the sorted column. See the "Compound expandable" example.
-  const [activeSortIndex, setActiveSortIndex] = React.useState<number | null>(null);
+  const [activeSortIndex, setActiveSortIndex] = React.useState<number>();
 
   // Sort direction of the currently sorted column
-  const [activeSortDirection, setActiveSortDirection] = React.useState<'asc' | 'desc' | null>(null);
+  const [activeSortDirection, setActiveSortDirection] = React.useState<'asc' | 'desc'>();
 
   // Favorite state is similar to selection state, see Selectable with checkbox.
   const [favoriteRepoNames, setFavoriteRepoNames] = React.useState<string[]>([]);
@@ -58,7 +58,7 @@ export const TableFavoritable: React.FunctionComponent = () => {
   // Note that we perform the sort as part of the component's render logic and not in onSort.
   // We shouldn't store the list of data in state because we don't want to have to sync that with props.
   let sortedRepositories = repositories;
-  if (activeSortIndex !== null) {
+  if (activeSortIndex !== undefined) {
     sortedRepositories = repositories.sort((a, b) => {
       const aValue = getSortableRowValues(a)[activeSortIndex];
       const bValue = getSortableRowValues(b)[activeSortIndex];
@@ -83,12 +83,16 @@ export const TableFavoritable: React.FunctionComponent = () => {
       setActiveSortIndex(index);
       setActiveSortDirection(direction);
     },
-    onFavorite: (_event, isFavorited: boolean) => {
-      repositories.forEach((repo) => setRepoFavorited(repo, isFavorited));
-      setHeaderFavorited(isFavorited);
-    },
-    favorited: headerFavorited,
-    columnIndex
+    'aria-label': 'Sort favorites',
+    columnIndex,
+    favoriteButtonProps: {
+      favorited: headerFavorited,
+      onClick: (_event) => {
+        repositories.forEach((repo) => setRepoFavorited(repo, !headerFavorited));
+        setHeaderFavorited(!headerFavorited);
+      },
+      'aria-label': headerFavorited ? 'Unfavorite all' : 'Favorite all'
+    }
   });
 
   return (

--- a/packages/react-table/src/components/Table/utils/decorators/sortable.tsx
+++ b/packages/react-table/src/components/Table/utils/decorators/sortable.tsx
@@ -3,18 +3,18 @@ import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 import { IExtra, IFormatterValueType, ITransform } from '../../TableTypes';
 import { SortColumn, SortByDirection } from '../../SortColumn';
+import StarIcon from '@patternfly/react-icons/dist/esm/icons/star-icon';
 
 export const sortableFavorites = (sort: any) => () =>
-  sortable(null, {
+  sortable(<StarIcon aria-hidden />, {
     columnIndex: sort.columnIndex,
     className: styles.tableFavorite,
-    ariaLabel: 'Sort favorites',
+    ariaLabel: sort.ariaLabel ?? 'Sort favorites',
     column: {
       extraParams: {
         sortBy: sort.sortBy,
         onSort: sort.onSort,
-        onFavorite: sort.onFavorite,
-        favorited: sort.favorited
+        favoriteButtonProps: sort.favoriteButtonProps
       }
     },
     tooltip: sort.tooltip,
@@ -27,7 +27,7 @@ export const sortable: ITransform = (
   { columnIndex, column, property, className, ariaLabel, tooltip, tooltipProps, tooltipHasDefaultBehavior }: IExtra
 ) => {
   const {
-    extraParams: { sortBy, onSort, onFavorite, favorited }
+    extraParams: { sortBy, onSort, favoriteButtonProps }
   } = column;
 
   const extraData = {
@@ -63,8 +63,7 @@ export const sortable: ITransform = (
         tooltip={tooltip}
         tooltipProps={tooltipProps}
         tooltipHasDefaultBehavior={tooltipHasDefaultBehavior}
-        onFavorite={onFavorite}
-        favorited={favorited}
+        favoriteButtonProps={favoriteButtonProps}
       >
         {label as React.ReactNode}
       </SortColumn>

--- a/packages/react-table/src/components/Table/utils/decorators/sortable.tsx
+++ b/packages/react-table/src/components/Table/utils/decorators/sortable.tsx
@@ -3,17 +3,18 @@ import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 import { IExtra, IFormatterValueType, ITransform } from '../../TableTypes';
 import { SortColumn, SortByDirection } from '../../SortColumn';
-import StarIcon from '@patternfly/react-icons/dist/esm/icons/star-icon';
 
 export const sortableFavorites = (sort: any) => () =>
-  sortable(<StarIcon aria-hidden />, {
+  sortable(null, {
     columnIndex: sort.columnIndex,
-    className: styles.modifiers.favorite,
+    className: styles.tableFavorite,
     ariaLabel: 'Sort favorites',
     column: {
       extraParams: {
         sortBy: sort.sortBy,
-        onSort: sort?.onSort
+        onSort: sort.onSort,
+        onFavorite: sort.onFavorite,
+        favorited: sort.favorited
       }
     },
     tooltip: sort.tooltip,
@@ -26,7 +27,7 @@ export const sortable: ITransform = (
   { columnIndex, column, property, className, ariaLabel, tooltip, tooltipProps, tooltipHasDefaultBehavior }: IExtra
 ) => {
   const {
-    extraParams: { sortBy, onSort }
+    extraParams: { sortBy, onSort, onFavorite, favorited }
   } = column;
 
   const extraData = {
@@ -62,6 +63,8 @@ export const sortable: ITransform = (
         tooltip={tooltip}
         tooltipProps={tooltipProps}
         tooltipHasDefaultBehavior={tooltipHasDefaultBehavior}
+        onFavorite={onFavorite}
+        favorited={favorited}
       >
         {label as React.ReactNode}
       </SortColumn>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #10415

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
I am not sure what styling should be applied to the star icon in the header when it is clicked. Previously it had the blue color applied (same as the sort arrow indicator). But now it is a separate button. I don't think we have a suitable class for that case. For now I just applied `pf-m-favorited` (the same as for the individual rows with stars), it can be seen on the example bellow:

https://github.com/user-attachments/assets/5032ec52-bab8-47e8-bfaa-ca7d12a98b83

Now that the `pf-v6-c-table__favorite` class (`styles.tableFavorite`) is applied to `th` instead of `pf-m-favorite` (`styles.modifiers.favorite`), it messes up the deprecated example. (I assume it is OK, given that it already was deprecated in V5)
![Screenshot 2024-08-21 at 13 45 09](https://github.com/user-attachments/assets/7c7f8f8c-5e5b-4ebe-a9b7-60cf19a4a51f)

