### PR TITLE
feat(Data list): Add isNoPlainOnGlass prop to add pf-m-no-plain modfier to the data list

### DIFF
--- a/packages/react-core/src/components/DataList/DataList.tsx
+++ b/packages/react-core/src/components/DataList/DataList.tsx
@@ -19,27 +19,29 @@ export enum DataListWrapModifier {
 }
 
 export interface DataListProps extends React.HTMLProps<HTMLUListElement> {
-  /** Content rendered inside the DataList list */
+  /** Content rendered inside the data list list */
   children?: React.ReactNode;
-  /** Additional classes added to the DataList list */
+  /** Additional classes added to the data list list */
   className?: string;
-  /** Adds accessible text to the DataList list */
+  /** Adds accessible text to the data list list */
   'aria-label': string;
-  /** Optional callback to make DataList selectable, fired when DataListItem selected */
+  /** Optional callback to make data list selectable, fired when data list item selected */
   onSelectDataListItem?: (event: React.MouseEvent | React.KeyboardEvent, id: string) => void;
-  /** Id of DataList item currently selected */
+  /** Id of data list item currently selected */
   selectedDataListItemId?: string;
-  /** Flag indicating if DataList should have compact styling */
+  /** Flag indicating if data list should have compact styling */
   isCompact?: boolean;
-  /** @beta Flag indicating if DataList should have plain styling with a transparent background */
+  /** @beta Flag indicating if data list should have plain styling with a transparent background */
   isPlain?: boolean;
+  /** @beta Flag to prevent the data list from automatically applying plain styling when glass theme is enabled. When both this and isPlain are true, isPlain takes precedence. */
+  isNoPlainOnGlass?: boolean;
   /** Specifies the grid breakpoints  */
   gridBreakpoint?: 'none' | 'always' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
-  /** Determines which wrapping modifier to apply to the DataList */
+  /** Determines which wrapping modifier to apply to the data list */
   wrapModifier?: DataListWrapModifier | 'nowrap' | 'truncate' | 'breakWord';
   /** Object that causes the data list to render hidden inputs which improve selectable item a11y */
   onSelectableRowChange?: (event: React.FormEvent<HTMLInputElement>, id: string) => void;
-  /** @hide custom ref of the DataList */
+  /** @hide custom ref of the data list */
   innerRef?: React.RefObject<HTMLUListElement | null>;
 }
 
