### PR TITLE
Draft: chore(docs): Generate code coverage table

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,7 +6,12 @@ import type { Config } from 'jest';
 
 const config: Config = {
   collectCoverage: true,
-  coverageReporters: ['lcov'],
+  coverageReporters: ['lcov', 'text'],
+  collectCoverageFrom: [
+    '<rootDir>/packages/react-core/src/components/**/*.tsx',
+    '!<rootDir>/packages/react-core/src/components/*/examples/*.tsx'
+  ],
+  coverageDirectory: './packages/react-docs/coverage/',
   clearMocks: true,
   testMatch: ['**/__tests__/**/*.{js,ts}?(x)', '**/*.test.{js,ts}?(x)'],
   modulePathIgnorePatterns: [


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: 
Nicole was interested in Jest coverage tables. It looks like this change would break CI, so not a great choice for right now.

<img width="941" alt="Screenshot 2024-10-22 at 11 55 40 AM" src="https://github.com/user-attachments/assets/47abf485-003d-4b73-8f9f-1662e39d9021">
