### PR TITLE
feat(Accordion): Added isPlain and isNoPlainOnGlass prop to Accordion

### DIFF
--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -54,7 +54,7 @@
     "tslib": "^2.8.1"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.5.0-prerelease.65",
+    "@patternfly/patternfly": "6.5.0-prerelease.67",
     "case-anything": "^3.1.2",
     "css": "^3.0.0",
     "fs-extra": "^11.3.3"

--- a/packages/react-core/src/components/Accordion/Accordion.tsx
+++ b/packages/react-core/src/components/Accordion/Accordion.tsx
@@ -1,6 +1,5 @@
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Accordion/accordion';
-import { hasGlassTheme } from '../../helpers/util';
 import { AccordionContext } from './AccordionContext';
 
 export interface AccordionProps extends React.HTMLProps<HTMLDListElement> {
@@ -16,11 +15,9 @@ export interface AccordionProps extends React.HTMLProps<HTMLDListElement> {
   asDefinitionList?: boolean;
   /** Flag to indicate the accordion had a border */
   isBordered?: boolean;
-  /**
-   * Flag to indicate if the accordion uses plain styling. Only applicable when the PatternFly glass
-   * theme is active (e.g. `pf-v6-theme-glass` on the document root); when the glass theme is not
-   * active, this prop has no effect.
-   */
+  /** Flag to prevent the accordion from automatically applying plain styling when glass theme is enabled. */
+  isNoPlainOnGlass?: boolean;
+  /** Flag to add plain styling to the accordion. */
   isPlain?: boolean;
   /** Display size variant. */
   displaySize?: 'default' | 'lg';
@@ -35,6 +32,7 @@ export const Accordion: React.FunctionComponent<AccordionProps> = ({
   headingLevel = 'h3',
   asDefinitionList = true,
   isBordered = false,
+  isNoPlainOnGlass = false,
   isPlain = false,
   displaySize = 'default',
   togglePosition = 'end',
@@ -46,7 +44,8 @@ export const Accordion: React.FunctionComponent<AccordionProps> = ({
       className={css(
         styles.accordion,
         isBordered && styles.modifiers.bordered,
-        !isPlain && hasGlassTheme() && styles.modifiers.noPlain,
+        isNoPlainOnGlass && styles.modifiers.noPlain,
+        isPlain && styles.modifiers.plain,
         togglePosition === 'start' && styles.modifiers.toggleStart,
         displaySize === 'lg' && styles.modifiers.displayLg,
         className

--- a/packages/react-core/src/components/Accordion/Accordion.tsx
+++ b/packages/react-core/src/components/Accordion/Accordion.tsx
@@ -38,20 +38,13 @@ export const Accordion: React.FunctionComponent<AccordionProps> = ({
   togglePosition = 'end',
   ...props
 }: AccordionProps) => {
-  if (isPlain && isNoPlainOnGlass) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `Accordion: When both isPlain and isNoPlainOnGlass are true, styling may conflict. It's recommended to pass only one prop according to the current theme.`
-    );
-  }
-
   const AccordionList: any = asDefinitionList ? 'dl' : 'div';
   return (
     <AccordionList
       className={css(
         styles.accordion,
         isBordered && styles.modifiers.bordered,
-        isNoPlainOnGlass && styles.modifiers.noPlain,
+        isNoPlainOnGlass && styles.modifiers.noPlainOnGlass,
         isPlain && styles.modifiers.plain,
         togglePosition === 'start' && styles.modifiers.toggleStart,
         displaySize === 'lg' && styles.modifiers.displayLg,

--- a/packages/react-core/src/components/Accordion/Accordion.tsx
+++ b/packages/react-core/src/components/Accordion/Accordion.tsx
@@ -16,7 +16,11 @@ export interface AccordionProps extends React.HTMLProps<HTMLDListElement> {
   asDefinitionList?: boolean;
   /** Flag to indicate the accordion had a border */
   isBordered?: boolean;
-  /** Flag to indicate if the accordion is plain */
+  /**
+   * Flag to indicate if the accordion uses plain styling. Only applicable when the PatternFly glass
+   * theme is active (e.g. `pf-v6-theme-glass` on the document root); when the glass theme is not
+   * active, this prop has no effect.
+   */
   isPlain?: boolean;
   /** Display size variant. */
   displaySize?: 'default' | 'lg';

--- a/packages/react-core/src/components/Accordion/Accordion.tsx
+++ b/packages/react-core/src/components/Accordion/Accordion.tsx
@@ -15,9 +15,9 @@ export interface AccordionProps extends React.HTMLProps<HTMLDListElement> {
   asDefinitionList?: boolean;
   /** Flag to indicate the accordion had a border */
   isBordered?: boolean;
-  /** Flag to prevent the accordion from automatically applying plain styling when glass theme is enabled. */
+  /** @beta Flag to prevent the accordion from automatically applying plain styling when glass theme is enabled. */
   isNoPlainOnGlass?: boolean;
-  /** Flag to add plain styling to the accordion. */
+  /** @beta Flag to add plain styling to the accordion. */
   isPlain?: boolean;
   /** Display size variant. */
   displaySize?: 'default' | 'lg';
@@ -38,6 +38,13 @@ export const Accordion: React.FunctionComponent<AccordionProps> = ({
   togglePosition = 'end',
   ...props
 }: AccordionProps) => {
+  if (isPlain && isNoPlainOnGlass) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `Accordion: When both isPlain and isNoPlainOnGlass are true, styling may conflict. It's recommended to pass only one prop according to the current theme.`
+    );
+  }
+
   const AccordionList: any = asDefinitionList ? 'dl' : 'div';
   return (
     <AccordionList

--- a/packages/react-core/src/components/Accordion/Accordion.tsx
+++ b/packages/react-core/src/components/Accordion/Accordion.tsx
@@ -1,5 +1,6 @@
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Accordion/accordion';
+import { hasGlassTheme } from '../../helpers/util';
 import { AccordionContext } from './AccordionContext';
 
 export interface AccordionProps extends React.HTMLProps<HTMLDListElement> {
@@ -15,6 +16,8 @@ export interface AccordionProps extends React.HTMLProps<HTMLDListElement> {
   asDefinitionList?: boolean;
   /** Flag to indicate the accordion had a border */
   isBordered?: boolean;
+  /** Flag to indicate if the accordion is plain */
+  isPlain?: boolean;
   /** Display size variant. */
   displaySize?: 'default' | 'lg';
   /** Sets the toggle icon position for all accordion toggles. */
@@ -28,6 +31,7 @@ export const Accordion: React.FunctionComponent<AccordionProps> = ({
   headingLevel = 'h3',
   asDefinitionList = true,
   isBordered = false,
+  isPlain = false,
   displaySize = 'default',
   togglePosition = 'end',
   ...props
@@ -38,6 +42,7 @@ export const Accordion: React.FunctionComponent<AccordionProps> = ({
       className={css(
         styles.accordion,
         isBordered && styles.modifiers.bordered,
+        !isPlain && hasGlassTheme() && styles.modifiers.noPlain,
         togglePosition === 'start' && styles.modifiers.toggleStart,
         displaySize === 'lg' && styles.modifiers.displayLg,
         className

--- a/packages/react-core/src/components/Accordion/__tests__/Accordion.test.tsx
+++ b/packages/react-core/src/components/Accordion/__tests__/Accordion.test.tsx
@@ -122,28 +122,79 @@ test('Renders with pf-m-bordered when isBordered=true', () => {
   expect(screen.getByText('Test')).toHaveClass('pf-m-bordered');
 });
 
-test('Renders without class pf-m-no-plain by default', () => {
+test(`Renders without class ${styles.modifiers.noPlain} by default`, () => {
   render(<Accordion>Test</Accordion>);
 
-  expect(screen.getByText('Test')).not.toHaveClass('pf-m-no-plain');
+  expect(screen.getByText('Test')).not.toHaveClass(styles.modifiers.noPlain);
 });
 
-test('Renders with class pf-m-no-plain when isNoPlainOnGlass', () => {
+test(`Renders with class ${styles.modifiers.noPlain} when isNoPlainOnGlass`, () => {
   render(<Accordion isNoPlainOnGlass>Test</Accordion>);
 
-  expect(screen.getByText('Test')).toHaveClass('pf-m-no-plain');
+  expect(screen.getByText('Test')).toHaveClass(styles.modifiers.noPlain);
 });
 
-test('Renders without class pf-m-plain by default', () => {
+test(`Renders without class ${styles.modifiers.plain} by default`, () => {
   render(<Accordion>Test</Accordion>);
 
-  expect(screen.getByText('Test')).not.toHaveClass('pf-m-plain');
+  expect(screen.getByText('Test')).not.toHaveClass(styles.modifiers.plain);
 });
 
-test('Renders with class pf-m-plain when isPlain', () => {
+test(`Renders with class ${styles.modifiers.plain} when isPlain`, () => {
   render(<Accordion isPlain>Test</Accordion>);
 
-  expect(screen.getByText('Test')).toHaveClass('pf-m-plain');
+  expect(screen.getByText('Test')).toHaveClass(styles.modifiers.plain);
+});
+
+test('warns when both isPlain and isNoPlainOnGlass are true', () => {
+  const consoleWarning = jest.spyOn(console, 'warn').mockImplementation();
+
+  render(
+    <Accordion isPlain isNoPlainOnGlass>
+      Test
+    </Accordion>
+  );
+
+  expect(consoleWarning).toHaveBeenCalledWith(
+    `Accordion: When both isPlain and isNoPlainOnGlass are true, styling may conflict. It's recommended to pass only one prop according to the current theme.`
+  );
+
+  consoleWarning.mockRestore();
+});
+
+test(`applies both ${styles.modifiers.plain} and ${styles.modifiers.noPlain} when both isPlain and isNoPlainOnGlass are true`, () => {
+  const consoleWarning = jest.spyOn(console, 'warn').mockImplementation();
+
+  render(
+    <Accordion isPlain isNoPlainOnGlass>
+      Test
+    </Accordion>
+  );
+
+  expect(screen.getByText('Test')).toHaveClass(styles.modifiers.plain);
+  expect(screen.getByText('Test')).toHaveClass(styles.modifiers.noPlain);
+
+  consoleWarning.mockRestore();
+});
+
+test('does not warn when only isNoPlainOnGlass is true', () => {
+  const consoleWarning = jest.spyOn(console, 'warn').mockImplementation();
+
+  render(<Accordion isNoPlainOnGlass>Test</Accordion>);
+
+  expect(consoleWarning).not.toHaveBeenCalled();
+
+  consoleWarning.mockRestore();
+});
+
+test('does not warn when only isPlain is true', () => {
+  const consoleWarning = jest.spyOn(console, 'warn').mockImplementation();
+
+  render(<Accordion isPlain>Test</Accordion>);
+
+  expect(consoleWarning).not.toHaveBeenCalled();
+
+  consoleWarning.mockRestore();
 });
 
 test('Renders without pf-m-display-lg by default', () => {

--- a/packages/react-core/src/components/Accordion/__tests__/Accordion.test.tsx
+++ b/packages/react-core/src/components/Accordion/__tests__/Accordion.test.tsx
@@ -143,10 +143,13 @@ test(`Renders without class ${styles.modifiers.noPlain} when isPlain=false and g
 
 test(`Renders with class ${styles.modifiers.noPlain} when isPlain=false and glass theme is applied`, () => {
   document.documentElement.classList.add('pf-v6-theme-glass');
-  render(<Accordion isPlain={false}>Test</Accordion>);
+  try {
+    render(<Accordion isPlain={false}>Test</Accordion>);
 
-  expect(screen.getByText('Test')).toHaveClass(styles.modifiers.noPlain);
-  document.documentElement.classList.remove('pf-v6-theme-glass');
+    expect(screen.getByText('Test')).toHaveClass(styles.modifiers.noPlain);
+  } finally {
+    document.documentElement.classList.remove('pf-v6-theme-glass');
+  }
 });
 
 test(`Renders without class ${styles.modifiers.noPlain} when isPlain=true`, () => {

--- a/packages/react-core/src/components/Accordion/__tests__/Accordion.test.tsx
+++ b/packages/react-core/src/components/Accordion/__tests__/Accordion.test.tsx
@@ -1,7 +1,11 @@
+import '@testing-library/jest-dom';
+// eslint-disable-next-line no-restricted-imports -- React in scope required for TS (test file)
+import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { Accordion } from '../Accordion';
 import { AccordionContext } from '../AccordionContext';
+// @ts-ignore - react-styles subpath module resolution
 import styles from '@patternfly/react-styles/css/components/Accordion/accordion';
 
 test('Renders without children', () => {
@@ -33,7 +37,7 @@ test('Renders with inherited element props spread to the component', () => {
   expect(screen.getByText('Test')).toHaveAccessibleName('Label');
 });
 
-test(`Renders with class name ${styles.accordion}`, () => {
+test(`Renders with class ${styles.accordion}`, () => {
   render(<Accordion>Test</Accordion>);
 
   expect(screen.getByText('Test')).toHaveClass(styles.accordion);
@@ -62,7 +66,7 @@ test('Renders Accordion as a "div" when asDefinitionList is false', () => {
 test('Provides a ContentContainer of "dd" in a context by default', () => {
   render(
     <Accordion>
-      <AccordionContext.Consumer>{({ ContentContainer }) => ContentContainer}</AccordionContext.Consumer>
+      <AccordionContext.Consumer>{({ ContentContainer }) => String(ContentContainer)}</AccordionContext.Consumer>
     </Accordion>
   );
 
@@ -72,7 +76,7 @@ test('Provides a ContentContainer of "dd" in a context by default', () => {
 test('Provides a ContentContainer of "div" in a context when asDefinitionList is false', () => {
   render(
     <Accordion asDefinitionList={false}>
-      <AccordionContext.Consumer>{({ ContentContainer }) => ContentContainer}</AccordionContext.Consumer>
+      <AccordionContext.Consumer>{({ ContentContainer }) => String(ContentContainer)}</AccordionContext.Consumer>
     </Accordion>
   );
 
@@ -82,7 +86,7 @@ test('Provides a ContentContainer of "div" in a context when asDefinitionList is
 test('Provides a ToggleContainer of "dt" in a context by default', () => {
   render(
     <Accordion>
-      <AccordionContext.Consumer>{({ ToggleContainer }) => ToggleContainer}</AccordionContext.Consumer>
+      <AccordionContext.Consumer>{({ ToggleContainer }) => String(ToggleContainer)}</AccordionContext.Consumer>
     </Accordion>
   );
 
@@ -92,7 +96,7 @@ test('Provides a ToggleContainer of "dt" in a context by default', () => {
 test('Provides a ToggleContainer of "h3" in a context when asDefinitionList is false', () => {
   render(
     <Accordion asDefinitionList={false}>
-      <AccordionContext.Consumer>{({ ToggleContainer }) => ToggleContainer}</AccordionContext.Consumer>
+      <AccordionContext.Consumer>{({ ToggleContainer }) => String(ToggleContainer)}</AccordionContext.Consumer>
     </Accordion>
   );
 
@@ -102,7 +106,7 @@ test('Provides a ToggleContainer of "h3" in a context when asDefinitionList is f
 test('Provides a ToggleContainer of "h2" in a context when asDefinitionList is false and headingLevel is "h2"', () => {
   render(
     <Accordion asDefinitionList={false} headingLevel="h2">
-      <AccordionContext.Consumer>{({ ToggleContainer }) => ToggleContainer}</AccordionContext.Consumer>
+      <AccordionContext.Consumer>{({ ToggleContainer }) => String(ToggleContainer)}</AccordionContext.Consumer>
     </Accordion>
   );
 
@@ -119,6 +123,38 @@ test('Renders with pf-m-bordered when isBordered=true', () => {
   render(<Accordion isBordered>Test</Accordion>);
 
   expect(screen.getByText('Test')).toHaveClass('pf-m-bordered');
+});
+
+test(`Renders without class ${styles.modifiers.noPlain} by default`, () => {
+  render(<Accordion>Test</Accordion>);
+
+  expect(screen.getByText('Test')).not.toHaveClass(styles.modifiers.noPlain);
+});
+
+test(`Renders without class ${styles.modifiers.noPlain} when isPlain is undefined`, () => {
+  render(<Accordion isPlain={undefined}>Test</Accordion>);
+
+  expect(screen.getByText('Test')).not.toHaveClass(styles.modifiers.noPlain);
+});
+
+test(`Renders without class ${styles.modifiers.noPlain} when isPlain=false and glass theme is not applied`, () => {
+  render(<Accordion isPlain={false}>Test</Accordion>);
+
+  expect(screen.getByText('Test')).not.toHaveClass(styles.modifiers.noPlain);
+});
+
+test(`Renders with class ${styles.modifiers.noPlain} when isPlain=false and glass theme is applied`, () => {
+  document.documentElement.classList.add('pf-v6-theme-glass');
+  render(<Accordion isPlain={false}>Test</Accordion>);
+
+  expect(screen.getByText('Test')).toHaveClass(styles.modifiers.noPlain);
+  document.documentElement.classList.remove('pf-v6-theme-glass');
+});
+
+test(`Renders without class ${styles.modifiers.noPlain} when isPlain=true`, () => {
+  render(<Accordion isPlain>Test</Accordion>);
+
+  expect(screen.getByText('Test')).not.toHaveClass(styles.modifiers.noPlain);
 });
 
 test('Renders without pf-m-display-lg by default', () => {

--- a/packages/react-core/src/components/Accordion/__tests__/Accordion.test.tsx
+++ b/packages/react-core/src/components/Accordion/__tests__/Accordion.test.tsx
@@ -122,16 +122,16 @@ test('Renders with pf-m-bordered when isBordered=true', () => {
   expect(screen.getByText('Test')).toHaveClass('pf-m-bordered');
 });
 
-test(`Renders without class ${styles.modifiers.noPlain} by default`, () => {
+test(`Renders without class ${styles.modifiers.noPlainOnGlass} by default`, () => {
   render(<Accordion>Test</Accordion>);
 
-  expect(screen.getByText('Test')).not.toHaveClass(styles.modifiers.noPlain);
+  expect(screen.getByText('Test')).not.toHaveClass(styles.modifiers.noPlainOnGlass);
 });
 
-test(`Renders with class ${styles.modifiers.noPlain} when isNoPlainOnGlass`, () => {
+test(`Renders with class ${styles.modifiers.noPlainOnGlass} when isNoPlainOnGlass`, () => {
   render(<Accordion isNoPlainOnGlass>Test</Accordion>);
 
-  expect(screen.getByText('Test')).toHaveClass(styles.modifiers.noPlain);
+  expect(screen.getByText('Test')).toHaveClass(styles.modifiers.noPlainOnGlass);
 });
 
 test(`Renders without class ${styles.modifiers.plain} by default`, () => {
@@ -146,25 +146,7 @@ test(`Renders with class ${styles.modifiers.plain} when isPlain`, () => {
   expect(screen.getByText('Test')).toHaveClass(styles.modifiers.plain);
 });
 
-test('warns when both isPlain and isNoPlainOnGlass are true', () => {
-  const consoleWarning = jest.spyOn(console, 'warn').mockImplementation();
-
-  render(
-    <Accordion isPlain isNoPlainOnGlass>
-      Test
-    </Accordion>
-  );
-
-  expect(consoleWarning).toHaveBeenCalledWith(
-    `Accordion: When both isPlain and isNoPlainOnGlass are true, styling may conflict. It's recommended to pass only one prop according to the current theme.`
-  );
-
-  consoleWarning.mockRestore();
-});
-
-test(`applies both ${styles.modifiers.plain} and ${styles.modifiers.noPlain} when both isPlain and isNoPlainOnGlass are true`, () => {
-  const consoleWarning = jest.spyOn(console, 'warn').mockImplementation();
-
+test(`applies both ${styles.modifiers.plain} and ${styles.modifiers.noPlainOnGlass} when both isPlain and isNoPlainOnGlass are true`, () => {
   render(
     <Accordion isPlain isNoPlainOnGlass>
       Test
@@ -172,29 +154,7 @@ test(`applies both ${styles.modifiers.plain} and ${styles.modifiers.noPlain} whe
   );
 
   expect(screen.getByText('Test')).toHaveClass(styles.modifiers.plain);
-  expect(screen.getByText('Test')).toHaveClass(styles.modifiers.noPlain);
-
-  consoleWarning.mockRestore();
-});
-
-test('does not warn when only isNoPlainOnGlass is true', () => {
-  const consoleWarning = jest.spyOn(console, 'warn').mockImplementation();
-
-  render(<Accordion isNoPlainOnGlass>Test</Accordion>);
-
-  expect(consoleWarning).not.toHaveBeenCalled();
-
-  consoleWarning.mockRestore();
-});
-
-test('does not warn when only isPlain is true', () => {
-  const consoleWarning = jest.spyOn(console, 'warn').mockImplementation();
-
-  render(<Accordion isPlain>Test</Accordion>);
-
-  expect(consoleWarning).not.toHaveBeenCalled();
-
-  consoleWarning.mockRestore();
+  expect(screen.getByText('Test')).toHaveClass(styles.modifiers.noPlainOnGlass);
 });
 
 test('Renders without pf-m-display-lg by default', () => {

--- a/packages/react-core/src/components/Accordion/__tests__/Accordion.test.tsx
+++ b/packages/react-core/src/components/Accordion/__tests__/Accordion.test.tsx
@@ -129,33 +129,22 @@ test(`Renders without class ${styles.modifiers.noPlain} by default`, () => {
   expect(screen.getByText('Test')).not.toHaveClass(styles.modifiers.noPlain);
 });
 
-test(`Renders without class ${styles.modifiers.noPlain} when isPlain is undefined`, () => {
-  render(<Accordion isPlain={undefined}>Test</Accordion>);
+test(`Renders with class ${styles.modifiers.noPlain} when isNoPlainOnGlass`, () => {
+  render(<Accordion isNoPlainOnGlass>Test</Accordion>);
 
-  expect(screen.getByText('Test')).not.toHaveClass(styles.modifiers.noPlain);
+  expect(screen.getByText('Test')).toHaveClass(styles.modifiers.noPlain);
 });
 
-test(`Renders without class ${styles.modifiers.noPlain} when isPlain=false and glass theme is not applied`, () => {
-  render(<Accordion isPlain={false}>Test</Accordion>);
+test(`Renders without class ${styles.modifiers.plain} by default`, () => {
+  render(<Accordion>Test</Accordion>);
 
-  expect(screen.getByText('Test')).not.toHaveClass(styles.modifiers.noPlain);
+  expect(screen.getByText('Test')).not.toHaveClass(styles.modifiers.plain);
 });
 
-test(`Renders with class ${styles.modifiers.noPlain} when isPlain=false and glass theme is applied`, () => {
-  document.documentElement.classList.add('pf-v6-theme-glass');
-  try {
-    render(<Accordion isPlain={false}>Test</Accordion>);
-
-    expect(screen.getByText('Test')).toHaveClass(styles.modifiers.noPlain);
-  } finally {
-    document.documentElement.classList.remove('pf-v6-theme-glass');
-  }
-});
-
-test(`Renders without class ${styles.modifiers.noPlain} when isPlain=true`, () => {
+test(`Renders with class ${styles.modifiers.plain} when isPlain`, () => {
   render(<Accordion isPlain>Test</Accordion>);
 
-  expect(screen.getByText('Test')).not.toHaveClass(styles.modifiers.noPlain);
+  expect(screen.getByText('Test')).toHaveClass(styles.modifiers.plain);
 });
 
 test('Renders without pf-m-display-lg by default', () => {

--- a/packages/react-core/src/components/Accordion/__tests__/Accordion.test.tsx
+++ b/packages/react-core/src/components/Accordion/__tests__/Accordion.test.tsx
@@ -1,11 +1,9 @@
 import '@testing-library/jest-dom';
-// eslint-disable-next-line no-restricted-imports -- React in scope required for TS (test file)
-import React from 'react';
+import { Fragment } from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { Accordion } from '../Accordion';
 import { AccordionContext } from '../AccordionContext';
-// @ts-ignore - react-styles subpath module resolution
 import styles from '@patternfly/react-styles/css/components/Accordion/accordion';
 
 test('Renders without children', () => {
@@ -28,10 +26,10 @@ test('Renders with the passed aria label', () => {
 
 test('Renders with inherited element props spread to the component', () => {
   render(
-    <>
+    <Fragment>
       <Accordion aria-labelledby="labelling-id">Test</Accordion>
       <p id="labelling-id">Label</p>
-    </>
+    </Fragment>
   );
 
   expect(screen.getByText('Test')).toHaveAccessibleName('Label');

--- a/packages/react-core/src/components/Accordion/__tests__/Accordion.test.tsx
+++ b/packages/react-core/src/components/Accordion/__tests__/Accordion.test.tsx
@@ -1,5 +1,4 @@
 import '@testing-library/jest-dom';
-import { Fragment } from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { Accordion } from '../Accordion';
@@ -26,10 +25,10 @@ test('Renders with the passed aria label', () => {
 
 test('Renders with inherited element props spread to the component', () => {
   render(
-    <Fragment>
+    <>
       <Accordion aria-labelledby="labelling-id">Test</Accordion>
       <p id="labelling-id">Label</p>
-    </Fragment>
+    </>
   );
 
   expect(screen.getByText('Test')).toHaveAccessibleName('Label');
@@ -111,16 +110,16 @@ test('Provides a ToggleContainer of "h2" in a context when asDefinitionList is f
   expect(screen.getByText('h2')).toBeVisible();
 });
 
-test('Renders without pf-m-bordered by default', () => {
+test(`Renders without class ${styles.modifiers.bordered} by default`, () => {
   render(<Accordion>Test</Accordion>);
 
-  expect(screen.getByText('Test')).not.toHaveClass('pf-m-bordered');
+  expect(screen.getByText('Test')).not.toHaveClass(styles.modifiers.bordered);
 });
 
-test('Renders with pf-m-bordered when isBordered=true', () => {
+test(`Renders with class ${styles.modifiers.bordered} when isBordered=true`, () => {
   render(<Accordion isBordered>Test</Accordion>);
 
-  expect(screen.getByText('Test')).toHaveClass('pf-m-bordered');
+  expect(screen.getByText('Test')).toHaveClass(styles.modifiers.bordered);
 });
 
 test(`Renders without class ${styles.modifiers.noPlain} by default`, () => {
@@ -147,16 +146,16 @@ test(`Renders with class ${styles.modifiers.plain} when isPlain`, () => {
   expect(screen.getByText('Test')).toHaveClass(styles.modifiers.plain);
 });
 
-test('Renders without pf-m-display-lg by default', () => {
+test(`Renders without class ${styles.modifiers.displayLg} by default`, () => {
   render(<Accordion>Test</Accordion>);
 
-  expect(screen.getByText('Test')).not.toHaveClass('pf-m-display-lg');
+  expect(screen.getByText('Test')).not.toHaveClass(styles.modifiers.displayLg);
 });
 
-test('Renders with pf-m-display-lg when displaySize="lg"', () => {
+test(`Renders with class ${styles.modifiers.displayLg} when displaySize="lg"`, () => {
   render(<Accordion displaySize="lg">Test</Accordion>);
 
-  expect(screen.getByText('Test')).toHaveClass('pf-m-display-lg');
+  expect(screen.getByText('Test')).toHaveClass(styles.modifiers.displayLg);
 });
 
 test(`Renders without class ${styles.modifiers.toggleStart} by default`, () => {

--- a/packages/react-core/src/components/Accordion/__tests__/Accordion.test.tsx
+++ b/packages/react-core/src/components/Accordion/__tests__/Accordion.test.tsx
@@ -34,7 +34,7 @@ test('Renders with inherited element props spread to the component', () => {
   expect(screen.getByText('Test')).toHaveAccessibleName('Label');
 });
 
-test(`Renders with class ${styles.accordion}`, () => {
+test(`Renders with class name ${styles.accordion}`, () => {
   render(<Accordion>Test</Accordion>);
 
   expect(screen.getByText('Test')).toHaveClass(styles.accordion);
@@ -63,7 +63,7 @@ test('Renders Accordion as a "div" when asDefinitionList is false', () => {
 test('Provides a ContentContainer of "dd" in a context by default', () => {
   render(
     <Accordion>
-      <AccordionContext.Consumer>{({ ContentContainer }) => String(ContentContainer)}</AccordionContext.Consumer>
+      <AccordionContext.Consumer>{({ ContentContainer }) => ContentContainer}</AccordionContext.Consumer>
     </Accordion>
   );
 
@@ -73,7 +73,7 @@ test('Provides a ContentContainer of "dd" in a context by default', () => {
 test('Provides a ContentContainer of "div" in a context when asDefinitionList is false', () => {
   render(
     <Accordion asDefinitionList={false}>
-      <AccordionContext.Consumer>{({ ContentContainer }) => String(ContentContainer)}</AccordionContext.Consumer>
+      <AccordionContext.Consumer>{({ ContentContainer }) => ContentContainer}</AccordionContext.Consumer>
     </Accordion>
   );
 
@@ -83,7 +83,7 @@ test('Provides a ContentContainer of "div" in a context when asDefinitionList is
 test('Provides a ToggleContainer of "dt" in a context by default', () => {
   render(
     <Accordion>
-      <AccordionContext.Consumer>{({ ToggleContainer }) => String(ToggleContainer)}</AccordionContext.Consumer>
+      <AccordionContext.Consumer>{({ ToggleContainer }) => ToggleContainer}</AccordionContext.Consumer>
     </Accordion>
   );
 
@@ -93,7 +93,7 @@ test('Provides a ToggleContainer of "dt" in a context by default', () => {
 test('Provides a ToggleContainer of "h3" in a context when asDefinitionList is false', () => {
   render(
     <Accordion asDefinitionList={false}>
-      <AccordionContext.Consumer>{({ ToggleContainer }) => String(ToggleContainer)}</AccordionContext.Consumer>
+      <AccordionContext.Consumer>{({ ToggleContainer }) => ToggleContainer}</AccordionContext.Consumer>
     </Accordion>
   );
 
@@ -103,59 +103,59 @@ test('Provides a ToggleContainer of "h3" in a context when asDefinitionList is f
 test('Provides a ToggleContainer of "h2" in a context when asDefinitionList is false and headingLevel is "h2"', () => {
   render(
     <Accordion asDefinitionList={false} headingLevel="h2">
-      <AccordionContext.Consumer>{({ ToggleContainer }) => String(ToggleContainer)}</AccordionContext.Consumer>
+      <AccordionContext.Consumer>{({ ToggleContainer }) => ToggleContainer}</AccordionContext.Consumer>
     </Accordion>
   );
 
   expect(screen.getByText('h2')).toBeVisible();
 });
 
-test(`Renders without class ${styles.modifiers.bordered} by default`, () => {
+test('Renders without pf-m-bordered by default', () => {
   render(<Accordion>Test</Accordion>);
 
-  expect(screen.getByText('Test')).not.toHaveClass(styles.modifiers.bordered);
+  expect(screen.getByText('Test')).not.toHaveClass('pf-m-bordered');
 });
 
-test(`Renders with class ${styles.modifiers.bordered} when isBordered=true`, () => {
+test('Renders with pf-m-bordered when isBordered=true', () => {
   render(<Accordion isBordered>Test</Accordion>);
 
-  expect(screen.getByText('Test')).toHaveClass(styles.modifiers.bordered);
+  expect(screen.getByText('Test')).toHaveClass('pf-m-bordered');
 });
 
-test(`Renders without class ${styles.modifiers.noPlain} by default`, () => {
+test('Renders without class pf-m-no-plain by default', () => {
   render(<Accordion>Test</Accordion>);
 
-  expect(screen.getByText('Test')).not.toHaveClass(styles.modifiers.noPlain);
+  expect(screen.getByText('Test')).not.toHaveClass('pf-m-no-plain');
 });
 
-test(`Renders with class ${styles.modifiers.noPlain} when isNoPlainOnGlass`, () => {
+test('Renders with class pf-m-no-plain when isNoPlainOnGlass', () => {
   render(<Accordion isNoPlainOnGlass>Test</Accordion>);
 
-  expect(screen.getByText('Test')).toHaveClass(styles.modifiers.noPlain);
+  expect(screen.getByText('Test')).toHaveClass('pf-m-no-plain');
 });
 
-test(`Renders without class ${styles.modifiers.plain} by default`, () => {
+test('Renders without class pf-m-plain by default', () => {
   render(<Accordion>Test</Accordion>);
 
-  expect(screen.getByText('Test')).not.toHaveClass(styles.modifiers.plain);
+  expect(screen.getByText('Test')).not.toHaveClass('pf-m-plain');
 });
 
-test(`Renders with class ${styles.modifiers.plain} when isPlain`, () => {
+test('Renders with class pf-m-plain when isPlain', () => {
   render(<Accordion isPlain>Test</Accordion>);
 
-  expect(screen.getByText('Test')).toHaveClass(styles.modifiers.plain);
+  expect(screen.getByText('Test')).toHaveClass('pf-m-plain');
 });
 
-test(`Renders without class ${styles.modifiers.displayLg} by default`, () => {
+test('Renders without pf-m-display-lg by default', () => {
   render(<Accordion>Test</Accordion>);
 
-  expect(screen.getByText('Test')).not.toHaveClass(styles.modifiers.displayLg);
+  expect(screen.getByText('Test')).not.toHaveClass('pf-m-display-lg');
 });
 
-test(`Renders with class ${styles.modifiers.displayLg} when displaySize="lg"`, () => {
+test('Renders with pf-m-display-lg when displaySize="lg"', () => {
   render(<Accordion displaySize="lg">Test</Accordion>);
 
-  expect(screen.getByText('Test')).toHaveClass(styles.modifiers.displayLg);
+  expect(screen.getByText('Test')).toHaveClass('pf-m-display-lg');
 });
 
 test(`Renders without class ${styles.modifiers.toggleStart} by default`, () => {

--- a/packages/react-core/src/helpers/util.ts
+++ b/packages/react-core/src/helpers/util.ts
@@ -401,8 +401,13 @@ export const canUseDOM = !!(typeof window !== 'undefined' && window.document && 
  *
  * @returns {boolean} - True if the glass theme class is present on the html element
  */
-export const hasGlassTheme = (): boolean =>
-  typeof document !== 'undefined' && document.documentElement.classList.contains('pf-v6-theme-glass');
+export const hasGlassTheme = (): boolean => {
+  if (typeof document === 'undefined') {
+    return false;
+  }
+  const classList = document.documentElement?.classList;
+  return classList ? classList.contains('pf-v6-theme-glass') : false;
+};
 
 /**
  * Calculate the width of the text

--- a/packages/react-core/src/helpers/util.ts
+++ b/packages/react-core/src/helpers/util.ts
@@ -396,20 +396,6 @@ export const toCamel = (s: string) => s.replace(/([-_][a-z])/gi, camelize);
 export const canUseDOM = !!(typeof window !== 'undefined' && window.document && window.document.createElement);
 
 /**
- * Checks if the PatternFly glass theme is applied at the document root.
- * Used by components that adapt styling for glass theme (e.g. Accordion).
- *
- * @returns {boolean} - True if the glass theme class is present on the html element
- */
-export const hasGlassTheme = (): boolean => {
-  if (typeof document === 'undefined') {
-    return false;
-  }
-  const classList = document.documentElement?.classList;
-  return classList ? classList.contains('pf-v6-theme-glass') : false;
-};
-
-/**
  * Calculate the width of the text
  * Example:
  * getTextWidth('my text', node)

--- a/packages/react-core/src/helpers/util.ts
+++ b/packages/react-core/src/helpers/util.ts
@@ -396,6 +396,15 @@ export const toCamel = (s: string) => s.replace(/([-_][a-z])/gi, camelize);
 export const canUseDOM = !!(typeof window !== 'undefined' && window.document && window.document.createElement);
 
 /**
+ * Checks if the PatternFly glass theme is applied at the document root.
+ * Used by components that adapt styling for glass theme (e.g. Accordion).
+ *
+ * @returns {boolean} - True if the glass theme class is present on the html element
+ */
+export const hasGlassTheme = (): boolean =>
+  typeof document !== 'undefined' && document.documentElement.classList.contains('pf-v6-theme-glass');
+
+/**
  * Calculate the width of the text
  * Example:
  * getTextWidth('my text', node)

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -23,7 +23,7 @@
     "test:a11y": "patternfly-a11y --config patternfly-a11y.config"
   },
   "dependencies": {
-    "@patternfly/patternfly": "6.5.0-prerelease.65",
+    "@patternfly/patternfly": "6.5.0-prerelease.67",
     "@patternfly/react-charts": "workspace:^",
     "@patternfly/react-code-editor": "workspace:^",
     "@patternfly/react-core": "workspace:^",

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -35,7 +35,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.15.4",
     "@fortawesome/free-regular-svg-icons": "^5.15.4",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
-    "@patternfly/patternfly": "6.5.0-prerelease.65",
+    "@patternfly/patternfly": "6.5.0-prerelease.67",
     "@rhds/icons": "^2.1.0",
     "fs-extra": "^11.3.3",
     "tslib": "^2.8.1"

--- a/packages/react-integration/cypress/integration/accordion.spec.ts
+++ b/packages/react-integration/cypress/integration/accordion.spec.ts
@@ -28,4 +28,28 @@ describe('Accordion Demo Test', () => {
     cy.get('#divAccordion-item3-content').should('have.attr', 'role', 'region');
     cy.get('#definitionListAccordion-item1-content').should('not.have.attr', 'role');
   });
+
+  it('in glass theme, does not apply glass plain transparent background when pf-m-no-plain-on-glass is present (even with pf-m-plain)', () => {
+    cy.visit('http://localhost:3000/accordion-demo-nav-link');
+    cy.document().then((doc) => {
+      doc.documentElement.classList.add('pf-v6-theme-glass');
+    });
+
+    cy.get('[data-testid="accordion-glass-plain-both"]')
+      .should('have.class', 'pf-m-no-plain-on-glass')
+      .and('have.class', 'pf-m-plain');
+
+    /**
+     * This test fails due to a css bug.
+     */
+    cy.get('[data-testid="accordion-glass-plain-both"]').then(($el) => {
+      const el = $el[0];
+      const win = el.ownerDocument.defaultView;
+      if (!win) {
+        throw new Error('expected window');
+      }
+      const bg = win.getComputedStyle(el).backgroundColor;
+      expect(bg).not.to.match(/rgba\(0,\s*0,\s*0,\s*0\)|transparent/);
+    });
+  });
 });

--- a/packages/react-integration/cypress/integration/accordion.spec.ts
+++ b/packages/react-integration/cypress/integration/accordion.spec.ts
@@ -49,7 +49,8 @@ describe('Accordion Demo Test', () => {
         throw new Error('expected window');
       }
       const bg = win.getComputedStyle(el).backgroundColor;
-      expect(bg).not.to.match(/rgba\(0,\s*0,\s*0,\s*0\)|transparent/);
+      const fullyTransparent = bg === 'transparent' || bg === 'rgba(0, 0, 0, 0)' || bg === 'rgba(0,0,0,0)';
+      expect(fullyTransparent, `expected non-transparent background, got ${bg}`).to.eq(false);
     });
   });
 });

--- a/packages/react-integration/demo-app-ts/src/components/demos/Accordion/AccordionDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/Accordion/AccordionDemo.tsx
@@ -103,6 +103,20 @@ export const AccordionDemo = () => {
           </AccordionContent>
         </AccordionItem>
       </Accordion>
+      <br />
+      <Accordion
+        data-testid="accordion-glass-plain-both"
+        aria-label="Accordion for glass theme integration test"
+        isPlain
+        isNoPlainOnGlass
+      >
+        <AccordionItem isExpanded>
+          <AccordionToggle id="glass-plain-both-toggle">Glass theme: isPlain and isNoPlainOnGlass</AccordionToggle>
+          <AccordionContent id="glass-plain-both-content">
+            <p>Used by Cypress to verify classes and styles under pf-v6-theme-glass.</p>
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
     </>
   );
 };

--- a/packages/react-styles/package.json
+++ b/packages/react-styles/package.json
@@ -19,7 +19,7 @@
     "clean": "rimraf dist css"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.5.0-prerelease.65",
+    "@patternfly/patternfly": "6.5.0-prerelease.67",
     "change-case": "^5.4.4",
     "fs-extra": "^11.3.3"
   },

--- a/packages/react-tokens/package.json
+++ b/packages/react-tokens/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@adobe/css-tools": "^4.4.4",
-    "@patternfly/patternfly": "6.5.0-prerelease.65",
+    "@patternfly/patternfly": "6.5.0-prerelease.67",
     "fs-extra": "^11.3.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5070,10 +5070,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/patternfly@npm:6.5.0-prerelease.65":
-  version: 6.5.0-prerelease.65
-  resolution: "@patternfly/patternfly@npm:6.5.0-prerelease.65"
-  checksum: 10c0/5d6042bb3b3a562b3b1421395edbbd5899f84a3349d45be29f9d3d9a9e18968b8e86275f75a86b9a3720db905679b52a4227377b640c0096f498d584e5f4c2fb
+"@patternfly/patternfly@npm:6.5.0-prerelease.67":
+  version: 6.5.0-prerelease.67
+  resolution: "@patternfly/patternfly@npm:6.5.0-prerelease.67"
+  checksum: 10c0/7e42179e955ef0b300a8814925d59482ca67c87e1018fe350be9875691da86c49d61d5fc1ffc1f37275dc524605351686dd462ee1d0d6703b477308ed75a7c88
   languageName: node
   linkType: hard
 
@@ -5171,7 +5171,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@patternfly/react-core@workspace:packages/react-core"
   dependencies:
-    "@patternfly/patternfly": "npm:6.5.0-prerelease.65"
+    "@patternfly/patternfly": "npm:6.5.0-prerelease.67"
     "@patternfly/react-icons": "workspace:^"
     "@patternfly/react-styles": "workspace:^"
     "@patternfly/react-tokens": "workspace:^"
@@ -5192,7 +5192,7 @@ __metadata:
   resolution: "@patternfly/react-docs@workspace:packages/react-docs"
   dependencies:
     "@patternfly/documentation-framework": "npm:^6.36.8"
-    "@patternfly/patternfly": "npm:6.5.0-prerelease.65"
+    "@patternfly/patternfly": "npm:6.5.0-prerelease.67"
     "@patternfly/patternfly-a11y": "npm:5.1.0"
     "@patternfly/react-charts": "workspace:^"
     "@patternfly/react-code-editor": "workspace:^"
@@ -5232,7 +5232,7 @@ __metadata:
     "@fortawesome/free-brands-svg-icons": "npm:^5.15.4"
     "@fortawesome/free-regular-svg-icons": "npm:^5.15.4"
     "@fortawesome/free-solid-svg-icons": "npm:^5.15.4"
-    "@patternfly/patternfly": "npm:6.5.0-prerelease.65"
+    "@patternfly/patternfly": "npm:6.5.0-prerelease.67"
     "@rhds/icons": "npm:^2.1.0"
     fs-extra: "npm:^11.3.3"
     tslib: "npm:^2.8.1"
@@ -5319,7 +5319,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@patternfly/react-styles@workspace:packages/react-styles"
   dependencies:
-    "@patternfly/patternfly": "npm:6.5.0-prerelease.65"
+    "@patternfly/patternfly": "npm:6.5.0-prerelease.67"
     change-case: "npm:^5.4.4"
     fs-extra: "npm:^11.3.3"
   languageName: unknown
@@ -5361,7 +5361,7 @@ __metadata:
   resolution: "@patternfly/react-tokens@workspace:packages/react-tokens"
   dependencies:
     "@adobe/css-tools": "npm:^4.4.4"
-    "@patternfly/patternfly": "npm:6.5.0-prerelease.65"
+    "@patternfly/patternfly": "npm:6.5.0-prerelease.67"
     fs-extra: "npm:^11.3.3"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #12276 

- Added `isPlain` prop to add `pf-m-plain` class when set 
- Added `isNoPlainOnGlass` prop that adds the `pf-m-no-plain` class to prevent the accordion from automatically applying plain styling when glass theme is enabled



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accordion adds two optional styling flags: a "plain" mode and a flag to adjust plain styling when the glass theme is active.
* **Tests**
  * Expanded tests to cover the new styling flags and verify conditional class behavior and inherited prop handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->