### PR TITLE
fix(dropdown): Delay setting focus on first item to prevent inadvertent scroll

### DIFF
--- a/packages/react-core/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-core/src/components/Dropdown/Dropdown.tsx
@@ -127,7 +127,7 @@ const DropdownBase: React.FunctionComponent<DropdownProps> = ({
             'li button:not(:disabled),li input:not(:disabled),li a:not([aria-disabled="true"])'
           );
           firstElement && (firstElement as HTMLElement).focus();
-        }, 0);
+        }, 10);
       }
 
       // If the event is not on the toggle and onOpenChange callback is provided, close the menu

--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -132,7 +132,7 @@ const SelectBase: React.FunctionComponent<SelectProps & OUIAProps> = ({
         setTimeout(() => {
           const firstElement = menuRef?.current?.querySelector('li button:not(:disabled),li input:not(:disabled)');
           firstElement && (firstElement as HTMLElement).focus();
-        }, 0);
+        }, 10);
       }
 
       // If the event is not on the toggle and onOpenChange callback is provided, close the menu


### PR DESCRIPTION
**What**: 
Closes #10896 

**Description**:
Add a slight delay before setting focus on the first dropdown item when `shouldFocusFirstItemOnOpen` is set. This gives enough time for the popover to be shown in the correct location so the scrollable doesn't scroll to the invalid location.