### PR TITLE
chore: Fixed release issue with transformer-react-styles-esm-imports

### DIFF
--- a/packages/transformer-react-styles-esm-imports/package.json
+++ b/packages/transformer-react-styles-esm-imports/package.json
@@ -1,7 +1,7 @@
 {
   "name": "transformer-react-styles-esm-imports",
   "private": true,
-  "version": "1.0.1-prerelease.0",
+  "version": "1.0.1-prerelease.2",
   "description": "Transform react-styles/css imports to target mjs files when compiling to ESM.",
   "main": "index.ts",
   "author": "Red Hat",


### PR DESCRIPTION
Fixes the build failure with the tags around transformer-react-styles-esm-imports.

Here is the error that this is fixing: https://github.com/patternfly/patternfly-react/actions/runs/10742197639/job/29794712314#step:4:35