### PR TITLE
chore(actions): fix failing workflow using outputs

### DIFF
--- a/.github/workflows/add-new-issues-to-project.yml
+++ b/.github/workflows/add-new-issues-to-project.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Team Membership Checker
+      id: teamcheck
       # You may pin to the exact commit or the version.
       # uses: TheModdingInquisition/actions-team-membership@a69636a92bc927f32c3910baac06bacc949c984c
       uses: TheModdingInquisition/actions-team-membership@v1.0
@@ -27,9 +28,10 @@ jobs:
         # The organization of the team to check for. Defaults to the context organization.
         organization: 'patternfly'
         # If the action should exit if the user is not part of the team.
-        exit: true
+        exit: false
               
     - name: Add label if user is a team member
+      if: steps.teamcheck.outputs.permitted == 'true'
       run: |
         curl -X POST \
           -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \


### PR DESCRIPTION
Currently, the workflow at
[https://github.com/patternfly/patternfly-react/blob/main/.github/workflows/add-new-issues-to-project.yml](https://github.com/patternfly/patternfly-react/blob/main/.github/workflows/add-new-issues-to-project.yml)
fails whenever an issue is opened by a contributor who is not a member of the configured team. This results in unnecessary workflow failures and a poor developer experience for external contributors.

Example: https://github.com/patternfly/patternfly-react/actions/runs/20227457367/job/58062113822

They might even get failure emails from GitHub.

This change updates the workflow to gracefully handle non-team contributors by skipping the team-specific labeling step instead of failing the job. As a result, issues opened by external contributors are still added to the project without causing workflow errors, while team members continue to be labeled correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation workflow configuration to improve issue processing reliability and handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->