### PR TITLE
fix(Table): remove blank scope in empty deprecated table headers

### DIFF
--- a/packages/react-table/src/components/Table/utils/transformers.test.tsx
+++ b/packages/react-table/src/components/Table/utils/transformers.test.tsx
@@ -312,7 +312,7 @@ describe('Transformer functions', () => {
   });
 
   test('emptyCol', () => {
-    expect(emptyCol('')).toEqual({ scope: '' });
+    expect(emptyCol('')).toEqual({ scope: null });
     expect(emptyCol('some')).toEqual({});
   });
 

--- a/packages/react-table/src/components/Table/utils/transformers.tsx
+++ b/packages/react-table/src/components/Table/utils/transformers.tsx
@@ -9,7 +9,7 @@ export const scopeColTransformer: ITransform = () => ({
 });
 
 export const emptyCol: ITransform = (label: IFormatterValueType) => ({
-  ...(label ? {} : { scope: '' })
+  ...(label ? {} : { scope: null })
 });
 
 export const parentId: ITransform = (_value: IFormatterValueType, { rowData }: IExtra) => ({

--- a/packages/react-table/src/deprecated/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/packages/react-table/src/deprecated/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -1393,7 +1393,6 @@ exports[`Table Collapsible nested table 1`] = `
           class="pf-v5-c-table__th"
           data-key="0"
           data-label=""
-          scope=""
           tabindex="-1"
         />
         <th
@@ -2146,7 +2145,6 @@ exports[`Table Collapsible table 1`] = `
           class="pf-v5-c-table__th"
           data-key="0"
           data-label=""
-          scope=""
           tabindex="-1"
         />
         <th
@@ -4166,7 +4164,6 @@ exports[`Table Selectable table 1`] = `
           class="pf-v5-c-table__th pf-v5-c-table__check"
           data-key="0"
           data-label=""
-          scope=""
           tabindex="-1"
         >
           <label>
@@ -4867,7 +4864,6 @@ exports[`Table Selectable table with Radio 1`] = `
           class="pf-v5-c-table__th"
           data-key="0"
           data-label=""
-          scope=""
           tabindex="-1"
         />
         <th
@@ -5560,7 +5556,6 @@ exports[`Table Selectable table with selected expandable row 1`] = `
           class="pf-v5-c-table__th pf-v5-c-table__check"
           data-key="0"
           data-label=""
-          scope=""
           tabindex="-1"
         >
           <label>
@@ -10291,7 +10286,6 @@ exports[`Table simple Editable table 1`] = `
             class="pf-v5-c-table__th"
             data-key="4"
             data-label=""
-            scope=""
             tabindex="-1"
           />
         </tr>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes https://github.com/patternfly/patternfly-react/issues/10874
