### PR TITLE
chore(dropdown): add split button action example

### DIFF
--- a/packages/react-core/src/components/Dropdown/examples/Dropdown.md
+++ b/packages/react-core/src/components/Dropdown/examples/Dropdown.md
@@ -16,7 +16,7 @@ propComponents:
   ]
 ---
 
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
 
 ## Examples

--- a/packages/react-core/src/components/Dropdown/examples/DropdownWithSplit.tsx
+++ b/packages/react-core/src/components/Dropdown/examples/DropdownWithSplit.tsx
@@ -7,11 +7,11 @@ import {
   Divider,
   MenuToggleElement
 } from '@patternfly/react-core';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 export const DropdownSplitButtonText: React.FunctionComponent = () => {
   const [isOpen, setIsOpen] = useState(false);
-  const toggleRef = React.useRef<MenuToggleElement>(null);
+  const toggleRef = useRef<MenuToggleElement>(null);
 
   const onFocus = () => {
     if (!toggleRef.current) {


### PR DESCRIPTION
Closes #10197 
References:
- https://v5-archive.patternfly.org/components/menus/dropdown/react-deprecated#split-button-checkbox
- https://www.patternfly.org/components/menus/menu-toggle#split-toggle-with-checkbox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new section describing split-toggle patterns that combine a control with a dropdown, including guidance on focus restoration after item selection and an example usage.

* **New Features**
  * Added an example component demonstrating a dropdown with a split-button toggle and an integrated checkbox, showing open/close behavior, disabled/aria-disabled items, separators, and manual focus handling after selection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->