### PR TITLE
fix(Button): rendered position modifier only when children are passed

### DIFF
--- a/packages/react-code-editor/src/components/CodeEditor/__test__/__snapshots__/CodeEditor.test.tsx.snap
+++ b/packages/react-code-editor/src/components/CodeEditor/__test__/__snapshots__/CodeEditor.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`Matches snapshot with control buttons enabled 1`] = `
                 type="button"
               >
                 <span
-                  class="pf-v6-c-button__icon pf-m-start"
+                  class="pf-v6-c-button__icon"
                 >
                   <svg
                     aria-hidden="true"
@@ -63,7 +63,7 @@ exports[`Matches snapshot with control buttons enabled 1`] = `
                 type="button"
               >
                 <span
-                  class="pf-v6-c-button__icon pf-m-start"
+                  class="pf-v6-c-button__icon"
                 >
                   <svg
                     aria-hidden="true"
@@ -94,7 +94,7 @@ exports[`Matches snapshot with control buttons enabled 1`] = `
                 type="button"
               >
                 <span
-                  class="pf-v6-c-button__icon pf-m-start"
+                  class="pf-v6-c-button__icon"
                 >
                   <svg
                     aria-hidden="true"

--- a/packages/react-code-editor/src/components/CodeEditor/__test__/__snapshots__/CodeEditorControl.test.tsx.snap
+++ b/packages/react-code-editor/src/components/CodeEditor/__test__/__snapshots__/CodeEditorControl.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Matches snapshot 1`] = `
       type="button"
     >
       <span
-        class="pf-v6-c-button__icon pf-m-start"
+        class="pf-v6-c-button__icon"
       >
         <div>
           icon

--- a/packages/react-core/src/components/AboutModal/__tests__/__snapshots__/AboutModalBoxCloseButton.test.tsx.snap
+++ b/packages/react-core/src/components/AboutModal/__tests__/__snapshots__/AboutModalBoxCloseButton.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`AboutModalBoxCloseButton Test 1`] = `
       type="button"
     >
       <span
-        class="pf-v6-c-button__icon pf-m-start"
+        class="pf-v6-c-button__icon"
       >
         <svg
           aria-hidden="true"
@@ -51,7 +51,7 @@ exports[`AboutModalBoxCloseButton Test close button aria label 1`] = `
       type="button"
     >
       <span
-        class="pf-v6-c-button__icon pf-m-start"
+        class="pf-v6-c-button__icon"
       >
         <svg
           aria-hidden="true"
@@ -87,7 +87,7 @@ exports[`AboutModalBoxCloseButton Test onclose 1`] = `
       type="button"
     >
       <span
-        class="pf-v6-c-button__icon pf-m-start"
+        class="pf-v6-c-button__icon"
       >
         <svg
           aria-hidden="true"

--- a/packages/react-core/src/components/Alert/__tests__/Generated/__snapshots__/AlertActionCloseButton.test.tsx.snap
+++ b/packages/react-core/src/components/Alert/__tests__/Generated/__snapshots__/AlertActionCloseButton.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`AlertActionCloseButton should match snapshot 1`] = `
     type="button"
   >
     <span
-      class="pf-v6-c-button__icon pf-m-start"
+      class="pf-v6-c-button__icon"
     >
       <svg
         aria-hidden="true"

--- a/packages/react-core/src/components/Button/Button.tsx
+++ b/packages/react-core/src/components/Button/Button.tsx
@@ -136,6 +136,7 @@ const ButtonBase: React.FunctionComponent<ButtonProps> = ({
   const Component = component as any;
   const isButtonElement = Component === 'button';
   const isInlineSpan = isInline && Component === 'span';
+  const isIconAlignedAtEnd = iconPosition === 'end' || iconPosition === 'right';
 
   const preventedEvents = inoperableEvents.reduce(
     (handlers, eventToPrevent) => ({
@@ -156,6 +157,13 @@ const ButtonBase: React.FunctionComponent<ButtonProps> = ({
       return 0;
     }
   };
+
+  const _icon = icon && (
+    <span className={css(styles.buttonIcon, children && styles.modifiers[isIconAlignedAtEnd ? 'end' : 'start'])}>
+      {icon}
+    </span>
+  );
+  const _children = children && <span className={css('pf-v6-c-button__text')}>{children}</span>;
 
   return (
     <Component
@@ -198,12 +206,16 @@ const ButtonBase: React.FunctionComponent<ButtonProps> = ({
           />
         </span>
       )}
-      {icon && (iconPosition === 'start' || iconPosition === 'left') && (
-        <span className={css(styles.buttonIcon, styles.modifiers.start)}>{icon}</span>
-      )}
-      {children && <span className={css('pf-v6-c-button__text')}>{children}</span>}
-      {icon && (iconPosition === 'end' || iconPosition === 'right') && (
-        <span className={css(styles.buttonIcon, styles.modifiers.end)}>{icon}</span>
+      {isIconAlignedAtEnd ? (
+        <>
+          {_children}
+          {_icon}
+        </>
+      ) : (
+        <>
+          {_icon}
+          {_children}
+        </>
       )}
       {countOptions && (
         <span className={css(styles.buttonCount, countOptions.className)}>

--- a/packages/react-core/src/components/Card/__tests__/__snapshots__/CardHeader.test.tsx.snap
+++ b/packages/react-core/src/components/Card/__tests__/__snapshots__/CardHeader.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`CardHeader onExpand adds the toggle button 1`] = `
         type="button"
       >
         <span
