### PR TITLE
fix(CalendarMonth): fix selection closing datepicker popover

### DIFF
--- a/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
+++ b/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
@@ -319,18 +319,15 @@ export const CalendarMonth = ({
                   onSelectToggle(isOpen);
                 }}
                 onSelect={(ev, monthNum) => {
-                  // When we put CalendarMonth in a Popover we want the Popover's onDocumentClick
-                  // to see the SelectOption as a child so it doesn't close the Popover.
-                  setTimeout(() => {
-                    setIsSelectOpen(false);
-                    onSelectToggle(false);
-                    const newDate = changeMonth(Number(monthNum as string));
-                    setFocusedDate(newDate);
-                    setShouldFocus(false);
-                    onMonthChange(ev, newDate);
-                  }, 0);
+                  setIsSelectOpen(false);
+                  onSelectToggle(false);
+                  const newDate = changeMonth(Number(monthNum as string));
+                  setFocusedDate(newDate);
+                  setShouldFocus(false);
+                  onMonthChange(ev, newDate);
                 }}
                 selected={monthFormatted}
+                popperProps={{ appendTo: 'inline' }}
               >
                 <SelectList>
                   {longMonths.map((longMonth, index) => (


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #11329

CalendarMonth's select was closing the Datepicker popover because the Select wasn't inline/was appended to the body (so the Datepicker saw the click as coming from outside the picker).

The timeout in the selection handler doesn't seem to be necessary in v6.
