### PR TITLE
fix(icons): update internal import specifier

### DIFF
--- a/packages/react-icons/scripts/writeIcons.mjs
+++ b/packages/react-icons/scripts/writeIcons.mjs
@@ -126,7 +126,7 @@ function writeIcons(icons) {
   });
 
   const esmIndexString = index
-    .map(({ fname, jsName }) => `export { ${jsName}, ${jsName}Config } from './${fname}';`)
+    .map(({ fname, jsName }) => `export { ${jsName}, ${jsName}Config } from './${fname}.js';`)
     .sort()
     .join('\n');
   outputFileSync(join(outDir, 'esm', 'icons/index.js'), esmIndexString);

--- a/packages/react-icons/src/index.ts
+++ b/packages/react-icons/src/index.ts
@@ -1,1 +1,1 @@
-export * from './icons/index';
+export * from './icons/index.js';


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #

Changes in our react/icons now fully specifies our dist/esm output as an ESM module, which requires all imports to be specified. So `import { createIcon } from '../createIcon` is not valid (and likely hasn't been, but this specifier rule either wasn't enforced by older versions of Node/webpack/etc, or the package wasn't fully being treated as ESM since we hadn't previously specified `type: module`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed module export paths to properly reference JavaScript files, improving ESM module resolution compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->