### PR TITLE
fix(NavItem): close managed sidebar on mobile item click

### DIFF
--- a/packages/react-core/src/components/Nav/NavItem.tsx
+++ b/packages/react-core/src/components/Nav/NavItem.tsx
@@ -196,9 +196,9 @@ const NavItemBase: React.FunctionComponent<NavItemProps> = ({
   const tabIndex = isSidebarOpen ? null : -1;
 
   const handleNavItemClick = (event: any, context: NavContextProps, preventLinkDefault: boolean) => {
-    context.onSelect(event, groupId, itemId, to, preventLinkDefault, onClick);
+    context.onSelect?.(event, groupId, itemId, to, preventLinkDefault, onClick);
 
-    if (isManagedSidebar && isMobile && isSidebarOpen) {
+    if (isManagedSidebar && isMobile && isSidebarOpen && !hasFlyout) {
       onSidebarToggle();
     }
   };

--- a/packages/react-core/src/components/Nav/NavItem.tsx
+++ b/packages/react-core/src/components/Nav/NavItem.tsx
@@ -15,6 +15,7 @@ import dividerStyles from '@patternfly/react-styles/css/components/Divider/divid
 import { css } from '@patternfly/react-styles';
 import { NavContext, NavSelectClickHandler } from './Nav';
 import { PageSidebarContext } from '../Page/PageSidebar';
+import { PageContext } from '../Page/PageContext';
 import { useOUIAProps, OUIAProps } from '../../helpers';
 import { Popper } from '../../helpers/Popper/Popper';
 import AngleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-right-icon';
@@ -81,6 +82,7 @@ const NavItemBase: React.FunctionComponent<NavItemProps> = ({
 }: NavItemProps) => {
   const { flyoutRef, setFlyoutRef, navRef } = useContext(NavContext);
   const { isSidebarOpen } = useContext(PageSidebarContext);
+  const { isManagedSidebar, isMobile, onSidebarToggle } = useContext(PageContext);
   const [flyoutTarget, setFlyoutTarget] = useState(null);
   const [isHovered, setIsHovered] = useState(false);
   const _ref = useRef<HTMLLIElement>(undefined);
@@ -193,13 +195,21 @@ const NavItemBase: React.FunctionComponent<NavItemProps> = ({
 
   const tabIndex = isSidebarOpen ? null : -1;
 
+  const handleNavItemClick = (event: any, context: any, preventLinkDefault: boolean) => {
+    context.onSelect(event, groupId, itemId, to, preventLinkDefault, onClick);
+
+    if (isManagedSidebar && isMobile && isSidebarOpen) {
+      onSidebarToggle();
+    }
+  };
+
   const renderDefaultLink = (context: any): React.ReactNode => {
     const preventLinkDefault = preventDefault || !to;
     return (
       <Component
         ref={anchorRef}
         href={to}
-        onClick={(e: any) => context.onSelect(e, groupId, itemId, to, preventLinkDefault, onClick)}
+        onClick={(e: any) => handleNavItemClick(e, context, preventLinkDefault)}
         className={css(
           styles.navLink,
           isActive && styles.modifiers.current,
@@ -220,7 +230,7 @@ const NavItemBase: React.FunctionComponent<NavItemProps> = ({
 
   const renderClonedChild = (context: any, child: React.ReactElement<any>): React.ReactNode =>
     cloneElement(child, {
-      onClick: (e: MouseEvent) => context.onSelect(e, groupId, itemId, to, preventDefault, onClick),
+      onClick: (e: MouseEvent) => handleNavItemClick(e, context, preventDefault),
       'aria-current': isActive ? 'page' : null,
       ...(styleChildren && {
         className: css(styles.navLink, isActive && styles.modifiers.current, child.props && child.props.className)

--- a/packages/react-core/src/components/Nav/NavItem.tsx
+++ b/packages/react-core/src/components/Nav/NavItem.tsx
@@ -13,7 +13,7 @@ import styles from '@patternfly/react-styles/css/components/Nav/nav';
 import menuStyles from '@patternfly/react-styles/css/components/Menu/menu';
 import dividerStyles from '@patternfly/react-styles/css/components/Divider/divider';
 import { css } from '@patternfly/react-styles';
-import { NavContext, NavSelectClickHandler } from './Nav';
+import { NavContext, NavContextProps, NavSelectClickHandler } from './Nav';
 import { PageSidebarContext } from '../Page/PageSidebar';
 import { PageContext } from '../Page/PageContext';
 import { useOUIAProps, OUIAProps } from '../../helpers';
@@ -195,7 +195,7 @@ const NavItemBase: React.FunctionComponent<NavItemProps> = ({
 
   const tabIndex = isSidebarOpen ? null : -1;
 
-  const handleNavItemClick = (event: any, context: any, preventLinkDefault: boolean) => {
+  const handleNavItemClick = (event: any, context: NavContextProps, preventLinkDefault: boolean) => {
     context.onSelect(event, groupId, itemId, to, preventLinkDefault, onClick);
 
     if (isManagedSidebar && isMobile && isSidebarOpen) {
@@ -203,7 +203,7 @@ const NavItemBase: React.FunctionComponent<NavItemProps> = ({
     }
   };
 
-  const renderDefaultLink = (context: any): React.ReactNode => {
+  const renderDefaultLink = (context: NavContextProps): React.ReactNode => {
     const preventLinkDefault = preventDefault || !to;
     return (
       <Component
@@ -228,7 +228,7 @@ const NavItemBase: React.FunctionComponent<NavItemProps> = ({
     );
   };
 
-  const renderClonedChild = (context: any, child: React.ReactElement<any>): React.ReactNode =>
+  const renderClonedChild = (context: NavContextProps, child: React.ReactElement<any>): React.ReactNode =>
     cloneElement(child, {
       onClick: (e: MouseEvent) => handleNavItemClick(e, context, preventDefault),
       'aria-current': isActive ? 'page' : null,


### PR DESCRIPTION
**What**:  
Close a managed Page sidebar on mobile when a nav item is clicked.

**Why**:
When the viewport width is below the desktop breakpoint, selecting a navigation item should automatically close the sidebar to reveal the main content area. (Ref patternfly/patternfly-org#4972)

**Changes**:
- Wire `PageContext` into the `NavItem` component.
- Call `onSidebarToggle` when `isManagedSidebar`, `isMobile`, and `isSidebarOpen` are all true.
- Improve typescript types by using `context: NavContextProps` instead of `context: any`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Navigation sidebar now closes reliably on mobile and in managed sidebar contexts when selecting items without flyouts, preventing it from remaining open unexpectedly.

* **Refactor**
  * Internal navigation handling and context typing improved to make selection and sidebar toggle behavior more consistent and robust.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->