### PR TITLE
fix(Label): render add variant labels as buttons

### DIFF
--- a/packages/react-core/src/components/Label/Label.tsx
+++ b/packages/react-core/src/components/Label/Label.tsx
@@ -338,7 +338,7 @@ export const Label: React.FunctionComponent<LabelProps> = ({
     );
   }
 
-  const LabelComponent = (isOverflowLabel ? 'button' : 'span') as any;
+  const LabelComponent = (isOverflowLabel || isAddLabel ? 'button' : 'span') as any;
 
   return (
     <LabelComponent


### PR DESCRIPTION
## Description
Fixed an issue where labels with `variant="add"` were not rendering as button elements, unlike labels with `variant="overflow"` which correctly rendered as buttons. (Closes #11975)

## Changes
- Updated the `LabelComponent` logic on line 348 to check for both `isOverflowLabel || isAddLabel` when determining whether to render as a button
- This ensures that add variant labels have the correct semantic HTML element and button behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Label component rendering logic to handle the add variant consistently with the overflow variant, ensuring proper element type selection in both cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->