### PR TITLE
Improvements to the TypeaheadSelect template

### DIFF
--- a/packages/react-templates/src/components/Select/TypeaheadSelect.tsx
+++ b/packages/react-templates/src/components/Select/TypeaheadSelect.tsx
@@ -26,7 +26,7 @@ export interface TypeaheadSelectOption extends Omit<SelectOptionProps, 'content'
 
 export interface TypeaheadSelectProps extends Omit<SelectProps, 'toggle' | 'onSelect'> {
   /** @hide Forwarded ref */
-  innerRef?: React.Ref<any>;
+  innerRef?: React.Ref<HTMLDivElement>;
   /** Options of the select */
   selectOptions: TypeaheadSelectOption[];
   /** Callback triggered on selection. */
@@ -386,7 +386,7 @@ export const TypeaheadSelectBase: React.FunctionComponent<TypeaheadSelectProps> 
 };
 TypeaheadSelectBase.displayName = 'TypeaheadSelectBase';
 
-export const TypeaheadSelect = React.forwardRef((props: TypeaheadSelectProps, ref: React.Ref<any>) => (
+export const TypeaheadSelect = React.forwardRef((props: TypeaheadSelectProps, ref: React.Ref<HTMLDivElement>) => (
   <TypeaheadSelectBase {...props} innerRef={ref} />
 ));
 

--- a/packages/react-templates/src/components/Select/TypeaheadSelect.tsx
+++ b/packages/react-templates/src/components/Select/TypeaheadSelect.tsx
@@ -349,7 +349,7 @@ export const TypeaheadSelectBase: React.FunctionComponent<TypeaheadSelectProps> 
           aria-controls="select-typeahead-listbox"
         />
         <TextInputGroupUtilities
-          {...(!(isFiltering && filterValue) && !selected ? { style: { display: 'none' } } : {})}
+          {...(!(isFiltering && filterValue) && !(selected && onClearSelection) ? { style: { display: 'none' } } : {})}
         >
           <Button variant="plain" onClick={onClearButtonClick} aria-label="Clear input value">
             <TimesIcon aria-hidden />

--- a/packages/react-templates/src/components/Select/TypeaheadSelect.tsx
+++ b/packages/react-templates/src/components/Select/TypeaheadSelect.tsx
@@ -325,7 +325,7 @@ export const TypeaheadSelectBase: React.FunctionComponent<TypeaheadSelectProps> 
       aria-label="Typeahead menu toggle"
       onClick={onToggleClick}
       isExpanded={isOpen}
-      isDisabled={isDisabled}
+      isDisabled={isDisabled || false}
       isFullWidth
       style={
         {


### PR DESCRIPTION
Here are a few small changes to the TypeaheadSelect that we could use in Cockpit.

 - Our linter doesn't like the "any" type.
 - TypeScript actually reports a typing error for the "isDisabled" property, which seems easily fixed.
 - Not all our typeahead users specify a "onClearSelection" function, and for those the "X" button was still there but did nothing. I think it is better to not show that button in that case.

Thanks!
