### PR TITLE
fix(DescriptionList): V5 - allow help text button popover to open via keyboard

### DIFF
--- a/packages/react-charts/victory/package.json
+++ b/packages/react-charts/victory/package.json
@@ -1,1 +1,0 @@
-{"name":"@patternfly/react-charts-victory","main":"../dist/js/victory/index.js","module":"../dist/esm/victory/index.js","typings":"../dist/esm/victory/index.d.ts","version":"8.2.0-prerelease.15","private":true}

--- a/packages/react-charts/victory/package.json
+++ b/packages/react-charts/victory/package.json
@@ -1,0 +1,1 @@
+{"name":"@patternfly/react-charts-victory","main":"../dist/js/victory/index.js","module":"../dist/esm/victory/index.js","typings":"../dist/esm/victory/index.d.ts","version":"8.2.0-prerelease.15","private":true}

--- a/packages/react-core/src/components/DescriptionList/DescriptionListTermHelpTextButton.tsx
+++ b/packages/react-core/src/components/DescriptionList/DescriptionListTermHelpTextButton.tsx
@@ -13,15 +13,33 @@ export const DescriptionListTermHelpTextButton: React.FunctionComponent<Descript
   children,
   className,
   ...props
-}: DescriptionListTermHelpTextButtonProps) => (
-  <span
-    className={css(className, styles.descriptionListText, styles.modifiers.helpText)}
-    role="button"
-    type="button"
-    tabIndex={0}
-    {...props}
-  >
-    {children}
-  </span>
-);
+}: DescriptionListTermHelpTextButtonProps) => {
+  const helpTextRef = React.createRef<HTMLSpanElement>();
+
+  const handleKeys = (event: React.KeyboardEvent<HTMLSpanElement>) => {
+    if (!helpTextRef.current || helpTextRef.current !== (event.target as HTMLElement)) {
+      return;
+    }
+
+    const key = event.key;
+    if (key === 'Enter' || key === ' ') {
+      event.preventDefault();
+      helpTextRef.current.click();
+    }
+  };
+
+  return (
+    <span
+      ref={helpTextRef}
+      className={css(className, styles.descriptionListText, styles.modifiers.helpText)}
+      role="button"
+      type="button"
+      tabIndex={0}
+      onKeyDown={(event) => handleKeys(event)}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+};
 DescriptionListTermHelpTextButton.displayName = 'DescriptionListTermHelpTextButton';


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #10350

V5 mirror of https://github.com/patternfly/patternfly-react/pull/11546
