### PR TITLE
feat(DataList): add tooltip to truncated DataListCell

### DIFF
--- a/packages/react-core/src/components/DataList/DataListCell.tsx
+++ b/packages/react-core/src/components/DataList/DataListCell.tsx
@@ -1,3 +1,4 @@
+import { FunctionComponent, useRef, useState, useEffect } from 'react';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/DataList/data-list';
 import { DataListWrapModifier } from './DataList';
@@ -20,7 +21,7 @@ export interface DataListCellProps extends Omit<React.HTMLProps<HTMLDivElement>,
   wrapModifier?: DataListWrapModifier | 'nowrap' | 'truncate' | 'breakWord';
 }
 
-export const DataListCell: React.FunctionComponent<DataListCellProps> = ({
+export const DataListCell: FunctionComponent<DataListCellProps> = ({
   children = null,
   className = '',
   width = 1,
@@ -30,10 +31,10 @@ export const DataListCell: React.FunctionComponent<DataListCellProps> = ({
   wrapModifier = null,
   ...props
 }: DataListCellProps) => {
-  const cellRef = React.useRef(null);
-  const [isTooltipVisible, setIsTooltipVisible] = React.useState(false);
+  const cellRef = useRef(null);
+  const [isTooltipVisible, setIsTooltipVisible] = useState(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!cellRef.current || wrapModifier !== 'truncate') {
       return;
     }

--- a/packages/react-core/src/components/DataList/DataListCell.tsx
+++ b/packages/react-core/src/components/DataList/DataListCell.tsx
@@ -1,6 +1,7 @@
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/DataList/data-list';
 import { DataListWrapModifier } from './DataList';
+import { Tooltip } from '../Tooltip';
 
 export interface DataListCellProps extends Omit<React.HTMLProps<HTMLDivElement>, 'width'> {
   /** Content rendered inside the DataList cell */
@@ -28,20 +29,38 @@ export const DataListCell: React.FunctionComponent<DataListCellProps> = ({
   isIcon = false,
   wrapModifier = null,
   ...props
-}: DataListCellProps) => (
-  <div
-    className={css(
-      styles.dataListCell,
-      width > 1 && styles.modifiers[`flex_${width}` as 'flex_2' | 'flex_3' | 'flex_4' | 'flex_5'],
-      !isFilled && styles.modifiers.noFill,
-      alignRight && styles.modifiers.alignRight,
-      isIcon && styles.modifiers.icon,
-      className,
-      wrapModifier && styles.modifiers[wrapModifier]
-    )}
-    {...props}
-  >
-    {children}
-  </div>
-);
+}: DataListCellProps) => {
+  const cellRef = React.useRef(null);
+  const [isTooltipVisible, setIsTooltipVisible] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!cellRef.current || wrapModifier !== 'truncate') {
+      return;
+    }
+    const showTooltip = cellRef.current && cellRef.current.offsetWidth < cellRef.current.scrollWidth;
+    if (isTooltipVisible !== showTooltip) {
+      setIsTooltipVisible(showTooltip);
+    }
+  }, [cellRef, wrapModifier, isTooltipVisible]);
+
+  return (
+    <div
+      className={css(
+        styles.dataListCell,
+        width > 1 && styles.modifiers[`flex_${width}` as 'flex_2' | 'flex_3' | 'flex_4' | 'flex_5'],
+        !isFilled && styles.modifiers.noFill,
+        alignRight && styles.modifiers.alignRight,
+        isIcon && styles.modifiers.icon,
+        className,
+        wrapModifier && styles.modifiers[wrapModifier]
+      )}
+      {...(isTooltipVisible && { tabIndex: 0 })}
+      ref={cellRef}
+      {...props}
+    >
+      {children}
+      {isTooltipVisible && <Tooltip content={children} triggerRef={cellRef} />}
+    </div>
+  );
+};
 DataListCell.displayName = 'DataListCell';


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #11389

Adds logic to display a tooltip when a DataListCell's wrap modifier is set to truncate and the content is overflowing.