### PR TITLE
chore(docs): update menutoggle examples icon prop

### DIFF
--- a/packages/react-core/src/components/ActionList/examples/ActionListSingleGroup.tsx
+++ b/packages/react-core/src/components/ActionList/examples/ActionListSingleGroup.tsx
@@ -7,6 +7,7 @@ import {
   Dropdown,
   DropdownList,
   DropdownItem,
+  Icon,
   MenuToggle,
   MenuToggleElement,
   Divider
@@ -84,9 +85,12 @@ export const ActionListSingleGroup: React.FunctionComponent = () => {
                   variant="plain"
                   isExpanded={isOpen}
                   aria-label="Action list single group kebab"
-                >
-                  <EllipsisVIcon />
-                </MenuToggle>
+                  icon={
+                    <Icon>
+                      <EllipsisVIcon />
+                    </Icon>
+                  }
+                />
               )}
               isOpen={isOpen}
               onOpenChange={(isOpen: boolean) => setIsOpen(isOpen)}

--- a/packages/react-core/src/components/Card/examples/CardExpandable.tsx
+++ b/packages/react-core/src/components/Card/examples/CardExpandable.tsx
@@ -11,6 +11,7 @@ import {
   DropdownList,
   DropdownItem,
   Divider,
+  Icon,
   MenuToggle,
   MenuToggleElement
 } from '@patternfly/react-core';
@@ -71,9 +72,12 @@ export const CardExpandable: React.FunctionComponent = () => {
             onClick={() => setIsOpen(!isOpen)}
             variant="plain"
             aria-label="Card expandable example kebab toggle"
-          >
-            <EllipsisVIcon aria-hidden="true" />
-          </MenuToggle>
+            icon={
+              <Icon>
+                <EllipsisVIcon aria-hidden="true" />
+              </Icon>
+            }
+          />
         )}
         isOpen={isOpen}
         onOpenChange={(isOpen: boolean) => setIsOpen(isOpen)}

--- a/packages/react-core/src/components/Card/examples/CardExpandableWithIcon.tsx
+++ b/packages/react-core/src/components/Card/examples/CardExpandableWithIcon.tsx
@@ -10,6 +10,7 @@ import {
   DropdownList,
   DropdownItem,
   Divider,
+  Icon,
   MenuToggle,
   MenuToggleElement
 } from '@patternfly/react-core';
@@ -67,9 +68,12 @@ export const CardExpandableWithIcon: React.FunctionComponent = () => {
             onClick={() => setIsOpen(!isOpen)}
             variant="plain"
             aria-label="Card expandable with icon example kebab toggle"
-          >
-            <EllipsisVIcon aria-hidden="true" />
-          </MenuToggle>
+            icon={
+              <Icon>
+                <EllipsisVIcon aria-hidden="true" />
+              </Icon>
+            }
+          />
         )}
         isOpen={isOpen}
         onOpenChange={(isOpen: boolean) => setIsOpen(isOpen)}

--- a/packages/react-core/src/components/Card/examples/CardHeaderInCardHead.tsx
+++ b/packages/react-core/src/components/Card/examples/CardHeaderInCardHead.tsx
@@ -9,6 +9,7 @@ import {
   Dropdown,
   DropdownList,
   DropdownItem,
+  Icon,
   MenuToggle,
   MenuToggleElement,
   Divider
@@ -58,9 +59,12 @@ export const CardTitleInHeader: React.FunctionComponent = () => {
             onClick={() => setIsOpen(!isOpen)}
             variant="plain"
             aria-label="Card title inline with images and actions example kebab toggle"
-          >
-            <EllipsisVIcon aria-hidden="true" />
-          </MenuToggle>
+            icon={
+              <Icon>
+                <EllipsisVIcon aria-hidden="true" />
+              </Icon>
+            }
+          />
         )}
         isOpen={isOpen}
         onOpenChange={(isOpen: boolean) => setIsOpen(isOpen)}

--- a/packages/react-core/src/components/Card/examples/CardOnlyActionsInCardHead.tsx
+++ b/packages/react-core/src/components/Card/examples/CardOnlyActionsInCardHead.tsx
@@ -7,6 +7,7 @@ import {
   Dropdown,
   DropdownList,
   DropdownItem,
+  Icon,
   MenuToggle,
   MenuToggleElement,
   Divider
@@ -56,9 +57,12 @@ export const CardOnlyActionsInCardHead: React.FunctionComponent = () => {
             onClick={() => setIsOpen(!isOpen)}
             variant="plain"
             aria-label="Card header without title example kebab toggle"
-          >
-            <EllipsisVIcon aria-hidden="true" />
-          </MenuToggle>
+            icon={
+              <Icon>
+                <EllipsisVIcon aria-hidden="true" />
+              </Icon>
+            }
+          />
         )}
         isOpen={isOpen}
         onOpenChange={(isOpen: boolean) => setIsOpen(isOpen)}

--- a/packages/react-core/src/components/Card/examples/CardWithImageAndActions.tsx
+++ b/packages/react-core/src/components/Card/examples/CardWithImageAndActions.tsx
@@ -10,6 +10,7 @@ import {
   Dropdown,
   DropdownList,
   DropdownItem,
+  Icon,
   MenuToggle,
   MenuToggleElement,
   Divider
@@ -64,9 +65,12 @@ export const CardWithImageAndActions: React.FunctionComponent = () => {
             onClick={() => setIsOpen(!isOpen)}
             variant="plain"
             aria-label="Card header images and actions example kebab toggle"
-          >
-            <EllipsisVIcon aria-hidden="true" />
-          </MenuToggle>
+            icon={
+              <Icon>
+                <EllipsisVIcon aria-hidden="true" />
+              </Icon>
+            }
+          />
         )}
         isOpen={isOpen}
         onOpenChange={(isOpen: boolean) => setIsOpen(isOpen)}

--- a/packages/react-core/src/components/DataList/examples/DataListActions.tsx
+++ b/packages/react-core/src/components/DataList/examples/DataListActions.tsx
@@ -10,6 +10,7 @@ import {
   Dropdown,
   DropdownList,
   DropdownItem,
+  Icon,
   MenuToggle,
   MenuToggleElement
 } from '@patternfly/react-core';
@@ -87,9 +88,12 @@ export const DataListActions: React.FunctionComponent = () => {
                     onClick={onToggle}
                     variant="plain"
                     aria-label="Data list with actions example kebab toggle"
-                  >
-                    <EllipsisVIcon aria-hidden="true" />
-                  </MenuToggle>
+                    icon={
+                      <Icon>
+                        <EllipsisVIcon aria-hidden="true" />
+                      </Icon>
+                    }
+                  />
                 )}
                 isOpen={isOpen}
                 onOpenChange={(isOpen: boolean) => setIsOpen(isOpen)}

--- a/packages/react-core/src/components/DataList/examples/DataListCheckboxes.tsx
+++ b/packages/react-core/src/components/DataList/examples/DataListCheckboxes.tsx
@@ -11,6 +11,7 @@ import {
   Dropdown,
   DropdownList,
   DropdownItem,
+  Icon,
   MenuToggle,
   MenuToggleElement
 } from '@patternfly/react-core';
@@ -85,9 +86,12 @@ export const DataListCheckboxes: React.FunctionComponent = () => {
                   onClick={onToggle1}
                   variant="plain"
                   aria-label="Data list with checkboxes, actions and additional cells example kebab toggle 1"
-                >
-                  <EllipsisVIcon aria-hidden="true" />
-                </MenuToggle>
+                  icon={
+                    <Icon>
+                      <EllipsisVIcon aria-hidden="true" />
+                    </Icon>
+                  }
+                />
               )}
               isOpen={isOpen1}
               onOpenChange={(isOpen: boolean) => setIsOpen1(isOpen)}
@@ -141,9 +145,12 @@ export const DataListCheckboxes: React.FunctionComponent = () => {
                   onClick={onToggle2}
                   variant="plain"
                   aria-label="Data list with checkboxes, actions and additional cells example kebab toggle 2"
-                >
-                  <EllipsisVIcon aria-hidden="true" />
-                </MenuToggle>
+                  icon={
+                    <Icon>
+                      <EllipsisVIcon aria-hidden="true" />
+                    </Icon>
+                  }
+                />
               )}
               isOpen={isOpen2}
               onOpenChange={(isOpen: boolean) => setIsOpen2(isOpen)}
@@ -206,9 +213,12 @@ export const DataListCheckboxes: React.FunctionComponent = () => {
                   onClick={onToggle3}
                   variant="plain"
                   aria-label="Data list with checkboxes, actions and additional cells example kebab toggle 3"
-                >
-                  <EllipsisVIcon aria-hidden="true" />
-                </MenuToggle>
+                  icon={
+                    <Icon>
+                      <EllipsisVIcon aria-hidden="true" />
+                    </Icon>
+                  }
+                />
               )}
               isOpen={isOpen3}
               onOpenChange={(isOpen: boolean) => setIsOpen3(isOpen)}

--- a/packages/react-core/src/components/DataList/examples/DataListClickableRows.tsx
+++ b/packages/react-core/src/components/DataList/examples/DataListClickableRows.tsx
@@ -9,6 +9,7 @@ import {
   Dropdown,
   DropdownList,
   DropdownItem,
+  Icon,
   MenuToggle,
   MenuToggleElement
 } from '@patternfly/react-core';
@@ -77,9 +78,12 @@ export const DataListClickableRows: React.FunctionComponent = () => {
                     onClick={onToggle1}
                     variant="plain"
                     aria-label="Data list clickable rows example kebab toggle 1"
-                  >
-                    <EllipsisVIcon aria-hidden="true" />
-                  </MenuToggle>
+                    icon={
+                      <Icon>
+                        <EllipsisVIcon aria-hidden="true" />
+                      </Icon>
+                    }
+                  />
                 )}
                 isOpen={isOpen1}
                 onOpenChange={(isOpen: boolean) => setIsOpen1(isOpen)}
@@ -128,9 +132,12 @@ export const DataListClickableRows: React.FunctionComponent = () => {
                     onClick={onToggle2}
                     variant="plain"
                     aria-label="Data list clickable rows example kebab toggle 2"
-                  >
-                    <EllipsisVIcon aria-hidden="true" />
-                  </MenuToggle>
+                    icon={
+                      <Icon>
+                        <EllipsisVIcon aria-hidden="true" />
+                      </Icon>
+                    }
+                  />
                 )}
                 isOpen={isOpen2}
                 onOpenChange={(isOpen: boolean) => setIsOpen2(isOpen)}

--- a/packages/react-core/src/components/DataList/examples/DataListExpandable.tsx
+++ b/packages/react-core/src/components/DataList/examples/DataListExpandable.tsx
@@ -11,6 +11,7 @@ import {
   Dropdown,
   DropdownList,
   DropdownItem,
+  Icon,
   MenuToggle,
   MenuToggleElement
 } from '@patternfly/react-core';
@@ -97,9 +98,12 @@ export const DataListExpandable: React.FunctionComponent = () => {
                     onClick={onToggle1}
                     variant="plain"
                     aria-label="Data list exapndable example kebaby toggle 1"
-                  >
-                    <EllipsisVIcon aria-hidden="true" />
-                  </MenuToggle>
+                    icon={
+                      <Icon>
+                        <EllipsisVIcon aria-hidden="true" />
+                      </Icon>
+                    }
+                  />
                 )}
                 isOpen={isOpen1}
                 onOpenChange={(isOpen: boolean) => setIsOpen1(isOpen)}
@@ -173,9 +177,12 @@ export const DataListExpandable: React.FunctionComponent = () => {
                     onClick={onToggle2}
                     variant="plain"
                     aria-label="Data list exapndable example kebaby toggle 2"
-                  >
-                    <EllipsisVIcon aria-hidden="true" />
-                  </MenuToggle>
+                    icon={
+                      <Icon>
+                        <EllipsisVIcon aria-hidden="true" />
+                      </Icon>
+                    }
+                  />
                 )}
                 isOpen={isOpen2}
                 onOpenChange={(isOpen: boolean) => setIsOpen2(isOpen)}
@@ -249,9 +256,12 @@ export const DataListExpandable: React.FunctionComponent = () => {
                     onClick={onToggle3}
                     variant="plain"
                     aria-label="Data list exapndable example kebaby toggle 3"
-                  >
-                    <EllipsisVIcon aria-hidden="true" />
-                  </MenuToggle>
+                    icon={
+                      <Icon>
+                        <EllipsisVIcon aria-hidden="true" />
+                      </Icon>
+                    }
+                  />
                 )}
                 isOpen={isOpen3}
                 onOpenChange={(isOpen: boolean) => setIsOpen3(isOpen)}

--- a/packages/react-core/src/components/DataList/examples/DataListMixedExpandable.tsx
+++ b/packages/react-core/src/components/DataList/examples/DataListMixedExpandable.tsx
@@ -11,6 +11,7 @@ import {
   Dropdown,
   DropdownList,
   DropdownItem,
+  Icon,
   MenuToggle,
   MenuToggleElement
 } from '@patternfly/react-core';
@@ -99,9 +100,12 @@ export const DataListMixedExpandable: React.FunctionComponent = () => {
                     onClick={onToggle1}
                     variant="plain"
                     aria-label="Data list mixed expandable example kebab toggle 1"
-                  >
-                    <EllipsisVIcon aria-hidden="true" />
-                  </MenuToggle>
+                    icon={
+                      <Icon>
+                        <EllipsisVIcon aria-hidden="true" />
+                      </Icon>
+                    }
+                  />
                 )}
                 isOpen={isOpen1}
                 onOpenChange={(isOpen: boolean) => setIsOpen1(isOpen)}
@@ -177,9 +181,12 @@ export const DataListMixedExpandable: React.FunctionComponent = () => {
                     onClick={onToggle2}
                     variant="plain"
                     aria-label="Data list mixed expandable example kebab toggle 2"
-                  >
-                    <EllipsisVIcon aria-hidden="true" />
-                  </MenuToggle>
+                    icon={
+                      <Icon>
+                        <EllipsisVIcon aria-hidden="true" />
+                      </Icon>
+                    }
+                  />
                 )}
                 isOpen={isOpen2}
                 onOpenChange={(isOpen: boolean) => setIsOpen2(isOpen)}
@@ -243,9 +250,12 @@ export const DataListMixedExpandable: React.FunctionComponent = () => {
                     onClick={onToggle3}
                     variant="plain"
                     aria-label="Data list mixed expandable example kebab toggle 3"
-                  >
-                    <EllipsisVIcon aria-hidden="true" />
-                  </MenuToggle>
+                    icon={
+                      <Icon>
+                        <EllipsisVIcon aria-hidden="true" />
+                      </Icon>
+                    }
+                  />
                 )}
                 isOpen={isOpen3}
                 onOpenChange={(isOpen: boolean) => setIsOpen3(isOpen)}

