### PR TITLE
fix(NotificationBadge): add `Button.variant` to allowed `NotificationBadgeVariant`s

### DIFF
--- a/packages/react-core/src/components/NotificationBadge/NotificationBadge.tsx
+++ b/packages/react-core/src/components/NotificationBadge/NotificationBadge.tsx
@@ -29,7 +29,7 @@ export interface NotificationBadgeProps extends Omit<ButtonProps, 'variant'> {
    */
   isExpanded?: boolean;
   /** Determines the variant of the notification badge. */
-  variant?: NotificationBadgeVariant | 'read' | 'unread' | 'attention';
+  variant?: NotificationBadgeVariant | ButtonProps['variant'] | 'read' | 'unread' | 'attention';
   /** Flag indicating whether the notification badge animation should be triggered. Each
    * time this prop is true, the animation will be triggered a single time.
    */


### PR DESCRIPTION
To be honest I don't know if these changes should be made to PF.. but `variant="plain"` looks the most "in place" in the context of OCP's masthead and we should definitely at least have that variant supported in PF

<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #12066

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: https://github.com/openshift/console/pull/15555
