### PR TITLE
fix: Updated to release the code on the v5 prerelase channel.

### DIFF
--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -11,7 +11,7 @@ packages=(
   @patternfly/react-templates
   @patternfly/react-tokens
 )
-prereleaseTag=prerelease
+prereleaseTag=prerelease-v5
 
 function getPrereleaseVersion {
   local version=$(


### PR DESCRIPTION
This fix allows us to promote the code on the prerelease-v5 channel to npm.