### PR TITLE
feat(Select/Dropdown/MenuContainer): arrow key handling to focus items

### DIFF
--- a/packages/react-core/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-core/src/components/Dropdown/Dropdown.tsx
@@ -51,8 +51,8 @@ export interface DropdownProps extends MenuProps, OUIAProps {
   onOpenChange?: (isOpen: boolean) => void;
   /** Keys that trigger onOpenChange, defaults to tab and escape. It is highly recommended to include Escape in the array, while Tab may be omitted if the menu contains non-menu items that are focusable. */
   onOpenChangeKeys?: string[];
-  /** Custom callback to override the default behaviour when pressing up/down arrows. Default is focusing the menu items (first item on arrow down, last item on arrow up). */
-  onArrowUpDownKeyDown?: (event: KeyboardEvent) => void;
+  /** Callback to override the default behavior when pressing up/down arrow keys when the toggle has focus and the menu is open. By default non-disabled menu items will receive focus - the first item on arrow down or the last item on arrow up. */
+  onToggleArrowKeydown?: (event: KeyboardEvent) => void;
   /** Indicates if the menu should be without the outer box-shadow. */
   isPlain?: boolean;
   /** Indicates if the menu should be scrollable. */
@@ -87,7 +87,7 @@ const DropdownBase: React.FunctionComponent<DropdownProps> = ({
   toggle,
   shouldFocusToggleOnSelect = false,
   onOpenChange,
-  onArrowUpDownKeyDown,
+  onToggleArrowKeydown,
   isPlain,
   isScrollable,
   innerRef,
@@ -130,7 +130,7 @@ const DropdownBase: React.FunctionComponent<DropdownProps> = ({
   }, [isOpen]);
 
   React.useEffect(() => {
-    const onArrowUpDownKeyDownDefault = (event: KeyboardEvent) => {
+    const onToggleArrowKeydownDefault = (event: KeyboardEvent) => {
       event.preventDefault();
 
       let listItem: HTMLLIElement;
@@ -160,11 +160,15 @@ const DropdownBase: React.FunctionComponent<DropdownProps> = ({
         }
       }
 
-      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
-        if (onArrowUpDownKeyDown) {
-          onArrowUpDownKeyDown(event);
+      if (
+        isOpen &&
+        toggleRef.current?.contains(event.target as Node) &&
+        (event.key === 'ArrowDown' || event.key === 'ArrowUp')
+      ) {
+        if (onToggleArrowKeydown) {
+          onToggleArrowKeydown(event);
         } else {
-          onArrowUpDownKeyDownDefault(event);
+          onToggleArrowKeydownDefault(event);
         }
       }
     };
@@ -191,7 +195,7 @@ const DropdownBase: React.FunctionComponent<DropdownProps> = ({
     toggleRef,
     onOpenChange,
     onOpenChangeKeys,
-    onArrowUpDownKeyDown,
+    onToggleArrowKeydown,
     shouldPreventScrollOnItemFocus,
     shouldFocusFirstItemOnOpen,
     focusTimeoutDelay

--- a/packages/react-core/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-core/src/components/Dropdown/Dropdown.tsx
@@ -51,8 +51,8 @@ export interface DropdownProps extends MenuProps, OUIAProps {
   onOpenChange?: (isOpen: boolean) => void;
   /** Keys that trigger onOpenChange, defaults to tab and escape. It is highly recommended to include Escape in the array, while Tab may be omitted if the menu contains non-menu items that are focusable. */
   onOpenChangeKeys?: string[];
-  /** Callback to override the default behavior when pressing up/down arrow keys when the toggle has focus and the menu is open. By default non-disabled menu items will receive focus - the first item on arrow down or the last item on arrow up. */
-  onToggleArrowKeydown?: (event: KeyboardEvent) => void;
+  /** Callback to override the toggle keydown behavior. By default, when the toggle has focus and the menu is open, pressing the up/down arrow keys will focus a valid non-disabled menu item - the first item for the down arrow key and last item for the up arrow key. */
+  onToggleKeydown?: (event: KeyboardEvent) => void;
   /** Indicates if the menu should be without the outer box-shadow. */
   isPlain?: boolean;
   /** Indicates if the menu should be scrollable. */
@@ -87,7 +87,7 @@ const DropdownBase: React.FunctionComponent<DropdownProps> = ({
   toggle,
   shouldFocusToggleOnSelect = false,
   onOpenChange,
-  onToggleArrowKeydown,
+  onToggleKeydown,
   isPlain,
   isScrollable,
   innerRef,
@@ -143,10 +143,10 @@ const DropdownBase: React.FunctionComponent<DropdownProps> = ({
         }
       }
 
-      if (isOpen && toggleRef.current?.contains(event.target as Node)) {
-        if (onToggleArrowKeydown) {
-          onToggleArrowKeydown(event);
-        } else {
+      if (toggleRef.current?.contains(event.target as Node)) {
+        if (onToggleKeydown) {
+          onToggleKeydown(event);
+        } else if (isOpen) {
           onToggleArrowKeydownDefault(event, menuRef);
         }
       }
@@ -174,7 +174,7 @@ const DropdownBase: React.FunctionComponent<DropdownProps> = ({
     toggleRef,
     onOpenChange,
     onOpenChangeKeys,
-    onToggleArrowKeydown,
+    onToggleKeydown,
     shouldPreventScrollOnItemFocus,
     shouldFocusFirstItemOnOpen,
     focusTimeoutDelay

--- a/packages/react-core/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-core/src/components/Dropdown/Dropdown.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from '@patternfly/react-styles';
 import { Menu, MenuContent, MenuProps } from '../Menu';
 import { Popper } from '../../helpers/Popper/Popper';
-import { useOUIAProps, OUIAProps } from '../../helpers';
+import { useOUIAProps, OUIAProps, onToggleArrowKeydownDefault } from '../../helpers';
 
 export interface DropdownPopperProps {
   /** Vertical direction of the popper. If enableFlip is set to true, this will set the initial direction before the popper flips. */
@@ -130,23 +130,6 @@ const DropdownBase: React.FunctionComponent<DropdownProps> = ({
   }, [isOpen]);
 
   React.useEffect(() => {
-    const onToggleArrowKeydownDefault = (event: KeyboardEvent) => {
-      event.preventDefault();
-
-      let listItem: HTMLLIElement;
-      if (event.key === 'ArrowDown') {
-        listItem = menuRef.current?.querySelector('li');
-      } else {
-        const allItems = menuRef.current?.querySelectorAll('li');
-        listItem = allItems ? allItems[allItems.length - 1] : null;
-      }
-
-      const focusableElement = listItem?.querySelector(
-        'button:not(:disabled),input:not(:disabled),a:not([aria-disabled="true"])'
-      );
-      focusableElement && (focusableElement as HTMLElement).focus();
-    };
-
     const handleMenuKeys = (event: KeyboardEvent) => {
       // Close the menu on tab or escape if onOpenChange is provided
       if (
@@ -160,15 +143,11 @@ const DropdownBase: React.FunctionComponent<DropdownProps> = ({
         }
       }
 
-      if (
-        isOpen &&
-        toggleRef.current?.contains(event.target as Node) &&
-        (event.key === 'ArrowDown' || event.key === 'ArrowUp')
-      ) {
+      if (isOpen && toggleRef.current?.contains(event.target as Node)) {
         if (onToggleArrowKeydown) {
           onToggleArrowKeydown(event);
         } else {
-          onToggleArrowKeydownDefault(event);
+          onToggleArrowKeydownDefault(event, menuRef);
         }
       }
     };

--- a/packages/react-core/src/components/Menu/MenuContainer.tsx
+++ b/packages/react-core/src/components/Menu/MenuContainer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Popper } from '../../helpers/Popper/Popper';
+import { onToggleArrowKeydownDefault, Popper } from '../../helpers';
 
 export interface MenuPopperProps {
   /** Vertical direction of the popper. If enableFlip is set to true, this will set the initial direction before the popper flips. */
@@ -83,23 +83,6 @@ export const MenuContainer: React.FunctionComponent<MenuContainerProps> = ({
   }, [isOpen]);
 
   React.useEffect(() => {
-    const onToggleArrowKeydownDefault = (event: KeyboardEvent) => {
-      event.preventDefault();
-
-      let listItem: HTMLLIElement;
-      if (event.key === 'ArrowDown') {
-        listItem = menuRef.current?.querySelector('li');
-      } else {
-        const allItems = menuRef.current?.querySelectorAll('li');
-        listItem = allItems ? allItems[allItems.length - 1] : null;
-      }
-
-      const focusableElement = listItem?.querySelector(
-        'button:not(:disabled),input:not(:disabled),a:not([aria-disabled="true"])'
-      );
-      focusableElement && (focusableElement as HTMLElement).focus();
-    };
-
     const handleMenuKeys = (event: KeyboardEvent) => {
       // Close the menu on tab or escape if onOpenChange is provided
       if (
@@ -112,15 +95,11 @@ export const MenuContainer: React.FunctionComponent<MenuContainerProps> = ({
         }
       }
 
-      if (
-        isOpen &&
-        toggleRef.current?.contains(event.target as Node) &&
-        (event.key === 'ArrowDown' || event.key === 'ArrowUp')
-      ) {
+      if (isOpen && toggleRef.current?.contains(event.target as Node)) {
         if (onToggleArrowKeydown) {
           onToggleArrowKeydown(event);
         } else {
-          onToggleArrowKeydownDefault(event);
+          onToggleArrowKeydownDefault(event, menuRef);
         }
       }
     };

--- a/packages/react-core/src/components/Menu/MenuContainer.tsx
+++ b/packages/react-core/src/components/Menu/MenuContainer.tsx
@@ -34,8 +34,8 @@ export interface MenuContainerProps {
   onOpenChange?: (isOpen: boolean) => void;
   /** Keys that trigger onOpenChange, defaults to tab and escape. It is highly recommended to include Escape in the array, while Tab may be omitted if the menu contains non-menu items that are focusable. */
   onOpenChangeKeys?: string[];
-  /** Callback to override the default behavior when pressing up/down arrow keys when the toggle has focus and the menu is open. By default non-disabled menu items will receive focus - the first item on arrow down or the last item on arrow up. */
-  onToggleArrowKeydown?: (event: KeyboardEvent) => void;
+  /** Callback to override the toggle keydown behavior. By default, when the toggle has focus and the menu is open, pressing the up/down arrow keys will focus a valid non-disabled menu item - the first item for the down arrow key and last item for the up arrow key. */
+  onToggleKeydown?: (event: KeyboardEvent) => void;
   /** z-index of the dropdown menu */
   zIndex?: number;
   /** Additional properties to pass to the Popper */
@@ -58,7 +58,7 @@ export const MenuContainer: React.FunctionComponent<MenuContainerProps> = ({
   toggle,
   toggleRef,
   onOpenChange,
-  onToggleArrowKeydown,
+  onToggleKeydown,
   zIndex = 9999,
   popperProps,
   onOpenChangeKeys = ['Escape', 'Tab'],
@@ -95,10 +95,10 @@ export const MenuContainer: React.FunctionComponent<MenuContainerProps> = ({
         }
       }
 
-      if (isOpen && toggleRef.current?.contains(event.target as Node)) {
-        if (onToggleArrowKeydown) {
-          onToggleArrowKeydown(event);
-        } else {
+      if (toggleRef.current?.contains(event.target as Node)) {
+        if (onToggleKeydown) {
+          onToggleKeydown(event);
+        } else if (isOpen) {
           onToggleArrowKeydownDefault(event, menuRef);
         }
       }
@@ -126,7 +126,7 @@ export const MenuContainer: React.FunctionComponent<MenuContainerProps> = ({
     menuRef,
     onOpenChange,
     onOpenChangeKeys,
-    onToggleArrowKeydown,
+    onToggleKeydown,
     shouldPreventScrollOnItemFocus,
     toggleRef
   ]);

--- a/packages/react-core/src/components/Menu/MenuContainer.tsx
+++ b/packages/react-core/src/components/Menu/MenuContainer.tsx
@@ -34,8 +34,8 @@ export interface MenuContainerProps {
   onOpenChange?: (isOpen: boolean) => void;
   /** Keys that trigger onOpenChange, defaults to tab and escape. It is highly recommended to include Escape in the array, while Tab may be omitted if the menu contains non-menu items that are focusable. */
   onOpenChangeKeys?: string[];
-  /** Custom callback to override the default behaviour when pressing up/down arrows. Default is focusing the menu items (first item on arrow down, last item on arrow up). */
-  onArrowUpDownKeyDown?: (event: KeyboardEvent) => void;
+  /** Callback to override the default behavior when pressing up/down arrow keys when the toggle has focus and the menu is open. By default non-disabled menu items will receive focus - the first item on arrow down or the last item on arrow up. */
+  onToggleArrowKeydown?: (event: KeyboardEvent) => void;
   /** z-index of the dropdown menu */
   zIndex?: number;
   /** Additional properties to pass to the Popper */
@@ -58,7 +58,7 @@ export const MenuContainer: React.FunctionComponent<MenuContainerProps> = ({
   toggle,
   toggleRef,
   onOpenChange,
-  onArrowUpDownKeyDown,
+  onToggleArrowKeydown,
   zIndex = 9999,
   popperProps,
   onOpenChangeKeys = ['Escape', 'Tab'],
@@ -83,7 +83,7 @@ export const MenuContainer: React.FunctionComponent<MenuContainerProps> = ({
   }, [isOpen]);
 
   React.useEffect(() => {
-    const onArrowUpDownKeyDownDefault = (event: KeyboardEvent) => {
+    const onToggleArrowKeydownDefault = (event: KeyboardEvent) => {
       event.preventDefault();
 
       let listItem: HTMLLIElement;
@@ -112,11 +112,15 @@ export const MenuContainer: React.FunctionComponent<MenuContainerProps> = ({
         }
       }
 
-      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
-        if (onArrowUpDownKeyDown) {
-          onArrowUpDownKeyDown(event);
+      if (
+        isOpen &&
+        toggleRef.current?.contains(event.target as Node) &&
+        (event.key === 'ArrowDown' || event.key === 'ArrowUp')
+      ) {
+        if (onToggleArrowKeydown) {
+          onToggleArrowKeydown(event);
         } else {
-          onArrowUpDownKeyDownDefault(event);
+          onToggleArrowKeydownDefault(event);
         }
       }
     };
@@ -143,7 +147,7 @@ export const MenuContainer: React.FunctionComponent<MenuContainerProps> = ({
     menuRef,
     onOpenChange,
     onOpenChangeKeys,
-    onArrowUpDownKeyDown,
+    onToggleArrowKeydown,
     shouldPreventScrollOnItemFocus,
     toggleRef
   ]);

--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -64,8 +64,8 @@ export interface SelectProps extends MenuProps, OUIAProps {
   onOpenChangeKeys?: string[];
   /** Callback to override the toggle keydown behavior. By default, when the toggle has focus and the menu is open, pressing the up/down arrow keys will focus a valid non-disabled menu item - the first item for the down arrow key and last item for the up arrow key. */
   onToggleKeydown?: (event: KeyboardEvent) => void;
-  /** Indicates that the Select is used as a typeahead (combobox). Focus won't shift to menu items when pressing up/down arrows. */
-  isTypeahead?: boolean;
+  /** Select variant. For typeahead variant focus won't shift to menu items when pressing up/down arrows. */
+  variant?: 'default' | 'typeahead';
   /** Indicates if the select should be without the outer box-shadow */
   isPlain?: boolean;
   /** @hide Forwarded ref */
@@ -100,7 +100,7 @@ const SelectBase: React.FunctionComponent<SelectProps & OUIAProps> = ({
   onOpenChange,
   onOpenChangeKeys = ['Escape', 'Tab'],
   onToggleKeydown,
-  isTypeahead,
+  variant,
   isPlain,
   innerRef,
   zIndex = 9999,
@@ -154,7 +154,7 @@ const SelectBase: React.FunctionComponent<SelectProps & OUIAProps> = ({
       if (toggleRef.current?.contains(event.target as Node)) {
         if (onToggleKeydown) {
           onToggleKeydown(event);
-        } else if (isOpen && !isTypeahead) {
+        } else if (isOpen && variant !== 'typeahead') {
           onToggleArrowKeydownDefault(event, menuRef);
         }
       }

--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -62,8 +62,8 @@ export interface SelectProps extends MenuProps, OUIAProps {
   onOpenChange?: (isOpen: boolean) => void;
   /** Keys that trigger onOpenChange, defaults to tab and escape. It is highly recommended to include Escape in the array, while Tab may be omitted if the menu contains non-menu items that are focusable. */
   onOpenChangeKeys?: string[];
-  /** Callback to override the default behavior when pressing up/down arrow keys when the toggle has focus and the menu is open. By default non-disabled menu items will receive focus - the first item on arrow down or the last item on arrow up. */
-  onToggleArrowKeydown?: (event: KeyboardEvent) => void;
+  /** Callback to override the toggle keydown behavior. By default, when the toggle has focus and the menu is open, pressing the up/down arrow keys will focus a valid non-disabled menu item - the first item for the down arrow key and last item for the up arrow key. */
+  onToggleKeydown?: (event: KeyboardEvent) => void;
   /** Indicates that the Select is used as a typeahead (combobox). Focus won't shift to menu items when pressing up/down arrows. */
   isTypeahead?: boolean;
   /** Indicates if the select should be without the outer box-shadow */
@@ -99,7 +99,7 @@ const SelectBase: React.FunctionComponent<SelectProps & OUIAProps> = ({
   shouldFocusFirstItemOnOpen = false,
   onOpenChange,
   onOpenChangeKeys = ['Escape', 'Tab'],
-  onToggleArrowKeydown,
+  onToggleKeydown,
   isTypeahead,
   isPlain,
   innerRef,
@@ -151,10 +151,10 @@ const SelectBase: React.FunctionComponent<SelectProps & OUIAProps> = ({
         }
       }
 
-      if (isOpen && toggleRef.current?.contains(event.target as Node)) {
-        if (onToggleArrowKeydown) {
-          onToggleArrowKeydown(event);
-        } else if (!isTypeahead) {
+      if (toggleRef.current?.contains(event.target as Node)) {
+        if (onToggleKeydown) {
+          onToggleKeydown(event);
+        } else if (isOpen && !isTypeahead) {
           onToggleArrowKeydownDefault(event, menuRef);
         }
       }
@@ -182,7 +182,7 @@ const SelectBase: React.FunctionComponent<SelectProps & OUIAProps> = ({
     toggleRef,
     onOpenChange,
     onOpenChangeKeys,
-    onToggleArrowKeydown,
+    onToggleKeydown,
     shouldPreventScrollOnItemFocus,
     shouldFocusFirstItemOnOpen,
     focusTimeoutDelay

--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { css } from '@patternfly/react-styles';
 import { Menu, MenuContent, MenuProps } from '../Menu';
 import { Popper } from '../../helpers/Popper/Popper';
-import { getOUIAProps, OUIAProps, getDefaultOUIAId } from '../../helpers';
+import { getOUIAProps, OUIAProps, getDefaultOUIAId, onToggleArrowKeydownDefault } from '../../helpers';
 
 export interface SelectPopperProps {
   /** Vertical direction of the popper. If enableFlip is set to true, this will set the initial direction before the popper flips. */
@@ -137,21 +137,6 @@ const SelectBase: React.FunctionComponent<SelectProps & OUIAProps> = ({
   }, [isOpen]);
 
   React.useEffect(() => {
-    const onToggleArrowKeydownDefault = (event: KeyboardEvent) => {
-      event.preventDefault();
-
-      let listItem: HTMLLIElement;
-      if (event.key === 'ArrowDown') {
-        listItem = menuRef.current?.querySelector('li');
-      } else {
-        const allItems = menuRef.current?.querySelectorAll('li');
-        listItem = allItems ? allItems[allItems.length - 1] : null;
-      }
-
-      const focusableElement = listItem?.querySelector('button:not(:disabled),input:not(:disabled)');
-      focusableElement && (focusableElement as HTMLElement).focus();
-    };
-
     const handleMenuKeys = (event: KeyboardEvent) => {
       // Close the menu on tab or escape if onOpenChange is provided
       if (
@@ -166,15 +151,11 @@ const SelectBase: React.FunctionComponent<SelectProps & OUIAProps> = ({
         }
       }
 
-      if (
-        isOpen &&
-        toggleRef.current?.contains(event.target as Node) &&
-        (event.key === 'ArrowDown' || event.key === 'ArrowUp')
-      ) {
+      if (isOpen && toggleRef.current?.contains(event.target as Node)) {
         if (onToggleArrowKeydown) {
           onToggleArrowKeydown(event);
         } else if (!isTypeahead) {
-          onToggleArrowKeydownDefault(event);
+          onToggleArrowKeydownDefault(event, menuRef);
         }
       }
     };

--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -62,6 +62,10 @@ export interface SelectProps extends MenuProps, OUIAProps {
   onOpenChange?: (isOpen: boolean) => void;
   /** Keys that trigger onOpenChange, defaults to tab and escape. It is highly recommended to include Escape in the array, while Tab may be omitted if the menu contains non-menu items that are focusable. */
   onOpenChangeKeys?: string[];
+  /** Custom callback to override the default behaviour when pressing up/down arrows. Default is focusing the menu items (first item on arrow down, last item on arrow up). */
+  onArrowUpDownKeyDown?: (event: KeyboardEvent) => void;
+  /** Indicates that the Select is used as a typeahead (combobox). Focus won't shift to menu items when pressing up/down arrows. */
+  isTypeahead?: boolean;
   /** Indicates if the select should be without the outer box-shadow */
   isPlain?: boolean;
   /** @hide Forwarded ref */
@@ -95,6 +99,8 @@ const SelectBase: React.FunctionComponent<SelectProps & OUIAProps> = ({
   shouldFocusFirstItemOnOpen = false,
   onOpenChange,
   onOpenChangeKeys = ['Escape', 'Tab'],
+  onArrowUpDownKeyDown,
+  isTypeahead,
   isPlain,
   innerRef,
   zIndex = 9999,
@@ -131,6 +137,21 @@ const SelectBase: React.FunctionComponent<SelectProps & OUIAProps> = ({
   }, [isOpen]);
 
   React.useEffect(() => {
+    const onArrowUpDownKeyDownDefault = (event: KeyboardEvent) => {
+      event.preventDefault();
+
+      let listItem: HTMLLIElement;
+      if (event.key === 'ArrowDown') {
+        listItem = menuRef.current?.querySelector('li');
+      } else {
+        const allItems = menuRef.current?.querySelectorAll('li');
+        listItem = allItems ? allItems[allItems.length - 1] : null;
+      }
+
+      const focusableElement = listItem?.querySelector('button:not(:disabled),input:not(:disabled)');
+      focusableElement && (focusableElement as HTMLElement).focus();
+    };
+
     const handleMenuKeys = (event: KeyboardEvent) => {
       // Close the menu on tab or escape if onOpenChange is provided
       if (
@@ -142,6 +163,14 @@ const SelectBase: React.FunctionComponent<SelectProps & OUIAProps> = ({
           event.preventDefault();
           onOpenChange(false);
           toggleRef.current?.focus();
+        }
+      }
+
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        if (onArrowUpDownKeyDown) {
+          onArrowUpDownKeyDown(event);
+        } else if (!isTypeahead) {
+          onArrowUpDownKeyDownDefault(event);
         }
       }
     };
@@ -168,6 +197,7 @@ const SelectBase: React.FunctionComponent<SelectProps & OUIAProps> = ({
     toggleRef,
     onOpenChange,
     onOpenChangeKeys,
+    onArrowUpDownKeyDown,
     shouldPreventScrollOnItemFocus,
     shouldFocusFirstItemOnOpen,
     focusTimeoutDelay

--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -62,8 +62,8 @@ export interface SelectProps extends MenuProps, OUIAProps {
   onOpenChange?: (isOpen: boolean) => void;
   /** Keys that trigger onOpenChange, defaults to tab and escape. It is highly recommended to include Escape in the array, while Tab may be omitted if the menu contains non-menu items that are focusable. */
   onOpenChangeKeys?: string[];
-  /** Custom callback to override the default behaviour when pressing up/down arrows. Default is focusing the menu items (first item on arrow down, last item on arrow up). */
-  onArrowUpDownKeyDown?: (event: KeyboardEvent) => void;
+  /** Callback to override the default behavior when pressing up/down arrow keys when the toggle has focus and the menu is open. By default non-disabled menu items will receive focus - the first item on arrow down or the last item on arrow up. */
+  onToggleArrowKeydown?: (event: KeyboardEvent) => void;
   /** Indicates that the Select is used as a typeahead (combobox). Focus won't shift to menu items when pressing up/down arrows. */
   isTypeahead?: boolean;
   /** Indicates if the select should be without the outer box-shadow */
@@ -99,7 +99,7 @@ const SelectBase: React.FunctionComponent<SelectProps & OUIAProps> = ({
   shouldFocusFirstItemOnOpen = false,
   onOpenChange,
   onOpenChangeKeys = ['Escape', 'Tab'],
-  onArrowUpDownKeyDown,
+  onToggleArrowKeydown,
   isTypeahead,
   isPlain,
   innerRef,
@@ -137,7 +137,7 @@ const SelectBase: React.FunctionComponent<SelectProps & OUIAProps> = ({
   }, [isOpen]);
 
   React.useEffect(() => {
-    const onArrowUpDownKeyDownDefault = (event: KeyboardEvent) => {
+    const onToggleArrowKeydownDefault = (event: KeyboardEvent) => {
       event.preventDefault();
 
       let listItem: HTMLLIElement;
@@ -166,11 +166,15 @@ const SelectBase: React.FunctionComponent<SelectProps & OUIAProps> = ({
         }
       }
 
-      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
-        if (onArrowUpDownKeyDown) {
-          onArrowUpDownKeyDown(event);
+      if (
+        isOpen &&
+        toggleRef.current?.contains(event.target as Node) &&
+        (event.key === 'ArrowDown' || event.key === 'ArrowUp')
+      ) {
+        if (onToggleArrowKeydown) {
+          onToggleArrowKeydown(event);
         } else if (!isTypeahead) {
-          onArrowUpDownKeyDownDefault(event);
+          onToggleArrowKeydownDefault(event);
         }
       }
     };
@@ -197,7 +201,7 @@ const SelectBase: React.FunctionComponent<SelectProps & OUIAProps> = ({
     toggleRef,
     onOpenChange,
     onOpenChangeKeys,
-    onArrowUpDownKeyDown,
+    onToggleArrowKeydown,
     shouldPreventScrollOnItemFocus,
     shouldFocusFirstItemOnOpen,
     focusTimeoutDelay

--- a/packages/react-core/src/components/Select/examples/SelectMultiTypeahead.tsx
+++ b/packages/react-core/src/components/Select/examples/SelectMultiTypeahead.tsx
@@ -247,7 +247,7 @@ export const SelectMultiTypeahead: React.FunctionComponent = () => {
         !isOpen && closeMenu();
       }}
       toggle={toggle}
-      isTypeahead
+      variant="typeahead"
     >
       <SelectList isAriaMultiselectable id="select-multi-typeahead-listbox">
         {selectOptions.map((option, index) => (

--- a/packages/react-core/src/components/Select/examples/SelectMultiTypeahead.tsx
+++ b/packages/react-core/src/components/Select/examples/SelectMultiTypeahead.tsx
@@ -247,7 +247,7 @@ export const SelectMultiTypeahead: React.FunctionComponent = () => {
         !isOpen && closeMenu();
       }}
       toggle={toggle}
-      shouldFocusFirstItemOnOpen={false}
+      isTypeahead
     >
       <SelectList isAriaMultiselectable id="select-multi-typeahead-listbox">
         {selectOptions.map((option, index) => (

--- a/packages/react-core/src/components/Select/examples/SelectMultiTypeaheadCheckbox.tsx
+++ b/packages/react-core/src/components/Select/examples/SelectMultiTypeaheadCheckbox.tsx
@@ -241,7 +241,7 @@ export const SelectMultiTypeaheadCheckbox: React.FunctionComponent = () => {
         !isOpen && closeMenu();
       }}
       toggle={toggle}
-      shouldFocusFirstItemOnOpen={false}
+      isTypeahead
     >
       <SelectList isAriaMultiselectable id="select-multi-typeahead-checkbox-listbox">
         {selectOptions.map((option, index) => (

--- a/packages/react-core/src/components/Select/examples/SelectMultiTypeaheadCheckbox.tsx
+++ b/packages/react-core/src/components/Select/examples/SelectMultiTypeaheadCheckbox.tsx
@@ -241,7 +241,7 @@ export const SelectMultiTypeaheadCheckbox: React.FunctionComponent = () => {
         !isOpen && closeMenu();
       }}
       toggle={toggle}
-      isTypeahead
+      variant="typeahead"
     >
       <SelectList isAriaMultiselectable id="select-multi-typeahead-checkbox-listbox">
         {selectOptions.map((option, index) => (

--- a/packages/react-core/src/components/Select/examples/SelectMultiTypeaheadCreatable.tsx
+++ b/packages/react-core/src/components/Select/examples/SelectMultiTypeaheadCreatable.tsx
@@ -260,7 +260,7 @@ export const SelectMultiTypeaheadCreatable: React.FunctionComponent = () => {
         !isOpen && closeMenu();
       }}
       toggle={toggle}
-      isTypeahead
+      variant="typeahead"
     >
       <SelectList isAriaMultiselectable id="select-multi-create-typeahead-listbox">
         {selectOptions.map((option, index) => (

--- a/packages/react-core/src/components/Select/examples/SelectMultiTypeaheadCreatable.tsx
+++ b/packages/react-core/src/components/Select/examples/SelectMultiTypeaheadCreatable.tsx
@@ -260,7 +260,7 @@ export const SelectMultiTypeaheadCreatable: React.FunctionComponent = () => {
         !isOpen && closeMenu();
       }}
       toggle={toggle}
-      shouldFocusFirstItemOnOpen={false}
+      isTypeahead
     >
       <SelectList isAriaMultiselectable id="select-multi-create-typeahead-listbox">
         {selectOptions.map((option, index) => (

--- a/packages/react-core/src/components/Select/examples/SelectTypeahead.tsx
+++ b/packages/react-core/src/components/Select/examples/SelectTypeahead.tsx
@@ -244,7 +244,7 @@ export const SelectTypeahead: React.FunctionComponent = () => {
         !isOpen && closeMenu();
       }}
       toggle={toggle}
-      isTypeahead
+      variant="typeahead"
     >
       <SelectList id="select-typeahead-listbox">
         {selectOptions.map((option, index) => (

--- a/packages/react-core/src/components/Select/examples/SelectTypeahead.tsx
+++ b/packages/react-core/src/components/Select/examples/SelectTypeahead.tsx
@@ -244,7 +244,7 @@ export const SelectTypeahead: React.FunctionComponent = () => {
         !isOpen && closeMenu();
       }}
       toggle={toggle}
-      shouldFocusFirstItemOnOpen={false}
+      isTypeahead
     >
       <SelectList id="select-typeahead-listbox">
         {selectOptions.map((option, index) => (

--- a/packages/react-core/src/components/Select/examples/SelectTypeaheadCreatable.tsx
+++ b/packages/react-core/src/components/Select/examples/SelectTypeaheadCreatable.tsx
@@ -251,7 +251,7 @@ export const SelectTypeaheadCreatable: React.FunctionComponent = () => {
         !isOpen && closeMenu();
       }}
       toggle={toggle}
-      isTypeahead
+      variant="typeahead"
     >
       <SelectList id="select-create-typeahead-listbox">
         {selectOptions.map((option, index) => (

--- a/packages/react-core/src/components/Select/examples/SelectTypeaheadCreatable.tsx
+++ b/packages/react-core/src/components/Select/examples/SelectTypeaheadCreatable.tsx
@@ -251,7 +251,7 @@ export const SelectTypeaheadCreatable: React.FunctionComponent = () => {
         !isOpen && closeMenu();
       }}
       toggle={toggle}
-      shouldFocusFirstItemOnOpen={false}
+      isTypeahead
     >
       <SelectList id="select-create-typeahead-listbox">
         {selectOptions.map((option, index) => (

--- a/packages/react-core/src/helpers/KeyboardHandler.tsx
+++ b/packages/react-core/src/helpers/KeyboardHandler.tsx
@@ -176,6 +176,33 @@ export const setTabIndex = (options: HTMLElement[]) => {
   }
 };
 
+/**
+ * This function is used in Dropdown, Select and MenuContainer as a default toggle keydown behavior. When the toggle has focus and the menu is open, pressing the up/down arrow keys will focus a valid non-disabled menu item - the first item for the down arrow key and last item for the up arrow key.
+ *
+ * @param event Event triggered by the keyboard
+ * @param menuRef Menu reference
+ */
+export const onToggleArrowKeydownDefault = (event: KeyboardEvent, menuRef: React.RefObject<HTMLDivElement>) => {
+  if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') {
+    return;
+  }
+
+  event.preventDefault();
+
+  const interactiveElementSelector = 'button:not(:disabled),input:not(:disabled),a:not([aria-disabled="true"])';
+  const listItemSelector = `li:has(${interactiveElementSelector})`;
+  let listItem: Element;
+  if (event.key === 'ArrowDown') {
+    listItem = menuRef.current?.querySelector(listItemSelector);
+  } else {
+    const allItems = menuRef.current?.querySelectorAll(listItemSelector);
+    listItem = allItems ? allItems[allItems.length - 1] : null;
+  }
+
+  const focusableElement = listItem?.querySelector(interactiveElementSelector);
+  focusableElement && (focusableElement as HTMLElement).focus();
+};
+
 class KeyboardHandler extends React.Component<KeyboardHandlerProps> {
   static displayName = 'KeyboardHandler';
   static defaultProps: KeyboardHandlerProps = {

--- a/packages/react-core/src/helpers/KeyboardHandler.tsx
+++ b/packages/react-core/src/helpers/KeyboardHandler.tsx
@@ -189,17 +189,17 @@ export const onToggleArrowKeydownDefault = (event: KeyboardEvent, menuRef: React
 
   event.preventDefault();
 
-  const interactiveElementSelector = 'button:not(:disabled),input:not(:disabled),a:not([aria-disabled="true"])';
-  const listItemSelector = `li:has(${interactiveElementSelector})`;
-  let listItem: Element;
-  if (event.key === 'ArrowDown') {
-    listItem = menuRef.current?.querySelector(listItemSelector);
-  } else {
-    const allItems = menuRef.current?.querySelectorAll(listItemSelector);
-    listItem = allItems ? allItems[allItems.length - 1] : null;
-  }
+  const listItems = Array.from(menuRef.current?.querySelectorAll('li'));
+  const focusableElements = listItems
+    .map((li) => li.querySelector('button:not(:disabled),input:not(:disabled),a:not([aria-disabled="true"])'))
+    .filter((el) => el !== null);
 
-  const focusableElement = listItem?.querySelector(interactiveElementSelector);
+  let focusableElement: Element;
+  if (event.key === 'ArrowDown') {
+    focusableElement = focusableElements[0];
+  } else {
+    focusableElement = focusableElements[focusableElements.length - 1];
+  }
   focusableElement && (focusableElement as HTMLElement).focus();
 };
 

--- a/packages/react-templates/src/components/Select/MultiTypeaheadSelect.tsx
+++ b/packages/react-templates/src/components/Select/MultiTypeaheadSelect.tsx
@@ -320,7 +320,7 @@ export const MultiTypeaheadSelectBase: React.FunctionComponent<MultiTypeaheadSel
         !isOpen && closeMenu();
       }}
       toggle={toggle}
-      shouldFocusFirstItemOnOpen={false}
+      isTypeahead
       ref={innerRef}
       {...props}
     >

--- a/packages/react-templates/src/components/Select/MultiTypeaheadSelect.tsx
+++ b/packages/react-templates/src/components/Select/MultiTypeaheadSelect.tsx
@@ -320,7 +320,7 @@ export const MultiTypeaheadSelectBase: React.FunctionComponent<MultiTypeaheadSel
         !isOpen && closeMenu();
       }}
       toggle={toggle}
-      isTypeahead
+      variant="typeahead"
       ref={innerRef}
       {...props}
     >

--- a/packages/react-templates/src/components/Select/TypeaheadSelect.tsx
+++ b/packages/react-templates/src/components/Select/TypeaheadSelect.tsx
@@ -361,7 +361,7 @@ export const TypeaheadSelectBase: React.FunctionComponent<TypeaheadSelectProps> 
         !isOpen && closeMenu();
       }}
       toggle={toggle}
-      shouldFocusFirstItemOnOpen={false}
+      isTypeahead
       ref={innerRef}
       {...props}
     >

--- a/packages/react-templates/src/components/Select/TypeaheadSelect.tsx
+++ b/packages/react-templates/src/components/Select/TypeaheadSelect.tsx
@@ -361,7 +361,7 @@ export const TypeaheadSelectBase: React.FunctionComponent<TypeaheadSelectProps> 
         !isOpen && closeMenu();
       }}
       toggle={toggle}
-      isTypeahead
+      variant="typeahead"
       ref={innerRef}
       {...props}
     >


### PR DESCRIPTION
Closes #11131

Potential problem: if consumers pass a `component` prop to MenuItem other than `button` / `input` / `a`, it won't focus the item. They can always override the `onArrowUpDownKeyDown` themselves, but I am wondering whether we should provide some prop to specify, what is the html element they want to focus.