-          class="pf-v6-c-button__icon pf-m-start"
+          class="pf-v6-c-button__icon"
         >
           <span
             class="pf-v6-c-card__header-toggle-icon"

--- a/packages/react-core/src/components/ClipboardCopy/__tests__/__snapshots__/ClipboardCopyButton.test.tsx.snap
+++ b/packages/react-core/src/components/ClipboardCopy/__tests__/__snapshots__/ClipboardCopyButton.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`Matches snapshot 1`] = `
       type="button"
     >
       <span
-        class="pf-v6-c-button__icon pf-m-start"
+        class="pf-v6-c-button__icon"
       >
         <svg
           aria-hidden="true"

--- a/packages/react-core/src/components/ClipboardCopy/__tests__/__snapshots__/ClipboardCopyToggle.test.tsx.snap
+++ b/packages/react-core/src/components/ClipboardCopy/__tests__/__snapshots__/ClipboardCopyToggle.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Matches snapshot 1`] = `
     type="button"
   >
     <span
-      class="pf-v6-c-button__icon pf-m-start"
+      class="pf-v6-c-button__icon"
     >
       <div
         class="pf-v6-c-clipboard-copy__toggle-icon"

--- a/packages/react-core/src/components/DataList/__tests__/Generated/__snapshots__/DataListToggle.test.tsx.snap
+++ b/packages/react-core/src/components/DataList/__tests__/Generated/__snapshots__/DataListToggle.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`DataListToggle should match snapshot (auto-generated) 1`] = `
         type="button"
       >
         <span
-          class="pf-v6-c-button__icon pf-m-start"
+          class="pf-v6-c-button__icon"
         >
           <div
             class="pf-v6-c-data-list__toggle-icon"

--- a/packages/react-core/src/components/DataList/__tests__/__snapshots__/DataListToggle.test.tsx.snap
+++ b/packages/react-core/src/components/DataList/__tests__/__snapshots__/DataListToggle.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`Renders to match snapshot 1`] = `
         type="button"
       >
         <span
-          class="pf-v6-c-button__icon pf-m-start"
+          class="pf-v6-c-button__icon"
         >
           <div
             class="pf-v6-c-data-list__toggle-icon"

--- a/packages/react-core/src/components/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react-core/src/components/DatePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -95,7 +95,7 @@ exports[`With popover opened 1`] = `
                   type="button"
                 >
                   <span
-                    class="pf-v6-c-button__icon pf-m-start"
+                    class="pf-v6-c-button__icon"
                   >
                     <svg
                       aria-hidden="true"
@@ -201,7 +201,7 @@ exports[`With popover opened 1`] = `
                   type="button"
                 >
                   <span
-                    class="pf-v6-c-button__icon pf-m-start"
+                    class="pf-v6-c-button__icon"
                   >
                     <svg
                       aria-hidden="true"

--- a/packages/react-core/src/components/Form/__tests__/__snapshots__/FormFieldGroup.test.tsx.snap
+++ b/packages/react-core/src/components/Form/__tests__/__snapshots__/FormFieldGroup.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`Check expandable form field group example against snapshot 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <span
               class="pf-v6-c-form__field-group-toggle-icon"

