### PR TITLE
fix(DescriptionList): use correct token for termWidth

### DIFF
--- a/packages/react-core/src/components/DescriptionList/DescriptionList.tsx
+++ b/packages/react-core/src/components/DescriptionList/DescriptionList.tsx
@@ -2,12 +2,8 @@ import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/DescriptionList/description-list';
 import { formatBreakpointMods } from '../../helpers';
 import cssGridTemplateColumnsMin from '@patternfly/react-tokens/dist/esm/c_description_list_GridTemplateColumns_min';
-// import cssTermWidth from '@patternfly/react-tokens/dist/esm/c_description_list__term_width';
+import cssTermWidth from '@patternfly/react-tokens/dist/esm/c_description_list__term_width';
 import cssHorizontalTermWidth from '@patternfly/react-tokens/dist/esm/c_description_list_m_horizontal__term_width';
-
-const cssTermWidth = {
-  name: `--${styles.descriptionList}_term-width`
-};
 
 export interface BreakpointModifiers {
   default?: string;

--- a/packages/react-core/src/components/DescriptionList/__tests__/DescriptionList.test.tsx
+++ b/packages/react-core/src/components/DescriptionList/__tests__/DescriptionList.test.tsx
@@ -133,7 +133,7 @@ test(`Renders style when isHorizontal and horizontalTermWidthModifier is set`, (
   expect(screen.getByLabelText('list')).toHaveStyle(listStyles);
 });
 
-test.skip(`Renders style when termWidth is set`, () => {
+test(`Renders style when termWidth is set`, () => {
   render(<DescriptionList aria-label="list" isHorizontal termWidth="30px" />);
   const listStyles = {};
   listStyles[`--${styles.descriptionList}__term--width`] = '30px';


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes https://github.com/patternfly/patternfly-react/issues/12252



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated component styling to use imported tokens from the token package instead of locally defined constants.

* **Tests**
  * Re-enabled two previously skipped tests for term width styling functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->