### PR TITLE
fix(Menu): prevent flyout crash when mixing keyboard and mouse interaction

### DIFF
--- a/packages/react-core/src/components/Menu/Menu.tsx
+++ b/packages/react-core/src/components/Menu/Menu.tsx
@@ -183,7 +183,6 @@ class MenuBase extends Component<MenuProps, MenuState> {
       !(event.target as HTMLElement).classList.contains(breadcrumbStyles.breadcrumbLink)
     ) {
       this.activeMenu = (event.target as HTMLElement).closest(`.${styles.menu}`);
-      this.setState({ disableHover: true });
     }
 
     if ((event.target as HTMLElement).tagName === 'INPUT') {

--- a/packages/react-core/src/components/Menu/MenuItem.tsx
+++ b/packages/react-core/src/components/Menu/MenuItem.tsx
@@ -210,10 +210,10 @@ const MenuItemBase: React.FunctionComponent<MenuItemProps> = ({
     if (flyoutTarget) {
       if (flyoutVisible) {
         const flyoutMenu = (flyoutTarget as HTMLElement).nextElementSibling;
-        const flyoutItems = Array.from(flyoutMenu.getElementsByTagName('UL')[0].children).filter(
+        const flyoutItems = Array.from(flyoutMenu?.getElementsByTagName('UL')[0]?.children || []).filter(
           (el) => !(el.classList.contains('pf-m-disabled') || el.classList.contains(styles.divider))
         );
-        (flyoutItems[0].firstChild as HTMLElement).focus();
+        (flyoutItems[0]?.firstChild as HTMLElement)?.focus();
       } else {
         flyoutTarget.focus();
       }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #11989

Fixes this at minimum by adding null checks to the focusing logic that was causing the crash, and also removes the line of logic that disables mouse hover interaction when keyboard interaction is triggered. The latter also ends up preventing the crash because the menu will open on hover before the mouse is clicked, and this enables mouse and keyboard to be used together more seamlessly (currently, when keyboard interaction begins it completely disables mouse hover interaction until the menu closes and reopens).

I'm not sure though if we were using `disableHover` for anything other than the flyout logic so LMK if I'm missing something and it should still be present.