### PR TITLE
feat(Popper): add passthrough for offset

### DIFF
--- a/packages/react-core/src/helpers/Popper/Popper.tsx
+++ b/packages/react-core/src/helpers/Popper/Popper.tsx
@@ -1,6 +1,7 @@
 import { cloneElement, isValidElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import * as ReactDOM from 'react-dom';
 import { usePopper } from './thirdparty/react-popper/usePopper';
+import { Options as OffsetOptions } from './thirdparty/popper-core/modifiers/offset';
 import { Placement, Modifier } from './thirdparty/popper-core';
 import { clearTimeouts } from '../util';
 import { css } from '@patternfly/react-styles';
@@ -108,7 +109,7 @@ export interface PopperProps {
   /** Distance of the popper to the trigger */
   distance?: number;
   /** Override for the popper's offset */
-  offset?: [number, number];
+  offset?: OffsetOptions['offset'];
   /** Callback function when mouse enters trigger */
   onMouseEnter?: (event?: MouseEvent) => void;
   /** Callback function when mouse leaves trigger */

--- a/packages/react-core/src/helpers/Popper/Popper.tsx
+++ b/packages/react-core/src/helpers/Popper/Popper.tsx
@@ -107,6 +107,8 @@ export interface PopperProps {
   };
   /** Distance of the popper to the trigger */
   distance?: number;
+  /** Override for the popper's offset */
+  offset?: [number, number];
   /** Callback function when mouse enters trigger */
   onMouseEnter?: (event?: MouseEvent) => void;
   /** Callback function when mouse leaves trigger */
@@ -190,6 +192,7 @@ export const Popper: React.FunctionComponent<PopperProps> = ({
   isVisible = true,
   positionModifiers,
   distance = 0,
+  offset,
   onMouseEnter,
   onMouseLeave,
   onFocus,
@@ -420,7 +423,7 @@ export const Popper: React.FunctionComponent<PopperProps> = ({
       {
         name: 'offset',
         options: {
-          offset: [0, distance]
+          offset: offset || [0, distance]
         }
       },
       {


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
Towards #11987 

Adds a passthrough for Popper's `offset` (`distance` may still be used and still remains as a default if `offset` isn't present).