--- a/packages/react-core/src/components/DataList/examples/DataListWidthModifiers.tsx
+++ b/packages/react-core/src/components/DataList/examples/DataListWidthModifiers.tsx
@@ -13,6 +13,7 @@ import {
   Dropdown,
   DropdownList,
   DropdownItem,
+  Icon,
   MenuToggle,
   MenuToggleElement
 } from '@patternfly/react-core';
@@ -104,9 +105,12 @@ export const DataListWidthModifiers: React.FunctionComponent = () => {
                       onClick={onToggle1}
                       variant="plain"
                       aria-label="Data list width modifiers example kebab toggle 1"
-                    >
-                      <EllipsisVIcon aria-hidden="true" />
-                    </MenuToggle>
+                      icon={
+                        <Icon>
+                          <EllipsisVIcon aria-hidden="true" />
+                        </Icon>
+                      }
+                    />
                   )}
                   isOpen={isOpen1}
                   onOpenChange={(isOpen: boolean) => setIsOpen1(isOpen)}
@@ -179,9 +183,12 @@ export const DataListWidthModifiers: React.FunctionComponent = () => {
                       onClick={onToggle2}
                       variant="plain"
                       aria-label="Data list width modifiers example kebab toggle 2"
-                    >
-                      <EllipsisVIcon aria-hidden="true" />
-                    </MenuToggle>
+                      icon={
+                        <Icon>
+                          <EllipsisVIcon aria-hidden="true" />
+                        </Icon>
+                      }
+                    />
                   )}
                   isOpen={isOpen2}
                   onOpenChange={(isOpen: boolean) => setIsOpen2(isOpen)}

--- a/packages/react-core/src/components/Dropdown/examples/DropdownWithKebabToggle.tsx
+++ b/packages/react-core/src/components/Dropdown/examples/DropdownWithKebabToggle.tsx
@@ -1,5 +1,13 @@
 import React from 'react';
-import { Dropdown, DropdownItem, DropdownList, Divider, MenuToggle, MenuToggleElement } from '@patternfly/react-core';
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownList,
+  Divider,
+  Icon,
+  MenuToggle,
+  MenuToggleElement
+} from '@patternfly/react-core';
 import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
 
 export const DropdownWithKebab: React.FunctionComponent = () => {
@@ -27,9 +35,12 @@ export const DropdownWithKebab: React.FunctionComponent = () => {
           variant="plain"
           onClick={onToggleClick}
           isExpanded={isOpen}
-        >
-          <EllipsisVIcon />
-        </MenuToggle>
+          icon={
+            <Icon>
+              <EllipsisVIcon />
+            </Icon>
+          }
+        />
       )}
       shouldFocusToggleOnSelect
     >

--- a/packages/react-core/src/components/DualListSelector/examples/DualListSelectorComplexOptionsActions.tsx
+++ b/packages/react-core/src/components/DualListSelector/examples/DualListSelectorComplexOptionsActions.tsx
@@ -18,6 +18,7 @@ import {
   EmptyStateFooter,
   EmptyStateBody,
   EmptyStateActions,
+  Icon,
   MenuToggle,
   MenuToggleElement
 } from '@patternfly/react-core';
@@ -166,9 +167,12 @@ export const DualListSelectorComplexOptionsActionsNext: React.FunctionComponent 
                 variant="plain"
                 id="complex-available-toggle"
                 aria-label="Complex actions example available kebab toggle"
-              >
-                <EllipsisVIcon aria-hidden="true" />
-              </MenuToggle>
+                icon={
+                  <Icon>
+                    <EllipsisVIcon aria-hidden="true" />
+                  </Icon>
+                }
+              />
             )}
             isOpen={isAvailableKebabOpen}
             onOpenChange={(isOpen: boolean) => setIsAvailableKebabOpen(isOpen)}
@@ -202,9 +206,12 @@ export const DualListSelectorComplexOptionsActionsNext: React.FunctionComponent 
                 variant="plain"
                 id="complex-chosen-toggle"
                 aria-label="Complex actions example chosen kebab toggle"
-              >
-                <EllipsisVIcon aria-hidden="true" />
-              </MenuToggle>
+                icon={
+                  <Icon>
+                    <EllipsisVIcon aria-hidden="true" />
+                  </Icon>
+                }
+              />
             )}
             isOpen={isChosenKebabOpen}
             onOpenChange={(isOpen: boolean) => setIsChosenKebabOpen(isOpen)}

--- a/packages/react-core/src/components/Hint/examples/HintBasicWithTitle.tsx
+++ b/packages/react-core/src/components/Hint/examples/HintBasicWithTitle.tsx
@@ -9,6 +9,7 @@ import {
   DropdownList,
   DropdownItem,
   Divider,
+  Icon,
   MenuToggle,
   MenuToggleElement
 } from '@patternfly/react-core';
@@ -37,9 +38,12 @@ export const HintBasicWithTitle: React.FunctionComponent = () => {
           variant="plain"
           onClick={onToggle}
           isExpanded={isOpen}
-        >
-          <EllipsisVIcon />
-        </MenuToggle>
+          icon={
+            <Icon>
+              <EllipsisVIcon />
+            </Icon>
+          }
+        />
       )}
     >
       <DropdownList>

--- a/packages/react-core/src/components/Hint/examples/HintBasicWithoutTitle.tsx
+++ b/packages/react-core/src/components/Hint/examples/HintBasicWithoutTitle.tsx
@@ -8,6 +8,7 @@ import {
   DropdownList,
   DropdownItem,
   Divider,
+  Icon,
   MenuToggle,
   MenuToggleElement
 } from '@patternfly/react-core';
@@ -36,9 +37,12 @@ export const HintBasicWithoutTitle: React.FunctionComponent = () => {
           variant="plain"
           onClick={onToggle}
           isExpanded={isOpen}
-        >
-          <EllipsisVIcon />
-        </MenuToggle>
+          icon={
+            <Icon>
+              <EllipsisVIcon />
+            </Icon>
+          }
+        />
       )}
     >
       <DropdownList>

--- a/packages/react-core/src/components/Label/examples/LabelGroupEditableAddModal.tsx
+++ b/packages/react-core/src/components/Label/examples/LabelGroupEditableAddModal.tsx
@@ -5,6 +5,7 @@ import {
   Button,
   Form,
   FormGroup,
+  Icon,
   TextInput,
   Menu,
   MenuContent,
@@ -200,8 +201,13 @@ export const LabelGroupEditableAddModal: React.FunctionComponent = () => {
   };
 
   const iconToggle = (
-    <MenuToggle ref={iconToggleRef} onClick={onIconToggleClick} isExpanded={isIconOpen}>
-      {icon || 'Select'}
+    <MenuToggle
+      ref={iconToggleRef}
+      onClick={onIconToggleClick}
+      isExpanded={isIconOpen}
+      icon={icon ? <Icon>{icon}</Icon> : null}
+    >
+      {icon ? '' : 'Select'}
     </MenuToggle>
   );
 

--- a/packages/react-core/src/components/MenuToggle/examples/MenuToggle.md
+++ b/packages/react-core/src/components/MenuToggle/examples/MenuToggle.md
@@ -127,13 +127,13 @@ This can be used alongside a text label that provides more context for the image
 
 ```ts
 import React from 'react';
-import { MenuToggle, Avatar } from '@patternfly/react-core';
+import { MenuToggle, Avatar, Icon } from '@patternfly/react-core';
 import imgAvatar from '@patternfly/react-core/src/components/assets/avatarImg.svg';
 
 <React.Fragment>
-  <MenuToggle icon={<Avatar src={imgAvatar} alt="avatar" />}>Ned Username</MenuToggle>{' '}
-  <MenuToggle icon={<Avatar src={imgAvatar} alt="avatar" />} isExpanded>Ned Username</MenuToggle>{' '}
-  <MenuToggle icon={<Avatar src={imgAvatar} alt="avatar" />} isDisabled>Ned Username</MenuToggle>
+  <MenuToggle icon={<Icon><Avatar src={imgAvatar} alt="avatar" /></Icon>}>Ned Username</MenuToggle>{' '}
+  <MenuToggle icon={<Icon><Avatar src={imgAvatar} alt="avatar" /></Icon>} isExpanded>Ned Username</MenuToggle>{' '}
+  <MenuToggle icon={<Icon><Avatar src={imgAvatar} alt="avatar" /></Icon>} isDisabled>Ned Username</MenuToggle>
 </React.Fragment>
 ```
 
@@ -166,15 +166,15 @@ If the toggle does not have any visible text content, use the `aria-label` prope
 
 ```ts
 import React from 'react';
-import { MenuToggle } from '@patternfly/react-core';
+import { MenuToggle, Icon } from '@patternfly/react-core';
 import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
 
 <React.Fragment>
-  <MenuToggle icon={<EllipsisVIcon />} variant="plain" aria-label="plain kebab"/>
+  <MenuToggle icon={<Icon><EllipsisVIcon /></Icon>} variant="plain" aria-label="plain kebab"/>
   {' '}
-  <MenuToggle icon={<EllipsisVIcon />} variant="plain" isExpanded aria-label="plain expanded kebab"/>
+  <MenuToggle icon={<Icon><EllipsisVIcon /></Icon>} variant="plain" isExpanded aria-label="plain expanded kebab"/>
   {' '}
-  <MenuToggle icon={<EllipsisVIcon />} variant="plain" isDisabled aria-label="disabled plain kebab"/>
+  <MenuToggle icon={<Icon><EllipsisVIcon /></Icon>} variant="plain" isDisabled aria-label="disabled plain kebab"/>
 </React.Fragment>
 ```
 

--- a/packages/react-core/src/components/NotificationDrawer/examples/NotificationDrawerBasic.tsx
+++ b/packages/react-core/src/components/NotificationDrawer/examples/NotificationDrawerBasic.tsx
@@ -10,6 +10,7 @@ import {
   Dropdown,
   DropdownList,
   DropdownItem,
+  Icon,
   MenuToggle,
   MenuToggleElement
 } from '@patternfly/react-core';
@@ -64,7 +65,11 @@ export const NotificationDrawerBasic: React.FunctionComponent = () => {
               onClick={onToggle(0)}
               variant="plain"
               aria-label={`Basic example header kebab toggle`}
-              icon={<EllipsisVIcon aria-hidden="true" />}
+              icon={
+                <Icon>
+                  <EllipsisVIcon aria-hidden="true" />
+                </Icon>
+              }
             />
           )}
         >
@@ -91,7 +96,11 @@ export const NotificationDrawerBasic: React.FunctionComponent = () => {
                     onClick={onToggle(1)}
                     variant="plain"
                     aria-label={`Basic example notification 1 kebab toggle`}
-                    icon={<EllipsisVIcon aria-hidden="true" />}
+                    icon={
+                      <Icon>
+                        <EllipsisVIcon aria-hidden="true" />
+                      </Icon>
+                    }
                   />
                 )}
               >
@@ -120,7 +129,11 @@ export const NotificationDrawerBasic: React.FunctionComponent = () => {
                     onClick={onToggle(2)}
                     variant="plain"
                     aria-label={`Basic example notification 2 kebab toggle`}
-                    icon={<EllipsisVIcon aria-hidden="true" />}
+                    icon={
+                      <Icon>
+                        <EllipsisVIcon aria-hidden="true" />
+                      </Icon>
+                    }
                   />
                 )}
               >
@@ -151,7 +164,11 @@ export const NotificationDrawerBasic: React.FunctionComponent = () => {
                     onClick={onToggle(3)}
                     variant="plain"
                     aria-label={`Basic example notification 3 kebab toggle`}
-                    icon={<EllipsisVIcon aria-hidden="true" />}
+                    icon={
+                      <Icon>
+                        <EllipsisVIcon aria-hidden="true" />
+                      </Icon>
+                    }
                   />
                 )}
               >
@@ -181,7 +198,11 @@ export const NotificationDrawerBasic: React.FunctionComponent = () => {
                     onClick={onToggle(4)}
                     variant="plain"
                     aria-label={`Basic example notification 4 kebab toggle`}
-                    icon={<EllipsisVIcon aria-hidden="true" />}
+                    icon={
+                      <Icon>
+                        <EllipsisVIcon aria-hidden="true" />
+                      </Icon>
+                    }
                   />
                 )}
               >
@@ -210,7 +231,11 @@ export const NotificationDrawerBasic: React.FunctionComponent = () => {
                     onClick={onToggle(5)}
                     variant="plain"
                     aria-label={`Basic example notification 5 kebab toggle`}
-                    icon={<EllipsisVIcon aria-hidden="true" />}
+                    icon={
+                      <Icon>
+                        <EllipsisVIcon aria-hidden="true" />
+                      </Icon>
+                    }
                   />
                 )}
               >
@@ -235,7 +260,11 @@ export const NotificationDrawerBasic: React.FunctionComponent = () => {
                     onClick={onToggle(6)}
                     variant="plain"
                     aria-label={`Basic example notification 6 kebab toggle`}
-                    icon={<EllipsisVIcon aria-hidden="true" />}
+                    icon={
+                      <Icon>
+                        <EllipsisVIcon aria-hidden="true" />
+                      </Icon>
+                    }
                   />
                 )}
               >

--- a/packages/react-core/src/components/NotificationDrawer/examples/NotificationDrawerGroups.tsx
+++ b/packages/react-core/src/components/NotificationDrawer/examples/NotificationDrawerGroups.tsx
@@ -18,6 +18,7 @@ import {
   Dropdown,
   DropdownList,
   DropdownItem,
+  Icon,
   MenuToggle,
   MenuToggleElement
 } from '@patternfly/react-core';
@@ -89,7 +90,11 @@ export const NotificationDrawerGroups: React.FunctionComponent = () => {
               onClick={() => onToggle('groups-kebab-toggle-1')}
               variant="plain"
               aria-label={`Groups example header kebab toggle`}
-              icon={<EllipsisVIcon aria-hidden="true" />}
+              icon={
+                <Icon>
+                  <EllipsisVIcon aria-hidden="true" />
+                </Icon>
+              }
             />
           )}
         >
@@ -124,7 +129,11 @@ export const NotificationDrawerGroups: React.FunctionComponent = () => {
                         onClick={() => onToggle('groups-kebab-toggle-2')}
                         variant="plain"
                         aria-label={`Groups example group 1 notification 1 kebab toggle`}
-                        icon={<EllipsisVIcon aria-hidden="true" />}
+                        icon={
+                          <Icon>
+                            <EllipsisVIcon aria-hidden="true" />
+                          </Icon>
+                        }
                       />
                     )}
                   >
@@ -154,7 +163,11 @@ export const NotificationDrawerGroups: React.FunctionComponent = () => {
                         onClick={() => onToggle('groups-kebab-toggle-3')}
                         variant="plain"
                         aria-label={`Groups example group 1 notification 2 kebab toggle`}
-                        icon={<EllipsisVIcon aria-hidden="true" />}
+                        icon={
+                          <Icon>
+                            <EllipsisVIcon aria-hidden="true" />
+                          </Icon>
+                        }
                       />
                     )}
                   >
