### PR TITLE
feat(misc): remove isFullHeight from page toolbar and dropdown

### DIFF
--- a/packages/react-core/src/demos/DashboardHeader.tsx
+++ b/packages/react-core/src/demos/DashboardHeader.tsx
@@ -99,7 +99,7 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({ notificationBa
         </MastheadBrand>
       </MastheadMain>
       <MastheadContent>
-        <Toolbar id="toolbar" isFullHeight isStatic>
+        <Toolbar id="toolbar" isStatic>
           <ToolbarContent>
             <ToolbarGroup
               variant="action-group-plain"
@@ -182,8 +182,7 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({ notificationBa
                     ref={toggleRef}
                     isExpanded={isDropdownOpen}
                     onClick={onDropdownToggle}
-                    icon={<Avatar src={imgAvatar} alt="" />}
-                    isFullHeight
+                    icon={<Avatar src={imgAvatar} alt="" size="sm" />}
                   >
                     Ned Username
                   </MenuToggle>

--- a/packages/react-core/src/demos/NotificationDrawer/examples/NotificationDrawerBasic.tsx
+++ b/packages/react-core/src/demos/NotificationDrawer/examples/NotificationDrawerBasic.tsx
@@ -174,7 +174,7 @@ export const NotificationDrawerBasic: React.FunctionComponent = () => {
     </>
   );
   const headerToolbar = (
-    <Toolbar isFullHeight>
+    <Toolbar>
       <ToolbarContent>
         <ToolbarGroup align={{ default: 'alignEnd' }}>
           <ToolbarGroup variant="action-group-plain">
@@ -242,8 +242,7 @@ export const NotificationDrawerBasic: React.FunctionComponent = () => {
                     ref={toggleRef}
                     isExpanded={isDropdownOpen}
                     onClick={onDropdownToggle}
-                    icon={<Avatar src={imgAvatar} alt="" />}
-                    isFullHeight
+                    icon={<Avatar src={imgAvatar} alt="" size="sm" />}
                   >
                     John Smith
                   </MenuToggle>

--- a/packages/react-core/src/demos/NotificationDrawer/examples/NotificationDrawerGrouped.tsx
+++ b/packages/react-core/src/demos/NotificationDrawer/examples/NotificationDrawerGrouped.tsx
@@ -224,7 +224,7 @@ export const NotificationDrawerGrouped: React.FunctionComponent = () => {
     </>
   );
   const headerToolbar = (
-    <Toolbar isFullHeight>
+    <Toolbar>
       <ToolbarContent>
         <ToolbarGroup align={{ default: 'alignEnd' }}>
           <ToolbarGroup variant="action-group-plain">
@@ -292,8 +292,7 @@ export const NotificationDrawerGrouped: React.FunctionComponent = () => {
                     ref={toggleRef}
                     isExpanded={isDropdownOpen}
                     onClick={onDropdownToggle}
-                    icon={<Avatar src={imgAvatar} alt="" />}
-                    isFullHeight
+                    icon={<Avatar src={imgAvatar} alt="" size="sm" />}
                   >
                     John Smith
                   </MenuToggle>

--- a/packages/react-core/src/demos/RTL/examples/PaginatedTable.jsx
+++ b/packages/react-core/src/demos/RTL/examples/PaginatedTable.jsx
@@ -338,7 +338,7 @@ export const PaginatedTableAction = () => {
         </MastheadBrand>
       </MastheadMain>
       <MastheadContent>
-        <Toolbar id="toolbar" isFullHeight isStatic>
+        <Toolbar id="toolbar" isStatic>
           <ToolbarContent>
             <ToolbarGroup
               variant="action-group-plain"
@@ -419,8 +419,7 @@ export const PaginatedTableAction = () => {
                     ref={toggleRef}
                     isExpanded={isDropdownOpen}
                     onClick={onDropdownToggle}
-                    icon={<Avatar src={imgAvatar} alt="" />}
-                    isFullHeight
+                    icon={<Avatar src={imgAvatar} alt="" size="sm" />}
                   >
                     {translation.username}
                   </MenuToggle>

--- a/packages/react-core/src/demos/RTL/examples/PaginatedTable.tsx
+++ b/packages/react-core/src/demos/RTL/examples/PaginatedTable.tsx
@@ -362,7 +362,7 @@ export const PaginatedTableAction: React.FunctionComponent = () => {
         </MastheadBrand>
       </MastheadMain>
       <MastheadContent>
-        <Toolbar id="toolbar" isFullHeight isStatic>
+        <Toolbar id="toolbar" isStatic>
           <ToolbarContent>
             <ToolbarGroup
               variant="action-group-plain"
@@ -443,8 +443,7 @@ export const PaginatedTableAction: React.FunctionComponent = () => {
                     ref={toggleRef}
                     isExpanded={isDropdownOpen}
                     onClick={onDropdownToggle}
-                    icon={<Avatar src={imgAvatar} alt="" />}
-                    isFullHeight
+                    icon={<Avatar src={imgAvatar} alt="" size="sm" />}
                   >
                     {translation.username}
                   </MenuToggle>

--- a/packages/react-core/src/demos/examples/Masthead/MastheadWithHorizontalNav.tsx
+++ b/packages/react-core/src/demos/examples/Masthead/MastheadWithHorizontalNav.tsx
@@ -179,7 +179,7 @@ export const MastheadWithHorizontalNav: React.FunctionComponent = () => {
   );
 
   const headerToolbar = (
-    <Toolbar id="toolbar" isFullHeight>
+    <Toolbar id="toolbar">
       <ToolbarContent>
         <PageHorizontalNav />
         <ToolbarGroup
@@ -255,9 +255,8 @@ export const MastheadWithHorizontalNav: React.FunctionComponent = () => {
               <MenuToggle
                 ref={toggleRef}
                 onClick={onDropdownToggle}
-                isFullHeight
                 isExpanded={isDropdownOpen}
-                icon={<Avatar src={imgAvatar} alt="" />}
+                icon={<Avatar src={imgAvatar} alt="" size="sm" />}
               >
                 Ned Username
               </MenuToggle>

--- a/packages/react-core/src/demos/examples/Masthead/MastheadWithUtilitiesAndUserDropdownMenu.tsx
+++ b/packages/react-core/src/demos/examples/Masthead/MastheadWithUtilitiesAndUserDropdownMenu.tsx
@@ -378,7 +378,7 @@ export const MastheadWithUtilitiesAndUserDropdownMenu: React.FunctionComponent =
   ];
 
   const headerToolbar = (
-    <Toolbar id="toolbar" isFullHeight isStatic>
+    <Toolbar id="toolbar" isStatic>
       <ToolbarContent>
         <ToolbarGroup
           variant="action-group-plain"
@@ -456,9 +456,8 @@ export const MastheadWithUtilitiesAndUserDropdownMenu: React.FunctionComponent =
               <MenuToggle
                 ref={toggleRef}
                 onClick={onDropdownToggle}
-                isFullHeight
                 isExpanded={isDropdownOpen}
-                icon={<Avatar src={imgAvatar} alt="" />}
+                icon={<Avatar src={imgAvatar} alt="" size="sm" />}
               >
                 Ned Username
               </MenuToggle>

--- a/packages/react-core/src/demos/examples/Nav/NavFlyout.tsx
+++ b/packages/react-core/src/demos/examples/Nav/NavFlyout.tsx
@@ -126,7 +126,7 @@ export const NavFlyout: React.FunctionComponent = () => {
   );
 
   const headerToolbar = (
-    <Toolbar id="toolbar" isFullHeight isStatic>
+    <Toolbar id="toolbar" isStatic>
       <ToolbarContent>
         <ToolbarGroup
           variant="action-group-plain"
@@ -202,8 +202,7 @@ export const NavFlyout: React.FunctionComponent = () => {
                 ref={toggleRef}
                 isExpanded={isDropdownOpen}
                 onClick={onDropdownToggle}
-                icon={<Avatar src={imgAvatar} alt="" />}
-                isFullHeight
+                icon={<Avatar src={imgAvatar} alt="" size="sm" />}
               >
                 Ned Username
               </MenuToggle>

--- a/packages/react-core/src/demos/examples/Nav/NavHorizontal.tsx
+++ b/packages/react-core/src/demos/examples/Nav/NavHorizontal.tsx
@@ -103,7 +103,7 @@ export const NavHorizontal: React.FunctionComponent = () => {
   );
 
   const headerToolbar = (
-    <Toolbar id="toolbar" isFullHeight isStatic>
+    <Toolbar id="toolbar" isStatic>
       <ToolbarContent>
         <ToolbarItem isOverflowContainer>{PageNav}</ToolbarItem>
         <ToolbarGroup
@@ -180,8 +180,7 @@ export const NavHorizontal: React.FunctionComponent = () => {
                 ref={toggleRef}
                 isExpanded={isDropdownOpen}
                 onClick={onDropdownToggle}
-                icon={<Avatar src={imgAvatar} alt="" />}
-                isFullHeight
+                icon={<Avatar src={imgAvatar} alt="" size="sm" />}
               >
                 Ned Username
               </MenuToggle>

--- a/packages/react-core/src/demos/examples/Nav/NavHorizontalWithSubnav.tsx
+++ b/packages/react-core/src/demos/examples/Nav/NavHorizontalWithSubnav.tsx
@@ -152,7 +152,7 @@ export const NavHorizontalWithSubnav: React.FunctionComponent = () => {
   );
 
   const headerToolbar = (
-    <Toolbar id="toolbar" isFullHeight isStatic>
+    <Toolbar id="toolbar" isStatic>
       <ToolbarContent>
         <ToolbarItem isOverflowContainer>{PageNav}</ToolbarItem>
         <ToolbarGroup
@@ -229,8 +229,7 @@ export const NavHorizontalWithSubnav: React.FunctionComponent = () => {
                 ref={toggleRef}
                 isExpanded={isDropdownOpen}
                 onClick={onDropdownToggle}
-                icon={<Avatar src={imgAvatar} alt="" />}
-                isFullHeight
+                icon={<Avatar src={imgAvatar} alt="" size="sm" />}
               >
                 Ned Username
               </MenuToggle>

--- a/packages/react-core/src/demos/examples/Nav/NavManual.tsx
+++ b/packages/react-core/src/demos/examples/Nav/NavManual.tsx
@@ -120,7 +120,7 @@ export const NavManual: React.FunctionComponent = () => {
   );
 
   const headerToolbar = (
-    <Toolbar id="toolbar" isFullHeight isStatic>
+    <Toolbar id="toolbar" isStatic>
       <ToolbarContent>
         <ToolbarGroup
           variant="action-group-plain"
@@ -196,8 +196,7 @@ export const NavManual: React.FunctionComponent = () => {
                 ref={toggleRef}
                 isExpanded={isDropdownOpen}
                 onClick={onDropdownToggle}
-                icon={<Avatar src={imgAvatar} alt="" />}
-                isFullHeight
+                icon={<Avatar src={imgAvatar} alt="" size="sm" />}
               >
                 Ned Username
               </MenuToggle>

--- a/packages/react-core/src/demos/examples/Page/PageContextSelector.tsx
+++ b/packages/react-core/src/demos/examples/Page/PageContextSelector.tsx
@@ -133,7 +133,7 @@ export const PageStickySectionBreadcrumb: React.FunctionComponent = () => {
   );
 
   const headerToolbar = (
-    <Toolbar id="toolbar" isFullHeight isStatic>
+    <Toolbar id="toolbar" isStatic>
       <ToolbarContent>
         <ToolbarGroup
           variant="action-group-plain"
@@ -208,9 +208,8 @@ export const PageStickySectionBreadcrumb: React.FunctionComponent = () => {
               <MenuToggle
                 ref={toggleRef}
                 onClick={onDropdownToggle}
-                isFullHeight
                 isExpanded={isDropdownOpen}
-                icon={<Avatar src={imgAvatar} alt="" />}
+                icon={<Avatar src={imgAvatar} alt="" size="sm" />}
               >
                 Ned Username
               </MenuToggle>

--- a/packages/react-core/src/demos/examples/Page/PageStickySectionBreadcrumb.tsx
+++ b/packages/react-core/src/demos/examples/Page/PageStickySectionBreadcrumb.tsx
@@ -116,7 +116,7 @@ export const PageStickySectionBreadcrumb: React.FunctionComponent = () => {
   );
 
   const headerToolbar = (
-    <Toolbar id="toolbar" isFullHeight isStatic>
+    <Toolbar id="toolbar" isStatic>
       <ToolbarContent>
         <ToolbarGroup
           variant="action-group-plain"
@@ -191,9 +191,8 @@ export const PageStickySectionBreadcrumb: React.FunctionComponent = () => {
               <MenuToggle
                 ref={toggleRef}
                 onClick={onDropdownToggle}
-                isFullHeight
                 isExpanded={isDropdownOpen}
-                icon={<Avatar src={imgAvatar} alt="" />}
+                icon={<Avatar src={imgAvatar} alt="" size="sm" />}
               >
                 Ned Username
               </MenuToggle>

--- a/packages/react-core/src/demos/examples/Page/PageStickySectionGroup.tsx
+++ b/packages/react-core/src/demos/examples/Page/PageStickySectionGroup.tsx
@@ -116,7 +116,7 @@ export const PageStickySectionGroup: React.FunctionComponent = () => {
   );
 
   const headerToolbar = (
-    <Toolbar id="toolbar" isFullHeight isStatic>
+    <Toolbar id="toolbar" isStatic>
       <ToolbarContent>
         <ToolbarGroup
           variant="action-group-plain"
@@ -191,9 +191,8 @@ export const PageStickySectionGroup: React.FunctionComponent = () => {
               <MenuToggle
                 ref={toggleRef}
                 onClick={onDropdownToggle}
-                isFullHeight
                 isExpanded={isDropdownOpen}
-                icon={<Avatar src={imgAvatar} alt="" />}
+                icon={<Avatar src={imgAvatar} alt="" size="sm" />}
               >
                 Ned Username
               </MenuToggle>

--- a/packages/react-core/src/demos/examples/Page/PageStickySectionGroupAlternate.tsx
+++ b/packages/react-core/src/demos/examples/Page/PageStickySectionGroupAlternate.tsx
@@ -108,7 +108,7 @@ export const PageStickySectionGroupAlternate: React.FunctionComponent = () => {
   );
 
   const headerToolbar = (
-    <Toolbar id="toolbar" isFullHeight isStatic>
+    <Toolbar id="toolbar" isStatic>
       <ToolbarContent>
         <ToolbarGroup
           variant="action-group-plain"
@@ -183,9 +183,8 @@ export const PageStickySectionGroupAlternate: React.FunctionComponent = () => {
               <MenuToggle
                 ref={toggleRef}
                 onClick={onDropdownToggle}
-                isFullHeight
                 isExpanded={isDropdownOpen}
-                icon={<Avatar src={imgAvatar} alt="" />}
+                icon={<Avatar src={imgAvatar} alt="" size="sm" />}
               >
                 Ned Username
               </MenuToggle>

--- a/packages/react-table/src/demos/DashboardHeader.tsx
+++ b/packages/react-table/src/demos/DashboardHeader.tsx
@@ -99,7 +99,7 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({ notificationBa
         </MastheadBrand>
       </MastheadMain>
       <MastheadContent>
-        <Toolbar id="toolbar" isFullHeight isStatic>
+        <Toolbar id="toolbar" isStatic>
           <ToolbarContent>
             <ToolbarGroup
               variant="action-group-plain"
@@ -182,8 +182,7 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({ notificationBa
                     ref={toggleRef}
                     isExpanded={isDropdownOpen}
                     onClick={onDropdownToggle}
-                    icon={<Avatar src={imgAvatar} alt="" />}
-                    isFullHeight
+                    icon={<Avatar src={imgAvatar} alt="" size="sm" />}
                   >
                     Ned Username
                   </MenuToggle>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #10814

- Removed `isFullHeight` from Toolbar and MenuToggle used in Page wrappers for examples/demos
- Added `size="sm"` to Avatar in the above MenuToggles
- Updated docs-framework version to pull in Masthead structure fix for surge
