### PR TITLE
chore(chart donut): convert to typescript

### DIFF
--- a/packages/react-charts/src/victory/components/ChartDonut/examples/ChartDonut.md
+++ b/packages/react-charts/src/victory/components/ChartDonut/examples/ChartDonut.md
@@ -16,108 +16,23 @@ The examples below are based on the [Victory](https://formidable.com/open-source
 
 ## Examples
 ### Basic
-```js
-import { ChartDonut } from '@patternfly/react-charts/victory';
+```ts file = "ChartDonutBasic.tsx"
 
-<div style={{ height: '230px', width: '230px' }}>
-  <ChartDonut
-    ariaDesc="Average number of pets"
-    ariaTitle="Donut chart example"
-    constrainToVisibleArea
-    data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-    labels={({ datum }) => `${datum.x}: ${datum.y}%`}
-    name="chart1"
-    subTitle="Pets"
-    title="100"
-  />
-</div>
 ```
 
 ### Right aligned legend
-```js
-import { ChartDonut } from '@patternfly/react-charts/victory';
+```ts file = "ChartDonutRightAlignedLegend.tsx"
 
-<div style={{ height: '230px', width: '350px' }}>
-  <ChartDonut
-    ariaDesc="Average number of pets"
-    ariaTitle="Donut chart example"
-    constrainToVisibleArea
-    data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-    labels={({ datum }) => `${datum.x}: ${datum.y}%`}
-    legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
-    legendOrientation="vertical"
-    legendPosition="right"
-    name="chart2"
-    padding={{
-      bottom: 20,
-      left: 20,
-      right: 140, // Adjusted to accommodate legend
-      top: 20
-    }}
-    subTitle="Pets"
-    title="100"
-    width={350}
-  />
-</div>
 ```
 
 ### Multi-color (ordered) with right aligned legend
-```js
-import { ChartDonut, ChartThemeColor } from '@patternfly/react-charts/victory';
+```ts file = "ChartDonutMultiColor.tsx"
 
-<div style={{ height: '230px', width: '350px' }}>
-  <ChartDonut
-    ariaDesc="Average number of pets"
-    ariaTitle="Donut chart example"
-    constrainToVisibleArea
-    data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-    labels={({ datum }) => `${datum.x}: ${datum.y}%`}
-    legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
-    legendOrientation="vertical"
-    legendPosition="right"
-    name="chart3"
-    padding={{
-      bottom: 20,
-      left: 20,
-      right: 140, // Adjusted to accommodate legend
-      top: 20
-    }}
-    subTitle="Pets"
-    title="100"
-    themeColor={ChartThemeColor.multiOrdered}
-    width={350}
-  />
-</div>
 ```
 
 ### Bottom aligned legend
-```js
-import { ChartDonut } from '@patternfly/react-charts/victory';
+```ts file = "ChartDonutBottomAlignedLegend.tsx"
 
-<div style={{ height: '275px', width: '300px' }}>
-  <ChartDonut
-    ariaDesc="Average number of pets"
-    ariaTitle="Donut chart example"
-    constrainToVisibleArea
-    data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-    donutOrientation="top"
-    height={275}
-    labels={({ datum }) => `${datum.x}: ${datum.y}%`}
-    legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
-    legendPosition="bottom"
-    legendWidth={225}
-    name="chart4"
-    padding={{
-      bottom: 65, // Adjusted to accommodate legend
-      left: 20,
-      right: 20,
-      top: 20
-    }}
-    subTitle="Pets"
-    title="100"
-    width={300}
-  />
-</div>
 ```
 
 ### Small

--- a/packages/react-charts/src/victory/components/ChartDonut/examples/ChartDonut.md
+++ b/packages/react-charts/src/victory/components/ChartDonut/examples/ChartDonut.md
@@ -36,111 +36,23 @@ The examples below are based on the [Victory](https://formidable.com/open-source
 ```
 
 ### Small
-```js
-import { ChartDonut } from '@patternfly/react-charts/victory';
+```ts file = "ChartDonutSmall.tsx"
 
-<div style={{ height: '150px', width: '150px' }}>
-  <ChartDonut
-    ariaDesc="Average number of pets"
-    ariaTitle="Donut chart example"
-    constrainToVisibleArea
-    data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-    height={150}
-    labels={({ datum }) => `${datum.x}: ${datum.y}%`}
-    name="chart5"
-    subTitle="Pets"
-    title="100"
-    width={150}
-  />
-</div>
 ```
 
 ### Small with right aligned legend
-```js
-import { ChartDonut } from '@patternfly/react-charts/victory';
+```ts file = "ChartDonutSmallRightLegend.tsx"
 
-<div style={{ height: '150px', width: '275px' }}>
-  <ChartDonut
-    ariaDesc="Average number of pets"
-    ariaTitle="Donut chart example"
-    constrainToVisibleArea
-    data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-    height={150}
-    labels={({ datum }) => `${datum.x}: ${datum.y}%`}
-    legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
-    legendOrientation="vertical"
-    legendPosition="right"
-    name="chart6"
-    padding={{
-      bottom: 20,
-      left: 20,
-      right: 145, // Adjusted to accommodate legend
-      top: 20
-    }}
-    subTitle="Pets"
-    title="100"
-    width={275}
-  />
-</div>
 ```
 
 ### Small with bottom aligned subtitle
-```js
-import { ChartDonut } from '@patternfly/react-charts/victory';
+```ts file = "ChartDonutSmallBottomSubtitle.tsx"
 
-<div style={{ height: '165px', width: '275px' }}>
-  <ChartDonut
-    ariaDesc="Average number of pets"
-    ariaTitle="Donut chart example"
-    constrainToVisibleArea
-    data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-    height={165}
-    labels={({ datum }) => `${datum.x}: ${datum.y}%`}
-    legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
-    legendOrientation="vertical"
-    legendPosition="right"
-    name="chart7"
-    padding={{
-      bottom: 25, // Adjusted to accommodate subTitle
-      left: 20,
-      right: 145, // Adjusted to accommodate legend
-      top: 20
-    }}
-    subTitle="Pets"
-    subTitlePosition="bottom"
-    title="100"
-    width={275}
-  />
-</div>
 ```
 
 ### Small with right aligned subtitle
-```js
-import { ChartDonut } from '@patternfly/react-charts/victory';
+```ts file = "ChartDonutSmallRightSubtitle.tsx"
 
-<div style={{ height: '200px', width: '300px' }}>
-  <ChartDonut
-    ariaDesc="Average number of pets"
-    ariaTitle="Donut chart example"
-    constrainToVisibleArea
-    data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-    height={200}
-    labels={({ datum }) => `${datum.x}: ${datum.y}%`}
-    legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
-    legendPosition="bottom"
-    name="chart8"
-    padding={{
-      bottom: 70, // Adjusted to accommodate legend
-      left: 20,
-      right: 50, // Adjusted to accommodate subTitle
-      top: 20
-    }}
-    subTitle="Pets"
-    subTitlePosition="right"
-    title="100"
-    width={300}
-  />
-</div>
 ```
 
 ## Documentation

--- a/packages/react-charts/src/victory/components/ChartDonut/examples/ChartDonutBasic.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonut/examples/ChartDonutBasic.tsx
@@ -1,0 +1,29 @@
+import { ChartDonut } from '@patternfly/react-charts/victory';
+
+interface PetData {
+  x: string;
+  y: number;
+}
+
+export const ChartDonutBasic: React.FunctionComponent = () => {
+  const data: PetData[] = [
+    { x: 'Cats', y: 35 },
+    { x: 'Dogs', y: 55 },
+    { x: 'Birds', y: 10 }
+  ];
+
+  return (
+    <div style={{ height: '230px', width: '230px' }}>
+      <ChartDonut
+        ariaDesc="Average number of pets"
+        ariaTitle="Donut chart example"
+        constrainToVisibleArea
+        data={data}
+        labels={({ datum }) => `${datum.x}: ${datum.y}%`}
+        name="chart1"
+        subTitle="Pets"
+        title="100"
+      />
+    </div>
+  );
+};

--- a/packages/react-charts/src/victory/components/ChartDonut/examples/ChartDonutBottomAlignedLegend.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonut/examples/ChartDonutBottomAlignedLegend.tsx
@@ -1,0 +1,43 @@
+import { ChartDonut } from '@patternfly/react-charts/victory';
+
+interface PetData {
+  x?: string;
+  y?: number;
+  name?: string;
+}
+
+export const ChartDonutBottomAlignedLegend: React.FunctionComponent = () => {
+  const data: PetData[] = [
+    { x: 'Cats', y: 35 },
+    { x: 'Dogs', y: 55 },
+    { x: 'Birds', y: 10 }
+  ];
+  const legendData: PetData[] = [{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }];
+
+  return (
+    <div style={{ height: '275px', width: '300px' }}>
+      <ChartDonut
+        ariaDesc="Average number of pets"
+        ariaTitle="Donut chart example"
+        constrainToVisibleArea
+        data={data}
+        donutOrientation="top"
+        height={275}
+        labels={({ datum }) => `${datum.x}: ${datum.y}%`}
+        legendData={legendData}
+        legendPosition="bottom"
+        legendWidth={225}
+        name="chart4"
+        padding={{
+          bottom: 65, // Adjusted to accommodate legend
+          left: 20,
+          right: 20,
+          top: 20
+        }}
+        subTitle="Pets"
+        title="100"
+        width={300}
+      />
+    </div>
+  );
+};

--- a/packages/react-charts/src/victory/components/ChartDonut/examples/ChartDonutMultiColor.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonut/examples/ChartDonutMultiColor.tsx
@@ -1,0 +1,42 @@
+import { ChartDonut, ChartThemeColor } from '@patternfly/react-charts/victory';
+
+interface PetData {
+  x?: string;
+  y?: number;
+  name?: string;
+}
+
+export const ChartDonutMultiColor: React.FunctionComponent = () => {
+  const data: PetData[] = [
+    { x: 'Cats', y: 35 },
+    { x: 'Dogs', y: 55 },
+    { x: 'Birds', y: 10 }
+  ];
+  const legendData: PetData[] = [{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }];
+
+  return (
+    <div style={{ height: '230px', width: '350px' }}>
+      <ChartDonut
+        ariaDesc="Average number of pets"
+        ariaTitle="Donut chart example"
+        constrainToVisibleArea
+        data={data}
+        labels={({ datum }) => `${datum.x}: ${datum.y}%`}
+        legendData={legendData}
+        legendOrientation="vertical"
+        legendPosition="right"
+        name="chart3"
+        padding={{
+          bottom: 20,
+          left: 20,
+          right: 140, // Adjusted to accommodate legend
+          top: 20
+        }}
+        subTitle="Pets"
+        title="100"
+        themeColor={ChartThemeColor.multiOrdered}
+        width={350}
+      />
+    </div>
+  );
+};

--- a/packages/react-charts/src/victory/components/ChartDonut/examples/ChartDonutRightAlignedLegend.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonut/examples/ChartDonutRightAlignedLegend.tsx
@@ -1,0 +1,41 @@
+import { ChartDonut } from '@patternfly/react-charts/victory';
+
+interface PetData {
+  x?: string;
+  y?: number;
+  name?: string;
+}
+
+export const ChartDonutRightAlignedLegend: React.FunctionComponent = () => {
+  const data: PetData[] = [
+    { x: 'Cats', y: 35 },
+    { x: 'Dogs', y: 55 },
+    { x: 'Birds', y: 10 }
+  ];
+  const legendData: PetData[] = [{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }];
+
+  return (
+    <div style={{ height: '230px', width: '350px' }}>
+      <ChartDonut
+        ariaDesc="Average number of pets"
+        ariaTitle="Donut chart example"
+        constrainToVisibleArea
+        data={data}
+        labels={({ datum }) => `${datum.x}: ${datum.y}%`}
+        legendData={legendData}
+        legendOrientation="vertical"
+        legendPosition="right"
+        name="chart2"
+        padding={{
+          bottom: 20,
+          left: 20,
+          right: 140, // Adjusted to accommodate legend
+          top: 20
+        }}
+        subTitle="Pets"
+        title="100"
+        width={350}
+      />
+    </div>
+  );
+};

--- a/packages/react-charts/src/victory/components/ChartDonut/examples/ChartDonutSmall.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonut/examples/ChartDonutSmall.tsx
@@ -1,0 +1,31 @@
+import { ChartDonut } from '@patternfly/react-charts/victory';
+
+interface PetData {
+  x: string;
+  y: number;
+}
+
+export const ChartDonutSmall: React.FunctionComponent = () => {
+  const data: PetData[] = [
+    { x: 'Cats', y: 35 },
+    { x: 'Dogs', y: 55 },
+    { x: 'Birds', y: 10 }
+  ];
+
+  return (
+    <div style={{ height: '150px', width: '150px' }}>
+      <ChartDonut
+        ariaDesc="Average number of pets"
+        ariaTitle="Donut chart example"
+        constrainToVisibleArea
+        data={data}
+        height={150}
+        labels={({ datum }) => `${datum.x}: ${datum.y}%`}
+        name="chart5"
+        subTitle="Pets"
+        title="100"
+        width={150}
+      />
+    </div>
+  );
+};

--- a/packages/react-charts/src/victory/components/ChartDonut/examples/ChartDonutSmallBottomSubtitle.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonut/examples/ChartDonutSmallBottomSubtitle.tsx
@@ -1,0 +1,43 @@
+import { ChartDonut } from '@patternfly/react-charts/victory';
+
+interface PetData {
+  x?: string;
+  y?: number;
+  name?: string;
+}
+
+export const ChartDonutSmallBottomSubtitle: React.FunctionComponent = () => {
+  const data: PetData[] = [
+    { x: 'Cats', y: 35 },
+    { x: 'Dogs', y: 55 },
+    { x: 'Birds', y: 10 }
+  ];
+  const legendData: PetData[] = [{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }];
+
+  return (
+    <div style={{ height: '165px', width: '275px' }}>
+      <ChartDonut
+        ariaDesc="Average number of pets"
+        ariaTitle="Donut chart example"
+        constrainToVisibleArea
+        data={data}
+        height={165}
+        labels={({ datum }) => `${datum.x}: ${datum.y}%`}
+        legendData={legendData}
+        legendOrientation="vertical"
+        legendPosition="right"
+        name="chart7"
+        padding={{
+          bottom: 25, // Adjusted to accommodate subTitle
+          left: 20,
+          right: 145, // Adjusted to accommodate legend
+          top: 20
+        }}
+        subTitle="Pets"
+        subTitlePosition="bottom"
+        title="100"
+        width={275}
+      />
+    </div>
+  );
+};

--- a/packages/react-charts/src/victory/components/ChartDonut/examples/ChartDonutSmallRightLegend.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonut/examples/ChartDonutSmallRightLegend.tsx
@@ -1,0 +1,42 @@
+import { ChartDonut } from '@patternfly/react-charts/victory';
+
+interface PetData {
+  x?: string;
+  y?: number;
+  name?: string;
+}
+
+export const ChartDonutSmallRightLegend: React.FunctionComponent = () => {
+  const data: PetData[] = [
+    { x: 'Cats', y: 35 },
+    { x: 'Dogs', y: 55 },
+    { x: 'Birds', y: 10 }
+  ];
+  const legendData: PetData[] = [{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }];
+
+  return (
+    <div style={{ height: '150px', width: '275px' }}>
+      <ChartDonut
+        ariaDesc="Average number of pets"
+        ariaTitle="Donut chart example"
+        constrainToVisibleArea
+        data={data}
+        height={150}
+        labels={({ datum }) => `${datum.x}: ${datum.y}%`}
+        legendData={legendData}
+        legendOrientation="vertical"
+        legendPosition="right"
+        name="chart6"
+        padding={{
+          bottom: 20,
+          left: 20,
+          right: 145, // Adjusted to accommodate legend
+          top: 20
+        }}
+        subTitle="Pets"
+        title="100"
+        width={275}
+      />
+    </div>
+  );
+};

--- a/packages/react-charts/src/victory/components/ChartDonut/examples/ChartDonutSmallRightSubtitle.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonut/examples/ChartDonutSmallRightSubtitle.tsx
@@ -1,0 +1,42 @@
+import { ChartDonut } from '@patternfly/react-charts/victory';
+
+interface PetData {
+  x?: string;
+  y?: number;
+  name?: string;
+}
+
+export const ChartDonutSmallRightSubtitle: React.FunctionComponent = () => {
+  const data: PetData[] = [
+    { x: 'Cats', y: 35 },
+    { x: 'Dogs', y: 55 },
+    { x: 'Birds', y: 10 }
+  ];
+  const legendData: PetData[] = [{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }];
+
+  return (
+    <div style={{ height: '200px', width: '300px' }}>
+      <ChartDonut
+        ariaDesc="Average number of pets"
+        ariaTitle="Donut chart example"
+        constrainToVisibleArea
+        data={data}
+        height={200}
+        labels={({ datum }) => `${datum.x}: ${datum.y}%`}
+        legendData={legendData}
+        legendPosition="bottom"
+        name="chart8"
+        padding={{
+          bottom: 70, // Adjusted to accommodate legend
+          left: 20,
+          right: 50, // Adjusted to accommodate subTitle
+          top: 20
+        }}
+        subTitle="Pets"
+        subTitlePosition="right"
+        title="100"
+        width={300}
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
Towards #11719 

The following examples of Chart Donut will be converted to TypeScript:
- Basic
- Right aligned legend
- Multi-color (ordered) with right aligned legend
- Bottom aligned legend
- Small
- Small with right aligned legend
- Small with bottom aligned subtitle
- Small with right aligned subtitle