### PR TITLE
fix(textarea): fix height logic for autoresize textarea

### DIFF
--- a/packages/react-core/src/components/TextArea/TextArea.tsx
+++ b/packages/react-core/src/components/TextArea/TextArea.tsx
@@ -62,13 +62,15 @@ class TextAreaBase extends Component<TextAreaProps> {
     const parent = field.parentElement;
     parent.style.setProperty('height', 'inherit');
     const computed = window.getComputedStyle(field);
+    const parentComputed = window.getComputedStyle(parent);
     // Calculate the height
     const height =
       parseInt(computed.getPropertyValue('border-top-width')) +
-      parseInt(computed.getPropertyValue('padding-top')) +
       field.scrollHeight +
-      parseInt(computed.getPropertyValue('padding-bottom')) +
-      parseInt(computed.getPropertyValue('border-bottom-width'));
+      parseInt(computed.getPropertyValue('border-bottom-width')) +
+      parseInt(parentComputed.getPropertyValue('padding-top')) +
+      parseInt(parentComputed.getPropertyValue('padding-bottom'));
+
     parent.style.setProperty('height', `${height}px`);
   };
 

--- a/packages/react-core/src/components/TextArea/__tests__/__snapshots__/TextArea.test.tsx.snap
+++ b/packages/react-core/src/components/TextArea/__tests__/__snapshots__/TextArea.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Matches the snapshot 1`] = `
 <DocumentFragment>
   <span
     class="pf-v6-c-form-control pf-m-textarea pf-m-resize-both pf-m-disabled custom class"
-    style="height: 6px;"
+    style="height: inherit;"
   >
     <textarea
       aria-invalid="false"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #11921 

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:  https://issues.redhat.com/browse/AAP-47692 

For consideration - 2 options for pulling this fix into Core as described by @mcoker but would change the markup so be potentially breaking:

Option 1:
```diff
diff --git a/packages/react-core/src/components/TextArea/TextArea.tsx b/packages/react-core/src/components/TextArea/TextArea.tsx
index 267e67728a..b794fed2d7 100644
--- a/packages/react-core/src/components/TextArea/TextArea.tsx
+++ b/packages/react-core/src/components/TextArea/TextArea.tsx
@@ -60,16 +60,12 @@ class TextAreaBase extends Component<TextAreaProps> {
 
   private setAutoHeight = (field: HTMLTextAreaElement) => {
     const parent = field.parentElement;
     parent.style.setProperty('height', 'inherit');
     const computed = window.getComputedStyle(field);
     // Calculate the height
-    const height =
-      parseInt(computed.getPropertyValue('border-top-width')) +
-      parseInt(computed.getPropertyValue('padding-top')) +
-      field.scrollHeight +
-      parseInt(computed.getPropertyValue('padding-bottom')) +
-      parseInt(computed.getPropertyValue('border-bottom-width'));
+    const height = field.scrollHeight;
     parent.style.setProperty('height', `${height}px`);
+    parent.style.setProperty('box-sizing', 'content-box');
   };
```
  - Pros - removes all the extra calc stuff and lets CSS handle it
  - Cons - Adds an extra `box-sizing: content-box` style to the existing `style="height: {n}px"` attribute in the rendered page markup (breaking?)

Option 2: - same as option 1, but instead of adding `box-sizing: content-box` as an inline style, we add a class in core/react (`.pf-m-auto-resize`) that sets that style for us
  - Pros - styles can be easier controlled on the core side, no style stuff needed for autoresize other than react applying the height of the box
  - Cons - same question about whether it's breaking since we'd add `.pf-m-auto-resize` probably on the other form control wrapper
