### PR TITLE
feat(FileUpload): expose dropdown error types

### DIFF
--- a/packages/react-core/src/components/FileUpload/FileUpload.tsx
+++ b/packages/react-core/src/components/FileUpload/FileUpload.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DropzoneInputProps, DropzoneOptions, FileRejection, useDropzone } from 'react-dropzone';
+import { DropzoneInputProps, DropzoneOptions, FileRejection, useDropzone, ErrorCode } from 'react-dropzone';
 import { FileUploadField, FileUploadFieldProps } from './FileUploadField';
 import { readFile, fileReaderType } from '../../helpers/fileUtils';
 import { DropEvent } from '../../helpers/typeUtils';
@@ -84,6 +84,8 @@ export interface FileUploadProps
   onTextChange?: (event: React.ChangeEvent<HTMLTextAreaElement>, text: string) => void;
 }
 
+export { ErrorCode as DropzoneErrorCode }; // FileInvalidType, FileTooLarge, FileTooSmall, TooManyFiles
+
 export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
   id,
   type,
@@ -123,8 +125,8 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
     dropzoneProps.onDropAccepted && dropzoneProps.onDropAccepted(acceptedFiles, event);
   };
 
-  const onDropRejected = (rejectedFiles: FileRejection[], event: DropEvent) => {
-    dropzoneProps.onDropRejected && dropzoneProps.onDropRejected(rejectedFiles, event);
+  const onDropRejected = (rejectedFiles: FileRejection[], event: DropEvent, error: ErrorCode) => {
+    dropzoneProps.onDropRejected && dropzoneProps.onDropRejected(rejectedFiles, event, error);
   };
 
   const onClearButtonClick = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {

--- a/packages/react-core/src/components/FileUpload/FileUpload.tsx
+++ b/packages/react-core/src/components/FileUpload/FileUpload.tsx
@@ -125,8 +125,8 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
     dropzoneProps.onDropAccepted && dropzoneProps.onDropAccepted(acceptedFiles, event);
   };
 
-  const onDropRejected = (rejectedFiles: FileRejection[], event: DropEvent, error: ErrorCode) => {
-    dropzoneProps.onDropRejected && dropzoneProps.onDropRejected(rejectedFiles, event, error);
+  const onDropRejected = (rejectedFiles: FileRejection[], event: DropEvent) => {
+    dropzoneProps.onDropRejected && dropzoneProps.onDropRejected(rejectedFiles, event);
   };
 
   const onClearButtonClick = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {

--- a/packages/react-core/src/components/FileUpload/examples/FileUpload.md
+++ b/packages/react-core/src/components/FileUpload/examples/FileUpload.md
@@ -40,7 +40,7 @@ Typing/pasting text in the box will call `onTextChange` with a string, and a str
 
 ### Restricting file size and type
 
-Any [props accepted by `react-dropzone`'s `Dropzone` component](https://react-dropzone.js.org/#!/Dropzone) can be passed as a `dropzoneProps` object in order to customize the behavior of the Dropzone, such as restricting the size and type of files allowed. The following example will only accept CSV files smaller than 1 KB. Note that file type determination is not reliable across platforms (see the note on react-dropzone's docs about the `accept` prop), so be sure to test the behavior of your file upload restriction on all browsers and operating systems targeted by your application.
+Any [props accepted by `react-dropzone`'s `Dropzone` component](https://react-dropzone.js.org/#!/Dropzone) can be passed as a `dropzoneProps` object in order to customize the behavior of the Dropzone, such as restricting the size and type of files allowed. You can also capture and act upon native `react-dropzone` errors using the exposed `DropzoneErrorCode` enum. The following example will only accept CSV files smaller than 1 KB. Note that file type determination is not reliable across platforms (see the note on react-dropzone's docs about the `accept` prop), so be sure to test the behavior of your file upload restriction on all browsers and operating systems targeted by your application.
 
 #### IMPORTANT: A note about security
 

--- a/packages/react-core/src/components/FileUpload/examples/FileUploadTextWithRestrictions.tsx
+++ b/packages/react-core/src/components/FileUpload/examples/FileUploadTextWithRestrictions.tsx
@@ -30,14 +30,23 @@ export const TextFileUploadWithRestrictions: React.FunctionComponent = () => {
     setValue(value);
   };
 
-  const handleClear = (_event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+  const reset = () => {
     setFilename('');
     setValue('');
+  };
+
+  const handleClear = (_event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    reset();
     setIsRejected(false);
   };
 
   const handleFileRejected = () => {
+    reset();
     setIsRejected(true);
+  };
+
+  const handleFileAccepted = () => {
+    setIsRejected(false);
   };
 
   const handleFileReadStarted = (_event: DropEvent, _fileHandle: File) => {
@@ -69,11 +78,14 @@ export const TextFileUploadWithRestrictions: React.FunctionComponent = () => {
             maxSize: 1024,
             onDropRejected: (rejections) => {
               const error = rejections[0].errors[0];
-              if (error.code === DropzoneErrorCode.FileInvalidType) {
-                setMessage('File must be a valid CSV file');
+              if (error.code === DropzoneErrorCode.FileTooLarge) {
+                setMessage('File is too big');
+              } else if (error.code === DropzoneErrorCode.FileInvalidType) {
+                setMessage('File is not a CSV file');
               }
               handleFileRejected();
-            }
+            },
+            onDropAccepted: handleFileAccepted
           }}
           validated={isRejected ? 'error' : 'default'}
           browseButtonText="Upload"
@@ -84,7 +96,7 @@ export const TextFileUploadWithRestrictions: React.FunctionComponent = () => {
               <HelperTextItem id="restricted-file-example-helpText" variant={isRejected ? 'error' : 'default'}>
                 {isRejected ? (
                   <>
-                    <Icon status="danger">{/* <ExclamationCircleIcon /> */}</Icon>
+                    <Icon status="danger" />
                     {message}
                   </>
                 ) : (

--- a/packages/react-core/src/components/FileUpload/examples/FileUploadTextWithRestrictions.tsx
+++ b/packages/react-core/src/components/FileUpload/examples/FileUploadTextWithRestrictions.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   FileUpload,
+  DropzoneErrorCode,
   FileUploadHelperText,
   Form,
   FormGroup,
@@ -9,13 +10,13 @@ import {
   DropEvent,
   Icon
 } from '@patternfly/react-core';
-import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 
 export const TextFileUploadWithRestrictions: React.FunctionComponent = () => {
   const [value, setValue] = React.useState('');
   const [filename, setFilename] = React.useState('');
   const [isLoading, setIsLoading] = React.useState(false);
   const [isRejected, setIsRejected] = React.useState(false);
+  const [message, setMessage] = React.useState('Must be a CSV file no larger than 1 KB');
 
   const handleFileInputChange = (_, file: File) => {
     setFilename(file.name);
@@ -66,7 +67,13 @@ export const TextFileUploadWithRestrictions: React.FunctionComponent = () => {
           dropzoneProps={{
             accept: { 'text/csv': ['.csv'] },
             maxSize: 1024,
-            onDropRejected: handleFileRejected
+            onDropRejected: (rejections) => {
+              const error = rejections[0].errors[0];
+              if (error.code === DropzoneErrorCode.FileInvalidType) {
+                setMessage('File must be a valid CSV file');
+              }
+              handleFileRejected();
+            }
           }}
           validated={isRejected ? 'error' : 'default'}
           browseButtonText="Upload"
@@ -77,10 +84,8 @@ export const TextFileUploadWithRestrictions: React.FunctionComponent = () => {
               <HelperTextItem id="restricted-file-example-helpText" variant={isRejected ? 'error' : 'default'}>
                 {isRejected ? (
                   <>
-                    <Icon status="danger">
-                      <ExclamationCircleIcon />
-                    </Icon>
-                    Must be a CSV file no larger than 1 KB
+                    <Icon status="danger">{/* <ExclamationCircleIcon /> */}</Icon>
+                    {message}
                   </>
                 ) : (
                   'Upload a CSV file'


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #10521 

This allows devs to capture and act on native react-dropzone error codes. Added an example of doing so to the existing FileUploadWithRestrictions example. Also fixed a legacy bug in that example in which, after dropping an invalid file, the error states were remaining even if subsequently dragging and dropping valid files.
