### PR TITLE
fix(Nav): added role presentation to NavItemSeparator

### DIFF
--- a/packages/react-core/src/components/Divider/Divider.tsx
+++ b/packages/react-core/src/components/Divider/Divider.tsx
@@ -32,7 +32,7 @@ export interface DividerProps extends React.HTMLProps<HTMLElement> {
     '2xl'?: 'vertical' | 'horizontal';
   };
   /** The ARIA role of the divider when the component property has a value other than "hr". */
-  role?: 'separator' | 'presentation';
+  role?: string;
 }
 
 export const Divider: React.FunctionComponent<DividerProps> = ({

--- a/packages/react-core/src/components/Divider/Divider.tsx
+++ b/packages/react-core/src/components/Divider/Divider.tsx
@@ -32,7 +32,7 @@ export interface DividerProps extends React.HTMLProps<HTMLElement> {
     '2xl'?: 'vertical' | 'horizontal';
   };
   /** The ARIA role of the divider when the component property has a value other than "hr". */
-  role?: string;
+  role?: 'separator' | 'presentation';
 }
 
 export const Divider: React.FunctionComponent<DividerProps> = ({

--- a/packages/react-core/src/components/Divider/Divider.tsx
+++ b/packages/react-core/src/components/Divider/Divider.tsx
@@ -31,6 +31,8 @@ export interface DividerProps extends React.HTMLProps<HTMLElement> {
     xl?: 'vertical' | 'horizontal';
     '2xl'?: 'vertical' | 'horizontal';
   };
+  /** The ARIA role of the divider when the component property has a value other than "hr". */
+  role?: 'separator' | 'presentation';
 }
 
 export const Divider: React.FunctionComponent<DividerProps> = ({
@@ -38,6 +40,7 @@ export const Divider: React.FunctionComponent<DividerProps> = ({
   component = DividerVariant.hr,
   inset,
   orientation,
+  role = 'separator',
   ...props
 }: DividerProps) => {
   const Component: any = component;
@@ -50,7 +53,7 @@ export const Divider: React.FunctionComponent<DividerProps> = ({
         formatBreakpointMods(orientation, styles),
         className
       )}
-      {...(component !== 'hr' && { role: 'separator' })}
+      {...(component !== 'hr' && { role })}
       {...props}
     />
   );

--- a/packages/react-core/src/components/Divider/__tests__/Divider.test.tsx
+++ b/packages/react-core/src/components/Divider/__tests__/Divider.test.tsx
@@ -91,6 +91,16 @@ test(`Test all insets`, () => {
   });
 });
 
+test('Does not render with value passed to role by default', () => {
+  render(<Divider role="presentation" />);
+  expect(screen.queryByRole('presentation')).not.toBeInTheDocument();
+});
+
+test('Renders with value passed to role when component is not "hr"', () => {
+  render(<Divider component="li" role="presentation" />);
+  expect(screen.getByRole('presentation')).toBeInTheDocument();
+});
+
 test('Matches the snapshot', () => {
   const { asFragment } = render(<Divider />);
   expect(asFragment()).toMatchSnapshot();

--- a/packages/react-core/src/components/Nav/NavItemSeparator.tsx
+++ b/packages/react-core/src/components/Nav/NavItemSeparator.tsx
@@ -2,6 +2,7 @@ import { Divider, DividerProps } from '../Divider';
 
 export const NavItemSeparator: React.FunctionComponent<DividerProps> = ({
   component = 'li',
+  role = 'presentation',
   ...props
-}: DividerProps) => <Divider component={component} {...props} />;
+}: DividerProps) => <Divider component={component} role={role} {...props} />;
 NavItemSeparator.displayName = 'NavItemSeparator';

--- a/packages/react-core/src/components/Toolbar/ToolbarItem.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarItem.tsx
@@ -185,12 +185,19 @@ export const ToolbarItem: React.FunctionComponent<ToolbarItemProps> = ({
   children,
   isAllExpanded,
   isOverflowContainer,
+  role,
   ...props
 }: ToolbarItemProps) => {
   if (variant === ToolbarItemVariant.separator) {
-    // TODO: consider removing spread props here so we can update Divider role prop to union of
-    // separator or presentation rather than generic string
-    return <Divider className={css(className)} orientation={{ default: 'vertical' }} {...props} />;
+    const isDividerRoleValid = role === 'separator' || role === 'presentation';
+    return (
+      <Divider
+        className={css(className)}
+        orientation={{ default: 'vertical' }}
+        {...props}
+        {...(isDividerRoleValid && { role: role as 'separator' | 'presentation' })}
+      />
+    );
   }
 
   return (
@@ -219,6 +226,7 @@ export const ToolbarItem: React.FunctionComponent<ToolbarItemProps> = ({
           )}
           {...(variant === 'label' && { 'aria-hidden': true })}
           id={id}
+          role={role}
           {...props}
         >
           {children}

--- a/packages/react-core/src/components/Toolbar/ToolbarItem.tsx
+++ b/packages/react-core/src/components/Toolbar/ToolbarItem.tsx
@@ -188,6 +188,8 @@ export const ToolbarItem: React.FunctionComponent<ToolbarItemProps> = ({
   ...props
 }: ToolbarItemProps) => {
   if (variant === ToolbarItemVariant.separator) {
+    // TODO: consider removing spread props here so we can update Divider role prop to union of
+    // separator or presentation rather than generic string
     return <Divider className={css(className)} orientation={{ default: 'vertical' }} {...props} />;
   }
 


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #11717 

Opted to not create an interface to expose for NavItemSeparator, as I'm wondering if we should consider deprecating it and just using the Divider component. Right now NavItemSeparator is just a wordier wrapper for Divider, and we're not doing anything special within it. One purpose of keeping this would be to have documentation explicitly about when to set the props to what (assuming we intend for this component to be used as either a separator between NavItems or just anywhere within a Nav; if the intent is only for between NavItems, then we should consider not allowing role or component to be customized).

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
