### PR TITLE
fix(HelperTextItem): allowed removal of SR text element

### DIFF
--- a/packages/react-core/src/components/HelperText/HelperTextItem.tsx
+++ b/packages/react-core/src/components/HelperText/HelperTextItem.tsx
@@ -56,6 +56,7 @@ export const HelperTextItem: React.FunctionComponent<HelperTextItemProps> = ({
   const Component = component as any;
   const isNotDefaultVariant = variant !== 'default';
   const defaultIcon = isNotDefaultVariant && defaultVariantIcons[variant];
+  const shouldRenderSRText = isNotDefaultVariant && screenReaderText && screenReaderText !== '';
   return (
     <Component
       className={css(styles.helperTextItem, isNotDefaultVariant && styles.modifiers[variant], className)}
@@ -66,7 +67,7 @@ export const HelperTextItem: React.FunctionComponent<HelperTextItemProps> = ({
 
       <span className={css(styles.helperTextItemText)}>
         {children}
-        {isNotDefaultVariant && <span className="pf-v6-screen-reader">: {screenReaderText};</span>}
+        {shouldRenderSRText && <span className="pf-v6-screen-reader">: {screenReaderText};</span>}
       </span>
     </Component>
   );

--- a/packages/react-core/src/components/HelperText/__tests__/HelperTextItem.test.tsx
+++ b/packages/react-core/src/components/HelperText/__tests__/HelperTextItem.test.tsx
@@ -53,6 +53,18 @@ Object.values(['indeterminate', 'warning', 'success', 'error']).forEach((variant
     );
     expect(screen.getByText(`: ${variant} status;`)).toBeInTheDocument();
   });
+
+  test('Renders without screenreader text when screenReaderText is empty string', () => {
+    render(
+      <HelperTextItem
+        screenReaderText=""
+        variant={variant as 'default' | 'indeterminate' | 'warning' | 'success' | 'error'}
+      >
+        text
+      </HelperTextItem>
+    );
+    expect(screen.queryByText(`: ${variant} status;`)).not.toBeInTheDocument();
+  });
 });
 
 test('Renders custom screen reader text', () => {


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #11678 

@Venefilyn For now I've allowed passing an empty string to remove the entire SR text element. As far as I'm aware there isn't an applicable aria attribute to use in place of it, and removing the SR text completely right now would be considered breaking. Please let me know if this is a viable solution until we can possibly revisit in our next breaking change.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
