### PR TITLE
fix(DataList): allow keyboard to trigger DataListActions

### DIFF
--- a/packages/react-core/src/components/DataList/DataListItem.tsx
+++ b/packages/react-core/src/components/DataList/DataListItem.tsx
@@ -65,6 +65,15 @@ class DataListItem extends Component<DataListItemProps> {
 
           const onKeyDown = (event: React.KeyboardEvent) => {
             if ([KeyTypes.Enter, KeyTypes.Space].includes(event.key)) {
+              const target: any = event.target;
+              if (
+                target.parentNode.classList.contains(styles.dataListItemAction) ||
+                target.parentNode.classList.contains(styles.dataListItemControl)
+              ) {
+                // check other event handlers are not present.
+                return;
+              }
+
               event.preventDefault();
               updateSelectedDataListItem(event, id);
             }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #11390

Updated to have the internal selection keyboard handler ignore events coming from DataListAction and DataListControl.