### PR TITLE
fix(FileUpload): hid input of type file from AT

### DIFF
--- a/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
@@ -679,7 +679,7 @@ class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState> {
                   {editorHeader}
                   <div className={css(styles.codeEditorMain, isDragActive && styles.modifiers.dragHover)}>
                     <div className={css(styles.codeEditorUpload)}>
-                      <input {...getInputProps()} /* hidden, necessary for react-dropzone */ />
+                      <input {...getInputProps()} /* hidden, necessary for react-dropzone */ hidden />
                       {(showEmptyState || providedEmptyState) && !value ? emptyState : editor}
                     </div>
                   </div>

--- a/packages/react-code-editor/src/components/CodeEditor/__test__/__snapshots__/CodeEditor.test.tsx.snap
+++ b/packages/react-code-editor/src/components/CodeEditor/__test__/__snapshots__/CodeEditor.test.tsx.snap
@@ -125,6 +125,7 @@ exports[`Matches snapshot with control buttons enabled 1`] = `
           class="pf-v6-c-code-editor__upload"
         >
           <input
+            hidden=""
             style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
             tabindex="-1"
             type="file"

--- a/packages/react-core/src/components/FileUpload/FileUpload.tsx
+++ b/packages/react-core/src/components/FileUpload/FileUpload.tsx
@@ -179,6 +179,7 @@ export const FileUpload: React.FunctionComponent<FileUploadProps> = ({
       <input
         /* hidden, necessary for react-dropzone */
         {...inputProps}
+        hidden
       />
       {children}
     </FileUploadField>

--- a/packages/react-core/src/components/FileUpload/__tests__/__snapshots__/FileUpload.test.tsx.snap
+++ b/packages/react-core/src/components/FileUpload/__tests__/__snapshots__/FileUpload.test.tsx.snap
@@ -87,6 +87,7 @@ exports[`simple fileupload 1`] = `
       </span>
     </div>
     <input
+      hidden=""
       style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       tabindex="-1"
       type="file"

--- a/packages/react-core/src/components/MultipleFileUpload/MultipleFileUpload.tsx
+++ b/packages/react-core/src/components/MultipleFileUpload/MultipleFileUpload.tsx
@@ -66,6 +66,7 @@ export const MultipleFileUpload: React.FunctionComponent<MultipleFileUploadProps
         <input
           /* hidden, necessary for react-dropzone */
           {...getInputProps()}
+          hidden
         />
         {children}
       </div>

--- a/packages/react-core/src/components/MultipleFileUpload/__tests__/__snapshots__/MultipleFileUpload.test.tsx.snap
+++ b/packages/react-core/src/components/MultipleFileUpload/__tests__/__snapshots__/MultipleFileUpload.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`MultipleFileUpload renders custom class names 1`] = `
     tabindex="0"
   >
     <input
+      hidden=""
       multiple=""
       style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       tabindex="-1"
@@ -26,6 +27,7 @@ exports[`MultipleFileUpload renders with expected class names when horizontal 1`
     tabindex="0"
   >
     <input
+      hidden=""
       multiple=""
       style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       tabindex="-1"
@@ -44,6 +46,7 @@ exports[`MultipleFileUpload renders with expected class names when not horizonta
     tabindex="0"
   >
     <input
+      hidden=""
       multiple=""
       style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
       tabindex="-1"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Towards #11343 

The input was not intended to be exposed to users to navigate to and was simply required for dropzone. Keeping it exposed ends up allowing it to be focused which when it is, focus ends up being lost on the page. There should be enough context elsewhere in the components to indicate file uploading capability.

To test, go to an example in both components and navigate via keyboard and VoiceOver. Via keyboard the focus shouldn't get lost when navigating through the component elements, and via VoiceOver you should not hear an announcement along the lines of "Choose a file: no file chosen" (this is the output from the input type="file" element).

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