@@ -185,7 +198,11 @@ export const NotificationDrawerGroups: React.FunctionComponent = () => {
                         onClick={() => onToggle('groups-kebab-toggle-4')}
                         variant="plain"
                         aria-label={`Groups example group 1 notification 3 kebab toggle`}
-                        icon={<EllipsisVIcon aria-hidden="true" />}
+                        icon={
+                          <Icon>
+                            <EllipsisVIcon aria-hidden="true" />
+                          </Icon>
+                        }
                       />
                     )}
                   >
@@ -215,7 +232,11 @@ export const NotificationDrawerGroups: React.FunctionComponent = () => {
                         onClick={() => onToggle('groups-kebab-toggle-5')}
                         variant="plain"
                         aria-label={`Groups example group 1 notification 4 kebab toggle`}
-                        icon={<EllipsisVIcon aria-hidden="true" />}
+                        icon={
+                          <Icon>
+                            <EllipsisVIcon aria-hidden="true" />
+                          </Icon>
+                        }
                       />
                     )}
                   >
@@ -254,7 +275,11 @@ export const NotificationDrawerGroups: React.FunctionComponent = () => {
                         onClick={() => onToggle('groups-kebab-toggle-6')}
                         variant="plain"
                         aria-label={`Groups example group 2 notification 1 kebab toggle`}
-                        icon={<EllipsisVIcon aria-hidden="true" />}
+                        icon={
+                          <Icon>
+                            <EllipsisVIcon aria-hidden="true" />
+                          </Icon>
+                        }
                       />
                     )}
                   >
@@ -284,7 +309,11 @@ export const NotificationDrawerGroups: React.FunctionComponent = () => {
                         onClick={() => onToggle('groups-kebab-toggle-7')}
                         variant="plain"
                         aria-label={`Groups example group 2 notification 2 kebab toggle`}
-                        icon={<EllipsisVIcon aria-hidden="true" />}
+                        icon={
+                          <Icon>
+                            <EllipsisVIcon aria-hidden="true" />
+                          </Icon>
+                        }
                       />
                     )}
                   >
@@ -315,7 +344,11 @@ export const NotificationDrawerGroups: React.FunctionComponent = () => {
                         onClick={() => onToggle('groups-kebab-toggle-8')}
                         variant="plain"
                         aria-label={`Groups example group 2 notification 3 kebab toggle`}
-                        icon={<EllipsisVIcon aria-hidden="true" />}
+                        icon={
+                          <Icon>
+                            <EllipsisVIcon aria-hidden="true" />
+                          </Icon>
+                        }
                       />
                     )}
                   >
@@ -345,7 +378,11 @@ export const NotificationDrawerGroups: React.FunctionComponent = () => {
                         onClick={() => onToggle('groups-kebab-toggle-9')}
                         variant="plain"
                         aria-label={`Groups example group 2 notification 4 kebab toggle`}
-                        icon={<EllipsisVIcon aria-hidden="true" />}
+                        icon={
+                          <Icon>
+                            <EllipsisVIcon aria-hidden="true" />
+                          </Icon>
+                        }
                       />
                     )}
                   >

--- a/packages/react-core/src/components/OverflowMenu/examples/OverflowMenuBreakpointOnContainer.tsx
+++ b/packages/react-core/src/components/OverflowMenu/examples/OverflowMenuBreakpointOnContainer.tsx
@@ -10,7 +10,8 @@ import {
   Slider,
   SliderOnChangeEvent,
   Dropdown,
-  DropdownList
+  DropdownList,
+  Icon
 } from '@patternfly/react-core';
 import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
 
@@ -95,9 +96,12 @@ export const OverflowMenuBreakpointOnContainer: React.FunctionComponent = () => 
                   variant="plain"
                   onClick={onToggle}
                   isExpanded={isOpen}
-                >
-                  <EllipsisVIcon />
-                </MenuToggle>
+                  icon={
+                    <Icon>
+                      <EllipsisVIcon />
+                    </Icon>
+                  }
+                />
               )}
               isOpen={isOpen}
               onOpenChange={(isOpen) => setIsOpen(isOpen)}

--- a/packages/react-core/src/components/OverflowMenu/examples/OverflowMenuGroupTypes.tsx
+++ b/packages/react-core/src/components/OverflowMenu/examples/OverflowMenuGroupTypes.tsx
@@ -10,7 +10,8 @@ import {
   Button,
   ButtonVariant,
   Dropdown,
-  DropdownList
+  DropdownList,
+  Icon
 } from '@patternfly/react-core';
 import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
 import AlignLeftIcon from '@patternfly/react-icons/dist/esm/icons/align-left-icon';
@@ -99,9 +100,12 @@ export const OverflowMenuGroupTypes: React.FunctionComponent = () => {
               variant="plain"
               onClick={onToggle}
               isExpanded={isOpen}
-            >
-              <EllipsisVIcon />
-            </MenuToggle>
+              icon={
+                <Icon>
+                  <EllipsisVIcon />
+                </Icon>
+              }
+            />
           )}
           isOpen={isOpen}
           onOpenChange={(isOpen) => setIsOpen(isOpen)}

--- a/packages/react-core/src/components/OverflowMenu/examples/OverflowMenuMultiGroup.tsx
+++ b/packages/react-core/src/components/OverflowMenu/examples/OverflowMenuMultiGroup.tsx
@@ -10,7 +10,8 @@ import {
   Button,
   ButtonVariant,
   Dropdown,
-  DropdownList
+  DropdownList,
+  Icon
 } from '@patternfly/react-core';
 import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
 import AlignLeftIcon from '@patternfly/react-icons/dist/esm/icons/align-left-icon';
@@ -88,9 +89,12 @@ export const OverflowMenuMultiGroup: React.FunctionComponent = () => {
               variant="plain"
               onClick={onToggle}
               isExpanded={isOpen}
-            >
-              <EllipsisVIcon />
-            </MenuToggle>
+              icon={
+                <Icon>
+                  <EllipsisVIcon />
+                </Icon>
+              }
+            />
           )}
           isOpen={isOpen}
           onOpenChange={(isOpen) => setIsOpen(isOpen)}

--- a/packages/react-core/src/components/OverflowMenu/examples/OverflowMenuPersistent.tsx
+++ b/packages/react-core/src/components/OverflowMenu/examples/OverflowMenuPersistent.tsx
@@ -10,7 +10,8 @@ import {
   Button,
   ButtonVariant,
   Dropdown,
-  DropdownList
+  DropdownList,
+  Icon
 } from '@patternfly/react-core';
 import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
 
@@ -62,9 +63,12 @@ export const OverflowMenuPersistent: React.FunctionComponent = () => {
               variant="plain"
               onClick={onToggle}
               isExpanded={isOpen}
-            >
-              <EllipsisVIcon />
-            </MenuToggle>
+              icon={
+                <Icon>
+                  <EllipsisVIcon />
+                </Icon>
+              }
+            />
           )}
           isOpen={isOpen}
           onOpenChange={(isOpen) => setIsOpen(isOpen)}

--- a/packages/react-core/src/components/OverflowMenu/examples/OverflowMenuSimple.tsx
+++ b/packages/react-core/src/components/OverflowMenu/examples/OverflowMenuSimple.tsx
@@ -8,7 +8,8 @@ import {
   OverflowMenuDropdownItem,
   MenuToggle,
   Dropdown,
-  DropdownList
+  DropdownList,
+  Icon
 } from '@patternfly/react-core';
 import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
 
@@ -62,9 +63,12 @@ export const OverflowMenuBreakpointOnContainer: React.FunctionComponent = () => 
               variant="plain"
               onClick={onToggle}
               isExpanded={isOpen}
-            >
-              <EllipsisVIcon />
-            </MenuToggle>
+              icon={
+                <Icon>
+                  <EllipsisVIcon />
+                </Icon>
+              }
+            />
           )}
           isOpen={isOpen}
           onOpenChange={(isOpen) => setIsOpen(isOpen)}

--- a/packages/react-core/src/components/Toolbar/examples/ToolbarStacked.tsx
+++ b/packages/react-core/src/components/Toolbar/examples/ToolbarStacked.tsx
@@ -10,6 +10,7 @@ import {
   DropdownItem,
   DropdownList,
   Divider,
+  Icon,
   MenuToggle,
   MenuToggleCheckbox,
   MenuToggleElement,
@@ -229,9 +230,12 @@ export const ToolbarStacked: React.FunctionComponent = () => {
                       variant="plain"
                       onClick={onKebabToggle}
                       isExpanded={kebabIsOpen}
-                    >
-                      <EllipsisVIcon />
-                    </MenuToggle>
+                      icon={
+                        <Icon>
+                          <EllipsisVIcon />
+                        </Icon>
+                      }
+                    />
                   )}
                   isOpen={kebabIsOpen}
                 >

--- a/packages/react-core/src/components/Toolbar/examples/ToolbarWithFilters.tsx
+++ b/packages/react-core/src/components/Toolbar/examples/ToolbarWithFilters.tsx
@@ -4,6 +4,7 @@ import {
   Dropdown,
   DropdownList,
   DropdownItem,
+  Icon,
   Toolbar,
   ToolbarItem,
   ToolbarContent,
@@ -231,9 +232,12 @@ export const ToolbarWithFilters: React.FunctionComponent = () => {
               onClick={onKebabToggle}
               variant="plain"
               aria-label="Toolbar with filters example kebab toggle"
-            >
-              <EllipsisVIcon aria-hidden="true" />
-            </MenuToggle>
+              icon={
+                <Icon>
+                  <EllipsisVIcon aria-hidden="true" />
+                </Icon>
+              }
+            />
           )}
         >
           <DropdownList>

--- a/packages/react-core/src/components/TreeView/examples/TreeViewWithActionItems.tsx
+++ b/packages/react-core/src/components/TreeView/examples/TreeViewWithActionItems.tsx
@@ -5,6 +5,7 @@ import {
   Dropdown,
   DropdownList,
   DropdownItem,
+  Icon,
   MenuToggle,
   TreeViewDataItem
 } from '@patternfly/react-core';
@@ -47,9 +48,12 @@ export const TreeViewWithActionItems: React.FunctionComponent = () => {
               onClick={onToggle}
               variant="plain"
               aria-label="Tree view with actions example kebab toggle"
-            >
-              <EllipsisVIcon aria-hidden="true" />
-            </MenuToggle>
+              icon={
+                <Icon>
+                  <EllipsisVIcon />
+                </Icon>
+              }
+            />
           )}
         >
           <DropdownList>

--- a/packages/react-core/src/demos/CardView/examples/CardView.tsx
+++ b/packages/react-core/src/demos/CardView/examples/CardView.tsx
@@ -17,6 +17,7 @@ import {
   EmptyStateVariant,
   EmptyStateActions,
   Gallery,
+  Icon,
   MenuToggle,
   MenuToggleCheckbox,
   OverflowMenu,
@@ -429,9 +430,12 @@ export const CardViewBasic: React.FunctionComponent = () => {
                   variant="plain"
                   onClick={onToolbarKebabDropdownToggle}
                   isExpanded={isLowerToolbarKebabDropdownOpen}
-                >
-                  <EllipsisVIcon />
-                </MenuToggle>
+                  icon={
+                    <Icon>
+                      <EllipsisVIcon />
+                    </Icon>
+                  }
+                />
               )}
               isOpen={isLowerToolbarKebabDropdownOpen}
               onOpenChange={(isOpen) => setIsLowerToolbarDropdownOpen(isOpen)}
@@ -520,9 +524,12 @@ export const CardViewBasic: React.FunctionComponent = () => {
                                 onCardKebabDropdownToggle(e, key.toString());
                               }}
                               isExpanded={!!state[key]}
-                            >
-                              <EllipsisVIcon />
-                            </MenuToggle>
+                              icon={
+                                <Icon>
+                                  <EllipsisVIcon />
+                                </Icon>
+                              }
+                            />
                           )}
                           popperProps={{ position: 'right' }}
                         >

--- a/packages/react-core/src/demos/CustomMenus/examples/ApplicationLauncherDemo.tsx
+++ b/packages/react-core/src/demos/CustomMenus/examples/ApplicationLauncherDemo.tsx
@@ -9,7 +9,8 @@ import {
   Dropdown,
   DropdownGroup,
   DropdownList,
-  DropdownItem
+  DropdownItem,
+  Icon
 } from '@patternfly/react-core';
 import ThIcon from '@patternfly/react-icons/dist/js/icons/th-icon';
 import pfIcon from '@patternfly/react-core/src/demos/Card/pf-logo-small.svg';
@@ -215,9 +216,12 @@ export const ApplicationLauncherDemo: React.FunctionComponent = () => {
           onClick={onToggleClick}
           isExpanded={isOpen}
           style={{ width: 'auto' }}
-        >
-          <ThIcon />
-        </MenuToggle>
+          icon={
+            <Icon>
+              <ThIcon />
+            </Icon>
+          }
+        />
       )}
       ref={menuRef}
       onActionClick={onFavorite}

