### PR TITLE
chore(chart donut utilization): convert to typescript part two

### DIFF
--- a/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
+++ b/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
@@ -9,6 +9,7 @@ hideDarkMode: true
 ---
 
 import { ChartDonutThreshold, ChartDonutUtilization, ChartThemeColor } from '@patternfly/react-charts/victory';
+import {  useEffect, useState } from 'react';
 
 ## Introduction
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!

--- a/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
+++ b/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
@@ -385,399 +385,51 @@ import { ChartDonutUtilization } from '@patternfly/react-charts/victory';
 
 ## Donut utilization threshold examples
 ### Static thresholds
-```js
-import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts/victory';
+```ts file = "ChartUtilStatic.tsx"
 
-<div style={{ height: '230px', width: '230px' }}>
-  <ChartDonutThreshold
-    ariaDesc="Storage capacity"
-    ariaTitle="Donut utilization chart with static threshold example"
-    constrainToVisibleArea
-    data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
-    labels={({ datum }) => datum.x ? datum.x : null}
-    name="chart10"
-  >
-    <ChartDonutUtilization
-      data={{ x: 'Storage capacity', y: 45 }}
-      labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
-      subTitle="of 100 GBps"
-      title="45%"
-    />
-  </ChartDonutThreshold>
-</div>
 ```
 
 ### Static thresholds with right aligned legend
-```js
-import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts/victory';
+```ts file = "ChartUtilStaticRightLegend.tsx"
 
-class ThresholdChart extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      used: 0
-    };
-  }
-
-  componentDidMount() {
-    this.interval = setInterval(() => {
-      const { used } = this.state;
-      this.setState({ used: (used + 10) % 100 });
-    }, 1000);
-  }
-
-  componentWillUnmount() {
-    clearInterval(this.interval);
-  }
-
-  render() {
-    const { used } = this.state;
-    return (
-      <div style={{ height: '230px', width: '500px' }}>
-        <ChartDonutThreshold
-          ariaDesc="Storage capacity"
-          ariaTitle="Donut utilization chart with static threshold example"
-          constrainToVisibleArea
-          data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
-          labels={({ datum }) => datum.x ? datum.x : null}
-          name="chart11"
-          padding={{
-            bottom: 20,
-            left: 20,
-            right: 290, // Adjusted to accommodate legend
-            top: 20
-          }}
-          width={500}
-        >
-          <ChartDonutUtilization
-            data={{ x: 'Storage capacity', y: used }}
-            labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
-            legendData={[{ name: `Storage capacity: ${used}%` }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at 90%' }]}
-            legendOrientation="vertical"
-            subTitle="of 100 GBps"
-            title={`${used}%`}
-            thresholds={[{ value: 60 }, { value: 90 }]}
-          />
-        </ChartDonutThreshold>
-      </div>
-    );
-  }
-}
 ```
 
 ### Inverted static thresholds with right aligned legend
-```js
-import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts/victory';
+```ts file = "ChartUtilInvertedStatic.tsx"
 
