### PR TITLE
fix(Truncate): allowed punctuation at start of content

### DIFF
--- a/packages/react-core/src/components/Truncate/Truncate.tsx
+++ b/packages/react-core/src/components/Truncate/Truncate.tsx
@@ -142,13 +142,18 @@ export const Truncate: React.FunctionComponent<TruncateProps> = ({
     setShouldRenderByMaxChars(maxCharsDisplayed > 0);
   }, [maxCharsDisplayed]);
 
+  const lrmEntity = <Fragment>&lrm;</Fragment>;
+  const isStartPosition = position === TruncatePosition.start;
+  const isEndPosition = position === TruncatePosition.end;
+
   const renderResizeObserverContent = () => {
-    if (position === TruncatePosition.end || position === TruncatePosition.start) {
+    if (isEndPosition || isStartPosition) {
       return (
         <>
           <span ref={textRef} className={truncateStyles[position]}>
+            {isStartPosition && lrmEntity}
             {content}
-            {position === TruncatePosition.start && <Fragment>&lrm;</Fragment>}
+            {isStartPosition && lrmEntity}
           </span>
         </>
       );
@@ -195,7 +200,7 @@ export const Truncate: React.FunctionComponent<TruncateProps> = ({
         </>
       );
     }
-    if (position === TruncatePosition.end) {
+    if (isEndPosition) {
       return (
         <>
           {renderVisibleContent(content.slice(0, maxCharsDisplayed))}

--- a/packages/react-core/src/components/Truncate/__tests__/Truncate.test.tsx
+++ b/packages/react-core/src/components/Truncate/__tests__/Truncate.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, within } from '@testing-library/react';
-import { Truncate } from '../Truncate';
+import { Truncate, TruncatePosition } from '../Truncate';
 import styles from '@patternfly/react-styles/css/components/Truncate/truncate';
 import '@testing-library/jest-dom';
 
@@ -67,7 +67,7 @@ test('renders default truncation', () => {
   expect(asFragment()).toMatchSnapshot();
 });
 
-test('renders start truncation with &lrm; at end', () => {
+test('renders start truncation with &lrm; at start and end', () => {
   const { asFragment } = render(
     <Truncate
       content={'Vestibulum interdum risus et enim faucibus, sit amet molestie est accumsan.'}

--- a/packages/react-core/src/components/Truncate/__tests__/Truncate.test.tsx
+++ b/packages/react-core/src/components/Truncate/__tests__/Truncate.test.tsx
@@ -67,6 +67,8 @@ test('renders default truncation', () => {
   expect(asFragment()).toMatchSnapshot();
 });
 
+// If this snapshot fails and the output text doesn't seem like it's changed, it most likely
+// is due to the &lrm; HTML entity isn't rendering correctly.
 test('renders start truncation with &lrm; at start and end', () => {
   const { asFragment } = render(
     <Truncate

--- a/packages/react-core/src/components/Truncate/__tests__/__snapshots__/Truncate.test.tsx.snap
+++ b/packages/react-core/src/components/Truncate/__tests__/__snapshots__/Truncate.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`renders default truncation 1`] = `
 </DocumentFragment>
 `;
 
-exports[`renders start truncation with &lrm; at end 1`] = `
+exports[`renders start truncation with &lrm; at start and end 1`] = `
 <DocumentFragment>
   <div
     data-testid="Tooltip-mock"
@@ -86,7 +86,7 @@ exports[`renders start truncation with &lrm; at end 1`] = `
     <span
       class="pf-v6-c-truncate__end"
     >
-      Vestibulum interdum risus et enim faucibus, sit amet molestie est accumsan.‎
+      ‎Vestibulum interdum risus et enim faucibus, sit amet molestie est accumsan.‎
     </span>
   </span>
 </DocumentFragment>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #11777

don't think we can rely on a unit test to validate this doesn't break again; everything renders in the DOM as expected, it's just the `direction: rtl` styling that causes things to visually get out of order.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
