### PR TITLE
feat(CC-table): init table

### DIFF
--- a/packages/code-connect/components/Table/BasicRow.figma.tsx
+++ b/packages/code-connect/components/Table/BasicRow.figma.tsx
@@ -1,0 +1,20 @@
+import figma from '@figma/code-connect';
+import { Tr } from '@patternfly/react-table';
+
+// Documentation for BasicRow can be found at https://www.patternfly.org/components/table
+
+figma.connect(Tr, 'https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/PatternFly-6--Components?node-id=2930-36939', {
+  props: {
+    // boolean
+    isExpanded: figma.boolean('Expanded'),
+    isRowSelected: figma.boolean('Selected'),
+
+    // enum
+    children: figma.children('*')
+  },
+  example: (props) => (
+    <Tr isExpanded={props.isExpanded} isRowSelected={props.isRowSelected}>
+      {props.children}
+    </Tr>
+  )
+});

--- a/packages/code-connect/components/Table/ClickableRow.figma.tsx
+++ b/packages/code-connect/components/Table/ClickableRow.figma.tsx
@@ -1,0 +1,26 @@
+import figma from '@figma/code-connect';
+import { Tr } from '@patternfly/react-table';
+
+// Documentation for BasicRow can be found at https://www.patternfly.org/components/table
+
+figma.connect(Tr, 'https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/PatternFly-6--Components?node-id=2930-40632', {
+  props: {
+    isExpanded: figma.boolean('Expanded'),
+    isRowSelected: figma.enum('State', {
+      Clicked: true
+    }),
+
+    children: figma.children('*')
+  },
+  example: (props) => (
+    <Tr
+      onRowClick={() => {}}
+      isSelectable
+      isExpanded={props.isExpanded}
+      isClickable
+      isRowSelected={props.isRowSelected}
+    >
+      {props.children}
+    </Tr>
+  )
+});

--- a/packages/code-connect/components/Table/ColumnBasedTableDoesNotSupportExpandableRows.figma.tsx
+++ b/packages/code-connect/components/Table/ColumnBasedTableDoesNotSupportExpandableRows.figma.tsx
@@ -1,0 +1,22 @@
+import figma from '@figma/code-connect';
+import { Table } from '@patternfly/react-table';
+
+// Documentation for BasicRow can be found at https://www.patternfly.org/components/table
+
+figma.connect(
+  Table,
+  'https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/PatternFly-6--Components?node-id=6482-49461',
+  {
+    props: {
+      // enum
+      variant: figma.enum('Size', { Compact: 'compact' }),
+
+      children: figma.children('*')
+    },
+    example: (props) => (
+      <Table variant={props.variant} aria-label="Column based table">
+        {props.children}test
+      </Table>
+    )
+  }
+);

--- a/packages/code-connect/components/Table/ColumnHeaderHeaderCell.figma.tsx
+++ b/packages/code-connect/components/Table/ColumnHeaderHeaderCell.figma.tsx
@@ -1,0 +1,22 @@
+import figma from '@figma/code-connect';
+import { Th } from '@patternfly/react-table';
+
+// Documentation for header cell can be found at https://www.patternfly.org/components/table
+
+figma.connect(Th, 'https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/PatternFly-6--Components?node-id=14-623', {
+  props: {
+    info: figma.boolean('Show help icon', {
+      true: { tooltip: 'More information ' },
+      false: undefined
+    }),
+    sort: figma.boolean('Sortable', {
+      true: `getSortParams(<row-index>)`,
+      false: undefined
+    })
+  },
+  example: (props) => (
+    <Th sort={props.sort} info={props.info}>
+      Header
+    </Th>
+  )
+});

--- a/packages/code-connect/components/Table/ColumnHeaderLeftControls.figma.tsx
+++ b/packages/code-connect/components/Table/ColumnHeaderLeftControls.figma.tsx
@@ -1,0 +1,43 @@
+import figma from '@figma/code-connect';
+import { Th } from '@patternfly/react-table';
+
+// Documentation for BasicRow can be found at https://www.patternfly.org/components/table
+
+figma.connect(Th, 'https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/PatternFly-6--Components?node-id=6241-29618', {
+  props: {
+    selectAll: figma.boolean('Select all', {
+      true: (
+        <Th
+          select={{
+            onSelect: () => {},
+            isSelected: false
+          }}
+          aria-label="Row select"
+        />
+      ),
+      false: undefined
+    }),
+    expandableAll: figma.boolean('Expandable all', {
+      true: (
+        <Th
+          expand={{
+            onToggle: () => {}
+          }}
+          aria-label="Row expand"
+        />
+      ),
+      false: undefined
+    }),
+    isDraggable: figma.boolean('Is draggable', {
+      true: <Th draggableRow={{ id: `draggable-row-id` }} />,
+      false: undefined
+    })
+  },
+  example: (props) => (
+    <>
+      {props.selectAll}
+      {props.expandableAll}
+      {props.isDraggable}
+    </>
+  )
+});

