### PR TITLE
chore(chart donut utilization): convert to typescript

### DIFF
--- a/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
+++ b/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
@@ -18,370 +18,51 @@ The examples below are based on the [Victory](https://formidable.com/open-source
 
 ## Donut utilization examples
 ### Basic
-```js
-import { ChartDonutUtilization } from '@patternfly/react-charts/victory';
+```ts file = "ChartUtilBasic.tsx"
 
-<div style={{ height: '230px', width: '230px' }}>
-  <ChartDonutUtilization
-    ariaDesc="Storage capacity"
-    ariaTitle="Donut utilization chart example"
-    constrainToVisibleArea
-    data={{ x: 'GBps capacity', y: 75 }}
-    labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
-    name="chart1"
-    subTitle="of 100 GBps"
-    title="75%"
-  />
-</div>
 ```
 
 ### Right aligned legend
-```js
-import { ChartDonutUtilization } from '@patternfly/react-charts/victory';
+```ts file = "ChartUtilRightAlignedLegend.tsx"
 
-class DonutUtilizationChart extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      spacer: '',
-      used: 0
-    };
-  }
-
-  componentDidMount() {
-    this.interval = setInterval(() => {
-      const { used } = this.state;
-      const val = (used + 10) % 100;
-      this.setState({
-        spacer: val < 10 ? ' ' : '',
-        used: val
-      });
-    }, 1000);
-  }
-
-  componentWillUnmount() {
-    clearInterval(this.interval);
-  }
-
-  render() {
-    const { spacer, used } = this.state;
-    return (
-      <div style={{  height: '230px', width: '435px' }}>
-        <ChartDonutUtilization
-          ariaDesc="Storage capacity"
-          ariaTitle="Donut utilization chart example"
-          constrainToVisibleArea
-          data={{ x: 'GBps capacity', y: used }}
-          labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
-          legendData={[{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }]}
-          legendOrientation="vertical"
-          name="chart2"
-          padding={{
-            bottom: 20,
-            left: 20,
-            right: 225, // Adjusted to accommodate legend
-            top: 20
-          }}
-          subTitle="of 100 GBps"
-          title={`${used}%`}
-          thresholds={[{ value: 60 }, { value: 90 }]}
-          width={435}
-        />
-      </div>
-    );
-  }
-}
 ```
 
 ### Inverted with right aligned legend
-```js
-import { ChartDonutUtilization } from '@patternfly/react-charts/victory';
+```ts file = "ChartUtilInvertedRightLegend.tsx"
 
-class InvertedDonutUtilizationChart extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      spacer: '',
-      used: 100
-    };
-  }
-
-  componentDidMount() {
-    this.interval = setInterval(() => {
-      const { used } = this.state;
-      const val = (((used - 10) % 100) + 100) % 100;
-      this.setState({
-        spacer: val < 10 ? ' ' : '',
-        used: val
-      });
-    }, 1000);
-  }
-
-  componentWillUnmount() {
-    clearInterval(this.interval);
-  }
-
-  render() {
-    const { spacer, used } = this.state;
-    return (
-      <div style={{ height: '230px', width: '435px' }}>
-        <ChartDonutUtilization
-          ariaDesc="Storage capacity"
-          ariaTitle="Donut utilization chart example"
-          constrainToVisibleArea
-          data={{ x: 'GBps capacity', y: used }}
-          invert
-          labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
-          legendData={[{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }]}
-          legendOrientation="vertical"
-          name="chart3"
-          padding={{
-            bottom: 20,
-            left: 20,
-            right: 225, // Adjusted to accommodate legend
-            top: 20
-          }}
-          subTitle="of 100 GBps"
-          title={`${used}%`}
-          thresholds={[{ value: 60 }, { value: 20 }]}
-          width={435}
-        />
-      </div>
-    );
-  }
-}
 ```
 
 ### Right aligned vertical legend
-```js
-import { ChartDonutUtilization, ChartThemeColor } from '@patternfly/react-charts/victory';
+```ts file = "ChartUtilRightVerticalLegend.tsx"
 
-class VerticalLegendUtilizationChart extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      spacer: '',
-      used: 0
-    };
-  }
-
-  componentDidMount() {
-    this.interval = setInterval(() => {
-      const { used } = this.state;
-      const val = (used + 10) % 100;
-      this.setState({
-        spacer: val < 10 ? ' ' : '',
-        used: val
-      });
-    }, 1000);
-  }
-
-  componentWillUnmount() {
-    clearInterval(this.interval);
-  }
-
-  render() {
-    const { spacer, used } = this.state;
-    return (
-      <div style={{ height: '300px', width: '230px' }}>
-        <ChartDonutUtilization
-          ariaDesc="Storage capacity"
-          ariaTitle="Donut utilization chart example"
-          constrainToVisibleArea
-          data={{ x: 'Storage capacity', y: used }}
-          height={300}
-          labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
-          legendData={[{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }]}
-          legendOrientation="vertical"
-          legendPosition="bottom"
-          name="chart4"
-          padding={{
-            bottom: 75, // Adjusted to accommodate legend
-            left: 20,
-            right: 20,
-            top: 20
-          }}
-          subTitle="of 100 GBps"
-          title={`${used}%`}
-          themeColor={ChartThemeColor.green}
-          thresholds={[{ value: 60 }, { value: 90 }]}
-          width={230}
-        />
-      </div>
-    );
-  }
-}
 ```
 
 ### Bottom aligned legend
