### PR TITLE
feat(MultiTypeaheadSelect): add initialInputValue prop

### DIFF
--- a/packages/react-templates/src/components/Select/MultiTypeaheadSelect.tsx
+++ b/packages/react-templates/src/components/Select/MultiTypeaheadSelect.tsx
@@ -53,6 +53,8 @@ export interface MultiTypeaheadSelectProps extends Omit<SelectProps, 'toggle' | 
   toggleProps?: MenuToggleProps;
   /** Additional props passed to each label of the selected option. */
   labelProps?: LabelProps;
+  /** Initial value of the typeahead text input. */
+  initialInputValue?: string;
 }
 
 export const MultiTypeaheadSelectBase: React.FunctionComponent<MultiTypeaheadSelectProps> = ({
@@ -68,13 +70,14 @@ export const MultiTypeaheadSelectBase: React.FunctionComponent<MultiTypeaheadSel
   toggleWidth,
   toggleProps,
   labelProps,
+  initialInputValue,
   ...props
 }: MultiTypeaheadSelectProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [selected, setSelected] = useState<(string | number)[]>(
     (initialOptions?.filter((o) => o.selected) ?? []).map((o) => o.value)
   );
-  const [inputValue, setInputValue] = useState<string>();
+  const [inputValue, setInputValue] = useState<string>(initialInputValue);
   const [selectOptions, setSelectOptions] = useState<MultiTypeaheadSelectOption[]>(initialOptions);
   const [focusedItemIndex, setFocusedItemIndex] = useState<number | null>(null);
   const [activeItemId, setActiveItemId] = useState<string | null>(null);
@@ -107,9 +110,6 @@ export const MultiTypeaheadSelectBase: React.FunctionComponent<MultiTypeaheadSel
           }
         ];
       }
-
-      // Open the menu when the input value changes and the new value is not empty
-      openMenu();
     }
 
     setSelectOptions(newSelectOptions);
@@ -172,6 +172,10 @@ export const MultiTypeaheadSelectBase: React.FunctionComponent<MultiTypeaheadSel
   const onTextInputChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => {
     setInputValue(value);
     onInputChange && onInputChange(value);
+
+    if (value && !isOpen) {
+      openMenu();
+    }
 
     resetActiveAndFocusedItem();
   };

--- a/packages/react-templates/src/components/Select/__tests__/MultiTypeaheadSelect.test.tsx
+++ b/packages/react-templates/src/components/Select/__tests__/MultiTypeaheadSelect.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { render, screen, waitForElementToBeRemoved, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MultiTypeaheadSelect } from '../MultiTypeaheadSelect';
 import styles from '@patternfly/react-styles/css/components/Menu/menu';
@@ -411,6 +411,36 @@ describe('MultiTypeaheadSelect', () => {
     expect(onInputKeyDownMock).not.toHaveBeenCalled();
     await user.keyboard('{Enter}');
     expect(onInputKeyDownMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('text input is empty by default', async () => {
+    render(<MultiTypeaheadSelect initialOptions={[]} />);
+
+    const input = screen.getByRole('combobox');
+    expect(input).toHaveValue('');
+  });
+
+  it('initialInputValue prop sets the default text input value', async () => {
+    const initialOptions = [
+      { content: 'Option 1', value: 'option1' },
+      { content: 'Option 2', value: 'option2' },
+      { content: 'Option 3', value: 'option3' }
+    ];
+
+    const user = userEvent.setup();
+
+    render(<MultiTypeaheadSelect initialInputValue={'Option 1'} initialOptions={initialOptions} />);
+
+    const input = screen.getByRole('combobox');
+    expect(input).toHaveValue('Option 1');
+
+    await user.click(input);
+
+    const menu = screen.getByRole('listbox');
+    const options = within(menu).getAllByRole('option');
+
+    expect(options).toHaveLength(1);
+    expect(options[0]).toHaveTextContent('Option 1');
   });
 
   it('Matches snapshot', async () => {

--- a/packages/react-templates/src/components/Select/__tests__/__snapshots__/MultiTypeaheadSelect.test.tsx.snap
+++ b/packages/react-templates/src/components/Select/__tests__/__snapshots__/MultiTypeaheadSelect.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`MultiTypeaheadSelect Matches snapshot 1`] = `
         <button
           aria-label="Clear input value"
           class="pf-v6-c-button pf-m-plain"
-          data-ouia-component-id="OUIA-Generated-Button-plain-21"
+          data-ouia-component-id="OUIA-Generated-Button-plain-23"
           data-ouia-component-type="PF6/Button"
           data-ouia-safe="true"
           type="button"
@@ -63,7 +63,7 @@ exports[`MultiTypeaheadSelect Matches snapshot 1`] = `
       aria-expanded="true"
       aria-label="Multi select Typeahead menu toggle"
       class="pf-v6-c-menu-toggle__button"
-      data-ouia-component-id="OUIA-Generated-MenuToggle-typeahead-18"
+      data-ouia-component-id="OUIA-Generated-MenuToggle-typeahead-20"
       data-ouia-component-type="PF6/MenuToggle"
       data-ouia-safe="true"
       tabindex="-1"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #11790 

~~- also removes the `setInputValue('')` line from the `closeMenu` function~~
  - this behavior (clearing caused by `onOpenChange` - clicking outside of the input or pressing escape) was not consistent with closing the menu by clicking on the toggle and then outside of the input, the [example code](https://www.patternfly.org/components/menus/select#multiple-typeahead-with-chips) also doesn't clear the input 
  - it actually might be a good feature and I don't want to break someone's existing code because of this change. I wonder whether I should instead add a prop, something like "`clearInputOnMenuClose`" (default to true?), which would also clear the input on closing by clicking the toggle (which is not happening now)
