### PR TITLE
feat(react-tokens): add dark theme token values

### DIFF
--- a/packages/react-tokens/scripts/writeTokens.mjs
+++ b/packages/react-tokens/scripts/writeTokens.mjs
@@ -74,13 +74,19 @@ function writeTokens(tokens) {
     Object.values(tokenValue)
       .map((values) => Object.entries(values))
       .reduce((acc, val) => acc.concat(val), []) // flatten
-      .forEach(([oldTokenName, { name, value }]) => {
+      .forEach(([oldTokenName, { name, value, darkValue }]) => {
         const isChart = oldTokenName.includes('chart');
         const oldToken = {
           name,
           value: isChart && !isNaN(+value) ? +value : value,
           var: isChart ? `var(${name}, ${value})` : `var(${name})` // Include fallback value for chart vars
         };
+
+        // Add dark theme values if they exist
+        if (darkValue !== undefined) {
+          oldToken.darkValue = isChart && !isNaN(+darkValue) ? +darkValue : darkValue;
+        }
+
         const oldTokenString = JSON.stringify(oldToken, null, 2);
         writeESMExport(oldTokenName, oldTokenString);
         writeCJSExport(oldTokenName, oldTokenString);


### PR DESCRIPTION
Closes #11803

Enhanced the @patternfly/react-tokens package to include dark theme values in semantic token definitions, making it easier for developers to access both light and dark theme values programmatically.

Changes:
- Added getDarkThemeDeclarations() to extract dark theme CSS rules
- Added getDarkLocalVarsMap() to build dark theme variable mappings
- Updated token generation to include darkValue and darkValues properties
- Enhanced variable resolution to support dark theme context
- Updated legacy token support to include dark values

Result:
- 1,998 tokens now include dark theme values
- Tokens with dark overrides expose darkValue property
- Backward compatible with existing code
- Enables programmatic theme switching and consistency

Implements: #11803

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dark theme token variants are now supported alongside light themes in the token generation system.

* **Chores**
  * Enhanced variable resolution to properly handle dark theme overrides across CSS files and dependencies.
  * Updated token export process to include dark theme values in legacy token compatibility paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->