### PR TITLE
fix(CodeBlock): remove deprecated textId prop from ClipboardCopyButton example

### DIFF
--- a/packages/react-core/src/components/CodeBlock/examples/CodeBlockBasic.tsx
+++ b/packages/react-core/src/components/CodeBlock/examples/CodeBlockBasic.tsx
@@ -37,7 +37,6 @@ url: https://raw.githubusercontent.com/Azure-Samples/helm-charts/master/docs`;
       <CodeBlockAction>
         <ClipboardCopyButton
           id="basic-copy-button"
-          textId="code-content"
           aria-label="Copy to clipboard basic example code block"
           onClick={(e) => onClick(e, code)}
           exitDelay={copied ? 1500 : 600}

--- a/packages/react-core/src/components/CodeBlock/examples/CodeBlockExpandable.tsx
+++ b/packages/react-core/src/components/CodeBlock/examples/CodeBlockExpandable.tsx
@@ -53,7 +53,6 @@ url: https://raw.githubusercontent.com/Azure-Samples/helm-charts/master/docs`;
       <CodeBlockAction>
         <ClipboardCopyButton
           id="expandable-copy-button"
-          textId="code-content"
           aria-label="Copy to clipboard"
           onClick={(e) => onClick(e, copyBlock)}
           exitDelay={copied ? 1500 : 600}


### PR DESCRIPTION
Changes:
Removes deprecated `textId` prop in `ClipboardCopyButton` component in the following example files:
- `packages/react-core/src/components/CodeBlock/examples/CodeBlockBasic.tsx`
- `packages/react-core/src/components/CodeBlock/examples/CodeBlockExpandable.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined clipboard copy functionality in code block examples by simplifying how copied content is identified, maintaining existing copy functionality while reducing component complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->