### PR TITLE
feat(Truncate): added tooltip props and anchor usage

### DIFF
--- a/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
+++ b/packages/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
@@ -204,7 +204,7 @@ class ClipboardCopy extends Component<ClipboardCopyProps, ClipboardCopyState> {
     const shouldTruncate = variant === ClipboardCopyVariant.inlineCompact && truncation;
     const inlineCompactContent = shouldTruncate ? (
       <Truncate
-        refToGetParent={this.clipboardRef}
+        tooltipProps={{ triggerRef: this.clipboardRef }}
         content={copyableText}
         {...(typeof truncation === 'object' && truncation)}
       />
@@ -223,6 +223,7 @@ class ClipboardCopy extends Component<ClipboardCopyProps, ClipboardCopyState> {
           className
         )}
         ref={this.clipboardRef}
+        {...(shouldTruncate && { tabIndex: 0 })}
         {...divProps}
         {...getOUIAProps(ClipboardCopy.displayName, ouiaId, ouiaSafe)}
       >

--- a/packages/react-core/src/components/Truncate/examples/Truncate.md
+++ b/packages/react-core/src/components/Truncate/examples/Truncate.md
@@ -5,6 +5,7 @@ cssPrefix: pf-v6-c-truncate
 propComponents: [Truncate]
 ---
 
+import { useRef } from 'react';
 import './TruncateExamples.css';
 
 ## Examples
@@ -50,5 +51,11 @@ Rather than observing container width, you can have truncation be based on a max
 Truncating based on a maximum amount of characters will truncate the content at the end by default. When the `position` property is set to "middle", the truncation will split the content as evenly as possible, providing a more "true middle" truncation.
 
 ```ts file="./TruncateMaxChars.tsx"
+
+```
+
+### With links
+
+```ts file="./TruncateLinks.tsx"
 
 ```

--- a/packages/react-core/src/components/Truncate/examples/TruncateLinks.tsx
+++ b/packages/react-core/src/components/Truncate/examples/TruncateLinks.tsx
@@ -1,0 +1,30 @@
+import { useRef } from 'react';
+import { Truncate, Button } from '@patternfly/react-core';
+
+export const TruncateLinks: React.FunctionComponent = () => {
+  const anchorRef = useRef(null);
+  const btnRef = useRef(null);
+  const content = 'A very lengthy anchor text content to trigger truncation';
+  return (
+    <>
+      <div>With default width-observing truncation:</div>
+      <div className="truncate-example-resize">
+        <a ref={anchorRef} href="#">
+          <Truncate tooltipProps={{ triggerRef: anchorRef }} content={content} />
+        </a>
+        <Button variant="control" ref={btnRef}>
+          <Truncate tooltipProps={{ triggerRef: btnRef }} content={content} />
+        </Button>
+        <Truncate position="start" href="#" content={content} />
+        <Truncate position="middle" href="#" content={content} />
+      </div>
+      <br />
+      <div>With max characters truncation:</div>
+      <Truncate maxCharsDisplayed={15} href="#" content={content} />
+      <br />
+      <Truncate maxCharsDisplayed={15} position="start" href="#" content={content} />
+      <br />
+      <Truncate maxCharsDisplayed={15} position="middle" href="#" content={content} />
+    </>
+  );
+};

--- a/packages/react-core/src/helpers/util.ts
+++ b/packages/react-core/src/helpers/util.ts
@@ -545,3 +545,20 @@ export const getLanguageDirection = (targetElement: HTMLElement, defaultDirectio
 
   return defaultDirection;
 };
+
+/**
+ * Gets a reference element based on a ref property, which can typically be 1 of several types.
+ *
+ * @param {HTMLElement | (() => HTMLElement) | React.RefObject<any>} refProp The ref property to get a reference element from.
+ * @returns The reference element if one is found.
+ */
+export const getReferenceElement = (refProp: HTMLElement | (() => HTMLElement) | React.RefObject<any>) => {
+  if (refProp instanceof HTMLElement) {
+    return refProp;
+  }
+  if (typeof refProp === 'function') {
+    return refProp();
+  }
+
+  return refProp?.current;
+};


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #10843 

Some notes about this draft:

- has a simpler means to create a truncated link (via `href` prop) and a more customizable way to do it+add truncation to more complex things like buttons (via `tooltipProps` prop and the triggerRef property) -- question is do we want to support truncating in things like buttons? You can do it now, it just doesn't apply the tooltip "correctly" (since the trigger is the text itself, the tooltip will render visually "inside" the button)
- Pro to just using the href prop is the underline styling on links is retained
- tooltipProps prop is able to be used in ClipboardCopy from the updates made in https://github.com/patternfly/patternfly-react/pull/11610, thus able to remove that refToGetParent prop that was hidden from the public API anyway

TODO:

- Add tests
- Provide example documentation + possibly split the example added here into 2: one for links and one for customization via tooltipProps

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
