### PR TITLE
chore(alert): put demo buttons into flex so they wrap

### DIFF
--- a/packages/react-core/src/components/Alert/examples/AlertDynamicLiveRegion.tsx
+++ b/packages/react-core/src/components/Alert/examples/AlertDynamicLiveRegion.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useState } from 'react';
-import { Alert, AlertGroup, AlertVariant, InputGroup } from '@patternfly/react-core';
+import { Alert, AlertGroup, AlertVariant, Flex, FlexItem } from '@patternfly/react-core';
 import buttonStyles from '@patternfly/react-styles/css/components/Button/button';
 
 interface AlertInfo {
@@ -41,17 +41,23 @@ export const DynamicLiveRegionAlert: React.FunctionComponent = () => {
 
   return (
     <Fragment>
-      <InputGroup style={{ marginBottom: '16px' }}>
-        <button onClick={addSuccessAlert} type="button" className={btnClasses}>
-          Add single success alert
-        </button>
-        <button onClick={addInfoAlert} type="button" className={btnClasses}>
-          Add single info alert
-        </button>
-        <button onClick={addDangerAlert} type="button" className={btnClasses}>
-          Add single danger alert
-        </button>
-      </InputGroup>
+      <Flex gap={{ default: 'gapXs' }} style={{ marginBottom: '16px' }}>
+        <FlexItem>
+          <button onClick={addSuccessAlert} type="button" className={btnClasses}>
+            Add single success alert
+          </button>
+        </FlexItem>
+        <FlexItem>
+          <button onClick={addInfoAlert} type="button" className={btnClasses}>
+            Add single info alert
+          </button>
+        </FlexItem>
+        <FlexItem>
+          <button onClick={addDangerAlert} type="button" className={btnClasses}>
+            Add single danger alert
+          </button>
+        </FlexItem>
+      </Flex>
       <AlertGroup hasAnimations isLiveRegion aria-live="polite" aria-relevant="additions text" aria-atomic="false">
         {alerts.map(({ title, variant, key }) => (
           <Alert variant={variant} title={title} key={key} />

--- a/packages/react-core/src/components/Alert/examples/AlertGroupMultipleDynamic.tsx
+++ b/packages/react-core/src/components/Alert/examples/AlertGroupMultipleDynamic.tsx
@@ -5,8 +5,8 @@ import {
   AlertGroup,
   AlertActionCloseButton,
   AlertVariant,
-  InputGroup,
-  InputGroupItem
+  Flex,
+  FlexItem
 } from '@patternfly/react-core';
 import buttonStyles from '@patternfly/react-styles/css/components/Button/button';
 
@@ -35,13 +35,13 @@ export const AlertGroupMultipleDynamic: React.FunctionComponent = () => {
 
   return (
     <Fragment>
-      <InputGroup style={{ marginBottom: '16px' }}>
-        <InputGroupItem>
+      <Flex gap={{ default: 'gapXs' }}>
+        <FlexItem>
           <button onClick={addAlertCollection} type="button" className={btnClasses}>
             Add alert collection
           </button>
-        </InputGroupItem>
-      </InputGroup>
+        </FlexItem>
+      </Flex>
       <AlertGroup hasAnimations isToast isLiveRegion>
         {alerts.map(({ title, variant, key }) => (
           <Alert

--- a/packages/react-core/src/components/Alert/examples/AlertGroupSingularDynamic.tsx
+++ b/packages/react-core/src/components/Alert/examples/AlertGroupSingularDynamic.tsx
@@ -5,8 +5,8 @@ import {
   AlertGroup,
   AlertActionCloseButton,
   AlertVariant,
-  InputGroup,
-  InputGroupItem
+  Flex,
+  FlexItem
 } from '@patternfly/react-core';
 import buttonStyles from '@patternfly/react-styles/css/components/Button/button';
 
@@ -39,23 +39,23 @@ export const AlertGroupSingularDynamic: React.FunctionComponent = () => {
 
   return (
     <Fragment>
-      <InputGroup style={{ marginBottom: '16px' }}>
-        <InputGroupItem>
+      <Flex gap={{ default: 'gapXs' }} style={{ marginBottom: '16px' }}>
+        <FlexItem>
           <button onClick={addSuccessAlert} type="button" className={btnClasses}>
             Add single success alert
           </button>
-        </InputGroupItem>
-        <InputGroupItem>
+        </FlexItem>
+        <FlexItem>
           <button onClick={addDangerAlert} type="button" className={btnClasses}>
             Add single danger alert
           </button>
-        </InputGroupItem>
-        <InputGroupItem>
+        </FlexItem>
+        <FlexItem>
           <button onClick={addInfoAlert} type="button" className={btnClasses}>
             Add single info alert
           </button>
-        </InputGroupItem>
-      </InputGroup>
+        </FlexItem>
+      </Flex>
       <AlertGroup hasAnimations isLiveRegion>
         {alerts.map(({ title, variant, key }) => (
           <Alert

--- a/packages/react-core/src/components/Alert/examples/AlertGroupSingularDynamicOverflow.tsx
+++ b/packages/react-core/src/components/Alert/examples/AlertGroupSingularDynamicOverflow.tsx
@@ -5,8 +5,8 @@ import {
   AlertGroup,
   AlertActionCloseButton,
   AlertVariant,
-  InputGroup,
-  InputGroupItem
+  Flex,
+  FlexItem
 } from '@patternfly/react-core';
 import buttonStyles from '@patternfly/react-styles/css/components/Button/button';
 
@@ -58,23 +58,23 @@ export const AlertGroupSingularDynamicOverflow: React.FunctionComponent = () => 
 
   return (
     <Fragment>
-      <InputGroup style={{ marginBottom: '16px' }}>
-        <InputGroupItem>
+      <Flex gap={{ default: 'gapXs' }} style={{ marginBottom: '16px' }}>
+        <FlexItem>
           <button onClick={addSuccessAlert} type="button" className={btnClasses}>
             Add single success alert
           </button>
-        </InputGroupItem>
-        <InputGroupItem>
+        </FlexItem>
+        <FlexItem>
           <button onClick={addDangerAlert} type="button" className={btnClasses}>
             Add single danger alert
           </button>
-        </InputGroupItem>
-        <InputGroupItem>
+        </FlexItem>
+        <FlexItem>
           <button onClick={addInfoAlert} type="button" className={btnClasses}>
             Add single info alert
           </button>
-        </InputGroupItem>
-      </InputGroup>
+        </FlexItem>
+      </Flex>
       <AlertGroup hasAnimations isLiveRegion onOverflowClick={onOverflowClick} overflowMessage={overflowMessage}>
         {alerts.slice(0, maxDisplayed).map(({ key, variant, title }) => (
           <Alert

--- a/packages/react-core/src/components/Alert/examples/AlertGroupToast.tsx
+++ b/packages/react-core/src/components/Alert/examples/AlertGroupToast.tsx
@@ -5,8 +5,8 @@ import {
   AlertGroup,
   AlertActionCloseButton,
   AlertVariant,
-  InputGroup,
-  InputGroupItem
+  Flex,
+  FlexItem
 } from '@patternfly/react-core';
 import buttonStyles from '@patternfly/react-styles/css/components/Button/button';
 
@@ -39,23 +39,23 @@ export const AlertGroupToast: React.FunctionComponent = () => {
 
   return (
     <Fragment>
-      <InputGroup style={{ marginBottom: '16px' }}>
-        <InputGroupItem>
+      <Flex gap={{ default: 'gapXs' }}>
+        <FlexItem>
           <button onClick={addSuccessAlert} type="button" className={btnClasses}>
             Add toast success alert
           </button>
-        </InputGroupItem>
-        <InputGroupItem>
+        </FlexItem>
+        <FlexItem>
           <button onClick={addDangerAlert} type="button" className={btnClasses}>
             Add toast danger alert
           </button>
-        </InputGroupItem>
-        <InputGroupItem>
+        </FlexItem>
+        <FlexItem>
           <button onClick={addInfoAlert} type="button" className={btnClasses}>
             Add toast info alert
           </button>
-        </InputGroupItem>
-      </InputGroup>
+        </FlexItem>
+      </Flex>
       <AlertGroup hasAnimations isToast isLiveRegion>
         {alerts.map(({ key, variant, title }) => (
           <Alert

--- a/packages/react-core/src/components/Alert/examples/AlertGroupToastOverflowCapture.tsx
+++ b/packages/react-core/src/components/Alert/examples/AlertGroupToastOverflowCapture.tsx
@@ -5,8 +5,8 @@ import {
   AlertGroup,
   AlertActionCloseButton,
   AlertVariant,
-  InputGroup,
-  InputGroupItem
+  Flex,
+  FlexItem
 } from '@patternfly/react-core';
 import buttonStyles from '@patternfly/react-styles/css/components/Button/button';
 
@@ -58,23 +58,23 @@ export const AlertGroupToastOverflowCapture: React.FunctionComponent = () => {
 
   return (
     <Fragment>
-      <InputGroup style={{ marginBottom: '16px' }}>
-        <InputGroupItem>
+      <Flex gap={{ default: 'gapXs' }} style={{ marginBottom: '16px' }}>
+        <FlexItem>
           <button onClick={addSuccessAlert} type="button" className={btnClasses}>
             Add toast success alert
           </button>
-        </InputGroupItem>
-        <InputGroupItem>
+        </FlexItem>
+        <FlexItem>
           <button onClick={addDangerAlert} type="button" className={btnClasses}>
             Add toast danger alert
           </button>
-        </InputGroupItem>
-        <InputGroupItem>
+        </FlexItem>
+        <FlexItem>
           <button onClick={addInfoAlert} type="button" className={btnClasses}>
             Add toast info alert
           </button>
-        </InputGroupItem>
-      </InputGroup>
+        </FlexItem>
+      </Flex>
       <AlertGroup
         hasAnimations
         isToast


### PR DESCRIPTION
**What**: Fixes #12019 

Replaces the InputGroup containing the demo buttons with a Flex container so the buttons can wrap.

