### PR TITLE
chore(patterns): convert to typescript

### DIFF
--- a/packages/react-charts/src/victory/components/Patterns/examples/PatternsBarChart.tsx
+++ b/packages/react-charts/src/victory/components/Patterns/examples/PatternsBarChart.tsx
@@ -1,0 +1,80 @@
+import {
+  Chart,
+  ChartAxis,
+  ChartBar,
+  ChartGroup,
+  ChartThemeColor,
+  ChartVoronoiContainer
+} from '@patternfly/react-charts/victory';
+
+interface PetData {
+  x?: string;
+  y?: number;
+  name?: string;
+}
+
+export const PatternsBarChart: React.FunctionComponent = () => {
+  const legendData: PetData[] = [{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }];
+  const data1: PetData[] = [
+    { name: 'Cats', x: '2015', y: 1 },
+    { name: 'Cats', x: '2016', y: 2 },
+    { name: 'Cats', x: '2017', y: 5 },
+    { name: 'Cats', x: '2018', y: 3 }
+  ];
+
+  const data2: PetData[] = [
+    { name: 'Dogs', x: '2015', y: 2 },
+    { name: 'Dogs', x: '2016', y: 1 },
+    { name: 'Dogs', x: '2017', y: 7 },
+    { name: 'Dogs', x: '2018', y: 4 }
+  ];
+
+  const data3: PetData[] = [
+    { name: 'Birds', x: '2015', y: 4 },
+    { name: 'Birds', x: '2016', y: 4 },
+    { name: 'Birds', x: '2017', y: 9 },
+    { name: 'Birds', x: '2018', y: 7 }
+  ];
+
+  const data4: PetData[] = [
+    { name: 'Mice', x: '2015', y: 3 },
+    { name: 'Mice', x: '2016', y: 3 },
+    { name: 'Mice', x: '2017', y: 8 },
+    { name: 'Mice', x: '2018', y: 5 }
+  ];
+
+  return (
+    <div style={{ height: '275px', width: '450px' }}>
+      <Chart
+        ariaDesc="Average number of pets"
+        ariaTitle="Bar chart example"
+        containerComponent={
+          <ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />
+        }
+        domainPadding={{ x: [30, 25] }}
+        legendData={legendData}
+        legendPosition="bottom"
+        hasPatterns
+        height={275}
+        name="chart2"
+        padding={{
+          bottom: 75, // Adjusted to accommodate legend
+          left: 50,
+          right: 50,
+          top: 50
+        }}
+        themeColor={ChartThemeColor.purple}
+        width={450}
+      >
+        <ChartAxis />
+        <ChartAxis dependentAxis showGrid />
+        <ChartGroup offset={11}>
+          <ChartBar data={data1} />
+          <ChartBar data={data2} />
+          <ChartBar data={data3} />
+          <ChartBar data={data4} />
+        </ChartGroup>
+      </Chart>
+    </div>
+  );
+};

--- a/packages/react-charts/src/victory/components/Patterns/examples/PatternsBasicPieChart.tsx
+++ b/packages/react-charts/src/victory/components/Patterns/examples/PatternsBasicPieChart.tsx
@@ -1,0 +1,41 @@
+import { ChartPie } from '@patternfly/react-charts/victory';
+
+interface PetData {
+  x?: string;
+  y?: number;
+  name?: string;
+}
+
+export const PatternsBasicPieChart: React.FunctionComponent = () => {
+  const data: PetData[] = [
+    { x: 'Cats', y: 35 },
+    { x: 'Dogs', y: 55 },
+    { x: 'Birds', y: 10 }
+  ];
+  const legendData: PetData[] = [{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }];
+
+  return (
+    <div style={{ height: '230px', width: '350px' }}>
+      <ChartPie
+        ariaDesc="Average number of pets"
+        ariaTitle="Pie chart example"
+        constrainToVisibleArea
+        data={data}
+        hasPatterns
+        height={230}
+        labels={({ datum }) => `${datum.x}: ${datum.y}`}
+        legendData={legendData}
+        legendOrientation="vertical"
+        legendPosition="right"
+        name="chart1"
+        padding={{
+          bottom: 20,
+          left: 20,
+          right: 140, // Adjusted to accommodate legend
+          top: 20
+        }}
+        width={350}
+      />
+    </div>
+  );
+};

