### PR TITLE
fix(Table): removed divider for expanded rows

### DIFF
--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -54,7 +54,7 @@
     "tslib": "^2.8.1"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.3.0-prerelease.6",
+    "@patternfly/patternfly": "6.3.0-prerelease.15",
     "case-anything": "^3.1.2",
     "css": "^3.0.0",
     "fs-extra": "^11.3.0"

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -23,7 +23,7 @@
     "test:a11y": "patternfly-a11y --config patternfly-a11y.config"
   },
   "dependencies": {
-    "@patternfly/patternfly": "6.3.0-prerelease.6",
+    "@patternfly/patternfly": "6.3.0-prerelease.15",
     "@patternfly/react-charts": "workspace:^",
     "@patternfly/react-code-editor": "workspace:^",
     "@patternfly/react-core": "workspace:^",

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -33,7 +33,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.15.4",
     "@fortawesome/free-regular-svg-icons": "^5.15.4",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
-    "@patternfly/patternfly": "6.3.0-prerelease.6",
+    "@patternfly/patternfly": "6.3.0-prerelease.15",
     "fs-extra": "^11.3.0",
     "tslib": "^2.8.1"
   },

--- a/packages/react-styles/package.json
+++ b/packages/react-styles/package.json
@@ -19,7 +19,7 @@
     "clean": "rimraf dist css"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.3.0-prerelease.6",
+    "@patternfly/patternfly": "6.3.0-prerelease.15",
     "change-case": "^5.4.4",
     "fs-extra": "^11.3.0"
   },

--- a/packages/react-table/src/components/Table/Tr.tsx
+++ b/packages/react-table/src/components/Table/Tr.tsx
@@ -14,10 +14,12 @@ export interface TrProps extends Omit<React.HTMLProps<HTMLTableRowElement>, 'onR
   innerRef?: React.Ref<any>;
   /** Flag indicating the Tr is hidden */
   isHidden?: boolean;
-  /** Only applicable to Tr within the Tbody: Makes the row expandable and determines if it's expanded or not.
+  /** Only applicable to Tr within the Tbody and determines if the expandable row content is expanded or not.
    * To prevent column widths from responding automatically when expandable rows are toggled, the width prop must also be passed into either the th or td component
    */
   isExpanded?: boolean;
+  /** Flag to indicate that a row is expandable. Only applicable to a tr that is intended to collapse or expand. */
+  isExpandable?: boolean;
   /** Only applicable to Tr within the Tbody: Whether the row is editable */
   isEditable?: boolean;
   /** Flag which adds hover styles for the clickable table row */
