### PR TITLE
Deprecate follow up

### DIFF
--- a/packages/react-integration/cypress/integration/form.spec.ts
+++ b/packages/react-integration/cypress/integration/form.spec.ts
@@ -1,4 +1,4 @@
-xdescribe('Form Demo Test', () => {
+describe('Form Demo Test', () => {
   it('Navigate to demo section', () => {
     cy.visit('http://localhost:3000/form-demo-nav-link');
   });
@@ -70,14 +70,14 @@ xdescribe('Form Demo Test', () => {
   });
 
   it('Verify keypress can control the multi-select-typeahead', () => {
-    cy.get('[id*="pf-select-toggle-id"][id*="select-multi-typeahead-typeahead"]').type('{downarrow}{downarrow}{enter}');
+    cy.get('.pf-v6-c-menu-toggle').type('{downarrow}{downarrow}{enter}');
     cy.get('.pf-v6-c-label__text').should('exist').and('have.text', 'Florida');
 
     cy.get('.pf-v6-c-label button').click();
 
-    cy.get('[id*="pf-select-toggle-id"][id*="select-multi-typeahead-typeahead"]').type('New J');
+    cy.get('.pf-v6-c-text-input-group__text-input').click().type('New J');
 
-    cy.get('.pf-v6-c-select__menu-item').should('exist').and('have.text', 'New Jersey');
+    cy.get('.pf-v6-c-text-input-group__text-input').should('exist').and('have.text', 'New Jersey');
     cy.focused().type('{backspace}{backspace}{backspace}{backspace}orth');
     cy.get('.pf-v6-c-select__menu-item').should('exist').and('have.text', 'North Carolina');
     cy.focused().type('{backspace}{backspace}{backspace}{backspace}{backspace}');

--- a/packages/react-integration/cypress/integration/form.spec.ts
+++ b/packages/react-integration/cypress/integration/form.spec.ts
@@ -69,7 +69,7 @@ describe('Form Demo Test', () => {
     cy.get('[aria-label="Close"]').type('{enter}');
   });
 
-  xit('Verify keypress can control the multi-select-typeahead', () => {
+  it('Verify keypress can control the multi-select-typeahead', () => {
     cy.get('.pf-v6-c-menu-toggle').type('{downarrow}{downarrow}{enter}');
     cy.get('.pf-v6-c-label__text').should('exist').and('have.text', 'Florida');
 
@@ -77,14 +77,14 @@ describe('Form Demo Test', () => {
 
     cy.get('.pf-v6-c-text-input-group__text-input').click().type('New J');
 
-    cy.get('.pf-v6-c-select__menu-item').should('exist').and('have.text', 'New Jersey');
+    cy.get('.pf-v6-c-menu__item').should('exist').and('have.text', 'New Jersey');
     cy.focused().type('{backspace}{backspace}{backspace}{backspace}orth');
-    cy.get('.pf-v6-c-select__menu-item').should('exist').and('have.text', 'North Carolina');
+    cy.get('.pf-v6-c-menu__item').should('exist').and('have.text', 'North Carolina');
     cy.focused().type('{backspace}{backspace}{backspace}{backspace}{backspace}');
 
     // @ts-ignore
     cy.tab();
-    cy.get('.pf-v6-c-select__menu-item').should('not.exist');
+    cy.get('.pf-v6-c-menu__item').should('not.exist');
   });
 
   it('Verify pressing spacebar selects the checkbox component', () => {

--- a/packages/react-integration/cypress/integration/form.spec.ts
+++ b/packages/react-integration/cypress/integration/form.spec.ts
@@ -69,7 +69,7 @@ describe('Form Demo Test', () => {
     cy.get('[aria-label="Close"]').type('{enter}');
   });
 
-  it('Verify keypress can control the multi-select-typeahead', () => {
+  xit('Verify keypress can control the multi-select-typeahead', () => {
     cy.get('.pf-v6-c-menu-toggle').type('{downarrow}{downarrow}{enter}');
     cy.get('.pf-v6-c-label__text').should('exist').and('have.text', 'Florida');
 
@@ -77,7 +77,7 @@ describe('Form Demo Test', () => {
 
     cy.get('.pf-v6-c-text-input-group__text-input').click().type('New J');
 
-    cy.get('.pf-v6-c-text-input-group__text-input').should('exist').and('have.text', 'New Jersey');
+    cy.get('.pf-v6-c-select__menu-item').should('exist').and('have.text', 'New Jersey');
     cy.focused().type('{backspace}{backspace}{backspace}{backspace}orth');
     cy.get('.pf-v6-c-select__menu-item').should('exist').and('have.text', 'North Carolina');
     cy.focused().type('{backspace}{backspace}{backspace}{backspace}{backspace}');

--- a/packages/react-integration/cypress/integration/page.spec.ts
+++ b/packages/react-integration/cypress/integration/page.spec.ts
@@ -3,7 +3,7 @@ describe('Page Demo Test', () => {
     cy.visit('http://localhost:3000/page-demo-nav-link');
   });
 
-  xit('Test Page elements', () => {
+  it('Test Page elements', () => {
     cy.get('#page-demo').within(() => {
       cy.get('#nav-toggle').then((hamburgerIcon: JQuery<HTMLDivElement>) => {
         cy.get('.pf-v6-c-page__sidebar.pf-m-expanded').should('exist');
@@ -12,9 +12,11 @@ describe('Page Demo Test', () => {
         cy.get('.pf-v6-c-page__sidebar.pf-m-collapsed').should('exist');
         cy.get('.pf-v6-c-page__sidebar.pf-m-expanded').should('not.exist');
       });
-      cy.get('#page-demo-header').should('not.have.attr', 'role');
+      cy.get('#page-demo-masthead').should('not.have.attr', 'role');
       cy.get('#page-demo-page-id').should('not.have.attr', 'role');
-      cy.get('div[class="pf-v6-c-page__header-brand-link"]').invoke('text').should('eq', "Logo that's a <div>");
+      cy.get(
+        '#page-demo-masthead > .pf-v6-c-masthead__main > .pf-v6-c-masthead__brand > .pf-v6-c-masthead__logo'
+      ).should('exist');
       cy.get('.pf-v6-c-page__main-section.pf-m-no-padding').should('exist');
       cy.get('.pf-v6-c-page__main-section.pf-m-no-padding-on-md').should('exist');
     });

--- a/packages/react-integration/cypress/integration/tableeditable.spec.ts
+++ b/packages/react-integration/cypress/integration/tableeditable.spec.ts
@@ -1,4 +1,4 @@
-xdescribe('Table Simple Test', () => {
+describe('Table Simple Test', () => {
   it('Navigate to demo section', () => {
     cy.visit('http://localhost:3000/table-editable-demo-nav-link');
   });
@@ -20,9 +20,9 @@ xdescribe('Table Simple Test', () => {
       '.pf-m-inline-editable > [data-label="Text input col 1"] > .pf-v6-c-inline-edit__input > .pf-v6-c-form-control > input'
     ).type('test');
     cy.get(
-      '.pf-m-inline-editable > [data-label="Dropdown col 5"] > .pf-v6-c-inline-edit__input > .pf-v6-c-select > .pf-v6-c-select__toggle > .pf-v6-c-select__toggle-button'
+      '.pf-m-inline-editable > [data-label="Dropdown col 5"] > .pf-v6-c-inline-edit__input > .pf-v6-c-menu-toggle > .pf-v6-c-menu-toggle__controls'
     ).click();
-    cy.get(':nth-child(4) > .pf-v6-c-check__label').click();
+    cy.get('#uniqueIdRow1Cell5Option3').click();
     cy.get(
       '.pf-m-inline-editable > .pf-v6-c-table__inline-edit-action > .pf-v6-c-inline-edit__group > :nth-child(1) > .pf-v6-c-button'
     ).click();
@@ -46,9 +46,9 @@ xdescribe('Table Simple Test', () => {
       .clear()
       .type('xyz');
     cy.get(
-      '.pf-m-inline-editable:nth-of-type(2) > [data-label="Dropdown col 5"] > .pf-v6-c-inline-edit__input > .pf-v6-c-select > .pf-v6-c-select__toggle > .pf-v6-c-select__toggle-button'
+      '.pf-m-inline-editable > [data-label="Dropdown col 5"] > .pf-v6-c-inline-edit__input > .pf-v6-c-menu-toggle > .pf-v6-c-menu-toggle__controls'
     ).click();
-    cy.get('#uniqueIdRow2Cell5Option3 > .pf-v6-c-select__menu-item').click();
+    cy.get('#uniqueIdRow2Cell5Option3').click();
     cy.get(
       '.pf-m-inline-editable:nth-of-type(2) > .pf-v6-c-table__inline-edit-action > .pf-v6-c-inline-edit__group > :nth-child(2) > .pf-v6-c-button'
     ).click();

--- a/packages/react-integration/cypress/integration/toolbar.spec.ts
+++ b/packages/react-integration/cypress/integration/toolbar.spec.ts
@@ -1,4 +1,4 @@
-xdescribe('Data Toolbar Demo Test', () => {
+describe('Data Toolbar Demo Test', () => {
   it('Navigate to demo section', () => {
     cy.visit('http://localhost:3000/toolbar-demo-nav-link');
   });

--- a/packages/react-integration/demo-app-ts/src/components/demos/FormDemo/FormDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/FormDemo/FormDemo.tsx
@@ -129,6 +129,7 @@ export class FormDemo extends Component<FormProps, FormState> {
         );
       }
     }
+    this.textInputRef.current?.focus();
   };
 
   handleMenuArrowKeys = (key: string) => {
@@ -216,7 +217,7 @@ export class FormDemo extends Component<FormProps, FormState> {
 
   closeMenu = () => {
     this.setState({
-      isOpen: !this.state.isOpen
+      isOpen: false
     });
     this.resetActiveAndFocusedItem();
   };
@@ -368,6 +369,10 @@ export class FormDemo extends Component<FormProps, FormState> {
                 isOpen={isOpen}
                 aria-labelledby={titleId}
                 toggle={toggle}
+                shouldFocusFirstItemOnOpen={false}
+                onOpenChange={(isOpen: any) => {
+                  !isOpen && this.closeMenu();
+                }}
               >
                 <SelectList>
                   {selectOptions.map((option, index) => (

--- a/packages/react-integration/demo-app-ts/src/components/demos/FormDemo/FormDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/FormDemo/FormDemo.tsx
@@ -231,7 +231,20 @@ export class FormDemo extends Component<FormProps, FormState> {
   };
 
   onTextInputChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => {
+    let newSelectOptions: SelectOptionProps[] = initialSelectOptions;
+    if (value) {
+      newSelectOptions = initialSelectOptions.filter((menuItem) =>
+        String(menuItem.children).toLowerCase().includes(value.toLowerCase())
+      );
+      if (!newSelectOptions.length) {
+        newSelectOptions = [{ isAriaDisabled: true, children: `No results found for "${value}"`, value: NO_RESULTS }];
+      }
+      if (!this.state.isOpen) {
+        this.setState({ isOpen: true });
+      }
+    }
     this.setState({ inputValue: value });
+    this.setState({ selectOptions: newSelectOptions });
     this.resetActiveAndFocusedItem();
   };
   onClearButtonClick = () => {

--- a/packages/react-integration/demo-app-ts/src/components/demos/FormDemo/FormDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/FormDemo/FormDemo.tsx
@@ -75,7 +75,7 @@ export class FormDemo extends Component<FormProps, FormState> {
   }
 
   labelHelpRef: React.RefObject<HTMLSpanElement> = React.createRef();
-  textInputRef: React.useRef<HTMLInputElement> = React.createRef();
+  textInputRef: React.RefObject<HTMLInputElement> = React.createRef();
 
   handleTextInputChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => {
     this.setState({ value, isValid: /^\d+$/.test(value) });
@@ -112,7 +112,7 @@ export class FormDemo extends Component<FormProps, FormState> {
     });
   };
 
-  onSelect = (_event: React.MouseEvent<Element, MouseEvent> | undefined, selection: string | number | undefined) => {
+  onSelect = (_ev: any, selection: string | number | undefined) => {
     const { selected } = this.state;
     if (selection) {
       if (selected.includes(selection.toString())) {

--- a/packages/react-integration/demo-app-ts/src/components/demos/PageDemo/PageDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/PageDemo/PageDemo.tsx
@@ -72,10 +72,15 @@ export class PageDemo extends Component {
     );
 
     const masthead = (
-      <Masthead>
+      <Masthead id="page-demo-masthead">
         <MastheadMain>
           <MastheadToggle>
-            <PageToggleButton variant="plain" aria-label="Global navigation">
+            <PageToggleButton
+              variant="plain"
+              aria-label="Global navigation"
+              isSidebarOpen={isNavOpen}
+              onSidebarToggle={this.onNavToggle}
+            >
               <BarsIcon />
             </PageToggleButton>
           </MastheadToggle>

--- a/packages/react-integration/demo-app-ts/src/components/demos/PageDemo/PageDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/PageDemo/PageDemo.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import {
   Page,
   PageSidebar,
@@ -25,7 +25,7 @@ export class PageDemo extends Component {
     isKebabDropdownOpen: false
   };
 
-  onNavToggle = (_event: React.MouseEvent) => {
+  onNavToggle = () => {
     this.setState({
       isNavOpen: !this.state.isNavOpen
     });

--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableEditableDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableEditableDemo.tsx
@@ -138,10 +138,12 @@ export class TableEditableDemo extends React.Component<TableProps, TableState> {
                   clearSelection={this.clearSelection}
                   isOpen={updatedProps.isSelectOpen}
                   options={(updatedProps as any).options.map((option: any, index: number) => (
-                    <SelectOption key={index} value={option.value} id={'uniqueIdRow1Cell5Option' + index} />
+                    <SelectOption key={index} value={option.value} id={'uniqueIdRow1Cell5Option' + index}>
+                      {option.value}
+                    </SelectOption>
                   ))}
-                  onToggle={(event: any) => {
-                    this.onToggle(event);
+                  onToggle={(_event: any) => {
+                    this.onToggle(rowIndex, cellIndex);
                   }}
                   selections={updatedProps.selected}
                 />
@@ -249,10 +251,12 @@ export class TableEditableDemo extends React.Component<TableProps, TableState> {
                   clearSelection={this.clearSelection}
                   isOpen={updatedProps.isSelectOpen}
                   options={(updatedProps as any).options.map((option: any, index: number) => (
-                    <SelectOption key={index} value={option.value} id={'uniqueIdRow2Cell5Option' + index} />
+                    <SelectOption key={index} value={option.value} id={'uniqueIdRow2Cell5Option' + index}>
+                      {option.value}
+                    </SelectOption>
                   ))}
                   onToggle={(_event: any) => {
-                    this.onToggle(_event);
+                    this.onToggle(rowIndex, cellIndex);
                   }}
                   selections={updatedProps.selected}
                 />
@@ -362,6 +366,7 @@ export class TableEditableDemo extends React.Component<TableProps, TableState> {
 
       newCellProps.editableValue = newSelected;
       newCellProps.selected = newSelected;
+      newCellProps.isSelectOpen = false;
     }
 
     this.setState({
@@ -369,8 +374,10 @@ export class TableEditableDemo extends React.Component<TableProps, TableState> {
     });
   };
 
-  onToggle = (_event: any) => {
+  onToggle = (rowIndex: string | number | undefined, cellIndex: string | number | undefined) => {
     const newRows = Array.from(this.state.rows);
+    newRows[rowIndex as number].cells[cellIndex].props.isSelectOpen =
+      !newRows[rowIndex as number].cells[cellIndex].props.isSelectOpen;
     this.setState({
       rows: newRows
     });

--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableEditableDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableEditableDemo.tsx
@@ -163,7 +163,8 @@ export class TableEditableDemo extends React.Component<TableProps, TableState> {
                 ],
                 editableSelectProps: {
                   variant: 'checkbox',
-                  'aria-label': 'Row 1 cell 5 content'
+                  'aria-label': 'Row 1 cell 5 content',
+                  onOpenChange: (isOpen: boolean) => this.onOpenChange(isOpen, 0, 4)
                 }
               }
             }
@@ -276,7 +277,8 @@ export class TableEditableDemo extends React.Component<TableProps, TableState> {
                 ],
                 editableSelectProps: {
                   variant: 'single',
-                  'aria-label': 'Row 2 cell 5 content'
+                  'aria-label': 'Row 2 cell 5 content',
+                  onOpenChange: (isOpen: boolean) => this.onOpenChange(isOpen, 1, 4)
                 }
               }
             }
@@ -369,6 +371,15 @@ export class TableEditableDemo extends React.Component<TableProps, TableState> {
       newCellProps.isSelectOpen = false;
     }
 
+    this.setState({
+      rows: newRows
+    });
+  };
+
+  // set open state if component closes menu on click (e.g. when you click outside of the menu)
+  onOpenChange = (isOpen: boolean, rowIndex: string | number | undefined, cellIndex: string | number | undefined) => {
+    const newRows = Array.from(this.state.rows);
+    newRows[rowIndex as number].cells[cellIndex].props.isSelectOpen = isOpen;
     this.setState({
       rows: newRows
     });

--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableEditableDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableEditableDemo.tsx
@@ -377,7 +377,7 @@ export class TableEditableDemo extends React.Component<TableProps, TableState> {
   };
 
   // set open state if component closes menu on click (e.g. when you click outside of the menu)
-  onOpenChange = (isOpen: boolean, rowIndex: string | number | undefined, cellIndex: string | number | undefined) => {
+  onOpenChange = (isOpen: boolean, rowIndex: number, cellIndex: number) => {
     const newRows = Array.from(this.state.rows);
     newRows[rowIndex as number].cells[cellIndex].props.isSelectOpen = isOpen;
     this.setState({
@@ -387,8 +387,10 @@ export class TableEditableDemo extends React.Component<TableProps, TableState> {
 
   onToggle = (rowIndex: string | number | undefined, cellIndex: string | number | undefined) => {
     const newRows = Array.from(this.state.rows);
-    newRows[rowIndex as number].cells[cellIndex].props.isSelectOpen =
-      !newRows[rowIndex as number].cells[cellIndex].props.isSelectOpen;
+    if (typeof rowIndex !== 'undefined' && typeof rowIndex !== 'undefined') {
+      newRows[rowIndex as number].cells[cellIndex as number].props.isSelectOpen =
+        !newRows[rowIndex as number].cells[cellIndex as number].props.isSelectOpen;
+    }
     this.setState({
       rows: newRows
     });

--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableEditableDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableEditableDemo.tsx
@@ -143,7 +143,7 @@ export class TableEditableDemo extends React.Component<TableProps, TableState> {
                     </SelectOption>
                   ))}
                   onToggle={(_event: any) => {
-                    this.onToggle(rowIndex, cellIndex);
+                    this.onToggle(updatedProps.isSelectOpen, rowIndex as number, cellIndex as number);
                   }}
                   selections={updatedProps.selected}
                 />
@@ -257,7 +257,7 @@ export class TableEditableDemo extends React.Component<TableProps, TableState> {
                     </SelectOption>
                   ))}
                   onToggle={(_event: any) => {
-                    this.onToggle(rowIndex, cellIndex);
+                    this.onToggle(updatedProps.isSelectOpen, rowIndex as number, cellIndex as number);
                   }}
                   selections={updatedProps.selected}
                 />
@@ -379,21 +379,30 @@ export class TableEditableDemo extends React.Component<TableProps, TableState> {
   // set open state if component closes menu on click (e.g. when you click outside of the menu)
   onOpenChange = (isOpen: boolean, rowIndex: number, cellIndex: number) => {
     const newRows = Array.from(this.state.rows);
-    newRows[rowIndex as number].cells[cellIndex].props.isSelectOpen = isOpen;
-    this.setState({
-      rows: newRows
-    });
+    const rowCells = newRows[rowIndex as number].cells;
+    if (rowCells) {
+      const cell = rowCells[cellIndex as number];
+      if (cell) {
+        (cell as IRowCell).props.isSelectOpen = isOpen;
+        this.setState({
+          rows: newRows
+        });
+      }
+    }
   };
 
-  onToggle = (rowIndex: string | number | undefined, cellIndex: string | number | undefined) => {
+  onToggle = (isOpen: boolean, rowIndex: number, cellIndex: number) => {
     const newRows = Array.from(this.state.rows);
-    if (typeof rowIndex !== 'undefined' && typeof rowIndex !== 'undefined') {
-      newRows[rowIndex as number].cells[cellIndex as number].props.isSelectOpen =
-        !newRows[rowIndex as number].cells[cellIndex as number].props.isSelectOpen;
+    const rowCells = newRows[rowIndex].cells;
+    if (rowCells) {
+      const cell = rowCells[cellIndex as number];
+      if (cell) {
+        (cell as IRowCell).props.isSelectOpen = isOpen;
+        this.setState({
+          rows: newRows
+        });
+      }
     }
-    this.setState({
-      rows: newRows
-    });
   };
 
   clearSelection = (_event: React.MouseEvent, rowIndex: number, cellIndex: number) => {

--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableEditableDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableEditableDemo.tsx
@@ -143,7 +143,7 @@ export class TableEditableDemo extends React.Component<TableProps, TableState> {
                     </SelectOption>
                   ))}
                   onToggle={(_event: any) => {
-                    this.onToggle(updatedProps.isSelectOpen, rowIndex as number, cellIndex as number);
+                    this.onToggle(rowIndex as number, cellIndex as number);
                   }}
                   selections={updatedProps.selected}
                 />
@@ -164,7 +164,7 @@ export class TableEditableDemo extends React.Component<TableProps, TableState> {
                 editableSelectProps: {
                   variant: 'checkbox',
                   'aria-label': 'Row 1 cell 5 content',
-                  onOpenChange: (isOpen: boolean) => this.onOpenChange(isOpen, 0, 4)
+                  onOpenChange: () => this.onOpenChange(0, 4)
                 }
               }
             }
@@ -257,7 +257,7 @@ export class TableEditableDemo extends React.Component<TableProps, TableState> {
                     </SelectOption>
                   ))}
                   onToggle={(_event: any) => {
-                    this.onToggle(updatedProps.isSelectOpen, rowIndex as number, cellIndex as number);
+                    this.onToggle(rowIndex as number, cellIndex as number);
                   }}
                   selections={updatedProps.selected}
                 />
@@ -278,7 +278,7 @@ export class TableEditableDemo extends React.Component<TableProps, TableState> {
                 editableSelectProps: {
                   variant: 'single',
                   'aria-label': 'Row 2 cell 5 content',
-                  onOpenChange: (isOpen: boolean) => this.onOpenChange(isOpen, 1, 4)
+                  onOpenChange: () => this.onOpenChange(1, 4)
                 }
               }
             }
@@ -377,13 +377,13 @@ export class TableEditableDemo extends React.Component<TableProps, TableState> {
   };
 
   // set open state if component closes menu on click (e.g. when you click outside of the menu)
-  onOpenChange = (isOpen: boolean, rowIndex: number, cellIndex: number) => {
+  onOpenChange = (rowIndex: number, cellIndex: number) => {
     const newRows = Array.from(this.state.rows);
     const rowCells = newRows[rowIndex as number].cells;
     if (rowCells) {
       const cell = rowCells[cellIndex as number];
       if (cell) {
-        (cell as IRowCell).props.isSelectOpen = isOpen;
+        (cell as IRowCell).props.isSelectOpen = !(cell as IRowCell).props.isSelectOpen;
         this.setState({
           rows: newRows
         });
@@ -391,13 +391,13 @@ export class TableEditableDemo extends React.Component<TableProps, TableState> {
     }
   };
 
-  onToggle = (isOpen: boolean, rowIndex: number, cellIndex: number) => {
+  onToggle = (rowIndex: number, cellIndex: number) => {
     const newRows = Array.from(this.state.rows);
     const rowCells = newRows[rowIndex].cells;
     if (rowCells) {
       const cell = rowCells[cellIndex as number];
       if (cell) {
-        (cell as IRowCell).props.isSelectOpen = isOpen;
+        (cell as IRowCell).props.isSelectOpen = !(cell as IRowCell).props.isSelectOpen;
         this.setState({
           rows: newRows
         });

--- a/packages/react-table/src/components/Table/EditableSelectInputCell.tsx
+++ b/packages/react-table/src/components/Table/EditableSelectInputCell.tsx
@@ -18,12 +18,15 @@ export interface IEditableSelectInputCell extends Omit<React.HTMLProps<HTMLEleme
     event: React.MouseEvent | React.ChangeEvent,
     newValue: any | any[],
     rowIndex: number,
-    cellIndex: number
+    cellIndex: number,
+    isPlaceholder: boolean
   ) => void;
   /** Options to display in the expandable select menu */
   options?: React.ReactElement[];
   /** Flag indicating the select input is disabled */
   isDisabled?: boolean;
+  /** Flag indicating the toggle gets placeholder styles **/
+  isPlaceholder?: boolean;
   /** Current selected options to display as the read only value of the table cell */
   selections?: any | any[];
   /** Flag indicating the select menu is open */
@@ -41,13 +44,14 @@ export const EditableSelectInputCell: React.FunctionComponent<IEditableSelectInp
   onSelect = () => {},
   clearSelection,
   isOpen = false,
+  isPlaceholder = false,
   onToggle = () => {},
   selections = [''],
   options = [] as React.ReactElement[],
   props
 }: IEditableSelectInputCell) => {
   const onSelectHandler = (event: React.MouseEvent | React.ChangeEvent, newValue: any | any[]) => {
-    onSelect(event, newValue, rowIndex, cellIndex);
+    onSelect(event, newValue, rowIndex, cellIndex, isPlaceholder);
   };
 
   const onClear = (event: React.MouseEvent) => {
@@ -61,7 +65,7 @@ export const EditableSelectInputCell: React.FunctionComponent<IEditableSelectInp
       isOpen={isOpen}
       selected={selections}
       toggle={(toggleRef: any) => (
-        <MenuToggle ref={toggleRef} onClick={onToggle} isExpanded={isOpen}>
+        <MenuToggle ref={toggleRef} onClick={onToggle} isExpanded={isOpen} isPlaceholder={isPlaceholder}>
           {isOpen ? 'Expanded' : 'Collapsed'}
         </MenuToggle>
       )}

--- a/packages/react-table/src/components/Table/EditableSelectInputCell.tsx
+++ b/packages/react-table/src/components/Table/EditableSelectInputCell.tsx
@@ -18,8 +18,7 @@ export interface IEditableSelectInputCell extends Omit<React.HTMLProps<HTMLEleme
     event: React.MouseEvent | React.ChangeEvent,
     newValue: any | any[],
     rowIndex: number,
-    cellIndex: number,
-    isPlaceholder?: boolean
+    cellIndex: number
   ) => void;
   /** Options to display in the expandable select menu */
   options?: React.ReactElement[];
@@ -47,13 +46,7 @@ export const EditableSelectInputCell: React.FunctionComponent<IEditableSelectInp
   options = [] as React.ReactElement[],
   props
 }: IEditableSelectInputCell) => {
-  const [isSelectOpen, setIsSelectOpen] = React.useState(isOpen);
-
-  const onSelectHandler = (
-    event: React.MouseEvent | React.ChangeEvent,
-    newValue: any | any[]
-    //    isPlaceholder: boolean
-  ) => {
+  const onSelectHandler = (event: React.MouseEvent | React.ChangeEvent, newValue: any | any[]) => {
     onSelect(event, newValue, rowIndex, cellIndex);
   };
 
@@ -63,17 +56,16 @@ export const EditableSelectInputCell: React.FunctionComponent<IEditableSelectInp
 
   const select = (
     <Select
-      {...props.editableSelectProps}
       onSelect={onSelectHandler}
       {...(clearSelection && { onClear })}
-      isOpen={isSelectOpen}
-      onOpenChange={(isOpen: boolean) => setIsSelectOpen(isOpen)}
+      isOpen={isOpen}
       selected={selections}
       toggle={(toggleRef: any) => (
-        <MenuToggle ref={toggleRef} onClick={onToggle} isExpanded={isSelectOpen}>
-          {isSelectOpen ? 'Expanded' : 'Collapsed'}
+        <MenuToggle ref={toggleRef} onClick={onToggle} isExpanded={isOpen}>
+          {isOpen ? 'Expanded' : 'Collapsed'}
         </MenuToggle>
       )}
+      {...props.editableSelectProps}
     >
       <SelectList>{options}</SelectList>
     </Select>

--- a/packages/react-table/src/components/Table/EditableSelectInputCell.tsx
+++ b/packages/react-table/src/components/Table/EditableSelectInputCell.tsx
@@ -19,7 +19,7 @@ export interface IEditableSelectInputCell extends Omit<React.HTMLProps<HTMLEleme
     newValue: any | any[],
     rowIndex: number,
     cellIndex: number,
-    isPlaceholder: boolean
+    isPlaceholder?: boolean
   ) => void;
   /** Options to display in the expandable select menu */
   options?: React.ReactElement[];

--- a/packages/react-table/src/components/Table/EditableSelectInputCell.tsx
+++ b/packages/react-table/src/components/Table/EditableSelectInputCell.tsx
@@ -47,6 +47,8 @@ export const EditableSelectInputCell: React.FunctionComponent<IEditableSelectInp
   options = [] as React.ReactElement[],
   props
 }: IEditableSelectInputCell) => {
+  const [isSelectOpen, setIsSelectOpen] = React.useState(isOpen);
+
   const onSelectHandler = (
     event: React.MouseEvent | React.ChangeEvent,
     newValue: any | any[]
@@ -64,11 +66,12 @@ export const EditableSelectInputCell: React.FunctionComponent<IEditableSelectInp
       {...props.editableSelectProps}
       onSelect={onSelectHandler}
       {...(clearSelection && { onClear })}
-      isOpen={isOpen}
+      isOpen={isSelectOpen}
+      onOpenChange={(isOpen: boolean) => setIsSelectOpen(isOpen)}
       selected={selections}
       toggle={(toggleRef: any) => (
-        <MenuToggle ref={toggleRef} onClick={onToggle} isExpanded={isOpen}>
-          {isOpen ? 'Expanded' : 'Collapsed'}
+        <MenuToggle ref={toggleRef} onClick={onToggle} isExpanded={isSelectOpen}>
+          {isSelectOpen ? 'Expanded' : 'Collapsed'}
         </MenuToggle>
       )}
     >

--- a/packages/react-table/src/deprecated/components/Table/examples/Table.md
+++ b/packages/react-table/src/deprecated/components/Table/examples/Table.md
@@ -436,8 +436,8 @@ class EditableRowsTable extends React.Component {
                   { value: 'Option 5' }
                 ],
                 editableSelectProps: {
-                  variant: 'single',
-                  'aria-label': 'Row 1 cell 4 content'
+                  'aria-label': 'Row 1 cell 4 content',
+                  onOpenChange: (isOpen: boolean) => this.onOpenChange(isOpen, 0, 3)
                 }
               }
             }
@@ -531,9 +531,10 @@ class EditableRowsTable extends React.Component {
                   { value: 'Option 5' }
                 ],
                 editableSelectProps: {
-                  variant: 'typeaheadmulti',
                   'aria-label': 'Row 2 cell 4 content',
-                  toggleId: 'editable-toggle'
+                  toggleId: 'editable-toggle',
+                  onOpenChange: (isOpen: boolean) => this.onOpenChange(isOpen, 1, 3)
+
                 }
               }
             }
@@ -647,8 +648,9 @@ class EditableRowsTable extends React.Component {
                   { value: 'Option 5' }
                 ],
                 editableSelectProps: {
-                  variant: 'checkbox',
-                  'aria-label': 'Row 3 cell 4 content'
+                  'aria-label': 'Row 3 cell 4 content',
+                  onOpenChange: (isOpen: boolean) => this.onOpenChange(isOpen, 2, 3)
+
                 }
               }
             }
@@ -735,6 +737,15 @@ class EditableRowsTable extends React.Component {
         rows: newRows
       });
     };
+
+    // set open state if component closes menu on click (e.g. when you click outside of the menu)
+    this.onOpenChange = (isOpen: boolean, rowIndex: string | number | undefined, cellIndex: string | number | undefined) => {
+      const newRows = Array.from(this.state.rows);
+      newRows[rowIndex].cells[cellIndex].props.isSelectOpen = isOpen;
+      this.setState({
+        rows: newRows
+      });
+    }
 
     this.onToggle = (isOpen, rowIndex, cellIndex) => {
       console.log('isOpen', isOpen);

--- a/packages/react-table/src/deprecated/components/Table/examples/Table.md
+++ b/packages/react-table/src/deprecated/components/Table/examples/Table.md
@@ -325,8 +325,9 @@ import {
   applyCellEdits,
   EditableTextCell,
   EditableSelectInputCell,
-  SelectOption
 } from '@patternfly/react-table';
+
+import { SelectOption as NewSelectOption} from '@patternfly/react-core/dist/esm/components/Select';
 
 class EditableRowsTable extends React.Component {
   constructor(props) {
@@ -412,12 +413,12 @@ class EditableRowsTable extends React.Component {
                   onSelect={this.onSelect}
                   isOpen={props.isSelectOpen}
                   options={props.options.map((option, index) => (
-                    <SelectOption key={index} value={option.value} id={'uniqueIdRow1Cell4Option' + index}>
+                    <NewSelectOption key={index} value={option.value} id={'uniqueIdRow1Cell4Option' + index}>
                       {option.value}
-                    </SelectOption>
+                    </NewSelectOption>
                   ))}
-                  onToggle={(event, isOpen) => {
-                    this.onToggle(isOpen, rowIndex, cellIndex);
+                  onToggle={(event) => {
+                    this.onToggle(props.isSelectOpen, rowIndex, cellIndex);
                   }}
                   selections={props.selected}
                 />
@@ -505,13 +506,13 @@ class EditableRowsTable extends React.Component {
                   isOpen={props.isSelectOpen}
                   options={props.options.map((option, index) => {
                     return (
-                      <SelectOption key={index} value={option.value} id={'uniqueIdRow2Cell4Option' + index}>
+                      <NewSelectOption key={index} value={option.value} id={'uniqueIdRow2Cell4Option' + index}>
                         {option.value}
-                      </SelectOption>
+                      </NewSelectOption>
                     );
                   })}
-                  onToggle={(event, isOpen) => {
-                    this.onToggle(isOpen, rowIndex, cellIndex);
+                  onToggle={(event) => {
+                    this.onToggle(props.isSelectOpen, rowIndex, cellIndex);
                   }}
                   selections={props.selected}
                 />
@@ -622,12 +623,12 @@ class EditableRowsTable extends React.Component {
                   clearSelection={this.clearSelection}
                   isOpen={props.isSelectOpen}
                   options={props.options.map((option, index) => (
-                    <SelectOption key={index} value={option.value} id={'uniqueIdRow3Cell4Option' + index}>
+                    <NewSelectOption key={index} value={option.value} id={'uniqueIdRow3Cell4Option' + index}>
                       {option.value}
-                    </SelectOption>
+                    </NewSelectOption>
                   ))}
-                  onToggle={(event, isOpen) => {
-                    this.onToggle(isOpen, rowIndex, cellIndex);
+                  onToggle={(event) => {
+                    this.onToggle(props.isSelectOpen, rowIndex, cellIndex);
                   }}
                   selections={props.selected}
                 />
@@ -738,7 +739,7 @@ class EditableRowsTable extends React.Component {
     this.onToggle = (isOpen, rowIndex, cellIndex) => {
       console.log('isOpen', isOpen);
       let newRows = Array.from(this.state.rows);
-      newRows[rowIndex].cells[cellIndex].props.isSelectOpen = isOpen;
+      newRows[rowIndex].cells[cellIndex].props.isSelectOpen = !newRows[rowIndex].cells[cellIndex].props.isSelectOpen;
       this.setState({
         rows: newRows
       });

--- a/packages/react-table/src/deprecated/components/Table/examples/Table.md
+++ b/packages/react-table/src/deprecated/components/Table/examples/Table.md
@@ -522,8 +522,9 @@ class EditableRowsTable extends React.Component {
                 name: 'uniqueIdRow2Cell4',
                 isSelectOpen: props.isSelectOpen || false,
                 selected: props.selected || [],
+                isPlaceholder: true,
                 options: [
-                  { value: 'Placeholder...', isPlaceholder: true },
+                   { value: 'Placeholder...', isPlaceholder: true},
                   { value: 'Option 1' },
                   { value: 'Option 2' },
                   { value: 'Option 3' },
@@ -639,8 +640,9 @@ class EditableRowsTable extends React.Component {
                 name: 'uniqueIdRow3Cell4',
                 isSelectOpen: props.isSelectOpen || false,
                 selected: props.selected || ['Option 3'],
+                isPlaceholder: false,
                 options: [
-                  { value: 'Placeholder...', isPlaceholder: true },
+                  { value: 'Placeholder...', isPlaceholder: true},
                   { value: 'Option 1' },
                   { value: 'Option 2' },
                   { value: 'Option 3' },


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #10365

- Updated deprecated Editable table example
- Reenabled editable table tests.
- Updated Page demo and reenabled page test
- reenabled toolbar test
- update form demo and reenabled test ~~(i disabled the select test that is not working due to this issue #10840)~~
- added isPlaceholder prop to `EditableSelectInputCell`