### PR TITLE
fix(Drawer): update refs in examples

### DIFF
--- a/packages/react-core/src/components/Drawer/examples/DrawerAdditionalSectionAboveContent.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerAdditionalSectionAboveContent.tsx
@@ -13,7 +13,7 @@ import {
 
 export const DrawerAdditionalSectionAboveContent: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const drawerRef = useRef<HTMLDivElement>(undefined);
+  const drawerRef = useRef<HTMLSpanElement>(null);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerBasic.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerBasic.tsx
@@ -14,7 +14,7 @@ import {
 
 export const DrawerBasic: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const drawerRef = useRef<HTMLDivElement>(undefined);
+  const drawerRef = useRef<HTMLSpanElement>(null);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerBasicInline.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerBasicInline.tsx
@@ -12,7 +12,7 @@ import {
 
 export const DrawerBasicInline: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const drawerRef = useRef<HTMLDivElement>(undefined);
+  const drawerRef = useRef<HTMLSpanElement>(null);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerBasicPill.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerBasicPill.tsx
@@ -12,7 +12,7 @@ import {
 
 export const DrawerBasicPill: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const drawerRef = useRef<HTMLDivElement>(undefined);
+  const drawerRef = useRef<HTMLSpanElement>(null);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerBreakpoint.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerBreakpoint.tsx
@@ -12,7 +12,7 @@ import {
 
 export const DrawerBreakpoint: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const drawerRef = useRef<HTMLDivElement>(undefined);
+  const drawerRef = useRef<HTMLSpanElement>(null);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerInlinePanelEnd.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerInlinePanelEnd.tsx
@@ -12,7 +12,7 @@ import {
 
 export const DrawerInlinePanelEnd: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const drawerRef = useRef<HTMLDivElement>(undefined);
+  const drawerRef = useRef<HTMLSpanElement>(null);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerInlinePanelStart.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerInlinePanelStart.tsx
@@ -12,7 +12,7 @@ import {
 
 export const DrawerInlinePanelStart: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const drawerRef = useRef<HTMLDivElement>(undefined);
+  const drawerRef = useRef<HTMLSpanElement>(null);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerModifiedContentPadding.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerModifiedContentPadding.tsx
@@ -12,7 +12,7 @@ import {
 
 export const DrawerModifiedContentPadding: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const drawerRef = useRef<HTMLDivElement>(undefined);
+  const drawerRef = useRef<HTMLSpanElement>(null);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerModifiedPanelPadding.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerModifiedPanelPadding.tsx
@@ -12,7 +12,7 @@ import {
 
 export const DrawerModifiedPanelPadding: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const drawerRef = useRef<HTMLDivElement>(undefined);
+  const drawerRef = useRef<HTMLSpanElement>(null);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerPanelBottom.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerPanelBottom.tsx
@@ -12,7 +12,7 @@ import {
 
 export const DrawerPanelBottom: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const drawerRef = useRef<HTMLDivElement>(undefined);
+  const drawerRef = useRef<HTMLSpanElement>(null);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerPanelEnd.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerPanelEnd.tsx
@@ -12,7 +12,7 @@ import {
 
 export const DrawerPanelEnd: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const drawerRef = useRef<HTMLDivElement>(undefined);
+  const drawerRef = useRef<HTMLSpanElement>(null);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerPanelStart.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerPanelStart.tsx
@@ -12,7 +12,7 @@ import {
 
 export const DrawerPanelStart: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const drawerRef = useRef<HTMLDivElement>(undefined);
+  const drawerRef = useRef<HTMLSpanElement>(null);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerPillInline.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerPillInline.tsx
@@ -12,7 +12,7 @@ import {
 
 export const DrawerBasicPill: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const drawerRef = useRef<HTMLDivElement>(undefined);
+  const drawerRef = useRef<HTMLSpanElement>(null);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerResizableAtEnd.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerResizableAtEnd.tsx
@@ -12,7 +12,7 @@ import {
 
 export const DrawerResizableAtEnd: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const drawerRef = useRef<HTMLDivElement>(undefined);
+  const drawerRef = useRef<HTMLSpanElement>(null);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerResizableAtStart.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerResizableAtStart.tsx
@@ -12,7 +12,7 @@ import {
 
 export const DrawerResizableAtStart: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const drawerRef = useRef<HTMLDivElement>(undefined);
+  const drawerRef = useRef<HTMLSpanElement>(null);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerResizableOnBottom.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerResizableOnBottom.tsx
@@ -12,7 +12,7 @@ import {
 
 export const DrawerResizableOnBottom: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const drawerRef = useRef<HTMLDivElement>(undefined);
+  const drawerRef = useRef<HTMLSpanElement>(null);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerResizableOnInline.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerResizableOnInline.tsx
@@ -12,7 +12,7 @@ import {
 
 export const DrawerResizableOnInline: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const drawerRef = useRef<HTMLDivElement>(undefined);
+  const drawerRef = useRef<HTMLSpanElement>(null);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();

--- a/packages/react-core/src/components/Drawer/examples/DrawerStatic.tsx
+++ b/packages/react-core/src/components/Drawer/examples/DrawerStatic.tsx
@@ -13,7 +13,7 @@ import accessibility from '@patternfly/react-styles/css/utilities/Accessibility/
 
 export const DrawerStatic: React.FunctionComponent = () => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const drawerRef = useRef<HTMLDivElement>(undefined);
+  const drawerRef = useRef<HTMLSpanElement>(null);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus();


### PR DESCRIPTION
Update ref types to HTMLSpanElement and initialize with null to fix TS errors

All Drawer examples use a `<span>` as the focusable element in DrawerHead, but the refs were typed as `HTMLDivElement`. This caused TypeScript errors and didn’t match the actual DOM element.

This PR fixes typescript errors by:
- Updating the ref type to `HTMLSpanElement` to match element.
- Initializing the refs with null since `HTMLSpanElement | undefined` is not assignable to `HTMLSpanElement | null`

Here is a screenshot of before:
<img width="1022" height="403" alt="Screenshot 2025-11-21 at 11 53 57 PM" src="https://github.com/user-attachments/assets/b0b0222f-011b-475f-a61a-7e268069c045" />
