### PR TITLE
fix(charts) - legend tooltip missing space between label and value (v5)

### DIFF
--- a/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
+++ b/packages/react-charts/src/components/ChartUtils/chart-tooltip.ts
@@ -123,7 +123,7 @@ export const getLegendTooltipSize = ({
   legendData,
   legendOrientation = 'vertical',
   legendProps,
-  minSpacing = 1,
+  minSpacing = 2, // Adjust min spacing, see https://issues.redhat.com/browse/COST-5648
   text = '',
   theme
 }: ChartLegendTooltipFlyoutInterface) => {


### PR DESCRIPTION
Fixes https://github.com/patternfly/patternfly-react/issues/11154

**Example 1**
![Screenshot 2024-10-31 at 10 18 25 AM](https://github.com/user-attachments/assets/fa8d7628-4eca-4d71-822b-6640eb94b867)

**Example 2**
![Screenshot 2024-10-31 at 10 19 09 AM](https://github.com/user-attachments/assets/0a1a3828-e9a2-4cd7-811b-4949bcab2135)__