-class InvertedThresholdChart extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      spacer: '',
-      used: 100
-    };
-  }
-  
-  componentDidMount() {
-    this.interval = setInterval(() => {
-      const { used } = this.state;
-      const val = (((used - 10) % 100) + 100) % 100;
-      this.setState({
-        spacer: val < 10 ? ' ' : '',
-        used: val
-      });
-    }, 1000);
-  }
-    
-  componentWillUnmount() {
-    clearInterval(this.interval);
-  }
-
-  render() {
-    const { used } = this.state;
-    return (
-      <div style={{ height: '230px', width: '500px' }}>
-        <ChartDonutThreshold
-          ariaDesc="Storage capacity"
-          ariaTitle="Donut utilization chart with static threshold example"
-          constrainToVisibleArea
-          data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 20%', y: 20 }]}
-          invert
-          labels={({ datum }) => datum.x ? datum.x : null}
-          name="chart12"
-          padding={{
-            bottom: 20,
-            left: 20,
-            right: 290, // Adjusted to accommodate legend
-            top: 20
-          }}
-          width={500}
-        >
-          <ChartDonutUtilization
-            data={{ x: 'Storage capacity', y: used }}
-            labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
-            legendData={[{ name: `Storage capacity: ${used}%` }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at 20%' }]}
-            legendOrientation="vertical"
-            subTitle="of 100 GBps"
-            title={`${used}%`}
-            thresholds={[{ value: 60 }, { value: 20 }]}
-          />
-        </ChartDonutThreshold>
-      </div>
-    );
-  }
-}
 ```
 
 ### Static thresholds with custom legend
-```js
-import { ChartDonutThreshold, ChartDonutUtilization, ChartThemeColor } from '@patternfly/react-charts/victory';
+```ts file = "ChartUtilStaticCustomLegend.tsx"
 
-class CustomLegendThresholdChart extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      used: 0
-    };
-  }
-
-  componentDidMount() {
-    this.interval = setInterval(() => {
-      const { used } = this.state;
-      this.setState({ used: (used + 10) % 100 });
-    }, 1000);
-  }
-
-  componentWillUnmount() {
-    clearInterval(this.interval);
-  }
-
-  render() {
-    const { used } = this.state;
-    return (
-      <div style={{ height: '350px', width: '230px' }}>
-        <ChartDonutThreshold
-          ariaDesc="Storage capacity"
-          ariaTitle="Donut utilization chart with static threshold example"
-          constrainToVisibleArea
-          data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
-          height={350}
-          labels={({ datum }) => datum.x ? datum.x : null}
-          name="chart13"
-          padding={{
-            bottom: 125, // Adjusted to accommodate legend
-            left: 20,
-            right: 20,
-            top: 20
-          }}
-          width={230}
-        >
-          <ChartDonutUtilization
-            data={{ x: 'Storage capacity', y: used }}
-            labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
-            legendData={[{ name: `Storage capacity: ${used}%` }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at 90%' }]}
-            legendOrientation="vertical"
-            legendPosition="bottom"
-            subTitle="of 100 GBps"
-            title={`${used}%`}
-            themeColor={ChartThemeColor.green}
-            thresholds={[{ value: 60 }, { value: 90 }]}
-          />
-        </ChartDonutThreshold>
-      </div>
-    );
-  }
-}
 ```
 
 ### Static thresholds with bottom aligned legend
-```js
-import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts/victory';
+```ts file = "ChartUtilStaticBottomLegend.tsx"
 
-<div style={{ height: '275px', width: '675px' }}>
-  <ChartDonutThreshold
-    ariaDesc="Storage capacity"
-    ariaTitle="Donut utilization chart with static threshold example"
-    constrainToVisibleArea
-    data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
-    height={275}
-    labels={({ datum }) => datum.x ? datum.x : null}
-    name="chart14"
-    padding={{
-      bottom: 65, // Adjusted to accommodate legend
-      left: 20,
-      right: 20,
-      top: 20
-    }}
-    width={675}
-  >
-    <ChartDonutUtilization
-      data={{ x: 'Storage capacity', y: 45 }}
-      labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
-      legendData={[{ name: `Storage capacity: 45%` }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at 90%' }]}
-      legendPosition="bottom"
-      subTitle="of 100 GBps"
-      title="45%"
-    />
-  </ChartDonutThreshold>
-</div>
 ```
 
 ### Small with static thresholds
-```js
-import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts/victory';
+```ts file = "ChartUtilSmallStatic.tsx"
 
-<div style={{ height: '185px', width: '185px' }}>
-  <ChartDonutThreshold
-    ariaDesc="Storage capacity"
-    ariaTitle="Donut utilization chart with static threshold example"
-    constrainToVisibleArea
-    data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
-    height={185}
-    labels={({ datum }) => datum.x ? datum.x : null}
-    name="chart15"
-    width={185}
-  >
-    <ChartDonutUtilization
-      data={{ x: 'Storage capacity', y: 45 }}
-      labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
-      subTitle="of 100 GBps"
-      title="45%"
-    />
-  </ChartDonutThreshold>
-</div>
 ```
 
 ### Small with static thresholds and right aligned legend
-```js
-import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts/victory';
+```ts file = "ChartUtilSmallStaticRightLegend.tsx"
 
-class ThresholdChart extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      used: 0
-    };
-  }
-
-  componentDidMount() {
-    this.interval = setInterval(() => {
-      const { used } = this.state;
-      this.setState({ used: (used + 10) % 100 });
-    }, 1000);
-  }
-
-  componentWillUnmount() {
-    clearInterval(this.interval);
-  }
-
-  render() {
-    const { used } = this.state;
-    return (
-      <div style={{ height: '185px', width: '425px' }}>
-        <ChartDonutThreshold
-          ariaDesc="Storage capacity"
-          ariaTitle="Donut utilization chart with static threshold example"
-          constrainToVisibleArea
-          data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
-          height={185}
-          labels={({ datum }) => datum.x ? datum.x : null}
-          name="chart16"
-          padding={{
-            bottom: 20,
-            left: 20,
-            right: 260, // Adjusted to accommodate legend
-            top: 20
-          }}
-          width={425}
-        >
-          <ChartDonutUtilization
-            data={{ x: 'Storage capacity', y: used }}
-            labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
-            legendData={[{ name: `Storage capacity: ${used}%` }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at 90%' }]}
-            legendOrientation="vertical"
-            subTitle="of 100 GBps"
-            title={`${used}%`}
-            thresholds={[{ value: 60 }, { value: 90 }]}
-          />
-        </ChartDonutThreshold>
-      </div>
-    );
-  }
-}
 ```
 
 ### Small with subtitle
 
 This is a small donut utilization chart with static thresholds with right aligned legend and bottom aligned subtitle.
 
-```js
-import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts/victory';
+```ts file = "ChartUtilSmallSubtitle.tsx"
 
-<div style={{ height: '200px', width: '425px' }}>
-  <ChartDonutThreshold
-    ariaDesc="Storage capacity"
-    ariaTitle="Donut utilization chart with static threshold example"
-    constrainToVisibleArea
-    data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
-    height={200}
-    labels={({ datum }) => datum.x ? datum.x : null}
-    name="chart17"
-    padding={{
-      bottom: 30, // Adjusted to accommodate label
-      left: 20,
-      right: 260, // Adjusted to accommodate legend
-      top: 20
-    }}
-    subTitlePosition="bottom"
-    width={425}
-  >
-    <ChartDonutUtilization
-      data={{ x: 'Storage capacity', y: 45 }}
-      labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
-      legendData={[{ name: `Storage capacity: 45%` }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at  90%' }]}
-      legendOrientation="vertical"
-      subTitle="of 100 GBps"
-      title="45%"
-      thresholds={[{ value: 60 }, { value: 90 }]}
-    />
-  </ChartDonutThreshold>
-</div>
 ```
 
 ### Small with thresholds and right aligned subtitle
-```js
-import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts/victory';
+```ts file = "ChartUtilSmallRightAlignedSubtitle.tsx"
 
-<div style={{ height: '225px', width: '675px' }}>
-  <ChartDonutThreshold
-    ariaDesc="Storage capacity"
-    ariaTitle="Donut utilization chart with static threshold example"
-    constrainToVisibleArea
-    data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
-    height={225}
-    labels={({ datum }) => datum.x ? datum.x : null}
-    name="chart18"
-    padding={{
-      bottom: 60, // Adjusted to accommodate legend
-      left: 20,
-      right: 20,
-      top: 20
-    }}
-    subTitlePosition="right"
-    width={675}
-  >
-    <ChartDonutUtilization
-      data={{ x: 'Storage capacity', y: 45 }}
-      labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
-      legendData={[{ name: `Storage capacity: 45%` }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at 90%' }]}
-      legendPosition="bottom"
-      subTitle="of 100 GBps"
-      title="45%"
-      thresholds={[{ value: 60 }, { value: 90 }]}
-    />
-  </ChartDonutThreshold>
-</div>
 ```
 
 ## Documentation

--- a/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilInvertedStatic.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilInvertedStatic.tsx
@@ -1,0 +1,64 @@
+import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts/victory';
+
+interface UsageData {
+  x?: string;
+  y?: number;
+  name?: string;
+}
+
+export const ChartUtilInvertedStatic: React.FunctionComponent = () => {
+  const [used, setUsed] = React.useState(100);
+
+  React.useEffect(() => {
+    const interval = setInterval(() => {
+      setUsed((prevUsed) => {
+        const val = (prevUsed - 10 + 100) % 100;
+        return val;
+      });
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  const dataThreshold: UsageData[] = [
+    { x: 'Warning at 60%', y: 60 },
+    { x: 'Danger at 20%', y: 20 }
+  ];
+  const dataUtil: UsageData = { x: 'Storage capacity', y: used };
+  const legendData: UsageData[] = [
+    { name: `Storage capacity: ${used}%` },
+    { name: 'Warning threshold at 60%' },
+    { name: 'Danger threshold at 20%' }
+  ];
+
+  return (
+    <div style={{ height: '230px', width: '500px' }}>
+      <ChartDonutThreshold
+        ariaDesc="Storage capacity"
+        ariaTitle="Donut utilization chart with static threshold example"
+        constrainToVisibleArea
+        data={dataThreshold}
+        invert
+        labels={({ datum }) => (datum.x ? datum.x : null)}
+        name="chart12"
+        padding={{
+          bottom: 20,
+          left: 20,
+          right: 290, // Adjusted to accommodate legend
+          top: 20
+        }}
+        width={500}
+      >
+        <ChartDonutUtilization
+          data={dataUtil}
+          labels={({ datum }) => (datum.x ? `${datum.x}: ${datum.y}%` : null)}
+          legendData={legendData}
+          legendOrientation="vertical"
+          subTitle="of 100 GBps"
+          title={`${used}%`}
+          thresholds={[{ value: 60 }, { value: 20 }]}
+        />
+      </ChartDonutThreshold>
+    </div>
+  );
+};

--- a/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilInvertedStatic.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilInvertedStatic.tsx
@@ -1,4 +1,5 @@
 import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts/victory';
+import { useEffect, useState } from 'react';
 
 interface UsageData {
   x?: string;
@@ -7,9 +8,9 @@ interface UsageData {
 }
 
 export const ChartUtilInvertedStatic: React.FunctionComponent = () => {
-  const [used, setUsed] = React.useState(100);
+  const [used, setUsed] = useState(100);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const interval = setInterval(() => {
       setUsed((prevUsed) => {
         const val = (prevUsed - 10 + 100) % 100;

--- a/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilSmallRightAlignedSubtitle.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilSmallRightAlignedSubtitle.tsx
@@ -1,0 +1,52 @@
+import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts/victory';
+
+interface UsageData {
+  x?: string;
+  y?: number;
+  name?: string;
+}
+
+export const ChartUtilSmallRightAlignedSubtitle: React.FunctionComponent = () => {
+  const dataThreshold: UsageData[] = [
+    { x: 'Warning at 60%', y: 60 },
+    { x: 'Danger at 90%', y: 90 }
+  ];
+  const dataUtil: UsageData = { x: 'Storage capacity', y: 45 };
+  const legendData: UsageData[] = [
+    { name: `Storage capacity: 45%` },
+    { name: 'Warning threshold at 60%' },
+    { name: 'Danger threshold at 90%' }
+  ];
+
+  return (
+    <div style={{ height: '225px', width: '675px' }}>
+      <ChartDonutThreshold
+        ariaDesc="Storage capacity"
+        ariaTitle="Donut utilization chart with static threshold example"
+        constrainToVisibleArea
+        data={dataThreshold}
+        height={225}
+        labels={({ datum }) => (datum.x ? datum.x : null)}
+        name="chart18"
+        padding={{
+          bottom: 60, // Adjusted to accommodate legend
+          left: 20,
+          right: 20,
+          top: 20
+        }}
+        subTitlePosition="right"
+        width={675}
+      >
+        <ChartDonutUtilization
+          data={dataUtil}
+          labels={({ datum }) => (datum.x ? `${datum.x}: ${datum.y}%` : null)}
+          legendData={legendData}
+          legendPosition="bottom"
+          subTitle="of 100 GBps"
+          title="45%"
+          thresholds={[{ value: 60 }, { value: 90 }]}
+        />
+      </ChartDonutThreshold>
+    </div>
+  );
+};

--- a/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilSmallStatic.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilSmallStatic.tsx
@@ -1,0 +1,36 @@
+import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts/victory';
+
+interface UsageData {
+  x: string;
+  y: number;
+}
+
+export const ChartUtilSmallStatic: React.FunctionComponent = () => {
+  const dataThreshold: UsageData[] = [
+    { x: 'Warning at 60%', y: 60 },
+    { x: 'Danger at 90%', y: 90 }
+  ];
+  const dataUtil: UsageData = { x: 'Storage capacity', y: 45 };
+
+  return (
+    <div style={{ height: '185px', width: '185px' }}>
+      <ChartDonutThreshold
+        ariaDesc="Storage capacity"
+        ariaTitle="Donut utilization chart with static threshold example"
+        constrainToVisibleArea
+        data={dataThreshold}
+        height={185}
+        labels={({ datum }) => (datum.x ? datum.x : null)}
+        name="chart15"
+        width={185}
+      >
+        <ChartDonutUtilization
+          data={dataUtil}
+          labels={({ datum }) => (datum.x ? `${datum.x}: ${datum.y}%` : null)}
+          subTitle="of 100 GBps"
+          title="45%"
+        />
+      </ChartDonutThreshold>
+    </div>
+  );
+};

--- a/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilSmallStaticRightLegend.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilSmallStaticRightLegend.tsx
@@ -1,0 +1,64 @@
+import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts/victory';
+
+interface UsageData {
+  x?: string;
+  y?: number;
+  name?: string;
+}
+
+export const ChartUtilSmallStaticRightLegend: React.FunctionComponent = () => {
+  const [used, setUsed] = React.useState(0);
+
+  React.useEffect(() => {
+    const interval = setInterval(() => {
+      setUsed((prevUsed) => {
+        const val = (prevUsed + 10) % 100;
+        return val;
+      });
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  const dataThreshold: UsageData[] = [
+    { x: 'Warning at 60%', y: 60 },
+    { x: 'Danger at 90%', y: 90 }
+  ];
+  const dataUtil: UsageData = { x: 'Storage capacity', y: used };
+  const legendData: UsageData[] = [
+    { name: `Storage capacity: ${used}%` },
+    { name: 'Warning threshold at 60%' },
+    { name: 'Danger threshold at 90%' }
+  ];
+
+  return (
+    <div style={{ height: '185px', width: '425px' }}>
+      <ChartDonutThreshold
+        ariaDesc="Storage capacity"
+        ariaTitle="Donut utilization chart with static threshold example"
+        constrainToVisibleArea
+        data={dataThreshold}
+        height={185}
+        labels={({ datum }) => (datum.x ? datum.x : null)}
+        name="chart16"
+        padding={{
+          bottom: 20,
+          left: 20,
+          right: 260, // Adjusted to accommodate legend
+          top: 20
+        }}
+        width={425}
+      >
+        <ChartDonutUtilization
+          data={dataUtil}
+          labels={({ datum }) => (datum.x ? `${datum.x}: ${datum.y}%` : null)}
+          legendData={legendData}
+          legendOrientation="vertical"
+          subTitle="of 100 GBps"
+          title={`${used}%`}
+          thresholds={[{ value: 60 }, { value: 90 }]}
+        />
+      </ChartDonutThreshold>
+    </div>
+  );
+};

--- a/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilSmallStaticRightLegend.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilSmallStaticRightLegend.tsx
@@ -1,4 +1,5 @@
 import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts/victory';
+import { useEffect, useState } from 'react';
 
 interface UsageData {
   x?: string;
@@ -7,9 +8,9 @@ interface UsageData {
 }
 
 export const ChartUtilSmallStaticRightLegend: React.FunctionComponent = () => {
-  const [used, setUsed] = React.useState(0);
+  const [used, setUsed] = useState(0);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const interval = setInterval(() => {
       setUsed((prevUsed) => {
         const val = (prevUsed + 10) % 100;

--- a/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilSmallSubtitle.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilSmallSubtitle.tsx
@@ -1,0 +1,52 @@
+import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts/victory';
+
+interface UsageData {
+  x?: string;
+  y?: number;
+  name?: string;
+}
+
+export const ChartUtilSmallSubtitle: React.FunctionComponent = () => {
+  const dataThreshold: UsageData[] = [
+    { x: 'Warning at 60%', y: 60 },
+    { x: 'Danger at 90%', y: 90 }
+  ];
+  const dataUtil: UsageData = { x: 'Storage capacity', y: 45 };
+  const legendData: UsageData[] = [
+    { name: `Storage capacity: 45%` },
+    { name: 'Warning threshold at 60%' },
+    { name: 'Danger threshold at  90%' }
+  ];
+
+  return (
+    <div style={{ height: '200px', width: '425px' }}>
+      <ChartDonutThreshold
+        ariaDesc="Storage capacity"
+        ariaTitle="Donut utilization chart with static threshold example"
+        constrainToVisibleArea
+        data={dataThreshold}
+        height={200}
+        labels={({ datum }) => (datum.x ? datum.x : null)}
+        name="chart17"
+        padding={{
+          bottom: 30, // Adjusted to accommodate label
+          left: 20,
+          right: 260, // Adjusted to accommodate legend
+          top: 20
+        }}
+        subTitlePosition="bottom"
+        width={425}
+      >
+        <ChartDonutUtilization
+          data={dataUtil}
+          labels={({ datum }) => (datum.x ? `${datum.x}: ${datum.y}%` : null)}
+          legendData={legendData}
+          legendOrientation="vertical"
+          subTitle="of 100 GBps"
+          title="45%"
+          thresholds={[{ value: 60 }, { value: 90 }]}
+        />
+      </ChartDonutThreshold>
+    </div>
+  );
+};

--- a/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilStatic.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilStatic.tsx
@@ -1,0 +1,34 @@
+import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts/victory';
+
+interface UsageData {
+  x: string;
+  y: number;
+}
+
+export const ChartUtilStatic: React.FunctionComponent = () => {
+  const dataThreshold: UsageData[] = [
+    { x: 'Warning at 60%', y: 60 },
+    { x: 'Danger at 90%', y: 90 }
+  ];
+  const dataUtil: UsageData = { x: 'Storage capacity', y: 45 };
+
+  return (
+    <div style={{ height: '230px', width: '230px' }}>
+      <ChartDonutThreshold
+        ariaDesc="Storage capacity"
+        ariaTitle="Donut utilization chart with static threshold example"
+        constrainToVisibleArea
+        data={dataThreshold}
+        labels={({ datum }) => (datum.x ? datum.x : null)}
+        name="chart10"
+      >
+        <ChartDonutUtilization
+          data={dataUtil}
+          labels={({ datum }) => (datum.x ? `${datum.x}: ${datum.y}%` : null)}
+          subTitle="of 100 GBps"
+          title="45%"
+        />
+      </ChartDonutThreshold>
+    </div>
+  );
+};

--- a/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilStaticBottomLegend.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilStaticBottomLegend.tsx
@@ -1,0 +1,50 @@
+import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts/victory';
+
+interface UsageData {
+  x?: string;
+  y?: number;
+  name?: string;
+}
+
+export const ChartUtilStaticBottomLegend: React.FunctionComponent = () => {
+  const dataThreshold: UsageData[] = [
+    { x: 'Warning at 60%', y: 60 },
+    { x: 'Danger at 90%', y: 90 }
+  ];
+  const dataUtil: UsageData = { x: 'Storage capacity', y: 45 };
+  const legendData: UsageData[] = [
+    { name: `Storage capacity: 45%` },
+    { name: 'Warning threshold at 60%' },
+    { name: 'Danger threshold at 90%' }
+  ];
+
+  return (
+    <div style={{ height: '275px', width: '675px' }}>
+      <ChartDonutThreshold
+        ariaDesc="Storage capacity"
+        ariaTitle="Donut utilization chart with static threshold example"
+        constrainToVisibleArea
+        data={dataThreshold}
+        height={275}
+        labels={({ datum }) => (datum.x ? datum.x : null)}
+        name="chart14"
+        padding={{
+          bottom: 65, // Adjusted to accommodate legend
+          left: 20,
+          right: 20,
+          top: 20
+        }}
+        width={675}
+      >
+        <ChartDonutUtilization
+          data={dataUtil}
+          labels={({ datum }) => (datum.x ? `${datum.x}: ${datum.y}%` : null)}
+          legendData={legendData}
+          legendPosition="bottom"
+          subTitle="of 100 GBps"
+          title="45%"
+        />
+      </ChartDonutThreshold>
+    </div>
+  );
+};

--- a/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilStaticCustomLegend.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilStaticCustomLegend.tsx
@@ -1,0 +1,66 @@
+import { ChartDonutThreshold, ChartDonutUtilization, ChartThemeColor } from '@patternfly/react-charts/victory';
+
+interface UsageData {
+  x?: string;
+  y?: number;
+  name?: string;
+}
+
+export const ChartUtilStaticCustomLegend: React.FunctionComponent = () => {
+  const [used, setUsed] = React.useState(0);
+
+  React.useEffect(() => {
+    const interval = setInterval(() => {
+      setUsed((prevUsed) => {
+        const val = (prevUsed + 10) % 100;
+        return val;
+      });
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  const dataThreshold: UsageData[] = [
+    { x: 'Warning at 60%', y: 60 },
+    { x: 'Danger at 90%', y: 90 }
+  ];
+  const dataUtil: UsageData = { x: 'Storage capacity', y: used };
+  const legendData: UsageData[] = [
+    { name: `Storage capacity: ${used}%` },
+    { name: 'Warning threshold at 60%' },
+    { name: 'Danger threshold at 90%' }
+  ];
+
+  return (
+    <div style={{ height: '350px', width: '230px' }}>
+      <ChartDonutThreshold
+        ariaDesc="Storage capacity"
+        ariaTitle="Donut utilization chart with static threshold example"
+        constrainToVisibleArea
+        data={dataThreshold}
+        height={350}
+        labels={({ datum }) => (datum.x ? datum.x : null)}
+        name="chart13"
+        padding={{
+          bottom: 125, // Adjusted to accommodate legend
+          left: 20,
+          right: 20,
+          top: 20
+        }}
+        width={230}
+      >
+        <ChartDonutUtilization
+          data={dataUtil}
+          labels={({ datum }) => (datum.x ? `${datum.x}: ${datum.y}%` : null)}
+          legendData={legendData}
+          legendOrientation="vertical"
+          legendPosition="bottom"
+          subTitle="of 100 GBps"
+          title={`${used}%`}
+          themeColor={ChartThemeColor.green}
+          thresholds={[{ value: 60 }, { value: 90 }]}
+        />
+      </ChartDonutThreshold>
+    </div>
+  );
+};

--- a/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilStaticCustomLegend.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilStaticCustomLegend.tsx
@@ -1,4 +1,5 @@
 import { ChartDonutThreshold, ChartDonutUtilization, ChartThemeColor } from '@patternfly/react-charts/victory';
+import { useEffect, useState } from 'react';
 
 interface UsageData {
   x?: string;
@@ -7,9 +8,9 @@ interface UsageData {
 }
 
 export const ChartUtilStaticCustomLegend: React.FunctionComponent = () => {
-  const [used, setUsed] = React.useState(0);
+  const [used, setUsed] = useState(0);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const interval = setInterval(() => {
       setUsed((prevUsed) => {
         const val = (prevUsed + 10) % 100;

--- a/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilStaticRightLegend.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilStaticRightLegend.tsx
@@ -1,4 +1,5 @@
 import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts/victory';
+import { useEffect, useState } from 'react';
 
 interface UsageData {
   x?: string;
@@ -7,9 +8,9 @@ interface UsageData {
 }
 
 export const ChartUtilStaticRightLegend: React.FunctionComponent = () => {
-  const [used, setUsed] = React.useState(0);
+  const [used, setUsed] = useState(0);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const interval = setInterval(() => {
       setUsed((prevUsed) => {
         const val = (prevUsed + 10) % 100;

--- a/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilStaticRightLegend.tsx
+++ b/packages/react-charts/src/victory/components/ChartDonutUtilization/examples/ChartUtilStaticRightLegend.tsx
@@ -1,0 +1,63 @@
+import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts/victory';
+
+interface UsageData {
+  x?: string;
+  y?: number;
+  name?: string;
+}
+
+export const ChartUtilStaticRightLegend: React.FunctionComponent = () => {
+  const [used, setUsed] = React.useState(0);
+
+  React.useEffect(() => {
+    const interval = setInterval(() => {
+      setUsed((prevUsed) => {
+        const val = (prevUsed + 10) % 100;
+        return val;
+      });
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  const dataThreshold: UsageData[] = [
+    { x: 'Warning at 60%', y: 60 },
+    { x: 'Danger at 90%', y: 90 }
+  ];
+  const dataUtil: UsageData = { x: 'Storage capacity', y: used };
+  const legendData: UsageData[] = [
+    { name: `Storage capacity: ${used}%` },
+    { name: 'Warning threshold at 60%' },
+    { name: 'Danger threshold at 90%' }
+  ];
+
+  return (
+    <div style={{ height: '230px', width: '500px' }}>
+      <ChartDonutThreshold
+        ariaDesc="Storage capacity"
+        ariaTitle="Donut utilization chart with static threshold example"
+        constrainToVisibleArea
+        data={dataThreshold}
+        labels={({ datum }) => (datum.x ? datum.x : null)}
+        name="chart11"
+        padding={{
+          bottom: 20,
+          left: 20,
+          right: 290, // Adjusted to accommodate legend
+          top: 20
+        }}
+        width={500}
+      >
+        <ChartDonutUtilization
+          data={dataUtil}
+          labels={({ datum }) => (datum.x ? `${datum.x}: ${datum.y}%` : null)}
+          legendData={legendData}
+          legendOrientation="vertical"
+          subTitle="of 100 GBps"
+          title={`${used}%`}
+          thresholds={[{ value: 60 }, { value: 90 }]}
+        />
+      </ChartDonutThreshold>
+    </div>
+  );
+};


### PR DESCRIPTION
 Towards #11719

The following examples of Chart Donut will be converted to TypeScript:
- Static thresholds
- Static thresholds with right aligned legend
- Inverted static thresholds with right aligned legend
- Static thresholds with custom legend
- Static thresholds with bottom aligned legend
- Small with static thresholds
- Small with static thresholds and right aligned legend
- Small with subtitle
- Small with thresholds and right aligned subtitle

This is related to #11819. The remaining 9 examples are converted in this PR to make it easier for reviewing.
