### PR TITLE
chore(deps): bump patternfly/patternfly to 6.3.0-prerelease.55

### DIFF
--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -54,7 +54,7 @@
     "tslib": "^2.8.1"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.3.0-prerelease.41",
+    "@patternfly/patternfly": "6.3.0-prerelease.55",
     "case-anything": "^3.1.2",
     "css": "^3.0.0",
     "fs-extra": "^11.3.0"

--- a/packages/react-core/src/components/Wizard/WizardNavItem.tsx
+++ b/packages/react-core/src/components/Wizard/WizardNavItem.tsx
@@ -116,7 +116,7 @@ export const WizardNavItem = ({
         <span className={css(styles.wizardNavLinkMain)}>
           {isExpandable ? (
             <>
-              <span className={css(styles.wizardNavLinkText)}>{content}</span>
+              <span className="pf-v6-c-wizard__nav-link-text">{content}</span>
               <span className={css(styles.wizardNavLinkToggle)}>
                 <span className={css(styles.wizardNavLinkToggleIcon)}>
                   <AngleRightIcon aria-label={`${isCurrent ? 'Collapse' : 'Expand'} step icon`} />

--- a/packages/react-core/src/deprecated/components/Wizard/WizardNavItem.tsx
+++ b/packages/react-core/src/deprecated/components/Wizard/WizardNavItem.tsx
@@ -92,7 +92,7 @@ export const WizardNavItem: React.FunctionComponent<WizardNavItemProps> = ({
         <span className={css(styles.wizardNavLinkMain)}>
           {isExpandable ? (
             <>
-              <span className={css(styles.wizardNavLinkText)}>{content}</span>
+              <span className="pf-v6-c-wizard__nav-link-text">{content}</span>
               <span className={css(styles.wizardNavLinkToggle)}>
                 <span className={css(styles.wizardNavLinkToggleIcon)}>
                   <AngleRightIcon />

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -23,7 +23,7 @@
     "test:a11y": "patternfly-a11y --config patternfly-a11y.config"
   },
   "dependencies": {
-    "@patternfly/patternfly": "6.3.0-prerelease.41",
+    "@patternfly/patternfly": "6.3.0-prerelease.55",
     "@patternfly/react-charts": "workspace:^",
     "@patternfly/react-code-editor": "workspace:^",
     "@patternfly/react-core": "workspace:^",

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -33,7 +33,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.15.4",
     "@fortawesome/free-regular-svg-icons": "^5.15.4",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
-    "@patternfly/patternfly": "6.3.0-prerelease.41",
+    "@patternfly/patternfly": "6.3.0-prerelease.55",
     "fs-extra": "^11.3.0",
     "tslib": "^2.8.1"
   },

--- a/packages/react-styles/package.json
+++ b/packages/react-styles/package.json
@@ -19,7 +19,7 @@
     "clean": "rimraf dist css"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.3.0-prerelease.41",
+    "@patternfly/patternfly": "6.3.0-prerelease.55",
     "change-case": "^5.4.4",
     "fs-extra": "^11.3.0"
   },

--- a/packages/react-tokens/package.json
+++ b/packages/react-tokens/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@adobe/css-tools": "^4.4.2",
-    "@patternfly/patternfly": "6.3.0-prerelease.41",
+    "@patternfly/patternfly": "6.3.0-prerelease.55",
     "fs-extra": "^11.3.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4089,10 +4089,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/patternfly@npm:6.3.0-prerelease.41":
-  version: 6.3.0-prerelease.41
-  resolution: "@patternfly/patternfly@npm:6.3.0-prerelease.41"
-  checksum: 10c0/1128566c1be4b62c9e34ddc52d36e110317679a467e0efc715b064c4a567b8babea8b38821378e09ac986a1ccdd841df8a0d3aa0442b087d8aa29ba144c7592e
+"@patternfly/patternfly@npm:6.3.0-prerelease.55":
+  version: 6.3.0-prerelease.55
+  resolution: "@patternfly/patternfly@npm:6.3.0-prerelease.55"
+  checksum: 10c0/5581e13a41001951da4e27b1774b97939f1f24b6107f32fa847724cfa101a8762d63d35a1e7602faea914cb12264526adaa6d423ac56b0931bf6f96854dacd63
   languageName: node
   linkType: hard
 
@@ -4190,7 +4190,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@patternfly/react-core@workspace:packages/react-core"
   dependencies:
-    "@patternfly/patternfly": "npm:6.3.0-prerelease.41"
+    "@patternfly/patternfly": "npm:6.3.0-prerelease.55"
     "@patternfly/react-icons": "workspace:^"
     "@patternfly/react-styles": "workspace:^"
     "@patternfly/react-tokens": "workspace:^"
@@ -4211,7 +4211,7 @@ __metadata:
   resolution: "@patternfly/react-docs@workspace:packages/react-docs"
   dependencies:
     "@patternfly/documentation-framework": "npm:^6.19.0"
-    "@patternfly/patternfly": "npm:6.3.0-prerelease.41"
+    "@patternfly/patternfly": "npm:6.3.0-prerelease.55"
     "@patternfly/patternfly-a11y": "npm:5.1.0"
     "@patternfly/react-charts": "workspace:^"
     "@patternfly/react-code-editor": "workspace:^"
@@ -4251,7 +4251,7 @@ __metadata:
     "@fortawesome/free-brands-svg-icons": "npm:^5.15.4"
     "@fortawesome/free-regular-svg-icons": "npm:^5.15.4"
     "@fortawesome/free-solid-svg-icons": "npm:^5.15.4"
-    "@patternfly/patternfly": "npm:6.3.0-prerelease.41"
+    "@patternfly/patternfly": "npm:6.3.0-prerelease.55"
     fs-extra: "npm:^11.3.0"
     tslib: "npm:^2.8.1"
   peerDependencies:
@@ -4335,7 +4335,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@patternfly/react-styles@workspace:packages/react-styles"
   dependencies:
-    "@patternfly/patternfly": "npm:6.3.0-prerelease.41"
+    "@patternfly/patternfly": "npm:6.3.0-prerelease.55"
     change-case: "npm:^5.4.4"
     fs-extra: "npm:^11.3.0"
   languageName: unknown
@@ -4377,7 +4377,7 @@ __metadata:
   resolution: "@patternfly/react-tokens@workspace:packages/react-tokens"
   dependencies:
     "@adobe/css-tools": "npm:^4.4.2"
-    "@patternfly/patternfly": "npm:6.3.0-prerelease.41"
+    "@patternfly/patternfly": "npm:6.3.0-prerelease.55"
     fs-extra: "npm:^11.3.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
manually bumps core to latest prerelease

closes https://github.com/patternfly/patternfly-react/pull/11971 - the renovate core bump which [wants to bump to 6.3.1](https://github.com/patternfly/patternfly-react/pull/11971#issuecomment-3254395504)