### PR TITLE
feat(Table): use Button favorites logic

### DIFF
--- a/packages/react-table/src/components/Table/FavoritesCell.tsx
+++ b/packages/react-table/src/components/Table/FavoritesCell.tsx
@@ -1,4 +1,3 @@
-import StarIcon from '@patternfly/react-icons/dist/esm/icons/star-icon';
 import { Button } from '@patternfly/react-core/dist/esm/components/Button';
 
 export interface FavoritesCellProps {
@@ -30,9 +29,10 @@ export const FavoritesCell: React.FunctionComponent<FavoritesCellProps> = ({
       type="button"
       aria-label={isFavorited ? 'Starred' : 'Not starred'}
       onClick={onFavorite}
+      isFavorite
+      isFavorited={isFavorited}
       {...ariaProps}
       {...props}
-      icon={<StarIcon />}
     />
   );
 };

--- a/packages/react-table/src/components/Table/SortColumn.tsx
+++ b/packages/react-table/src/components/Table/SortColumn.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import LongArrowAltUpIcon from '@patternfly/react-icons/dist/esm/icons/long-arrow-alt-up-icon';
 import LongArrowAltDownIcon from '@patternfly/react-icons/dist/esm/icons/long-arrow-alt-down-icon';
 import ArrowsAltVIcon from '@patternfly/react-icons/dist/esm/icons/arrows-alt-v-icon';
-import StarIcon from '@patternfly/react-icons/dist/esm/icons/star-icon';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 import { TableText } from './TableText';
@@ -50,10 +49,11 @@ export const SortColumn: React.FunctionComponent<SortColumnProps> = ({
   }
 
   if (favoriteButtonProps) {
+    const { favorited, ...rest } = favoriteButtonProps;
     return (
       <ActionList isIconList>
         <ActionListItem>
-          <Button variant="plain" icon={<StarIcon />} {...favoriteButtonProps} />
+          <Button variant="plain" isFavorite isFavorited={favorited} {...rest} />
         </ActionListItem>
         <ActionListItem>
           <Button

--- a/packages/react-table/src/components/Table/examples/TableFavoritable.tsx
+++ b/packages/react-table/src/components/Table/examples/TableFavoritable.tsx
@@ -99,7 +99,7 @@ export const TableFavoritable: React.FunctionComponent = () => {
     <Table aria-label="Favoritable table" variant="compact">
       <Thead>
         <Tr>
-          <Th sort={getSortParams(0)} />
+          <Th sort={getSortParams(0)} screenReaderText="Favorite all button" />
           <Th>{columnNames.name}</Th>
           <Th>{columnNames.branches}</Th>
           <Th>{columnNames.prs}</Th>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #11932

Updates Table to use the Button favorites instead of manually creating its own favorites icon buttons. This enables the favorites animation for Table.
