### PR TITLE
fix(FileUpload): Remove empty icon from example

### DIFF
--- a/packages/react-core/src/components/FileUpload/examples/FileUploadTextWithRestrictions.tsx
+++ b/packages/react-core/src/components/FileUpload/examples/FileUploadTextWithRestrictions.tsx
@@ -7,8 +7,7 @@ import {
   FormGroup,
   HelperText,
   HelperTextItem,
-  DropEvent,
-  Icon
+  DropEvent
 } from '@patternfly/react-core';
 
 export const TextFileUploadWithRestrictions: React.FunctionComponent = () => {
@@ -94,14 +93,7 @@ export const TextFileUploadWithRestrictions: React.FunctionComponent = () => {
           <FileUploadHelperText>
             <HelperText isLiveRegion>
               <HelperTextItem id="restricted-file-example-helpText" variant={isRejected ? 'error' : 'default'}>
-                {isRejected ? (
-                  <>
-                    <Icon status="danger" />
-                    {message}
-                  </>
-                ) : (
-                  'Upload a CSV file'
-                )}
+                {isRejected ? message : 'Upload a CSV file'}
               </HelperTextItem>
             </HelperText>
           </FileUploadHelperText>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #11347 

This is a follow-up to #11289 in which the `FileUploadTextWithRestrictions` example was changed to take advantage of `react-dropzone` error codes, and as part of that the double icon issue on error was fixed. But an empty `<Icon>` remained in the code example, and although it's not visible or breaking anything, it could confuse viewers of the code example. So it's now removed and that part of the example is more simplified.