--- a/packages/react-core/src/demos/DashboardHeader.tsx
+++ b/packages/react-core/src/demos/DashboardHeader.tsx
@@ -9,6 +9,7 @@ import {
   DropdownGroup,
   DropdownItem,
   DropdownList,
+  Icon,
   Masthead,
   MastheadMain,
   MastheadToggle,
@@ -137,9 +138,12 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({ notificationBa
                       onClick={onKebabDropdownToggle}
                       variant="plain"
                       aria-label="Settings and help"
-                    >
-                      <EllipsisVIcon aria-hidden="true" />
-                    </MenuToggle>
+                      icon={
+                        <Icon>
+                          <EllipsisVIcon aria-hidden="true" />
+                        </Icon>
+                      }
+                    />
                   )}
                 >
                   <DropdownList>{kebabDropdownItems}</DropdownList>
@@ -158,9 +162,12 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({ notificationBa
                       onClick={onFullKebabToggle}
                       variant="plain"
                       aria-label="Toolbar menu"
-                    >
-                      <EllipsisVIcon aria-hidden="true" />
-                    </MenuToggle>
+                      icon={
+                        <Icon>
+                          <EllipsisVIcon aria-hidden="true" />
+                        </Icon>
+                      }
+                    />
                   )}
                 >
                   <DropdownGroup key="group 2" aria-label="User actions">
@@ -182,7 +189,11 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({ notificationBa
                     ref={toggleRef}
                     isExpanded={isDropdownOpen}
                     onClick={onDropdownToggle}
-                    icon={<Avatar src={imgAvatar} alt="" size="sm" />}
+                    icon={
+                      <Icon>
+                        <Avatar src={imgAvatar} alt="" size="sm" />
+                      </Icon>
+                    }
                   >
                     Ned Username
                   </MenuToggle>

--- a/packages/react-core/src/demos/DataList/examples/DataListBasic.tsx
+++ b/packages/react-core/src/demos/DataList/examples/DataListBasic.tsx
@@ -9,6 +9,7 @@ import {
   DataListItemCells,
   Flex,
   FlexItem,
+  Icon,
   MenuToggle,
   MenuToggleCheckbox,
   OverflowMenu,
@@ -58,9 +59,15 @@ export const DataListBasic: React.FunctionComponent = () => {
             <Button variant="primary">Create instance</Button>
           </OverflowMenuItem>
           <OverflowMenuControl hasAdditionalOptions>
-            <MenuToggle aria-label="Toolbar kebab overflow menu" variant="plain">
-              <EllipsisVIcon />
-            </MenuToggle>
+            <MenuToggle
+              aria-label="Toolbar kebab overflow menu"
+              variant="plain"
+              icon={
+                <Icon>
+                  <EllipsisVIcon />
+                </Icon>
+              }
+            />
           </OverflowMenuControl>
         </OverflowMenu>
       </ToolbarItem>

--- a/packages/react-core/src/demos/DataList/examples/DataListExpandableControlInToolbar.tsx
+++ b/packages/react-core/src/demos/DataList/examples/DataListExpandableControlInToolbar.tsx
@@ -187,9 +187,12 @@ export const DataListExpandableControlInToolbar: React.FunctionComponent = () =>
                         isExpanded={isOpen1}
                         variant="plain"
                         aria-label="Primary content kebab toggle"
-                      >
-                        <EllipsisVIcon aria-hidden="true" />
-                      </MenuToggle>
+                        icon={
+                          <Icon>
+                            <EllipsisVIcon aria-hidden="true" />
+                          </Icon>
+                        }
+                      />
                     )}
                   >
                     <DropdownList>
@@ -269,9 +272,12 @@ export const DataListExpandableControlInToolbar: React.FunctionComponent = () =>
                         isExpanded={isOpen2}
                         variant="plain"
                         aria-label="Secondary content kebab toggle"
-                      >
-                        <EllipsisVIcon aria-hidden="true" />
-                      </MenuToggle>
+                        icon={
+                          <Icon>
+                            <EllipsisVIcon aria-hidden="true" />
+                          </Icon>
+                        }
+                      />
                     )}
                   >
                     <DropdownList>
@@ -351,9 +357,12 @@ export const DataListExpandableControlInToolbar: React.FunctionComponent = () =>
                         isExpanded={isOpen3}
                         variant="plain"
                         aria-label="Tertiary content kebab toggle"
-                      >
-                        <EllipsisVIcon aria-hidden="true" />
-                      </MenuToggle>
+                        icon={
+                          <Icon>
+                            <EllipsisVIcon aria-hidden="true" />
+                          </Icon>
+                        }
+                      />
                     )}
                   >
                     <DropdownList>

--- a/packages/react-core/src/demos/Filters/examples/FilterAttributeSearch.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterAttributeSearch.tsx
@@ -21,7 +21,8 @@ import {
   ToolbarGroup,
   ToolbarFilter,
   ToolbarToggleGroup,
-  EmptyStateActions
+  EmptyStateActions,
+  Icon
 } from '@patternfly/react-core';
 import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
@@ -525,7 +526,11 @@ export const FilterAttributeSearch: React.FunctionComponent = () => {
       ref={attributeToggleRef}
       onClick={onAttributeToggleClick}
       isExpanded={isAttributeMenuOpen}
-      icon={<FilterIcon />}
+      icon={
+        <Icon>
+          <FilterIcon />
+        </Icon>
+      }
     >
       {activeAttributeMenu}
     </MenuToggle>

--- a/packages/react-core/src/demos/Filters/examples/FilterCheckboxSelect.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterCheckboxSelect.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  Icon,
   Menu,
   MenuContent,
   MenuList,
@@ -291,7 +292,11 @@ export const FilterCheckboxSelect: React.FunctionComponent = () => {
       ref={toggleRef}
       onClick={onToggleClick}
       isExpanded={isOpen}
-      icon={<FilterIcon />}
+      icon={
+        <Icon>
+          <FilterIcon />
+        </Icon>
+      }
       {...(selections.length > 0 && { badge: <Badge isRead>{selections.length}</Badge> })}
       style={
         {

--- a/packages/react-core/src/demos/Filters/examples/FilterFaceted.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterFaceted.tsx
@@ -20,7 +20,8 @@ import {
   ToolbarFilter,
   ToolbarToggleGroup,
   MenuGroup,
-  EmptyStateActions
+  EmptyStateActions,
+  Icon
 } from '@patternfly/react-core';
 import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
@@ -322,7 +323,11 @@ export const FilterFaceted: React.FunctionComponent = () => {
       {...(areSelectionsPresent && {
         badge: <Badge isRead>{locationSelections.length + statusSelections.length}</Badge>
       })}
-      icon={<FilterIcon />}
+      icon={
+        <Icon>
+          <FilterIcon />
+        </Icon>
+      }
       style={
         {
           width: '200px'

--- a/packages/react-core/src/demos/Filters/examples/FilterMixedSelectGroup.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterMixedSelectGroup.tsx
@@ -19,7 +19,8 @@ import {
   Badge,
   ToolbarFilter,
   ToolbarToggleGroup,
-  EmptyStateActions
+  EmptyStateActions,
+  Icon
 } from '@patternfly/react-core';
 import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
@@ -292,7 +293,11 @@ export const FilterMixedSelectGroup: React.FunctionComponent = () => {
       ref={statusToggleRef}
       onClick={onStatusToggleClick}
       isExpanded={isStatusMenuOpen}
-      icon={<FilterIcon />}
+      icon={
+        <Icon>
+          <FilterIcon />
+        </Icon>
+      }
       style={
         {
           width: '200px'
@@ -391,7 +396,11 @@ export const FilterMixedSelectGroup: React.FunctionComponent = () => {
       onClick={onLocationMenuToggleClick}
       isExpanded={isLocationMenuOpen}
       {...(locationSelections.length > 0 && { badge: <Badge isRead>{locationSelections.length}</Badge> })}
-      icon={<FilterIcon />}
+      icon={
+        <Icon>
+          <FilterIcon />
+        </Icon>
+      }
       style={
         {
           width: '200px'

--- a/packages/react-core/src/demos/Filters/examples/FilterSameSelectGroup.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterSameSelectGroup.tsx
@@ -17,7 +17,8 @@ import {
   Button,
   Bullseye,
   ToolbarToggleGroup,
-  EmptyStateActions
+  EmptyStateActions,
+  Icon
 } from '@patternfly/react-core';
 import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
@@ -293,7 +294,11 @@ export const FilterSameSelectGroup: React.FunctionComponent = () => {
       ref={statusToggleRef}
       onClick={onStatusToggleClick}
       isExpanded={isStatusMenuOpen}
-      icon={<FilterIcon />}
+      icon={
+        <Icon>
+          <FilterIcon />
+        </Icon>
+      }
       style={
         {
           width: '200px'
@@ -387,7 +392,11 @@ export const FilterSameSelectGroup: React.FunctionComponent = () => {
       ref={locationToggleRef}
       onClick={onLocationMenuToggleClick}
       isExpanded={isLocationMenuOpen}
-      icon={<FilterIcon />}
+      icon={
+        <Icon>
+          <FilterIcon />
+        </Icon>
+      }
       style={
         {
           width: '200px'

--- a/packages/react-core/src/demos/Filters/examples/FilterSingleSelect.tsx
+++ b/packages/react-core/src/demos/Filters/examples/FilterSingleSelect.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  Icon,
   Menu,
   MenuContent,
   MenuList,
@@ -295,7 +296,11 @@ export const FilterSingleSelect: React.FunctionComponent = () => {
       ref={toggleRef}
       onClick={onToggleClick}
       isExpanded={isOpen}
-      icon={<FilterIcon />}
+      icon={
+        <Icon>
+          <FilterIcon />
+        </Icon>
+      }
       style={
         {
           width: '200px'

--- a/packages/react-core/src/demos/NotificationDrawer/examples/NotificationDrawerBasic.tsx
+++ b/packages/react-core/src/demos/NotificationDrawer/examples/NotificationDrawerBasic.tsx
@@ -16,6 +16,7 @@ import {
   EmptyStateBody,
   EmptyStateFooter,
   EmptyStateVariant,
+  Icon,
   MenuToggle,
   Nav,
   NavItem,
@@ -221,9 +222,12 @@ export const NotificationDrawerBasic: React.FunctionComponent = () => {
                     onClick={onKebabDropdownToggle}
                     variant="plain"
                     aria-label="Settings and help"
-                  >
-                    <EllipsisVIcon aria-hidden="true" />
-                  </MenuToggle>
+                    icon={
+                      <Icon>
+                        <EllipsisVIcon aria-hidden="true" />
+                      </Icon>
+                    }
+                  />
                 )}
               >
                 <DropdownList>{kebabDropdownItems}</DropdownList>
@@ -341,9 +345,12 @@ export const NotificationDrawerBasic: React.FunctionComponent = () => {
               variant="plain"
               onClick={() => onToggle('toggle-id-0')}
               isExpanded={isActionsMenuOpen['toggle-id-0'] || false}
-            >
-              <EllipsisVIcon aria-hidden="true" />
-            </MenuToggle>
+              icon={
+                <Icon>
+                  <EllipsisVIcon aria-hidden="true" />
+                </Icon>
+              }
+            />
           )}
         >
           <DropdownList>{notificationDrawerActions}</DropdownList>
@@ -376,9 +383,12 @@ export const NotificationDrawerBasic: React.FunctionComponent = () => {
                       variant="plain"
                       onClick={() => onToggle('toggle-id-1')}
                       isExpanded={isActionsMenuOpen['toggle-id-1'] || false}
-                    >
-                      <EllipsisVIcon aria-hidden="true" />
-                    </MenuToggle>
+                      icon={
+                        <Icon>
+                          <EllipsisVIcon aria-hidden="true" />
+                        </Icon>
+                      }
+                    />
                   )}
                 >
                   <DropdownList>{notificationDrawerDropdownItems}</DropdownList>
@@ -412,9 +422,12 @@ export const NotificationDrawerBasic: React.FunctionComponent = () => {
                       variant="plain"
                       onClick={() => onToggle('toggle-id-2')}
                       isExpanded={isActionsMenuOpen['toggle-id-2'] || false}
-                    >
-                      <EllipsisVIcon aria-hidden="true" />
-                    </MenuToggle>
+                      icon={
+                        <Icon>
+                          <EllipsisVIcon aria-hidden="true" />
+                        </Icon>
+                      }
+                    />
                   )}
                 >
                   <DropdownList>{notificationDrawerDropdownItems}</DropdownList>
@@ -449,9 +462,12 @@ export const NotificationDrawerBasic: React.FunctionComponent = () => {
                       variant="plain"
                       onClick={() => onToggle('toggle-id-3')}
                       isExpanded={isActionsMenuOpen['toggle-id-3'] || false}
-                    >
-                      <EllipsisVIcon aria-hidden="true" />
-                    </MenuToggle>
+                      icon={
+                        <Icon>
+                          <EllipsisVIcon aria-hidden="true" />
+                        </Icon>
+                      }
+                    />
                   )}
                 >
                   <DropdownList>{notificationDrawerDropdownItems}</DropdownList>
@@ -485,9 +501,12 @@ export const NotificationDrawerBasic: React.FunctionComponent = () => {
                       variant="plain"
                       onClick={() => onToggle('toggle-id-4')}
                       isExpanded={isActionsMenuOpen['toggle-id-4'] || false}
-                    >
-                      <EllipsisVIcon aria-hidden="true" />
-                    </MenuToggle>
+                      icon={
+                        <Icon>
+                          <EllipsisVIcon aria-hidden="true" />
+                        </Icon>
+                      }
+                    />
                   )}
                 >
                   <DropdownList>{notificationDrawerDropdownItems}</DropdownList>

--- a/packages/react-core/src/demos/NotificationDrawer/examples/NotificationDrawerGrouped.tsx
+++ b/packages/react-core/src/demos/NotificationDrawer/examples/NotificationDrawerGrouped.tsx
@@ -16,6 +16,7 @@ import {
   EmptyStateBody,
   EmptyStateFooter,
   EmptyStateVariant,
+  Icon,
   MenuToggle,
   Nav,
   NavItem,
@@ -271,9 +272,12 @@ export const NotificationDrawerGrouped: React.FunctionComponent = () => {
                     onClick={onKebabDropdownToggle}
                     variant="plain"
                     aria-label="Settings and help"
-                  >
-                    <EllipsisVIcon aria-hidden="true" />
-                  </MenuToggle>
+                    icon={
+                      <Icon>
+                        <EllipsisVIcon aria-hidden="true" />
+                      </Icon>
+                    }
+                  />
                 )}
               >
                 <DropdownList>{kebabDropdownItems}</DropdownList>
@@ -392,9 +396,12 @@ export const NotificationDrawerGrouped: React.FunctionComponent = () => {
               variant="plain"
               onClick={() => onToggle('toggle-id-0')}
               isExpanded={isActionsMenuOpen['toggle-id-0'] || false}
-            >
-              <EllipsisVIcon aria-hidden="true" />
-            </MenuToggle>
+              icon={
+                <Icon>
+                  <EllipsisVIcon aria-hidden="true" />
+                </Icon>
+              }
+            />
           )}
         >
           <DropdownList>{notificationDrawerActions}</DropdownList>
@@ -434,9 +441,12 @@ export const NotificationDrawerGrouped: React.FunctionComponent = () => {
                           variant="plain"
                           onClick={() => onToggle('toggle-id-5')}
                           isExpanded={isActionsMenuOpen['toggle-id-5'] || false}
-                        >
-                          <EllipsisVIcon aria-hidden="true" />
-                        </MenuToggle>
+                          icon={
+                            <Icon>
+                              <EllipsisVIcon aria-hidden="true" />
+                            </Icon>
+                          }
+                        />
                       )}
                     >
                       <DropdownList>{notificationDrawerDropdownItems}</DropdownList>
@@ -470,9 +480,12 @@ export const NotificationDrawerGrouped: React.FunctionComponent = () => {
                           variant="plain"
                           onClick={() => onToggle('toggle-id-6')}
                           isExpanded={isActionsMenuOpen['toggle-id-6'] || false}
-                        >
-                          <EllipsisVIcon aria-hidden="true" />
-                        </MenuToggle>
+                          icon={
+                            <Icon>
+                              <EllipsisVIcon aria-hidden="true" />
+                            </Icon>
+                          }
+                        />
                       )}
                     >
                       <DropdownList>{notificationDrawerDropdownItems}</DropdownList>
@@ -507,9 +520,12 @@ export const NotificationDrawerGrouped: React.FunctionComponent = () => {
                           variant="plain"
                           onClick={() => onToggle('toggle-id-7')}
                           isExpanded={isActionsMenuOpen['toggle-id-7'] || false}
-                        >
-                          <EllipsisVIcon aria-hidden="true" />
-                        </MenuToggle>
+                          icon={
+                            <Icon>
+                              <EllipsisVIcon aria-hidden="true" />
+                            </Icon>
+                          }
+                        />
                       )}
                     >
                       <DropdownList>{notificationDrawerDropdownItems}</DropdownList>
@@ -543,9 +559,12 @@ export const NotificationDrawerGrouped: React.FunctionComponent = () => {
                           variant="plain"
                           onClick={() => onToggle('toggle-id-8')}
                           isExpanded={isActionsMenuOpen['toggle-id-8'] || false}
-                        >
-                          <EllipsisVIcon aria-hidden="true" />
-                        </MenuToggle>
+                          icon={
+                            <Icon>
+                              <EllipsisVIcon aria-hidden="true" />
+                            </Icon>
+                          }
+                        />
                       )}
                     >
                       <DropdownList>{notificationDrawerDropdownItems}</DropdownList>
@@ -588,9 +607,12 @@ export const NotificationDrawerGrouped: React.FunctionComponent = () => {
                           variant="plain"
                           onClick={() => onToggle('toggle-id-9')}
                           isExpanded={isActionsMenuOpen['toggle-id-9'] || false}
-                        >
-                          <EllipsisVIcon aria-hidden="true" />
-                        </MenuToggle>
+                          icon={
+                            <Icon>
+                              <EllipsisVIcon aria-hidden="true" />
+                            </Icon>
+                          }
+                        />
                       )}
                     >
                       <DropdownList>{notificationDrawerDropdownItems}</DropdownList>
@@ -624,9 +646,12 @@ export const NotificationDrawerGrouped: React.FunctionComponent = () => {
                           variant="plain"
                           onClick={() => onToggle('toggle-id-10')}
                           isExpanded={isActionsMenuOpen['toggle-id-10'] || false}
-                        >
-                          <EllipsisVIcon aria-hidden="true" />
-                        </MenuToggle>
+                          icon={
+                            <Icon>
+                              <EllipsisVIcon aria-hidden="true" />
+                            </Icon>
+                          }
+                        />
                       )}
                     >
                       <DropdownList>{notificationDrawerDropdownItems}</DropdownList>
@@ -661,9 +686,12 @@ export const NotificationDrawerGrouped: React.FunctionComponent = () => {
                           variant="plain"
                           onClick={() => onToggle('toggle-id-11')}
                           isExpanded={isActionsMenuOpen['toggle-id-11'] || false}
-                        >
-                          <EllipsisVIcon aria-hidden="true" />
-                        </MenuToggle>
+                          icon={
+                            <Icon>
+                              <EllipsisVIcon aria-hidden="true" />
+                            </Icon>
+                          }
+                        />
                       )}
                     >
                       <DropdownList>{notificationDrawerDropdownItems}</DropdownList>
@@ -697,9 +725,12 @@ export const NotificationDrawerGrouped: React.FunctionComponent = () => {
                           variant="plain"
                           onClick={() => onToggle('toggle-id-12')}
                           isExpanded={isActionsMenuOpen['toggle-id-12'] || false}
-                        >
-                          <EllipsisVIcon aria-hidden="true" />
-                        </MenuToggle>
+                          icon={
+                            <Icon>
+                              <EllipsisVIcon aria-hidden="true" />
+                            </Icon>
+                          }
+                        />
                       )}
                     >
                       <DropdownList>{notificationDrawerDropdownItems}</DropdownList>

--- a/packages/react-core/src/demos/RTL/examples/PaginatedTable.jsx
+++ b/packages/react-core/src/demos/RTL/examples/PaginatedTable.jsx
@@ -374,9 +374,12 @@ export const PaginatedTableAction = () => {
                       onClick={onKebabDropdownToggle}
                       variant="plain"
                       aria-label={translation.kebabDropdown.settingsAndHelp}
-                    >
-                      <EllipsisVIcon aria-hidden="true" />
-                    </MenuToggle>
+                      icon={
+                        <Icon>
+                          <EllipsisVIcon aria-hidden="true" />
+                        </Icon>
+                      }
+                    />
                   )}
                 >
                   <DropdownList>{kebabDropdownItems}</DropdownList>
@@ -395,9 +398,12 @@ export const PaginatedTableAction = () => {
                       onClick={onFullKebabToggle}
                       variant="plain"
                       aria-label={translation.kebabAndUserDropdown.toolbarMenuAriaLabel}
-                    >
-                      <EllipsisVIcon aria-hidden="true" />
-                    </MenuToggle>
+                      icon={
+                        <Icon>
+                          <EllipsisVIcon aria-hidden="true" />
+                        </Icon>
+                      }
+                    />
                   )}
                 >
                   <DropdownGroup key="group 2" aria-label={translation.kebabAndUserDropdown.groupAriaLabel}>

--- a/packages/react-core/src/demos/RTL/examples/PaginatedTable.tsx
+++ b/packages/react-core/src/demos/RTL/examples/PaginatedTable.tsx
@@ -398,9 +398,12 @@ export const PaginatedTableAction: React.FunctionComponent = () => {
                       onClick={onKebabDropdownToggle}
                       variant="plain"
                       aria-label={translation.kebabDropdown.settingsAndHelp}
-                    >
-                      <EllipsisVIcon aria-hidden="true" />
-                    </MenuToggle>
+                      icon={
+                        <Icon>
+                          <EllipsisVIcon aria-hidden="true" />
+                        </Icon>
+                      }
+                    />
                   )}
                 >
                   <DropdownList>{kebabDropdownItems}</DropdownList>
@@ -419,9 +422,12 @@ export const PaginatedTableAction: React.FunctionComponent = () => {
                       onClick={onFullKebabToggle}
                       variant="plain"
                       aria-label={translation.kebabAndUserDropdown.toolbarMenuAriaLabel}
-                    >
-                      <EllipsisVIcon aria-hidden="true" />
-                    </MenuToggle>
+                      icon={
+                        <Icon>
+                          <EllipsisVIcon aria-hidden="true" />
+                        </Icon>
+                      }
+                    />
                   )}
                 >
                   <DropdownGroup key="group 2" aria-label={translation.kebabAndUserDropdown.groupAriaLabel}>

--- a/packages/react-core/src/demos/examples/AlertGroup/AlertGroupToastWithNotificationDrawer.tsx
+++ b/packages/react-core/src/demos/examples/AlertGroup/AlertGroupToastWithNotificationDrawer.tsx
@@ -24,6 +24,7 @@ import {
   Dropdown,
   DropdownList,
   DropdownItem,
+  Icon,
   MenuToggle,
   MenuToggleElement
 } from '@patternfly/react-core';
@@ -248,9 +249,12 @@ export const AlertGroupToastWithNotificationDrawer: React.FunctionComponent = ()
               variant="plain"
               onClick={() => onDropdownToggle('dropdown-toggle-id-0')}
               aria-label="Notification drawer actions"
-            >
-              <EllipsisVIcon aria-hidden="true" />
-            </MenuToggle>
+              icon={
+                <Icon>
+                  <EllipsisVIcon aria-hidden="true" />
+                </Icon>
+              }
+            />
           )}
         >
           <DropdownList>{notificationDrawerActions}</DropdownList>
@@ -280,9 +284,12 @@ export const AlertGroupToastWithNotificationDrawer: React.FunctionComponent = ()
                         variant="plain"
                         onClick={() => onDropdownToggle(key)}
                         aria-label={`Notification ${index + 1} actions`}
-                      >
-                        <EllipsisVIcon aria-hidden="true" />
-                      </MenuToggle>
+                        icon={
+                          <Icon>
+                            <EllipsisVIcon aria-hidden="true" />
+                          </Icon>
+                        }
+                      />
                     )}
                   >
                     <DropdownList>{notificationDrawerDropdownItems(key)}</DropdownList>