--- a/packages/react-charts/src/victory/components/Patterns/examples/PatternsStackChart.tsx
+++ b/packages/react-charts/src/victory/components/Patterns/examples/PatternsStackChart.tsx
@@ -1,0 +1,81 @@
+import {
+  Chart,
+  ChartAxis,
+  ChartBar,
+  ChartStack,
+  ChartThemeColor,
+  ChartVoronoiContainer
+} from '@patternfly/react-charts/victory';
+
+interface PetData {
+  x?: string;
+  y?: number;
+  name?: string;
+}
+
+export const PatternsStackChart: React.FunctionComponent = () => {
+  const legendData: PetData[] = [{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }];
+  const data1: PetData[] = [
+    { name: 'Cats', x: '2015', y: 1 },
+    { name: 'Cats', x: '2016', y: 2 },
+    { name: 'Cats', x: '2017', y: 5 },
+    { name: 'Cats', x: '2018', y: 3 }
+  ];
+
+  const data2: PetData[] = [
+    { name: 'Dogs', x: '2015', y: 2 },
+    { name: 'Dogs', x: '2016', y: 1 },
+    { name: 'Dogs', x: '2017', y: 7 },
+    { name: 'Dogs', x: '2018', y: 4 }
+  ];
+
+  const data3: PetData[] = [
+    { name: 'Birds', x: '2015', y: 4 },
+    { name: 'Birds', x: '2016', y: 4 },
+    { name: 'Birds', x: '2017', y: 9 },
+    { name: 'Birds', x: '2018', y: 7 }
+  ];
+
+  const data4: PetData[] = [
+    { name: 'Mice', x: '2015', y: 3 },
+    { name: 'Mice', x: '2016', y: 3 },
+    { name: 'Mice', x: '2017', y: 8 },
+    { name: 'Mice', x: '2018', y: 5 }
+  ];
+
+  return (
+    <div style={{ height: '250px', width: '600px' }}>
+      <Chart
+        ariaDesc="Average number of pets"
+        ariaTitle="Stack chart example"
+        containerComponent={
+          <ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />
+        }
+        domainPadding={{ x: [30, 25] }}
+        legendData={legendData}
+        legendOrientation="vertical"
+        legendPosition="right"
+        hasPatterns
+        height={250}
+        name="chart3"
+        padding={{
+          bottom: 50,
+          left: 50,
+          right: 200, // Adjusted to accommodate legend
+          top: 50
+        }}
+        themeColor={ChartThemeColor.green}
+        width={600}
+      >
+        <ChartAxis />
+        <ChartAxis dependentAxis showGrid />
+        <ChartStack>
+          <ChartBar data={data1} />
+          <ChartBar data={data2} />
+          <ChartBar data={data3} />
+          <ChartBar data={data4} />
+        </ChartStack>
+      </Chart>
+    </div>
+  );
+};