-```js
-import { ChartDonutUtilization } from '@patternfly/react-charts/victory';
+```ts file = "ChartUtilBottomAlignedLegend.tsx"
 
-<div style={{ height: '275px', width: '300px' }}>
-  <ChartDonutUtilization
-    ariaDesc="Storage capacity"
-    ariaTitle="Donut utilization chart example"
-    constrainToVisibleArea
-    data={{ x: 'Storage capacity', y: 45 }}
-    height={275}
-    labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
-    legendData={[{ name: `Storage capacity: 45%` }, { name: 'Unused' }]}
-    legendPosition="bottom"
-    name="chart5"
-    padding={{
-      bottom: 65, // Adjusted to accommodate legend
-      left: 20,
-      right: 20,
-      top: 20
-    }}
-    subTitle="of 100 GBps"
-    title="45%"
-    thresholds={[{ value: 60 }, { value: 90 }]}
-    width={300}
-  />
-</div>
 ```
 
 ### Small
-```js
-import { ChartDonutUtilization } from '@patternfly/react-charts/victory';
+```ts file = "ChartUtilSmall.tsx"
 
-<div style={{ height: '175px', width: '175px' }}>
-  <ChartDonutUtilization
-    ariaDesc="Storage capacity"
-    ariaTitle="Donut utilization chart example"
-    constrainToVisibleArea
-    data={{ x: 'Storage capacity', y: 75 }}
-    height={175}
-    labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
-    name="chart6"
-    subTitle="of 100 GBps"
-    title="75%"
-    width={175}
-  />
-</div>
 ```
 
 ### Small with right aligned legend
-```js
-import { ChartDonutUtilization } from '@patternfly/react-charts/victory';
+```ts file = "ChartUtilSmallRightLegend.tsx"
 
-class UtilizationChart extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      spacer: '',
-      used: 0
-    };
-  }
-
-  componentDidMount() {
-    this.interval = setInterval(() => {
-      const { used } = this.state;
-      const val = (used + 10) % 100;
-      this.setState({
-        spacer: val < 10 ? ' ' : '',
-        used: val
-      });
-    }, 1000);
-  }
-
-  componentWillUnmount() {
-    clearInterval(this.interval);
-  }
-
-  render() {
-    const { spacer, used } = this.state;
-    return (
-      <div style={{ width: '350px', height: '175px' }}>
-        <ChartDonutUtilization
-          ariaDesc="Storage capacity"
-          ariaTitle="Donut utilization chart example"
-          constrainToVisibleArea
-          data={{ x: 'Storage capacity', y: used }}
-          height={175}
-          labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
-          legendData={[{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }]}
-          legendOrientation="vertical"
-          name="chart7"
-          padding={{
-            bottom: 20,
-            left: 20,
-            right: 195, // Adjusted to accommodate legend
-            top: 20
-          }}
-          subTitle="of 100 GBps"
-          title={`${used}%`}
-          thresholds={[{ value: 60 }, { value: 90 }]}
-          width={350}
-        />
-      </div>
-    );
-  }
-}
 ```
 
 ### Small with bottom aligned subtitle
 
 This is a small donut utilization chart with bottom aligned legend and right aligned subtitle.
 
-```js
-import { ChartDonutUtilization } from '@patternfly/react-charts/victory';
+```ts file = "ChartUtilSmallBottomSubtitle.tsx"
 
-<div style={{ height: '185px', width: '350px' }}>
-  <ChartDonutUtilization
-    ariaDesc="Storage capacity"
-    ariaTitle="Donut utilization chart example"
-    constrainToVisibleArea
-    data={{ x: 'Storage capacity', y: 45 }}
-    height={185}
-    labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
-    legendData={[{ name: `Storage capacity: 45%` }, { name: 'Unused' }]}
-    legendOrientation="vertical"
-    name="chart8"
-    padding={{
-      bottom: 25, // Adjusted to accommodate subTitle
-      left: 20,
-      right: 195, // Adjusted to accommodate legend
-      top: 20
-    }}
-    subTitle="of 100 GBps"
-    subTitlePosition="bottom"
-    title="45%"
-    thresholds={[{ value: 60 }, { value: 90 }]}
-    width={350}
-  />
-</div>
 ```
 
 ### Small with right aligned subtitle