@@ -62,12 +64,20 @@ export const DataListBase: React.FunctionComponent<DataListProps> = ({
   selectedDataListItemId = '',
   isCompact = false,
   isPlain = false,
+  isNoPlainOnGlass = false,
   gridBreakpoint = 'md',
   wrapModifier = null,
   onSelectableRowChange,
   innerRef,
   ...props
 }: DataListProps) => {
+  if (isPlain && isNoPlainOnGlass) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `DataList: When both isPlain and isNoPlainOnGlass are true, isPlain will take precedence and isNoPlainOnGlass will have no effect. It's recommended to pass only one prop according to the current theme.`
+    );
+  }
+
   const isSelectable = onSelectDataListItem !== undefined;
 
   const updateSelectedDataListItem = (event: React.MouseEvent | React.KeyboardEvent, id: string) => {
@@ -88,6 +98,7 @@ export const DataListBase: React.FunctionComponent<DataListProps> = ({
           styles.dataList,
           isCompact && styles.modifiers.compact,
           isPlain && styles.modifiers.plain,
+          isNoPlainOnGlass && styles.modifiers.noPlain,
           gridBreakpointClasses[gridBreakpoint],
           wrapModifier && styles.modifiers[wrapModifier],
           className

--- a/packages/react-core/src/components/DataList/DataList.tsx
+++ b/packages/react-core/src/components/DataList/DataList.tsx
@@ -33,7 +33,7 @@ export interface DataListProps extends React.HTMLProps<HTMLUListElement> {
   isCompact?: boolean;
   /** @beta Flag indicating if data list should have plain styling with a transparent background */
   isPlain?: boolean;
-  /** @beta Flag to prevent the data list from automatically applying plain styling when glass theme is enabled. When both this and isPlain are true, isPlain takes precedence. */
+  /** @beta Flag to prevent the data list from automatically applying plain styling when glass theme is enabled. */
   isNoPlainOnGlass?: boolean;
   /** Specifies the grid breakpoints  */
   gridBreakpoint?: 'none' | 'always' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
@@ -71,13 +71,6 @@ export const DataListBase: React.FunctionComponent<DataListProps> = ({
   innerRef,
   ...props
 }: DataListProps) => {
-  if (isPlain && isNoPlainOnGlass) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `DataList: When both isPlain and isNoPlainOnGlass are true, isPlain will take precedence and isNoPlainOnGlass will have no effect. It's recommended to pass only one prop according to the current theme.`
-    );
-  }
-
   const isSelectable = onSelectDataListItem !== undefined;
 
   const updateSelectedDataListItem = (event: React.MouseEvent | React.KeyboardEvent, id: string) => {
@@ -98,7 +91,7 @@ export const DataListBase: React.FunctionComponent<DataListProps> = ({
           styles.dataList,
           isCompact && styles.modifiers.compact,
           isPlain && styles.modifiers.plain,
-          isNoPlainOnGlass && styles.modifiers.noPlain,
+          isNoPlainOnGlass && styles.modifiers.noPlainOnGlass,
           gridBreakpointClasses[gridBreakpoint],
           wrapModifier && styles.modifiers[wrapModifier],
           className

--- a/packages/react-core/src/components/DataList/DataListAction.tsx
+++ b/packages/react-core/src/components/DataList/DataListAction.tsx
@@ -3,15 +3,15 @@ import styles from '@patternfly/react-styles/css/components/DataList/data-list';
 import { formatBreakpointMods } from '../../helpers/util';
 
 export interface DataListActionProps extends Omit<React.HTMLProps<HTMLDivElement>, 'children'> {
-  /** Content rendered as DataList Action  (e.g <Button> or <Dropdown>) */
+  /** Content rendered as data list action  (e.g <Button> or <Dropdown>) */
   children: React.ReactNode;
-  /** Additional classes added to the DataList Action */
+  /** Additional classes added to the data list action */
   className?: string;
-  /** Identify the DataList toggle number */
+  /** Identify the data list toggle number */
   id: string;
-  /** Adds accessible text to the DataList Action */
+  /** Adds accessible text to the data list action */
   'aria-labelledby': string;
-  /** Adds accessible text to the DataList Action */
+  /** Adds accessible text to the data list action */
   'aria-label': string;
   /** What breakpoints to hide/show the data list action */
   visibility?: {

--- a/packages/react-core/src/components/DataList/DataListCell.tsx
+++ b/packages/react-core/src/components/DataList/DataListCell.tsx
@@ -5,19 +5,19 @@ import { DataListWrapModifier } from './DataList';
 import { Tooltip } from '../Tooltip';
 
 export interface DataListCellProps extends Omit<React.HTMLProps<HTMLDivElement>, 'width'> {
-  /** Content rendered inside the DataList cell */
+  /** Content rendered inside the data list cell */
   children?: React.ReactNode;
-  /** Additional classes added to the DataList cell */
+  /** Additional classes added to the data list cell */
   className?: string;
-  /** Width (from 1-5) to the DataList cell */
+  /** Width (from 1-5) to the data list cell */
   width?: 1 | 2 | 3 | 4 | 5;
-  /** Enables the body Content to fill the height of the card */
+  /** Enables the body content to fill the height of the card */
   isFilled?: boolean;
   /**  Aligns the cell content to the right of its parent. */
   alignRight?: boolean;
-  /** Set to true if the cell content is an Icon */
+  /** Set to true if the cell content is an icon */
   isIcon?: boolean;
-  /** Determines which wrapping modifier to apply to the DataListCell */
+  /** Determines which wrapping modifier to apply to the data list cell */
   wrapModifier?: DataListWrapModifier | 'nowrap' | 'truncate' | 'breakWord';
 }
 

--- a/packages/react-core/src/components/DataList/DataListItemCells.tsx
+++ b/packages/react-core/src/components/DataList/DataListItemCells.tsx
@@ -2,7 +2,7 @@ import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/DataList/data-list';
 
 export interface DataListItemCellsProps extends React.HTMLProps<HTMLDivElement> {
-  /** Additional classes added to the DataList item Content Wrapper.  Children should be one ore more <DataListCell> nodes */
+  /** Additional classes added to the data list item content wrapper.  Children should be one ore more <DataListCell> nodes */
   className?: string;
   /** Array of <DataListCell> nodes that are rendered one after the other. */
   dataListCells?: React.ReactNode;

--- a/packages/react-core/src/components/DataList/DataListItemCells.tsx
+++ b/packages/react-core/src/components/DataList/DataListItemCells.tsx
@@ -2,7 +2,7 @@ import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/DataList/data-list';
 
 export interface DataListItemCellsProps extends React.HTMLProps<HTMLDivElement> {
-  /** Additional classes added to the data list item content wrapper.  Children should be one ore more <DataListCell> nodes */
+  /** Additional classes added to the data list item content wrapper.  Children should be one or more <DataListCell> nodes */
   className?: string;
   /** Array of <DataListCell> nodes that are rendered one after the other. */
   dataListCells?: React.ReactNode;

--- a/packages/react-core/src/components/DataList/DataListToggle.tsx
+++ b/packages/react-core/src/components/DataList/DataListToggle.tsx
@@ -4,17 +4,17 @@ import styles from '@patternfly/react-styles/css/components/DataList/data-list';
 import { Button, ButtonProps, ButtonVariant } from '../Button';
 
 export interface DataListToggleProps extends React.HTMLProps<HTMLDivElement> {
-  /** Additional classes added to the DataList cell */
+  /** Additional classes added to the data list cell */
   className?: string;
-  /** Flag to show if the expanded content of the DataList item is visible */
+  /** Flag to show if the expanded content of the data list item is visible */
   isExpanded?: boolean;
-  /** Identify the DataList toggle number */
+  /** Identify the data list toggle number */
   id: string;
   /** Id for the row */
   rowid?: string;
-  /** Adds accessible text to the DataList toggle */
+  /** Adds accessible text to the data list toggle */
   'aria-labelledby'?: string;
-  /** Adds accessible text to the DataList toggle */
+  /** Adds accessible text to the data list toggle */
   'aria-label'?: string;
   /** Allows users of some screen readers to shift focus to the controlled element. Should be used when the controlled contents are not adjacent to the toggle that controls them. */
   'aria-controls'?: string;

--- a/packages/react-core/src/components/DataList/__tests__/DataList.test.tsx
+++ b/packages/react-core/src/components/DataList/__tests__/DataList.test.tsx
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -75,6 +76,43 @@ test(`Renders with class ${styles.modifiers.plain} when isPlain is true`, () => 
   render(<DataList key="list-id-1" isPlain aria-label="list" />);
 
   expect(screen.getByLabelText('list')).toHaveClass(styles.modifiers.plain);
+});
+
+test(`Renders with ${styles.modifiers.noPlain} when isNoPlainOnGlass is true`, () => {
+  render(<DataList aria-label="list" isNoPlainOnGlass />);
+  expect(screen.getByLabelText('list')).toHaveClass(styles.modifiers.noPlain);
+});
+
+test('Warns when both isPlain and isNoPlainOnGlass are true', () => {
+  const warnSpy = jest.spyOn(global.console, 'warn').mockImplementation(() => {});
+
+  render(<DataList aria-label="list" isPlain isNoPlainOnGlass />);
+
+  expect(warnSpy).toHaveBeenCalledWith(
+    `DataList: When both isPlain and isNoPlainOnGlass are true, isPlain will take precedence and isNoPlainOnGlass will have no effect. It's recommended to pass only one prop according to the current theme.`
+  );
+
+  warnSpy.mockRestore();
+});
+
+test('Does not warn when only isPlain is true', () => {
+  const warnSpy = jest.spyOn(global.console, 'warn').mockImplementation(() => {});
+
+  render(<DataList aria-label="list" isPlain />);
+
+  expect(warnSpy).not.toHaveBeenCalled();
+
+  warnSpy.mockRestore();
+});
+
+test('Does not warn when only isNoPlainOnGlass is true', () => {
+  const warnSpy = jest.spyOn(global.console, 'warn').mockImplementation(() => {});
+
+  render(<DataList aria-label="list" isNoPlainOnGlass />);
+
+  expect(warnSpy).not.toHaveBeenCalled();
+
+  warnSpy.mockRestore();
 });
 
 test('Renders with a hidden input to improve a11y when onSelectableRowChange is passed', () => {

--- a/packages/react-core/src/components/DataList/__tests__/DataList.test.tsx
+++ b/packages/react-core/src/components/DataList/__tests__/DataList.test.tsx
@@ -78,41 +78,16 @@ test(`Renders with class ${styles.modifiers.plain} when isPlain is true`, () => 
   expect(screen.getByLabelText('list')).toHaveClass(styles.modifiers.plain);
 });
 
-test(`Renders with ${styles.modifiers.noPlain} when isNoPlainOnGlass is true`, () => {
+test(`Renders with ${styles.modifiers.noPlainOnGlass} when isNoPlainOnGlass is true`, () => {
   render(<DataList aria-label="list" isNoPlainOnGlass />);
-  expect(screen.getByLabelText('list')).toHaveClass(styles.modifiers.noPlain);
+  expect(screen.getByLabelText('list')).toHaveClass(styles.modifiers.noPlainOnGlass);
 });
 
-test('Warns when both isPlain and isNoPlainOnGlass are true', () => {
-  const warnSpy = jest.spyOn(global.console, 'warn').mockImplementation(() => {});
-
+test(`Renders with both ${styles.modifiers.plain} and ${styles.modifiers.noPlainOnGlass} when isPlain and isNoPlainOnGlass are true`, () => {
   render(<DataList aria-label="list" isPlain isNoPlainOnGlass />);
-
-  expect(warnSpy).toHaveBeenCalledWith(
-    `DataList: When both isPlain and isNoPlainOnGlass are true, isPlain will take precedence and isNoPlainOnGlass will have no effect. It's recommended to pass only one prop according to the current theme.`
-  );
-
-  warnSpy.mockRestore();
-});
-
-test('Does not warn when only isPlain is true', () => {
-  const warnSpy = jest.spyOn(global.console, 'warn').mockImplementation(() => {});
-
-  render(<DataList aria-label="list" isPlain />);
-
-  expect(warnSpy).not.toHaveBeenCalled();
-
-  warnSpy.mockRestore();
-});
-
-test('Does not warn when only isNoPlainOnGlass is true', () => {
-  const warnSpy = jest.spyOn(global.console, 'warn').mockImplementation(() => {});
-
-  render(<DataList aria-label="list" isNoPlainOnGlass />);
-
-  expect(warnSpy).not.toHaveBeenCalled();
-
-  warnSpy.mockRestore();
+  const list = screen.getByLabelText('list');
+  expect(list).toHaveClass(styles.modifiers.plain);
+  expect(list).toHaveClass(styles.modifiers.noPlainOnGlass);
 });
 
 test('Renders with a hidden input to improve a11y when onSelectableRowChange is passed', () => {

--- a/packages/react-integration/cypress/integration/accordion.spec.ts
+++ b/packages/react-integration/cypress/integration/accordion.spec.ts
@@ -39,9 +39,6 @@ describe('Accordion Demo Test', () => {
       .should('have.class', 'pf-m-no-plain-on-glass')
       .and('have.class', 'pf-m-plain');
 
-    /**
-     * This test fails due to a css bug.
-     */
     cy.get('[data-testid="accordion-glass-plain-both"]').then(($el) => {
       const el = $el[0];
       const win = el.ownerDocument.defaultView;

--- a/packages/react-integration/cypress/integration/datalist.spec.ts
+++ b/packages/react-integration/cypress/integration/datalist.spec.ts
@@ -13,19 +13,20 @@ describe('Data List Demo Test', () => {
       .should('have.class', 'pf-m-no-plain-on-glass')
       .and('have.class', 'pf-m-plain');
 
-    /**
-     * This test fails due to a css bug.
-     */
-    cy.get('[data-testid="data-list-glass-plain-both"]').then(($el) => {
-      const el = $el[0];
-      const win = el.ownerDocument.defaultView;
-      if (!win) {
-        throw new Error('expected window');
-      }
-      const bg = win.getComputedStyle(el).backgroundColor;
-      const fullyTransparent = bg === 'transparent' || bg === 'rgba(0, 0, 0, 0)' || bg === 'rgba(0,0,0,0)';
-      expect(fullyTransparent, `expected non-transparent background, got ${bg}`).to.eq(false);
-    });
+    // Glass/plain tokens set --pf-v6-c-data-list__item--BackgroundColor on the list; items paint it.
+    // The `<ul>` has no background-color rule, so its computed background stays transparent.
+    cy.get('[data-testid="data-list-glass-plain-both"] .pf-v6-c-data-list__item')
+      .first()
+      .then(($item) => {
+        const el = $item[0];
+        const win = el.ownerDocument.defaultView;
+        if (!win) {
+          throw new Error('expected window');
+        }
+        const bg = win.getComputedStyle(el).backgroundColor;
+        const fullyTransparent = bg === 'transparent' || bg === 'rgba(0, 0, 0, 0)' || bg === 'rgba(0,0,0,0)';
+        expect(fullyTransparent, `expected non-transparent item background, got ${bg}`).to.eq(false);
+      });
   });
 
   it('Verify rows selectable', () => {

--- a/packages/react-integration/cypress/integration/datalist.spec.ts
+++ b/packages/react-integration/cypress/integration/datalist.spec.ts
@@ -3,7 +3,32 @@ describe('Data List Demo Test', () => {
     cy.visit('http://localhost:3000/data-list-demo-nav-link');
   });
 
+  it('in glass theme, does not apply glass plain transparent background when pf-m-no-plain-on-glass is present (even with pf-m-plain)', () => {
+    cy.visit('http://localhost:3000/data-list-demo-nav-link');
+    cy.document().then((doc) => {
+      doc.documentElement.classList.add('pf-v6-theme-glass');
+    });
+
+    cy.get('[data-testid="data-list-glass-plain-both"]')
+      .should('have.class', 'pf-m-no-plain-on-glass')
+      .and('have.class', 'pf-m-plain');
+
+    /**
+     * This test fails due to a css bug.
+     */
+    cy.get('[data-testid="data-list-glass-plain-both"]').then(($el) => {
+      const el = $el[0];
+      const win = el.ownerDocument.defaultView;
+      if (!win) {
+        throw new Error('expected window');
+      }
+      const bg = win.getComputedStyle(el).backgroundColor;
+      expect(bg).not.to.match(/rgba\(0,\s*0,\s*0,\s*0\)|transparent/);
+    });
+  });
+
   it('Verify rows selectable', () => {
+    cy.visit('http://localhost:3000/data-list-demo-nav-link');
     cy.get('#row1.pf-m-clickable').should('exist');
     cy.get('#row2.pf-m-clickable').should('exist');
 

--- a/packages/react-integration/cypress/integration/datalist.spec.ts
+++ b/packages/react-integration/cypress/integration/datalist.spec.ts
@@ -23,7 +23,8 @@ describe('Data List Demo Test', () => {
         throw new Error('expected window');
       }
       const bg = win.getComputedStyle(el).backgroundColor;
-      expect(bg).not.to.match(/rgba\(0,\s*0,\s*0,\s*0\)|transparent/);
+      const fullyTransparent = bg === 'transparent' || bg === 'rgba(0, 0, 0, 0)' || bg === 'rgba(0,0,0,0)';
+      expect(fullyTransparent, `expected non-transparent background, got ${bg}`).to.eq(false);
     });
   });
 

--- a/packages/react-integration/demo-app-ts/src/components/demos/DataListDemo/DataListDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DataListDemo/DataListDemo.tsx
@@ -48,89 +48,110 @@ class DataListDemo extends Component<DataListProps, DataListState> {
 
   render() {
     return (
-      <DataList
-        aria-label="Simple data list example"
-        selectedDataListItemId={this.state.selectedDataListItemId}
-        onSelectDataListItem={this.onSelectDataListItem}
-      >
-        <DataListItem aria-labelledby="simple-item1" id="row1">
-          <DataListItemRow>
-            <DataListItemCells
-              dataListCells={[
-                <DataListCell key="primary content">
-                  <span id="simple-item1">Primary content</span>
-                </DataListCell>,
-                <DataListCell key="secondary content">
-                  <span id="simple-item2">Secondary content</span>
-                </DataListCell>
-              ]}
-            />
-            <DataListAction
-              aria-labelledby="selectable-action-item1 selectable-action-action1"
-              id="selectable-action-action1"
-              aria-label="Actions"
-            >
-              <Dropdown
-                id="dropdown"
-                isOpen={this.state.isOpen}
-                onSelect={this.onSelect}
-                onOpenChange={(isOpen) => this.setState({ isOpen })}
-                toggle={(toggleRef) => (
-                  <MenuToggle
-                    variant="plain"
-                    ref={toggleRef}
-                    isExpanded={this.state.isOpen}
-                    onClick={this.onToggle}
-                    icon={<EllipsisVIcon />}
-                  />
-                )}
+      <>
+        <DataList
+          aria-label="Simple data list example"
+          selectedDataListItemId={this.state.selectedDataListItemId}
+          onSelectDataListItem={this.onSelectDataListItem}
+        >
+          <DataListItem aria-labelledby="simple-item1" id="row1">
+            <DataListItemRow>
+              <DataListItemCells
+                dataListCells={[
+                  <DataListCell key="primary content">
+                    <span id="simple-item1">Primary content</span>
+                  </DataListCell>,
+                  <DataListCell key="secondary content">
+                    <span id="simple-item2">Secondary content</span>
+                  </DataListCell>
+                ]}
+              />
+              <DataListAction
+                aria-labelledby="selectable-action-item1 selectable-action-action1"
+                id="selectable-action-action1"
+                aria-label="Actions"
               >
-                <DropdownList>
-                  <DropdownItem key="link">Link</DropdownItem>
-                  <DropdownItem key="action">Action</DropdownItem>
-                  <DropdownItem key="disabled link" isDisabled>
-                    Disabled Link
-                  </DropdownItem>
-                </DropdownList>
-              </Dropdown>
-            </DataListAction>
-          </DataListItemRow>
-        </DataListItem>
-        <DataListItem aria-labelledby="simple-item2" id="row2">
-          <DataListItemRow>
-            <DataListItemCells
-              dataListCells={[
-                <DataListCell isFilled={false} key="secondary content fill">
-                  <span id="simple-item3">Secondary content (pf-m-no-fill)</span>
-                </DataListCell>,
-                <DataListCell isFilled={false} alignRight key="secondary content align">
-                  <span id="simple-item4">Secondary content (pf-m-align-right pf-m-no-fill)</span>
-                </DataListCell>
-              ]}
-            />
-          </DataListItemRow>
-        </DataListItem>
-        <DataListItem aria-labelledby="simple-item3">
-          <DataListItemRow>
-            <DataListItemCells
-              dataListCells={[
-                <DataListCell key="primary content" wrapModifier={DataListWrapModifier.breakWord}>
-                  <span id="simple-item1">Primary content</span>
-                </DataListCell>,
-                <DataListCell
-                  id="truncate-content"
-                  key="secondary content"
-                  wrapModifier={DataListWrapModifier.truncate}
+                <Dropdown
+                  id="dropdown"
+                  isOpen={this.state.isOpen}
+                  onSelect={this.onSelect}
+                  onOpenChange={(isOpen) => this.setState({ isOpen })}
+                  toggle={(toggleRef) => (
+                    <MenuToggle
+                      variant="plain"
+                      ref={toggleRef}
+                      isExpanded={this.state.isOpen}
+                      onClick={this.onToggle}
+                      icon={<EllipsisVIcon />}
+                    />
+                  )}
                 >
-                  Really really really really really really really really really really really really really really
-                  really really really really really really really really really really really really really really long
-                  description that should be truncated before it ends
-                </DataListCell>
-              ]}
-            />
-          </DataListItemRow>
-        </DataListItem>
-      </DataList>
+                  <DropdownList>
+                    <DropdownItem key="link">Link</DropdownItem>
+                    <DropdownItem key="action">Action</DropdownItem>
+                    <DropdownItem key="disabled link" isDisabled>
+                      Disabled Link
+                    </DropdownItem>
+                  </DropdownList>
+                </Dropdown>
+              </DataListAction>
+            </DataListItemRow>
+          </DataListItem>
+          <DataListItem aria-labelledby="simple-item2" id="row2">
+            <DataListItemRow>
+              <DataListItemCells
+                dataListCells={[
+                  <DataListCell isFilled={false} key="secondary content fill">
+                    <span id="simple-item3">Secondary content (pf-m-no-fill)</span>
+                  </DataListCell>,
+                  <DataListCell isFilled={false} alignRight key="secondary content align">
+                    <span id="simple-item4">Secondary content (pf-m-align-right pf-m-no-fill)</span>
+                  </DataListCell>
+                ]}
+              />
+            </DataListItemRow>
+          </DataListItem>
+          <DataListItem aria-labelledby="simple-item3">
+            <DataListItemRow>
+              <DataListItemCells
+                dataListCells={[
+                  <DataListCell key="primary content" wrapModifier={DataListWrapModifier.breakWord}>
+                    <span id="simple-item1">Primary content</span>
+                  </DataListCell>,
+                  <DataListCell
+                    id="truncate-content"
+                    key="secondary content"
+                    wrapModifier={DataListWrapModifier.truncate}
+                  >
+                    Really really really really really really really really really really really really really really
+                    really really really really really really really really really really really really really really
+                    long description that should be truncated before it ends
+                  </DataListCell>
+                ]}
+              />
+            </DataListItemRow>
+          </DataListItem>
+        </DataList>
+        <br />
+        <DataList
+          data-testid="data-list-glass-plain-both"
+          aria-label="Data list for glass theme integration test"
+          isPlain
+          isNoPlainOnGlass
+        >
+          <DataListItem aria-labelledby="glass-plain-item1">
+            <DataListItemRow>
+              <DataListItemCells
+                dataListCells={[
+                  <DataListCell key="primary">
+                    <span id="glass-plain-item1">Glass theme: isPlain and isNoPlainOnGlass</span>
+                  </DataListCell>
+                ]}
+              />
+            </DataListItemRow>
+          </DataListItem>
+        </DataList>
+      </>
     );
   }
 }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #12275 

- Added beta prop `isNoPlainOnGlass`; when true, applies the `pf-m-no-plain` on the root list so plain styling is not forced under the glass theme.
- Added test to  over `isNoPlainOnGlass` by asserting `styles.modifiers.noPlain`. 


<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
Normalize JSDoc wording to “data list” (and small casing tweaks) in DataListAction, DataListCell, DataListItemCells, and DataListToggle — no API or behavior changes there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a beta toggle to DataList to enable an alternative "no plain on glass" styling modifier.

* **Documentation**
  * Standardized and clarified JSDoc wording across DataList, DataListAction, DataListCell, DataListItemCells, and DataListToggle.

* **Tests**
  * Added unit and end-to-end tests verifying the new styling toggle and combined-styles behavior, and ensured demo navigation before row selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->