--- a/packages/code-connect/components/Table/ColumnHeaderRightActionPlaceholder.figma.tsx
+++ b/packages/code-connect/components/Table/ColumnHeaderRightActionPlaceholder.figma.tsx
@@ -1,0 +1,11 @@
+import figma from '@figma/code-connect';
+import { Th } from '@patternfly/react-table';
+
+// Documentation for BasicRow can be found at https://www.patternfly.org/components/table
+
+figma.connect(Th, 'https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/PatternFly-6--Components?node-id=6241-29627', {
+  props: {
+    children: figma.children('*')
+  },
+  example: (props) => <Th>{props.children}</Th>
+});

--- a/packages/code-connect/components/Table/CompoundExpandableRows.figma.tsx
+++ b/packages/code-connect/components/Table/CompoundExpandableRows.figma.tsx
@@ -1,0 +1,12 @@
+import figma from '@figma/code-connect';
+import { Tr } from '@patternfly/react-table';
+
+// Documentation for BasicRow can be found at https://www.patternfly.org/components/table
+
+figma.connect(Tr, 'https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/PatternFly-6--Components?node-id=2945-48504', {
+  props: {
+    showActions: figma.boolean('Show actions'),
+    children: figma.children('*')
+  },
+  example: (props) => <Tr>{props.children}</Tr>
+});

--- a/packages/code-connect/components/Table/CompoundExpandableTable.figma.tsx
+++ b/packages/code-connect/components/Table/CompoundExpandableTable.figma.tsx
@@ -1,0 +1,19 @@
+import figma from '@figma/code-connect';
+import { Table } from '@patternfly/react-table';
+
+// Documentation for Table can be found at https://www.patternfly.org/components/table
+
+figma.connect(
+  Table,
+  'https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/PatternFly-6--Components?node-id=6482-55919',
+  {
+    props: {
+      children: figma.children('*')
+    },
+    example: (props) => (
+      <Table isExpandable aria-label="Compound expandable table">
+        {props.children}
+      </Table>
+    )
+  }
+);

--- a/packages/code-connect/components/Table/DraggableRow.figma.tsx
+++ b/packages/code-connect/components/Table/DraggableRow.figma.tsx
@@ -1,0 +1,15 @@
+import figma from '@figma/code-connect';
+import { Tr } from '@patternfly/react-table';
+
+// Documentation for Table can be found at https://www.patternfly.org/components/table
+
+figma.connect(Tr, 'https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/PatternFly-6--Components?node-id=21288-130668', {
+  props: {
+    children: figma.children('*')
+  },
+  example: (props) => (
+    <Tr id="draggable-row-id" draggable onDrop={() => {}} onDragEnd={() => {}} onDragStart={() => {}}>
+      {props.children}
+    </Tr>
+  )
+});

--- a/packages/code-connect/components/Table/LeftActionsColumn.figma.tsx
+++ b/packages/code-connect/components/Table/LeftActionsColumn.figma.tsx
@@ -1,0 +1,18 @@
+import figma from '@figma/code-connect';
+import { ActionsColumn, Td, Th } from '@patternfly/react-table';
+
+// Documentation for Table can be found at https://www.patternfly.org/components/table
+
+figma.connect(Td, 'https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/PatternFly-6--Components?node-id=6441-38440', {
+  props: {
+    tableCell: figma.boolean('Column header', {
+      true: <Th screenReaderText="Action cell" />,
+      false: (
+        <Td isActionCell>
+          <ActionsColumn items={[]} />
+        </Td>
+      )
+    })
+  },
+  example: (props) => <>{props.tableCell}</>
+});

