### PR TITLE
chore(React19): ran upgrade eslint and codemods

### DIFF
--- a/packages/react-charts/src/victory/components/Chart/Chart.tsx
+++ b/packages/react-charts/src/victory/components/Chart/Chart.tsx
@@ -71,7 +71,7 @@ export interface ChartProps extends VictoryChartProps {
    * will be provided with the following properties calculated by Chart: height, polar, scale, style, x, y, width.
    * All of these props on Background should take prececence over what VictoryChart is trying to set.
    */
-  backgroundComponent?: React.ReactElement;
+  backgroundComponent?: React.ReactElement<any>;
   /**
    * The children to render with the chart
    */

--- a/packages/react-charts/src/victory/components/ChartBoxPlot/ChartBoxPlot.tsx
+++ b/packages/react-charts/src/victory/components/ChartBoxPlot/ChartBoxPlot.tsx
@@ -254,7 +254,7 @@ export interface ChartBoxPlotProps extends VictoryBoxPlotProps {
    * supplied component, or modified or ignored within the custom component itself. If a maxComponent is not provided,
    * ChartBoxPlot will use its default Whisker component.
    */
-  maxComponent?: React.ReactElement;
+  maxComponent?: React.ReactElement<any>;
   /**
    * The maxDomain prop defines a maximum domain value for a chart. This prop is useful in situations where the maximum
    * domain of a chart is static, while the minimum value depends on data or other variable information. If the domain
@@ -278,7 +278,7 @@ export interface ChartBoxPlotProps extends VictoryBoxPlotProps {
    * custom component itself. If maxLabelComponent is omitted, a new ChartLabel will be created with props described
    * above.
    */
-  maxLabelComponent?: React.ReactElement;
+  maxLabelComponent?: React.ReactElement<any>;
   /**
    * The maxLabels prop defines the labels that will appear above each point. This prop should be given as a boolean,
    * an array or as a function of the props corresponding to that label. When given as a boolean value, the max value
@@ -314,7 +314,7 @@ export interface ChartBoxPlotProps extends VictoryBoxPlotProps {
    * props may be overridden by passing in props to the supplied component, or modified or ignored within the custom
    * component itself. If a medianComponent is not provided, ChartBoxPlot will use its default Line component.
    */
-  medianComponent?: React.ReactElement;
+  medianComponent?: React.ReactElement<any>;
   /**
    * The medianLabelComponent prop takes a component instance which will be used to render the label corresponding to
    * the median value for each box. The new element created from the passed medianLabelComponent will be supplied with
@@ -323,7 +323,7 @@ export interface ChartBoxPlotProps extends VictoryBoxPlotProps {
    * custom component itself. If medianLabelComponent is omitted, a new ChartLabel will be created with props
    * described above.
    */
-  medianLabelComponent?: React.ReactElement;
+  medianLabelComponent?: React.ReactElement<any>;
   /**
    * The medianLabels prop defines the labels that will appear above each point. This prop should be given as a boolean,
    * an array or as a function of the props corresponding to that label. When given as a boolean value, the median value
@@ -362,7 +362,7 @@ export interface ChartBoxPlotProps extends VictoryBoxPlotProps {
    * supplied component, or modified or ignored within the custom component itself. If a minComponent is not provided,
    * ChartBoxPlot will use its default Whisker component.
    */
-  minComponent?: React.ReactElement;
+  minComponent?: React.ReactElement<any>;
   /**
    * The minDomain prop defines a minimum domain value for a chart. This prop is useful in situations where the minimum
    * domain of a chart is static, while the maximum value depends on data or other variable information. If the domain
@@ -386,7 +386,7 @@ export interface ChartBoxPlotProps extends VictoryBoxPlotProps {
    * custom component itself. If minLabelComponent is omitted, a new ChartLabel will be created with props described
    * above.
    */
-  minLabelComponent?: React.ReactElement;
+  minLabelComponent?: React.ReactElement<any>;
   /**
    * The minLabels prop defines the labels that will appear above each point. This prop should be given as a boolean, an
    * array or as a function of the props corresponding to that label. When given as a boolean value, the min value of
@@ -453,7 +453,7 @@ export interface ChartBoxPlotProps extends VictoryBoxPlotProps {
    * may be overridden by passing in props to the supplied component, or modified or ignored within the custom component
    * itself. If a q1Component is not provided, ChartBoxPlot will use its default Box component.
    */
-  q1Component?: React.ReactElement;
+  q1Component?: React.ReactElement<any>;
   /**
    * The q1LabelComponent prop takes a component instance which will be used to render the label corresponding to the q1
    * value for each box. The new element created from the passed q1LabelComponent will be supplied with the following
@@ -461,7 +461,7 @@ export interface ChartBoxPlotProps extends VictoryBoxPlotProps {
    * props may be overridden by passing in props to the supplied component, or modified or ignored within the custom
    * component itself. If q1LabelComponent is omitted, a new ChartLabel will be created with props described above.
    */
-  q1LabelComponent?: React.ReactElement;
+  q1LabelComponent?: React.ReactElement<any>;
   /**
    * The q1Labels prop defines the labels that will appear above each point. This prop should be given as a boolean, an
    * array or as a function of the props corresponding to that label. When given as a boolean value, the q1 value of
@@ -498,7 +498,7 @@ export interface ChartBoxPlotProps extends VictoryBoxPlotProps {
    * may be overridden by passing in props to the supplied component, or modified or ignored within the custom component
    * itself. If a q3Component is not provided, ChartBoxPlot will use its default Box component.
    */
-  q3Component?: React.ReactElement;
+  q3Component?: React.ReactElement<any>;
   /**
    * The q3LabelComponent prop takes a component instance which will be used to render the label corresponding to the q3
    * value for each box. The new element created from the passed q3LabelComponent will be supplied with the following
@@ -506,7 +506,7 @@ export interface ChartBoxPlotProps extends VictoryBoxPlotProps {
    * props may be overridden by passing in props to the supplied component, or modified or ignored within the custom
    * component itself. If q3LabelComponent is omitted, a new ChartLabel will be created with props described above.
    */
-  q3LabelComponent?: React.ReactElement;
+  q3LabelComponent?: React.ReactElement<any>;
   /**
    * The q3Labels prop defines the labels that will appear above each point. This prop should be given as a boolean, an
    * array or as a function of the props corresponding to that label. When given as a boolean value, the q3 value of

--- a/packages/react-charts/src/victory/components/ChartContainer/ChartContainer.tsx
+++ b/packages/react-charts/src/victory/components/ChartContainer/ChartContainer.tsx
@@ -16,7 +16,7 @@ export interface ChartContainerProps extends VictoryContainerProps {
    * The children prop specifies the child or children that will be rendered within the container. It will be set by
    * whatever Victory component is rendering the container.
    */
-  children?: React.ReactElement | React.ReactElement[];
+  children?: React.ReactElement<any> | React.ReactElement<any>[];
   /**
    * The className prop specifies a className that will be applied to the outermost div rendered by ChartContainer
    */
@@ -31,7 +31,7 @@ export interface ChartContainerProps extends VictoryContainerProps {
    *
    * @example containerRef={(ref) => { this.chartRef = ref; }}
    */
-  containerRef?: React.RefObject<HTMLElement>;
+  containerRef?: React.RefObject<HTMLElement | null>;
   /**
    * The desc prop specifies the description of the chart/SVG to assist with
    * accessibility for screen readers. The more info about the chart provided in
@@ -86,7 +86,7 @@ export interface ChartContainerProps extends VictoryContainerProps {
    * render in the portal container. This prop defaults to Portal, and should only be overridden when changing rendered
    * elements from SVG to another type of element e.g., react-native-svg elements.
    */
-  portalComponent?: React.ReactElement;
+  portalComponent?: React.ReactElement<any>;
   /**
    * The portalZIndex prop determines the z-index of the div enclosing the portal component. If a portalZIndex prop is
    * not set, the z-index of the enclosing div will be set to 99.

--- a/packages/react-charts/src/victory/components/ChartCursorContainer/ChartCursorContainer.tsx
+++ b/packages/react-charts/src/victory/components/ChartCursorContainer/ChartCursorContainer.tsx
@@ -31,7 +31,7 @@ export interface ChartCursorContainerProps extends VictoryCursorContainerProps {
    * @private
    * @hide
    */
-  children?: React.ReactElement | React.ReactElement[];
+  children?: React.ReactElement<any> | React.ReactElement<any>[];
   /**
    * The className prop specifies a className that will be applied to the outermost div rendered by the container
    */
@@ -66,7 +66,7 @@ export interface ChartCursorContainerProps extends VictoryCursorContainerProps {
    * new element created from the passed cursorLabelComponent will be supplied with the following props: x, y, active,
    * text. If cursorLabelComponent is omitted, a new ChartLabel will be created with the props described above.
    */
-  cursorLabelComponent?: React.ReactElement;
+  cursorLabelComponent?: React.ReactElement<any>;
   /**
    * The cursorLabelOffset prop determines the pixel offset of the cursor label from the cursor point. This prop should
    * be an Object with x and y properties, or a number to be used for both dimensions.
@@ -150,7 +150,7 @@ export interface ChartCursorContainerProps extends VictoryCursorContainerProps {
    * render in the portal container. This prop defaults to Portal, and should only be overridden when changing rendered
    * elements from SVG to another type of element e.g., react-native-svg elements.
    */
-  portalComponent?: React.ReactElement;
+  portalComponent?: React.ReactElement<any>;
   /**
    * The portalZIndex prop determines the z-index of the div enclosing the portal component. If a portalZIndex prop is
    * not set, the z-index of the enclosing div will be set to 99.

--- a/packages/react-charts/src/victory/components/ChartCursorTooltip/ChartCursorFlyout.tsx
+++ b/packages/react-charts/src/victory/components/ChartCursorTooltip/ChartCursorFlyout.tsx
@@ -102,7 +102,7 @@ interface ChartCursorFlyoutProps extends VictoryCommonPrimitiveProps {
   dy?: number;
   height?: number;
   orientation?: OrientationTypes;
-  pathComponent?: React.ReactElement;
+  pathComponent?: React.ReactElement<any>;
   pointerLength?: number;
   pointerWidth?: number;
   width?: number;

--- a/packages/react-charts/src/victory/components/ChartVoronoiContainer/ChartVoronoiContainer.tsx
+++ b/packages/react-charts/src/victory/components/ChartVoronoiContainer/ChartVoronoiContainer.tsx
@@ -41,7 +41,7 @@ export interface ChartVoronoiContainerProps extends VictoryVoronoiContainerProps
    * @private
    * @hide
    */
-  children?: React.ReactElement | React.ReactElement[];
+  children?: React.ReactElement<any> | React.ReactElement<any>[];
   /**
    * The className prop specifies a className that will be applied to the outermost div rendered by the container
    */
@@ -150,7 +150,7 @@ export interface ChartVoronoiContainerProps extends VictoryVoronoiContainerProps
    * render in the portal container. This prop defaults to Portal, and should only be overridden when changing rendered
    * elements from SVG to another type of element e.g., react-native-svg elements.
    */
-  portalComponent?: React.ReactElement;
+  portalComponent?: React.ReactElement<any>;
   /**
    * The portalZIndex prop determines the z-index of the div enclosing the portal component. If a portalZIndex prop is
    * not set, the z-index of the enclosing div will be set to 99.

--- a/packages/react-core/src/components/Alert/Alert.tsx
+++ b/packages/react-core/src/components/Alert/Alert.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useState } from 'react';
+import { useState, type JSX } from 'react';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Alert/alert';
 import { AlertIcon } from './AlertIcon';
@@ -124,7 +124,7 @@ export const Alert: React.FunctionComponent<AlertProps> = ({
   const titleRef = React.useRef(null);
   const TitleComponent = component as any;
 
-  const divRef = React.useRef<HTMLDivElement>();
+  const divRef = React.useRef<HTMLDivElement>(undefined);
   const [isTooltipVisible, setIsTooltipVisible] = useState(false);
   React.useEffect(() => {
     if (!titleRef.current || !truncateTitle) {

--- a/packages/react-core/src/components/Alert/__tests__/Alert.test.tsx
+++ b/packages/react-core/src/components/Alert/__tests__/Alert.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 
 import { Alert, AlertVariant } from '../Alert';
 import { AlertContext } from '../AlertContext';

--- a/packages/react-core/src/components/BackToTop/__tests__/BackToTop.test.tsx
+++ b/packages/react-core/src/components/BackToTop/__tests__/BackToTop.test.tsx
@@ -76,7 +76,7 @@ test('Renders with passed aria-label', () => {
 });
 
 test('BackToTop can be accessed via passed innerRef', () => {
-  const testRef: RefObject<HTMLElement> = React.createRef();
+  const testRef: RefObject<HTMLElement | null> = React.createRef();
   render(<BackToTop innerRef={testRef} isAlwaysVisible />);
   global.scrollTo = jest.fn();
   testRef.current?.click();

--- a/packages/react-core/src/components/Breadcrumb/examples/BreadcrumbDropdown.tsx
+++ b/packages/react-core/src/components/Breadcrumb/examples/BreadcrumbDropdown.tsx
@@ -48,7 +48,7 @@ const dropdownItems = [
 
 export const BreadcrumbDropdown: React.FunctionComponent = () => {
   const [isOpen, setIsOpen] = React.useState(false);
-  const badgeToggleRef = React.useRef<HTMLButtonElement>();
+  const badgeToggleRef = React.useRef<HTMLButtonElement>(undefined);
 
   const onToggle = () => setIsOpen(!isOpen);
 

--- a/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
+++ b/packages/react-core/src/components/CalendarMonth/CalendarMonth.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, type JSX } from 'react';
 import { TextInput } from '../TextInput';
 import { Button } from '../Button';
 import { Select, SelectList, SelectOption } from '../Select';
@@ -169,7 +169,7 @@ export const CalendarMonth = ({
   const [yearInput, setYearInput] = React.useState(yearFormatted.toString());
 
   const [hoveredDate, setHoveredDate] = React.useState<Date>(undefined);
-  const focusRef = React.useRef<HTMLButtonElement>();
+  const focusRef = React.useRef<HTMLButtonElement>(undefined);
   const [hiddenMonthId] = React.useState(getUniqueId('hidden-month-span'));
   const [shouldFocus, setShouldFocus] = React.useState(false);
 

--- a/packages/react-core/src/components/Card/Card.tsx
+++ b/packages/react-core/src/components/Card/Card.tsx
@@ -3,6 +3,8 @@ import styles from '@patternfly/react-styles/css/components/Card/card';
 import { css } from '@patternfly/react-styles';
 import { useOUIAProps, OUIAProps } from '../../helpers';
 
+import type { JSX } from 'react';
+
 export interface CardProps extends React.HTMLProps<HTMLElement>, OUIAProps {
   /** Content rendered inside the Card */
   children?: React.ReactNode;

--- a/packages/react-core/src/components/Card/CardBody.tsx
+++ b/packages/react-core/src/components/Card/CardBody.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/Card/card';
 import { css } from '@patternfly/react-styles';
 
+import type { JSX } from 'react';
+
 export interface CardBodyProps extends React.HTMLProps<HTMLDivElement> {
   /** Content rendered inside the Card Body */
   children?: React.ReactNode;

--- a/packages/react-core/src/components/Card/CardFooter.tsx
+++ b/packages/react-core/src/components/Card/CardFooter.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/Card/card';
 import { css } from '@patternfly/react-styles';
 
+import type { JSX } from 'react';
+
 export interface CardFooterProps extends React.HTMLProps<HTMLDivElement> {
   /** Content rendered inside the Card Footer */
   children?: React.ReactNode;

--- a/packages/react-core/src/components/Card/CardTitle.tsx
+++ b/packages/react-core/src/components/Card/CardTitle.tsx
@@ -3,6 +3,8 @@ import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Card/card';
 import { CardContext } from './Card';
 
+import type { JSX } from 'react';
+
 export interface CardTitleProps extends React.HTMLProps<HTMLDivElement> {
   /** Content rendered inside the CardTitle */
   children?: React.ReactNode;

--- a/packages/react-core/src/components/Card/__tests__/Card.test.tsx
+++ b/packages/react-core/src/components/Card/__tests__/Card.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { type JSX } from 'react';
 
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';

--- a/packages/react-core/src/components/Card/__tests__/CardBody.test.tsx
+++ b/packages/react-core/src/components/Card/__tests__/CardBody.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { type JSX } from 'react';
 import { render, screen } from '@testing-library/react';
 import { CardBody } from '../CardBody';
 

--- a/packages/react-core/src/components/Card/__tests__/CardFooter.test.tsx
+++ b/packages/react-core/src/components/Card/__tests__/CardFooter.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { type JSX } from 'react';
 import { render, screen } from '@testing-library/react';
 import { CardFooter } from '../CardFooter';
 

--- a/packages/react-core/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react-core/src/components/Checkbox/Checkbox.tsx
@@ -125,7 +125,9 @@ class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
         aria-label={ariaLabel}
         disabled={isDisabled}
         required={isRequired}
-        ref={(elem) => elem && (elem.indeterminate = isChecked === null)}
+        ref={(elem) => {
+          elem && (elem.indeterminate = isChecked === null);
+        }}
         {...checkedProps}
         {...getOUIAProps(Checkbox.displayName, ouiaId !== undefined ? ouiaId : this.state.ouiaStateId, ouiaSafe)}
       />

--- a/packages/react-core/src/components/DataList/DataList.tsx
+++ b/packages/react-core/src/components/DataList/DataList.tsx
@@ -38,7 +38,7 @@ export interface DataListProps extends React.HTMLProps<HTMLUListElement> {
   /** Object that causes the data list to render hidden inputs which improve selectable item a11y */
   onSelectableRowChange?: (event: React.FormEvent<HTMLInputElement>, id: string) => void;
   /** @hide custom ref of the DataList */
-  innerRef?: React.RefObject<HTMLUListElement>;
+  innerRef?: React.RefObject<HTMLUListElement | null>;
 }
 
 interface DataListContextProps {

--- a/packages/react-core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-core/src/components/DatePicker/DatePicker.tsx
@@ -133,9 +133,9 @@ const DatePickerBase = (
   const [textInputFocused, setTextInputFocused] = React.useState(false);
   const widthChars = React.useMemo(() => Math.max(dateFormat(new Date()).length, placeholder.length), [dateFormat]);
   const style = { [cssFormControlWidthChars.name]: widthChars, ...styleProps };
-  const buttonRef = React.useRef<HTMLButtonElement>();
-  const datePickerWrapperRef = React.useRef<HTMLDivElement>();
-  const triggerRef = React.useRef<HTMLDivElement>();
+  const buttonRef = React.useRef<HTMLButtonElement>(undefined);
+  const datePickerWrapperRef = React.useRef<HTMLDivElement>(undefined);
+  const triggerRef = React.useRef<HTMLDivElement>(undefined);
   const dateIsRequired = requiredDateOptions?.isRequired || false;
   const emptyDateText = requiredDateOptions?.emptyDateText || 'Date cannot be blank';
 

--- a/packages/react-core/src/components/Drawer/Drawer.tsx
+++ b/packages/react-core/src/components/Drawer/Drawer.tsx
@@ -30,8 +30,8 @@ export interface DrawerContextProps {
   isStatic: boolean;
   onExpand?: (event: KeyboardEvent | React.MouseEvent | React.TransitionEvent) => void;
   position?: string;
-  drawerRef?: React.RefObject<HTMLDivElement>;
-  drawerContentRef?: React.RefObject<HTMLDivElement>;
+  drawerRef?: React.RefObject<HTMLDivElement | null>;
+  drawerContentRef?: React.RefObject<HTMLDivElement | null>;
   isInline: boolean;
 }
 
@@ -55,8 +55,8 @@ export const Drawer: React.FunctionComponent<DrawerProps> = ({
   onExpand = () => {},
   ...props
 }: DrawerProps) => {
-  const drawerRef = React.useRef<HTMLDivElement>();
-  const drawerContentRef = React.useRef<HTMLDivElement>();
+  const drawerRef = React.useRef<HTMLDivElement>(undefined);
+  const drawerContentRef = React.useRef<HTMLDivElement>(undefined);
 
   return (
     <DrawerContext.Provider value={{ isExpanded, isStatic, onExpand, position, drawerRef, drawerContentRef, isInline }}>

--- a/packages/react-core/src/components/Drawer/DrawerPanelContent.tsx
+++ b/packages/react-core/src/components/Drawer/DrawerPanelContent.tsx
@@ -79,8 +79,8 @@ export const DrawerPanelContent: React.FunctionComponent<DrawerPanelContentProps
   focusTrap,
   ...props
 }: DrawerPanelContentProps) => {
-  const panel = React.useRef<HTMLDivElement>();
-  const splitterRef = React.useRef<HTMLDivElement>();
+  const panel = React.useRef<HTMLDivElement>(undefined);
+  const splitterRef = React.useRef<HTMLDivElement>(undefined);
   const [separatorValue, setSeparatorValue] = React.useState(0);
   const { position, isExpanded, isStatic, onExpand, drawerRef, drawerContentRef, isInline } =
     React.useContext(DrawerContext);

--- a/packages/react-core/src/components/Drawer/examples/DrawerAdditionalSectionAboveContent.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerAdditionalSectionAboveContent.tsx
@@ -13,7 +13,7 @@ import {
 
 export const DrawerAdditionalSectionAboveContent: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = React.useState(false);
-  const drawerRef = React.useRef<HTMLDivElement>();
+  const drawerRef = React.useRef<HTMLDivElement>(undefined);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerBasic.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerBasic.tsx
@@ -14,7 +14,7 @@ import {
 
 export const DrawerBasic: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = React.useState(false);
-  const drawerRef = React.useRef<HTMLDivElement>();
+  const drawerRef = React.useRef<HTMLDivElement>(undefined);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerBasicInline.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerBasicInline.tsx
@@ -12,7 +12,7 @@ import {
 
 export const DrawerBasicInline: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = React.useState(false);
-  const drawerRef = React.useRef<HTMLDivElement>();
+  const drawerRef = React.useRef<HTMLDivElement>(undefined);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerBreakpoint.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerBreakpoint.tsx
@@ -12,7 +12,7 @@ import {
 
 export const DrawerBreakpoint: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = React.useState(false);
-  const drawerRef = React.useRef<HTMLDivElement>();
+  const drawerRef = React.useRef<HTMLDivElement>(undefined);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerInlinePanelEnd.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerInlinePanelEnd.tsx
@@ -12,7 +12,7 @@ import {
 
 export const DrawerInlinePanelEnd: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = React.useState(false);
-  const drawerRef = React.useRef<HTMLDivElement>();
+  const drawerRef = React.useRef<HTMLDivElement>(undefined);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerInlinePanelStart.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerInlinePanelStart.tsx
@@ -12,7 +12,7 @@ import {
 
 export const DrawerInlinePanelStart: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = React.useState(false);
-  const drawerRef = React.useRef<HTMLDivElement>();
+  const drawerRef = React.useRef<HTMLDivElement>(undefined);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerModifiedContentPadding.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerModifiedContentPadding.tsx
@@ -12,7 +12,7 @@ import {
 
 export const DrawerModifiedContentPadding: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = React.useState(false);
-  const drawerRef = React.useRef<HTMLDivElement>();
+  const drawerRef = React.useRef<HTMLDivElement>(undefined);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerModifiedPanelPadding.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerModifiedPanelPadding.tsx
@@ -12,7 +12,7 @@ import {
 
 export const DrawerModifiedPanelPadding: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = React.useState(false);
-  const drawerRef = React.useRef<HTMLDivElement>();
+  const drawerRef = React.useRef<HTMLDivElement>(undefined);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerPanelBottom.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerPanelBottom.tsx
@@ -12,7 +12,7 @@ import {
 
 export const DrawerPanelBottom: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = React.useState(false);
-  const drawerRef = React.useRef<HTMLDivElement>();
+  const drawerRef = React.useRef<HTMLDivElement>(undefined);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerPanelEnd.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerPanelEnd.tsx
@@ -12,7 +12,7 @@ import {
 
 export const DrawerPanelEnd: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = React.useState(false);
-  const drawerRef = React.useRef<HTMLDivElement>();
+  const drawerRef = React.useRef<HTMLDivElement>(undefined);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerPanelStart.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerPanelStart.tsx
@@ -12,7 +12,7 @@ import {
 
 export const DrawerPanelStart: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = React.useState(false);
-  const drawerRef = React.useRef<HTMLDivElement>();
+  const drawerRef = React.useRef<HTMLDivElement>(undefined);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerResizableAtEnd.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerResizableAtEnd.tsx
@@ -12,7 +12,7 @@ import {
 
 export const DrawerResizableAtEnd: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = React.useState(false);
-  const drawerRef = React.useRef<HTMLDivElement>();
+  const drawerRef = React.useRef<HTMLDivElement>(undefined);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerResizableAtStart.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerResizableAtStart.tsx
@@ -12,7 +12,7 @@ import {
 
 export const DrawerResizableAtStart: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = React.useState(false);
-  const drawerRef = React.useRef<HTMLDivElement>();
+  const drawerRef = React.useRef<HTMLDivElement>(undefined);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerResizableOnBottom.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerResizableOnBottom.tsx
@@ -12,7 +12,7 @@ import {
 
 export const DrawerResizableOnBottom: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = React.useState(false);
-  const drawerRef = React.useRef<HTMLDivElement>();
+  const drawerRef = React.useRef<HTMLDivElement>(undefined);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerResizableOnInline.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerResizableOnInline.tsx
@@ -12,7 +12,7 @@ import {
 
 export const DrawerResizableOnInline: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = React.useState(false);
-  const drawerRef = React.useRef<HTMLDivElement>();
+  const drawerRef = React.useRef<HTMLDivElement>(undefined);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerStackedContentBodyElements.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerStackedContentBodyElements.tsx
@@ -14,7 +14,7 @@ import {
 
 export const DrawerStackedContentBodyElements: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = React.useState(false);
-  const drawerRef = React.useRef<HTMLDivElement>();
+  const drawerRef = React.useRef<HTMLDivElement>(undefined);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerStatic.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerStatic.tsx
@@ -13,7 +13,7 @@ import accessibility from '@patternfly/react-styles/css/utilities/Accessibility/
 
 export const DrawerStatic: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = React.useState(false);
-  const drawerRef = React.useRef<HTMLDivElement>();
+  const drawerRef = React.useRef<HTMLDivElement>(undefined);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react-core/src/components/Dropdown/Dropdown.tsx
@@ -27,7 +27,7 @@ export interface DropdownToggleProps {
   /**  Dropdown toggle node. */
   toggleNode: React.ReactNode;
   /** Reference to the toggle. */
-  toggleRef?: React.RefObject<HTMLButtonElement>;
+  toggleRef?: React.RefObject<HTMLButtonElement | null>;
 }
 
 /**
@@ -103,15 +103,15 @@ const DropdownBase: React.FunctionComponent<DropdownProps> = ({
   focusTimeoutDelay = 0,
   ...props
 }: DropdownProps) => {
-  const localMenuRef = React.useRef<HTMLDivElement>();
-  const localToggleRef = React.useRef<HTMLButtonElement>();
+  const localMenuRef = React.useRef<HTMLDivElement>(undefined);
+  const localToggleRef = React.useRef<HTMLButtonElement>(undefined);
   const ouiaProps = useOUIAProps(Dropdown.displayName, ouiaId, ouiaSafe);
 
-  const menuRef = (innerRef as React.RefObject<HTMLDivElement>) || localMenuRef;
+  const menuRef = (innerRef as React.RefObject<HTMLDivElement | null>) || localMenuRef;
   const toggleRef =
     typeof toggle === 'function' || (typeof toggle !== 'function' && !toggle.toggleRef)
       ? localToggleRef
-      : (toggle?.toggleRef as React.RefObject<HTMLButtonElement>);
+      : (toggle?.toggleRef as React.RefObject<HTMLButtonElement | null>);
 
   const prevIsOpen = React.useRef<boolean>(isOpen);
   React.useEffect(() => {

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorControlsWrapper.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorControlsWrapper.tsx
@@ -11,7 +11,7 @@ export interface DualListSelectorControlsWrapperProps extends React.HTMLProps<HT
   /** Additional classes added to the wrapper. */
   className?: string;
   /** @hide Forwarded ref */
-  innerRef?: React.RefObject<HTMLDivElement>;
+  innerRef?: React.RefObject<HTMLDivElement | null>;
   /** Accessible label for the dual list selector controls wrapper. */
   'aria-label'?: string;
 }

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorList.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorList.tsx
@@ -10,7 +10,7 @@ export interface DualListSelectorListProps extends React.HTMLProps<HTMLUListElem
   /** Content rendered inside the dual list selector list. */
   children?: React.ReactNode;
   /** @hide forwarded ref */
-  innerRef?: React.RefObject<HTMLUListElement>;
+  innerRef?: React.RefObject<HTMLUListElement | null>;
 }
 
 export const DualListSelectorListBase: React.FunctionComponent<DualListSelectorListProps> = ({

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorListItem.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorListItem.tsx
@@ -24,7 +24,7 @@ export interface DualListSelectorListItemProps extends React.HTMLProps<HTMLLIEle
   /** @hide Internal field used to keep track of order of unfiltered options. */
   orderIndex?: number;
   /** @hide Forwarded ref */
-  innerRef?: React.RefObject<HTMLLIElement>;
+  innerRef?: React.RefObject<HTMLLIElement | null>;
   /** Flag indicating this item is draggable for reordering. */
   isDraggable?: boolean;
   /** Accessible label for the draggable button on draggable list items. */

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorListWrapper.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorListWrapper.tsx
@@ -15,7 +15,7 @@ export interface DualListSelectorListWrapperProps extends React.HTMLProps<HTMLDi
   /** Accessibly label for the list. */
   'aria-labelledby': string;
   /** @hide forwarded ref */
-  innerRef?: React.RefObject<HTMLDivElement>;
+  innerRef?: React.RefObject<HTMLDivElement | null>;
   /** @hide Options to list in the pane. */
   options?: React.ReactNode[];
   /** @hide Options currently selected in the pane. */

--- a/packages/react-core/src/components/DualListSelector/DualListSelectorTreeItem.tsx
+++ b/packages/react-core/src/components/DualListSelector/DualListSelectorTreeItem.tsx
@@ -138,7 +138,9 @@ const DualListSelectorTreeItemBase: React.FunctionComponent<DualListSelectorTree
                     e.preventDefault();
                   }
                 }}
-                ref={(elem) => elem && (elem.indeterminate = isChecked === null)}
+                ref={(elem) => {
+                  elem && (elem.indeterminate = isChecked === null);
+                }}
                 checked={isChecked || false}
                 tabIndex={-1}
                 {...checkProps}
@@ -148,7 +150,7 @@ const DualListSelectorTreeItemBase: React.FunctionComponent<DualListSelectorTree
             <span className={css(styles.dualListSelectorItemText)}>{text}</span>
             {hasBadge && children && (
               <span className={css(styles.dualListSelectorItemCount)}>
-                <Badge {...badgeProps}>{flattenTree((children as React.ReactElement).props.data).length}</Badge>
+                <Badge {...badgeProps}>{flattenTree((children as React.ReactElement<any>).props.data).length}</Badge>
               </span>
             )}
           </span>

--- a/packages/react-core/src/components/Form/FormGroup.tsx
+++ b/packages/react-core/src/components/Form/FormGroup.tsx
@@ -14,7 +14,7 @@ export interface FormGroupProps extends Omit<React.HTMLProps<HTMLDivElement>, 'l
   /** Additional label information displayed after the label. */
   labelInfo?: React.ReactNode;
   /** A help button for the label. We recommend using FormGroupLabelHelp element as a help icon button. The help button should be wrapped or linked to our popover component. */
-  labelHelp?: React.ReactElement;
+  labelHelp?: React.ReactElement<any>;
   /** Sets the FormGroup required. */
   isRequired?: boolean;
   /** Sets the FormGroup isInline. */

--- a/packages/react-core/src/components/JumpLinks/JumpLinks.tsx
+++ b/packages/react-core/src/components/JumpLinks/JumpLinks.tsx
@@ -21,7 +21,7 @@ export interface JumpLinksProps extends Omit<React.HTMLProps<HTMLElement>, 'labe
   /** Adds an accessible label to the internal nav element. Defaults to the value of the label prop. */
   'aria-label'?: string;
   /** Reference to the scrollable element to spy on. Takes precedence over scrollableSelector. Not passing a scrollableRef or scrollableSelector disables spying. */
-  scrollableRef?: HTMLElement | (() => HTMLElement) | React.RefObject<HTMLElement>;
+  scrollableRef?: HTMLElement | (() => HTMLElement) | React.RefObject<HTMLElement | null>;
   /** Selector for the scrollable element to spy on. Not passing a scrollableSelector or scrollableRef disables spying. */
   scrollableSelector?: string;
   /** The index of the child Jump link to make active. */
@@ -102,7 +102,7 @@ export const JumpLinks: React.FunctionComponent<JumpLinksProps> = ({
   const [isExpanded, setIsExpanded] = React.useState(isExpandedProp);
   // Boolean to disable scroll listener from overriding active state of clicked jumplink
   const isLinkClicked = React.useRef(false);
-  const navRef = React.useRef<HTMLElement>();
+  const navRef = React.useRef<HTMLElement>(undefined);
 
   let scrollableElement: HTMLElement;
 
@@ -113,7 +113,7 @@ export const JumpLinks: React.FunctionComponent<JumpLinksProps> = ({
       } else if (typeof scrollableRef === 'function') {
         return scrollableRef();
       }
-      return (scrollableRef as React.RefObject<HTMLElement>).current;
+      return (scrollableRef as React.RefObject<HTMLElement | null>).current;
     } else if (scrollableSelector) {
       return document.querySelector(scrollableSelector) as HTMLElement;
     }

--- a/packages/react-core/src/components/Label/Label.tsx
+++ b/packages/react-core/src/components/Label/Label.tsx
@@ -127,8 +127,8 @@ export const Label: React.FunctionComponent<LabelProps> = ({
 }: LabelProps) => {
   const [isEditableActive, setIsEditableActive] = useState<boolean>(false);
   const [currValue, setCurrValue] = useState(children);
-  const editableButtonRef = React.useRef<HTMLButtonElement>();
-  const editableInputRef = React.useRef<HTMLInputElement>();
+  const editableButtonRef = React.useRef<HTMLButtonElement>(undefined);
+  const editableInputRef = React.useRef<HTMLInputElement>(undefined);
 
   const isOverflowLabel = variant === 'overflow';
   const isAddLabel = variant === 'add';
@@ -245,7 +245,7 @@ export const Label: React.FunctionComponent<LabelProps> = ({
   const closeButton = <span className={css(styles.labelActions)}>{closeBtn || defaultCloseButton}</span>;
   const textRef = React.createRef<any>();
   // ref to apply tooltip when rendered is used
-  const componentRef = React.useRef();
+  const componentRef = React.useRef(undefined);
   const [isTooltipVisible, setIsTooltipVisible] = React.useState(false);
   useIsomorphicLayoutEffect(() => {
     const currTextRef = isEditable ? editableButtonRef : textRef;

--- a/packages/react-core/src/components/Label/examples/LabelGroupEditableAddDropdown.tsx
+++ b/packages/react-core/src/components/Label/examples/LabelGroupEditableAddDropdown.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { LabelGroup, Label, Menu, MenuContent, MenuList, MenuItem, Popper } from '@patternfly/react-core';
 
 export const LabelGroupEditableAddDropdown: React.FunctionComponent = () => {
-  const toggleRef = React.useRef<HTMLDivElement>();
-  const menuRef = React.useRef<HTMLDivElement>();
-  const containerRef = React.useRef<HTMLDivElement>();
+  const toggleRef = React.useRef<HTMLDivElement>(undefined);
+  const menuRef = React.useRef<HTMLDivElement>(undefined);
+  const containerRef = React.useRef<HTMLDivElement>(undefined);
 
   const [idIndex, setIdIndex] = React.useState<number>(3);
   const [isOpen, setIsOpen] = React.useState<boolean>(false);

--- a/packages/react-core/src/components/List/List.tsx
+++ b/packages/react-core/src/components/List/List.tsx
@@ -54,7 +54,7 @@ export const List: React.FunctionComponent<ListProps> = ({
 }: ListProps) =>
   component === ListComponent.ol ? (
     <ol
-      ref={ref as React.LegacyRef<HTMLOListElement>}
+      ref={ref as React.Ref<HTMLOListElement>}
       type={type}
       {...(isPlain && { role: 'list' })}
       {...props}
@@ -71,7 +71,7 @@ export const List: React.FunctionComponent<ListProps> = ({
     </ol>
   ) : (
     <ul
-      ref={ref as React.LegacyRef<HTMLUListElement>}
+      ref={ref as React.Ref<HTMLUListElement>}
       {...(isPlain && { role: 'list' })}
       {...props}
       className={css(

--- a/packages/react-core/src/components/Menu/Menu.tsx
+++ b/packages/react-core/src/components/Menu/Menu.tsx
@@ -90,7 +90,7 @@ class MenuBase extends React.Component<MenuProps, MenuState> {
   constructor(props: MenuProps) {
     super(props);
     if (props.innerRef) {
-      this.menuRef = props.innerRef as React.RefObject<HTMLDivElement>;
+      this.menuRef = props.innerRef as React.RefObject<HTMLDivElement | null>;
     }
   }
 
@@ -290,7 +290,7 @@ class MenuBase extends React.Component<MenuProps, MenuState> {
       >
         {isRootMenu && (
           <KeyboardHandler
-            containerRef={(this.menuRef as React.RefObject<HTMLDivElement>) || null}
+            containerRef={(this.menuRef as React.RefObject<HTMLDivElement | null>) || null}
             additionalKeyHandler={this.handleExtraKeys}
             createNavigableElements={this.createNavigableElements}
             isActiveElement={(element: Element) =>

--- a/packages/react-core/src/components/Menu/MenuContent.tsx
+++ b/packages/react-core/src/components/Menu/MenuContent.tsx
@@ -57,7 +57,9 @@ export const MenuContent = React.forwardRef((props: MenuContentProps, ref: React
         <div
           {...rest}
           className={css(styles.menuContent, props.className)}
-          ref={(el) => refCallback(el, menuId, onGetMenuHeight)}
+          ref={(el) => {
+            refCallback(el, menuId, onGetMenuHeight);
+          }}
           style={
             {
               ...(menuHeight && { [cssHeight.name]: menuHeight }),

--- a/packages/react-core/src/components/Menu/MenuItem.tsx
+++ b/packages/react-core/src/components/Menu/MenuItem.tsx
@@ -68,7 +68,7 @@ export interface MenuItemProps extends Omit<React.HTMLProps<HTMLLIElement>, 'onC
   /** Flag indicating the item is in danger state */
   isDanger?: boolean;
   /** Flyout menu. Should not be used if the to prop is defined. */
-  flyoutMenu?: React.ReactElement;
+  flyoutMenu?: React.ReactElement<any>;
   /** Callback function when mouse leaves trigger */
   onShowFlyout?: (event?: any) => void;
   /** Drilldown menu of the item. Should be a Menu or DrilldownMenu type. */
@@ -146,7 +146,7 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
   const [flyoutTarget, setFlyoutTarget] = React.useState(null);
   const flyoutContext = React.useContext(FlyoutContext);
   const [flyoutXDirection, setFlyoutXDirection] = React.useState(flyoutContext.direction);
-  const ref = React.useRef<HTMLLIElement>();
+  const ref = React.useRef<HTMLLIElement>(undefined);
   const flyoutVisible = ref === flyoutRef;
 
   const hasFlyout = flyoutMenu !== undefined;
@@ -259,7 +259,7 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
           menuId,
           typeof drilldownMenu === 'function'
             ? (drilldownMenu() as any).props.id
-            : (drilldownMenu as React.ReactElement).props.id,
+            : (drilldownMenu as React.ReactElement<any>).props.id,
           itemId
         );
     } else {

--- a/packages/react-core/src/components/Menu/examples/MenuWithDrilldownBreadcrumbs.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuWithDrilldownBreadcrumbs.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { type JSX } from 'react';
 import {
   Badge,
   Breadcrumb,

--- a/packages/react-core/src/components/MenuToggle/MenuToggleCheckbox.tsx
+++ b/packages/react-core/src/components/MenuToggle/MenuToggleCheckbox.tsx
@@ -90,7 +90,9 @@ class MenuToggleCheckbox extends React.Component<MenuToggleCheckboxProps, { ouia
           {...(this.calculateChecked() !== undefined && { onChange: this.handleChange })}
           name={id}
           type="checkbox"
-          ref={(elem) => elem && (elem.indeterminate = isChecked === null)}
+          ref={(elem) => {
+            elem && (elem.indeterminate = isChecked === null);
+          }}
           aria-invalid={!isValid}
           disabled={isDisabled}
           {...(defaultChecked !== undefined ? { defaultChecked } : { checked: this.calculateChecked() })}

--- a/packages/react-core/src/components/Modal/Modal.tsx
+++ b/packages/react-core/src/components/Modal/Modal.tsx
@@ -183,7 +183,7 @@ class Modal extends React.Component<ModalProps, ModalState> {
         {...props}
       />,
       this.getElement(appendTo)
-    ) as React.ReactElement;
+    ) as React.ReactElement<any>;
   }
 }
 

--- a/packages/react-core/src/components/Nav/Nav.tsx
+++ b/packages/react-core/src/components/Nav/Nav.tsx
@@ -57,7 +57,7 @@ export interface NavContextProps {
   isHorizontal?: boolean;
   flyoutRef?: React.Ref<HTMLLIElement>;
   setFlyoutRef?: (ref: React.Ref<HTMLLIElement>) => void;
-  navRef?: React.RefObject<HTMLElement>;
+  navRef?: React.RefObject<HTMLElement | null>;
 }
 export const navContextDefaults = {};
 export const NavContext = React.createContext<NavContextProps>(navContextDefaults);

--- a/packages/react-core/src/components/Nav/NavItem.tsx
+++ b/packages/react-core/src/components/Nav/NavItem.tsx
@@ -31,7 +31,7 @@ export interface NavItemProps extends Omit<React.HTMLProps<HTMLAnchorElement>, '
   /** Component used to render NavItems if  React.isValidElement(children) is false */
   component?: React.ElementType<any> | React.ComponentType<any>;
   /** Flyout of a nav item. This should be a Menu component. Should not be used if the to prop is defined. */
-  flyout?: React.ReactElement;
+  flyout?: React.ReactElement<any>;
   /** Callback when flyout is opened or closed */
   onShowFlyout?: () => void;
   /** z-index of the flyout nav item */
@@ -67,9 +67,9 @@ export const NavItem: React.FunctionComponent<NavItemProps> = ({
   const { isSidebarOpen } = React.useContext(PageSidebarContext);
   const [flyoutTarget, setFlyoutTarget] = React.useState(null);
   const [isHovered, setIsHovered] = React.useState(false);
-  const ref = React.useRef<HTMLLIElement>();
+  const ref = React.useRef<HTMLLIElement>(undefined);
   const flyoutVisible = ref === flyoutRef;
-  const popperRef = React.useRef<HTMLDivElement>();
+  const popperRef = React.useRef<HTMLDivElement>(undefined);
   const hasFlyout = flyout !== undefined;
   const Component = hasFlyout ? 'button' : (component as any);
 
@@ -200,7 +200,7 @@ export const NavItem: React.FunctionComponent<NavItemProps> = ({
     );
   };
 
-  const renderClonedChild = (context: any, child: React.ReactElement): React.ReactNode =>
+  const renderClonedChild = (context: any, child: React.ReactElement<any>): React.ReactNode =>
     React.cloneElement(child, {
       onClick: (e: MouseEvent) => context.onSelect(e, groupId, itemId, to, preventDefault, onClick),
       'aria-current': isActive ? 'page' : null,
@@ -256,7 +256,7 @@ export const NavItem: React.FunctionComponent<NavItemProps> = ({
         <NavContext.Consumer>
           {(context) =>
             React.isValidElement(children)
-              ? renderClonedChild(context, children as React.ReactElement)
+              ? renderClonedChild(context, children as React.ReactElement<any>)
               : renderDefaultLink(context)
           }
         </NavContext.Consumer>

--- a/packages/react-core/src/components/Nav/examples/NavDrilldown.tsx
+++ b/packages/react-core/src/components/Nav/examples/NavDrilldown.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { type JSX } from 'react';
 
 import { Nav, MenuContent, MenuItem, MenuList, DrilldownMenu, Menu } from '@patternfly/react-core';
 

--- a/packages/react-core/src/components/Page/Page.tsx
+++ b/packages/react-core/src/components/Page/Page.tsx
@@ -11,6 +11,8 @@ import { getBreakpoint, getVerticalBreakpoint } from '../../helpers/util';
 import { PageContextProvider } from './PageContext';
 import { PageBody } from './PageBody';
 
+import type { JSX } from 'react';
+
 export enum PageLayouts {
   vertical = 'vertical',
   horizontal = 'horizontal'
@@ -39,7 +41,7 @@ export interface PageProps extends React.HTMLProps<HTMLDivElement> {
   /** Callback when notification drawer panel is finished expanding. */
   onNotificationDrawerExpand?: (event: KeyboardEvent | React.MouseEvent | React.TransitionEvent) => void;
   /** Skip to content component for the page */
-  skipToContent?: React.ReactElement;
+  skipToContent?: React.ReactElement<any>;
   /** Sets the value for role on the <main> element */
   role?: string;
   /** an id to use for the [role="main"] element */

--- a/packages/react-core/src/components/Page/PageSection.tsx
+++ b/packages/react-core/src/components/Page/PageSection.tsx
@@ -5,6 +5,8 @@ import { formatBreakpointMods } from '../../helpers/util';
 import { PageContext } from './PageContext';
 import { PageBody } from './PageBody';
 
+import type { JSX } from 'react';
+
 export enum PageSectionVariants {
   default = 'default',
   secondary = 'secondary'

--- a/packages/react-core/src/components/Pagination/Pagination.tsx
+++ b/packages/react-core/src/components/Pagination/Pagination.tsx
@@ -160,7 +160,7 @@ export interface PaginationProps extends React.HTMLProps<HTMLDivElement>, OUIAPr
   /** This will be shown in pagination toggle span. You can use firstIndex, lastIndex,
    * itemCount, itemsTitle, and/or ofWord props.
    */
-  toggleTemplate?: ((props: PaginationToggleTemplateProps) => React.ReactElement) | string;
+  toggleTemplate?: ((props: PaginationToggleTemplateProps) => React.ReactElement<any>) | string;
   /** Position where pagination is rendered. */
   variant?: 'top' | 'bottom' | PaginationVariant;
   /** Id to ideintify widget on page. */
@@ -304,7 +304,7 @@ export const Pagination: React.FunctionComponent<PaginationProps> = ({
             fillTemplate(toggleTemplate, PaginationToggleTemplateProps)}
           {toggleTemplate &&
             typeof toggleTemplate !== 'string' &&
-            (toggleTemplate as (props: PaginationToggleTemplateProps) => React.ReactElement)(
+            (toggleTemplate as (props: PaginationToggleTemplateProps) => React.ReactElement<any>)(
               PaginationToggleTemplateProps
             )}
           {!toggleTemplate && (

--- a/packages/react-core/src/components/Pagination/PaginationOptionsMenu.tsx
+++ b/packages/react-core/src/components/Pagination/PaginationOptionsMenu.tsx
@@ -48,13 +48,13 @@ export interface PaginationOptionsMenuProps extends React.HTMLProps<HTMLDivEleme
   /** This will be shown in pagination toggle span. You can use firstIndex, lastIndex,
    * itemCount, and/or itemsTitle props.
    */
-  toggleTemplate: ((props: PaginationToggleTemplateProps) => React.ReactElement) | string;
+  toggleTemplate: ((props: PaginationToggleTemplateProps) => React.ReactElement<any>) | string;
   /** Function called when user selects number of items per page. */
   onPerPageSelect?: OnPerPageSelect;
   /** Label for the English word "of". */
   ofWord?: string;
   /** React ref for the container to append the options menu to. This is a static ref provided by the main pagination component. */
-  containerRef?: React.RefObject<HTMLDivElement>;
+  containerRef?: React.RefObject<HTMLDivElement | null>;
   /** @beta The container to append the pagination options menu to. Overrides the containerRef prop. */
   appendTo?: HTMLElement | (() => HTMLElement) | 'inline';
   /** Flag indicating if scroll on focus of the first menu item should occur. */
@@ -193,7 +193,7 @@ export const PaginationOptionsMenu: React.FunctionComponent<PaginationOptionsMen
           fillTemplate(toggleTemplate, { firstIndex, lastIndex, ofWord, itemCount, itemsTitle })}
         {toggleTemplate &&
           typeof toggleTemplate !== 'string' &&
-          (toggleTemplate as (props: PaginationToggleTemplateProps) => React.ReactElement)({
+          (toggleTemplate as (props: PaginationToggleTemplateProps) => React.ReactElement<any>)({
             firstIndex,
             lastIndex,
             ofWord,

--- a/packages/react-core/src/components/Panel/__tests__/Panel.test.tsx
+++ b/packages/react-core/src/components/Panel/__tests__/Panel.test.tsx
@@ -58,7 +58,7 @@ test(`Renders with class name ${styles.modifiers.scrollable} when isScrollable i
 
 test('Renders with ref', async () => {
   const user = userEvent.setup();
-  const panelRef: React.RefObject<HTMLDivElement> = React.createRef();
+  const panelRef: React.RefObject<HTMLDivElement | null> = React.createRef();
 
   const BasicPanel = () => {
     const [lastClickWasInPanel, setLastClickWasInPanel] = React.useState(false);

--- a/packages/react-core/src/components/ProgressStepper/ProgressStep.tsx
+++ b/packages/react-core/src/components/ProgressStepper/ProgressStep.tsx
@@ -70,7 +70,7 @@ export const ProgressStep: React.FunctionComponent<ProgressStepProps> = ({
 }: ProgressStepProps) => {
   const _icon = icon !== undefined ? icon : variantIcons[variant];
   const Component = popoverRender !== undefined ? 'button' : 'div';
-  const stepRef = React.useRef();
+  const stepRef = React.useRef(undefined);
 
   if (props.id === undefined || titleId === undefined) {
     /* eslint-disable no-console */

--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -33,7 +33,7 @@ export interface SelectToggleProps {
   /**  Select toggle node. */
   toggleNode: React.ReactNode;
   /** Reference to the toggle. */
-  toggleRef?: React.RefObject<HTMLButtonElement>;
+  toggleRef?: React.RefObject<HTMLButtonElement | null>;
 }
 
 /**
@@ -113,14 +113,14 @@ const SelectBase: React.FunctionComponent<SelectProps & OUIAProps> = ({
   focusTimeoutDelay = 0,
   ...props
 }: SelectProps & OUIAProps) => {
-  const localMenuRef = React.useRef<HTMLDivElement>();
-  const localToggleRef = React.useRef<HTMLButtonElement>();
+  const localMenuRef = React.useRef<HTMLDivElement>(undefined);
+  const localToggleRef = React.useRef<HTMLButtonElement>(undefined);
 
-  const menuRef = (innerRef as React.RefObject<HTMLDivElement>) || localMenuRef;
+  const menuRef = (innerRef as React.RefObject<HTMLDivElement | null>) || localMenuRef;
   const toggleRef =
     typeof toggle === 'function' || (typeof toggle !== 'function' && !toggle.toggleRef)
       ? localToggleRef
-      : (toggle?.toggleRef as React.RefObject<HTMLButtonElement>);
+      : (toggle?.toggleRef as React.RefObject<HTMLButtonElement | null>);
 
   const prevIsOpen = React.useRef<boolean>(isOpen);
   React.useEffect(() => {

--- a/packages/react-core/src/components/Select/examples/SelectMultiTypeahead.tsx
+++ b/packages/react-core/src/components/Select/examples/SelectMultiTypeahead.tsx
@@ -31,7 +31,7 @@ export const SelectMultiTypeahead: React.FunctionComponent = () => {
   const [selectOptions, setSelectOptions] = React.useState<SelectOptionProps[]>(initialSelectOptions);
   const [focusedItemIndex, setFocusedItemIndex] = React.useState<number | null>(null);
   const [activeItemId, setActiveItemId] = React.useState<string | null>(null);
-  const textInputRef = React.useRef<HTMLInputElement>();
+  const textInputRef = React.useRef<HTMLInputElement>(undefined);
 
   const NO_RESULTS = 'no results';
 

--- a/packages/react-core/src/components/Select/examples/SelectMultiTypeaheadCheckbox.tsx
+++ b/packages/react-core/src/components/Select/examples/SelectMultiTypeaheadCheckbox.tsx
@@ -30,7 +30,7 @@ export const SelectMultiTypeaheadCheckbox: React.FunctionComponent = () => {
   const [focusedItemIndex, setFocusedItemIndex] = React.useState<number | null>(null);
   const [activeItemId, setActiveItemId] = React.useState<string | null>(null);
   const [placeholder, setPlaceholder] = React.useState('0 items selected');
-  const textInputRef = React.useRef<HTMLInputElement>();
+  const textInputRef = React.useRef<HTMLInputElement>(undefined);
 
   const NO_RESULTS = 'no results';
 

--- a/packages/react-core/src/components/Select/examples/SelectMultiTypeaheadCreatable.tsx
+++ b/packages/react-core/src/components/Select/examples/SelectMultiTypeaheadCreatable.tsx
@@ -32,7 +32,7 @@ export const SelectMultiTypeaheadCreatable: React.FunctionComponent = () => {
   const [focusedItemIndex, setFocusedItemIndex] = React.useState<number | null>(null);
   const [activeItemId, setActiveItemId] = React.useState<string | null>(null);
   const [onCreation, setOnCreation] = React.useState<boolean>(false); // Boolean to refresh filter state after new option is created
-  const textInputRef = React.useRef<HTMLInputElement>();
+  const textInputRef = React.useRef<HTMLInputElement>(undefined);
 
   const CREATE_NEW = 'create';
 

--- a/packages/react-core/src/components/Select/examples/SelectTypeahead.tsx
+++ b/packages/react-core/src/components/Select/examples/SelectTypeahead.tsx
@@ -30,7 +30,7 @@ export const SelectTypeahead: React.FunctionComponent = () => {
   const [selectOptions, setSelectOptions] = React.useState<SelectOptionProps[]>(initialSelectOptions);
   const [focusedItemIndex, setFocusedItemIndex] = React.useState<number | null>(null);
   const [activeItemId, setActiveItemId] = React.useState<string | null>(null);
-  const textInputRef = React.useRef<HTMLInputElement>();
+  const textInputRef = React.useRef<HTMLInputElement>(undefined);
 
   const NO_RESULTS = 'no results';
 

--- a/packages/react-core/src/components/Select/examples/SelectTypeaheadCreatable.tsx
+++ b/packages/react-core/src/components/Select/examples/SelectTypeaheadCreatable.tsx
@@ -30,7 +30,7 @@ export const SelectTypeaheadCreatable: React.FunctionComponent = () => {
   const [selectOptions, setSelectOptions] = React.useState<SelectOptionProps[]>(initialSelectOptions);
   const [focusedItemIndex, setFocusedItemIndex] = React.useState<number | null>(null);
   const [activeItemId, setActiveItemId] = React.useState<string | null>(null);
-  const textInputRef = React.useRef<HTMLInputElement>();
+  const textInputRef = React.useRef<HTMLInputElement>(undefined);
 
   const CREATE_NEW = 'create';
 

--- a/packages/react-core/src/components/SimpleList/SimpleList.tsx
+++ b/packages/react-core/src/components/SimpleList/SimpleList.tsx
@@ -11,7 +11,7 @@ export interface SimpleListProps extends Omit<React.HTMLProps<HTMLDivElement>, '
   className?: string;
   /** Callback when an item is selected */
   onSelect?: (
-    ref: React.RefObject<HTMLButtonElement> | React.RefObject<HTMLAnchorElement>,
+    ref: React.RefObject<HTMLButtonElement | null> | React.RefObject<HTMLAnchorElement | null>,
     props: SimpleListItemProps
   ) => void;
   /** Indicates whether component is controlled by its internal state */
@@ -22,13 +22,13 @@ export interface SimpleListProps extends Omit<React.HTMLProps<HTMLDivElement>, '
 
 export interface SimpleListState {
   /** Ref of the current SimpleListItem */
-  currentRef: React.RefObject<HTMLButtonElement> | React.RefObject<HTMLAnchorElement>;
+  currentRef: React.RefObject<HTMLButtonElement | null> | React.RefObject<HTMLAnchorElement | null>;
 }
 
 interface SimpleListContextProps {
-  currentRef: React.RefObject<HTMLButtonElement> | React.RefObject<HTMLAnchorElement>;
+  currentRef: React.RefObject<HTMLButtonElement | null> | React.RefObject<HTMLAnchorElement | null>;
   updateCurrentRef: (
-    id: React.RefObject<HTMLButtonElement> | React.RefObject<HTMLAnchorElement>,
+    id: React.RefObject<HTMLButtonElement | null> | React.RefObject<HTMLAnchorElement | null>,
     props: SimpleListItemProps
   ) => void;
   isControlled: boolean;
@@ -39,7 +39,7 @@ export const SimpleListContext = React.createContext<Partial<SimpleListContextPr
 class SimpleList extends React.Component<SimpleListProps, SimpleListState> {
   static displayName = 'SimpleList';
   state = {
-    currentRef: null as React.RefObject<HTMLButtonElement> | React.RefObject<HTMLAnchorElement>
+    currentRef: null as React.RefObject<HTMLButtonElement | null> | React.RefObject<HTMLAnchorElement | null>
   };
 
   static defaultProps: SimpleListProps = {
@@ -49,7 +49,7 @@ class SimpleList extends React.Component<SimpleListProps, SimpleListState> {
   };
 
   handleCurrentUpdate = (
-    newCurrentRef: React.RefObject<HTMLButtonElement> | React.RefObject<HTMLAnchorElement>,
+    newCurrentRef: React.RefObject<HTMLButtonElement | null> | React.RefObject<HTMLAnchorElement | null>,
     itemProps: SimpleListItemProps
   ) => {
     this.setState({ currentRef: newCurrentRef });
@@ -63,7 +63,7 @@ class SimpleList extends React.Component<SimpleListProps, SimpleListState> {
 
     let isGrouped = false;
     if (children) {
-      isGrouped = (React.Children.toArray(children)[0] as React.ReactElement).type === SimpleListGroup;
+      isGrouped = (React.Children.toArray(children)[0] as React.ReactElement<any>).type === SimpleListGroup;
     }
 
     return (

--- a/packages/react-core/src/components/SimpleList/examples/SimpleListUncontrolled.tsx
+++ b/packages/react-core/src/components/SimpleList/examples/SimpleListUncontrolled.tsx
@@ -5,7 +5,7 @@ export const SimpleListUncontrolled: React.FunctionComponent = () => {
   const [activeItem, setActiveItem] = React.useState(0);
 
   const onSelect = (
-    selectedItem: React.RefObject<HTMLButtonElement> | React.RefObject<HTMLAnchorElement>,
+    selectedItem: React.RefObject<HTMLButtonElement | null> | React.RefObject<HTMLAnchorElement | null>,
     selectedItemProps: SimpleListItemProps
   ) => {
     setActiveItem(selectedItemProps.itemId as number);

--- a/packages/react-core/src/components/Slider/Slider.tsx
+++ b/packages/react-core/src/components/Slider/Slider.tsx
@@ -117,8 +117,8 @@ export const Slider: React.FunctionComponent<SliderProps> = ({
   'aria-labelledby': ariaLabelledby,
   ...props
 }: SliderProps) => {
-  const sliderRailRef = React.useRef<HTMLDivElement>();
-  const thumbRef = React.useRef<HTMLDivElement>();
+  const sliderRailRef = React.useRef<HTMLDivElement>(undefined);
+  const thumbRef = React.useRef<HTMLDivElement>(undefined);
 
   const [localValue, setValue] = useState(value);
   const [localInputValue, setLocalInputValue] = useState(inputValue);

--- a/packages/react-core/src/components/Tabs/OverflowTab.tsx
+++ b/packages/react-core/src/components/Tabs/OverflowTab.tsx
@@ -38,9 +38,9 @@ export const OverflowTab: React.FunctionComponent<OverflowTabProps> = ({
   focusTimeoutDelay = 0,
   ...props
 }: OverflowTabProps) => {
-  const menuRef = React.useRef<HTMLDivElement>();
-  const overflowTabRef = React.useRef<HTMLButtonElement>();
-  const overflowLIRef = React.useRef<HTMLLIElement>();
+  const menuRef = React.useRef<HTMLDivElement>(undefined);
+  const overflowTabRef = React.useRef<HTMLButtonElement>(undefined);
+  const overflowLIRef = React.useRef<HTMLLIElement>(undefined);
 
   const [isExpanded, setIsExpanded] = React.useState(false);
 

--- a/packages/react-core/src/components/Tabs/examples/TabsDynamic.tsx
+++ b/packages/react-core/src/components/Tabs/examples/TabsDynamic.tsx
@@ -5,7 +5,7 @@ export const TabsDynamic: React.FunctionComponent = () => {
   const [activeTabKey, setActiveTabKey] = React.useState<number>(0);
   const [tabs, setTabs] = React.useState<string[]>(['Terminal 1', 'Terminal 2', 'Terminal 3']);
   const [newTabNumber, setNewTabNumber] = React.useState<number>(4);
-  const tabComponentRef = React.useRef<any>();
+  const tabComponentRef = React.useRef<any>(undefined);
   const firstMount = React.useRef(true);
 
   const onClose = (event: any, tabIndex: string | number) => {

--- a/packages/react-core/src/components/Tabs/examples/TabsHelpAndClose.tsx
+++ b/packages/react-core/src/components/Tabs/examples/TabsHelpAndClose.tsx
@@ -6,7 +6,7 @@ import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
 export const TabsHelpAndClose: React.FunctionComponent = () => {
   const [activeTabKey, setActiveTabKey] = React.useState<number>(0);
   const [tabs, setTabs] = React.useState<string[]>(['Terminal 1', 'Terminal 2', 'Terminal 3']);
-  const tabComponentRef = React.useRef<any>();
+  const tabComponentRef = React.useRef<any>(undefined);
   const firstMount = React.useRef(true);
 
   const onClose = (event: any, tabIndex: string | number) => {

--- a/packages/react-core/src/components/TextArea/__tests__/TextArea.test.tsx
+++ b/packages/react-core/src/components/TextArea/__tests__/TextArea.test.tsx
@@ -149,7 +149,7 @@ test('Does not throw console error when aria-label is given but no id', () => {
 });
 
 test('TextArea can be accessed via passed ref', () => {
-  const testRef: React.RefObject<HTMLTextAreaElement> = React.createRef();
+  const testRef: React.RefObject<HTMLTextAreaElement | null> = React.createRef();
   render(<TextArea ref={testRef} />);
   global.scrollTo = jest.fn();
   testRef.current?.focus();

--- a/packages/react-core/src/components/Toolbar/ToolbarExpandableContent.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarExpandableContent.tsx
@@ -15,7 +15,7 @@ export interface ToolbarExpandableContentProps extends React.HTMLProps<HTMLDivEl
   /** Flag indicating the expandable content is expanded */
   isExpanded?: boolean;
   /** Expandable content reference for passing to data toolbar children */
-  expandableContentRef?: RefObject<HTMLDivElement>;
+  expandableContentRef?: RefObject<HTMLDivElement | null>;
   /** Label container reference for passing to data toolbar children */
   labelContainerRef?: RefObject<any>;
   /** optional callback for clearing all filters in the toolbar */

--- a/packages/react-core/src/components/Toolbar/ToolbarFilter.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarFilter.tsx
@@ -39,7 +39,7 @@ export interface ToolbarFilterProps extends ToolbarItemProps {
   /** Flag to show the toolbar item */
   showToolbarItem?: boolean;
   /** Reference to a label container created with a custom expandable content group, for non-managed multiple toolbar toggle groups. */
-  expandableLabelContainerRef?: React.RefObject<HTMLDivElement>;
+  expandableLabelContainerRef?: React.RefObject<HTMLDivElement | null>;
 }
 
 interface ToolbarFilterState {

--- a/packages/react-core/src/components/Toolbar/ToolbarUtils.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarUtils.tsx
@@ -8,7 +8,7 @@ import globalBreakpoint2xl from '@patternfly/react-tokens/dist/esm/t_global_brea
 export interface ToolbarContextProps {
   isExpanded: boolean;
   toggleIsExpanded: () => void;
-  labelGroupContentRef: RefObject<HTMLDivElement>;
+  labelGroupContentRef: RefObject<HTMLDivElement | null>;
   updateNumberFilters: (categoryName: string, numberOfFilters: number) => void;
   numberOfFilters: number;
   clearAllFilters?: () => void;
@@ -28,7 +28,7 @@ export const ToolbarContext = React.createContext<ToolbarContextProps>({
 });
 
 interface ToolbarContentContextProps {
-  expandableContentRef: RefObject<HTMLDivElement>;
+  expandableContentRef: RefObject<HTMLDivElement | null>;
   expandableContentId: string;
   labelContainerRef: RefObject<any>;
   isExpanded?: boolean;

--- a/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
+++ b/packages/react-core/src/components/TreeView/TreeViewListItem.tsx
@@ -151,7 +151,9 @@ const TreeViewListItemBase: React.FunctionComponent<TreeViewListItemProps> = ({
         type="checkbox"
         onChange={(evt) => onCheck && onCheck(evt, itemData, parentItem)}
         onClick={(evt) => evt.stopPropagation()}
-        ref={(elem) => elem && (elem.indeterminate = checkProps.checked === null)}
+        ref={(elem) => {
+          elem && (elem.indeterminate = checkProps.checked === null);
+        }}
         {...checkProps}
         checked={isCheckboxChecked}
         id={randomId}
@@ -185,7 +187,7 @@ const TreeViewListItemBase: React.FunctionComponent<TreeViewListItemProps> = ({
       {hasBadge && children && (
         <span className={css(styles.treeViewNodeCount)}>
           <Badge {...badgeProps}>
-            {customBadgeContent ? customBadgeContent : (children as React.ReactElement).props.data.length}
+            {customBadgeContent ? customBadgeContent : (children as React.ReactElement<any>).props.data.length}
           </Badge>
         </span>
       )}

--- a/packages/react-core/src/components/Wizard/WizardContext.tsx
+++ b/packages/react-core/src/components/Wizard/WizardContext.tsx
@@ -9,7 +9,7 @@ export interface WizardContextProps {
   /** Current step */
   activeStep: WizardStepType;
   /** Footer element */
-  footer: React.ReactElement;
+  footer: React.ReactElement<any>;
   /** Close the wizard */
   close: () => void;
   /** Navigate to the next step */
@@ -23,7 +23,7 @@ export interface WizardContextProps {
   /** Navigate to step by index */
   goToStepByIndex: (index: number) => void;
   /** Update the footer with any react element */
-  setFooter: (footer: React.ReactElement | Partial<WizardFooterProps>) => void;
+  setFooter: (footer: React.ReactElement<any> | Partial<WizardFooterProps>) => void;
   /** Get step by ID */
   getStep: (stepId: number | string) => WizardStepType;
   /** Set step by ID */
@@ -33,7 +33,7 @@ export interface WizardContextProps {
    */
   shouldFocusContent: boolean;
   /** Ref for main wizard content element. */
-  mainWrapperRef: React.RefObject<HTMLElement>;
+  mainWrapperRef: React.RefObject<HTMLElement | null>;
 }
 
 export const WizardContext = React.createContext({} as WizardContextProps);
@@ -42,7 +42,7 @@ export interface WizardContextProviderProps {
   steps: WizardStepType[];
   activeStepIndex: number;
   footer: WizardFooterType;
-  children: React.ReactElement;
+  children: React.ReactElement<any>;
   onNext(event: React.MouseEvent<HTMLButtonElement>, steps: WizardStepType[]): void;
   onBack(event: React.MouseEvent<HTMLButtonElement>, steps: WizardStepType[]): void;
   onClose?(event: React.MouseEvent<HTMLButtonElement>): void;
@@ -54,7 +54,7 @@ export interface WizardContextProviderProps {
     index: number
   ): void;
   shouldFocusContent: boolean;
-  mainWrapperRef: React.RefObject<HTMLElement>;
+  mainWrapperRef: React.RefObject<HTMLElement | null>;
 }
 
 export const WizardContextProvider: React.FunctionComponent<WizardContextProviderProps> = ({

--- a/packages/react-core/src/components/Wizard/WizardStep.tsx
+++ b/packages/react-core/src/components/Wizard/WizardStep.tsx
@@ -27,7 +27,7 @@ export interface WizardStepProps {
   /** Replaces the step's navigation item or its properties. */
   navItem?: WizardNavItemType;
   /** Replaces the step's footer. The step's footer takes precedance over the wizard's footer. */
-  footer?: React.ReactElement | Partial<WizardFooterProps>;
+  footer?: React.ReactElement<any> | Partial<WizardFooterProps>;
   /** Used to determine icon next to the step's navigation item */
   status?: 'default' | 'error' | 'success';
   /** Flag to determine whether parent steps can expand or not. Defaults to false. */

--- a/packages/react-core/src/components/Wizard/WizardToggle.tsx
+++ b/packages/react-core/src/components/Wizard/WizardToggle.tsx
@@ -23,7 +23,7 @@ export interface WizardToggleProps {
   /** The current step */
   activeStep: WizardStepType;
   /** Wizard footer */
-  footer: React.ReactElement;
+  footer: React.ReactElement<any>;
   /** Wizard navigation */
   nav: React.ReactElement<WizardNavProps>;
   /** The expandable dropdown button's aria-label */

--- a/packages/react-core/src/components/Wizard/examples/WizardStepStatus.tsx
+++ b/packages/react-core/src/components/Wizard/examples/WizardStepStatus.tsx
@@ -10,7 +10,7 @@ interface SomeContextProps {
 }
 type SomeContextRenderProps = Pick<SomeContextProps, 'successMessage', 'errorMessage'>;
 interface SomeContextProviderProps {
-  children: (context: SomeContextRenderProps) => React.ReactElement;
+  children: (context: SomeContextRenderProps) => React.ReactElement<any>;
 }
 
 const SomeContext: React.Context<SomeContextProps> = React.createContext({} as SomeContextProps);

--- a/packages/react-core/src/components/Wizard/examples/WizardToggleStepVisibility.tsx
+++ b/packages/react-core/src/components/Wizard/examples/WizardToggleStepVisibility.tsx
@@ -8,7 +8,7 @@ interface SomeContextProps {
 }
 type SomeContextRenderProps = Pick<SomeContextProps, 'isToggleStepChecked'>;
 interface SomeContextProviderProps {
-  children: (context: SomeContextRenderProps) => React.ReactElement;
+  children: (context: SomeContextRenderProps) => React.ReactElement<any>;
 }
 
 const SomeContext: React.Context<SomeContextProps> = React.createContext({} as SomeContextProps);

--- a/packages/react-core/src/components/Wizard/hooks/useWizardFooter.tsx
+++ b/packages/react-core/src/components/Wizard/hooks/useWizardFooter.tsx
@@ -8,7 +8,10 @@ import { WizardFooterProps } from '../WizardFooter';
  * @param footer
  * @param stepId
  */
-export const useWizardFooter = (footer: React.ReactElement | Partial<WizardFooterProps>, stepId?: string | number) => {
+export const useWizardFooter = (
+  footer: React.ReactElement<any> | Partial<WizardFooterProps>,
+  stepId?: string | number
+) => {
   const { activeStep, setFooter } = useWizardContext();
 
   React.useEffect(() => {

--- a/packages/react-core/src/components/Wizard/types.tsx
+++ b/packages/react-core/src/components/Wizard/types.tsx
@@ -17,11 +17,11 @@ export interface WizardBasicStep {
   /** Flag to determine whether the step is hidden */
   isHidden?: boolean;
   /** Content shown when the step's navigation item is selected. When treated as a parent step, only sub-step content will be shown. */
-  component?: React.ReactElement;
+  component?: React.ReactElement<any>;
   /** Replaces the step's navigation item or its properties. */
   navItem?: WizardNavItemType;
   /** Replaces the step's footer. The step's footer takes precedance over the wizard's footer. */
-  footer?: React.ReactElement | Partial<WizardFooterProps>;
+  footer?: React.ReactElement<any> | Partial<WizardFooterProps>;
   /** Used to determine icon next to the step's navItem */
   status?: 'default' | 'error' | 'success';
 }
@@ -58,9 +58,9 @@ export enum WizardStepChangeScope {
   Nav = 'nav'
 }
 
-export type WizardFooterType = Partial<WizardFooterProps> | CustomWizardFooterFunction | React.ReactElement;
-export type WizardNavType = Partial<WizardNavProps> | CustomWizardNavFunction | React.ReactElement;
-export type WizardNavItemType = Partial<WizardNavItemProps> | CustomWizardNavItemFunction | React.ReactElement;
+export type WizardFooterType = Partial<WizardFooterProps> | CustomWizardFooterFunction | React.ReactElement<any>;
+export type WizardNavType = Partial<WizardNavProps> | CustomWizardNavFunction | React.ReactElement<any>;
+export type WizardNavItemType = Partial<WizardNavItemProps> | CustomWizardNavItemFunction | React.ReactElement<any>;
 
 /** Callback for the Wizard's 'nav' property. Returns element which replaces the Wizard's default navigation. */
 export type CustomWizardNavFunction = (
@@ -86,19 +86,19 @@ export type CustomWizardFooterFunction = (
   onClose: (event: React.MouseEvent<HTMLButtonElement>) => void | Promise<void>
 ) => React.ReactElement<WizardFooterProps>;
 
-export function isCustomWizardNav(nav: WizardNavType): nav is CustomWizardNavFunction | React.ReactElement {
+export function isCustomWizardNav(nav: WizardNavType): nav is CustomWizardNavFunction | React.ReactElement<any> {
   return typeof nav === 'function' || React.isValidElement(nav);
 }
 
 export function isCustomWizardNavItem(
   navItem: WizardNavItemType
-): navItem is CustomWizardNavItemFunction | React.ReactElement {
+): navItem is CustomWizardNavItemFunction | React.ReactElement<any> {
   return typeof navItem === 'function' || React.isValidElement(navItem);
 }
 
 export function isCustomWizardFooter(
   footer: WizardFooterType
-): footer is CustomWizardFooterFunction | React.ReactElement {
+): footer is CustomWizardFooterFunction | React.ReactElement<any> {
   return typeof footer === 'function' || React.isValidElement(footer);
 }
 

--- a/packages/react-core/src/demos/CustomMenus/examples/DateSelectDemo.tsx
+++ b/packages/react-core/src/demos/CustomMenus/examples/DateSelectDemo.tsx
@@ -4,7 +4,7 @@ import { MenuToggle, Select, SelectList, SelectOption, Timestamp } from '@patter
 export const DateSelectDemo: React.FunctionComponent = () => {
   const [isOpen, setIsOpen] = React.useState(false);
   const [selected, setSelected] = React.useState<number>(0);
-  const menuRef = React.useRef<HTMLDivElement>();
+  const menuRef = React.useRef<HTMLDivElement>(undefined);
 
   const onToggleClick = () => {
     setIsOpen(!isOpen);

--- a/packages/react-core/src/demos/CustomMenus/examples/FavoritesDemo.tsx
+++ b/packages/react-core/src/demos/CustomMenus/examples/FavoritesDemo.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { type JSX } from 'react';
 import { MenuToggle, Divider, Dropdown, DropdownGroup, DropdownList, DropdownItem } from '@patternfly/react-core';
 
 export const FavoritesDemo: React.FunctionComponent = () => {

--- a/packages/react-core/src/demos/CustomMenus/examples/FlyoutDemo.tsx
+++ b/packages/react-core/src/demos/CustomMenus/examples/FlyoutDemo.tsx
@@ -6,7 +6,7 @@ const onSelect = (event: React.MouseEvent | undefined, itemId: string | number |
   console.log('selected', itemId);
 /* eslint-enable no-console */
 interface FlyoutMenuProps {
-  children?: React.ReactElement;
+  children?: React.ReactElement<any>;
   depth: number;
 }
 

--- a/packages/react-core/src/demos/CustomMenus/examples/InlineSearchFilterMenuDemo.tsx
+++ b/packages/react-core/src/demos/CustomMenus/examples/InlineSearchFilterMenuDemo.tsx
@@ -16,8 +16,8 @@ export const InlineSearchFilterMenuDemo: React.FunctionComponent = () => {
   const [activeItem, setActiveItem] = React.useState(0);
   const [input, setInput] = React.useState('');
   const [isOpen, setIsOpen] = React.useState(false);
-  const toggleRef = React.useRef<any>();
-  const menuRef = React.useRef<any>();
+  const toggleRef = React.useRef<any>(undefined);
+  const menuRef = React.useRef<any>(undefined);
 
   const onSelect = (_event: React.MouseEvent<Element, MouseEvent> | undefined, itemId: number | string | undefined) => {
     const item = itemId as number;

--- a/packages/react-core/src/demos/CustomMenus/examples/OptionsMenuDemo.tsx
+++ b/packages/react-core/src/demos/CustomMenus/examples/OptionsMenuDemo.tsx
@@ -4,7 +4,7 @@ import { MenuToggle, Divider, Select, SelectList, SelectOption, SelectGroup } fr
 export const OptionsMenuDemo: React.FunctionComponent = () => {
   const [isOpen, setIsOpen] = React.useState<boolean>(false);
   const [selected, setSelected] = React.useState<string>('');
-  const menuRef = React.useRef<HTMLDivElement>();
+  const menuRef = React.useRef<HTMLDivElement>(undefined);
 
   const onToggleClick = () => {
     setIsOpen(!isOpen);

--- a/packages/react-core/src/demos/CustomMenus/examples/TreeViewMenuDemo.tsx
+++ b/packages/react-core/src/demos/CustomMenus/examples/TreeViewMenuDemo.tsx
@@ -14,7 +14,7 @@ export const TreeViewMenuDemo: React.FunctionComponent = () => {
   const [isOpen, setIsOpen] = React.useState<boolean>(false);
   const [checkedItems, setCheckedItems] = React.useState<TreeViewDataItem[]>([]);
   const toggleRef = React.useRef<HTMLButtonElement>(null);
-  const menuRef = React.useRef<HTMLDivElement>();
+  const menuRef = React.useRef<HTMLDivElement>(undefined);
 
   const statusOptions: TreeViewDataItem[] = [
     {

--- a/packages/react-core/src/demos/SearchInput/SearchInput.md
+++ b/packages/react-core/src/demos/SearchInput/SearchInput.md
@@ -244,8 +244,8 @@ AdvancedComposableSearchInput = () => {
   const firstAttrRef = React.useRef(null);
   const searchInputRef = React.useRef(null);
   const advancedSearchPaneRef = React.useRef(null);
-  const dateWithinToggleRef = React.useRef();
-  const dateWithinMenuRef = React.useRef();
+  const dateWithinToggleRef = React.useRef(undefined);
+  const dateWithinMenuRef = React.useRef(undefined);
 
   const onClear = () => {
     setValue('');

--- a/packages/react-core/src/demos/examples/Card/CardAggregateStatus.tsx
+++ b/packages/react-core/src/demos/examples/Card/CardAggregateStatus.tsx
@@ -18,6 +18,8 @@ import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclama
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 import l_gallery_GridTemplateColumns_min from '@patternfly/react-tokens/dist/esm/l_gallery_GridTemplateColumns_min';
 
+import type { JSX } from 'react';
+
 interface ContentType {
   icon?: React.ReactNode;
   count?: number;

--- a/packages/react-core/src/demos/examples/JumpLinks/JumpLinksWithDrawer.js
+++ b/packages/react-core/src/demos/examples/JumpLinks/JumpLinksWithDrawer.js
@@ -44,7 +44,7 @@ export const JumpLinksWithDrawer = () => {
   const headings = ['First', 'Second', 'Third', 'Fourth', 'Fifth'];
 
   const [isExpanded, setIsExpanded] = React.useState(false);
-  const drawerRef = React.useRef();
+  const drawerRef = React.useRef(undefined);
 
   const onCloseClick = () => {
     setIsExpanded(false);

--- a/packages/react-core/src/demos/examples/Nav/NavDrilldown.tsx
+++ b/packages/react-core/src/demos/examples/Nav/NavDrilldown.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { type JSX } from 'react';
 
 import {
   Page,

--- a/packages/react-core/src/demos/examples/PasswordStrength/PasswordStrengthDemo.tsx
+++ b/packages/react-core/src/demos/examples/PasswordStrength/PasswordStrengthDemo.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { type JSX } from 'react';
 import { Form, FormGroup, FormHelperText, HelperText, HelperTextItem, TextInput } from '@patternfly/react-core';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';

--- a/packages/react-core/src/demos/examples/TextInputGroup/AttributeValueFiltering.tsx
+++ b/packages/react-core/src/demos/examples/TextInputGroup/AttributeValueFiltering.tsx
@@ -37,11 +37,11 @@ export const AttributeValueFiltering: React.FunctionComponent = () => {
   };
   const keyNames = ['Cluster', 'Kind', 'Label', 'Name', 'Namespace', 'Status'];
   const [menuItemsText, setMenuItemsText] = React.useState(keyNames);
-  const [menuItems, setMenuItems] = React.useState<React.ReactElement[]>([]);
+  const [menuItems, setMenuItems] = React.useState<React.ReactElement<any>[]>([]);
 
   /** refs used to detect when clicks occur inside vs outside of the textInputGroup and menu popper */
-  const menuRef = React.useRef<HTMLDivElement>();
-  const textInputGroupRef = React.useRef<HTMLDivElement>();
+  const menuRef = React.useRef<HTMLDivElement>(undefined);
+  const textInputGroupRef = React.useRef<HTMLDivElement>(undefined);
 
   /** callback for updating the inputValue state in this component so that the input can be controlled */
   const handleInputChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => {

--- a/packages/react-core/src/demos/examples/TextInputGroup/AutoCompleteSearch.tsx
+++ b/packages/react-core/src/demos/examples/TextInputGroup/AutoCompleteSearch.tsx
@@ -24,11 +24,11 @@ export const AutoCompleteSearch: React.FunctionComponent = () => {
 
   /** auto-completing suggestion text items to be shown in the menu */
   const suggestionItems = ['Cluster', 'Kind', 'Label', 'Name', 'Namespace', 'Status'];
-  const [menuItems, setMenuItems] = React.useState<React.ReactElement[]>([]);
+  const [menuItems, setMenuItems] = React.useState<React.ReactElement<any>[]>([]);
 
   /** refs used to detect when clicks occur inside vs outside of the textInputGroup and menu popper */
-  const menuRef = React.useRef<HTMLDivElement>();
-  const textInputGroupRef = React.useRef<HTMLDivElement>();
+  const menuRef = React.useRef<HTMLDivElement>(undefined);
+  const textInputGroupRef = React.useRef<HTMLDivElement>(undefined);
 
   /** callback for updating the inputValue state in this component so that the input can be controlled */
   const handleInputChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => {

--- a/packages/react-core/src/deprecated/components/DragDrop/Draggable.tsx
+++ b/packages/react-core/src/deprecated/components/DragDrop/Draggable.tsx
@@ -320,7 +320,7 @@ export const Draggable: React.FunctionComponent<DraggableProps> = ({
         </div>
       )}
       {hasNoWrapper ? (
-        React.cloneElement(children as React.ReactElement, childProps)
+        React.cloneElement(children as React.ReactElement<any>, childProps)
       ) : (
         <div {...childProps}>{children}</div>
       )}

--- a/packages/react-core/src/deprecated/components/DragDrop/Droppable.tsx
+++ b/packages/react-core/src/deprecated/components/DragDrop/Droppable.tsx
@@ -30,7 +30,7 @@ export const Droppable: React.FunctionComponent<DroppableProps> = ({
     // if has no wrapper is set, don't overwrite children className with the className prop
     className:
       hasNoWrapper && React.Children.count(children) === 1
-        ? css(styles.droppable, className, (children as React.ReactElement).props.className)
+        ? css(styles.droppable, className, (children as React.ReactElement<any>).props.className)
         : css(styles.droppable, className),
     ...props
   };
@@ -38,7 +38,7 @@ export const Droppable: React.FunctionComponent<DroppableProps> = ({
   return (
     <DroppableContext.Provider value={{ zone, droppableId }}>
       {hasNoWrapper ? (
-        React.cloneElement(children as React.ReactElement, childProps)
+        React.cloneElement(children as React.ReactElement<any>, childProps)
       ) : (
         <div {...childProps}>{children}</div>
       )}

--- a/packages/react-core/src/deprecated/components/DualListSelector/DualListSelectorControlsWrapper.tsx
+++ b/packages/react-core/src/deprecated/components/DualListSelector/DualListSelectorControlsWrapper.tsx
@@ -11,7 +11,7 @@ export interface DualListSelectorControlsWrapperProps extends React.HTMLProps<HT
   /** Additional classes added to the wrapper. */
   className?: string;
   /** @hide Forwarded ref */
-  innerRef?: React.RefObject<HTMLDivElement>;
+  innerRef?: React.RefObject<HTMLDivElement | null>;
   /** Accessible label for the dual list selector controls wrapper. */
   'aria-label'?: string;
 }

--- a/packages/react-core/src/deprecated/components/DualListSelector/DualListSelectorListItem.tsx
+++ b/packages/react-core/src/deprecated/components/DualListSelector/DualListSelectorListItem.tsx
@@ -24,7 +24,7 @@ export interface DualListSelectorListItemProps extends React.HTMLProps<HTMLLIEle
   /** @hide Internal field used to keep track of order of unfiltered options. */
   orderIndex?: number;
   /** @hide Forwarded ref */
-  innerRef?: React.RefObject<HTMLLIElement>;
+  innerRef?: React.RefObject<HTMLLIElement | null>;
   /** Flag indicating this item is draggable for reordring */
   isDraggable?: boolean;
   /** Accessible label for the draggable button on draggable list items */

--- a/packages/react-core/src/deprecated/components/DualListSelector/DualListSelectorListWrapper.tsx
+++ b/packages/react-core/src/deprecated/components/DualListSelector/DualListSelectorListWrapper.tsx
@@ -15,7 +15,7 @@ export interface DualListSelectorListWrapperProps extends React.HTMLProps<HTMLDi
   /** Accessibly label for the list */
   'aria-labelledby': string;
   /** @hide forwarded ref */
-  innerRef?: React.RefObject<HTMLDivElement>;
+  innerRef?: React.RefObject<HTMLDivElement | null>;
   /** @hide Options to list in the pane. */
   options?: React.ReactNode[];
   /** @hide Options currently selected in the pane. */

--- a/packages/react-core/src/deprecated/components/DualListSelector/DualListSelectorTreeItem.tsx
+++ b/packages/react-core/src/deprecated/components/DualListSelector/DualListSelectorTreeItem.tsx
@@ -138,7 +138,9 @@ const DualListSelectorTreeItemBase: React.FunctionComponent<DualListSelectorTree
                     e.preventDefault();
                   }
                 }}
-                ref={(elem) => elem && (elem.indeterminate = isChecked === null)}
+                ref={(elem) => {
+                  elem && (elem.indeterminate = isChecked === null);
+                }}
                 checked={isChecked || false}
                 tabIndex={-1}
                 {...checkProps}
@@ -148,7 +150,7 @@ const DualListSelectorTreeItemBase: React.FunctionComponent<DualListSelectorTree
             <span className={css(styles.dualListSelectorItemText)}>{text}</span>
             {hasBadge && children && (
               <span className={css(styles.dualListSelectorItemCount)}>
-                <Badge {...badgeProps}>{flattenTree((children as React.ReactElement).props.data).length}</Badge>
+                <Badge {...badgeProps}>{flattenTree((children as React.ReactElement<any>).props.data).length}</Badge>
               </span>
             )}
           </span>

--- a/packages/react-core/src/deprecated/components/DualListSelector/examples/DualListSelectorComplexOptionsActions.tsx
+++ b/packages/react-core/src/deprecated/components/DualListSelector/examples/DualListSelectorComplexOptionsActions.tsx
@@ -20,7 +20,7 @@ export const DualListSelectorComplexOptionsActions: React.FunctionComponent = ()
 
   const onSort = (pane: string) => {
     const toSort = pane === 'available' ? [...availableOptions] : [...chosenOptions];
-    (toSort as React.ReactElement[]).sort((a, b) => {
+    (toSort as React.ReactElement<any>[]).sort((a, b) => {
       if (a.props.children > b.props.children) {
         return 1;
       }
@@ -38,7 +38,7 @@ export const DualListSelectorComplexOptionsActions: React.FunctionComponent = ()
   };
 
   const filterOption = (option: React.ReactNode, input: string) =>
-    (option as React.ReactElement).props.children.includes(input);
+    (option as React.ReactElement<any>).props.children.includes(input);
 
   const availableOptionsActions = [
     <Button

--- a/packages/react-core/src/deprecated/components/Modal/Modal.tsx
+++ b/packages/react-core/src/deprecated/components/Modal/Modal.tsx
@@ -263,7 +263,7 @@ class Modal extends React.Component<ModalProps, ModalState> {
         elementToFocus={elementToFocus}
       />,
       this.getElement(appendTo)
-    ) as React.ReactElement;
+    ) as React.ReactElement<any>;
   }
 }
 

--- a/packages/react-core/src/deprecated/components/Wizard/WizardDrawerWrapper.tsx
+++ b/packages/react-core/src/deprecated/components/Wizard/WizardDrawerWrapper.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 
+import type { JSX } from 'react';
+
 export interface WizardDrawerWrapperProps {
   /** The wizard content  */
-  children: React.ReactElement;
+  children: React.ReactElement<any>;
   /** Flag indicating the wizard has a drawer for at least one of the wizard steps */
   hasDrawer: boolean;
   /** The drawer component which wraps the wizard content */
-  wrapper: (children: React.ReactElement) => JSX.Element;
+  wrapper: (children: React.ReactElement<any>) => JSX.Element;
 }
 
 export const WizardDrawerWrapper: React.FunctionComponent<WizardDrawerWrapperProps> = ({

--- a/packages/react-core/src/deprecated/components/Wizard/WizardToggle.tsx
+++ b/packages/react-core/src/deprecated/components/Wizard/WizardToggle.tsx
@@ -8,7 +8,7 @@ import { WizardBody } from './WizardBody';
 
 export interface WizardToggleProps {
   /** Function that returns the WizardNav component */
-  nav: (isWizardNavOpen: boolean) => React.ReactElement;
+  nav: (isWizardNavOpen: boolean) => React.ReactElement<any>;
   /** The wizard steps */
   steps: WizardStep[];
   /** The currently active WizardStep */

--- a/packages/react-core/src/deprecated/components/Wizard/__tests__/Generated/WizardToggle.test.tsx
+++ b/packages/react-core/src/deprecated/components/Wizard/__tests__/Generated/WizardToggle.test.tsx
@@ -10,7 +10,7 @@ import {} from '../..';
 it('WizardToggle should match snapshot (auto-generated)', () => {
   const { asFragment } = render(
     <WizardToggle
-      nav={(_isWizardNavOpen: boolean) => undefined as React.ReactElement}
+      nav={(_isWizardNavOpen: boolean) => undefined as unknown as React.ReactElement<any>}
       steps={[]}
       activeStep={{ name: 'some step' }}
       children={<div>ReactNode</div>}

--- a/packages/react-core/src/helpers/KeyboardHandler.tsx
+++ b/packages/react-core/src/helpers/KeyboardHandler.tsx
@@ -182,7 +182,7 @@ export const setTabIndex = (options: HTMLElement[]) => {
  * @param event Event triggered by the keyboard
  * @param menuRef Menu reference
  */
-export const onToggleArrowKeydownDefault = (event: KeyboardEvent, menuRef: React.RefObject<HTMLDivElement>) => {
+export const onToggleArrowKeydownDefault = (event: KeyboardEvent, menuRef: React.RefObject<HTMLDivElement | null>) => {
   if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') {
     return;
   }

--- a/packages/react-core/src/helpers/Popper/Popper.tsx
+++ b/packages/react-core/src/helpers/Popper/Popper.tsx
@@ -58,7 +58,7 @@ export interface PopperProps {
    */
   triggerRef?: HTMLElement | (() => HTMLElement) | React.RefObject<any>;
   /** The popper (menu/tooltip/popover) element */
-  popper: React.ReactElement;
+  popper: React.ReactElement<any>;
   /**
    * Reference to the popper (menu/tooltip/popover) element.
    * Passing this prop will remove the wrapper div element from the popper.
@@ -225,7 +225,7 @@ export const Popper: React.FunctionComponent<PopperProps> = ({
   const transitionTimerRef = React.useRef(null);
   const showTimerRef = React.useRef(null);
   const hideTimerRef = React.useRef(null);
-  const prevExitDelayRef = React.useRef<number>();
+  const prevExitDelayRef = React.useRef<number>(undefined);
 
   const refOrTrigger = refElement || triggerElement;
   const showPopper = isVisible || internalIsVisible;
@@ -527,7 +527,12 @@ export const Popper: React.FunctionComponent<PopperProps> = ({
     return popperRef ? (
       localPopper
     ) : (
-      <div style={{ display: 'contents' }} ref={(node) => setPopperElement(node?.firstElementChild as HTMLElement)}>
+      <div
+        style={{ display: 'contents' }}
+        ref={(node) => {
+          setPopperElement(node?.firstElementChild as HTMLElement);
+        }}
+      >
         {localPopper}
       </div>
     );
@@ -545,7 +550,12 @@ export const Popper: React.FunctionComponent<PopperProps> = ({
   return (
     <>
       {!triggerRef && trigger && React.isValidElement(trigger) && (
-        <div style={{ display: 'contents' }} ref={(node) => setTriggerElement(node?.firstElementChild as HTMLElement)}>
+        <div
+          style={{ display: 'contents' }}
+          ref={(node) => {
+            setTriggerElement(node?.firstElementChild as HTMLElement);
+          }}
+        >
           {trigger}
         </div>
       )}

--- a/packages/react-core/src/helpers/Popper/thirdparty/react-popper/usePopper.ts
+++ b/packages/react-core/src/helpers/Popper/thirdparty/react-popper/usePopper.ts
@@ -102,7 +102,7 @@ export const usePopper = (
     updateStateModifier
   ]);
 
-  const popperInstanceRef = React.useRef<any>();
+  const popperInstanceRef = React.useRef<any>(undefined);
 
   useIsomorphicLayoutEffect(() => {
     if (popperInstanceRef && popperInstanceRef.current) {

--- a/packages/react-core/src/layouts/Bullseye/Bullseye.tsx
+++ b/packages/react-core/src/layouts/Bullseye/Bullseye.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/layouts/Bullseye/bullseye';
 
+import type { JSX } from 'react';
+
 export interface BullseyeProps extends React.HTMLProps<HTMLDivElement> {
   /** content rendered inside the Bullseye layout */
   children?: React.ReactNode;

--- a/packages/react-core/src/layouts/Bullseye/__tests__/Bullseye.test.tsx
+++ b/packages/react-core/src/layouts/Bullseye/__tests__/Bullseye.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { type JSX } from 'react';
 import { render, screen } from '@testing-library/react';
 import { Bullseye } from '../Bullseye';
 

--- a/packages/react-drag-drop/src/components/DragDrop/DragDropSort.tsx
+++ b/packages/react-drag-drop/src/components/DragDrop/DragDropSort.tsx
@@ -12,7 +12,7 @@ export type DragDropSortDragStartEvent = DragStartEvent;
 export interface DragDropSortProps extends DndContextProps {
   /** Custom defined content wrapper for draggable items. By default, draggable items are wrapped in a styled div.
    * Intended to be a 'DataList' or 'DualListSelectorList' without children. */
-  children?: React.ReactElement;
+  children?: React.ReactElement<any>;
   /** Sorted array of draggable objects */
   items: DraggableObject[];
   /** Callback when user drops a draggable object */

--- a/packages/react-drag-drop/src/components/DragDrop/DraggableDualListSelectorListItem.tsx
+++ b/packages/react-drag-drop/src/components/DragDrop/DraggableDualListSelectorListItem.tsx
@@ -23,7 +23,7 @@ export interface DraggableDualListSelectorListItemProps extends React.HTMLProps<
   /** @hide Internal field used to keep track of order of unfiltered options. */
   orderIndex?: number;
   /** @hide Forwarded ref */
-  innerRef?: React.RefObject<HTMLLIElement>;
+  innerRef?: React.RefObject<HTMLLIElement | null>;
   /** Flag indicating if the dual list selector is in a disabled state */
   isDisabled?: boolean;
 }

--- a/packages/react-drag-drop/src/components/DragDrop/Droppable.tsx
+++ b/packages/react-drag-drop/src/components/DragDrop/Droppable.tsx
@@ -14,7 +14,7 @@ interface DroppableProps extends React.HTMLProps<HTMLDivElement> {
   /** Array of draggable objects */
   items: DraggableObject[];
   /** Alternative to wrapping drop zone in a div, will override any ref and style set on the element. */
-  wrapper?: React.ReactElement;
+  wrapper?: React.ReactElement<any>;
   /** The variant determines which component wraps the draggable object.
    * Default variant wraps the draggable object in a div.
    * DataList vairant wraps the draggable object in a DataListItem

--- a/packages/react-integration/demo-app-ts/src/components/demos/AlertGroupDemo/AlertGroupDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/AlertGroupDemo/AlertGroupDemo.tsx
@@ -13,7 +13,7 @@ import buttonStyles from '@patternfly/react-styles/css/components/Button/button'
 interface AlertDemoAlert {
   title: string;
   variant: keyof typeof AlertVariant;
-  key: React.ReactText;
+  key: number | string;
 }
 
 interface AlertGroupDemoState {
@@ -24,9 +24,9 @@ interface AlertGroupDemoState {
 export class AlertGroupDemo extends React.Component<{}, AlertGroupDemoState> {
   static displayName = 'AlertGroupDemo';
   stopAsyncAlerts: () => void;
-  removeAlert: (key: React.ReactText) => void;
+  removeAlert: (key: number | string) => void;
 
-  constructor(props: {}, removeAlert: (key: React.ReactText) => void) {
+  constructor(props: {}, removeAlert: (key: number | string) => void) {
     super(props);
     this.state = {
       alerts: [],
@@ -46,7 +46,7 @@ export class AlertGroupDemo extends React.Component<{}, AlertGroupDemoState> {
     };
     const getUniqueId = () => new Date().getTime();
     const btnClasses = css(buttonStyles.button, buttonStyles.modifiers.secondary);
-    this.removeAlert = (key: React.ReactText) => {
+    this.removeAlert = (key: number | string) => {
       this.setState({ alerts: [...this.state.alerts.filter((el: AlertDemoAlert) => el.key !== key)] });
     };
     const startAsyncAlerts = () => {

--- a/packages/react-integration/demo-app-ts/src/components/demos/FormDemo/FormDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/FormDemo/FormDemo.tsx
@@ -74,8 +74,8 @@ export class FormDemo extends Component<FormProps, FormState> {
     this.handleCheckboxChange = this.handleCheckboxChange.bind(this);
   }
 
-  labelHelpRef: React.RefObject<HTMLSpanElement> = React.createRef();
-  textInputRef: React.RefObject<HTMLInputElement> = React.createRef();
+  labelHelpRef: React.RefObject<HTMLSpanElement | null> = React.createRef();
+  textInputRef: React.RefObject<HTMLInputElement | null> = React.createRef();
 
   handleTextInputChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => {
     this.setState({ value, isValid: /^\d+$/.test(value) });

--- a/packages/react-integration/demo-app-ts/src/components/demos/PopoverDemo/PopoverDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/PopoverDemo/PopoverDemo.tsx
@@ -1,4 +1,4 @@
-import { Popover } from '@patternfly/react-core';
+import { Popover, Button } from '@patternfly/react-core';
 import React, { Component } from 'react';
 
 export class PopoverDemo extends Component {
@@ -35,9 +35,9 @@ export class PopoverDemo extends Component {
           />
         </div>
         <div>
-          <button ref={this.popoverRef} id="popover-ref">
+          <Button ref={this.popoverRef} id="popover-ref">
             Popover attached via react ref
-          </button>
+          </Button>
           <Popover
             position="right-start"
             headerContent={headerContent}

--- a/packages/react-integration/demo-app-ts/src/components/demos/PopoverDemo/PopoverDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/PopoverDemo/PopoverDemo.tsx
@@ -2,7 +2,7 @@ import { Popover } from '@patternfly/react-core';
 import React, { Component } from 'react';
 
 export class PopoverDemo extends Component {
-  popoverRef: React.RefObject<HTMLButtonElement>;
+  popoverRef: React.RefObject<HTMLButtonElement | null>;
   myPopoverProps = {
     headerContent: <div>Popover Header</div>,
     bodyContent: <div>Popover Body</div>,

--- a/packages/react-integration/demo-app-ts/src/components/demos/SearchInputDemo/SearchInputDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/SearchInputDemo/SearchInputDemo.tsx
@@ -9,7 +9,7 @@ interface SearchInputState {
 
 export class SearchInputDemo extends Component<SearchInputProps, SearchInputState> {
   static displayName = 'SearchInputDemo';
-  inputRef: React.RefObject<HTMLInputElement>;
+  inputRef: React.RefObject<HTMLInputElement | null>;
   constructor(props: SearchInputProps) {
     super(props);
     this.inputRef = React.createRef();

--- a/packages/react-integration/demo-app-ts/src/components/demos/SearchInputDemo/SearchInputDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/SearchInputDemo/SearchInputDemo.tsx
@@ -70,7 +70,7 @@ export class SearchInputDemo extends Component<SearchInputProps, SearchInputStat
       <>
         <SearchInput
           id="enabled-search"
-          ref={this.inputRef}
+          ref={this.inputRef as React.RefObject<HTMLInputElement>}
           attributes={[
             { attr: 'username', display: 'Username' },
             { attr: 'firstname', display: 'First name' }

--- a/packages/react-integration/demo-app-ts/src/components/demos/SimpleList/SimpleListDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/SimpleList/SimpleListDemo.tsx
@@ -49,7 +49,7 @@ export class SimpleListDemo extends Component<any, SimpleListDemoState> {
         <SimpleList
           id="simple-list-demo-uncontrolled"
           onSelect={(
-            _ref: React.RefObject<HTMLButtonElement> | React.RefObject<HTMLAnchorElement>,
+            _ref: React.RefObject<HTMLButtonElement | null> | React.RefObject<HTMLAnchorElement | null>,
             props: SimpleListItemProps
           ) => {
             this.setState({ activeItem: props.itemId! });

--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableRowWrapperDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableRowWrapperDemo.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, type JSX } from 'react';
 import { RowWrapperProps, ICell, IRow } from '@patternfly/react-table';
 import { Table, TableHeader, TableBody, TableProps } from '@patternfly/react-table/deprecated';
 

--- a/packages/react-integration/demo-app-ts/src/components/demos/TabsDemo/TabsDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TabsDemo/TabsDemo.tsx
@@ -10,9 +10,9 @@ export class TabDemo extends Component {
     activeTabKey4: 0,
     isTab2Hidden: true
   };
-  private contentRef1: RefObject<HTMLDivElement>;
-  private contentRef2: RefObject<HTMLDivElement>;
-  private contentRef3: RefObject<HTMLDivElement>;
+  private contentRef1: RefObject<HTMLDivElement | null>;
+  private contentRef2: RefObject<HTMLDivElement | null>;
+  private contentRef3: RefObject<HTMLDivElement | null>;
 
   constructor(props: {}) {
     super(props);

--- a/packages/react-integration/demo-app-ts/src/components/demos/TabsDemo/TabsDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TabsDemo/TabsDemo.tsx
@@ -99,17 +99,29 @@ export class TabDemo extends Component {
           <TabContent
             eventKey={0}
             id="demoTab1Section"
-            ref={this.contentRef1}
+            ref={this.contentRef1 as RefObject<HTMLDivElement>}
             aria-label="Tab item 1"
             // eslint-disable-next-line no-console
             onAuxClick={(event) => console.log(event)}
           >
             Tab 1 section
           </TabContent>
-          <TabContent eventKey={1} id="demoTab2Section" ref={this.contentRef2} aria-label="Tab item 2" hidden>
+          <TabContent
+            eventKey={1}
+            id="demoTab2Section"
+            ref={this.contentRef2 as RefObject<HTMLDivElement>}
+            aria-label="Tab item 2"
+            hidden
+          >
             Tab 2 section
           </TabContent>
-          <TabContent eventKey={2} id="demoTab3Section" ref={this.contentRef3} aria-label="Tab item 3" hidden>
+          <TabContent
+            eventKey={2}
+            id="demoTab3Section"
+            ref={this.contentRef3 as RefObject<HTMLDivElement>}
+            aria-label="Tab item 3"
+            hidden
+          >
             Tab 3 section
           </TabContent>
         </div>

--- a/packages/react-integration/demo-app-ts/src/components/demos/TabsDemo/TabsStringEventKeyDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TabsDemo/TabsStringEventKeyDemo.tsx
@@ -6,9 +6,9 @@ export class TabsStringEventKeyDemo extends Component {
     activeTabKey: 'one'
   };
 
-  private contentRefOne: RefObject<HTMLDivElement>;
-  private contentRefTwo: RefObject<HTMLDivElement>;
-  private contentRefThree: RefObject<HTMLDivElement>;
+  private contentRefOne: RefObject<HTMLDivElement | null>;
+  private contentRefTwo: RefObject<HTMLDivElement | null>;
+  private contentRefThree: RefObject<HTMLDivElement | null>;
 
   constructor(props: {}) {
     super(props);

--- a/packages/react-integration/demo-app-ts/src/components/demos/TabsDemo/TabsStringEventKeyDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TabsDemo/TabsStringEventKeyDemo.tsx
@@ -56,13 +56,30 @@ export class TabsStringEventKeyDemo extends Component {
           />
         </Tabs>
         <div>
-          <TabContent eventKey={'one'} id="demoTab1Section" ref={this.contentRefOne} aria-label="Tab item 1">
+          <TabContent
+            eventKey={'one'}
+            id="demoTab1Section"
+            ref={this.contentRefOne as RefObject<HTMLDivElement>}
+            aria-label="Tab item 1"
+          >
             Tab 1 section
           </TabContent>
-          <TabContent eventKey={'two'} id="demoTab2Section" ref={this.contentRefTwo} aria-label="Tab item 2" hidden>
+          <TabContent
+            eventKey={'two'}
+            id="demoTab2Section"
+            ref={this.contentRefTwo as RefObject<HTMLDivElement>}
+            aria-label="Tab item 2"
+            hidden
+          >
             Tab 2 section
           </TabContent>
-          <TabContent eventKey={'three'} id="demoTab3Section" ref={this.contentRefThree} aria-label="Tab item 3" hidden>
+          <TabContent
+            eventKey={'three'}
+            id="demoTab3Section"
+            ref={this.contentRefThree as RefObject<HTMLDivElement>}
+            aria-label="Tab item 3"
+            hidden
+          >
             Tab 3 section
           </TabContent>
         </div>

--- a/packages/react-integration/demo-app-ts/src/components/demos/TabsDemo/TabsUncontrolledDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TabsDemo/TabsUncontrolledDemo.tsx
@@ -6,9 +6,9 @@ export class TabUncontrolledDemo extends Component {
   state = {
     isTab2Hidden: true
   };
-  private contentRef1: RefObject<HTMLDivElement>;
-  private contentRef2: RefObject<HTMLDivElement>;
-  private contentRef3: RefObject<HTMLDivElement>;
+  private contentRef1: RefObject<HTMLDivElement | null>;
+  private contentRef2: RefObject<HTMLDivElement | null>;
+  private contentRef3: RefObject<HTMLDivElement | null>;
 
   constructor(props: {}) {
     super(props);

--- a/packages/react-integration/demo-app-ts/src/components/demos/TabsDemo/TabsUncontrolledDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TabsDemo/TabsUncontrolledDemo.tsx
@@ -67,17 +67,29 @@ export class TabUncontrolledDemo extends Component {
           <TabContent
             eventKey={0}
             id="demoTab1Section"
-            ref={this.contentRef1}
+            ref={this.contentRef1 as RefObject<HTMLDivElement>}
             aria-label="Tab item 1"
             // eslint-disable-next-line no-console
             onAuxClick={(event) => console.log(event)}
           >
             Tab 1 section
           </TabContent>
-          <TabContent eventKey={1} id="demoTab2Section" ref={this.contentRef2} aria-label="Tab item 2" hidden>
+          <TabContent
+            eventKey={1}
+            id="demoTab2Section"
+            ref={this.contentRef2 as RefObject<HTMLDivElement>}
+            aria-label="Tab item 2"
+            hidden
+          >
             Tab 2 section
           </TabContent>
-          <TabContent eventKey={2} id="demoTab3Section" ref={this.contentRef3} aria-label="Tab item 3" hidden>
+          <TabContent
+            eventKey={2}
+            id="demoTab3Section"
+            ref={this.contentRef3 as RefObject<HTMLDivElement>}
+            aria-label="Tab item 3"
+            hidden
+          >
             Tab 3 section
           </TabContent>
         </div>

--- a/packages/react-integration/demo-app-ts/src/components/demos/TooltipDemo/TooltipDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TooltipDemo/TooltipDemo.tsx
@@ -26,7 +26,7 @@ export class TooltipDemo extends Component {
           </Tooltip>
         </div>
         <div>
-          <button ref={this.tooltipRef} id="tooltip-ref-trigger">
+          <button ref={this.tooltipRef as React.RefObject<HTMLButtonElement>} id="tooltip-ref-trigger">
             Tooltip trigger attached via react ref
           </button>
           <Tooltip

--- a/packages/react-integration/demo-app-ts/src/components/demos/TooltipDemo/TooltipDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TooltipDemo/TooltipDemo.tsx
@@ -2,7 +2,7 @@ import { Tooltip } from '@patternfly/react-core';
 import React, { Component } from 'react';
 
 export class TooltipDemo extends Component {
-  tooltipRef: React.RefObject<HTMLButtonElement>;
+  tooltipRef: React.RefObject<HTMLButtonElement | null>;
   myTooltipProps = {
     content: <div>World</div>,
     children: <div id="tooltipTarget">Hello</div>

--- a/packages/react-table/src/components/Table/ActionsColumn.tsx
+++ b/packages/react-table/src/components/Table/ActionsColumn.tsx
@@ -88,10 +88,9 @@ const ActionsColumnBase: React.FunctionComponent<ActionsColumnProps> = ({
               {title}
             </Button>
           ) : (
-            React.cloneElement(title as React.ReactElement, { onClick, isDisabled, ...props })
+            React.cloneElement(title as React.ReactElement<any>, { onClick, isDisabled, ...props })
           )
         )}
-
       <Dropdown
         isOpen={isOpen}
         onOpenChange={!isOnOpenChangeDisabled ? (isOpen: boolean) => setIsOpen(isOpen) : undefined}

--- a/packages/react-table/src/components/Table/EditableSelectInputCell.tsx
+++ b/packages/react-table/src/components/Table/EditableSelectInputCell.tsx
@@ -22,7 +22,7 @@ export interface IEditableSelectInputCell extends Omit<React.HTMLProps<HTMLEleme
     isPlaceholder?: boolean
   ) => void;
   /** Options to display in the expandable select menu */
-  options?: React.ReactElement[];
+  options?: React.ReactElement<any>[];
   /** Flag indicating the select input is disabled */
   isDisabled?: boolean;
   /** Flag indicating the toggle gets placeholder styles **/
@@ -47,7 +47,7 @@ export const EditableSelectInputCell: React.FunctionComponent<IEditableSelectInp
   isPlaceholder = false,
   onToggle = () => {},
   selections = [''],
-  options = [] as React.ReactElement[],
+  options = [] as React.ReactElement<any>[],
   props
 }: IEditableSelectInputCell) => {
   const onSelectHandler = (event: React.MouseEvent | React.ChangeEvent, newValue: any | any[]) => {

--- a/packages/react-table/src/components/Table/Table.tsx
+++ b/packages/react-table/src/components/Table/Table.tsx
@@ -10,6 +10,8 @@ import { KeyTypes } from '@patternfly/react-core/dist/esm/helpers/constants';
 import { useOUIAProps, OUIAProps } from '@patternfly/react-core/dist/esm/helpers/OUIA/ouia';
 import { TableGridBreakpoint, TableVariant } from './TableTypes';
 
+import type { JSX } from 'react';
+
 export interface BaseCellProps {
   /** Content rendered inside the cell */
   children?: React.ReactNode;

--- a/packages/react-table/src/components/Table/TableTypes.tsx
+++ b/packages/react-table/src/components/Table/TableTypes.tsx
@@ -195,7 +195,7 @@ export interface decoratorReturnType {
   scope?: string;
   parentId?: number;
   colSpan?: number;
-  id?: React.ReactText;
+  id?: number | string;
 }
 
 export type ITransform = (label?: IFormatterValueType, extra?: IExtra) => decoratorReturnType;

--- a/packages/react-table/src/components/Table/Td.tsx
+++ b/packages/react-table/src/components/Table/Td.tsx
@@ -263,8 +263,8 @@ const TdBase: React.FunctionComponent<TdProps> = ({
 
   React.useEffect(() => {
     setTruncated(
-      (cellRef as React.RefObject<HTMLElement>).current.offsetWidth <
-        (cellRef as React.RefObject<HTMLElement>).current.scrollWidth
+      (cellRef as React.RefObject<HTMLElement | null>).current.offsetWidth <
+        (cellRef as React.RefObject<HTMLElement | null>).current.scrollWidth
     );
   }, [cellRef]);
 

--- a/packages/react-table/src/components/Table/Th.tsx
+++ b/packages/react-table/src/components/Table/Th.tsx
@@ -198,8 +198,8 @@ const ThBase: React.FunctionComponent<ThProps> = ({
 
   React.useEffect(() => {
     setTruncated(
-      (cellRef as React.RefObject<HTMLElement>).current.offsetWidth <
-        (cellRef as React.RefObject<HTMLElement>).current.scrollWidth
+      (cellRef as React.RefObject<HTMLElement | null>).current.offsetWidth <
+        (cellRef as React.RefObject<HTMLElement | null>).current.scrollWidth
     );
   }, [cellRef]);
 

--- a/packages/react-table/src/components/Table/base/types.tsx
+++ b/packages/react-table/src/components/Table/base/types.tsx
@@ -298,7 +298,7 @@ export interface EditableSelectInputProps {
   /** Single select option value for single select menus, or array of select option values for multi select. You can also specify isSelected on the SelectOption */
   selected: any | any[];
   /** Array of react elements to display in the select menu */
-  options: React.ReactElement[];
+  options: React.ReactElement<any>[];
   /** Props to be passed down to the select component */
   editableSelectProps?: SelectProps;
   /** arbitrary data to pass to the internal select component in the editable select input cell */

--- a/packages/react-table/src/components/Table/examples/TableDraggable.tsx
+++ b/packages/react-table/src/components/Table/examples/TableDraggable.tsx
@@ -9,7 +9,7 @@ export const TableDraggable: React.FunctionComponent = () => {
   const [itemOrder, setItemOrder] = React.useState(['row1', 'row2', 'row3']);
   const [tempItemOrder, setTempItemOrder] = React.useState<string[]>([]);
 
-  const bodyRef = React.useRef<HTMLTableSectionElement>();
+  const bodyRef = React.useRef<HTMLTableSectionElement>(undefined);
 
   const onDragStart: TrProps['onDragStart'] = (evt) => {
     evt.dataTransfer.effectAllowed = 'move';

--- a/packages/react-table/src/components/Table/examples/TableEditable.tsx
+++ b/packages/react-table/src/components/Table/examples/TableEditable.tsx
@@ -18,7 +18,7 @@ const EditButtonsCell: React.FunctionComponent<EditButtonsCellProps> = ({
   elementToFocusOnEditRef,
   rowAriaLabel = 'row'
 }) => {
-  const editButtonRef = React.useRef<HTMLButtonElement>();
+  const editButtonRef = React.useRef<HTMLButtonElement>(undefined);
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>, button: 'edit' | 'stopEditing') => {
     const focusRef = button === 'edit' ? elementToFocusOnEditRef : editButtonRef;
@@ -104,7 +104,7 @@ const EditableCell: React.FunctionComponent<EditableCellProps> = ({
       <div className={css(inlineEditStyles.inlineEditValue)}>{staticValue}</div>
       {hasMultipleInputs ? (
         <div className={css(inlineEditStyles.inlineEditGroup, 'pf-m-column')} role={role} aria-label={ariaLabel}>
-          {(editingValue as React.ReactElement[]).map((elem, index) => (
+          {(editingValue as React.ReactElement<any>[]).map((elem, index) => (
             <div key={index} className={css(inlineEditStyles.inlineEditInput)}>
               {elem}
             </div>
@@ -137,7 +137,7 @@ const EditableRow: React.FunctionComponent<EditableRow> = ({
   const [editable, setEditable] = React.useState(false);
   const [editedData, setEditedData] = React.useState(data);
 
-  const inputRef = React.useRef();
+  const inputRef = React.useRef(undefined);
 
   return (
     <Tr className={css(inlineEditStyles.inlineEdit, editable ? inlineEditStyles.modifiers.inlineEditable : '')}>

--- a/packages/react-table/src/demos/DashboardWrapper.tsx
+++ b/packages/react-table/src/demos/DashboardWrapper.tsx
@@ -38,7 +38,7 @@ interface DashboardWrapperProps {
   /** Callback when notification drawer panel is finished expanding. */
   onNotificationDrawerExpand?: (event: KeyboardEvent | React.MouseEvent | React.TransitionEvent) => void;
   /** Skip to content component for the page */
-  skipToContent?: React.ReactElement;
+  skipToContent?: React.ReactElement<any>;
   /** Sets the value for role on the <main> element */
   role?: string;
   /** an id to use for the [role="main"] element */

--- a/packages/react-table/src/demos/examples/TableColumnManagement.tsx
+++ b/packages/react-table/src/demos/examples/TableColumnManagement.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { type JSX } from 'react';
 
 import {
   Button,

--- a/packages/react-table/src/demos/examples/TableColumnManagementWithDraggable.tsx
+++ b/packages/react-table/src/demos/examples/TableColumnManagementWithDraggable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { type JSX } from 'react';
 
 import {
   Button,

--- a/packages/react-table/src/deprecated/components/Table/BodyCell.tsx
+++ b/packages/react-table/src/deprecated/components/Table/BodyCell.tsx
@@ -18,7 +18,7 @@ export interface BodyCellProps {
   ariaControls?: string;
   editableValue?: any;
   editableSelectProps?: SelectProps;
-  options?: React.ReactElement[];
+  options?: React.ReactElement<any>[];
   isSelectOpen?: boolean;
   value?: any;
   isValid?: boolean;
@@ -69,10 +69,10 @@ export const BodyCell: React.FunctionComponent<BodyCellProps> = ({
   let isEmptyStateCell = false;
   if (children) {
     isEmptyStateCell =
-      ((children as React.ReactElement).type === Bullseye &&
-        (children as React.ReactElement).props.children &&
-        (children as React.ReactElement).props.children.type === EmptyState) ||
-      (children as React.ReactElement).type === EmptyState;
+      ((children as React.ReactElement<any>).type === Bullseye &&
+        (children as React.ReactElement<any>).props.children &&
+        (children as React.ReactElement<any>).props.children.type === EmptyState) ||
+      (children as React.ReactElement<any>).type === EmptyState;
   }
 
   const cell = (

--- a/packages/react-table/src/deprecated/components/Table/Table.tsx
+++ b/packages/react-table/src/deprecated/components/Table/Table.tsx
@@ -29,6 +29,8 @@ import {
   CustomActionsToggleProps
 } from '../../../components';
 
+import type { JSX } from 'react';
+
 export interface TableProps extends OUIAProps {
   /** Adds an accessible name for the Table */
   'aria-label'?: string;

--- a/packages/react-table/src/deprecated/components/Table/examples/LegacyTableMisc.tsx
+++ b/packages/react-table/src/deprecated/components/Table/examples/LegacyTableMisc.tsx
@@ -36,7 +36,7 @@ export const LegacyTableMisc: React.FunctionComponent = () => {
     };
     return (
       <tr
-        ref={trRef as React.LegacyRef<HTMLTableRowElement>}
+        ref={trRef as React.Ref<HTMLTableRowElement>}
         className={css(className, isOddRow ? 'odd-row-class' : 'even-row-class', 'custom-static-class')}
         style={isOddRow ? customStyle : {}}
       />

--- a/packages/react-table/src/deprecated/components/Table/examples/LegacyTableStripedCustomTr.tsx
+++ b/packages/react-table/src/deprecated/components/Table/examples/LegacyTableStripedCustomTr.tsx
@@ -29,9 +29,7 @@ export const LegacyTableStripedCustomTr: React.FunctionComponent = () => {
 
   const customRowWrapper: TableProps['rowWrapper'] = ({ trRef, className, rowProps, row: _row }) => {
     const isOddRow = rowProps ? !!((rowProps.rowIndex + 1) % 2) : true;
-    return (
-      <tr ref={trRef as React.LegacyRef<HTMLTableRowElement>} className={css(className, isOddRow && 'pf-m-striped')} />
-    );
+    return <tr ref={trRef as React.Ref<HTMLTableRowElement>} className={css(className, isOddRow && 'pf-m-striped')} />;
   };
 
   return (

--- a/packages/react-table/src/test-helpers/MockedTableChanges.js
+++ b/packages/react-table/src/test-helpers/MockedTableChanges.js
@@ -41,7 +41,7 @@ export const TableProvider = withContext({
   contextType: { columns: PropTypes.any, renderers: PropTypes.any }
 })('table');
 
-const MockedTableChanges = ({ updateFunc, columns }) => (
+const MockedTableChanges = ({ updateFunc = () => undefined, columns = [] }) => (
   <TableContext.Provider value={{ updateHeaderData: updateFunc }}>
     <TableProvider>
       <TableHeader headerRows={columns} />
@@ -52,11 +52,6 @@ const MockedTableChanges = ({ updateFunc, columns }) => (
 MockedTableChanges.propTypes = {
   updateFunc: PropTypes.func,
   columns: PropTypes.array
-};
-
-MockedTableChanges.defaultProps = {
-  updateFunc: () => undefined,
-  columns: []
 };
 
 export default MockedTableChanges;

--- a/packages/react-templates/src/components/Select/MultiTypeaheadSelect.tsx
+++ b/packages/react-templates/src/components/Select/MultiTypeaheadSelect.tsx
@@ -70,7 +70,7 @@ export const MultiTypeaheadSelectBase: React.FunctionComponent<MultiTypeaheadSel
   const [selectOptions, setSelectOptions] = React.useState<MultiTypeaheadSelectOption[]>(initialOptions);
   const [focusedItemIndex, setFocusedItemIndex] = React.useState<number | null>(null);
   const [activeItemId, setActiveItemId] = React.useState<string | null>(null);
-  const textInputRef = React.useRef<HTMLInputElement>();
+  const textInputRef = React.useRef<HTMLInputElement>(undefined);
 
   const NO_RESULTS = 'no results';
 

--- a/packages/react-templates/src/components/Select/TypeaheadSelect.tsx
+++ b/packages/react-templates/src/components/Select/TypeaheadSelect.tsx
@@ -88,7 +88,7 @@ export const TypeaheadSelectBase: React.FunctionComponent<TypeaheadSelectProps> 
   const [selectOptions, setSelectOptions] = React.useState<TypeaheadSelectOption[]>(initialOptions);
   const [focusedItemIndex, setFocusedItemIndex] = React.useState<number | null>(null);
   const [activeItemId, setActiveItemId] = React.useState<string | null>(null);
-  const textInputRef = React.useRef<HTMLInputElement>();
+  const textInputRef = React.useRef<HTMLInputElement>(undefined);
 
   const NO_RESULTS = 'no results';
 


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #11483 , #11369, #11368

The eslint plug from 11483 only auto-updated the MockedTableChanges file (in react-table's test-helpers)

I also ran the React 19 codemod from their upgrade guide, which only auto-updated the Alert test file's `act` import.

Everything else was autoupdated by the typescript React 19 codemod (I had to manually update 3 other instance of a useRef).

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