--- a/packages/react-charts/src/victory/components/Patterns/examples/patterns.md
+++ b/packages/react-charts/src/victory/components/Patterns/examples/patterns.md
@@ -56,104 +56,18 @@ The examples below are based on the [Victory](https://formidable.com/open-source
 
 ## Examples
 ### Basic pie chart
-```js
-import { ChartPie } from '@patternfly/react-charts/victory';
+```ts file = "PatternsBasicPieChart.tsx"
 
-<div style={{ height: '230px', width: '350px' }}>
-  <ChartPie
-    ariaDesc="Average number of pets"
-    ariaTitle="Pie chart example"
-    constrainToVisibleArea
-    data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-    hasPatterns
-    height={230}
-    labels={({ datum }) => `${datum.x}: ${datum.y}`}
-    legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
-    legendOrientation="vertical"
-    legendPosition="right"
-    name="chart1"
-    padding={{
-      bottom: 20,
-      left: 20,
-      right: 140, // Adjusted to accommodate legend
-      top: 20
-    }}
-    width={350}
-  />
-</div>
 ```
 
 ### Bar chart
-```js
-import { Chart, ChartAxis, ChartBar, ChartGroup, ChartThemeColor, ChartVoronoiContainer } from '@patternfly/react-charts/victory';
+```ts file = "PatternsBarChart.tsx"
 
-<div style={{ height: '275px', width: '450px' }}>
-  <Chart
-    ariaDesc="Average number of pets"
-    ariaTitle="Bar chart example"
-    containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
-    domainPadding={{ x: [30, 25] }}
-    legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
-    legendPosition="bottom"
-    hasPatterns
-    height={275}
-    name="chart2"
-    padding={{
-      bottom: 75, // Adjusted to accommodate legend
-      left: 50,
-      right: 50,
-      top: 50
-    }}
-    themeColor={ChartThemeColor.purple}
-    width={450}
-  >
-    <ChartAxis />
-    <ChartAxis dependentAxis showGrid />
-    <ChartGroup offset={11}>
-      <ChartBar data={[{ name: 'Cats', x: '2015', y: 1 }, { name: 'Cats', x: '2016', y: 2 }, { name: 'Cats', x: '2017', y: 5 }, { name: 'Cats', x: '2018', y: 3 }]} />
-      <ChartBar data={[{ name: 'Dogs', x: '2015', y: 2 }, { name: 'Dogs', x: '2016', y: 1 }, { name: 'Dogs', x: '2017', y: 7 }, { name: 'Dogs', x: '2018', y: 4 }]} />
-      <ChartBar data={[{ name: 'Birds', x: '2015', y: 4 }, { name: 'Birds', x: '2016', y: 4 }, { name: 'Birds', x: '2017', y: 9 }, { name: 'Birds', x: '2018', y: 7 }]} />
-      <ChartBar data={[{ name: 'Mice', x: '2015', y: 3 }, { name: 'Mice', x: '2016', y: 3 }, { name: 'Mice', x: '2017', y: 8 }, { name: 'Mice', x: '2018', y: 5 }]} />
-    </ChartGroup>
-  </Chart>
-</div>
 ```
 
 ### Stack chart
-```js
-import { Chart, ChartAxis, ChartBar, ChartStack, ChartThemeColor, ChartVoronoiContainer } from '@patternfly/react-charts/victory';
+```ts file = "PatternsStackChart.tsx"
 
-<div style={{ height: '250px', width: '600px' }}>
-  <Chart
-    ariaDesc="Average number of pets"
-    ariaTitle="Stack chart example"
-    containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
-    domainPadding={{ x: [30, 25] }}
-    legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
-    legendOrientation="vertical"
-    legendPosition="right"
-    hasPatterns
-    height={250}
-    name="chart3"
-    padding={{
-      bottom: 50,
-      left: 50,
-      right: 200, // Adjusted to accommodate legend
-      top: 50
-    }}
-    themeColor={ChartThemeColor.green}
-    width={600}
-  >
-    <ChartAxis />
-    <ChartAxis dependentAxis showGrid />
-    <ChartStack>
-      <ChartBar data={[{ name: 'Cats', x: '2015', y: 1 }, { name: 'Cats', x: '2016', y: 2 }, { name: 'Cats', x: '2017', y: 5 }, { name: 'Cats', x: '2018', y: 3 }]} />
-      <ChartBar data={[{ name: 'Dogs', x: '2015', y: 2 }, { name: 'Dogs', x: '2016', y: 1 }, { name: 'Dogs', x: '2017', y: 7 }, { name: 'Dogs', x: '2018', y: 4 }]} />
-      <ChartBar data={[{ name: 'Birds', x: '2015', y: 4 }, { name: 'Birds', x: '2016', y: 4 }, { name: 'Birds', x: '2017', y: 9 }, { name: 'Birds', x: '2018', y: 7 }]} />
-      <ChartBar data={[{ name: 'Mice', x: '2015', y: 3 }, { name: 'Mice', x: '2016', y: 3 }, { name: 'Mice', x: '2017', y: 8 }, { name: 'Mice', x: '2018', y: 5 }]} />
-    </ChartStack>
-  </Chart>
-</div>
 ```
 
 ### Donut chart


### PR DESCRIPTION
Towards #11719 

The following examples are converted:

- Basic pie chart
- Bar chart
- Stack chart
- Donut chart
- Donut utilization chart
- Donut utilization chart with thresholds

Since there are 12 examples, I'll divide this into 2 PRs making it easier for review.