--- a/packages/react-core/src/demos/examples/Card/CardHorizontalGrid.tsx
+++ b/packages/react-core/src/demos/examples/Card/CardHorizontalGrid.tsx
@@ -10,6 +10,7 @@ import {
   Label,
   Grid,
   Flex,
+  Icon,
   List,
   ListItem,
   Button,
@@ -63,9 +64,12 @@ export const CardHorizontalGrid: React.FunctionComponent = () => {
           onClick={onActionToggle}
           variant="plain"
           aria-label="Horizontal card grid demo kebab toggle"
-        >
-          <EllipsisVIcon aria-hidden="true" />
-        </MenuToggle>
+          icon={
+            <Icon>
+              <EllipsisVIcon aria-hidden="true" />
+            </Icon>
+          }
+        />
       )}
     >
       <DropdownList>{dropdownItems}</DropdownList>

--- a/packages/react-core/src/demos/examples/DateTimePicker/DateTimePicker.tsx
+++ b/packages/react-core/src/demos/examples/DateTimePicker/DateTimePicker.tsx
@@ -9,6 +9,7 @@ import {
   Dropdown,
   DropdownItem,
   DropdownList,
+  Icon,
   MenuToggle,
   MenuToggleElement
 } from '@patternfly/react-core';
@@ -65,7 +66,11 @@ export const DateTimePicker: React.FunctionComponent = () => {
           onClick={onToggleTime}
           isExpanded={isTimeOpen}
           aria-label="Time picker"
-          icon={<OutlinedClockIcon aria-hidden="true" />}
+          icon={
+            <Icon>
+              <OutlinedClockIcon aria-hidden="true" />
+            </Icon>
+          }
         />
       )}
     >

--- a/packages/react-core/src/demos/examples/Masthead/MastheadWithHorizontalNav.tsx
+++ b/packages/react-core/src/demos/examples/Masthead/MastheadWithHorizontalNav.tsx
@@ -15,6 +15,7 @@ import {
   DropdownList,
   Gallery,
   GalleryItem,
+  Icon,
   Masthead,
   MastheadMain,
   MastheadLogo,
@@ -211,9 +212,12 @@ export const MastheadWithHorizontalNav: React.FunctionComponent = () => {
                   isExpanded={isKebabDropdownOpen}
                   variant="plain"
                   aria-label="Settings and help"
-                >
-                  <EllipsisVIcon aria-hidden="true" />
-                </MenuToggle>
+                  icon={
+                    <Icon>
+                      <EllipsisVIcon aria-hidden="true" />
+                    </Icon>
+                  }
+                />
               )}
             >
               <DropdownList>{kebabDropdownItems}</DropdownList>
@@ -232,9 +236,12 @@ export const MastheadWithHorizontalNav: React.FunctionComponent = () => {
                   isExpanded={isFullKebabDropdownOpen}
                   variant="plain"
                   aria-label="Toolbar menu"
-                >
-                  <EllipsisVIcon aria-hidden="true" />
-                </MenuToggle>
+                  icon={
+                    <Icon>
+                      <EllipsisVIcon aria-hidden="true" />
+                    </Icon>
+                  }
+                />
               )}
             >
               <DropdownGroup key="group 2" aria-label="User actions">

--- a/packages/react-core/src/demos/examples/Masthead/MastheadWithUtilitiesAndUserDropdownMenu.tsx
+++ b/packages/react-core/src/demos/examples/Masthead/MastheadWithUtilitiesAndUserDropdownMenu.tsx
@@ -16,6 +16,7 @@ import {
   DropdownList,
   Gallery,
   GalleryItem,
+  Icon,
   Masthead,
   MastheadMain,
   MastheadLogo,
@@ -156,9 +157,12 @@ export const MastheadWithUtilitiesAndUserDropdownMenu: React.FunctionComponent =
       onClick={onToggleClick}
       isExpanded={isOpen}
       style={{ width: 'auto' }}
-    >
-      <ThIcon />
-    </MenuToggle>
+      icon={
+        <Icon>
+          <ThIcon />
+        </Icon>
+      }
+    />
   );
 
   const menuItems = [
@@ -412,9 +416,12 @@ export const MastheadWithUtilitiesAndUserDropdownMenu: React.FunctionComponent =
                   isExpanded={isKebabDropdownOpen}
                   variant="plain"
                   aria-label="Settings and help"
-                >
-                  <EllipsisVIcon aria-hidden="true" />
-                </MenuToggle>
+                  icon={
+                    <Icon>
+                      <EllipsisVIcon aria-hidden="true" />
+                    </Icon>
+                  }
+                />
               )}
             >
               <DropdownList>{kebabDropdownItems}</DropdownList>
@@ -433,9 +440,12 @@ export const MastheadWithUtilitiesAndUserDropdownMenu: React.FunctionComponent =
                   isExpanded={isFullKebabDropdownOpen}
                   variant="plain"
                   aria-label="Toolbar menu"
-                >
-                  <EllipsisVIcon aria-hidden="true" />
-                </MenuToggle>
+                  icon={
+                    <Icon>
+                      <EllipsisVIcon aria-hidden="true" />
+                    </Icon>
+                  }
+                />
               )}
             >
               <DropdownGroup key="group 2" aria-label="User actions">

--- a/packages/react-core/src/demos/examples/Nav/NavFlyout.tsx
+++ b/packages/react-core/src/demos/examples/Nav/NavFlyout.tsx
@@ -9,6 +9,7 @@ import {
   DropdownGroup,
   DropdownItem,
   DropdownList,
+  Icon,
   Masthead,
   MastheadMain,
   MastheadLogo,
@@ -157,9 +158,12 @@ export const NavFlyout: React.FunctionComponent = () => {
                   onClick={onKebabDropdownToggle}
                   variant="plain"
                   aria-label="Settings and help"
-                >
-                  <EllipsisVIcon aria-hidden="true" />
-                </MenuToggle>
+                  icon={
+                    <Icon>
+                      <EllipsisVIcon aria-hidden="true" />
+                    </Icon>
+                  }
+                />
               )}
             >
               <DropdownList>{kebabDropdownItems}</DropdownList>
@@ -178,9 +182,12 @@ export const NavFlyout: React.FunctionComponent = () => {
                   onClick={onFullKebabToggle}
                   variant="plain"
                   aria-label="Toolbar menu"
-                >
-                  <EllipsisVIcon aria-hidden="true" />
-                </MenuToggle>
+                  icon={
+                    <Icon>
+                      <EllipsisVIcon aria-hidden="true" />
+                    </Icon>
+                  }
+                />
               )}
             >
               <DropdownGroup key="group 2" aria-label="User actions">

--- a/packages/react-core/src/demos/examples/Nav/NavHorizontal.tsx
+++ b/packages/react-core/src/demos/examples/Nav/NavHorizontal.tsx
@@ -14,6 +14,7 @@ import {
   DropdownList,
   Gallery,
   GalleryItem,
+  Icon,
   Masthead,
   MastheadMain,
   MastheadBrand,
@@ -135,9 +136,12 @@ export const NavHorizontal: React.FunctionComponent = () => {
                   onClick={onKebabDropdownToggle}
                   variant="plain"
                   aria-label="Settings and help"
-                >
-                  <EllipsisVIcon aria-hidden="true" />
-                </MenuToggle>
+                  icon={
+                    <Icon>
+                      <EllipsisVIcon aria-hidden="true" />
+                    </Icon>
+                  }
+                />
               )}
             >
               <DropdownList>{kebabDropdownItems}</DropdownList>
@@ -156,9 +160,12 @@ export const NavHorizontal: React.FunctionComponent = () => {
                   onClick={onFullKebabToggle}
                   variant="plain"
                   aria-label="Toolbar menu"
-                >
-                  <EllipsisVIcon aria-hidden="true" />
-                </MenuToggle>
+                  icon={
+                    <Icon>
+                      <EllipsisVIcon aria-hidden="true" />
+                    </Icon>
+                  }
+                />
               )}
             >
               <DropdownGroup key="group 2" aria-label="User actions">

