### PR TITLE
feat(Page): added styles for glass

### DIFF
--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -54,7 +54,7 @@
     "tslib": "^2.8.1"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.5.0-prerelease.62",
+    "@patternfly/patternfly": "6.5.0-prerelease.65",
     "case-anything": "^3.1.2",
     "css": "^3.0.0",
     "fs-extra": "^11.3.3"

--- a/packages/react-core/src/components/Page/Page.tsx
+++ b/packages/react-core/src/components/Page/Page.tsx
@@ -348,7 +348,13 @@ class Page extends Component<PageProps, PageState> {
           )}
         >
           {skipToContent}
-          {variant === 'docked' ? <div className={css(styles.pageDock)}>{masthead}</div> : masthead}
+          {variant === 'docked' ? (
+            <div className={css(styles.pageDock)}>
+              <div className={css(styles.pageDockMain)}>{masthead}</div>
+            </div>
+          ) : (
+            masthead
+          )}
           {sidebar}
           {notificationDrawer && (
             <div className={css(styles.pageDrawer)}>

--- a/packages/react-core/src/components/Page/PageGroup.tsx
+++ b/packages/react-core/src/components/Page/PageGroup.tsx
@@ -27,6 +27,10 @@ export interface PageGroupProps extends React.HTMLProps<HTMLDivElement> {
   hasOverflowScroll?: boolean;
   /** Adds an accessible name to the page group when the hasOverflowScroll prop is set to true. */
   'aria-label'?: string;
+  /** Adds plain styling to the page group. */
+  isPlain?: boolean;
+  /** @beta Prevents the page group from automatically applying plain styling when glass theme is enabled. */
+  isNoPlainOnGlass?: boolean;
 }
 
 export const PageGroup = ({
@@ -38,6 +42,8 @@ export const PageGroup = ({
   hasShadowBottom = false,
   hasOverflowScroll = false,
   'aria-label': ariaLabel,
+  isPlain = false,
+  isNoPlainOnGlass = false,
   ...props
 }: PageGroupProps) => {
   const { height, getVerticalBreakpoint } = useContext(PageContext);
@@ -60,6 +66,8 @@ export const PageGroup = ({
         hasShadowTop && styles.modifiers.shadowTop,
         hasShadowBottom && styles.modifiers.shadowBottom,
         hasOverflowScroll && styles.modifiers.overflowScroll,
+        isPlain && styles.modifiers.plain,
+        isNoPlainOnGlass && styles.modifiers.noPlainOnGlass,
         className
       )}
       {...(hasOverflowScroll && { tabIndex: 0, role: 'region', 'aria-label': ariaLabel })}

--- a/packages/react-core/src/components/Page/PageGroup.tsx
+++ b/packages/react-core/src/components/Page/PageGroup.tsx
@@ -46,13 +46,6 @@ export const PageGroup = ({
   isNoPlainOnGlass = false,
   ...props
 }: PageGroupProps) => {
-  if (isPlain && isNoPlainOnGlass) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `PageGroup: When both isPlain and isNoPlainOnGlass are true, isPlain will take precedence and isNoPlainOnGlass will have no effect. It's recommended to pass only one prop according to the current theme.`
-    );
-  }
-
   const { height, getVerticalBreakpoint } = useContext(PageContext);
 
   useEffect(() => {

--- a/packages/react-core/src/components/Page/PageGroup.tsx
+++ b/packages/react-core/src/components/Page/PageGroup.tsx
@@ -29,7 +29,7 @@ export interface PageGroupProps extends React.HTMLProps<HTMLDivElement> {
   'aria-label'?: string;
   /** Adds plain styling to the page group. */
   isPlain?: boolean;
-  /** @beta Prevents the page group from automatically applying plain styling when glass theme is enabled. */
+  /** @beta Prevents the page group from automatically applying plain styling when glass theme is enabled. When both this and isPlain are true, isPlain takes precedence. */
   isNoPlainOnGlass?: boolean;
 }
 
@@ -46,6 +46,13 @@ export const PageGroup = ({
   isNoPlainOnGlass = false,
   ...props
 }: PageGroupProps) => {
+  if (isPlain && isNoPlainOnGlass) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `PageGroup: When both isPlain and isNoPlainOnGlass are true, isPlain will take precedence and isNoPlainOnGlass will have no effect. It's recommended to pass only one prop according to the current theme.`
+    );
+  }
+
   const { height, getVerticalBreakpoint } = useContext(PageContext);
 
   useEffect(() => {

--- a/packages/react-core/src/components/Page/PageGroup.tsx
+++ b/packages/react-core/src/components/Page/PageGroup.tsx
@@ -29,7 +29,7 @@ export interface PageGroupProps extends React.HTMLProps<HTMLDivElement> {
   'aria-label'?: string;
   /** Adds plain styling to the page group. */
   isPlain?: boolean;
-  /** @beta Prevents the page group from automatically applying plain styling when glass theme is enabled. When both this and isPlain are true, isPlain takes precedence. */
+  /** @beta Prevents the page group from automatically applying plain styling when glass theme is enabled. */
   isNoPlainOnGlass?: boolean;
 }
 

--- a/packages/react-core/src/components/Page/PageSection.tsx
+++ b/packages/react-core/src/components/Page/PageSection.tsx
@@ -67,6 +67,10 @@ export interface PageSectionProps extends React.HTMLProps<HTMLDivElement> {
   'aria-label'?: string;
   /** Sets the base component to render. Defaults to section */
   component?: keyof React.JSX.IntrinsicElements;
+  /** Adds plain styling to the page section. */
+  isPlain?: boolean;
+  /** @beta Prevents the page section from automatically applying plain styling when glass theme is enabled. */
+  isNoPlainOnGlass?: boolean;
 }
 
 const variantType = {
@@ -98,6 +102,8 @@ export const PageSection: React.FunctionComponent<PageSectionProps> = ({
   'aria-label': ariaLabel,
   component = 'section',
   hasBodyWrapper = true,
+  isPlain = false,
+  isNoPlainOnGlass = false,
   ...props
 }: PageSectionProps) => {
   const { height, getVerticalBreakpoint } = useContext(PageContext);
@@ -126,6 +132,8 @@ export const PageSection: React.FunctionComponent<PageSectionProps> = ({
         hasShadowTop && styles.modifiers.shadowTop,
         hasShadowBottom && styles.modifiers.shadowBottom,
         hasOverflowScroll && styles.modifiers.overflowScroll,
+        isPlain && styles.modifiers.plain,
+        isNoPlainOnGlass && styles.modifiers.noPlainOnGlass,
         className
       )}
       {...(hasOverflowScroll && { tabIndex: 0 })}

--- a/packages/react-core/src/components/Page/PageSection.tsx
+++ b/packages/react-core/src/components/Page/PageSection.tsx
@@ -69,7 +69,7 @@ export interface PageSectionProps extends React.HTMLProps<HTMLDivElement> {
   component?: keyof React.JSX.IntrinsicElements;
   /** Adds plain styling to the page section. */
   isPlain?: boolean;
-  /** @beta Prevents the page section from automatically applying plain styling when glass theme is enabled. When both this and isPlain are true, isPlain takes precedence. */
+  /** @beta Prevents the page section from automatically applying plain styling when glass theme is enabled. */
   isNoPlainOnGlass?: boolean;
 }
 

--- a/packages/react-core/src/components/Page/PageSection.tsx
+++ b/packages/react-core/src/components/Page/PageSection.tsx
@@ -69,7 +69,7 @@ export interface PageSectionProps extends React.HTMLProps<HTMLDivElement> {
   component?: keyof React.JSX.IntrinsicElements;
   /** Adds plain styling to the page section. */
   isPlain?: boolean;
-  /** @beta Prevents the page section from automatically applying plain styling when glass theme is enabled. */
+  /** @beta Prevents the page section from automatically applying plain styling when glass theme is enabled. When both this and isPlain are true, isPlain takes precedence. */
   isNoPlainOnGlass?: boolean;
 }
 
@@ -106,6 +106,13 @@ export const PageSection: React.FunctionComponent<PageSectionProps> = ({
   isNoPlainOnGlass = false,
   ...props
 }: PageSectionProps) => {
+  if (isPlain && isNoPlainOnGlass) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `PageSection: When both isPlain and isNoPlainOnGlass are true, isPlain will take precedence and isNoPlainOnGlass will have no effect. It's recommended to pass only one prop according to the current theme.`
+    );
+  }
+
   const { height, getVerticalBreakpoint } = useContext(PageContext);
 
   useEffect(() => {

--- a/packages/react-core/src/components/Page/PageSection.tsx
+++ b/packages/react-core/src/components/Page/PageSection.tsx
@@ -106,13 +106,6 @@ export const PageSection: React.FunctionComponent<PageSectionProps> = ({
   isNoPlainOnGlass = false,
   ...props
 }: PageSectionProps) => {
-  if (isPlain && isNoPlainOnGlass) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `PageSection: When both isPlain and isNoPlainOnGlass are true, isPlain will take precedence and isNoPlainOnGlass will have no effect. It's recommended to pass only one prop according to the current theme.`
-    );
-  }
-
   const { height, getVerticalBreakpoint } = useContext(PageContext);
 
   useEffect(() => {

--- a/packages/react-core/src/components/Page/PageSidebar.tsx
+++ b/packages/react-core/src/components/Page/PageSidebar.tsx
@@ -50,7 +50,9 @@ export const PageSidebar: React.FunctionComponent<PageSidebarProps> = ({
           aria-hidden={!sidebarOpen}
           {...props}
         >
-          <PageSidebarContext.Provider value={{ isSidebarOpen: sidebarOpen }}>{children}</PageSidebarContext.Provider>
+          <PageSidebarContext.Provider value={{ isSidebarOpen: sidebarOpen }}>
+            <div className={css(styles.pageSidebarMain)}>{children}</div>
+          </PageSidebarContext.Provider>
         </div>
       );
     }}

--- a/packages/react-core/src/components/Page/__tests__/Generated/__snapshots__/PageSidebar.test.tsx.snap
+++ b/packages/react-core/src/components/Page/__tests__/Generated/__snapshots__/PageSidebar.test.tsx.snap
@@ -7,8 +7,12 @@ exports[`PageSidebar should match snapshot (auto-generated) 1`] = `
     class="pf-v6-c-page__sidebar ''"
     id="page-sidebar"
   >
-    <div>
-      ReactNode
+    <div
+      class="pf-v6-c-page__sidebar-main"
+    >
+      <div>
+        ReactNode
+      </div>
     </div>
   </div>
 </DocumentFragment>

--- a/packages/react-core/src/components/Page/__tests__/Page.test.tsx
+++ b/packages/react-core/src/components/Page/__tests__/Page.test.tsx
@@ -408,13 +408,6 @@ describe('Page', () => {
   });
 
   test(`Renders with ${styles.pageDockMain} wrapper when variant is docked`, () => {
-    render(<Page masthead={<>Masthead</>} data-testid="page"></Page>);
-
-    const pageDockMain = screen.getByText('Masthead').closest(`.${styles.pageDockMain}`);
-    expect(pageDockMain).not.toBeInTheDocument();
-  });
-
-  test(`Renders with ${styles.pageDockMain} wrapper when variant is docked`, () => {
     render(<Page variant="docked" masthead={<>Masthead</>} data-testid="page"></Page>);
 
     const pageDockMain = screen.getByText('Masthead').closest(`.${styles.pageDockMain}`);

--- a/packages/react-core/src/components/Page/__tests__/Page.test.tsx
+++ b/packages/react-core/src/components/Page/__tests__/Page.test.tsx
@@ -406,4 +406,18 @@ describe('Page', () => {
     render(<Page data-testid="page"></Page>);
     expect(screen.getByTestId('page')).not.toHaveClass(styles.modifiers.dock);
   });
+
+  test(`Renders with ${styles.pageDockMain} wrapper when variant is docked`, () => {
+    render(<Page masthead={<>Masthead</>} data-testid="page"></Page>);
+
+    const pageDockMain = screen.getByText('Masthead').closest(`.${styles.pageDockMain}`);
+    expect(pageDockMain).not.toBeInTheDocument();
+  });
+
+  test(`Renders with ${styles.pageDockMain} wrapper when variant is docked`, () => {
+    render(<Page variant="docked" masthead={<>Masthead</>} data-testid="page"></Page>);
+
+    const pageDockMain = screen.getByText('Masthead').closest(`.${styles.pageDockMain}`);
+    expect(pageDockMain).toBeInTheDocument();
+  });
 });

--- a/packages/react-core/src/components/Page/__tests__/PageGroup.test.tsx
+++ b/packages/react-core/src/components/Page/__tests__/PageGroup.test.tsx
@@ -96,7 +96,7 @@ test(`Renders with ${styles.modifiers.plain} class when isPlain is true`, () => 
   expect(screen.getByText('test')).toHaveClass(styles.modifiers.plain);
 });
 
-test(`Renders with ${styles.modifiers.noPlainOnGlass} class when isPlain is true`, () => {
+test(`Renders with ${styles.modifiers.noPlainOnGlass} class when isNoPlainOnGlass is true`, () => {
   render(<PageGroup isNoPlainOnGlass>test</PageGroup>);
 
   expect(screen.getByText('test')).toHaveClass(styles.modifiers.noPlainOnGlass);

--- a/packages/react-core/src/components/Page/__tests__/PageGroup.test.tsx
+++ b/packages/react-core/src/components/Page/__tests__/PageGroup.test.tsx
@@ -101,3 +101,33 @@ test(`Renders with ${styles.modifiers.noPlainOnGlass} class when isPlain is true
 
   expect(screen.getByText('test')).toHaveClass(styles.modifiers.noPlainOnGlass);
 });
+
+test('Does not log a warning when only isPlain is passed', () => {
+  const consoleWarning = jest.spyOn(console, 'warn').mockImplementation();
+
+  render(<PageGroup isPlain>test</PageGroup>);
+
+  expect(consoleWarning).not.toHaveBeenCalled();
+});
+
+test('Does not log a warning when only isNoPlainOnGlass is passed', () => {
+  const consoleWarning = jest.spyOn(console, 'warn').mockImplementation();
+
+  render(<PageGroup isNoPlainOnGlass>test</PageGroup>);
+
+  expect(consoleWarning).not.toHaveBeenCalled();
+});
+
+test('Logs a warning when both isPlain and isNoPlainOnGlass are passed', () => {
+  const consoleWarning = jest.spyOn(console, 'warn').mockImplementation();
+
+  render(
+    <PageGroup isPlain isNoPlainOnGlass>
+      test
+    </PageGroup>
+  );
+
+  expect(consoleWarning).toHaveBeenCalledWith(
+    `PageGroup: When both isPlain and isNoPlainOnGlass are true, isPlain will take precedence and isNoPlainOnGlass will have no effect. It's recommended to pass only one prop according to the current theme.`
+  );
+});

--- a/packages/react-core/src/components/Page/__tests__/PageGroup.test.tsx
+++ b/packages/react-core/src/components/Page/__tests__/PageGroup.test.tsx
@@ -2,92 +2,102 @@ import { render, screen } from '@testing-library/react';
 import { PageGroup } from '../PageGroup';
 import styles from '@patternfly/react-styles/css/components/Page/page';
 
-describe('page group', () => {
-  test('Verify basic render', () => {
-    const { asFragment } = render(<PageGroup>test</PageGroup>);
-    expect(asFragment()).toMatchSnapshot();
-  });
-  test('Verify top sticky', () => {
-    const { asFragment } = render(<PageGroup stickyOnBreakpoint={{ default: 'top' }}>test</PageGroup>);
-    expect(asFragment()).toMatchSnapshot();
-  });
-  test('Verify bottom sticky', () => {
-    const { asFragment } = render(<PageGroup stickyOnBreakpoint={{ default: 'bottom' }}>test</PageGroup>);
-    expect(asFragment()).toMatchSnapshot();
-  });
-  test('Verify top shadow', () => {
-    const { asFragment } = render(<PageGroup hasShadowTop>test</PageGroup>);
-    expect(asFragment()).toMatchSnapshot();
-  });
-  test('Verify bottom shadow', () => {
-    const { asFragment } = render(<PageGroup hasShadowBottom>test</PageGroup>);
-    expect(asFragment()).toMatchSnapshot();
-  });
-  test('Verify overflow scroll', () => {
-    const { asFragment } = render(<PageGroup hasOverflowScroll>test</PageGroup>);
-    expect(asFragment()).toMatchSnapshot();
-  });
+test('Verify basic render', () => {
+  const { asFragment } = render(<PageGroup>test</PageGroup>);
+  expect(asFragment()).toMatchSnapshot();
+});
+test('Verify top sticky', () => {
+  const { asFragment } = render(<PageGroup stickyOnBreakpoint={{ default: 'top' }}>test</PageGroup>);
+  expect(asFragment()).toMatchSnapshot();
+});
+test('Verify bottom sticky', () => {
+  const { asFragment } = render(<PageGroup stickyOnBreakpoint={{ default: 'bottom' }}>test</PageGroup>);
+  expect(asFragment()).toMatchSnapshot();
+});
+test('Verify top shadow', () => {
+  const { asFragment } = render(<PageGroup hasShadowTop>test</PageGroup>);
+  expect(asFragment()).toMatchSnapshot();
+});
+test('Verify bottom shadow', () => {
+  const { asFragment } = render(<PageGroup hasShadowBottom>test</PageGroup>);
+  expect(asFragment()).toMatchSnapshot();
+});
+test('Verify overflow scroll', () => {
+  const { asFragment } = render(<PageGroup hasOverflowScroll>test</PageGroup>);
+  expect(asFragment()).toMatchSnapshot();
+});
 
-  test('Renders without an aria-label by default', () => {
-    render(<PageGroup>test</PageGroup>);
+test('Renders without an aria-label by default', () => {
+  render(<PageGroup>test</PageGroup>);
 
-    expect(screen.getByText('test')).not.toHaveAccessibleName('Test label');
-  });
+  expect(screen.getByText('test')).not.toHaveAccessibleName('Test label');
+});
 
-  test('Renders with the passed aria-label applied', () => {
-    render(
-      <PageGroup aria-label="Test label" hasOverflowScroll>
-        test
-      </PageGroup>
-    );
+test('Renders with the passed aria-label applied', () => {
+  render(
+    <PageGroup aria-label="Test label" hasOverflowScroll>
+      test
+    </PageGroup>
+  );
 
-    expect(screen.getByText('test')).toHaveAccessibleName('Test label');
-  });
+  expect(screen.getByText('test')).toHaveAccessibleName('Test label');
+});
 
-  test('Does not log a warning in the console by default', () => {
-    const consoleWarning = jest.spyOn(console, 'warn').mockImplementation();
+test('Does not log a warning in the console by default', () => {
+  const consoleWarning = jest.spyOn(console, 'warn').mockImplementation();
 
-    render(<PageGroup>test</PageGroup>);
+  render(<PageGroup>test</PageGroup>);
 
-    expect(consoleWarning).not.toHaveBeenCalled();
-  });
+  expect(consoleWarning).not.toHaveBeenCalled();
+});
 
-  test('Does not log a warning in the console when an aria-label is included with hasOverflowScroll', () => {
-    const consoleWarning = jest.spyOn(console, 'warn').mockImplementation();
+test('Does not log a warning in the console when an aria-label is included with hasOverflowScroll', () => {
+  const consoleWarning = jest.spyOn(console, 'warn').mockImplementation();
 
-    render(
-      <PageGroup hasOverflowScroll aria-label="Test label">
-        test
-      </PageGroup>
-    );
+  render(
+    <PageGroup hasOverflowScroll aria-label="Test label">
+      test
+    </PageGroup>
+  );
 
-    expect(consoleWarning).not.toHaveBeenCalled();
-  });
+  expect(consoleWarning).not.toHaveBeenCalled();
+});
 
-  test('Logs a warning in the console when an aria-label is not included with hasOverflowScroll', () => {
-    const consoleWarning = jest.spyOn(console, 'warn').mockImplementation();
+test('Logs a warning in the console when an aria-label is not included with hasOverflowScroll', () => {
+  const consoleWarning = jest.spyOn(console, 'warn').mockImplementation();
 
-    render(<PageGroup hasOverflowScroll>test</PageGroup>);
+  render(<PageGroup hasOverflowScroll>test</PageGroup>);
 
-    expect(consoleWarning).toHaveBeenCalled();
-  });
+  expect(consoleWarning).toHaveBeenCalled();
+});
 
-  test(`Does not render with ${styles.modifiers.fill} or ${styles.modifiers.noFill} if isFilled is not passed`, () => {
-    render(<PageGroup>test</PageGroup>);
+test(`Does not render with ${styles.modifiers.fill} or ${styles.modifiers.noFill} if isFilled is not passed`, () => {
+  render(<PageGroup>test</PageGroup>);
 
-    expect(screen.getByText('test')).not.toHaveClass(styles.modifiers.fill);
-    expect(screen.getByText('test')).not.toHaveClass(styles.modifiers.noFill);
-  });
+  expect(screen.getByText('test')).not.toHaveClass(styles.modifiers.fill);
+  expect(screen.getByText('test')).not.toHaveClass(styles.modifiers.noFill);
+});
 
-  test(`Renders with ${styles.modifiers.fill} if isFilled={true} is passed`, () => {
-    render(<PageGroup isFilled={true}>test</PageGroup>);
+test(`Renders with ${styles.modifiers.fill} if isFilled={true} is passed`, () => {
+  render(<PageGroup isFilled={true}>test</PageGroup>);
 
-    expect(screen.getByText('test')).toHaveClass(styles.modifiers.fill);
-  });
+  expect(screen.getByText('test')).toHaveClass(styles.modifiers.fill);
+});
 
-  test(`Renders with ${styles.modifiers.noFill} if isFilled={false} is passed`, () => {
-    render(<PageGroup isFilled={false}>test</PageGroup>);
+test(`Renders with ${styles.modifiers.noFill} if isFilled={false} is passed`, () => {
+  render(<PageGroup isFilled={false}>test</PageGroup>);
 
-    expect(screen.getByText('test')).toHaveClass(styles.modifiers.noFill);
-  });
+  expect(screen.getByText('test')).toHaveClass(styles.modifiers.noFill);
+});
+
+test(`Renders with ${styles.modifiers.plain} class when isPlain is true`, () => {
+  render(<PageGroup isPlain>test</PageGroup>);
+
+  expect(screen.getByText('test')).toHaveClass(styles.modifiers.plain);
+});
+
+test(`Renders with ${styles.modifiers.noPlainOnGlass} class when isPlain is true`, () => {
+  render(<PageGroup isNoPlainOnGlass>test</PageGroup>);
+
+  expect(screen.getByText('test')).toHaveClass(styles.modifiers.noPlainOnGlass);
 });

--- a/packages/react-core/src/components/Page/__tests__/PageGroup.test.tsx
+++ b/packages/react-core/src/components/Page/__tests__/PageGroup.test.tsx
@@ -101,33 +101,3 @@ test(`Renders with ${styles.modifiers.noPlainOnGlass} class when isPlain is true
 
   expect(screen.getByText('test')).toHaveClass(styles.modifiers.noPlainOnGlass);
 });
-
-test('Does not log a warning when only isPlain is passed', () => {
-  const consoleWarning = jest.spyOn(console, 'warn').mockImplementation();
-
-  render(<PageGroup isPlain>test</PageGroup>);
-
-  expect(consoleWarning).not.toHaveBeenCalled();
-});
-
-test('Does not log a warning when only isNoPlainOnGlass is passed', () => {
-  const consoleWarning = jest.spyOn(console, 'warn').mockImplementation();
-
-  render(<PageGroup isNoPlainOnGlass>test</PageGroup>);
-
-  expect(consoleWarning).not.toHaveBeenCalled();
-});
-
-test('Logs a warning when both isPlain and isNoPlainOnGlass are passed', () => {
-  const consoleWarning = jest.spyOn(console, 'warn').mockImplementation();
-
-  render(
-    <PageGroup isPlain isNoPlainOnGlass>
-      test
-    </PageGroup>
-  );
-
-  expect(consoleWarning).toHaveBeenCalledWith(
-    `PageGroup: When both isPlain and isNoPlainOnGlass are true, isPlain will take precedence and isNoPlainOnGlass will have no effect. It's recommended to pass only one prop according to the current theme.`
-  );
-});

--- a/packages/react-core/src/components/Page/__tests__/PageSection.test.tsx
+++ b/packages/react-core/src/components/Page/__tests__/PageSection.test.tsx
@@ -179,3 +179,15 @@ test(`Renders with ${styles.modifiers.noFill} if isFilled={false} is passed`, ()
 
   expect(screen.getByRole('main')).toHaveClass(styles.modifiers.noFill);
 });
+
+test(`Renders with ${styles.modifiers.plain} class when isPlain is true`, () => {
+  render(<PageSection isPlain>test</PageSection>);
+
+  expect(screen.getByText('test')).toHaveClass(styles.modifiers.plain);
+});
+
+test(`Renders with ${styles.modifiers.noPlainOnGlass} class when isPlain is true`, () => {
+  render(<PageSection isNoPlainOnGlass>test</PageSection>);
+
+  expect(screen.getByText('test')).toHaveClass(styles.modifiers.noPlainOnGlass);
+});

--- a/packages/react-core/src/components/Page/__tests__/PageSection.test.tsx
+++ b/packages/react-core/src/components/Page/__tests__/PageSection.test.tsx
@@ -181,13 +181,21 @@ test(`Renders with ${styles.modifiers.noFill} if isFilled={false} is passed`, ()
 });
 
 test(`Renders with ${styles.modifiers.plain} class when isPlain is true`, () => {
-  render(<PageSection isPlain>test</PageSection>);
+  render(
+    <PageSection hasBodyWrapper={false} isPlain>
+      test
+    </PageSection>
+  );
 
   expect(screen.getByText('test')).toHaveClass(styles.modifiers.plain);
 });
 
 test(`Renders with ${styles.modifiers.noPlainOnGlass} class when isPlain is true`, () => {
-  render(<PageSection isNoPlainOnGlass>test</PageSection>);
+  render(
+    <PageSection hasBodyWrapper={false} isNoPlainOnGlass>
+      test
+    </PageSection>
+  );
 
   expect(screen.getByText('test')).toHaveClass(styles.modifiers.noPlainOnGlass);
 });

--- a/packages/react-core/src/components/Page/__tests__/PageSection.test.tsx
+++ b/packages/react-core/src/components/Page/__tests__/PageSection.test.tsx
@@ -190,7 +190,7 @@ test(`Renders with ${styles.modifiers.plain} class when isPlain is true`, () => 
   expect(screen.getByText('test')).toHaveClass(styles.modifiers.plain);
 });
 
-test(`Renders with ${styles.modifiers.noPlainOnGlass} class when isPlain is true`, () => {
+test(`Renders with ${styles.modifiers.noPlainOnGlass} class when isNoPlainOnGlass is true`, () => {
   render(
     <PageSection hasBodyWrapper={false} isNoPlainOnGlass>
       test

--- a/packages/react-core/src/components/Page/__tests__/PageSection.test.tsx
+++ b/packages/react-core/src/components/Page/__tests__/PageSection.test.tsx
@@ -191,3 +191,33 @@ test(`Renders with ${styles.modifiers.noPlainOnGlass} class when isPlain is true
 
   expect(screen.getByText('test')).toHaveClass(styles.modifiers.noPlainOnGlass);
 });
+
+test('Does not log a warning when only isPlain is passed', () => {
+  const consoleWarning = jest.spyOn(console, 'warn').mockImplementation();
+
+  render(<PageSection isPlain>test</PageSection>);
+
+  expect(consoleWarning).not.toHaveBeenCalled();
+});
+
+test('Does not log a warning when only isNoPlainOnGlass is passed', () => {
+  const consoleWarning = jest.spyOn(console, 'warn').mockImplementation();
+
+  render(<PageSection isNoPlainOnGlass>test</PageSection>);
+
+  expect(consoleWarning).not.toHaveBeenCalled();
+});
+
+test('Logs a warning when both isPlain and isNoPlainOnGlass are passed', () => {
+  const consoleWarning = jest.spyOn(console, 'warn').mockImplementation();
+
+  render(
+    <PageSection isPlain isNoPlainOnGlass>
+      test
+    </PageSection>
+  );
+
+  expect(consoleWarning).toHaveBeenCalledWith(
+    `PageSection: When both isPlain and isNoPlainOnGlass are true, isPlain will take precedence and isNoPlainOnGlass will have no effect. It's recommended to pass only one prop according to the current theme.`
+  );
+});

--- a/packages/react-core/src/components/Page/__tests__/PageSection.test.tsx
+++ b/packages/react-core/src/components/Page/__tests__/PageSection.test.tsx
@@ -199,33 +199,3 @@ test(`Renders with ${styles.modifiers.noPlainOnGlass} class when isPlain is true
 
   expect(screen.getByText('test')).toHaveClass(styles.modifiers.noPlainOnGlass);
 });
-
-test('Does not log a warning when only isPlain is passed', () => {
-  const consoleWarning = jest.spyOn(console, 'warn').mockImplementation();
-
-  render(<PageSection isPlain>test</PageSection>);
-
-  expect(consoleWarning).not.toHaveBeenCalled();
-});
-
-test('Does not log a warning when only isNoPlainOnGlass is passed', () => {
-  const consoleWarning = jest.spyOn(console, 'warn').mockImplementation();
-
-  render(<PageSection isNoPlainOnGlass>test</PageSection>);
-
-  expect(consoleWarning).not.toHaveBeenCalled();
-});
-
-test('Logs a warning when both isPlain and isNoPlainOnGlass are passed', () => {
-  const consoleWarning = jest.spyOn(console, 'warn').mockImplementation();
-
-  render(
-    <PageSection isPlain isNoPlainOnGlass>
-      test
-    </PageSection>
-  );
-
-  expect(consoleWarning).toHaveBeenCalledWith(
-    `PageSection: When both isPlain and isNoPlainOnGlass are true, isPlain will take precedence and isNoPlainOnGlass will have no effect. It's recommended to pass only one prop according to the current theme.`
-  );
-});

--- a/packages/react-core/src/components/Page/__tests__/PageSidebar.test.tsx
+++ b/packages/react-core/src/components/Page/__tests__/PageSidebar.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import { PageSidebar } from '../PageSidebar';
+import styles from '@patternfly/react-styles/css/components/Page/page';
+
+test(`Renders with ${styles.pageSidebarMain} wrapper`, () => {
+  render(<PageSidebar data-testid="sidebar">Test</PageSidebar>);
+
+  expect(screen.getByText('Test')).toHaveClass(styles.pageSidebarMain);
+});

--- a/packages/react-core/src/components/Page/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/packages/react-core/src/components/Page/__tests__/__snapshots__/Page.test.tsx.snap
@@ -16,9 +16,13 @@ exports[`Page Check dark page against snapshot 1`] = `
       id="page-sidebar"
     >
       <div
-        class="pf-v6-c-page__sidebar-body"
+        class="pf-v6-c-page__sidebar-main"
       >
-        Navigation
+        <div
+          class="pf-v6-c-page__sidebar-body"
+        >
+          Navigation
+        </div>
       </div>
     </div>
     <div
@@ -57,7 +61,11 @@ exports[`Page Check page horizontal layout example against snapshot 1`] = `
       aria-hidden="false"
       class="pf-v6-c-page__sidebar"
       id="page-sidebar"
-    />
+    >
+      <div
+        class="pf-v6-c-page__sidebar-main"
+      />
+    </div>
     <div
       class="pf-v6-c-page__main-container"
     >
@@ -94,7 +102,11 @@ exports[`Page Check page to verify breadcrumb is created - PageBreadcrumb syntax
       aria-hidden="false"
       class="pf-v6-c-page__sidebar"
       id="page-sidebar"
-    />
+    >
+      <div
+        class="pf-v6-c-page__sidebar-main"
+      />
+    </div>
     <div
       class="pf-v6-c-page__main-container"
     >
@@ -239,7 +251,11 @@ exports[`Page Check page to verify breadcrumb is created 1`] = `
       aria-hidden="false"
       class="pf-v6-c-page__sidebar"
       id="page-sidebar"
-    />
+    >
+      <div
+        class="pf-v6-c-page__sidebar-main"
+      />
+    </div>
     <div
       class="pf-v6-c-page__main-container"
     >
@@ -388,7 +404,11 @@ exports[`Page Check page to verify grouped nav and breadcrumb - new components s
       aria-hidden="false"
       class="pf-v6-c-page__sidebar"
       id="page-sidebar"
-    />
+    >
+      <div
+        class="pf-v6-c-page__sidebar-main"
+      />
+    </div>
     <div
       class="pf-v6-c-page__main-container"
     >
@@ -631,7 +651,11 @@ exports[`Page Check page to verify grouped nav and breadcrumb - old / props synt
       aria-hidden="false"
       class="pf-v6-c-page__sidebar"
       id="page-sidebar"
-    />
+    >
+      <div
+        class="pf-v6-c-page__sidebar-main"
+      />
+    </div>
     <div
       class="pf-v6-c-page__main-container"
     >
@@ -915,7 +939,11 @@ exports[`Page Check page to verify skip to content points to main content region
       aria-hidden="false"
       class="pf-v6-c-page__sidebar"
       id="page-sidebar"
-    />
+    >
+      <div
+        class="pf-v6-c-page__sidebar-main"
+      />
+    </div>
     <div
       class="pf-v6-c-page__main-container"
     >
@@ -1067,9 +1095,13 @@ exports[`Page Check page vertical layout example against snapshot 1`] = `
       id="page-sidebar"
     >
       <div
-        class="pf-v6-c-page__sidebar-body"
+        class="pf-v6-c-page__sidebar-main"
       >
-        Navigation
+        <div
+          class="pf-v6-c-page__sidebar-body"
+        >
+          Navigation
+        </div>
       </div>
     </div>
     <div
@@ -1108,7 +1140,11 @@ exports[`Page Sticky bottom breadcrumb on all height breakpoints - PageBreadcrum
       aria-hidden="false"
       class="pf-v6-c-page__sidebar"
       id="page-sidebar"
-    />
+    >
+      <div
+        class="pf-v6-c-page__sidebar-main"
+      />
+    </div>
     <div
       class="pf-v6-c-page__main-container"
     >
@@ -1253,7 +1289,11 @@ exports[`Page Verify sticky bottom breadcrumb on all height breakpoints 1`] = `
       aria-hidden="false"
       class="pf-v6-c-page__sidebar"
       id="page-sidebar"
-    />
+    >
+      <div
+        class="pf-v6-c-page__sidebar-main"
+      />
+    </div>
     <div
       class="pf-v6-c-page__main-container"
     >
@@ -1402,7 +1442,11 @@ exports[`Page Verify sticky top breadcrumb on all height breakpoints - PageBread
       aria-hidden="false"
       class="pf-v6-c-page__sidebar"
       id="page-sidebar"
-    />
+    >
+      <div
+        class="pf-v6-c-page__sidebar-main"
+      />
+    </div>
     <div
       class="pf-v6-c-page__main-container"
     >
@@ -1547,7 +1591,11 @@ exports[`Page Verify sticky top breadcrumb on all height breakpoints 1`] = `
       aria-hidden="false"
       class="pf-v6-c-page__sidebar"
       id="page-sidebar"
-    />
+    >
+      <div
+        class="pf-v6-c-page__sidebar-main"
+      />
+    </div>
     <div
       class="pf-v6-c-page__main-container"
     >

--- a/packages/react-core/src/components/Page/__tests__/__snapshots__/PageGroup.test.tsx.snap
+++ b/packages/react-core/src/components/Page/__tests__/__snapshots__/PageGroup.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`page group Verify basic render 1`] = `
+exports[`Verify basic render 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-page__main-group"
@@ -10,7 +10,7 @@ exports[`page group Verify basic render 1`] = `
 </DocumentFragment>
 `;
 
-exports[`page group Verify bottom shadow 1`] = `
+exports[`Verify bottom shadow 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-page__main-group pf-m-shadow-bottom"
@@ -20,7 +20,7 @@ exports[`page group Verify bottom shadow 1`] = `
 </DocumentFragment>
 `;
 
-exports[`page group Verify bottom sticky 1`] = `
+exports[`Verify bottom sticky 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-page__main-group pf-m-sticky-bottom"
@@ -30,7 +30,7 @@ exports[`page group Verify bottom sticky 1`] = `
 </DocumentFragment>
 `;
 
-exports[`page group Verify overflow scroll 1`] = `
+exports[`Verify overflow scroll 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-page__main-group pf-m-overflow-scroll"
@@ -42,7 +42,7 @@ exports[`page group Verify overflow scroll 1`] = `
 </DocumentFragment>
 `;
 
-exports[`page group Verify top shadow 1`] = `
+exports[`Verify top shadow 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-page__main-group pf-m-shadow-top"
@@ -52,7 +52,7 @@ exports[`page group Verify top shadow 1`] = `
 </DocumentFragment>
 `;
 
-exports[`page group Verify top sticky 1`] = `
+exports[`Verify top sticky 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-page__main-group pf-m-sticky-top"

--- a/packages/react-core/src/components/Page/examples/Page.md
+++ b/packages/react-core/src/components/Page/examples/Page.md
@@ -20,7 +20,7 @@ A page will typically contain the following components:
 
 The `<MastheadMain>` component includes the smaller area that typically contains the `<MastheadToggle>` and a `<MastheadLogo>`. `<MastheadContent>` represents the main portion of the masthead, and will typically contain a `<Toolbar>` or other menu-like components, like a `<Dropdown>`.
 
-  - Mastheads contain a `<MastheadMain>` component, which includes the `<MastheadToggle>`, a `<MastheadLogo>`,  and the page's toolbar (via `<MastheadContent>`.) The `<MastheadToggle>` component contains a `<PageToggleButton>`, and the `<MastheadLogo>` component contains a `<MastheadBrand>`. 
+- Mastheads contain a `<MastheadMain>` component, which includes the `<MastheadToggle>`, a `<MastheadLogo>`, and the page's toolbar (via `<MastheadContent>`.) The `<MastheadToggle>` component contains a `<PageToggleButton>`, and the `<MastheadLogo>` component contains a `<MastheadBrand>`.
 - 1 or more `<PageSidebarBody>` components inside `<PageSidebar>` for vertical navigation or other sidebar content
 - 1 or more `<PageSection>` components
 
@@ -121,5 +121,13 @@ By default, a page section spans the width of the page. To reduce the width of a
 The content in this example is placed in a card to better illustrate how the section behaves when it is centered, but a card is not required to center a page section.
 
 ```ts file="./PageCenteredSection.tsx"
+
+```
+
+### Plain sections and groups
+
+To remove the default background color from a page section or group, use the `isPlain` property on `<PageSection>` or `<PageGroup>` components.
+
+```ts file="./PagePlainSections.tsx"
 
 ```

--- a/packages/react-core/src/components/Page/examples/PagePlainSections.tsx
+++ b/packages/react-core/src/components/Page/examples/PagePlainSections.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+import {
+  Page,
+  Masthead,
+  MastheadMain,
+  MastheadToggle,
+  MastheadBrand,
+  MastheadLogo,
+  MastheadContent,
+  PageSidebar,
+  PageSidebarBody,
+  PageSection,
+  PageGroup,
+  PageToggleButton,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem
+} from '@patternfly/react-core';
+
+export const PagePlainSections: React.FunctionComponent = () => {
+  const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+
+  const onSidebarToggle = () => {
+    setIsSidebarOpen(!isSidebarOpen);
+  };
+
+  const headerToolbar = (
+    <Toolbar id="plain-sections-toolbar">
+      <ToolbarContent>
+        <ToolbarItem>header-tools</ToolbarItem>
+      </ToolbarContent>
+    </Toolbar>
+  );
+
+  const masthead = (
+    <Masthead>
+      <MastheadMain>
+        <MastheadToggle>
+          <PageToggleButton
+            aria-label="Plain sections example navigation"
+            isSidebarOpen={isSidebarOpen}
+            onSidebarToggle={onSidebarToggle}
+            id="plain-sections-nav-toggle"
+            isHamburgerButton
+          />
+        </MastheadToggle>
+        <MastheadBrand>
+          <MastheadLogo href="https://patternfly.org" target="_blank">
+            Logo
+          </MastheadLogo>
+        </MastheadBrand>
+      </MastheadMain>
+      <MastheadContent>{headerToolbar}</MastheadContent>
+    </Masthead>
+  );
+
+  const sidebar = (
+    <PageSidebar isSidebarOpen={isSidebarOpen} id="plain-sections-sidebar">
+      <PageSidebarBody>Navigation</PageSidebarBody>
+    </PageSidebar>
+  );
+
+  return (
+    <Page masthead={masthead} sidebar={sidebar}>
+      <PageSection isPlain aria-label="Plain section example">
+        <h2>Plain PageSection</h2>
+        <p>
+          This section uses <code>isPlain</code> to apply plain styling with no background color.
+        </p>
+      </PageSection>
+      <PageSection aria-label="Default section example">
+        <h2>Default PageSection</h2>
+        <p>This section has the default styling with a background color.</p>
+      </PageSection>
+      <PageGroup isPlain>
+        <PageSection aria-label="Section in plain group">
+          <h2>PageSection inside Plain PageGroup</h2>
+          <p>
+            This section is inside a PageGroup with <code>isPlain</code> applied.
+          </p>
+        </PageSection>
+        <PageSection aria-label="Another section in plain group">
+          <h2>Another Section in Plain Group</h2>
+          <p>Both sections are grouped with plain styling.</p>
+        </PageSection>
+      </PageGroup>
+      <PageSection variant="secondary" aria-label="Secondary variant section">
+        <h2>Secondary Variant Section</h2>
+        <p>This section uses the secondary variant for contrast.</p>
+      </PageSection>
+    </Page>
+  );
+};

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -23,7 +23,7 @@
     "test:a11y": "patternfly-a11y --config patternfly-a11y.config"
   },
   "dependencies": {
-    "@patternfly/patternfly": "6.5.0-prerelease.62",
+    "@patternfly/patternfly": "6.5.0-prerelease.65",
     "@patternfly/react-charts": "workspace:^",
     "@patternfly/react-code-editor": "workspace:^",
     "@patternfly/react-core": "workspace:^",

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -35,7 +35,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.15.4",
     "@fortawesome/free-regular-svg-icons": "^5.15.4",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
-    "@patternfly/patternfly": "6.5.0-prerelease.62",
+    "@patternfly/patternfly": "6.5.0-prerelease.65",
     "@rhds/icons": "^2.1.0",
     "fs-extra": "^11.3.3",
     "tslib": "^2.8.1"

--- a/packages/react-styles/package.json
+++ b/packages/react-styles/package.json
@@ -19,7 +19,7 @@
     "clean": "rimraf dist css"
   },
   "devDependencies": {
-    "@patternfly/patternfly": "6.5.0-prerelease.62",
+    "@patternfly/patternfly": "6.5.0-prerelease.65",
     "change-case": "^5.4.4",
     "fs-extra": "^11.3.3"
   },

--- a/packages/react-tokens/package.json
+++ b/packages/react-tokens/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@adobe/css-tools": "^4.4.4",
-    "@patternfly/patternfly": "6.5.0-prerelease.62",
+    "@patternfly/patternfly": "6.5.0-prerelease.65",
     "fs-extra": "^11.3.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5070,10 +5070,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/patternfly@npm:6.5.0-prerelease.62":
-  version: 6.5.0-prerelease.62
-  resolution: "@patternfly/patternfly@npm:6.5.0-prerelease.62"
-  checksum: 10c0/e918cd5e92df7bd6d69e27394a0053a84bd82c5e7f5028bea101f4687019afb46887c6fd27cbbc8f0e759b66dd40a25315637fb509eef17066d319a6e82167d6
+"@patternfly/patternfly@npm:6.5.0-prerelease.65":
+  version: 6.5.0-prerelease.65
+  resolution: "@patternfly/patternfly@npm:6.5.0-prerelease.65"
+  checksum: 10c0/5d6042bb3b3a562b3b1421395edbbd5899f84a3349d45be29f9d3d9a9e18968b8e86275f75a86b9a3720db905679b52a4227377b640c0096f498d584e5f4c2fb
   languageName: node
   linkType: hard
 
@@ -5171,7 +5171,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@patternfly/react-core@workspace:packages/react-core"
   dependencies:
-    "@patternfly/patternfly": "npm:6.5.0-prerelease.62"
+    "@patternfly/patternfly": "npm:6.5.0-prerelease.65"
     "@patternfly/react-icons": "workspace:^"
     "@patternfly/react-styles": "workspace:^"
     "@patternfly/react-tokens": "workspace:^"
@@ -5192,7 +5192,7 @@ __metadata:
   resolution: "@patternfly/react-docs@workspace:packages/react-docs"
   dependencies:
     "@patternfly/documentation-framework": "npm:^6.36.8"
-    "@patternfly/patternfly": "npm:6.5.0-prerelease.62"
+    "@patternfly/patternfly": "npm:6.5.0-prerelease.65"
     "@patternfly/patternfly-a11y": "npm:5.1.0"
     "@patternfly/react-charts": "workspace:^"
     "@patternfly/react-code-editor": "workspace:^"
@@ -5232,7 +5232,7 @@ __metadata:
     "@fortawesome/free-brands-svg-icons": "npm:^5.15.4"
     "@fortawesome/free-regular-svg-icons": "npm:^5.15.4"
     "@fortawesome/free-solid-svg-icons": "npm:^5.15.4"
-    "@patternfly/patternfly": "npm:6.5.0-prerelease.62"
+    "@patternfly/patternfly": "npm:6.5.0-prerelease.65"
     "@rhds/icons": "npm:^2.1.0"
     fs-extra: "npm:^11.3.3"
     tslib: "npm:^2.8.1"
@@ -5319,7 +5319,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@patternfly/react-styles@workspace:packages/react-styles"
   dependencies:
-    "@patternfly/patternfly": "npm:6.5.0-prerelease.62"
+    "@patternfly/patternfly": "npm:6.5.0-prerelease.65"
     change-case: "npm:^5.4.4"
     fs-extra: "npm:^11.3.3"
   languageName: unknown
@@ -5361,7 +5361,7 @@ __metadata:
   resolution: "@patternfly/react-tokens@workspace:packages/react-tokens"
   dependencies:
     "@adobe/css-tools": "npm:^4.4.4"
-    "@patternfly/patternfly": "npm:6.5.0-prerelease.62"
+    "@patternfly/patternfly": "npm:6.5.0-prerelease.65"
     fs-extra: "npm:^11.3.3"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #12270

Waiting on core bump to go in to pull in correct styles object properties

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added isPlain prop to PageSection and PageGroup to remove default background
  * Added isNoPlainOnGlass (beta) prop for specialized styling control
  * Added a new example showcasing plain sections and groups

* **Refactor**
  * Adjusted masthead and sidebar markup wrappers for improved structure and styling consistency

* **Tests**
  * Added/updated tests for docked masthead, sidebar wrapper, and plain/no-plain modifiers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->