### PR TITLE
Victory packages to be marked optional (v6)

### DIFF
--- a/packages/react-charts/package.json
+++ b/packages/react-charts/package.json
@@ -63,6 +63,59 @@
     "victory-voronoi-container": "^37.1.1",
     "victory-zoom-container": "^37.1.1"
   },
+  "peerDependenciesMeta": {
+    "victory-area": {
+      "optional": true
+    },
+    "victory-axis": {
+      "optional": true
+    },
+    "victory-bar": {
+      "optional": true
+    },
+    "victory-box-plot": {
+      "optional": true
+    },
+    "victory-chart": {
+      "optional": true
+    },
+    "victory-core": {
+      "optional": true
+    },
+    "victory-create-container": {
+      "optional": true
+    },
+    "victory-cursor-container": {
+      "optional": true
+    },
+    "victory-group": {
+      "optional": true
+    },
+    "victory-legend": {
+      "optional": true
+    },
+    "victory-line": {
+      "optional": true
+    },
+    "victory-pie": {
+      "optional": true
+    },
+    "victory-scatter": {
+      "optional": true
+    },
+    "victory-stack": {
+      "optional": true
+    },
+    "victory-tooltip": {
+      "optional": true
+    },
+    "victory-voronoi-container": {
+      "optional": true
+    },
+    "victory-zoom-container": {
+      "optional": true
+    }
+  },
   "scripts": {
     "clean": "rimraf dist echarts victory",
     "build:single:packages": "node ../../scripts/build-single-packages.mjs --config single-packages.config.json",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3185,6 +3185,41 @@ __metadata:
     victory-tooltip: ^37.1.1
     victory-voronoi-container: ^37.1.1
     victory-zoom-container: ^37.1.1
+  peerDependenciesMeta:
+    victory-area:
+      optional: true
+    victory-axis:
+      optional: true
+    victory-bar:
+      optional: true
+    victory-box-plot:
+      optional: true
+    victory-chart:
+      optional: true
+    victory-core:
+      optional: true
+    victory-create-container:
+      optional: true
+    victory-cursor-container:
+      optional: true
+    victory-group:
+      optional: true
+    victory-legend:
+      optional: true
+    victory-line:
+      optional: true
+    victory-pie:
+      optional: true
+    victory-scatter:
+      optional: true
+    victory-stack:
+      optional: true
+    victory-tooltip:
+      optional: true
+    victory-voronoi-container:
+      optional: true
+    victory-zoom-container:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Victory peer dependencies should be marked optional via `peerDependenciesMeta`

https://github.com/patternfly/patternfly-react/issues/11125