--- a/packages/react-core/src/demos/examples/Nav/NavHorizontalWithSubnav.tsx
+++ b/packages/react-core/src/demos/examples/Nav/NavHorizontalWithSubnav.tsx
@@ -14,6 +14,7 @@ import {
   DropdownList,
   Gallery,
   GalleryItem,
+  Icon,
   MenuToggle,
   Masthead,
   MastheadMain,
@@ -184,9 +185,12 @@ export const NavHorizontalWithSubnav: React.FunctionComponent = () => {
                   onClick={onKebabDropdownToggle}
                   variant="plain"
                   aria-label="Settings and help"
-                >
-                  <EllipsisVIcon aria-hidden="true" />
-                </MenuToggle>
+                  icon={
+                    <Icon>
+                      <EllipsisVIcon aria-hidden="true" />
+                    </Icon>
+                  }
+                />
               )}
             >
               <DropdownList>{kebabDropdownItems}</DropdownList>
@@ -205,9 +209,12 @@ export const NavHorizontalWithSubnav: React.FunctionComponent = () => {
                   onClick={onFullKebabToggle}
                   variant="plain"
                   aria-label="Toolbar menu"
-                >
-                  <EllipsisVIcon aria-hidden="true" />
-                </MenuToggle>
+                  icon={
+                    <Icon>
+                      <EllipsisVIcon aria-hidden="true" />
+                    </Icon>
+                  }
+                />
               )}
             >
               <DropdownGroup key="group 2" aria-label="User actions">

--- a/packages/react-core/src/demos/examples/Nav/NavManual.tsx
+++ b/packages/react-core/src/demos/examples/Nav/NavManual.tsx
@@ -14,6 +14,7 @@ import {
   DropdownList,
   Gallery,
   GalleryItem,
+  Icon,
   Masthead,
   MastheadMain,
   MastheadLogo,
@@ -151,9 +152,12 @@ export const NavManual: React.FunctionComponent = () => {
                   onClick={onKebabDropdownToggle}
                   variant="plain"
                   aria-label="Settings and help"
-                >
-                  <EllipsisVIcon aria-hidden="true" />
-                </MenuToggle>
+                  icon={
+                    <Icon>
+                      <EllipsisVIcon aria-hidden="true" />
+                    </Icon>
+                  }
+                />
               )}
             >
               <DropdownList>{kebabDropdownItems}</DropdownList>
@@ -172,9 +176,12 @@ export const NavManual: React.FunctionComponent = () => {
                   onClick={onFullKebabToggle}
                   variant="plain"
                   aria-label="Toolbar menu"
-                >
-                  <EllipsisVIcon aria-hidden="true" />
-                </MenuToggle>
+                  icon={
+                    <Icon>
+                      <EllipsisVIcon aria-hidden="true" />
+                    </Icon>
+                  }
+                />
               )}
             >
               <DropdownGroup key="group 2" aria-label="User actions">

--- a/packages/react-core/src/demos/examples/Page/PageContextSelector.tsx
+++ b/packages/react-core/src/demos/examples/Page/PageContextSelector.tsx
@@ -15,6 +15,7 @@ import {
   DropdownList,
   Gallery,
   GalleryItem,
+  Icon,
   Masthead,
   MastheadMain,
   MastheadLogo,
@@ -164,9 +165,12 @@ export const PageStickySectionBreadcrumb: React.FunctionComponent = () => {
                   isExpanded={isKebabDropdownOpen}
                   variant="plain"
                   aria-label="Settings and help"
-                >
-                  <EllipsisVIcon aria-hidden="true" />
-                </MenuToggle>
+                  icon={
+                    <Icon>
+                      <EllipsisVIcon aria-hidden="true" />
+                    </Icon>
+                  }
+                />
               )}
             >
               <DropdownList>{kebabDropdownItems}</DropdownList>
@@ -185,9 +189,12 @@ export const PageStickySectionBreadcrumb: React.FunctionComponent = () => {
                   isExpanded={isFullKebabDropdownOpen}
                   variant="plain"
                   aria-label="Toolbar menu"
-                >
-                  <EllipsisVIcon aria-hidden="true" />
-                </MenuToggle>
+                  icon={
+                    <Icon>
+                      <EllipsisVIcon aria-hidden="true" />
+                    </Icon>
+                  }
+                />
               )}
             >
               <DropdownGroup key="group 2" aria-label="User actions">

--- a/packages/react-core/src/demos/examples/Page/PageStickySectionBreadcrumb.tsx
+++ b/packages/react-core/src/demos/examples/Page/PageStickySectionBreadcrumb.tsx
@@ -16,6 +16,7 @@ import {
   DropdownList,
   Gallery,
   GalleryItem,
+  Icon,
   Masthead,
   MastheadMain,
   MastheadLogo,
@@ -147,9 +148,12 @@ export const PageStickySectionBreadcrumb: React.FunctionComponent = () => {
                   isExpanded={isKebabDropdownOpen}
                   variant="plain"
                   aria-label="Settings and help"
-                >
-                  <EllipsisVIcon aria-hidden="true" />
-                </MenuToggle>
+                  icon={
+                    <Icon>
+                      <EllipsisVIcon aria-hidden="true" />
+                    </Icon>
+                  }
+                />
               )}
             >
               <DropdownList>{kebabDropdownItems}</DropdownList>
@@ -168,9 +172,12 @@ export const PageStickySectionBreadcrumb: React.FunctionComponent = () => {
                   isExpanded={isFullKebabDropdownOpen}
                   variant="plain"
                   aria-label="Toolbar menu"
-                >
-                  <EllipsisVIcon aria-hidden="true" />
-                </MenuToggle>
+                  icon={
+                    <Icon>
+                      <EllipsisVIcon aria-hidden="true" />
+                    </Icon>
+                  }
+                />
               )}
             >
               <DropdownGroup key="group 2" aria-label="User actions">

--- a/packages/react-core/src/demos/examples/Page/PageStickySectionGroup.tsx
+++ b/packages/react-core/src/demos/examples/Page/PageStickySectionGroup.tsx
@@ -16,6 +16,7 @@ import {
   DropdownList,
   Gallery,
   GalleryItem,
+  Icon,
   Masthead,
   MastheadMain,
   MastheadLogo,
@@ -147,9 +148,12 @@ export const PageStickySectionGroup: React.FunctionComponent = () => {
                   isExpanded={isKebabDropdownOpen}
                   variant="plain"
                   aria-label="Settings and help"
-                >
-                  <EllipsisVIcon aria-hidden="true" />
-                </MenuToggle>
+                  icon={
+                    <Icon>
+                      <EllipsisVIcon aria-hidden="true" />
+                    </Icon>
+                  }
+                />
               )}
             >
               <DropdownList>{kebabDropdownItems}</DropdownList>
@@ -168,9 +172,12 @@ export const PageStickySectionGroup: React.FunctionComponent = () => {
                   isExpanded={isFullKebabDropdownOpen}
                   variant="plain"
                   aria-label="Toolbar menu"
-                >
-                  <EllipsisVIcon aria-hidden="true" />
-                </MenuToggle>
+                  icon={
+                    <Icon>
+                      <EllipsisVIcon aria-hidden="true" />
+                    </Icon>
+                  }
+                />
               )}
             >
               <DropdownGroup key="group 2" aria-label="User actions">

--- a/packages/react-core/src/demos/examples/Page/PageStickySectionGroupAlternate.tsx
+++ b/packages/react-core/src/demos/examples/Page/PageStickySectionGroupAlternate.tsx
@@ -16,6 +16,7 @@ import {
   DropdownList,
   Gallery,
   GalleryItem,
+  Icon,
   Masthead,
   MastheadMain,
   MastheadLogo,
@@ -139,9 +140,12 @@ export const PageStickySectionGroupAlternate: React.FunctionComponent = () => {
                   isExpanded={isKebabDropdownOpen}
                   variant="plain"
                   aria-label="Settings and help"
-                >
-                  <EllipsisVIcon aria-hidden="true" />
-                </MenuToggle>
+                  icon={
+                    <Icon>
+                      <EllipsisVIcon aria-hidden="true" />
+                    </Icon>
+                  }
+                />
               )}
             >
               <DropdownList>{kebabDropdownItems}</DropdownList>
@@ -160,9 +164,12 @@ export const PageStickySectionGroupAlternate: React.FunctionComponent = () => {
                   isExpanded={isFullKebabDropdownOpen}
                   variant="plain"
                   aria-label="Toolbar menu"
-                >
-                  <EllipsisVIcon aria-hidden="true" />
-                </MenuToggle>
+                  icon={
+                    <Icon>
+                      <EllipsisVIcon aria-hidden="true" />
+                    </Icon>
+                  }
+                />
               )}
             >
               <DropdownGroup key="group 2" aria-label="User actions">

--- a/packages/react-core/src/demos/examples/PrimaryDetail/PrimaryDetailCardView.tsx
+++ b/packages/react-core/src/demos/examples/PrimaryDetail/PrimaryDetailCardView.tsx
@@ -22,6 +22,7 @@ import {
   Flex,
   FlexItem,
   Gallery,
+  Icon,
   MenuToggle,
   MenuToggleCheckbox,
   PageSection,
@@ -469,9 +470,12 @@ export const PrimaryDetailCardView: React.FunctionComponent = () => {
               variant="plain"
               onClick={onToolbarKebabDropdownToggle}
               aria-label="Toolbar actions"
-            >
-              <EllipsisVIcon aria-hidden="true" />
-            </MenuToggle>
+              icon={
+                <Icon>
+                  <EllipsisVIcon aria-hidden="true" />
+                </Icon>
+              }
+            />
           )}
         >
           <DropdownList>{toolbarKebabDropdownItems}</DropdownList>
@@ -528,9 +532,12 @@ export const PrimaryDetailCardView: React.FunctionComponent = () => {
                           onCardKebabDropdownToggle(e, key.toString());
                         }}
                         isExpanded={!!state[key]}
-                      >
-                        <EllipsisVIcon />
-                      </MenuToggle>
+                        icon={
+                          <Icon>
+                            <EllipsisVIcon />
+                          </Icon>
+                        }
+                      />
                     )}
                   >
                     <DropdownList>

--- a/packages/react-core/src/demos/examples/Tabs/TabsAndTable.tsx
+++ b/packages/react-core/src/demos/examples/Tabs/TabsAndTable.tsx
@@ -15,6 +15,7 @@ import {
   DropdownList,
   Flex,
   FlexItem,
+  Icon,
   Label,
   LabelGroup,
   MenuToggle,
@@ -171,9 +172,12 @@ export const TablesAndTabs = () => {
       aria-haspopup="menu"
       isExpanded={props.isOpen}
       ref={props.toggleRef}
-    >
-      <EllipsisVIcon />
-    </MenuToggle>
+      icon={
+        <Icon>
+          <EllipsisVIcon />
+        </Icon>
+      }
+    />
   );
 
   const toolbar = (
@@ -185,7 +189,15 @@ export const TablesAndTabs = () => {
           </ToolbarItem>
         </ToolbarToggleGroup>
         <ToolbarItem>
-          <MenuToggle variant="plain" aria-label="Sort columns" icon={<SortAmountDownIcon aria-hidden="true" />} />
+          <MenuToggle
+            variant="plain"
+            aria-label="Sort columns"
+            icon={
+              <Icon>
+                <SortAmountDownIcon aria-hidden="true" />
+              </Icon>
+            }
+          />
         </ToolbarItem>
         <OverflowMenu breakpoint="md">
           <OverflowMenuContent>
@@ -208,7 +220,11 @@ export const TablesAndTabs = () => {
                   variant="plain"
                   onClick={() => {}}
                   isExpanded={false}
-                  icon={<EllipsisVIcon />}
+                  icon={
+                    <Icon>
+                      <EllipsisVIcon />
+                    </Icon>
+                  }
                 />
               )}
               isOpen={false}

--- a/packages/react-core/src/demos/examples/Toolbar/ConsoleLogViewerToolbar.tsx
+++ b/packages/react-core/src/demos/examples/Toolbar/ConsoleLogViewerToolbar.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   Badge,
   Button,
+  Icon,
   MenuToggle,
   SearchInput,
   Select,
@@ -301,7 +302,16 @@ export const ConsoleLogViewerToolbar: React.FC = () => {
           onOpenChangeKeys={['Escape']}
           onSelect={onOptionSelect}
           toggle={(toggleRef) => (
-            <MenuToggle ref={toggleRef} isExpanded={optionExpanded} onClick={onOptionToggle} icon={<CogIcon />}>
+            <MenuToggle
+              ref={toggleRef}
+              isExpanded={optionExpanded}
+              onClick={onOptionToggle}
+              icon={
+                <Icon>
+                  <CogIcon />
+                </Icon>
+              }
+            >
               Options
             </MenuToggle>
           )}
@@ -355,7 +365,11 @@ export const ConsoleLogViewerToolbar: React.FC = () => {
                 ref={toggleRef}
                 isExpanded={optionExpandedMobile}
                 onClick={onOptionToggleMobile}
-                icon={<CogIcon />}
+                icon={
+                  <Icon>
+                    <CogIcon />
+                  </Icon>
+                }
                 aria-label="Options"
               />
             )}
@@ -431,7 +445,11 @@ export const ConsoleLogViewerToolbar: React.FC = () => {
                 ref={toggleRef}
                 isExpanded={externalExpandedMobile}
                 onClick={onExternalToggleMobile}
-                icon={<ExternalLinkAltIcon />}
+                icon={
+                  <Icon>
+                    <ExternalLinkAltIcon />
+                  </Icon>
+                }
                 aria-label="External logs"
               />
             )}
@@ -452,7 +470,11 @@ export const ConsoleLogViewerToolbar: React.FC = () => {
                 ref={toggleRef}
                 isExpanded={downloadExpandedMobile}
                 onClick={onDownloadToggleMobile}
-                icon={<DownloadIcon />}
+                icon={
+                  <Icon>
+                    <DownloadIcon />
+                  </Icon>
+                }
                 aria-label="Download"
               />
             )}

--- a/packages/react-integration/demo-app-ts/src/components/demos/CardDemo/CardDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/CardDemo/CardDemo.tsx
@@ -14,6 +14,7 @@ import {
   Dropdown,
   DropdownItem,
   DropdownList,
+  Icon,
   MenuToggle
 } from '@patternfly/react-core';
 import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
@@ -149,7 +150,11 @@ class CardDemo extends Component {
               ref={toggleRef}
               isExpanded={this.state.isOpen}
               onClick={this.onToggle}
-              icon={<EllipsisVIcon />}
+              icon={
+                <Icon>
+                  <EllipsisVIcon />
+                </Icon>
+              }
             />
           )}
         >

