### PR TITLE
feat(CC-page): page init

### DIFF
--- a/packages/code-connect/components/Page/DesktopPageWithHorizontalNav.figma.tsx
+++ b/packages/code-connect/components/Page/DesktopPageWithHorizontalNav.figma.tsx
@@ -1,0 +1,59 @@
+import figma from '@figma/code-connect';
+import {
+  Masthead,
+  MastheadMain,
+  MastheadBrand,
+  MastheadLogo,
+  MastheadContent,
+  Page,
+  PageSection,
+  PageSidebar,
+  PageSidebarBody,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem
+} from '@patternfly/react-core';
+
+// Documentation for Page can be found at https://www.patternfly.org/components/page
+
+figma.connect(Page, 'https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/PatternFly-6--Components?node-id=7620-35193', {
+  props: {
+    masthead: (
+      <Masthead inset={{ default: 'insetXs' }}>
+        <MastheadMain>
+          <MastheadBrand>
+            <MastheadLogo href="https://patternfly.org" target="_blank">
+              Logo
+            </MastheadLogo>
+          </MastheadBrand>
+        </MastheadMain>
+        <MastheadContent>
+          <Toolbar id="horizontal-toolbar">
+            <ToolbarContent>
+              <ToolbarItem>Navigation</ToolbarItem>
+              <ToolbarItem>header-tools</ToolbarItem>
+            </ToolbarContent>
+          </Toolbar>
+        </MastheadContent>
+      </Masthead>
+    ),
+    sidebar: (
+      <PageSidebar isSidebarOpen={false} id="vertical-sidebar">
+        <PageSidebarBody>Navigation</PageSidebarBody>
+      </PageSidebar>
+    )
+  },
+  example: (props) => (
+    <Page masthead={props.masthead}>
+      <PageSection aria-labelledby="section-1">
+        <h2 id="section-1">Horizontal nav example section 1</h2>
+      </PageSection>
+      <PageSection variant="secondary" aria-labelledby="section-2">
+        <h2 id="section-2">Horizontal nav example section 2 with secondary variant styling</h2>
+      </PageSection>
+      <PageSection aria-labelledby="section-3">
+        <h2 id="section-3">Horizontal nav example section 3</h2>
+      </PageSection>
+    </Page>
+  )
+});

--- a/packages/code-connect/components/Page/DesktopPageWithLeftNav.figma.tsx
+++ b/packages/code-connect/components/Page/DesktopPageWithLeftNav.figma.tsx
@@ -1,0 +1,73 @@
+import figma from '@figma/code-connect';
+import {
+  Masthead,
+  MastheadBrand,
+  MastheadContent,
+  MastheadLogo,
+  MastheadMain,
+  MastheadToggle,
+  Page,
+  PageSection,
+  PageSidebar,
+  PageSidebarBody,
+  PageToggleButton,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem
+} from '@patternfly/react-core';
+
+// Documentation for Page can be found at https://www.patternfly.org/components/page
+
+figma.connect(
+  Page,
+  'https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/PatternFly-6--Components?node-id=25656-311374',
+  {
+    props: {
+      masthead: (
+        <Masthead>
+          <MastheadMain>
+            <MastheadToggle>
+              <PageToggleButton
+                isHamburgerButton
+                aria-label="Global navigation"
+                isSidebarOpen={true}
+                onSidebarToggle={() => {}}
+                id="vertical-nav-toggle"
+              />
+            </MastheadToggle>
+            <MastheadBrand>
+              <MastheadLogo href="https://patternfly.org" target="_blank">
+                Logo
+              </MastheadLogo>
+            </MastheadBrand>
+          </MastheadMain>
+          <MastheadContent>
+            <Toolbar id="vertical-toolbar">
+              <ToolbarContent>
+                <ToolbarItem>header-tools</ToolbarItem>
+              </ToolbarContent>
+            </Toolbar>
+          </MastheadContent>
+        </Masthead>
+      ),
+      sidebar: (
+        <PageSidebar isSidebarOpen={true} id="vertical-sidebar">
+          <PageSidebarBody>Navigation</PageSidebarBody>
+        </PageSidebar>
+      )
+    },
+    example: (props) => (
+      <Page masthead={props.masthead} sidebar={props.sidebar}>
+        <PageSection aria-labelledby="section-1">
+          <h2 id="section-1">Vertical nav example section 1</h2>
+        </PageSection>
+        <PageSection variant="secondary" aria-labelledby="section-2">
+          <h2 id="section-2">Vertical nav example section 2 with secondary variant styling</h2>
+        </PageSection>
+        <PageSection aria-labelledby="section-3">
+          <h2 id="section-3">Vertical nav example section 3</h2>
+        </PageSection>
+      </Page>
+    )
+  }
+);

--- a/packages/code-connect/figma.config.json
+++ b/packages/code-connect/figma.config.json
@@ -1,15 +1,9 @@
 {
   "codeConnect": {
     "parser": "react",
-    "include": [
-      "components/DatePicker/*.tsx",
-      "components/EmptyState/*.tsx",
-      "components/FileUpload/*.tsx",
-      "components/Hint/*.tsx",
-      "components/InlineEdit/*.tsx"
-    ],
-    "paths": {
-      "src/components": "src/components"
+    "include": ["components/Page/*.figma.tsx"],
+    "documentUrlSubstitutions": {
+      "https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/PatternFly-6--Components": "https://www.figma.com/design/VMEX8Xg2nzhBX8rfBx53jp/branch/9HiAevBhEc2iYY9rxZtovA/PatternFly-6--Components"
     },
     "aliases": {
       "@patternfly/react-core": "."


### PR DESCRIPTION
Relates to: https://github.com/patternfly/patternfly-react/issues/11624

TLDR: This PR is intended to serve as stubbed content. The page Figma component designs are fully demos, which is untenable from a maintenance perspective to fully integrate in Code Connect. Page variants include page with vertical nav and page with vertical and horizontal nav. 

Included components: Page

[Component tracker](https://docs.google.com/spreadsheets/d/1RpZ4AtDU6gAEMgcj59mDfHJHP4bZs3Zisp8jrQENlGs/edit?gid=1902662552#gid=1902662552)

[Figma preview](https://www.figma.com/design/aEBBvq0J3EPXxHvv6WgDx9/PatternFly-6--Components-Test?node-id=3-18&p=f&m=dev)

Resources: [Getting started](https://gist.github.com/mattnolting/da60420274e7aa51d9d03e7096e66393)