--- a/packages/code-connect/components/Table/RightActionColumn.figma.tsx
+++ b/packages/code-connect/components/Table/RightActionColumn.figma.tsx
@@ -1,0 +1,22 @@
+import figma from '@figma/code-connect';
+import { ActionsColumn, Td, Th } from '@patternfly/react-table';
+
+// Documentation for Table can be found at https://www.patternfly.org/components/table
+
+figma.connect(
+  Td,
+  'https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/PatternFly-6--Components?node-id=6441-38900&m=dev',
+  {
+    props: {
+      tableCell: figma.boolean('Column header', {
+        true: <Th screenReaderText="Action cell" />,
+        false: (
+          <Td isActionCell>
+            <ActionsColumn items={[]} />
+          </Td>
+        )
+      })
+    },
+    example: (props) => <>{props.tableCell}</>
+  }
+);

--- a/packages/code-connect/components/Table/RowBackgrounds.figma.tsx
+++ b/packages/code-connect/components/Table/RowBackgrounds.figma.tsx
@@ -1,0 +1,11 @@
+import figma from '@figma/code-connect';
+import { Tr } from '@patternfly/react-table';
+
+// Documentation for Table can be found at https://www.patternfly.org/components/table
+
+figma.connect(Tr, 'https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/PatternFly-6--Components?node-id=6441-39265', {
+  props: {
+    children: figma.children('*')
+  },
+  example: (props) => <Tr>{props.children}</Tr>
+});

--- a/packages/code-connect/components/Table/RowBasedTableRecommended.figma.tsx
+++ b/packages/code-connect/components/Table/RowBasedTableRecommended.figma.tsx
@@ -1,0 +1,25 @@
+import figma from '@figma/code-connect';
+import { Table } from '@patternfly/react-table';
+
+// Documentation for Table can be found at https://www.patternfly.org/components/table
+
+figma.connect(
+  Table,
+  'https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/PatternFly-6--Components?node-id=3331-12049',
+  {
+    props: {
+      // boolean
+      isBordered: figma.boolean('Bordered'),
+      isExpandable: figma.boolean('Expandable'),
+
+      // enum
+      variant: figma.enum('Size', { Compact: 'compact' }),
+      children: figma.children('*')
+    },
+    example: (props) => (
+      <Table variant={props.variant} borders={props.isBordered} isExpandable={props.isExpandable}>
+        {props.children}
+      </Table>
+    )
+  }
+);

--- a/packages/code-connect/components/Table/TableCellCompoundExpandableContentCell.figma.tsx
+++ b/packages/code-connect/components/Table/TableCellCompoundExpandableContentCell.figma.tsx
@@ -1,0 +1,11 @@
+import figma from '@figma/code-connect';
+import { Td } from '@patternfly/react-table';
+
+// Documentation for Table can be found at https://www.patternfly.org/components/table
+
+figma.connect(Td, 'https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/PatternFly-6--Components?node-id=2912-36168', {
+  props: {
+    children: figma.children('*')
+  },
+  example: (props) => <Td>{props.children}</Td>
+});

--- a/packages/code-connect/components/Table/TableCellDefaultContentCell.figma.tsx
+++ b/packages/code-connect/components/Table/TableCellDefaultContentCell.figma.tsx
@@ -1,0 +1,11 @@
+import figma from '@figma/code-connect';
+import { Td } from '@patternfly/react-table';
+
+// Documentation for Table can be found at https://www.patternfly.org/components/table
+
+figma.connect(Td, 'https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/PatternFly-6--Components?node-id=14-389', {
+  props: {
+    children: figma.children('*')
+  },
+  example: (props) => <Td>{props.children}</Td>
+});

--- a/packages/code-connect/components/Table/TableCellLeftControls.figma.tsx
+++ b/packages/code-connect/components/Table/TableCellLeftControls.figma.tsx
@@ -1,0 +1,43 @@
+import figma from '@figma/code-connect';
+import { Td } from '@patternfly/react-table';
+
+// Documentation for Table can be found at https://www.patternfly.org/components/table
+
+figma.connect(Td, 'https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/PatternFly-6--Components?node-id=2930-36766', {
+  props: {
+    selectAll: figma.boolean('Row select', {
+      true: (
+        <Td
+          select={{
+            onSelect: () => {},
+            isSelected: false
+          }}
+          aria-label="Row select"
+        />
+      ),
+      false: undefined
+    }),
+    expandableAll: figma.boolean('Row expansion', {
+      true: (
+        <Td
+          expand={{
+            onToggle: () => {}
+          }}
+          aria-label="Row expand"
+        />
+      ),
+      false: undefined
+    }),
+    isDraggable: figma.boolean('Is draggable', {
+      true: <Td draggableRow={{ id: `draggable-row-id` }} />,
+      false: undefined
+    })
+  },
+  example: (props) => (
+    <>
+      {props.selectAll}
+      {props.expandableAll}
+      {props.isDraggable}
+    </>
+  )
+});