-```js
-import { ChartDonutUtilization } from '@patternfly/react-charts/victory';
+```ts file = "ChartUtilSmallRightSubtitle.tsx"
 
-<div style={{ height: '200px', width: '350px' }}>
-  <ChartDonutUtilization
-    ariaDesc="Storage capacity"
-    ariaTitle="Donut utilization chart example"
-    constrainToVisibleArea
-    data={{ x: 'Storage capacity', y: 45 }}
-    height={200}
-    labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
-    legendData={[{ name: `Storage capacity: 45%` }, { name: 'Unused' }]}
-    legendPosition="bottom"
-    name="chart9"
-    padding={{
-      bottom: 45, // Adjusted to accommodate legend
-      left: 20,
-      right: 20,
-      top: 20
-    }}
-    subTitle="of 100 GBps"
-    subTitlePosition="right"
-    title="45%"
-    thresholds={[{ value: 60 }, { value: 90 }]}
-    width={350}
-  />
-</div>
 ```
 
 ## Donut utilization threshold examples

--- a/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilBasic.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilBasic.tsx
@@ -1,0 +1,25 @@
+import { ChartDonutUtilization } from '@patternfly/react-charts/victory';
+
+interface UsageData {
+  x: string;
+  y: number;
+}
+
+export const ChartUtilBasic: React.FunctionComponent = () => {
+  const data: UsageData = { x: 'GBps capacity', y: 75 };
+
+  return (
+    <div style={{ height: '230px', width: '230px' }}>
+      <ChartDonutUtilization
+        ariaDesc="Storage capacity"
+        ariaTitle="Donut utilization chart example"
+        constrainToVisibleArea
+        data={data}
+        labels={({ datum }) => (datum.x ? `${datum.x}: ${datum.y}%` : null)}
+        name="chart1"
+        subTitle="of 100 GBps"
+        title="75%"
+      />
+    </div>
+  );
+};

--- a/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilBottomAlignedLegend.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilBottomAlignedLegend.tsx
@@ -1,0 +1,38 @@
+import { ChartDonutUtilization } from '@patternfly/react-charts/victory';
+
+interface UsageData {
+  x?: string;
+  y?: number;
+  name?: string;
+}
+
+export const ChartUtilBottomAlignedLegend: React.FunctionComponent = () => {
+  const data: UsageData = { x: 'Storage capacity', y: 45 };
+  const legendData: UsageData[] = [{ name: `Storage capacity: 45%` }, { name: 'Unused' }];
+
+  return (
+    <div style={{ height: '275px', width: '300px' }}>
+      <ChartDonutUtilization
+        ariaDesc="Storage capacity"
+        ariaTitle="Donut utilization chart example"
+        constrainToVisibleArea
+        data={data}
+        height={275}
+        labels={({ datum }) => (datum.x ? `${datum.x}: ${datum.y}%` : null)}
+        legendData={legendData}
+        legendPosition="bottom"
+        name="chart5"
+        padding={{
+          bottom: 65, // Adjusted to accommodate legend
+          left: 20,
+          right: 20,
+          top: 20
+        }}
+        subTitle="of 100 GBps"
+        title="45%"
+        thresholds={[{ value: 60 }, { value: 90 }]}
+        width={300}
+      />
+    </div>
+  );
+};

--- a/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilInvertedRightLegend.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilInvertedRightLegend.tsx
@@ -1,0 +1,53 @@
+import { ChartDonutUtilization } from '@patternfly/react-charts/victory';
+
+interface UsageData {
+  x?: string;
+  y?: number;
+  name?: string;
+}
+
+export const ChartUtilInvertedRightLegend: React.FunctionComponent = () => {
+  const [spacer, setSpacer] = React.useState('');
+  const [used, setUsed] = React.useState(0);
+
+  React.useEffect(() => {
+    const interval = setInterval(() => {
+      setUsed((prevUsed) => {
+        const val = (((prevUsed - 10) % 100) + 100) % 100;
+        setSpacer(val < 10 ? ' ' : '');
+        return val;
+      });
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  const data: UsageData = { x: 'GBps capacity', y: used };
+  const legendData: UsageData[] = [{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }];
+
+  return (
+    <div style={{ height: '230px', width: '435px' }}>
+      <ChartDonutUtilization
+        ariaDesc="Storage capacity"
+        ariaTitle="Donut utilization chart example"
+        constrainToVisibleArea
+        data={data}
+        invert
+        labels={({ datum }) => (datum.x ? `${datum.x}: ${datum.y}%` : null)}
+        legendData={legendData}
+        legendOrientation="vertical"
+        name="chart3"
+        padding={{
+          bottom: 20,
+          left: 20,
+          right: 225, // Adjusted to accommodate legend
+          top: 20
+        }}
+        subTitle="of 100 GBps"
+        title={`${used}%`}
+        thresholds={[{ value: 60 }, { value: 20 }]}
+        width={435}
+      />
+    </div>
+  );
+};

--- a/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilInvertedRightLegend.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilInvertedRightLegend.tsx
@@ -1,4 +1,5 @@
 import { ChartDonutUtilization } from '@patternfly/react-charts/victory';
+import { useEffect, useState } from 'react';
 
 interface UsageData {
   x?: string;
@@ -7,10 +8,10 @@ interface UsageData {
 }
 
 export const ChartUtilInvertedRightLegend: React.FunctionComponent = () => {
-  const [spacer, setSpacer] = React.useState('');
-  const [used, setUsed] = React.useState(0);
+  const [spacer, setSpacer] = useState('');
+  const [used, setUsed] = useState(0);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const interval = setInterval(() => {
       setUsed((prevUsed) => {
         const val = (((prevUsed - 10) % 100) + 100) % 100;

--- a/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilRightAlignedLegend.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilRightAlignedLegend.tsx
@@ -1,0 +1,52 @@
+import { ChartDonutUtilization } from '@patternfly/react-charts/victory';
+
+interface UsageData {
+  x?: string;
+  y?: number;
+  name?: string;
+}
+
+export const ChartUtilRightAlignedLegend: React.FunctionComponent = () => {
+  const [spacer, setSpacer] = React.useState('');
+  const [used, setUsed] = React.useState(0);
+
+  React.useEffect(() => {
+    const interval = setInterval(() => {
+      setUsed((prevUsed) => {
+        const val = (prevUsed + 10) % 100;
+        setSpacer(val < 10 ? ' ' : '');
+        return val;
+      });
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  const data: UsageData = { x: 'GBps capacity', y: used };
+  const legendData: UsageData[] = [{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }];
+
+  return (
+    <div style={{ height: '230px', width: '435px' }}>
+      <ChartDonutUtilization
+        ariaDesc="Storage capacity"
+        ariaTitle="Donut utilization chart example"
+        constrainToVisibleArea
+        data={data}
+        labels={({ datum }) => (datum.x ? `${datum.x}: ${datum.y}%` : null)}
+        legendData={legendData}
+        legendOrientation="vertical"
+        name="chart2"
+        padding={{
+          bottom: 20,
+          left: 20,
+          right: 225, // Adjusted to accommodate legend
+          top: 20
+        }}
+        subTitle="of 100 GBps"
+        title={`${used}%`}
+        thresholds={[{ value: 60 }, { value: 90 }]}
+        width={435}
+      />
+    </div>
+  );
+};

--- a/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilRightAlignedLegend.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilRightAlignedLegend.tsx
@@ -1,4 +1,5 @@
 import { ChartDonutUtilization } from '@patternfly/react-charts/victory';
+import { useEffect, useState } from 'react';
 
 interface UsageData {
   x?: string;
@@ -7,10 +8,10 @@ interface UsageData {
 }
 
 export const ChartUtilRightAlignedLegend: React.FunctionComponent = () => {
-  const [spacer, setSpacer] = React.useState('');
-  const [used, setUsed] = React.useState(0);
+  const [spacer, setSpacer] = useState('');
+  const [used, setUsed] = useState(0);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const interval = setInterval(() => {
       setUsed((prevUsed) => {
         const val = (prevUsed + 10) % 100;

--- a/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilRightVerticalLegend.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilRightVerticalLegend.tsx
@@ -1,0 +1,55 @@
+import { ChartDonutUtilization, ChartThemeColor } from '@patternfly/react-charts/victory';
+
+interface UsageData {
+  x?: string;
+  y?: number;
+  name?: string;
+}
+
+export const ChartUtilRightVerticalLegend: React.FunctionComponent = () => {
+  const [spacer, setSpacer] = React.useState('');
+  const [used, setUsed] = React.useState(0);
+
+  React.useEffect(() => {
+    const interval = setInterval(() => {
+      setUsed((prevUsed) => {
+        const val = (prevUsed + 10) % 100;
+        setSpacer(val < 10 ? ' ' : '');
+        return val;
+      });
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  const data: UsageData = { x: 'Storage capacity', y: used };
+  const legendData: UsageData[] = [{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }];
+
+  return (
+    <div style={{ height: '300px', width: '230px' }}>
+      <ChartDonutUtilization
+        ariaDesc="Storage capacity"
+        ariaTitle="Donut utilization chart example"
+        constrainToVisibleArea
+        data={data}
+        height={300}
+        labels={({ datum }) => (datum.x ? `${datum.x}: ${datum.y}%` : null)}
+        legendData={legendData}
+        legendOrientation="vertical"
+        legendPosition="bottom"
+        name="chart4"
+        padding={{
+          bottom: 75, // Adjusted to accommodate legend
+          left: 20,
+          right: 20,
+          top: 20
+        }}
+        subTitle="of 100 GBps"
+        title={`${used}%`}
+        themeColor={ChartThemeColor.green}
+        thresholds={[{ value: 60 }, { value: 90 }]}
+        width={230}
+      />
+    </div>
+  );
+};

--- a/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilRightVerticalLegend.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilRightVerticalLegend.tsx
@@ -1,4 +1,5 @@
 import { ChartDonutUtilization, ChartThemeColor } from '@patternfly/react-charts/victory';
+import { useEffect, useState } from 'react';
 
 interface UsageData {
   x?: string;
@@ -7,10 +8,10 @@ interface UsageData {
 }
 
 export const ChartUtilRightVerticalLegend: React.FunctionComponent = () => {
-  const [spacer, setSpacer] = React.useState('');
-  const [used, setUsed] = React.useState(0);
+  const [spacer, setSpacer] = useState('');
+  const [used, setUsed] = useState(0);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const interval = setInterval(() => {
       setUsed((prevUsed) => {
         const val = (prevUsed + 10) % 100;

--- a/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilSmall.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilSmall.tsx
@@ -1,0 +1,26 @@
+import { ChartDonutUtilization } from '@patternfly/react-charts/victory';
+
+interface UsageData {
+  x: string;
+  y: number;
+}
+
+export const ChartUtilSmall: React.FunctionComponent = () => {
+  const data: UsageData = { x: 'Storage capacity', y: 75 };
+  return (
+    <div style={{ height: '175px', width: '175px' }}>
+      <ChartDonutUtilization
+        ariaDesc="Storage capacity"
+        ariaTitle="Donut utilization chart example"
+        constrainToVisibleArea
+        data={data}
+        height={175}
+        labels={({ datum }) => (datum.x ? `${datum.x}: ${datum.y}%` : null)}
+        name="chart6"
+        subTitle="of 100 GBps"
+        title="75%"
+        width={175}
+      />
+    </div>
+  );
+};

--- a/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilSmallBottomSubtitle.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilSmallBottomSubtitle.tsx
@@ -1,0 +1,39 @@
+import { ChartDonutUtilization } from '@patternfly/react-charts/victory';
+
+interface UsageData {
+  x?: string;
+  y?: number;
+  name?: string;
+}
+
+export const ChartUtilSmallBottomSubtitle: React.FunctionComponent = () => {
+  const data: UsageData = { x: 'Storage capacity', y: 45 };
+  const legendData: UsageData[] = [{ name: `Storage capacity: 45%` }, { name: 'Unused' }];
+
+  return (
+    <div style={{ height: '185px', width: '350px' }}>
+      <ChartDonutUtilization
+        ariaDesc="Storage capacity"
+        ariaTitle="Donut utilization chart example"
+        constrainToVisibleArea
+        data={data}
+        height={185}
+        labels={({ datum }) => (datum.x ? `${datum.x}: ${datum.y}%` : null)}
+        legendData={legendData}
+        legendOrientation="vertical"
+        name="chart8"
+        padding={{
+          bottom: 25, // Adjusted to accommodate subTitle
+          left: 20,
+          right: 195, // Adjusted to accommodate legend
+          top: 20
+        }}
+        subTitle="of 100 GBps"
+        subTitlePosition="bottom"
+        title="45%"
+        thresholds={[{ value: 60 }, { value: 90 }]}
+        width={350}
+      />
+    </div>
+  );
+};

--- a/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilSmallRightLegend.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilSmallRightLegend.tsx
@@ -1,0 +1,53 @@
+import { ChartDonutUtilization } from '@patternfly/react-charts/victory';
+
+interface UsageData {
+  x?: string;
+  y?: number;
+  name?: string;
+}
+
+export const ChartUtilSmallRightLegend: React.FunctionComponent = () => {
+  const [spacer, setSpacer] = React.useState('');
+  const [used, setUsed] = React.useState(0);
+
+  React.useEffect(() => {
+    const interval = setInterval(() => {
+      setUsed((prevUsed) => {
+        const val = (prevUsed + 10) % 100;
+        setSpacer(val < 10 ? ' ' : '');
+        return val;
+      });
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  const data: UsageData = { x: 'Storage capacity', y: used };
+  const legendData: UsageData[] = [{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }];
+
+  return (
+    <div style={{ width: '350px', height: '175px' }}>
+      <ChartDonutUtilization
+        ariaDesc="Storage capacity"
+        ariaTitle="Donut utilization chart example"
+        constrainToVisibleArea
+        data={data}
+        height={175}
+        labels={({ datum }) => (datum.x ? `${datum.x}: ${datum.y}%` : null)}
+        legendData={legendData}
+        legendOrientation="vertical"
+        name="chart7"
+        padding={{
+          bottom: 20,
+          left: 20,
+          right: 195, // Adjusted to accommodate legend
+          top: 20
+        }}
+        subTitle="of 100 GBps"
+        title={`${used}%`}
+        thresholds={[{ value: 60 }, { value: 90 }]}
+        width={350}
+      />
+    </div>
+  );
+};

--- a/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilSmallRightLegend.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilSmallRightLegend.tsx
@@ -1,4 +1,5 @@
 import { ChartDonutUtilization } from '@patternfly/react-charts/victory';
+import { useEffect, useState } from 'react';
 
 interface UsageData {
   x?: string;
@@ -7,10 +8,10 @@ interface UsageData {
 }
 
 export const ChartUtilSmallRightLegend: React.FunctionComponent = () => {
-  const [spacer, setSpacer] = React.useState('');
-  const [used, setUsed] = React.useState(0);
+  const [spacer, setSpacer] = useState('');
+  const [used, setUsed] = useState(0);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const interval = setInterval(() => {
       setUsed((prevUsed) => {
         const val = (prevUsed + 10) % 100;

--- a/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilSmallRightSubtitle.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilSmallRightSubtitle.tsx
@@ -1,0 +1,39 @@
+import { ChartDonutUtilization } from '@patternfly/react-charts/victory';
+
+interface UsageData {
+  x?: string;
+  y?: number;
+  name?: string;
+}
+
+export const ChartUtilSmallRightSubtitle: React.FunctionComponent = () => {
+  const data: UsageData = { x: 'Storage capacity', y: 45 };
+  const legendData: UsageData[] = [{ name: `Storage capacity: 45%` }, { name: 'Unused' }];
+
+  return (
+    <div style={{ height: '200px', width: '350px' }}>
+      <ChartDonutUtilization
+        ariaDesc="Storage capacity"
+        ariaTitle="Donut utilization chart example"
+        constrainToVisibleArea
+        data={data}
+        height={200}
+        labels={({ datum }) => (datum.x ? `${datum.x}: ${datum.y}%` : null)}
+        legendData={legendData}
+        legendPosition="bottom"
+        name="chart9"
+        padding={{
+          bottom: 45, // Adjusted to accommodate legend
+          left: 20,
+          right: 20,
+          top: 20
+        }}
+        subTitle="of 100 GBps"
+        subTitlePosition="right"
+        title="45%"
+        thresholds={[{ value: 60 }, { value: 90 }]}
+        width={350}
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
Towards #11719

The following examples of Chart Donut will be converted to TypeScript:
- Basic
- Right aligned legend
- Inverted with right aligned legend
- Right aligned vertical legend
- Bottom aligned legend
- Small
- Small with right aligned legend
- Small with bottom aligned subtitle
- Small with right aligned subtitle

Since there are 18 examples, I'll divide this into 2 PRs making it easier for reviewing.
2nd PR - #11822
