### PR TITLE
fix(Wizard): Fix crash in nav when first sub-step is hidden

### DIFF
--- a/packages/react-core/src/components/Wizard/WizardNavInternal.tsx
+++ b/packages/react-core/src/components/Wizard/WizardNavInternal.tsx
@@ -48,7 +48,7 @@ export const WizardNavInternal = ({
           let firstSubStepIndex: number;
           let hasActiveChild = false;
 
-          const subNavItems = step.subStepIds?.map((subStepId, subStepIndex) => {
+          const subNavItems = step.subStepIds?.map((subStepId, _subStepIndex) => {
             const subStep = steps.find((step) => step.id === subStepId);
             const hasVisitedNextStep = steps.some((step) => step.index > subStep.index && step.isVisited);
             const isSubStepDisabled =
@@ -66,8 +66,8 @@ export const WizardNavInternal = ({
               return;
             }
 
-            // Store the first sub-step index so that when its parent is clicked, the first sub-step is focused
-            if (subStepIndex === 0) {
+            // Store the first visible sub-step index so that when its parent is clicked, the first sub-step is focused
+            if (firstSubStepIndex === undefined) {
               firstSubStepIndex = subStep.index;
             }
 


### PR DESCRIPTION
Update logic to focus on the first visible sub-step when navigating from a parent step.

<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Fixes #12165

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
- https://github.com/osbuild/image-builder-frontend/issues/3909