--- a/packages/react-core/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
+++ b/packages/react-core/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`Label editable label 1`] = `
         type="button"
       >
         <span
-          class="pf-v6-c-button__icon pf-m-start"
+          class="pf-v6-c-button__icon"
         >
           <svg
             aria-hidden="true"
@@ -166,7 +166,7 @@ exports[`Label label with close button 1`] = `
         type="button"
       >
         <span
-          class="pf-v6-c-button__icon pf-m-start"
+          class="pf-v6-c-button__icon"
         >
           <svg
             aria-hidden="true"
@@ -215,7 +215,7 @@ exports[`Label label with close button and outline variant 1`] = `
         type="button"
       >
         <span
-          class="pf-v6-c-button__icon pf-m-start"
+          class="pf-v6-c-button__icon"
         >
           <svg
             aria-hidden="true"

--- a/packages/react-core/src/components/Label/__tests__/__snapshots__/LabelGroup.test.tsx.snap
+++ b/packages/react-core/src/components/Label/__tests__/__snapshots__/LabelGroup.test.tsx.snap
@@ -264,7 +264,7 @@ exports[`LabelGroup label group with closable category 1`] = `
         type="button"
       >
         <span
-          class="pf-v6-c-button__icon pf-m-start"
+          class="pf-v6-c-button__icon"
         >
           <svg
             aria-hidden="true"

--- a/packages/react-core/src/components/LoginPage/__tests__/__snapshots__/LoginForm.test.tsx.snap
+++ b/packages/react-core/src/components/LoginPage/__tests__/__snapshots__/LoginForm.test.tsx.snap
@@ -263,7 +263,7 @@ exports[`LoginForm LoginForm with show password 1`] = `
               type="button"
             >
               <span
-                class="pf-v6-c-button__icon pf-m-start"
+                class="pf-v6-c-button__icon"
               >
                 <svg
                   aria-hidden="true"

--- a/packages/react-core/src/components/Modal/__tests__/__snapshots__/ModalContent.test.tsx.snap
+++ b/packages/react-core/src/components/Modal/__tests__/__snapshots__/ModalContent.test.tsx.snap
@@ -106,7 +106,7 @@ exports[`Modal Content Test with onclose 1`] = `
             type="button"
           >
             <span
-              class="pf-v6-c-button__icon pf-m-start"
+              class="pf-v6-c-button__icon"
             >
               <svg
                 aria-hidden="true"

--- a/packages/react-core/src/components/MultipleFileUpload/__tests__/__snapshots__/MultipleFileUploadStatusItem.test.tsx.snap
+++ b/packages/react-core/src/components/MultipleFileUpload/__tests__/__snapshots__/MultipleFileUploadStatusItem.test.tsx.snap
@@ -98,7 +98,7 @@ exports[`MultipleFileUploadStatusItem renders custom aria labels 1`] = `
         type="button"
       >
         <span
-          class="pf-v6-c-button__icon pf-m-start"
+          class="pf-v6-c-button__icon"
         >
           <svg
             aria-hidden="true"
@@ -215,7 +215,7 @@ exports[`MultipleFileUploadStatusItem renders custom class names 1`] = `
         type="button"
       >
         <span
-          class="pf-v6-c-button__icon pf-m-start"
+          class="pf-v6-c-button__icon"
         >
           <svg
             aria-hidden="true"
