### PR TITLE
feat(Tabs): add the option to disable the Add button

### DIFF
--- a/packages/react-core/src/components/Tabs/Tabs.tsx
+++ b/packages/react-core/src/components/Tabs/Tabs.tsx
@@ -59,10 +59,12 @@ export interface TabsProps
   onClose?: (event: React.MouseEvent<HTMLElement, MouseEvent>, eventKey: number | string) => void;
   /** Callback for the add button. Passing this property inserts the add button */
   onAdd?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
-  /** Aria-label for the add button */
+  /** Flag indicating that the add button is disabled when onAdd is passed in */
   addButtonAriaLabel?: string;
   /** Uniquely identifies the tabs */
   id?: string;
+  /** Disables the add button */
+  isAddButtonDisabled?: boolean;
   /** Enables the filled tab list layout */
   isFilled?: boolean;
   /** Enables subtab tab styling */
@@ -464,6 +466,7 @@ class Tabs extends Component<TabsProps, TabsState> {
       activeKey,
       defaultActiveKey,
       id,
+      isAddButtonDisabled,
       isFilled,
       isSubtab,
       isVertical,
@@ -631,6 +634,7 @@ class Tabs extends Component<TabsProps, TabsState> {
                 aria-label={addButtonAriaLabel || 'Add tab'}
                 onClick={onAdd}
                 icon={<PlusIcon />}
+                isDisabled={isAddButtonDisabled}
               />
             </span>
           )}

--- a/packages/react-core/src/components/Tabs/Tabs.tsx
+++ b/packages/react-core/src/components/Tabs/Tabs.tsx
@@ -59,11 +59,11 @@ export interface TabsProps
   onClose?: (event: React.MouseEvent<HTMLElement, MouseEvent>, eventKey: number | string) => void;
   /** Callback for the add button. Passing this property inserts the add button */
   onAdd?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
-  /** Flag indicating that the add button is disabled when onAdd is passed in */
+  /** Aria-label for the add button */
   addButtonAriaLabel?: string;
   /** Uniquely identifies the tabs */
   id?: string;
-  /** Disables the add button */
+  /** Flag indicating that the add button is disabled when onAdd is passed in */
   isAddButtonDisabled?: boolean;
   /** Enables the filled tab list layout */
   isFilled?: boolean;

--- a/packages/react-core/src/components/Tabs/__tests__/Tabs.test.tsx
+++ b/packages/react-core/src/components/Tabs/__tests__/Tabs.test.tsx
@@ -492,3 +492,25 @@ test('should not render scroll buttons when isVertical is true', () => {
   expect(screen.queryByLabelText('Scroll left')).not.toBeInTheDocument();
   expect(screen.queryByLabelText('Scroll right')).not.toBeInTheDocument();
 });
+
+test('should render a disabled add button', () => {
+  render(
+    <Tabs onAdd={jest.fn()} addButtonAriaLabel="add-label" isAddButtonDisabled={true}>
+      <div>Tab content</div>
+    </Tabs>
+  );
+
+  const addButton = screen.getByLabelText('add-label');
+  expect(addButton).toBeDisabled();
+});
+
+test('should render an enabled add button', () => {
+  render(
+    <Tabs onAdd={jest.fn()} addButtonAriaLabel="add-label" isAddButtonDisabled={false}>
+      <div>Tab content</div>
+    </Tabs>
+  );
+
+  const addButton = screen.getByLabelText('add-label');
+  expect(addButton).not.toBeDisabled();
+});


### PR DESCRIPTION
Closes https://github.com/patternfly/patternfly-react/issues/11873

This PR adds the option to make the `+` button in the `Tabs` component disabled, if the isAddButtonDisabled prop is set.

Although the change in the code is really small, I'm not fully familiar with the project and couldn't make it run locally to check visually how the component behaves :cry: . Feel free to confirm that it behaves as expected. All tests pass on my end, so it should be good to go.