--- a/packages/react-integration/demo-app-ts/src/components/demos/DataListDemo/DataListDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DataListDemo/DataListDemo.tsx
@@ -11,6 +11,7 @@ import {
   Dropdown,
   DropdownItem,
   DropdownList,
+  Icon,
   MenuToggle
 } from '@patternfly/react-core';
 import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
@@ -82,7 +83,11 @@ class DataListDemo extends React.Component<DataListProps, DataListState> {
                     ref={toggleRef}
                     isExpanded={this.state.isOpen}
                     onClick={this.onToggle}
-                    icon={<EllipsisVIcon />}
+                    icon={
+                      <Icon>
+                        <EllipsisVIcon />
+                      </Icon>
+                    }
                   />
                 )}
               >

--- a/packages/react-integration/demo-app-ts/src/components/demos/DualListSelectorDemo/DualListSelectorWithActionsDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DualListSelectorDemo/DualListSelectorWithActionsDemo.tsx
@@ -18,6 +18,7 @@ import {
   EmptyStateFooter,
   EmptyStateBody,
   EmptyStateActions,
+  Icon,
   MenuToggle,
   MenuToggleElement
 } from '@patternfly/react-core';
@@ -190,9 +191,12 @@ export const DualListSelectorWithActionsDemo: React.FunctionComponent = () => {
                 variant="plain"
                 id="complex-available-toggle"
                 aria-label="Complex actions example available kebab toggle"
-              >
-                <EllipsisVIcon aria-hidden="true" />
-              </MenuToggle>
+                icon={
+                  <Icon>
+                    <EllipsisVIcon aria-hidden="true" />
+                  </Icon>
+                }
+              />
             )}
             isOpen={isAvailableKebabOpen}
             onOpenChange={(isOpen: boolean) => setIsAvailableKebabOpen(isOpen)}
@@ -226,9 +230,12 @@ export const DualListSelectorWithActionsDemo: React.FunctionComponent = () => {
                 variant="plain"
                 id="complex-chosen-toggle"
                 aria-label="Complex actions example chosen kebab toggle"
-              >
-                <EllipsisVIcon aria-hidden="true" />
-              </MenuToggle>
+                icon={
+                  <Icon>
+                    <EllipsisVIcon aria-hidden="true" />
+                  </Icon>
+                }
+              />
             )}
             isOpen={isChosenKebabOpen}
             onOpenChange={(isOpen: boolean) => setIsChosenKebabOpen(isOpen)}

--- a/packages/react-integration/demo-app-ts/src/components/demos/DualListSelectorDeprecatedDemo/DualListSelectorDeprecatedWithActionsDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DualListSelectorDeprecatedDemo/DualListSelectorDeprecatedWithActionsDemo.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, ButtonVariant, Dropdown, DropdownItem, DropdownList, MenuToggle } from '@patternfly/react-core';
+import { Button, ButtonVariant, Dropdown, DropdownItem, DropdownList, Icon, MenuToggle } from '@patternfly/react-core';
 import {
   DualListSelector as DLSDeprecated,
   DualListSelectorProps as DLSPropsDeprecated
@@ -139,7 +139,11 @@ class DualListSelectorDeprecatedWithActionsDemo extends React.Component<DLSProps
             ref={toggleRef}
             isExpanded={this.state.isAvailableKebabOpen}
             onClick={() => this.onToggle('available')}
-            icon={<EllipsisVIcon />}
+            icon={
+              <Icon>
+                <EllipsisVIcon />
+              </Icon>
+            }
           />
         )}
       >
@@ -166,7 +170,11 @@ class DualListSelectorDeprecatedWithActionsDemo extends React.Component<DLSProps
             ref={toggleRef}
             isExpanded={this.state.isChosenKebabOpen}
             onClick={() => this.onToggle('chosen')}
-            icon={<EllipsisVIcon />}
+            icon={
+              <Icon>
+                <EllipsisVIcon />
+              </Icon>
+            }
           />
         )}
       >

--- a/packages/react-integration/demo-app-ts/src/components/demos/MastheadDemo/MastheadDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/MastheadDemo/MastheadDemo.tsx
@@ -16,6 +16,7 @@ import {
   DropdownList,
   MenuToggle,
   Divider,
+  Icon,
   MenuToggleElement,
   MastheadProps
 } from '@patternfly/react-core';
@@ -181,9 +182,12 @@ export class MastheadDemo extends Component<MastheadProps> {
                         onClick={this.onKebabToggle}
                         id="toggle-id-kebab"
                         variant="plain"
-                      >
-                        <EllipsisVIcon />
-                      </MenuToggle>
+                        icon={
+                          <Icon>
+                            <EllipsisVIcon />
+                          </Icon>
+                        }
+                      />
                     )}
                   >
                     <DropdownList>{dropdownItems}</DropdownList>

--- a/packages/react-integration/demo-app-ts/src/components/demos/NotificationDrawerDemo/NotificationDrawerBasicDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/NotificationDrawerDemo/NotificationDrawerBasicDemo.tsx
@@ -11,6 +11,7 @@ import {
   Dropdown,
   DropdownItem,
   DropdownList,
+  Icon,
   MenuToggle,
   MenuToggleElement,
   Divider
@@ -74,9 +75,12 @@ export class BasicNotificationDrawerDemo extends React.Component<
                 onClick={() => this.onToggle(0)}
                 id="toggle-id-0"
                 variant="plain"
-              >
-                <EllipsisVIcon aria-hidden="true" />
-              </MenuToggle>
+                icon={
+                  <Icon>
+                    <EllipsisVIcon aria-hidden="true" />
+                  </Icon>
+                }
+              />
             )}
           >
             <DropdownList>{dropdownItems}</DropdownList>
@@ -105,9 +109,12 @@ export class BasicNotificationDrawerDemo extends React.Component<
                       onClick={() => this.onToggle(1)}
                       id="toggle-id-1"
                       variant="plain"
-                    >
-                      <EllipsisVIcon aria-hidden="true" />
-                    </MenuToggle>
+                      icon={
+                        <Icon>
+                          <EllipsisVIcon aria-hidden="true" />
+                        </Icon>
+                      }
+                    />
                   )}
                 >
                   <DropdownList>{dropdownItems}</DropdownList>
@@ -135,9 +142,12 @@ export class BasicNotificationDrawerDemo extends React.Component<
                       onClick={() => this.onToggle(2)}
                       id="toggle-id-2"
                       variant="plain"
-                    >
-                      <EllipsisVIcon aria-hidden="true" />
-                    </MenuToggle>
+                      icon={
+                        <Icon>
+                          <EllipsisVIcon aria-hidden="true" />
+                        </Icon>
+                      }
+                    />
                   )}
                 >
                   <DropdownList>{dropdownItems}</DropdownList>
@@ -167,9 +177,12 @@ export class BasicNotificationDrawerDemo extends React.Component<
                       onClick={() => this.onToggle(3)}
                       id="toggle-id-3"
                       variant="plain"
-                    >
-                      <EllipsisVIcon aria-hidden="true" />
-                    </MenuToggle>
+                      icon={
+                        <Icon>
+                          <EllipsisVIcon aria-hidden="true" />
+                        </Icon>
+                      }
+                    />
                   )}
                 >
                   <DropdownList>{dropdownItems}</DropdownList>
@@ -201,9 +214,12 @@ export class BasicNotificationDrawerDemo extends React.Component<
                       onClick={() => this.onToggle(4)}
                       id="toggle-id-4"
                       variant="plain"
-                    >
-                      <EllipsisVIcon aria-hidden="true" />
-                    </MenuToggle>
+                      icon={
+                        <Icon>
+                          <EllipsisVIcon aria-hidden="true" />
+                        </Icon>
+                      }
+                    />
                   )}
                 >
                   <DropdownList>{dropdownItems}</DropdownList>
@@ -228,9 +244,12 @@ export class BasicNotificationDrawerDemo extends React.Component<
                       onClick={() => this.onToggle(5)}
                       id="toggle-id-5"
                       variant="plain"
-                    >
-                      <EllipsisVIcon aria-hidden="true" />
-                    </MenuToggle>
+                      icon={
+                        <Icon>
+                          <EllipsisVIcon aria-hidden="true" />
+                        </Icon>
+                      }
+                    />
                   )}
                 >
                   <DropdownList>{dropdownItems}</DropdownList>

--- a/packages/react-integration/demo-app-ts/src/components/demos/NotificationDrawerDemo/NotificationDrawerGroupsDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/NotificationDrawerDemo/NotificationDrawerGroupsDemo.tsx
@@ -4,6 +4,7 @@ import {
   EmptyState,
   EmptyStateBody,
   EmptyStateVariant,
+  Icon,
   NotificationDrawer,
   NotificationDrawerProps,
   NotificationDrawerBody,
@@ -106,9 +107,12 @@ class GroupsNotificationDrawerDemo extends React.Component<NotificationDrawerPro
                 variant="plain"
                 onClick={() => this.onToggle('toggle-id-0')}
                 isExpanded={isOpenMap['toggle-id-0'] || false}
-              >
-                <EllipsisVIcon aria-hidden="true" />
-              </MenuToggle>
+                icon={
+                  <Icon>
+                    <EllipsisVIcon aria-hidden="true" />
+                  </Icon>
+                }
+              />
             )}
           >
             <DropdownList>{dropdownItems}</DropdownList>
@@ -144,9 +148,12 @@ class GroupsNotificationDrawerDemo extends React.Component<NotificationDrawerPro
                           variant="plain"
                           onClick={() => this.onToggle('toggle-id-5')}
                           isExpanded={isOpenMap['toggle-id-5'] || false}
-                        >
-                          <EllipsisVIcon aria-hidden="true" />
-                        </MenuToggle>
+                          icon={
+                            <Icon>
+                              <EllipsisVIcon aria-hidden="true" />
+                            </Icon>
+                          }
+                        />
                       )}
                     >
                       <DropdownList>{dropdownItems}</DropdownList>
@@ -175,9 +182,12 @@ class GroupsNotificationDrawerDemo extends React.Component<NotificationDrawerPro
                           variant="plain"
                           onClick={() => this.onToggle('toggle-id-6')}
                           isExpanded={isOpenMap['toggle-id-6'] || false}
-                        >
-                          <EllipsisVIcon aria-hidden="true" />
-                        </MenuToggle>
+                          icon={
+                            <Icon>
+                              <EllipsisVIcon aria-hidden="true" />
+                            </Icon>
+                          }
+                        />
                       )}
                     >
                       <DropdownList>{dropdownItems}</DropdownList>
@@ -207,9 +217,12 @@ class GroupsNotificationDrawerDemo extends React.Component<NotificationDrawerPro
                           variant="plain"
                           onClick={() => this.onToggle('toggle-id-7')}
                           isExpanded={isOpenMap['toggle-id-7'] || false}
-                        >
-                          <EllipsisVIcon aria-hidden="true" />
-                        </MenuToggle>
+                          icon={
+                            <Icon>
+                              <EllipsisVIcon aria-hidden="true" />
+                            </Icon>
+                          }
+                        />
                       )}
                     >
                       <DropdownList>{dropdownItems}</DropdownList>
@@ -238,9 +251,12 @@ class GroupsNotificationDrawerDemo extends React.Component<NotificationDrawerPro
                           variant="plain"
                           onClick={() => this.onToggle('toggle-id-8')}
                           isExpanded={isOpenMap['toggle-id-8'] || false}
-                        >
-                          <EllipsisVIcon aria-hidden="true" />
-                        </MenuToggle>
+                          icon={
+                            <Icon>
+                              <EllipsisVIcon aria-hidden="true" />
+                            </Icon>
+                          }
+                        />
                       )}
                     >
                       <DropdownList>{dropdownItems}</DropdownList>
@@ -281,9 +297,12 @@ class GroupsNotificationDrawerDemo extends React.Component<NotificationDrawerPro
                           variant="plain"
                           onClick={() => this.onToggle('toggle-id-9')}
                           isExpanded={isOpenMap['toggle-id-9'] || false}
-                        >
-                          <EllipsisVIcon aria-hidden="true" />
-                        </MenuToggle>
+                          icon={
+                            <Icon>
+                              <EllipsisVIcon aria-hidden="true" />
+                            </Icon>
+                          }
+                        />
                       )}
                     >
                       <DropdownList>{dropdownItems}</DropdownList>
@@ -312,9 +331,12 @@ class GroupsNotificationDrawerDemo extends React.Component<NotificationDrawerPro
                           variant="plain"
                           onClick={() => this.onToggle('toggle-id-10')}
                           isExpanded={isOpenMap['toggle-id-10'] || false}
-                        >
-                          <EllipsisVIcon aria-hidden="true" />
-                        </MenuToggle>
+                          icon={
+                            <Icon>
+                              <EllipsisVIcon aria-hidden="true" />
+                            </Icon>
+                          }
+                        />
                       )}
                     >
                       <DropdownList>{dropdownItems}</DropdownList>
@@ -344,9 +366,12 @@ class GroupsNotificationDrawerDemo extends React.Component<NotificationDrawerPro
                           variant="plain"
                           onClick={() => this.onToggle('toggle-id-11')}
                           isExpanded={isOpenMap['toggle-id-11'] || false}
-                        >
-                          <EllipsisVIcon aria-hidden="true" />
-                        </MenuToggle>
+                          icon={
+                            <Icon>
+                              <EllipsisVIcon aria-hidden="true" />
+                            </Icon>
+                          }
+                        />
                       )}
                     >
                       <DropdownList>{dropdownItems}</DropdownList>
@@ -375,9 +400,12 @@ class GroupsNotificationDrawerDemo extends React.Component<NotificationDrawerPro
                           variant="plain"
                           onClick={() => this.onToggle('toggle-id-12')}
                           isExpanded={isOpenMap['toggle-id-12'] || false}
-                        >
-                          <EllipsisVIcon aria-hidden="true" />
-                        </MenuToggle>
+                          icon={
+                            <Icon>
+                              <EllipsisVIcon aria-hidden="true" />
+                            </Icon>
+                          }
+                        />
                       )}
                     >
                       <DropdownList>{dropdownItems}</DropdownList>

--- a/packages/react-integration/demo-app-ts/src/components/demos/OverflowMenuDemo/OverflowMenuDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/OverflowMenuDemo/OverflowMenuDemo.tsx
@@ -9,7 +9,8 @@ import {
   MenuToggle,
   Button,
   Dropdown,
-  DropdownList
+  DropdownList,
+  Icon
 } from '@patternfly/react-core';
 import AlignLeftIcon from '@patternfly/react-icons/dist/esm/icons/align-left-icon';
 import AlignCenterIcon from '@patternfly/react-icons/dist/esm/icons/align-center-icon';
@@ -88,9 +89,12 @@ export class OverflowMenuDemo extends React.Component {
                 variant="plain"
                 onClick={this.onSimpleToggle}
                 isExpanded={isSimpleOpen}
-              >
-                <EllipsisVIcon />
-              </MenuToggle>
+                icon={
+                  <Icon>
+                    <EllipsisVIcon />
+                  </Icon>
+                }
+              />
             )}
             isOpen={isSimpleOpen}
           >