--- a/packages/code-connect/components/Table/TableCellRightAction.figma.tsx
+++ b/packages/code-connect/components/Table/TableCellRightAction.figma.tsx
@@ -1,0 +1,11 @@
+import figma from '@figma/code-connect';
+import { Td } from '@patternfly/react-table';
+
+// Documentation for Table can be found at https://www.patternfly.org/components/table
+
+figma.connect(Td, 'https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/PatternFly-6--Components?node-id=2912-36519', {
+  props: {
+    children: figma.children('*')
+  },
+  example: (props) => <Td>{props.children}</Td>
+});

--- a/packages/code-connect/components/Table/TableHeaderRow.figma.tsx
+++ b/packages/code-connect/components/Table/TableHeaderRow.figma.tsx
@@ -1,0 +1,15 @@
+import figma from '@figma/code-connect';
+import { Thead, Tr } from '@patternfly/react-table';
+
+// Documentation for Table can be found at https://www.patternfly.org/components/table
+
+figma.connect(Tr, 'https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/PatternFly-6--Components?node-id=2912-35117', {
+  props: {
+    children: figma.children('*')
+  },
+  example: (props) => (
+    <Thead>
+      <Tr>{props.children}</Tr>
+    </Thead>
+  )
+});

--- a/packages/code-connect/components/Table/_ContentColumn.figma.tsx
+++ b/packages/code-connect/components/Table/_ContentColumn.figma.tsx
@@ -1,0 +1,15 @@
+// import figma from '@figma/code-connect';
+// import { ContentColumn } from '@patternfly/react-table';
+
+// // Documentation for Table can be found at https://www.patternfly.org/components/table
+
+// figma.connect(
+//   ContentColumn,
+//   'https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/PatternFly-6--Components?node-id=6441-38677',
+//   {
+//     props: {
+//       columnHeader: figma.boolean('Column header')
+//     },
+//     example: (props) => <ContentColumn />
+//   }
+// );

--- a/packages/code-connect/figma.config.json
+++ b/packages/code-connect/figma.config.json
@@ -1,13 +1,10 @@
 {
   "codeConnect": {
     "parser": "react",
-    "include": [
-      "components/DatePicker/*.tsx",
-      "components/EmptyState/*.tsx",
-      "components/FileUpload/*.tsx",
-      "components/Hint/*.tsx",
-      "components/InlineEdit/*.tsx"
-    ],
+    "include": ["components/Table/*.figma.tsx"],
+    "documentUrlSubstitutions": {
+      "https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/PatternFly-6--Components": "https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/branch/Em2QWrHDxDS4LUxo58Hust/PatternFly-6--Components"
+    },
     "paths": {
       "src/components": "src/components"
     },


### PR DESCRIPTION
# TLDR
[Table](https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/branch/istD6Z7Ugu0ZQnsXZOnkbP/PatternFly-6--Components?node-id=3331-12049&m=dev) is mostly complete and partially functional. 

A couple of notes: 
## [Row based table](https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/branch/istD6Z7Ugu0ZQnsXZOnkbP/PatternFly-6--Components?node-id=3331-12049&m=dev) = React component aligned table

**Example:** 
``` 
<table />
  <thead /> <- though missing currently 
    <tr />
      <th />
  <tbody /> <- though missing currently 
    <tr />
      <th />

```

## [Column base tables](https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/branch/istD6Z7Ugu0ZQnsXZOnkbP/PatternFly-6--Components?node-id=6482-49461&m=dev) = purely presentational/Figma usage only

**Why is the column based table mis-aligned?** 
Figma structure dictates that row are structured vertically, which is inconsistent with `html` structural requirements.

The Figma Table component lacks `<Thead>` and `<Tbody>` equivalent. Table source code won't include these, thus will be semantically invalid.

## Action items:
- [ ] Followup with design, add missing elements  @kaylachumley 
- [ ] Update `.figma.tsx` file to match newly added Figma elements. 

