### PR TITLE
fix(Nav): ensure scroll buttons respond to window resize in horizontal nav

### DIFF
--- a/packages/react-core/src/components/Nav/NavList.tsx
+++ b/packages/react-core/src/components/Nav/NavList.tsx
@@ -4,7 +4,7 @@ import { css } from '@patternfly/react-styles';
 import { Button } from '../Button';
 import AngleLeftIcon from '@patternfly/react-icons/dist/esm/icons/angle-left-icon';
 import AngleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-right-icon';
-import { getLanguageDirection, isElementInView } from '../../helpers/util';
+import { debounce, getLanguageDirection, isElementInView } from '../../helpers/util';
 import { NavContext } from './Nav';
 import { PageSidebarContext } from '../Page/PageSidebar';
 import { getResizeObserver } from '../../helpers/resizeObserver';
@@ -38,6 +38,7 @@ class NavList extends Component<NavListProps> {
 
   navList = createRef<HTMLUListElement>();
   observer: any = () => {};
+  handleWindowResize: any;
 
   handleScrollButtons = () => {
     const container = this.navList.current;
@@ -108,11 +109,18 @@ class NavList extends Component<NavListProps> {
   componentDidMount() {
     this.observer = getResizeObserver(this.navList.current, this.handleScrollButtons, true);
     this.direction = getLanguageDirection(this.navList.current);
+    // Add window resize listener to handle cases where the window resizes but the container doesn't
+    // This ensures scroll buttons appear/disappear when the window size changes
+    this.handleWindowResize = debounce(this.handleScrollButtons, 250);
+    window.addEventListener('resize', this.handleWindowResize);
     this.handleScrollButtons();
   }
 
   componentWillUnmount() {
     this.observer();
+    if (this.handleWindowResize) {
+      window.removeEventListener('resize', this.handleWindowResize);
+    }
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
## What
Closes #12047 - This PR fixes horizontal navigation scroll buttons not appearing/disappearing when the browser window is resized.

### Problem Description
When using horizontal navigation, the scroll buttons (left/right arrows) were not responding to window resize events. This caused two issues:

1. **Shrinking the window**: When the window becomes narrow enough that nav items overflow, the scroll buttons don't appear until the user manually scrolls or focuses a nav item.

2. **Expanding the window**: When the window becomes wide enough that all nav items fit, the scroll buttons don't disappear until the user clicks on them.

### Root Cause
The `NavList` component relies on a `ResizeObserver` that only monitors the nav list container element itself. When the browser window resizes but the container's dimensions don't change (common in flex/grid layouts), the `ResizeObserver` doesn't fire, so `handleScrollButtons()` is never called to update scroll button visibility.

## How
Added a (debounced) window resize event listener alongside the existing `ResizeObserver`:

### Changes in `NavList.tsx`:
1. **Import debounce utility** - Used to prevent excessive calls during rapid window resize
2. **Add `handleWindowResize` property** - Stores the debounced handler for cleanup
3. **Enhanced `componentDidMount()`** - Creates debounced resize handler and adds window listener
4. **Enhanced `componentWillUnmount()`** - Properly removes the window listener to prevent memory leaks

### Approach
The fix implements dual monitoring:
- **ResizeObserver**: Provides immediate response when the container itself changes
- **Window resize listener**: Catches cases where window resize doesn't trigger container resize
- **Debouncing (250ms)**: Prevents performance issues from rapid resize events

### Manual Testing Steps
To verify the fix on the [horizontal nav demo](https://www.patternfly.org/components/navigation/react-demos/horizontal-nav/):

1. **Test scroll buttons appear on shrink**:
   - Load the demo on a wide screen where scroll buttons don't show
   - Shrink the window until nav items overflow
   - ✅ Scroll buttons should now appear automatically

2. **Test scroll buttons disappear on expand**:
   - Load the demo on a narrow screen where scroll buttons show
   - Expand the window until all nav items fit
   - ✅ Scroll buttons should now disappear automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)