### PR TITLE
fix(CodeEditorControl): make icon prop optional

### DIFF
--- a/packages/react-code-editor/src/components/CodeEditor/CodeEditorControl.tsx
+++ b/packages/react-code-editor/src/components/CodeEditor/CodeEditorControl.tsx
@@ -13,7 +13,7 @@ export interface CodeEditorControlProps extends Omit<ButtonProps, 'onClick'> {
   /** Additional classes added to the code editor control. */
   className?: string;
   /** Icon rendered inside the code editor control. */
-  icon: React.ReactNode;
+  icon?: React.ReactNode;
   /** Event handler for the click of the button */
   onClick: (code: string, event?: any) => void;
   /** Flag indicating that the button is visible above the code editor. */


### PR DESCRIPTION
This allows the usage of `isSettings` without a workaround

<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #12065

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: https://github.com/openshift/console/pull/15555