### PR TITLE
Convert scripts to ES modules

### DIFF
--- a/.github/split.mjs
+++ b/.github/split.mjs
@@ -1,8 +1,8 @@
 /* eslint-disable no-console */
-const fs = require('fs');
-const path = require('path');
+import fs from 'node:fs';
+import path from 'node:path';
 
-const BASE_DIR = path.join(__dirname, '../packages/react-integration/cypress/integration');
+const BASE_DIR = path.resolve(import.meta.dirname, '../packages/react-integration/cypress/integration');
 const WORKER_NUM = +process.env.WORKER_NUM;
 const WORKER_COUNT = +process.env.WORKER_COUNT;
 

--- a/.github/upload-preview.mjs
+++ b/.github/upload-preview.mjs
@@ -1,8 +1,9 @@
 /* eslint-disable no-console, camelcase */
-const path = require('path');
-const { Octokit } = require('@octokit/rest');
+import { Octokit } from '@octokit/rest';
+import path from 'node:path';
+import surge from 'surge';
+
 const octokit = new Octokit({ auth: process.env.GH_PR_TOKEN });
-const surge = require('surge');
 const publishFn = surge().publish();
 
 // From github actions

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -39,11 +39,11 @@ jobs:
 
       - name: Upload documentation
         if: always()
-        run: node .github/upload-preview.js packages/react-docs/public
+        run: node .github/upload-preview.mjs packages/react-docs/public
 
       - name: Run accessibility tests
         run: yarn serve:docs & yarn test:a11y
 
       - name: Upload accessibility results
         if: always()
-        run: node .github/upload-preview.js packages/react-docs/coverage
+        run: node .github/upload-preview.mjs packages/react-docs/coverage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,7 +93,7 @@ jobs:
         run: printenv
 
       - name: Run Cypress tests
-        run: yarn serve:integration & yarn test:integration -s $(node .github/split.js)
+        run: yarn serve:integration & yarn test:integration -s $(node .github/split.mjs)
         env:
           WORKER_NUM: ${{ matrix.worker }}
           WORKER_COUNT: 5


### PR DESCRIPTION
Converts the various scripts in the repository to use the ES module syntax instead of CommonJS. This helps future proof these scripts and makes it more consistent with how the rest of the code is written.