### PR TITLE
fix(Popper): add null & connected checks for document

### DIFF
--- a/packages/react-core/src/helpers/Popper/thirdparty/popper-core/dom-utils/getDocumentElement.ts
+++ b/packages/react-core/src/helpers/Popper/thirdparty/popper-core/dom-utils/getDocumentElement.ts
@@ -7,5 +7,5 @@ import { Window } from '../types';
  */
 export default function getDocumentElement(element: Element | Window): HTMLElement {
   // $FlowFixMe: assume body is always available
-  return (isElement(element) ? element.ownerDocument : element.document).documentElement;
+  return ((isElement(element) ? element.ownerDocument : element.document) || window.document).documentElement;
 }

--- a/packages/react-core/src/helpers/Popper/thirdparty/react-popper/usePopper.ts
+++ b/packages/react-core/src/helpers/Popper/thirdparty/react-popper/usePopper.ts
@@ -35,6 +35,17 @@ type State = {
 
 const EMPTY_MODIFIERS: any = [];
 
+function isReferenceConnected(reference: Element | VirtualElement): boolean {
+  if (reference instanceof Element) {
+    return reference.isConnected;
+  }
+  const { contextElement } = reference;
+  if (contextElement instanceof Element) {
+    return contextElement.isConnected;
+  }
+  return true;
+}
+
 export const usePopper = (
   referenceElement: (Element | VirtualElement) | null | undefined,
   popperElement: HTMLElement | null | undefined,
@@ -111,6 +122,10 @@ export const usePopper = (
 
   useIsomorphicLayoutEffect(() => {
     if (referenceElement == null || popperElement == null) {
+      return;
+    }
+
+    if (!isReferenceConnected(referenceElement) || !popperElement.isConnected) {
       return;
     }
 


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #12255

Adds a fallback to `window.document` for `getDocumentElement.ts` and adds `isConnected` checks for `useIsomorphicLayoutEffect` before `createPopper` is called.