### PR TITLE
fix(FileUploadField): don't render empty dom node

### DIFF
--- a/packages/react-core/src/components/FileUpload/FileUploadField.tsx
+++ b/packages/react-core/src/components/FileUpload/FileUploadField.tsx
@@ -172,29 +172,31 @@ export const FileUploadField: React.FunctionComponent<FileUploadFieldProps> = ({
           </InputGroupItem>
         </InputGroup>
       </div>
-      <div className={styles.fileUploadFileDetails}>
-        {!hideDefaultPreview && type === fileReaderType.text && (
-          <TextArea
-            readOnly={isReadOnly || (!!filename && !allowEditingUploadedText)}
-            disabled={isDisabled}
-            isRequired={isRequired}
-            resizeOrientation={TextAreResizeOrientation.vertical}
-            validated={validated}
-            id={id}
-            aria-label={ariaLabel}
-            value={value as string}
-            onChange={onTextAreaChange}
-            onClick={onTextAreaClick}
-            onBlur={onTextAreaBlur}
-            placeholder={textAreaPlaceholder}
-          />
-        )}
-        {isLoading && (
-          <div className={styles.fileUploadFileDetailsSpinner}>
-            <Spinner size={spinnerSize.lg} aria-valuetext={spinnerAriaValueText} />
-          </div>
-        )}
-      </div>
+      {(isLoading || (!hideDefaultPreview && type === fileReaderType.text)) && (
+        <div className={styles.fileUploadFileDetails}>
+          {!hideDefaultPreview && type === fileReaderType.text && (
+            <TextArea
+              readOnly={isReadOnly || (!!filename && !allowEditingUploadedText)}
+              disabled={isDisabled}
+              isRequired={isRequired}
+              resizeOrientation={TextAreResizeOrientation.vertical}
+              validated={validated}
+              id={id}
+              aria-label={ariaLabel}
+              value={value as string}
+              onChange={onTextAreaChange}
+              onClick={onTextAreaClick}
+              onBlur={onTextAreaBlur}
+              placeholder={textAreaPlaceholder}
+            />
+          )}
+          {isLoading && (
+            <div className={styles.fileUploadFileDetailsSpinner}>
+              <Spinner size={spinnerSize.lg} aria-valuetext={spinnerAriaValueText} />
+            </div>
+          )}
+        </div>
+      )}
       {children}
     </div>
   );


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes https://github.com/patternfly/patternfly-react/issues/12235


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file upload field rendering logic to better handle loading states and text preview display together, ensuring the details section appears appropriately based on active states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->