### PR TITLE
fix(table,a11y): only apply aria-sort when sorting for V6

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,7 +16,8 @@ export default [
       'packages/react-core/src/helpers/Popper/thirdparty',
       'packages/react-docs/patternfly-docs/generated',
       '.history/*',
-      'packages/react-docs/static'
+      'packages/react-docs/static',
+      '**/.cache'
     ]
   },
   js.configs.recommended,

--- a/packages/react-table/src/components/Table/utils/decorators/sortable.tsx
+++ b/packages/react-table/src/components/Table/utils/decorators/sortable.tsx
@@ -53,7 +53,7 @@ export const sortable: ITransform = (
 
   return {
     className: css(styles.tableSort, isSortedBy && styles.modifiers.selected, className),
-    'aria-sort': isSortedBy ? `${sortBy.direction}ending` : 'none',
+    ...(isSortedBy && { 'aria-sort': `${sortBy.direction}ending` }),
     children: (
       <SortColumn
         isSortedBy={isSortedBy}

--- a/packages/react-table/src/deprecated/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/packages/react-table/src/deprecated/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -20,8 +20,12 @@ exports[`Table Actions table 1`] = `
         data-ouia-safe="true"
       >
         <th
+<<<<<<< HEAD
           aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
+=======
+          class="pf-v5-c-table__th pf-v5-c-table__sort"
+>>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="0"
           data-label="Header cell"
           scope="col"
@@ -861,8 +865,12 @@ exports[`Table Cell header table 1`] = `
         data-ouia-safe="true"
       >
         <th
+<<<<<<< HEAD
           aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
+=======
+          class="pf-v5-c-table__th pf-v5-c-table__sort"
+>>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="0"
           data-label="Header cell"
           scope="col"
@@ -1433,8 +1441,12 @@ exports[`Table Collapsible nested table 1`] = `
           tabindex="-1"
         />
         <th
+<<<<<<< HEAD
           aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
+=======
+          class="pf-v5-c-table__th pf-v5-c-table__sort"
+>>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="1"
           data-label="Header cell"
           scope="col"
@@ -2198,8 +2210,12 @@ exports[`Table Collapsible table 1`] = `
           tabindex="-1"
         />
         <th
+<<<<<<< HEAD
           aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
+=======
+          class="pf-v5-c-table__th pf-v5-c-table__sort"
+>>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="1"
           data-label="Header cell"
           scope="col"
@@ -4234,8 +4250,12 @@ exports[`Table Selectable table 1`] = `
           </label>
         </th>
         <th
+<<<<<<< HEAD
           aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
+=======
+          class="pf-v5-c-table__th pf-v5-c-table__sort"
+>>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="1"
           data-label="Header cell"
           scope="col"
@@ -4927,8 +4947,12 @@ exports[`Table Selectable table with Radio 1`] = `
           tabindex="-1"
         />
         <th
+<<<<<<< HEAD
           aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
+=======
+          class="pf-v5-c-table__th pf-v5-c-table__sort"
+>>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="1"
           data-label="Header cell"
           scope="col"
@@ -5717,8 +5741,12 @@ exports[`Table Simple Actions table 1`] = `
         data-ouia-safe="true"
       >
         <th
+<<<<<<< HEAD
           aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
+=======
+          class="pf-v5-c-table__th pf-v5-c-table__sort"
+>>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="0"
           data-label="Header cell"
           scope="col"
@@ -6640,8 +6668,12 @@ exports[`Table Table variants Breakpoint -  1`] = `
         data-ouia-safe="true"
       >
         <th
+<<<<<<< HEAD
           aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
+=======
+          class="pf-v5-c-table__th pf-v5-c-table__sort"
+>>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="0"
           data-label="Header cell"
           scope="col"
@@ -7169,8 +7201,12 @@ exports[`Table Table variants Breakpoint - grid 1`] = `
         data-ouia-safe="true"
       >
         <th
+<<<<<<< HEAD
           aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
+=======
+          class="pf-v5-c-table__th pf-v5-c-table__sort"
+>>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="0"
           data-label="Header cell"
           scope="col"
@@ -7698,8 +7734,12 @@ exports[`Table Table variants Breakpoint - grid-2xl 1`] = `
         data-ouia-safe="true"
       >
         <th
+<<<<<<< HEAD
           aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
+=======
+          class="pf-v5-c-table__th pf-v5-c-table__sort"
+>>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="0"
           data-label="Header cell"
           scope="col"
@@ -8227,8 +8267,12 @@ exports[`Table Table variants Breakpoint - grid-lg 1`] = `
         data-ouia-safe="true"
       >
         <th
+<<<<<<< HEAD
           aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
+=======
+          class="pf-v5-c-table__th pf-v5-c-table__sort"
+>>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="0"
           data-label="Header cell"
           scope="col"
@@ -8756,8 +8800,12 @@ exports[`Table Table variants Breakpoint - grid-md 1`] = `
         data-ouia-safe="true"
       >
         <th
+<<<<<<< HEAD
           aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
+=======
+          class="pf-v5-c-table__th pf-v5-c-table__sort"
+>>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="0"
           data-label="Header cell"
           scope="col"
@@ -9285,8 +9333,12 @@ exports[`Table Table variants Breakpoint - grid-xl 1`] = `
         data-ouia-safe="true"
       >
         <th
+<<<<<<< HEAD
           aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
+=======
+          class="pf-v5-c-table__th pf-v5-c-table__sort"
+>>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="0"
           data-label="Header cell"
           scope="col"
@@ -9814,8 +9866,12 @@ exports[`Table Table variants Size - compact 1`] = `
         data-ouia-safe="true"
       >
         <th
+<<<<<<< HEAD
           aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
+=======
+          class="pf-v5-c-table__th pf-v5-c-table__sort"
+>>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="0"
           data-label="Header cell"
           scope="col"
@@ -10908,8 +10964,12 @@ exports[`Table simple Row click table 1`] = `
         data-ouia-safe="true"
       >
         <th
+<<<<<<< HEAD
           aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
+=======
+          class="pf-v5-c-table__th pf-v5-c-table__sort"
+>>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="0"
           data-label="Header cell"
           scope="col"
@@ -11437,8 +11497,12 @@ exports[`Table simple Sortable table 1`] = `
         data-ouia-safe="true"
       >
         <th
+<<<<<<< HEAD
           aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
+=======
+          class="pf-v5-c-table__th pf-v5-c-table__sort"
+>>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="0"
           data-label="Header cell"
           scope="col"

--- a/packages/react-table/src/deprecated/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/packages/react-table/src/deprecated/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -20,12 +20,7 @@ exports[`Table Actions table 1`] = `
         data-ouia-safe="true"
       >
         <th
-<<<<<<< HEAD
-          aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
-=======
-          class="pf-v5-c-table__th pf-v5-c-table__sort"
->>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="0"
           data-label="Header cell"
           scope="col"
@@ -865,12 +860,7 @@ exports[`Table Cell header table 1`] = `
         data-ouia-safe="true"
       >
         <th
-<<<<<<< HEAD
-          aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
-=======
-          class="pf-v5-c-table__th pf-v5-c-table__sort"
->>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="0"
           data-label="Header cell"
           scope="col"
@@ -1441,12 +1431,7 @@ exports[`Table Collapsible nested table 1`] = `
           tabindex="-1"
         />
         <th
-<<<<<<< HEAD
-          aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
-=======
-          class="pf-v5-c-table__th pf-v5-c-table__sort"
->>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="1"
           data-label="Header cell"
           scope="col"
@@ -2210,12 +2195,7 @@ exports[`Table Collapsible table 1`] = `
           tabindex="-1"
         />
         <th
-<<<<<<< HEAD
-          aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
-=======
-          class="pf-v5-c-table__th pf-v5-c-table__sort"
->>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="1"
           data-label="Header cell"
           scope="col"
@@ -4250,12 +4230,7 @@ exports[`Table Selectable table 1`] = `
           </label>
         </th>
         <th
-<<<<<<< HEAD
-          aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
-=======
-          class="pf-v5-c-table__th pf-v5-c-table__sort"
->>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="1"
           data-label="Header cell"
           scope="col"
@@ -4947,12 +4922,7 @@ exports[`Table Selectable table with Radio 1`] = `
           tabindex="-1"
         />
         <th
-<<<<<<< HEAD
-          aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
-=======
-          class="pf-v5-c-table__th pf-v5-c-table__sort"
->>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="1"
           data-label="Header cell"
           scope="col"
@@ -5741,12 +5711,7 @@ exports[`Table Simple Actions table 1`] = `
         data-ouia-safe="true"
       >
         <th
-<<<<<<< HEAD
-          aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
-=======
-          class="pf-v5-c-table__th pf-v5-c-table__sort"
->>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="0"
           data-label="Header cell"
           scope="col"
@@ -6668,12 +6633,7 @@ exports[`Table Table variants Breakpoint -  1`] = `
         data-ouia-safe="true"
       >
         <th
-<<<<<<< HEAD
-          aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
-=======
-          class="pf-v5-c-table__th pf-v5-c-table__sort"
->>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="0"
           data-label="Header cell"
           scope="col"
@@ -7201,12 +7161,7 @@ exports[`Table Table variants Breakpoint - grid 1`] = `
         data-ouia-safe="true"
       >
         <th
-<<<<<<< HEAD
-          aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
-=======
-          class="pf-v5-c-table__th pf-v5-c-table__sort"
->>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="0"
           data-label="Header cell"
           scope="col"
@@ -7734,12 +7689,7 @@ exports[`Table Table variants Breakpoint - grid-2xl 1`] = `
         data-ouia-safe="true"
       >
         <th
-<<<<<<< HEAD
-          aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
-=======
-          class="pf-v5-c-table__th pf-v5-c-table__sort"
->>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="0"
           data-label="Header cell"
           scope="col"
@@ -8267,12 +8217,7 @@ exports[`Table Table variants Breakpoint - grid-lg 1`] = `
         data-ouia-safe="true"
       >
         <th
-<<<<<<< HEAD
-          aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
-=======
-          class="pf-v5-c-table__th pf-v5-c-table__sort"
->>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="0"
           data-label="Header cell"
           scope="col"
@@ -8800,12 +8745,7 @@ exports[`Table Table variants Breakpoint - grid-md 1`] = `
         data-ouia-safe="true"
       >
         <th
-<<<<<<< HEAD
-          aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
-=======
-          class="pf-v5-c-table__th pf-v5-c-table__sort"
->>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="0"
           data-label="Header cell"
           scope="col"
@@ -9333,12 +9273,7 @@ exports[`Table Table variants Breakpoint - grid-xl 1`] = `
         data-ouia-safe="true"
       >
         <th
-<<<<<<< HEAD
-          aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
-=======
-          class="pf-v5-c-table__th pf-v5-c-table__sort"
->>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="0"
           data-label="Header cell"
           scope="col"
@@ -9866,12 +9801,7 @@ exports[`Table Table variants Size - compact 1`] = `
         data-ouia-safe="true"
       >
         <th
-<<<<<<< HEAD
-          aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
-=======
-          class="pf-v5-c-table__th pf-v5-c-table__sort"
->>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="0"
           data-label="Header cell"
           scope="col"
@@ -10964,12 +10894,7 @@ exports[`Table simple Row click table 1`] = `
         data-ouia-safe="true"
       >
         <th
-<<<<<<< HEAD
-          aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
-=======
-          class="pf-v5-c-table__th pf-v5-c-table__sort"
->>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="0"
           data-label="Header cell"
           scope="col"
@@ -11497,12 +11422,7 @@ exports[`Table simple Sortable table 1`] = `
         data-ouia-safe="true"
       >
         <th
-<<<<<<< HEAD
-          aria-sort="none"
           class="pf-v6-c-table__th pf-v6-c-table__sort"
-=======
-          class="pf-v5-c-table__th pf-v5-c-table__sort"
->>>>>>> e135998c7 (fix(table,a11y): only apply aria-sort when sorting)
           data-key="0"
           data-label="Header cell"
           scope="col"


### PR DESCRIPTION
V6 versions of https://github.com/patternfly/patternfly-react/pull/11144