### PR TITLE
feat(NotificationBadge): add support for plain variant

### DIFF
--- a/packages/react-core/src/components/NotificationBadge/NotificationBadge.tsx
+++ b/packages/react-core/src/components/NotificationBadge/NotificationBadge.tsx
@@ -8,7 +8,8 @@ import { css } from '@patternfly/react-styles';
 export enum NotificationBadgeVariant {
   read = 'read',
   unread = 'unread',
-  attention = 'attention'
+  attention = 'attention',
+  plain = 'plain'
 }
 
 export interface NotificationBadgeProps extends Omit<ButtonProps, 'variant'> {
@@ -29,7 +30,7 @@ export interface NotificationBadgeProps extends Omit<ButtonProps, 'variant'> {
    */
   isExpanded?: boolean;
   /** Determines the variant of the notification badge. */
-  variant?: NotificationBadgeVariant | 'read' | 'unread' | 'attention';
+  variant?: NotificationBadgeVariant | 'read' | 'unread' | 'attention' | 'plain';
   /** Flag indicating whether the notification badge animation should be triggered. Each
    * time this prop is true, the animation will be triggered a single time.
    */
@@ -55,6 +56,8 @@ export const NotificationBadge: React.FunctionComponent<NotificationBadgeProps> 
   const hasCount = count > 0;
   const hasChildren = children !== undefined;
   const isAttention = variant === NotificationBadgeVariant.attention;
+  const isPlain = variant === NotificationBadgeVariant.plain;
+  const _buttonState = isPlain ? undefined : (variant as 'read' | 'unread' | 'attention');
   const notificationIcon = isAttention ? attentionIcon : icon;
   let notificationContent: React.ReactNode = null;
 
@@ -77,10 +80,10 @@ export const NotificationBadge: React.FunctionComponent<NotificationBadgeProps> 
 
   return (
     <Button
-      variant={ButtonVariant.stateful}
+      variant={isPlain ? ButtonVariant.plain : ButtonVariant.stateful}
       className={buttonClassName}
       aria-expanded={isExpanded}
-      state={variant}
+      state={_buttonState}
       isClicked={isExpanded}
       icon={notificationIcon}
       onAnimationEnd={handleAnimationEnd}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #12066

Currently I've added support for "plain" based on the issue's usage (adding it to the existing `variant` prop), but I'm wondering whether this may be better as a separate `isPlain` flag. Though the NotificationBadge props are not 1:1 with Button's props, so maybe adding it as part of the `variant` prop is still fine. LMK if anyone has thoughts or preferences about one method or another.