### PR TITLE
chore(panel): move examples to separate files

### DIFF
--- a/packages/react-core/src/components/Panel/examples/Panel.md
+++ b/packages/react-core/src/components/Panel/examples/Panel.md
@@ -9,199 +9,50 @@ propComponents: [Panel, PanelMain, PanelMainBody, PanelHeader, PanelFooter]
 
 ### Basic
 
-```js
-import { Panel, PanelMain, PanelMainBody } from '@patternfly/react-core';
-
-const BasicPanel = () => (
-  <Panel>
-    <PanelMain>
-      <PanelMainBody>Main content</PanelMainBody>
-    </PanelMain>
-  </Panel>
-);
+```ts file="PanelBasic.tsx"
 ```
 
 ### Header
 
-```js
-import { Panel, PanelMain, PanelMainBody, PanelHeader, Divider } from '@patternfly/react-core';
-
-const HeaderPanel = () => (
-  <Panel>
-    <PanelHeader>Header content</PanelHeader>
-    <Divider />
-    <PanelMain>
-      <PanelMainBody>Main content</PanelMainBody>
-    </PanelMain>
-  </Panel>
-);
+```ts file="PanelHeaderExample.tsx"
 ```
 
 ### Footer
 
-```js
-import { Panel, PanelMain, PanelMainBody, PanelFooter } from '@patternfly/react-core';
-
-const FooterPanel = () => (
-  <Panel>
-    <PanelMain>
-      <PanelMainBody>Main content</PanelMainBody>
-    </PanelMain>
-    <PanelFooter>Footer content</PanelFooter>
-  </Panel>
-);
+```ts file="PanelFooterExample.tsx"
 ```
 
 ### Header and footer
 
-```js
-import { Panel, PanelMain, PanelMainBody, PanelHeader, Divider, PanelFooter } from '@patternfly/react-core';
-
-const HeaderFooterPanel = () => (
-  <Panel>
-    <PanelHeader>Header content</PanelHeader>
-    <Divider />
-    <PanelMain>
-      <PanelMainBody>Main content</PanelMainBody>
-    </PanelMain>
-    <PanelFooter>Footer content</PanelFooter>
-  </Panel>
-);
+```ts file="PanelHeaderFooter.tsx"
 ```
 
 ### No body
 
-```js
-import { Panel, PanelMain } from '@patternfly/react-core';
-
-const NoBodyPanel = () => (
-  <Panel>
-    <PanelMain>Main content</PanelMain>
-  </Panel>
-);
+```ts file="PanelNoBody.tsx"
 ```
 
 ### Raised
 
-```js
-import { Panel, PanelMain, PanelMainBody } from '@patternfly/react-core';
-
-const RaisedPanel = () => (
-  <Panel variant="raised">
-    <PanelMain>
-      <PanelMainBody>Main content</PanelMainBody>
-    </PanelMain>
-  </Panel>
-);
+```ts file="PanelRaised.tsx"
 ```
 
 ### Bordered
 
-```js
-import { Panel, PanelMain, PanelMainBody } from '@patternfly/react-core';
-
-const BorderedPanel = () => (
-  <Panel variant="bordered">
-    <PanelMain>
-      <PanelMainBody>Main content</PanelMainBody>
-    </PanelMain>
-  </Panel>
-);
+```ts file="PanelBordered.tsx"
 ```
 
 ### Secondary variant
 
-```js
-import { Panel, PanelMain, PanelMainBody } from '@patternfly/react-core';
-
-const PanelSecondaryVariant = () => (
-  <Panel variant="secondary">
-    <PanelMain>
-      <PanelMainBody>Main content</PanelMainBody>
-    </PanelMain>
-  </Panel>
-);
+```ts file="PanelSecondaryVariant.tsx"
 ```
 
 ### Scrollable
 
