### PR TITLE
chore: bump core and docs-framework

### DIFF
--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -54,7 +54,7 @@
     "tslib": "^2.8.1"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.3.0-prerelease.78",
+    "@patternfly/patternfly": "6.3.0-prerelease.79",
     "case-anything": "^3.1.2",
     "css": "^3.0.0",
     "fs-extra": "^11.3.0"

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -23,7 +23,7 @@
     "test:a11y": "patternfly-a11y --config patternfly-a11y.config"
   },
   "dependencies": {
-    "@patternfly/patternfly": "6.3.0-prerelease.78",
+    "@patternfly/patternfly": "6.3.0-prerelease.79",
     "@patternfly/react-charts": "workspace:^",
     "@patternfly/react-code-editor": "workspace:^",
     "@patternfly/react-core": "workspace:^",
@@ -37,7 +37,7 @@
     "victory": "^37.3.6"
   },
   "devDependencies": {
-    "@patternfly/documentation-framework": "^6.19.0",
+    "@patternfly/documentation-framework": "^6.22.8",
     "@patternfly/patternfly-a11y": "5.1.0"
   },
   "keywords": [

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -33,7 +33,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.15.4",
     "@fortawesome/free-regular-svg-icons": "^5.15.4",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
-    "@patternfly/patternfly": "6.3.0-prerelease.78",
+    "@patternfly/patternfly": "6.3.0-prerelease.79",
     "fs-extra": "^11.3.0",
     "tslib": "^2.8.1"
   },

--- a/packages/react-styles/package.json
+++ b/packages/react-styles/package.json
@@ -19,7 +19,7 @@
     "clean": "rimraf dist css"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.3.0-prerelease.78",
+    "@patternfly/patternfly": "6.3.0-prerelease.79",
     "change-case": "^5.4.4",
     "fs-extra": "^11.3.0"
   },

--- a/packages/react-tokens/package.json
+++ b/packages/react-tokens/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@adobe/css-tools": "^4.4.2",
-    "@patternfly/patternfly": "6.3.0-prerelease.78",
+    "@patternfly/patternfly": "6.3.0-prerelease.79",
     "fs-extra": "^11.3.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4210,7 +4210,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/documentation-framework@npm:^6.19.0":
+"@patternfly/documentation-framework@npm:^6.22.8":
   version: 6.22.8
   resolution: "@patternfly/documentation-framework@npm:6.22.8"
   dependencies:
@@ -4320,10 +4320,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/patternfly@npm:6.3.0-prerelease.78":
-  version: 6.3.0-prerelease.78
-  resolution: "@patternfly/patternfly@npm:6.3.0-prerelease.78"
-  checksum: 10c0/9393994331c0c062d56d55f1a4b924e65f689cce0e22cfac90cf9ce5e17dc83479dc6d532a49773269a5779ed2857ad065af012f437b571caa163fb90272f4c5
+"@patternfly/patternfly@npm:6.3.0-prerelease.79":
+  version: 6.3.0-prerelease.79
+  resolution: "@patternfly/patternfly@npm:6.3.0-prerelease.79"
+  checksum: 10c0/7436af69a0c3164d7d0cd4a6232f0de2da1b7865a3ae03c354d5d019b6a40671d8e666d02604dd82cd0de780f41394e2c5074903d0e2e80e49a71c5f357010ed
   languageName: node
   linkType: hard
 
@@ -4421,7 +4421,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@patternfly/react-core@workspace:packages/react-core"
   dependencies:
-    "@patternfly/patternfly": "npm:6.3.0-prerelease.78"
+    "@patternfly/patternfly": "npm:6.3.0-prerelease.79"
     "@patternfly/react-icons": "workspace:^"
     "@patternfly/react-styles": "workspace:^"
     "@patternfly/react-tokens": "workspace:^"
@@ -4441,8 +4441,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@patternfly/react-docs@workspace:packages/react-docs"
   dependencies:
-    "@patternfly/documentation-framework": "npm:^6.19.0"
-    "@patternfly/patternfly": "npm:6.3.0-prerelease.78"
+    "@patternfly/documentation-framework": "npm:^6.22.8"
+    "@patternfly/patternfly": "npm:6.3.0-prerelease.79"
     "@patternfly/patternfly-a11y": "npm:5.1.0"
     "@patternfly/react-charts": "workspace:^"
     "@patternfly/react-code-editor": "workspace:^"
@@ -4482,7 +4482,7 @@ __metadata:
     "@fortawesome/free-brands-svg-icons": "npm:^5.15.4"
     "@fortawesome/free-regular-svg-icons": "npm:^5.15.4"
     "@fortawesome/free-solid-svg-icons": "npm:^5.15.4"
-    "@patternfly/patternfly": "npm:6.3.0-prerelease.78"
+    "@patternfly/patternfly": "npm:6.3.0-prerelease.79"
     fs-extra: "npm:^11.3.0"
     tslib: "npm:^2.8.1"
   peerDependencies:
@@ -4567,7 +4567,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@patternfly/react-styles@workspace:packages/react-styles"
   dependencies:
-    "@patternfly/patternfly": "npm:6.3.0-prerelease.78"
+    "@patternfly/patternfly": "npm:6.3.0-prerelease.79"
     change-case: "npm:^5.4.4"
     fs-extra: "npm:^11.3.0"
   languageName: unknown
@@ -4609,7 +4609,7 @@ __metadata:
   resolution: "@patternfly/react-tokens@workspace:packages/react-tokens"
   dependencies:
     "@adobe/css-tools": "npm:^4.4.2"
-    "@patternfly/patternfly": "npm:6.3.0-prerelease.78"
+    "@patternfly/patternfly": "npm:6.3.0-prerelease.79"
     fs-extra: "npm:^11.3.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Contains core fixes from https://github.com/patternfly/patternfly/issues/7878

* Plain header removes border but leaves bottom border
* Make sure header bottom border renders without content in header
* Language tab should be aligned to right without content in header
* In read only, the code tab should also have a read only background color
