### PR TITLE
Fix publint errors for `eslint-plugin-patternfly-react`

### DIFF
--- a/packages/eslint-plugin-patternfly-react/package.json
+++ b/packages/eslint-plugin-patternfly-react/package.json
@@ -1,7 +1,10 @@
 {
   "name": "eslint-plugin-patternfly-react",
   "version": "6.0.0-prerelease.0",
-  "main": "./lib/index.js",
+  "type": "commonjs",
+  "exports": {
+    ".": "./lib/index.js"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public",
@@ -9,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/patternfly/patternfly-react.git"
+    "url": "git+https://github.com/patternfly/patternfly-react.git"
   },
   "author": "Red Hat",
   "keywords": [


### PR DESCRIPTION
This change fixes the publication issues outlined by [`publint`](https://publint.dev/), namely:

- Add an explicit `type` of `commonjs` to the package.
- Replace `main` with the more modern `exports`, which restricts the importable API surface.
- Fix a misformatted URL in the `repository` field.

Works towards closing #10833