-```js
-import { Panel, PanelMain, PanelMainBody } from '@patternfly/react-core';
-
-const ScrollablePanel = () => (
-  <Panel isScrollable>
-    <PanelMain tabIndex={0}>
-      <PanelMainBody>
-        Main content
-        <br />
-        <br />
-        Main content
-        <br />
-        <br />
-        Main content
-        <br />
-        <br />
-        Main content
-        <br />
-        <br />
-        Main content
-        <br />
-        <br />
-        Main content
-        <br />
-        <br />
-        Main content
-        <br />
-        <br />
-        Main content
-        <br />
-        <br />
-        Main content
-      </PanelMainBody>
-    </PanelMain>
-  </Panel>
-);
+```ts file="PanelScrollable.tsx"
 ```
 
 ### Scrollable with header and footer
 
-```js
-import { Panel, PanelMain, PanelMainBody, PanelHeader, Divider, PanelFooter } from '@patternfly/react-core';
-
-const ScrollableHeaderFooterPanel = () => (
-  <Panel isScrollable>
-    <PanelHeader>Header content</PanelHeader>
-    <Divider />
-    <PanelMain tabIndex={0}>
-      <PanelMainBody>
-        Main content
-        <br />
-        <br />
-        Main content
-        <br />
-        <br />
-        Main content
-        <br />
-        <br />
-        Main content
-        <br />
-        <br />
-        Main content
-        <br />
-        <br />
-        Main content
-        <br />
-        <br />
-        Main content
-        <br />
-        <br />
-        Main content
-        <br />
-        <br />
-        Main content
-      </PanelMainBody>
-    </PanelMain>
-    <PanelFooter>Footer content</PanelFooter>
-  </Panel>
-);
+```ts file="PanelScrollableHeaderFooter.tsx"
 ```

--- a/packages/react-core/src/components/Panel/examples/PanelBasic.tsx
+++ b/packages/react-core/src/components/Panel/examples/PanelBasic.tsx
@@ -1,0 +1,9 @@
+import { Panel, PanelMain, PanelMainBody } from '@patternfly/react-core';
+
+export const PanelBasic: React.FunctionComponent = () => (
+  <Panel>
+    <PanelMain>
+      <PanelMainBody>Main content</PanelMainBody>
+    </PanelMain>
+  </Panel>
+);

--- a/packages/react-core/src/components/Panel/examples/PanelBordered.tsx
+++ b/packages/react-core/src/components/Panel/examples/PanelBordered.tsx
@@ -1,0 +1,9 @@
+import { Panel, PanelMain, PanelMainBody } from '@patternfly/react-core';
+
+export const PanelBordered: React.FunctionComponent = () => (
+  <Panel variant="bordered">
+    <PanelMain>
+      <PanelMainBody>Main content</PanelMainBody>
+    </PanelMain>
+  </Panel>
+);

--- a/packages/react-core/src/components/Panel/examples/PanelFooterExample.tsx
+++ b/packages/react-core/src/components/Panel/examples/PanelFooterExample.tsx
@@ -1,0 +1,10 @@
+import { Panel, PanelMain, PanelMainBody, PanelFooter } from '@patternfly/react-core';
+
+export const PanelFooterExample: React.FunctionComponent = () => (
+  <Panel>
+    <PanelMain>
+      <PanelMainBody>Main content</PanelMainBody>
+    </PanelMain>
+    <PanelFooter>Footer content</PanelFooter>
+  </Panel>
+);

--- a/packages/react-core/src/components/Panel/examples/PanelHeaderExample.tsx
+++ b/packages/react-core/src/components/Panel/examples/PanelHeaderExample.tsx
@@ -1,0 +1,11 @@
+import { Panel, PanelMain, PanelMainBody, PanelHeader, Divider } from '@patternfly/react-core';
+
+export const PanelHeaderExample: React.FunctionComponent = () => (
+  <Panel>
+    <PanelHeader>Header content</PanelHeader>
+    <Divider />
+    <PanelMain>
+      <PanelMainBody>Main content</PanelMainBody>
+    </PanelMain>
+  </Panel>
+);

--- a/packages/react-core/src/components/Panel/examples/PanelHeaderFooter.tsx
+++ b/packages/react-core/src/components/Panel/examples/PanelHeaderFooter.tsx
@@ -1,0 +1,12 @@
+import { Panel, PanelMain, PanelMainBody, PanelHeader, Divider, PanelFooter } from '@patternfly/react-core';
+
+export const PanelHeaderFooter: React.FunctionComponent = () => (
+  <Panel>
+    <PanelHeader>Header content</PanelHeader>
+    <Divider />
+    <PanelMain>
+      <PanelMainBody>Main content</PanelMainBody>
+    </PanelMain>
+    <PanelFooter>Footer content</PanelFooter>
+  </Panel>
+);

