### PR TITLE
fix(MenuToggle): incorrect inheritance of HTMLInputElement

### DIFF
--- a/packages/react-core/src/components/MenuToggle/MenuToggleCheckbox.tsx
+++ b/packages/react-core/src/components/MenuToggle/MenuToggleCheckbox.tsx
@@ -20,7 +20,7 @@ export interface MenuToggleCheckboxProps
   /** Flag to set the default checked value of the checkbox when it is uncontrolled by React state.
    * To make the checkbox controlled instead use the isChecked prop, but do not use both.
    */
-  defaultChecked?: boolean | null;
+  defaultChecked?: boolean;
   /** A callback for when the checkbox selection changes */
   onChange?: (checked: boolean, event: React.FormEvent<HTMLInputElement>) => void;
   /** Element to be rendered inside the <span> */


### PR DESCRIPTION
MenuToggleCheckboxProps inherits from HTMLInputElement and defaultChecked is typed there as `undefined | boolean`, null is not a valid type.

Found by typescript's `tsc` in strict mode.