### PR TITLE
chore(MenuToggle/Select): promoted status/validation

### DIFF
--- a/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
+++ b/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
@@ -48,7 +48,7 @@ export interface MenuToggleProps
   splitButtonOptions?: SplitButtonOptions;
   /** Variant styles of the menu toggle */
   variant?: 'default' | 'plain' | 'primary' | 'plainText' | 'secondary' | 'typeahead';
-  /** @beta Status styles of the menu toggle */
+  /** Status styles of the menu toggle */
   status?: 'success' | 'warning' | 'danger';
   /** Overrides the status icon */
   statusIcon?: React.ReactNode;

--- a/packages/react-core/src/components/MenuToggle/examples/MenuToggle.md
+++ b/packages/react-core/src/components/MenuToggle/examples/MenuToggle.md
@@ -195,7 +195,7 @@ import { MenuToggle } from '@patternfly/react-core';
 
 ### Split toggle with checkbox
 
-To add a checkbox (or other action/control) to a menu toggle, use a split button. 
+To add a checkbox (or other action/control) to a menu toggle, use a split button.
 
 A `<MenuToggle>` can be rendered as a split button by adding a `splitButtonOptions` object. Elements to be displayed before the toggle button must be included in the `items` property of `splitButtonOptions`.
 
@@ -287,6 +287,6 @@ To create a toggle with a status, pass in the `status` property to the `MenuTogg
 
 When the status value is "warning" or "danger", you must include helper text that conveys what is causing the warning/error.
 
-```ts isBeta file='MenuToggleStatus.tsx'
+```ts file='MenuToggleStatus.tsx'
 
 ```

--- a/packages/react-core/src/components/Select/examples/Select.md
+++ b/packages/react-core/src/components/Select/examples/Select.md
@@ -60,7 +60,7 @@ To create a toggle with a status, pass in `status` to the `MenuToggle`. The defa
 
 When the status value is "warning" or "danger", you must include helper text that conveys what is causing the warning/error.
 
-```ts isBeta file="./SelectValidated.tsx"
+```ts file="./SelectValidated.tsx"
 
 ```
 


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #10836 

Per convo this PR only promotes MenuToggle/Select validation from beta since it was a consumer request, we can take stock of other v6 promotions that can/should be made in v5 in another PR.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
