### PR TITLE
fix(docs): drilldown infinite loop

### DIFF
--- a/packages/react-core/src/demos/CustomMenus/examples/DrilldownMenuDemo.tsx
+++ b/packages/react-core/src/demos/CustomMenus/examples/DrilldownMenuDemo.tsx
@@ -52,7 +52,7 @@ export const DrilldownMenuDemo: React.FunctionComponent = () => {
   };
 
   const setHeight = (menuId: string, height: number) => {
-    if (!menuHeights[menuId] || (menuId !== 'rootMenu' && menuHeights[menuId] !== height)) {
+    if (menuHeights[menuId] === undefined || (menuId !== 'rootMenu' && menuHeights[menuId] !== height)) {
       setMenuHeights({
         ...menuHeights,
         [menuId]: height


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #11135

Turns out this was a demo issue rather than a component issue, caused by setState being called until the component rendering crashed.
