### PR TITLE
fix(Menu): adjust initially drilled-in root menu height

### DIFF
--- a/packages/react-core/src/components/Menu/examples/MenuWithDrilldownInitialState.tsx
+++ b/packages/react-core/src/components/Menu/examples/MenuWithDrilldownInitialState.tsx
@@ -11,7 +11,7 @@ export const MenuDrilldownInitialState: React.FunctionComponent = () => {
     'initial-state-drilldownMenuStart'
   ]);
   const [drilldownPath, setDrilldownPath] = useState<string[]>(['group:start_rollout', 'group:app_grouping']);
-  const [menuHeights, setMenuHeights] = useState<any>({ 'initial-state-rootMenu': 216 }); // The root menu height must be defined when starting from a drilled in state
+  const [menuHeights, setMenuHeights] = useState<any>({ 'initial-state-rootMenu': 186 }); // The root menu height must be defined when starting from a drilled in state
   const [activeMenu, setActiveMenu] = useState<string>('initial-state-drilldownMenuStartGrouping');
 
   const drillIn = (


### PR DESCRIPTION
Closes #11967 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected menu height calculation in the drilldown menu component example for accurate initial state rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->