### PR TITLE
fix(CodeeEditor): rendered file input when editor has content

### DIFF
--- a/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx
@@ -696,7 +696,12 @@ class CodeEditor extends Component<CodeEditorProps, CodeEditorState> {
               ) : (
                 <>
                   {editorHeader}
-                  {showEditor && <div className={css(styles.codeEditorMain)}>{editor}</div>}
+                  {showEditor && (
+                    <div className={css(styles.codeEditorMain)}>
+                      {hiddenFileInput}
+                      {editor}
+                    </div>
+                  )}
                 </>
               )}
             </div>

--- a/packages/react-code-editor/src/components/CodeEditor/__test__/__snapshots__/CodeEditor.test.tsx.snap
+++ b/packages/react-code-editor/src/components/CodeEditor/__test__/__snapshots__/CodeEditor.test.tsx.snap
@@ -110,6 +110,12 @@ exports[`Matches snapshot with control buttons enabled 1`] = `
     <div
       class="pf-v6-c-code-editor__main"
     >
+      <input
+        hidden=""
+        style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+        tabindex="-1"
+        type="file"
+      />
       <div
         class="pf-v6-c-code-editor__code"
         dir="ltr"
@@ -135,6 +141,12 @@ exports[`Matches snapshot without props 1`] = `
     <div
       class="pf-v6-c-code-editor__main"
     >
+      <input
+        hidden=""
+        style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+        tabindex="-1"
+        type="file"
+      />
       <div
         class="pf-v6-c-code-editor__code"
         dir="ltr"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #11726

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
