### PR TITLE
refactor(Table): prefer Object.assign where applicable

### DIFF
--- a/packages/react-table/src/components/Table/base/merge-props.ts
+++ b/packages/react-table/src/components/Table/base/merge-props.ts
@@ -12,15 +12,15 @@ import { css } from '@patternfly/react-styles';
  * @param {any} props - Props
  */
 export function mergeProps(...props: any) {
-  const firstProps = props[0];
+  const firstProps = Object.assign({}, props[0]);
   const restProps = props.slice(1);
 
   if (!restProps.length) {
-    return mergeWith({}, firstProps);
+    return firstProps;
   }
 
   // Avoid mutating the first prop collection
-  return mergeWith(mergeWith({}, firstProps), ...restProps, (a: any, b: any, key: any) => {
+  return mergeWith(firstProps, ...restProps, (a: any, b: any, key: any) => {
     if (key === 'children') {
       if (a && b) {
         // compose the two


### PR DESCRIPTION
`mergeWith` is called without a third function argument making it a plain `merge` which can be implemented with `Object.assign` as this function should always receive objects.

<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal props handling in table components for improved stability and performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->