@@ -46,6 +48,7 @@ const TrBase: React.FunctionComponent<TrProps> = ({
   children,
   className,
   isExpanded,
+  isExpandable,
   isEditable,
   isHidden = false,
   isClickable = false,
@@ -75,7 +78,7 @@ const TrBase: React.FunctionComponent<TrProps> = ({
     };
   }
 
-  const rowIsHidden = isHidden || (isExpanded !== undefined && !isExpanded);
+  const rowIsHidden = isHidden || (isExpanded !== undefined && !isExpanded && isExpandable);
 
   const { registerSelectableRow } = useContext(TableContext);
 
@@ -96,7 +99,7 @@ const TrBase: React.FunctionComponent<TrProps> = ({
         className={css(
           styles.tableTr,
           className,
-          isExpanded !== undefined && styles.tableExpandableRow,
+          isExpandable !== undefined && styles.tableExpandableRow,
           isExpanded && styles.modifiers.expanded,
           isEditable && inlineStyles.modifiers.inlineEditable,
           isClickable && styles.modifiers.clickable,

--- a/packages/react-table/src/components/Table/__tests__/__snapshots__/RowWrapper.test.tsx.snap
+++ b/packages/react-table/src/components/Table/__tests__/__snapshots__/RowWrapper.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`RowWrapper renders expanded correctly 1`] = `
   <table>
     <tbody>
       <tr
-        class="pf-v6-c-table__tr pf-v6-c-table__expandable-row pf-m-expanded"
+        class="pf-v6-c-table__tr pf-m-expanded"
         data-ouia-component-id="OUIA-Generated-TableRow-2"
         data-ouia-component-type="PF6/TableRow"
         data-ouia-safe="true"

--- a/packages/react-table/src/components/Table/examples/TableExpandable.tsx
+++ b/packages/react-table/src/components/Table/examples/TableExpandable.tsx
@@ -116,7 +116,7 @@ export const TableExpandable: React.FunctionComponent = () => {
         id="toggle-compact"
         name="toggle-compact"
       />
-      <Table aria-label="Expandable table" variant={isExampleCompact ? 'compact' : undefined}>
+      <Table isExpandable aria-label="Expandable table" variant={isExampleCompact ? 'compact' : undefined}>
         <Thead>
           <Tr>
             <Th screenReaderText="Row expansion" />
@@ -152,7 +152,7 @@ export const TableExpandable: React.FunctionComponent = () => {
           }
           return (
             <Tbody key={repo.name} isExpanded={isRepoExpanded(repo)}>
-              <Tr>
+              <Tr isExpanded={isRepoExpanded(repo)}>
                 <Td
                   expand={
                     repo.details
@@ -172,7 +172,7 @@ export const TableExpandable: React.FunctionComponent = () => {
                 <Td dataLabel={columnNames.lastCommit}>{repo.lastCommit}</Td>
               </Tr>
               {repo.details ? (
-                <Tr isExpanded={isRepoExpanded(repo)}>
+                <Tr isExpandable isExpanded={isRepoExpanded(repo)}>
                   {!childIsFullWidth ? <Td /> : null}
                   {repo.details.detail1 ? (
                     <Td dataLabel="Repo detail 1" noPadding={childHasNoPadding} colSpan={detail1Colspan}>

--- a/packages/react-table/src/components/Table/examples/TableNestedTableExpandable.tsx
+++ b/packages/react-table/src/components/Table/examples/TableNestedTableExpandable.tsx
@@ -128,7 +128,7 @@ export const TableExpandable: React.FunctionComponent = () => {
   ];
 
   return (
-    <Table aria-label="Simple table">
+    <Table isExpandable aria-label="Simple table">
       <Thead>
         <Tr>
           <Th screenReaderText="Row expansion" />
@@ -141,7 +141,7 @@ export const TableExpandable: React.FunctionComponent = () => {
       </Thead>
       {repositories.map((repo, rowIndex) => (
         <Tbody key={repo.name} isExpanded={isRepoExpanded(repo)}>
-          <Tr>
+          <Tr isExpanded={isRepoExpanded(repo)}>
             <Td
               expand={
                 repo.nestedComponent
@@ -163,7 +163,7 @@ export const TableExpandable: React.FunctionComponent = () => {
             </Td>
           </Tr>
           {repo.nestedComponent ? (
-            <Tr isExpanded={isRepoExpanded(repo)}>
+            <Tr isExpandable isExpanded={isRepoExpanded(repo)}>
               <Td
                 noPadding={repo.noPadding}
                 dataLabel={`${columnNames.name} expended`}

--- a/packages/react-table/src/demos/examples/TableExpandCollapseAll.tsx
+++ b/packages/react-table/src/demos/examples/TableExpandCollapseAll.tsx
@@ -156,7 +156,7 @@ export const TableExpandCollapseAll: React.FunctionComponent = () => {
           aria-label="Collapsible table data"
         >
           <Card component="div">
-            <Table aria-label="Collapsible table">
+            <Table isExpandable aria-label="Collapsible table">
               <Thead>
                 <Tr>
                   <Th
@@ -175,7 +175,7 @@ export const TableExpandCollapseAll: React.FunctionComponent = () => {
 
               {serverData.map((server, serverIndex) => (
                 <Tbody key={server.name} isExpanded={isServerExpanded(server)}>
-                  <Tr>
+                  <Tr isExpanded={isServerExpanded(server)}>
                     <Td
                       expand={
                         server.details
@@ -195,7 +195,7 @@ export const TableExpandCollapseAll: React.FunctionComponent = () => {
                     <Td>{server?.workspaces}</Td>
                     <Td>{server?.status?.title}</Td>
                   </Tr>
-                  <Tr isExpanded={isServerExpanded(server)}>
+                  <Tr isExpandable isExpanded={isServerExpanded(server)}>
                     <Td></Td>
                     <Td colSpan={expandableColumns.length}>
                       <ExpandableRowContent>{server?.details}</ExpandableRowContent>

--- a/packages/react-table/src/deprecated/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/packages/react-table/src/deprecated/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -1602,11 +1602,10 @@ exports[`Table Collapsible nested table 1`] = `
         </td>
       </tr>
       <tr
-        class="pf-v6-c-table__tr pf-v6-c-table__expandable-row"
+        class="pf-v6-c-table__tr"
         data-ouia-component-id="OUIA-Generated-TableRow-182"
         data-ouia-component-type="PF6/TableRow"
         data-ouia-safe="true"
-        hidden=""
       >
         <td
           class="pf-v6-c-table__td pf-v6-c-table__toggle"
@@ -1698,11 +1697,10 @@ exports[`Table Collapsible nested table 1`] = `
         </td>
       </tr>
       <tr
-        class="pf-v6-c-table__tr pf-v6-c-table__expandable-row"
+        class="pf-v6-c-table__tr"
         data-ouia-component-id="OUIA-Generated-TableRow-183"
         data-ouia-component-type="PF6/TableRow"
         data-ouia-safe="true"
-        hidden=""
       >
         <td
           class="pf-v6-c-table__td"
@@ -1855,11 +1853,10 @@ exports[`Table Collapsible nested table 1`] = `
         </td>
       </tr>
       <tr
-        class="pf-v6-c-table__tr pf-v6-c-table__expandable-row"
+        class="pf-v6-c-table__tr"
         data-ouia-component-id="OUIA-Generated-TableRow-185"
         data-ouia-component-type="PF6/TableRow"
         data-ouia-safe="true"
-        hidden=""
       >
         <td
           class="pf-v6-c-table__td"
@@ -2363,7 +2360,7 @@ exports[`Table Collapsible table 1`] = `
         </td>
       </tr>
       <tr
-        class="pf-v6-c-table__tr pf-v6-c-table__expandable-row pf-m-expanded"
+        class="pf-v6-c-table__tr pf-m-expanded"
         data-ouia-component-id="OUIA-Generated-TableRow-167"
         data-ouia-component-type="PF6/TableRow"
         data-ouia-safe="true"
@@ -2580,11 +2577,10 @@ exports[`Table Collapsible table 1`] = `
         </td>
       </tr>
       <tr
-        class="pf-v6-c-table__tr pf-v6-c-table__expandable-row"
+        class="pf-v6-c-table__tr"
         data-ouia-component-id="OUIA-Generated-TableRow-170"
         data-ouia-component-type="PF6/TableRow"
         data-ouia-safe="true"
-        hidden=""
       >
         <td
           class="pf-v6-c-table__td"
@@ -2979,7 +2975,7 @@ exports[`Table Compound Expandable table 1`] = `
         </td>
       </tr>
       <tr
-        class="pf-v6-c-table__tr pf-v6-c-table__expandable-row pf-m-expanded"
+        class="pf-v6-c-table__tr pf-m-expanded"
         data-ouia-component-id="OUIA-Generated-TableRow-177"
         data-ouia-component-type="PF6/TableRow"
         data-ouia-safe="true"
@@ -3045,11 +3041,10 @@ exports[`Table Compound Expandable table 1`] = `
         </td>
       </tr>
       <tr
-        class="pf-v6-c-table__tr pf-v6-c-table__expandable-row"
+        class="pf-v6-c-table__tr"
         data-ouia-component-id="OUIA-Generated-TableRow-179"
         data-ouia-component-type="PF6/TableRow"
         data-ouia-safe="true"
-        hidden=""
       >
         <td
           class="pf-v6-c-table__td pf-v6-c-table__compound-expansion-toggle"
@@ -3188,11 +3183,10 @@ exports[`Table Control text table 1`] = `
         </td>
       </tr>
       <tr
-        class="pf-v6-c-table__tr pf-v6-c-table__expandable-row"
+        class="pf-v6-c-table__tr"
         data-ouia-component-id="OUIA-Generated-TableRow-212"
         data-ouia-component-type="PF6/TableRow"
         data-ouia-safe="true"
-        hidden=""
       >
         <th
           class="pf-v6-c-table__td"
@@ -3240,11 +3234,10 @@ exports[`Table Control text table 1`] = `
         </td>
       </tr>
       <tr
-        class="pf-v6-c-table__tr pf-v6-c-table__expandable-row"
+        class="pf-v6-c-table__tr"
         data-ouia-component-id="OUIA-Generated-TableRow-213"
         data-ouia-component-type="PF6/TableRow"
         data-ouia-safe="true"
-        hidden=""
       >
         <th
           class="pf-v6-c-table__td"
@@ -3348,11 +3341,10 @@ exports[`Table Control text table 1`] = `
         </td>
       </tr>
       <tr
-        class="pf-v6-c-table__tr pf-v6-c-table__expandable-row"
+        class="pf-v6-c-table__tr"
         data-ouia-component-id="OUIA-Generated-TableRow-215"
         data-ouia-component-type="PF6/TableRow"
         data-ouia-safe="true"
-        hidden=""
       >
         <th
           class="pf-v6-c-table__td"
@@ -3750,11 +3742,10 @@ exports[`Table Header width table 1`] = `
         </td>
       </tr>
       <tr
-        class="pf-v6-c-table__tr pf-v6-c-table__expandable-row"
+        class="pf-v6-c-table__tr"
         data-ouia-component-id="OUIA-Generated-TableRow-222"
         data-ouia-component-type="PF6/TableRow"
         data-ouia-safe="true"
-        hidden=""
       >
         <th
           class="pf-v6-c-table__td"
@@ -3802,11 +3793,10 @@ exports[`Table Header width table 1`] = `
         </td>
       </tr>
       <tr
-        class="pf-v6-c-table__tr pf-v6-c-table__expandable-row"
+        class="pf-v6-c-table__tr"
         data-ouia-component-id="OUIA-Generated-TableRow-223"
         data-ouia-component-type="PF6/TableRow"
         data-ouia-safe="true"
-        hidden=""
       >
         <th
           class="pf-v6-c-table__td"
@@ -3910,11 +3900,10 @@ exports[`Table Header width table 1`] = `
         </td>
       </tr>
       <tr
-        class="pf-v6-c-table__tr pf-v6-c-table__expandable-row"
+        class="pf-v6-c-table__tr"
         data-ouia-component-id="OUIA-Generated-TableRow-225"
         data-ouia-component-type="PF6/TableRow"
         data-ouia-safe="true"
-        hidden=""
       >
         <th
           class="pf-v6-c-table__td"
@@ -4370,11 +4359,10 @@ exports[`Table Selectable table 1`] = `
         </td>
       </tr>
       <tr
-        class="pf-v6-c-table__tr pf-v6-c-table__expandable-row"
+        class="pf-v6-c-table__tr"
         data-ouia-component-id="OUIA-Generated-TableRow-192"
         data-ouia-component-type="PF6/TableRow"
         data-ouia-safe="true"
-        hidden=""
       >
         <td
           class="pf-v6-c-table__td"
@@ -4427,11 +4415,10 @@ exports[`Table Selectable table 1`] = `
         </td>
       </tr>
       <tr
-        class="pf-v6-c-table__tr pf-v6-c-table__expandable-row"
+        class="pf-v6-c-table__tr"
         data-ouia-component-id="OUIA-Generated-TableRow-193"
         data-ouia-component-type="PF6/TableRow"
         data-ouia-safe="true"
-        hidden=""
       >
         <td
           class="pf-v6-c-table__td"
@@ -4553,11 +4540,10 @@ exports[`Table Selectable table 1`] = `
         </td>
       </tr>
       <tr
-        class="pf-v6-c-table__tr pf-v6-c-table__expandable-row"
+        class="pf-v6-c-table__tr"
         data-ouia-component-id="OUIA-Generated-TableRow-195"
         data-ouia-component-type="PF6/TableRow"
         data-ouia-safe="true"
-        hidden=""
       >
         <td
           class="pf-v6-c-table__td"
@@ -5062,11 +5048,10 @@ exports[`Table Selectable table with Radio 1`] = `
         </td>
       </tr>
       <tr
-        class="pf-v6-c-table__tr pf-v6-c-table__expandable-row"
+        class="pf-v6-c-table__tr"
         data-ouia-component-id="OUIA-Generated-TableRow-202"
         data-ouia-component-type="PF6/TableRow"
         data-ouia-safe="true"
-        hidden=""
       >
         <td
           class="pf-v6-c-table__td"
@@ -5119,11 +5104,10 @@ exports[`Table Selectable table with Radio 1`] = `
         </td>
       </tr>
       <tr
-        class="pf-v6-c-table__tr pf-v6-c-table__expandable-row"
+        class="pf-v6-c-table__tr"
         data-ouia-component-id="OUIA-Generated-TableRow-203"
         data-ouia-component-type="PF6/TableRow"
         data-ouia-safe="true"
-        hidden=""
       >
         <td
           class="pf-v6-c-table__td"
@@ -5245,11 +5229,10 @@ exports[`Table Selectable table with Radio 1`] = `
         </td>
       </tr>
       <tr
-        class="pf-v6-c-table__tr pf-v6-c-table__expandable-row"
+        class="pf-v6-c-table__tr"
         data-ouia-component-id="OUIA-Generated-TableRow-205"
         data-ouia-component-type="PF6/TableRow"
         data-ouia-safe="true"
-        hidden=""
       >
         <td
           class="pf-v6-c-table__td"

--- a/packages/react-tokens/package.json
+++ b/packages/react-tokens/package.json
@@ -29,8 +29,8 @@
     "clean": "rimraf dist"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.3.0-prerelease.6",
-    "css": "^3.0.0",
+    "@adobe/css-tools": "^4.4.2",
+    "@patternfly/patternfly": "6.3.0-prerelease.15",
     "fs-extra": "^11.3.0"
   }
 }

--- a/packages/react-tokens/scripts/generateTokens.mjs
+++ b/packages/react-tokens/scripts/generateTokens.mjs
@@ -1,7 +1,7 @@
 import { glob } from 'glob';
 import { createRequire } from 'node:module';
 import { dirname, basename, sep } from 'node:path';
-import { parse, stringify } from 'css';
+import { parse, stringify } from '@adobe/css-tools';
 import { readFileSync } from 'node:fs';
 
 const require = createRequire(import.meta.url);

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@adobe/css-tools@npm:^4.4.2":
+  version: 4.4.2
+  resolution: "@adobe/css-tools@npm:4.4.2"
+  checksum: 10c0/19433666ad18536b0ed05d4b53fbb3dd6ede266996796462023ec77a90b484890ad28a3e528cdf3ab8a65cb2fcdff5d8feb04db6bc6eed6ca307c40974239c94
+  languageName: node
+  linkType: hard
+
 "@ampproject/remapping@npm:^2.2.0":
   version: 2.3.0
   resolution: "@ampproject/remapping@npm:2.3.0"
@@ -3632,10 +3639,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/patternfly@npm:6.3.0-prerelease.6":
-  version: 6.3.0-prerelease.6
-  resolution: "@patternfly/patternfly@npm:6.3.0-prerelease.6"
-  checksum: 10c0/ceace4e78eaa5b5ea6da6cecf121a5d9c281d423be4a806332af8f90489f1ef80723762a3b3071e78653545ab89e7f9e773cffe215b6251c4eec34dee06dbcab
+"@patternfly/patternfly@npm:6.3.0-prerelease.15":
+  version: 6.3.0-prerelease.15
+  resolution: "@patternfly/patternfly@npm:6.3.0-prerelease.15"
+  checksum: 10c0/833780ce555cd5b8bbf1043fcedd578c4786904bda2766980875cf3cbbe80ed389fc6f76183fd20fc383620f4572c496c4d5eec7dc791a40dc4e03e82e6fe243
   languageName: node
   linkType: hard
 
@@ -3733,7 +3740,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@patternfly/react-core@workspace:packages/react-core"
   dependencies:
-    "@patternfly/patternfly": "npm:6.3.0-prerelease.6"
+    "@patternfly/patternfly": "npm:6.3.0-prerelease.15"
     "@patternfly/react-icons": "workspace:^"
     "@patternfly/react-styles": "workspace:^"
     "@patternfly/react-tokens": "workspace:^"
@@ -3754,7 +3761,7 @@ __metadata:
   resolution: "@patternfly/react-docs@workspace:packages/react-docs"
   dependencies:
     "@patternfly/documentation-framework": "npm:^6.5.20"
-    "@patternfly/patternfly": "npm:6.3.0-prerelease.6"
+    "@patternfly/patternfly": "npm:6.3.0-prerelease.15"
     "@patternfly/patternfly-a11y": "npm:5.1.0"
     "@patternfly/react-charts": "workspace:^"
     "@patternfly/react-code-editor": "workspace:^"
@@ -3794,7 +3801,7 @@ __metadata:
     "@fortawesome/free-brands-svg-icons": "npm:^5.15.4"
     "@fortawesome/free-regular-svg-icons": "npm:^5.15.4"
     "@fortawesome/free-solid-svg-icons": "npm:^5.15.4"
-    "@patternfly/patternfly": "npm:6.3.0-prerelease.6"
+    "@patternfly/patternfly": "npm:6.3.0-prerelease.15"
     fs-extra: "npm:^11.3.0"
     tslib: "npm:^2.8.1"
   peerDependencies:
@@ -3878,7 +3885,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@patternfly/react-styles@workspace:packages/react-styles"
   dependencies:
-    "@patternfly/patternfly": "npm:6.3.0-prerelease.6"
+    "@patternfly/patternfly": "npm:6.3.0-prerelease.15"
     change-case: "npm:^5.4.4"
     fs-extra: "npm:^11.3.0"
   languageName: unknown
@@ -3919,8 +3926,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@patternfly/react-tokens@workspace:packages/react-tokens"
   dependencies:
-    "@patternfly/patternfly": "npm:6.3.0-prerelease.6"
-    css: "npm:^3.0.0"
+    "@adobe/css-tools": "npm:^4.4.2"
+    "@patternfly/patternfly": "npm:6.3.0-prerelease.15"
     fs-extra: "npm:^11.3.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #11812, closes #11807, closes #11808

Table was updated to a more correct logic of applying certain classes from Core as were a few examples updates to show the correct way to set the tables up with those closes.

The animations aspect just needs to have confirmed that accordion, expandable section, and table expansion look good.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