@@ -175,9 +179,12 @@ export class OverflowMenuDemo extends React.Component {
                 variant="plain"
                 onClick={this.onAdditionalOptionsToggle}
                 isExpanded={isAdditionalOptionsOpen}
-              >
-                <EllipsisVIcon />
-              </MenuToggle>
+                icon={
+                  <Icon>
+                    <EllipsisVIcon />
+                  </Icon>
+                }
+              />
             )}
             isOpen={isAdditionalOptionsOpen}
           >
@@ -242,9 +249,12 @@ export class OverflowMenuDemo extends React.Component {
                 variant="plain"
                 onClick={this.onPersistToggle}
                 isExpanded={isPersistOpen}
-              >
-                <EllipsisVIcon />
-              </MenuToggle>
+                icon={
+                  <Icon>
+                    <EllipsisVIcon />
+                  </Icon>
+                }
+              />
             )}
             isOpen={isPersistOpen}
           >
@@ -317,9 +327,12 @@ export class OverflowMenuDemo extends React.Component {
                   variant="plain"
                   onClick={this.onContainerBreakpointToggle}
                   isExpanded={isContainerBreakpointOpen}
-                >
-                  <EllipsisVIcon />
-                </MenuToggle>
+                  icon={
+                    <Icon>
+                      <EllipsisVIcon />
+                    </Icon>
+                  }
+                />
               )}
               isOpen={isContainerBreakpointOpen}
             >

--- a/packages/react-integration/demo-app-ts/src/components/demos/ToolbarDemo/ToolbarDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/ToolbarDemo/ToolbarDemo.tsx
@@ -11,6 +11,7 @@ import {
   ToolbarToggleGroup,
   ToolbarGroup,
   ToolbarProps,
+  Icon,
   InputGroup,
   InputGroupItem,
   TextInput,
@@ -273,7 +274,11 @@ class ToolbarDemo extends React.Component<ToolbarProps, ToolbarState> {
                 ref={toggleRef}
                 onClick={this.onKebabToggle}
                 isExpanded={kebabIsOpen}
-                icon={<EllipsisVIcon />}
+                icon={
+                  <Icon>
+                    <EllipsisVIcon />
+                  </Icon>
+                }
               />
             )}
           >

--- a/packages/react-table/src/components/Table/ActionsColumn.tsx
+++ b/packages/react-table/src/components/Table/ActionsColumn.tsx
@@ -3,6 +3,7 @@ import { Dropdown, DropdownItem, DropdownList } from '@patternfly/react-core/dis
 import { Button } from '@patternfly/react-core/dist/esm/components/Button';
 import { Divider } from '@patternfly/react-core/dist/esm/components/Divider';
 import { MenuToggle } from '@patternfly/react-core/dist/esm/components/MenuToggle';
+import { Icon } from '@patternfly/react-core/dist/esm/components/Icon';
 import { IAction, IExtraData, IRowData } from './TableTypes';
 import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
 import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip';
@@ -106,7 +107,11 @@ const ActionsColumnBase: React.FunctionComponent<ActionsColumnProps> = ({
               isExpanded={isOpen}
               isDisabled={isDisabled}
               variant="plain"
-              icon={<EllipsisVIcon />}
+              icon={
+                <Icon>
+                  <EllipsisVIcon />
+                </Icon>
+              }
             />
           )
         }

--- a/packages/react-table/src/components/Table/examples/TableActionsOverflow.tsx
+++ b/packages/react-table/src/components/Table/examples/TableActionsOverflow.tsx
@@ -9,7 +9,8 @@ import {
   OverflowMenuDropdownItem,
   MenuToggle,
   Dropdown,
-  DropdownList
+  DropdownList,
+  Icon
 } from '@patternfly/react-core';
 import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
@@ -105,7 +106,11 @@ export const TableActions: React.FunctionComponent = () => {
                             setRepos(repos.map((r) => (r.name !== repo.name ? r : { ...r, isMenuOpen: !r.isMenuOpen })))
                           }
                           isExpanded={repo.isMenuOpen}
-                          icon={<EllipsisVIcon />}
+                          icon={
+                            <Icon>
+                              <EllipsisVIcon />
+                            </Icon>
+                          }
                         />
                       )}
                       isOpen={repo.isMenuOpen}

--- a/packages/react-table/src/components/Table/examples/TableSortableCustom.tsx
+++ b/packages/react-table/src/components/Table/examples/TableSortableCustom.tsx
@@ -9,7 +9,8 @@ import {
   SelectList,
   SelectOption,
   MenuToggle,
-  MenuToggleElement
+  MenuToggleElement,
+  Icon
 } from '@patternfly/react-core';
 import SortAmountDownIcon from '@patternfly/react-icons/dist/esm/icons/sort-amount-down-icon';
 
@@ -117,7 +118,11 @@ export const TableSortableCustom: React.FunctionComponent = () => {
                   isExpanded={isSortDropdownOpen}
                   variant="plain"
                   aria-label="Sort columns"
-                  icon={<SortAmountDownIcon />}
+                  icon={
+                    <Icon>
+                      <SortAmountDownIcon />
+                    </Icon>
+                  }
                 />
               )}
             >

--- a/packages/react-table/src/demos/DashboardHeader.tsx
+++ b/packages/react-table/src/demos/DashboardHeader.tsx
@@ -9,6 +9,7 @@ import {
   DropdownGroup,
   DropdownItem,
   DropdownList,
+  Icon,
   Masthead,
   MastheadMain,
   MastheadToggle,
@@ -137,9 +138,12 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({ notificationBa
                       onClick={onKebabDropdownToggle}
                       variant="plain"
                       aria-label="Settings and help"
-                    >
-                      <EllipsisVIcon aria-hidden="true" />
-                    </MenuToggle>
+                      icon={
+                        <Icon>
+                          <EllipsisVIcon aria-hidden="true" />
+                        </Icon>
+                      }
+                    />
                   )}
                 >
                   <DropdownList>{kebabDropdownItems}</DropdownList>
@@ -158,9 +162,12 @@ export const DashboardHeader: React.FC<DashboardHeaderProps> = ({ notificationBa
                       onClick={onFullKebabToggle}
                       variant="plain"
                       aria-label="Toolbar menu"
-                    >
-                      <EllipsisVIcon aria-hidden="true" />
-                    </MenuToggle>
+                      icon={
+                        <Icon>
+                          <EllipsisVIcon aria-hidden="true" />
+                        </Icon>
+                      }
+                    />
                   )}
                 >
                   <DropdownGroup key="group 2" aria-label="User actions">

--- a/packages/react-table/src/demos/examples/TableColumnManagement.tsx
+++ b/packages/react-table/src/demos/examples/TableColumnManagement.tsx
@@ -10,6 +10,7 @@ import {
   DataListItemRow,
   DataListCell,
   DataListItemCells,
+  Icon,
   Label,
   Toolbar,
   ToolbarContent,
@@ -402,14 +403,26 @@ export const TableColumnManagement: React.FunctionComponent = () => {
           <ToolbarItem variant="overflow-menu">
             <OverflowMenu breakpoint="md">
               <OverflowMenuItem>
-                <MenuToggle>
-                  <FilterIcon /> Name
+                <MenuToggle
+                  icon={
+                    <Icon>
+                      <FilterIcon />
+                    </Icon>
+                  }
+                >
+                  Name
                 </MenuToggle>
               </OverflowMenuItem>
               <OverflowMenuItem>
-                <MenuToggle variant="plain" aria-label="Sort columns">
-                  <SortAmountDownIcon aria-hidden="true" />
-                </MenuToggle>
+                <MenuToggle
+                  variant="plain"
+                  aria-label="Sort columns"
+                  icon={
+                    <Icon>
+                      <SortAmountDownIcon aria-hidden="true" />
+                    </Icon>
+                  }
+                />
               </OverflowMenuItem>
               <OverflowMenuGroup groupType="button" isPersistent>
                 <OverflowMenuItem>

--- a/packages/react-table/src/demos/examples/TableColumnManagementWithDraggable.tsx
+++ b/packages/react-table/src/demos/examples/TableColumnManagementWithDraggable.tsx
@@ -10,6 +10,7 @@ import {
   DataListItemRow,
   DataListCell,
   DataListItemCells,
+  Icon,
   Toolbar,
   ToolbarContent,
   ToolbarItem,
@@ -591,10 +592,26 @@ export const TableColumnManagementWithDraggable: React.FunctionComponent = () =>
         <ToolbarItem variant="overflow-menu">
           <OverflowMenu breakpoint="md">
             <OverflowMenuItem isPersistent>
-              <MenuToggle icon={<FilterIcon />}>Name</MenuToggle>
+              <MenuToggle
+                icon={
+                  <Icon>
+                    <FilterIcon />
+                  </Icon>
+                }
+              >
+                Name
+              </MenuToggle>
             </OverflowMenuItem>
             <OverflowMenuItem>
-              <MenuToggle variant="plain" aria-label="Sort columns" icon={<SortAmountDownIcon aria-hidden="true" />} />
+              <MenuToggle
+                variant="plain"
+                aria-label="Sort columns"
+                icon={
+                  <Icon>
+                    <SortAmountDownIcon aria-hidden="true" />
+                  </Icon>
+                }
+              />
             </OverflowMenuItem>
             <OverflowMenuGroup groupType="button" isPersistent>
               <OverflowMenuItem>

--- a/packages/react-table/src/demos/examples/TableCompact.tsx
+++ b/packages/react-table/src/demos/examples/TableCompact.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   Button,
   Card,
+  Icon,
   MenuToggle,
   MenuToggleElement,
   Pagination,
@@ -73,7 +74,11 @@ export const TableCompact: React.FunctionComponent = () => {
             aria-label="Select Input"
             toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
               <MenuToggle
-                icon={<FilterIcon />}
+                icon={
+                  <Icon>
+                    <FilterIcon />
+                  </Icon>
+                }
                 ref={toggleRef}
                 onClick={() => setIsSelectOpen(!isSelectOpen)}
                 isExpanded={isSelectOpen}

--- a/packages/react-table/src/demos/examples/TableCompoundExpansion.tsx
+++ b/packages/react-table/src/demos/examples/TableCompoundExpansion.tsx
@@ -5,6 +5,7 @@ import {
   Card,
   Flex,
   FlexItem,
+  Icon,
   MenuToggle,
   MenuToggleElement,
   Toolbar,
@@ -91,8 +92,17 @@ export const TableCompoundExpansion: React.FunctionComponent = () => {
             id="select-example"
             aria-label="Select Input"
             toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-              <MenuToggle ref={toggleRef} onClick={() => setIsSelectOpen(!isSelectOpen)} isExpanded={isSelectOpen}>
-                <FilterIcon /> Status
+              <MenuToggle
+                ref={toggleRef}
+                onClick={() => setIsSelectOpen(!isSelectOpen)}
+                isExpanded={isSelectOpen}
+                icon={
+                  <Icon>
+                    <FilterIcon />
+                  </Icon>
+                }
+              >
+                Status
               </MenuToggle>
             )}
             isOpen={isSelectOpen}

--- a/packages/react-table/src/demos/examples/TableFilterable.tsx
+++ b/packages/react-table/src/demos/examples/TableFilterable.tsx
@@ -7,6 +7,7 @@ import {
   EmptyStateActions,
   EmptyStateBody,
   EmptyStateFooter,
+  Icon,
   Label,
   MenuToggle,
   MenuToggleElement,
@@ -125,7 +126,11 @@ export const TableFilterable: React.FunctionComponent = () => {
               ref={toggleRef}
               onClick={onCategoryToggle}
               isExpanded={isCategoryDropdownOpen}
-              icon={<FilterIcon />}
+              icon={
+                <Icon>
+                  <FilterIcon />
+                </Icon>
+              }
               style={
                 {
                   width: '100%',

--- a/packages/react-table/src/demos/examples/TableSortableResponsive.tsx
+++ b/packages/react-table/src/demos/examples/TableSortableResponsive.tsx
@@ -8,6 +8,7 @@ import {
   DropdownList,
   Flex,
   FlexItem,
+  Icon,
   MenuToggle,
   MenuToggleElement,
   PageSection,
@@ -153,7 +154,11 @@ export const TableSortableResponsive: React.FunctionComponent = () => {
                 onClick={() => setIsSortDropdownOpen(!isSortDropdownOpen)}
                 isExpanded={isSortDropdownOpen}
                 variant="plain"
-                icon={<SortAmountDownIcon />}
+                icon={
+                  <Icon>
+                    <SortAmountDownIcon />
+                  </Icon>
+                }
               />
             )}
           >
@@ -201,7 +206,11 @@ export const TableSortableResponsive: React.FunctionComponent = () => {
                     variant="plain"
                     onClick={() => setIsKebabDropdownOpen(!isKebabDropdownOpen)}
                     isExpanded={false}
-                    icon={<EllipsisVIcon />}
+                    icon={
+                      <Icon>
+                        <EllipsisVIcon />
+                      </Icon>
+                    }
                   />
                 )}
                 isOpen={isKebabDropdownOpen}

--- a/packages/react-table/src/demos/examples/TableStaticBottomPagination.tsx
+++ b/packages/react-table/src/demos/examples/TableStaticBottomPagination.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {
   Button,
   Card,
+  Icon,
   Toolbar,
   ToolbarContent,
   ToolbarGroup,
@@ -102,7 +103,11 @@ export const TableStaticBottomPagination: React.FunctionComponent = () => {
             aria-label="Select Input"
             toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
               <MenuToggle
-                icon={<FilterIcon />}
+                icon={
+                  <Icon>
+                    <FilterIcon />
+                  </Icon>
+                }
                 ref={toggleRef}
                 onClick={() => setIsSelectOpen(!isSelectOpen)}
                 isExpanded={isSelectOpen}

--- a/packages/react-table/src/deprecated/components/Table/examples/LegacyTableSortableCustom.tsx
+++ b/packages/react-table/src/deprecated/components/Table/examples/LegacyTableSortableCustom.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { sortable, info } from '@patternfly/react-table';
 import { Table, TableHeader, TableBody, TableProps } from '@patternfly/react-table/deprecated';
-import { Toolbar, ToolbarContent, ToolbarItem, MenuToggle, MenuToggleElement } from '@patternfly/react-core';
+import { Toolbar, ToolbarContent, ToolbarItem, MenuToggle, MenuToggleElement, Icon } from '@patternfly/react-core';
 import {
   Select as NewSelect,
   SelectGroup as NewSelectGroup,
@@ -137,7 +137,11 @@ export const LegacyTableSortableCustom: React.FunctionComponent = () => {
                   isExpanded={isSortDropdownOpen}
                   variant="plain"
                   aria-label="Sort columns"
-                  icon={<SortAmountDownIcon />}
+                  icon={
+                    <Icon>
+                      <SortAmountDownIcon />
+                    </Icon>
+                  }
                 />
               )}
             >


### PR DESCRIPTION
Closes: #10841 

This PR updates the `<MenuToggle>` components across all examples/demos to use the `icon` prop to pass icons where they are currently being passed as children.