### PR TITLE
fix(CodeEditor): do not include extra div if `headerMainContent` is unset

### DIFF
--- a/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
@@ -612,7 +612,7 @@ class CodeEditor extends React.Component<CodeEditorProps, CodeEditorState> {
                   {customControls && customControls}
                 </CodeEditorContext.Provider>
               </div>
-              {<div className={css(styles.codeEditorHeaderMain)}>{headerMainContent}</div>}
+              {headerMainContent && <div className={css(styles.codeEditorHeaderMain)}>{headerMainContent}</div>}
               {!!shortcutsPopoverProps.bodyContent && (
                 <div className={`${styles.codeEditor}__keyboard-shortcuts`}>
                   <Popover {...shortcutsPopoverProps}>

--- a/packages/react-code-editor/src/components/CodeEditor/__test__/__snapshots__/CodeEditor.test.tsx.snap
+++ b/packages/react-code-editor/src/components/CodeEditor/__test__/__snapshots__/CodeEditor.test.tsx.snap
@@ -110,9 +110,6 @@ exports[`Matches snapshot with control buttons enabled 1`] = `
               </button>
             </div>
           </div>
-          <div
-            class="pf-v6-c-code-editor__header-main"
-          />
         </div>
       </div>
       <div


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #11533
