### PR TITLE
feat(Table): update isPlain to apply no-plain when false

### DIFF
--- a/packages/react-table/src/components/Table/Table.tsx
+++ b/packages/react-table/src/components/Table/Table.tsx
@@ -50,7 +50,7 @@ export interface TableProps extends React.HTMLProps<HTMLTableElement>, OUIAProps
   role?: string;
   /** @beta Flag indicating if the table should have plain styling with a transparent background */
   isPlain?: boolean;
-  /** @beta Flag indicating if the table should not have plain styling when in the glass theme. If isPlain is also set, this property will be ignored. */
+  /** @beta Flag indicating if the table should not have plain styling when in the glass theme */
   isNoPlainOnGlass?: boolean;
   /** If set to true, the table header sticks to the top of its container */
   isStickyHeader?: boolean;
@@ -123,13 +123,6 @@ const TableBase: React.FunctionComponent<TableProps> = ({
 
   const [hasSelectableRows, setHasSelectableRows] = useState(false);
   const [tableCaption, setTableCaption] = useState<React.JSX.Element | undefined>();
-
-  if (isPlain && isNoPlainOnGlass) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      "Table: When both isPlain and isNoPlainOnGlass are true, isPlain will take precedence and isNoPlainOnGlass will have no effect. It's recommended to pass only one prop according to the current theme."
-    );
-  }
 
   useEffect(() => {
     document.addEventListener('keydown', handleKeys);
@@ -236,7 +229,7 @@ const TableBase: React.FunctionComponent<TableProps> = ({
           isStriped && styles.modifiers.striped,
           isExpandable && styles.modifiers.expandable,
           isPlain && styles.modifiers.plain,
-          isNoPlainOnGlass && styles.modifiers.noPlain,
+          isNoPlainOnGlass && styles.modifiers.noPlainOnGlass,
           hasNoInset && stylesTreeView.modifiers.noInset,
           isNested && 'pf-m-nested',
           hasAnimations && styles.modifiers.animateExpand

--- a/packages/react-table/src/components/Table/__tests__/Table.test.tsx
+++ b/packages/react-table/src/components/Table/__tests__/Table.test.tsx
@@ -169,20 +169,20 @@ test(`Does not render with class ${styles.modifiers.plain} when isPlain is false
   expect(screen.getByRole('grid', { name: 'Test table' })).not.toHaveClass(styles.modifiers.plain);
 });
 
-test(`Renders with class ${styles.modifiers.noPlain} when isNoPlainOnGlass is true`, () => {
+test(`Renders with class ${styles.modifiers.noPlainOnGlass} when isNoPlainOnGlass is true`, () => {
   render(<Table isNoPlainOnGlass aria-label="Test table" />);
 
-  expect(screen.getByRole('grid', { name: 'Test table' })).toHaveClass(styles.modifiers.noPlain);
+  expect(screen.getByRole('grid', { name: 'Test table' })).toHaveClass(styles.modifiers.noPlainOnGlass);
 });
 
-test(`Does not render with class ${styles.modifiers.noPlain} when isNoPlainOnGlass is undefined`, () => {
+test(`Does not render with class ${styles.modifiers.noPlainOnGlass} when isNoPlainOnGlass is undefined`, () => {
   render(<Table aria-label="Test table" />);
 
-  expect(screen.getByRole('grid', { name: 'Test table' })).not.toHaveClass(styles.modifiers.noPlain);
+  expect(screen.getByRole('grid', { name: 'Test table' })).not.toHaveClass(styles.modifiers.noPlainOnGlass);
 });
 
-test(`Does not render with class ${styles.modifiers.noPlain} when isNoPlainOnGlass is false`, () => {
+test(`Does not render with class ${styles.modifiers.noPlainOnGlass} when isNoPlainOnGlass is false`, () => {
   render(<Table isNoPlainOnGlass={false} aria-label="Test table" />);
 
-  expect(screen.getByRole('grid', { name: 'Test table' })).not.toHaveClass(styles.modifiers.noPlain);
+  expect(screen.getByRole('grid', { name: 'Test table' })).not.toHaveClass(styles.modifiers.noPlainOnGlass);
 });


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #12272

- Adds `isNoPlainOnGlass` flag to apply `pf-m-no-plain`.
- Adds unit tests for `isNoPlainOnGlass`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Table component now includes a new optional `isNoPlainOnGlass` beta prop that provides an alternative styling mode, enabling enhanced visual customization while working independently from existing styling options.

* **Tests**
  * Expanded Table component test coverage to verify correct application of style modifiers based on prop configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->