@@ -334,7 +334,7 @@ exports[`MultipleFileUploadStatusItem renders custom file name/size/icon/progres
         type="button"
       >
         <span
-          class="pf-v6-c-button__icon pf-m-start"
+          class="pf-v6-c-button__icon"
         >
           <svg
             aria-hidden="true"
@@ -453,7 +453,7 @@ exports[`MultipleFileUploadStatusItem renders custom function progressAriaLiveMe
         type="button"
       >
         <span
-          class="pf-v6-c-button__icon pf-m-start"
+          class="pf-v6-c-button__icon"
         >
           <svg
             aria-hidden="true"
@@ -589,7 +589,7 @@ exports[`MultipleFileUploadStatusItem renders custom progress value/variant when
         type="button"
       >
         <span
-          class="pf-v6-c-button__icon pf-m-start"
+          class="pf-v6-c-button__icon"
         >
           <svg
             aria-hidden="true"
@@ -708,7 +708,7 @@ exports[`MultipleFileUploadStatusItem renders expected values from a passed file
         type="button"
       >
         <span
-          class="pf-v6-c-button__icon pf-m-start"
+          class="pf-v6-c-button__icon"
         >
           <svg
             aria-hidden="true"
@@ -825,7 +825,7 @@ exports[`MultipleFileUploadStatusItem renders with expected class names 1`] = `
         type="button"
       >
         <span
-          class="pf-v6-c-button__icon pf-m-start"
+          class="pf-v6-c-button__icon"
         >
           <svg
             aria-hidden="true"
@@ -944,7 +944,7 @@ exports[`MultipleFileUploadStatusItem rendersdefault progressAriaLiveMessage whe
         type="button"
       >
         <span
-          class="pf-v6-c-button__icon pf-m-start"
+          class="pf-v6-c-button__icon"
         >
           <svg
             aria-hidden="true"

--- a/packages/react-core/src/components/Pagination/__tests__/Generated/__snapshots__/Navigation.test.tsx.snap
+++ b/packages/react-core/src/components/Pagination/__tests__/Generated/__snapshots__/Navigation.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`Navigation should match snapshot (auto-generated) 1`] = `
         type="button"
       >
         <span
-          class="pf-v6-c-button__icon pf-m-start"
+          class="pf-v6-c-button__icon"
         >
           <svg
             aria-hidden="true"
@@ -58,7 +58,7 @@ exports[`Navigation should match snapshot (auto-generated) 1`] = `
         type="button"
       >
         <span
-          class="pf-v6-c-button__icon pf-m-start"
+          class="pf-v6-c-button__icon"
         >
           <svg
             aria-hidden="true"
@@ -109,7 +109,7 @@ exports[`Navigation should match snapshot (auto-generated) 1`] = `
         type="button"
       >
         <span
-          class="pf-v6-c-button__icon pf-m-start"
+          class="pf-v6-c-button__icon"
         >
           <svg
             aria-hidden="true"
@@ -141,7 +141,7 @@ exports[`Navigation should match snapshot (auto-generated) 1`] = `
         type="button"
       >
         <span
-          class="pf-v6-c-button__icon pf-m-start"
+          class="pf-v6-c-button__icon"
         >
           <svg
             aria-hidden="true"

--- a/packages/react-core/src/components/Pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/react-core/src/components/Pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -89,7 +89,7 @@ exports[`Pagination API verify inset2xl inset breakpoints 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -122,7 +122,7 @@ exports[`Pagination API verify inset2xl inset breakpoints 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -173,7 +173,7 @@ exports[`Pagination API verify inset2xl inset breakpoints 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -205,7 +205,7 @@ exports[`Pagination API verify inset2xl inset breakpoints 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -318,7 +318,7 @@ exports[`Pagination API verify insetLg inset breakpoints 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -351,7 +351,7 @@ exports[`Pagination API verify insetLg inset breakpoints 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -402,7 +402,7 @@ exports[`Pagination API verify insetLg inset breakpoints 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -434,7 +434,7 @@ exports[`Pagination API verify insetLg inset breakpoints 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -547,7 +547,7 @@ exports[`Pagination API verify insetMd inset breakpoints 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -580,7 +580,7 @@ exports[`Pagination API verify insetMd inset breakpoints 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -631,7 +631,7 @@ exports[`Pagination API verify insetMd inset breakpoints 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -663,7 +663,7 @@ exports[`Pagination API verify insetMd inset breakpoints 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -776,7 +776,7 @@ exports[`Pagination API verify insetNone inset breakpoints 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -809,7 +809,7 @@ exports[`Pagination API verify insetNone inset breakpoints 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -860,7 +860,7 @@ exports[`Pagination API verify insetNone inset breakpoints 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -892,7 +892,7 @@ exports[`Pagination API verify insetNone inset breakpoints 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -1005,7 +1005,7 @@ exports[`Pagination API verify insetSm inset breakpoints 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -1038,7 +1038,7 @@ exports[`Pagination API verify insetSm inset breakpoints 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -1089,7 +1089,7 @@ exports[`Pagination API verify insetSm inset breakpoints 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -1121,7 +1121,7 @@ exports[`Pagination API verify insetSm inset breakpoints 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -1234,7 +1234,7 @@ exports[`Pagination API verify insetXl inset breakpoints 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -1267,7 +1267,7 @@ exports[`Pagination API verify insetXl inset breakpoints 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -1318,7 +1318,7 @@ exports[`Pagination API verify insetXl inset breakpoints 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -1350,7 +1350,7 @@ exports[`Pagination API verify insetXl inset breakpoints 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -1449,7 +1449,7 @@ exports[`Pagination component render custom pagination toggle 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -1482,7 +1482,7 @@ exports[`Pagination component render custom pagination toggle 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -1538,7 +1538,7 @@ exports[`Pagination component render custom pagination toggle 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -1570,7 +1570,7 @@ exports[`Pagination component render custom pagination toggle 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -1682,7 +1682,7 @@ exports[`Pagination component render custom perPageOptions 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -1715,7 +1715,7 @@ exports[`Pagination component render custom perPageOptions 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -1771,7 +1771,7 @@ exports[`Pagination component render custom perPageOptions 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -1803,7 +1803,7 @@ exports[`Pagination component render custom perPageOptions 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -1914,7 +1914,7 @@ exports[`Pagination component render custom start end 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -1946,7 +1946,7 @@ exports[`Pagination component render custom start end 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -2002,7 +2002,7 @@ exports[`Pagination component render custom start end 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -2034,7 +2034,7 @@ exports[`Pagination component render custom start end 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -2098,7 +2098,7 @@ exports[`Pagination component render empty per page options 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -2131,7 +2131,7 @@ exports[`Pagination component render empty per page options 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -2187,7 +2187,7 @@ exports[`Pagination component render empty per page options 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -2219,7 +2219,7 @@ exports[`Pagination component render empty per page options 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -2330,7 +2330,7 @@ exports[`Pagination component render last page 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -2362,7 +2362,7 @@ exports[`Pagination component render last page 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -2419,7 +2419,7 @@ exports[`Pagination component render last page 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -2452,7 +2452,7 @@ exports[`Pagination component render last page 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -2564,7 +2564,7 @@ exports[`Pagination component render limited number of pages 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -2597,7 +2597,7 @@ exports[`Pagination component render limited number of pages 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -2655,7 +2655,7 @@ exports[`Pagination component render limited number of pages 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -2688,7 +2688,7 @@ exports[`Pagination component render limited number of pages 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -2788,7 +2788,7 @@ exports[`Pagination component render should render correctly bottom 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -2821,7 +2821,7 @@ exports[`Pagination component render should render correctly bottom 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -2877,7 +2877,7 @@ exports[`Pagination component render should render correctly bottom 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -2909,7 +2909,7 @@ exports[`Pagination component render should render correctly bottom 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -3009,7 +3009,7 @@ exports[`Pagination component render should render correctly bottom sticky 1`] =
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -3042,7 +3042,7 @@ exports[`Pagination component render should render correctly bottom sticky 1`] =
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -3098,7 +3098,7 @@ exports[`Pagination component render should render correctly bottom sticky 1`] =
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -3130,7 +3130,7 @@ exports[`Pagination component render should render correctly bottom sticky 1`] =
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -3242,7 +3242,7 @@ exports[`Pagination component render should render correctly compact 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -3275,7 +3275,7 @@ exports[`Pagination component render should render correctly compact 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -3331,7 +3331,7 @@ exports[`Pagination component render should render correctly compact 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -3363,7 +3363,7 @@ exports[`Pagination component render should render correctly compact 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -3476,7 +3476,7 @@ exports[`Pagination component render should render correctly disabled 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -3509,7 +3509,7 @@ exports[`Pagination component render should render correctly disabled 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -3567,7 +3567,7 @@ exports[`Pagination component render should render correctly disabled 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -3600,7 +3600,7 @@ exports[`Pagination component render should render correctly disabled 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -3712,7 +3712,7 @@ exports[`Pagination component render should render correctly sticky 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -3745,7 +3745,7 @@ exports[`Pagination component render should render correctly sticky 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -3801,7 +3801,7 @@ exports[`Pagination component render should render correctly sticky 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -3833,7 +3833,7 @@ exports[`Pagination component render should render correctly sticky 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -3945,7 +3945,7 @@ exports[`Pagination component render should render correctly top 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -3978,7 +3978,7 @@ exports[`Pagination component render should render correctly top 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -4034,7 +4034,7 @@ exports[`Pagination component render should render correctly top 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -4066,7 +4066,7 @@ exports[`Pagination component render should render correctly top 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -4178,7 +4178,7 @@ exports[`Pagination component render titles 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -4211,7 +4211,7 @@ exports[`Pagination component render titles 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -4267,7 +4267,7 @@ exports[`Pagination component render titles 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -4299,7 +4299,7 @@ exports[`Pagination component render titles 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -4411,7 +4411,7 @@ exports[`Pagination component render up drop direction 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -4444,7 +4444,7 @@ exports[`Pagination component render up drop direction 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -4500,7 +4500,7 @@ exports[`Pagination component render up drop direction 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -4532,7 +4532,7 @@ exports[`Pagination component render up drop direction 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -4644,7 +4644,7 @@ exports[`Pagination component render zero results 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -4677,7 +4677,7 @@ exports[`Pagination component render zero results 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -4735,7 +4735,7 @@ exports[`Pagination component render zero results 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -4768,7 +4768,7 @@ exports[`Pagination component render zero results 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"

--- a/packages/react-core/src/components/Popover/__tests__/Generated/__snapshots__/PopoverCloseButton.test.tsx.snap
+++ b/packages/react-core/src/components/Popover/__tests__/Generated/__snapshots__/PopoverCloseButton.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`PopoverCloseButton should match snapshot (auto-generated) 1`] = `
       type="button"
     >
       <span
-        class="pf-v6-c-button__icon pf-m-start"
+        class="pf-v6-c-button__icon"
       >
         <svg
           aria-hidden="true"

--- a/packages/react-core/src/components/SearchInput/__tests__/__snapshots__/SearchInput.test.tsx.snap
+++ b/packages/react-core/src/components/SearchInput/__tests__/__snapshots__/SearchInput.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`SearchInput advanced search 1`] = `
               type="button"
             >
               <span
-                class="pf-v6-c-button__icon pf-m-start"
+                class="pf-v6-c-button__icon"
               >
                 <svg
                   aria-hidden="true"
@@ -86,7 +86,7 @@ exports[`SearchInput advanced search 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -114,7 +114,7 @@ exports[`SearchInput advanced search 1`] = `
           type="submit"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <span
               class="pf-v6-c-icon"
@@ -208,7 +208,7 @@ exports[`SearchInput advanced search with custom attributes 1`] = `
               type="button"
             >
               <span
-                class="pf-v6-c-button__icon pf-m-start"
+                class="pf-v6-c-button__icon"
               >
                 <svg
                   aria-hidden="true"
@@ -239,7 +239,7 @@ exports[`SearchInput advanced search with custom attributes 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -267,7 +267,7 @@ exports[`SearchInput advanced search with custom attributes 1`] = `
           type="submit"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <span
               class="pf-v6-c-icon"
@@ -547,7 +547,7 @@ exports[`SearchInput renders search input in strict mode 1`] = `
               type="button"
             >
               <span
-                class="pf-v6-c-button__icon pf-m-start"
+                class="pf-v6-c-button__icon"
               >
                 <svg
                   aria-hidden="true"
@@ -578,7 +578,7 @@ exports[`SearchInput renders search input in strict mode 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -606,7 +606,7 @@ exports[`SearchInput renders search input in strict mode 1`] = `
           type="submit"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <span
               class="pf-v6-c-icon"
@@ -706,7 +706,7 @@ exports[`SearchInput search input with hint 1`] = `
               type="button"
             >
               <span
-                class="pf-v6-c-button__icon pf-m-start"
+                class="pf-v6-c-button__icon"
               >
                 <svg
                   aria-hidden="true"
@@ -730,7 +730,7 @@ exports[`SearchInput search input with hint 1`] = `
               type="button"
             >
               <span
-                class="pf-v6-c-button__icon pf-m-start"
+                class="pf-v6-c-button__icon"
               >
                 <svg
                   aria-hidden="true"
@@ -755,7 +755,7 @@ exports[`SearchInput search input with hint 1`] = `
             type="button"
           >
             <span
-              class="pf-v6-c-button__icon pf-m-start"
+              class="pf-v6-c-button__icon"
             >
               <svg
                 aria-hidden="true"
@@ -785,7 +785,7 @@ exports[`SearchInput search input with hint 1`] = `
         type="submit"
       >
         <span
-          class="pf-v6-c-button__icon pf-m-start"
+          class="pf-v6-c-button__icon"
         >
           <span
             class="pf-v6-c-icon"
@@ -870,7 +870,7 @@ exports[`SearchInput simple search input 1`] = `
               type="button"
             >
               <span
-                class="pf-v6-c-button__icon pf-m-start"
+                class="pf-v6-c-button__icon"
               >
                 <svg
                   aria-hidden="true"
@@ -894,7 +894,7 @@ exports[`SearchInput simple search input 1`] = `
               type="button"
             >
               <span
-                class="pf-v6-c-button__icon pf-m-start"
+                class="pf-v6-c-button__icon"
               >
                 <svg
                   aria-hidden="true"
@@ -919,7 +919,7 @@ exports[`SearchInput simple search input 1`] = `
             type="button"
           >
             <span
-              class="pf-v6-c-button__icon pf-m-start"
+              class="pf-v6-c-button__icon"
             >
               <svg
                 aria-hidden="true"
@@ -949,7 +949,7 @@ exports[`SearchInput simple search input 1`] = `
         type="submit"
       >
         <span
-          class="pf-v6-c-button__icon pf-m-start"
+          class="pf-v6-c-button__icon"
         >
           <span
             class="pf-v6-c-icon"

--- a/packages/react-core/src/components/Toolbar/__tests__/__snapshots__/Toolbar.test.tsx.snap
+++ b/packages/react-core/src/components/Toolbar/__tests__/__snapshots__/Toolbar.test.tsx.snap
@@ -79,7 +79,7 @@ exports[`Toolbar should render with custom label content 1`] = `
               type="button"
             >
               <span
-                class="pf-v6-c-button__icon pf-m-start"
+                class="pf-v6-c-button__icon"
               />
             </button>
           </div>
@@ -152,7 +152,7 @@ exports[`Toolbar should render with custom label content 1`] = `
                         type="button"
                       >
                         <span
-                          class="pf-v6-c-button__icon pf-m-start"
+                          class="pf-v6-c-button__icon"
                         >
                           <svg
                             aria-hidden="true"
@@ -200,7 +200,7 @@ exports[`Toolbar should render with custom label content 1`] = `
                         type="button"
                       >
                         <span
-                          class="pf-v6-c-button__icon pf-m-start"
+                          class="pf-v6-c-button__icon"
                         >
                           <svg
                             aria-hidden="true"
@@ -237,7 +237,7 @@ exports[`Toolbar should render with custom label content 1`] = `
                 type="button"
               >
                 <span
-                  class="pf-v6-c-button__icon pf-m-start"
+                  class="pf-v6-c-button__icon"
                 >
                   <svg
                     aria-hidden="true"

--- a/packages/react-core/src/deprecated/components/Chip/__tests__/__snapshots__/Chip.test.tsx.snap
+++ b/packages/react-core/src/deprecated/components/Chip/__tests__/__snapshots__/Chip.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`Matches snapshot 1`] = `
         type="button"
       >
         <span
-          class="pf-v6-c-button__icon pf-m-start"
+          class="pf-v6-c-button__icon"
         >
           <svg
             aria-hidden="true"

--- a/packages/react-core/src/deprecated/components/Modal/__tests__/__snapshots__/ModalContent.test.tsx.snap
+++ b/packages/react-core/src/deprecated/components/Modal/__tests__/__snapshots__/ModalContent.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`Modal Content Test description 1`] = `
             type="button"
           >
             <span
-              class="pf-v6-c-button__icon pf-m-start"
+              class="pf-v6-c-button__icon"
             >
               <svg
                 aria-hidden="true"
@@ -111,7 +111,7 @@ exports[`Modal Content Test isOpen 1`] = `
             type="button"
           >
             <span
-              class="pf-v6-c-button__icon pf-m-start"
+              class="pf-v6-c-button__icon"
             >
               <svg
                 aria-hidden="true"
@@ -186,7 +186,7 @@ exports[`Modal Content Test only body 1`] = `
             type="button"
           >
             <span
-              class="pf-v6-c-button__icon pf-m-start"
+              class="pf-v6-c-button__icon"
             >
               <svg
                 aria-hidden="true"
@@ -261,7 +261,7 @@ exports[`Modal Content Test with footer 1`] = `
             type="button"
           >
             <span
-              class="pf-v6-c-button__icon pf-m-start"
+              class="pf-v6-c-button__icon"
             >
               <svg
                 aria-hidden="true"
@@ -341,7 +341,7 @@ exports[`Modal Content Test with onclose 1`] = `
             type="button"
           >
             <span
-              class="pf-v6-c-button__icon pf-m-start"
+              class="pf-v6-c-button__icon"
             >
               <svg
                 aria-hidden="true"
@@ -421,7 +421,7 @@ exports[`Modal Content test without footer 1`] = `
             type="button"
           >
             <span
-              class="pf-v6-c-button__icon pf-m-start"
+              class="pf-v6-c-button__icon"
             >
               <svg
                 aria-hidden="true"
@@ -496,7 +496,7 @@ exports[`Modal Test with custom footer 1`] = `
             type="button"
           >
             <span
-              class="pf-v6-c-button__icon pf-m-start"
+              class="pf-v6-c-button__icon"
             >
               <svg
                 aria-hidden="true"
@@ -580,7 +580,7 @@ exports[`Modal Test with custom header 1`] = `
             type="button"
           >
             <span
-              class="pf-v6-c-button__icon pf-m-start"
+              class="pf-v6-c-button__icon"
             >
               <svg
                 aria-hidden="true"

--- a/packages/react-core/src/deprecated/components/Wizard/__tests__/__snapshots__/Wizard.test.tsx.snap
+++ b/packages/react-core/src/deprecated/components/Wizard/__tests__/__snapshots__/Wizard.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`Wizard Expandable Nav Wizard should match snapshot 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"
@@ -336,7 +336,7 @@ exports[`Wizard Wizard should match snapshot 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"

--- a/packages/react-table/src/deprecated/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/packages/react-table/src/deprecated/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -10556,7 +10556,7 @@ exports[`Table simple Editable table 1`] = `
                   type="button"
                 >
                   <span
-                    class="pf-v6-c-button__icon pf-m-start"
+                    class="pf-v6-c-button__icon"
                   >
                     <svg
                       aria-hidden="true"
@@ -10587,7 +10587,7 @@ exports[`Table simple Editable table 1`] = `
                   type="button"
                 >
                   <span
-                    class="pf-v6-c-button__icon pf-m-start"
+                    class="pf-v6-c-button__icon"
                   >
                     <svg
                       aria-hidden="true"
@@ -10619,7 +10619,7 @@ exports[`Table simple Editable table 1`] = `
                 type="button"
               >
                 <span
-                  class="pf-v6-c-button__icon pf-m-start"
+                  class="pf-v6-c-button__icon"
                 >
                   <svg
                     aria-hidden="true"
@@ -10799,7 +10799,7 @@ exports[`Table simple Editable table 1`] = `
                   type="button"
                 >
                   <span
-                    class="pf-v6-c-button__icon pf-m-start"
+                    class="pf-v6-c-button__icon"
                   >
                     <svg
                       aria-hidden="true"
@@ -10830,7 +10830,7 @@ exports[`Table simple Editable table 1`] = `
                   type="button"
                 >
                   <span
-                    class="pf-v6-c-button__icon pf-m-start"
+                    class="pf-v6-c-button__icon"
                   >
                     <svg
                       aria-hidden="true"
@@ -10862,7 +10862,7 @@ exports[`Table simple Editable table 1`] = `
                 type="button"
               >
                 <span
-                  class="pf-v6-c-button__icon pf-m-start"
+                  class="pf-v6-c-button__icon"
                 >
                   <svg
                     aria-hidden="true"

--- a/packages/react-templates/src/components/Select/__tests__/__snapshots__/TypeaheadSelect.test.tsx.snap
+++ b/packages/react-templates/src/components/Select/__tests__/__snapshots__/TypeaheadSelect.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`Matches snapshot 1`] = `
           type="button"
         >
           <span
-            class="pf-v6-c-button__icon pf-m-start"
+            class="pf-v6-c-button__icon"
           >
             <svg
               aria-hidden="true"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #10693

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