--- a/packages/react-core/src/components/Panel/examples/PanelNoBody.tsx
+++ b/packages/react-core/src/components/Panel/examples/PanelNoBody.tsx
@@ -1,0 +1,7 @@
+import { Panel, PanelMain } from '@patternfly/react-core';
+
+export const PanelNoBody: React.FunctionComponent = () => (
+  <Panel>
+    <PanelMain>Main content</PanelMain>
+  </Panel>
+);

--- a/packages/react-core/src/components/Panel/examples/PanelRaised.tsx
+++ b/packages/react-core/src/components/Panel/examples/PanelRaised.tsx
@@ -1,0 +1,9 @@
+import { Panel, PanelMain, PanelMainBody } from '@patternfly/react-core';
+
+export const PanelRaised: React.FunctionComponent = () => (
+  <Panel variant="raised">
+    <PanelMain>
+      <PanelMainBody>Main content</PanelMainBody>
+    </PanelMain>
+  </Panel>
+);

--- a/packages/react-core/src/components/Panel/examples/PanelScrollable.tsx
+++ b/packages/react-core/src/components/Panel/examples/PanelScrollable.tsx
@@ -1,0 +1,35 @@
+import { Panel, PanelMain, PanelMainBody } from '@patternfly/react-core';
+
+export const PanelScrollable: React.FunctionComponent = () => (
+  <Panel isScrollable>
+    <PanelMain tabIndex={0}>
+      <PanelMainBody>
+        Main content
+        <br />
+        <br />
+        Main content
+        <br />
+        <br />
+        Main content
+        <br />
+        <br />
+        Main content
+        <br />
+        <br />
+        Main content
+        <br />
+        <br />
+        Main content
+        <br />
+        <br />
+        Main content
+        <br />
+        <br />
+        Main content
+        <br />
+        <br />
+        Main content
+      </PanelMainBody>
+    </PanelMain>
+  </Panel>
+);

--- a/packages/react-core/src/components/Panel/examples/PanelScrollableHeaderFooter.tsx
+++ b/packages/react-core/src/components/Panel/examples/PanelScrollableHeaderFooter.tsx
@@ -1,0 +1,38 @@
+import { Panel, PanelMain, PanelMainBody, PanelHeader, Divider, PanelFooter } from '@patternfly/react-core';
+
+export const PanelScrollableHeaderFooter: React.FunctionComponent = () => (
+  <Panel isScrollable>
+    <PanelHeader>Header content</PanelHeader>
+    <Divider />
+    <PanelMain tabIndex={0}>
+      <PanelMainBody>
+        Main content
+        <br />
+        <br />
+        Main content
+        <br />
+        <br />
+        Main content
+        <br />
+        <br />
+        Main content
+        <br />
+        <br />
+        Main content
+        <br />
+        <br />
+        Main content
+        <br />
+        <br />
+        Main content
+        <br />
+        <br />
+        Main content
+        <br />
+        <br />
+        Main content
+      </PanelMainBody>
+    </PanelMain>
+    <PanelFooter>Footer content</PanelFooter>
+  </Panel>
+);

--- a/packages/react-core/src/components/Panel/examples/PanelSecondaryVariant.tsx
+++ b/packages/react-core/src/components/Panel/examples/PanelSecondaryVariant.tsx
@@ -1,0 +1,9 @@
+import { Panel, PanelMain, PanelMainBody } from '@patternfly/react-core';
+
+export const PanelSecondaryVariant: React.FunctionComponent = () => (
+  <Panel variant="secondary">
+    <PanelMain>
+      <PanelMainBody>Main content</PanelMainBody>
+    </PanelMain>
+  </Panel>
+);


### PR DESCRIPTION
Towards #11952

The following examples have been updated:

- Basic
- Header
- Footer
- Header and Footer
- No body
- Raised 
- Bordered
- Secondary variant
- Scrollable
- Scrollable with header and footer