### PR TITLE
fix(tabs): honor hash-linked nav tabs

### DIFF
--- a/packages/react-core/src/components/Tabs/Tabs.tsx
+++ b/packages/react-core/src/components/Tabs/Tabs.tsx
@@ -171,7 +171,8 @@ interface TabsState {
   disableBackScrollButton: boolean;
   disableForwardScrollButton: boolean;
   shownKeys: (string | number)[];
-  uncontrolledActiveKey: number | string;
+  uncontrolledActiveKey: number | string | undefined;
+  initialActiveKey: number | string | undefined;
   uncontrolledIsExpandedLocal: boolean;
   overflowingTabCount: number;
   isInitializingAccent: boolean;
@@ -198,7 +199,8 @@ class Tabs extends Component<TabsProps, TabsState> {
         this.props.defaultActiveKey !== undefined
           ? [hashActiveKey ?? this.props.defaultActiveKey]
           : [hashActiveKey ?? this.props.activeKey], // only for mountOnEnter case
-      uncontrolledActiveKey: this.props.defaultActiveKey,
+      uncontrolledActiveKey: hashActiveKey ?? this.props.defaultActiveKey,
+      initialActiveKey: this.props.defaultActiveKey === undefined ? hashActiveKey : undefined,
       uncontrolledIsExpandedLocal: this.props.defaultIsExpanded,
       overflowingTabCount: 0,
       isInitializingAccent: true,
@@ -245,7 +247,7 @@ class Tabs extends Component<TabsProps, TabsState> {
     eventKey: number | string,
     tabContentRef: React.RefObject<any>
   ) {
-    const { shownKeys } = this.state;
+    const { shownKeys, initialActiveKey } = this.state;
     const { onSelect, defaultActiveKey } = this.props;
 
     // if defaultActiveKey Tabs are uncontrolled, set new active key internally
@@ -254,6 +256,9 @@ class Tabs extends Component<TabsProps, TabsState> {
         uncontrolledActiveKey: eventKey
       });
     } else {
+      if (initialActiveKey !== undefined) {
+        this.setState({ initialActiveKey: undefined });
+      }
       onSelect(event, eventKey);
     }
 
@@ -426,7 +431,7 @@ class Tabs extends Component<TabsProps, TabsState> {
   componentDidUpdate(prevProps: TabsProps, prevState: TabsState) {
     this.direction = getLanguageDirection(this.tabList.current);
     const { activeKey, mountOnEnter, isOverflowHorizontal, children, defaultActiveKey } = this.props;
-    const { shownKeys, overflowingTabCount, enableScrollButtons, uncontrolledActiveKey } = this.state;
+    const { shownKeys, overflowingTabCount, enableScrollButtons, uncontrolledActiveKey, initialActiveKey } = this.state;
     const isOnCloseUpdate = !!prevProps.onClose !== !!this.props.onClose;
 
     if (
@@ -441,6 +446,10 @@ class Tabs extends Component<TabsProps, TabsState> {
       this.setState({
         shownKeys: shownKeys.concat(activeKey)
       });
+    }
+
+    if (defaultActiveKey === undefined && prevProps.activeKey !== activeKey && initialActiveKey !== undefined) {
+      this.setState({ initialActiveKey: undefined });
     }
 
     if (
@@ -543,6 +552,7 @@ class Tabs extends Component<TabsProps, TabsState> {
       disableForwardScrollButton,
       shownKeys,
       uncontrolledActiveKey,
+      initialActiveKey,
       uncontrolledIsExpandedLocal,
       overflowingTabCount,
       isInitializingAccent,
@@ -559,8 +569,7 @@ class Tabs extends Component<TabsProps, TabsState> {
 
     const defaultComponent = isNav && !component ? 'nav' : 'div';
     const Component: any = component !== undefined ? component : defaultComponent;
-    const hashActiveKey = getTabHashActiveKey({ children, component, isNav });
-    const localActiveKey = hashActiveKey ?? (defaultActiveKey !== undefined ? uncontrolledActiveKey : activeKey);
+    const localActiveKey = defaultActiveKey !== undefined ? uncontrolledActiveKey : (initialActiveKey ?? activeKey);
 
     const isExpandedLocal = defaultIsExpanded !== undefined ? uncontrolledIsExpandedLocal : isExpanded;
     /*  Uncontrolled expandable tabs */

--- a/packages/react-core/src/components/Tabs/Tabs.tsx
+++ b/packages/react-core/src/components/Tabs/Tabs.tsx
@@ -195,10 +195,7 @@ class Tabs extends Component<TabsProps, TabsState> {
       renderScrollButtons: false,
       disableBackScrollButton: true,
       disableForwardScrollButton: true,
-      shownKeys:
-        this.props.defaultActiveKey !== undefined
-          ? [hashActiveKey ?? this.props.defaultActiveKey]
-          : [hashActiveKey ?? this.props.activeKey], // only for mountOnEnter case
+      shownKeys: [hashActiveKey ?? this.props.defaultActiveKey ?? this.props.activeKey],
       uncontrolledActiveKey: hashActiveKey ?? this.props.defaultActiveKey,
       initialActiveKey: this.props.defaultActiveKey === undefined ? hashActiveKey : undefined,
       uncontrolledIsExpandedLocal: this.props.defaultIsExpanded,

--- a/packages/react-core/src/components/Tabs/Tabs.tsx
+++ b/packages/react-core/src/components/Tabs/Tabs.tsx
@@ -248,7 +248,15 @@ class Tabs extends Component<TabsProps, TabsState> {
     tabContentRef: React.RefObject<any>
   ) {
     const { shownKeys, initialActiveKey } = this.state;
-    const { onSelect, defaultActiveKey } = this.props;
+    const { onSelect, defaultActiveKey, component, isNav } = this.props;
+
+    if (event.currentTarget instanceof HTMLAnchorElement && event.currentTarget.hasAttribute('href')) {
+      event.preventDefault();
+
+      if (canUseDOM && (component === TabsComponent.nav || isNav)) {
+        window.history.pushState(null, '', event.currentTarget.href);
+      }
+    }
 
     // if defaultActiveKey Tabs are uncontrolled, set new active key internally
     if (defaultActiveKey !== undefined) {

--- a/packages/react-core/src/components/Tabs/Tabs.tsx
+++ b/packages/react-core/src/components/Tabs/Tabs.tsx
@@ -140,6 +140,25 @@ const variantStyle = {
   secondary: styles.modifiers.secondary
 };
 
+const getHashFromHref = (href?: string) => {
+  const hashIndex = href?.indexOf('#') ?? -1;
+
+  return hashIndex >= 0 ? href.slice(hashIndex) : undefined;
+};
+
+const getTabHashActiveKey = ({ children, component, isNav }: Pick<TabsProps, 'children' | 'component' | 'isNav'>) => {
+  if (!canUseDOM || !(component === TabsComponent.nav || isNav) || !window.location.hash) {
+    return undefined;
+  }
+
+  return Children.toArray(children)
+    .filter((child): child is TabElement => isValidElement(child))
+    .filter(({ props }) => !props.isHidden)
+    .find(
+      ({ props }) => !props.isDisabled && !props.isAriaDisabled && getHashFromHref(props.href) === window.location.hash
+    )?.props.eventKey;
+};
+
 interface TabsState {
   /** Used to signal if the scroll buttons should be used  */
   enableScrollButtons: boolean;
@@ -167,13 +186,18 @@ class Tabs extends Component<TabsProps, TabsState> {
   private direction = 'ltr';
   constructor(props: TabsProps) {
     super(props);
+    const hashActiveKey = getTabHashActiveKey(props);
+
     this.state = {
       enableScrollButtons: false,
       showScrollButtons: false,
       renderScrollButtons: false,
       disableBackScrollButton: true,
       disableForwardScrollButton: true,
-      shownKeys: this.props.defaultActiveKey !== undefined ? [this.props.defaultActiveKey] : [this.props.activeKey], // only for mountOnEnter case
+      shownKeys:
+        this.props.defaultActiveKey !== undefined
+          ? [hashActiveKey ?? this.props.defaultActiveKey]
+          : [hashActiveKey ?? this.props.activeKey], // only for mountOnEnter case
       uncontrolledActiveKey: this.props.defaultActiveKey,
       uncontrolledIsExpandedLocal: this.props.defaultIsExpanded,
       overflowingTabCount: 0,
@@ -223,6 +247,7 @@ class Tabs extends Component<TabsProps, TabsState> {
   ) {
     const { shownKeys } = this.state;
     const { onSelect, defaultActiveKey } = this.props;
+
     // if defaultActiveKey Tabs are uncontrolled, set new active key internally
     if (defaultActiveKey !== undefined) {
       this.setState({
@@ -403,6 +428,7 @@ class Tabs extends Component<TabsProps, TabsState> {
     const { activeKey, mountOnEnter, isOverflowHorizontal, children, defaultActiveKey } = this.props;
     const { shownKeys, overflowingTabCount, enableScrollButtons, uncontrolledActiveKey } = this.state;
     const isOnCloseUpdate = !!prevProps.onClose !== !!this.props.onClose;
+
     if (
       (defaultActiveKey !== undefined && prevState.uncontrolledActiveKey !== uncontrolledActiveKey) ||
       (defaultActiveKey === undefined && prevProps.activeKey !== activeKey) ||
@@ -533,7 +559,8 @@ class Tabs extends Component<TabsProps, TabsState> {
 
     const defaultComponent = isNav && !component ? 'nav' : 'div';
     const Component: any = component !== undefined ? component : defaultComponent;
-    const localActiveKey = defaultActiveKey !== undefined ? uncontrolledActiveKey : activeKey;
+    const hashActiveKey = getTabHashActiveKey({ children, component, isNav });
+    const localActiveKey = hashActiveKey ?? (defaultActiveKey !== undefined ? uncontrolledActiveKey : activeKey);
 
     const isExpandedLocal = defaultIsExpanded !== undefined ? uncontrolledIsExpandedLocal : isExpanded;
     /*  Uncontrolled expandable tabs */

--- a/packages/react-core/src/components/Tabs/__tests__/Tabs.test.tsx
+++ b/packages/react-core/src/components/Tabs/__tests__/Tabs.test.tsx
@@ -7,7 +7,7 @@ import { TabTitleText } from '../TabTitleText';
 import { TabTitleIcon } from '../TabTitleIcon';
 import { TabContent } from '../TabContent';
 import { TabContentBody } from '../TabContentBody';
-import { createRef } from 'react';
+import { createRef, useState } from 'react';
 
 jest.mock('../../../helpers/GenerateId/GenerateId');
 
@@ -117,6 +117,130 @@ test(`Does not render with class ${styles.modifiers.initializingAccent} when com
   });
   expect(screen.getByRole('region')).not.toHaveClass(styles.modifiers.initializingAccent);
   jest.useRealTimers();
+});
+
+describe('hash-based nav selection', () => {
+  beforeEach(() => {
+    window.location.hash = '#/items/2';
+  });
+
+  afterEach(() => {
+    window.location.hash = '';
+  });
+
+  test('should select the nav tab that matches the current URL hash on initial render', () => {
+    render(
+      <Tabs activeKey={0} onSelect={() => undefined} component="nav">
+        <Tab eventKey={0} title={<TabTitleText>Tab item 1</TabTitleText>} href="#/items/1">
+          Tab item 1
+        </Tab>
+        <Tab eventKey={1} title={<TabTitleText>Tab item 2</TabTitleText>} href="#/items/2">
+          Tab item 2
+        </Tab>
+        <Tab eventKey={2} title={<TabTitleText>Tab item 3</TabTitleText>} href="#/items/3">
+          Tab item 3
+        </Tab>
+      </Tabs>
+    );
+
+    expect(screen.getByRole('tab', { name: 'Tab item 2' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'Tab item 1' })).toHaveAttribute('aria-selected', 'false');
+  });
+
+  test('should respect later controlled selections after the initial hash match', async () => {
+    const user = userEvent.setup();
+    const ControlledTabs = () => {
+      const [activeKey, setActiveKey] = useState<string | number>(0);
+
+      return (
+        <Tabs activeKey={activeKey} onSelect={(_event, eventKey) => setActiveKey(eventKey)} component="nav">
+          <Tab eventKey={0} title={<TabTitleText>Tab item 1</TabTitleText>} href="#/items/1">
+            Tab item 1
+          </Tab>
+          <Tab eventKey={1} title={<TabTitleText>Tab item 2</TabTitleText>} href="#/items/2">
+            Tab item 2
+          </Tab>
+          <Tab eventKey={2} title={<TabTitleText>Tab item 3</TabTitleText>} href="#/items/3">
+            Tab item 3
+          </Tab>
+        </Tabs>
+      );
+    };
+
+    render(<ControlledTabs />);
+
+    expect(screen.getByRole('tab', { name: 'Tab item 2' })).toHaveAttribute('aria-selected', 'true');
+
+    await user.click(screen.getByRole('tab', { name: 'Tab item 3' }));
+
+    expect(screen.getByRole('tab', { name: 'Tab item 3' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'Tab item 2' })).toHaveAttribute('aria-selected', 'false');
+  });
+
+  test('should use the URL hash to initialize uncontrolled nav tabs', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Tabs defaultActiveKey={0} isNav>
+        <Tab eventKey={0} title={<TabTitleText>Tab item 1</TabTitleText>} href="#/items/1">
+          Tab item 1
+        </Tab>
+        <Tab eventKey={1} title={<TabTitleText>Tab item 2</TabTitleText>} href="#/items/2">
+          Tab item 2
+        </Tab>
+        <Tab eventKey={2} title={<TabTitleText>Tab item 3</TabTitleText>} href="#/items/3">
+          Tab item 3
+        </Tab>
+      </Tabs>
+    );
+
+    expect(screen.getByRole('tab', { name: 'Tab item 2' })).toHaveAttribute('aria-selected', 'true');
+
+    await user.click(screen.getByRole('tab', { name: 'Tab item 1' }));
+
+    expect(screen.getByRole('tab', { name: 'Tab item 1' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'Tab item 2' })).toHaveAttribute('aria-selected', 'false');
+  });
+
+  test('should ignore hidden, disabled and aria-disabled tabs when matching the current hash', () => {
+    render(
+      <Tabs activeKey={0} onSelect={() => undefined} component="nav">
+        <Tab eventKey={0} title={<TabTitleText>Tab item 1</TabTitleText>} href="#/items/1">
+          Tab item 1
+        </Tab>
+        <Tab eventKey={1} title={<TabTitleText>Hidden tab</TabTitleText>} href="#/items/2" isHidden>
+          Hidden tab
+        </Tab>
+        <Tab eventKey={2} title={<TabTitleText>Disabled tab</TabTitleText>} href="#/items/2" isDisabled>
+          Disabled tab
+        </Tab>
+        <Tab eventKey={3} title={<TabTitleText>Aria disabled tab</TabTitleText>} href="#/items/2" isAriaDisabled>
+          Aria disabled tab
+        </Tab>
+      </Tabs>
+    );
+
+    expect(screen.queryByRole('tab', { name: 'Hidden tab' })).not.toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Tab item 1' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'Disabled tab' })).toHaveAttribute('aria-selected', 'false');
+    expect(screen.getByRole('tab', { name: 'Aria disabled tab' })).toHaveAttribute('aria-selected', 'false');
+  });
+
+  test('should ignore the current URL hash when nav behavior is not enabled', () => {
+    render(
+      <Tabs activeKey={0} onSelect={() => undefined}>
+        <Tab eventKey={0} title={<TabTitleText>Tab item 1</TabTitleText>} href="#/items/1">
+          Tab item 1
+        </Tab>
+        <Tab eventKey={1} title={<TabTitleText>Tab item 2</TabTitleText>} href="#/items/2">
+          Tab item 2
+        </Tab>
+      </Tabs>
+    );
+
+    expect(screen.getByRole('tab', { name: 'Tab item 1' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'Tab item 2' })).toHaveAttribute('aria-selected', 'false');
+  });
 });
 
 test(`Renders with class ${styles.modifiers.initializingAccent} when uncontrolled expandable component initially mounts`, async () => {

--- a/packages/react-core/src/components/Tabs/__tests__/Tabs.test.tsx
+++ b/packages/react-core/src/components/Tabs/__tests__/Tabs.test.tsx
@@ -147,6 +147,58 @@ describe('hash-based nav selection', () => {
     expect(screen.getByRole('tab', { name: 'Tab item 1' })).toHaveAttribute('aria-selected', 'false');
   });
 
+  test('should select the nav tab that matches the current URL hash when isNav is enabled', () => {
+    render(
+      <Tabs activeKey={0} onSelect={() => undefined} isNav>
+        <Tab eventKey={0} title={<TabTitleText>Tab item 1</TabTitleText>} href="#/items/1">
+          Tab item 1
+        </Tab>
+        <Tab eventKey={1} title={<TabTitleText>Tab item 2</TabTitleText>} href="#/items/2">
+          Tab item 2
+        </Tab>
+      </Tabs>
+    );
+
+    expect(screen.getByRole('tab', { name: 'Tab item 2' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'Tab item 1' })).toHaveAttribute('aria-selected', 'false');
+  });
+
+  test('should fall back to activeKey when no tab href matches the current hash', () => {
+    window.location.hash = '#/items/unknown';
+
+    render(
+      <Tabs activeKey={0} onSelect={() => undefined} component="nav">
+        <Tab eventKey={0} title={<TabTitleText>Tab item 1</TabTitleText>} href="#/items/1">
+          Tab item 1
+        </Tab>
+        <Tab eventKey={1} title={<TabTitleText>Tab item 2</TabTitleText>} href="#/items/2">
+          Tab item 2
+        </Tab>
+      </Tabs>
+    );
+
+    expect(screen.getByRole('tab', { name: 'Tab item 1' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'Tab item 2' })).toHaveAttribute('aria-selected', 'false');
+  });
+
+  test('should fall back to activeKey when the URL hash is empty', () => {
+    window.location.hash = '';
+
+    render(
+      <Tabs activeKey={0} onSelect={() => undefined} component="nav">
+        <Tab eventKey={0} title={<TabTitleText>Tab item 1</TabTitleText>} href="#/items/1">
+          Tab item 1
+        </Tab>
+        <Tab eventKey={1} title={<TabTitleText>Tab item 2</TabTitleText>} href="#/items/2">
+          Tab item 2
+        </Tab>
+      </Tabs>
+    );
+
+    expect(screen.getByRole('tab', { name: 'Tab item 1' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'Tab item 2' })).toHaveAttribute('aria-selected', 'false');
+  });
+
   test('should respect later controlled selections after the initial hash match', async () => {
     const user = userEvent.setup();
     const ControlledTabs = () => {
@@ -240,6 +292,46 @@ describe('hash-based nav selection', () => {
 
     expect(screen.getByRole('tab', { name: 'Tab item 1' })).toHaveAttribute('aria-selected', 'true');
     expect(screen.getByRole('tab', { name: 'Tab item 2' })).toHaveAttribute('aria-selected', 'false');
+  });
+
+  test('should prevent default anchor navigation when selecting a tab with an href', async () => {
+    const user = userEvent.setup();
+    window.location.hash = '';
+
+    render(
+      <Tabs activeKey={0} onSelect={() => undefined}>
+        <Tab eventKey={0} title={<TabTitleText>Tab item 1</TabTitleText>} href="#/items/1">
+          Tab item 1
+        </Tab>
+        <Tab eventKey={1} title={<TabTitleText>Tab item 2</TabTitleText>} href="#/items/2">
+          Tab item 2
+        </Tab>
+      </Tabs>
+    );
+
+    await user.click(screen.getByRole('tab', { name: 'Tab item 2' }));
+
+    expect(window.location.hash).toBe('');
+  });
+
+  test('should update the URL hash when selecting a nav tab with an href', async () => {
+    const user = userEvent.setup();
+    window.location.hash = '';
+
+    render(
+      <Tabs activeKey={0} onSelect={() => undefined} isNav>
+        <Tab eventKey={0} title={<TabTitleText>Users</TabTitleText>} href="#users">
+          Users
+        </Tab>
+        <Tab eventKey={1} title={<TabTitleText>Containers</TabTitleText>} href="#containers">
+          Containers
+        </Tab>
+      </Tabs>
+    );
+
+    await user.click(screen.getByRole('tab', { name: 'Containers' }));
+
+    expect(window.location.hash).toBe('#containers');
   });
 });
 

--- a/packages/react-core/src/components/Tabs/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/react-core/src/components/Tabs/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`should not render tablist aria-label or aria-labelledby when neither is
 <DocumentFragment>
   <div
     class="pf-v6-c-tabs pf-m-animate-current pf-m-initializing-accent"
-    data-ouia-component-id="OUIA-Generated-Tabs-:r2n:"
+    data-ouia-component-id="OUIA-Generated-Tabs-:r3b:"
     data-ouia-component-type="PF6/Tabs"
     data-ouia-safe="true"
     id="noTabListLabelTabs"
@@ -89,7 +89,7 @@ exports[`should render accessible tabs 1`] = `
   <nav
     aria-label="accessible Tabs example"
     class="pf-v6-c-tabs pf-m-animate-current pf-m-initializing-accent"
-    data-ouia-component-id="OUIA-Generated-Tabs-:r1b:"
+    data-ouia-component-id="OUIA-Generated-Tabs-:r1v:"
     data-ouia-component-type="PF6/Tabs"
     data-ouia-safe="true"
     id="accessibleTabs"
@@ -206,7 +206,7 @@ exports[`should render box tabs 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-tabs pf-m-animate-current pf-m-box pf-m-initializing-accent"
-    data-ouia-component-id="OUIA-Generated-Tabs-:r19:"
+    data-ouia-component-id="OUIA-Generated-Tabs-:r1t:"
     data-ouia-component-type="PF6/Tabs"
     data-ouia-safe="true"
     id="boxTabs"
@@ -365,7 +365,7 @@ exports[`should render box tabs of secondary variant 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-tabs pf-m-animate-current pf-m-box pf-m-secondary pf-m-initializing-accent"
-    data-ouia-component-id="OUIA-Generated-Tabs-:r1v:"
+    data-ouia-component-id="OUIA-Generated-Tabs-:r2j:"
     data-ouia-component-type="PF6/Tabs"
     data-ouia-safe="true"
     id="boxSecondaryVariantTabs"
@@ -482,7 +482,7 @@ exports[`should render expandable vertical tabs 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-tabs pf-m-animate-current pf-m-vertical pf-m-expandable pf-m-initializing-accent"
-    data-ouia-component-id="OUIA-Generated-Tabs-:r13:"
+    data-ouia-component-id="OUIA-Generated-Tabs-:r1n:"
     data-ouia-component-type="PF6/Tabs"
     data-ouia-safe="true"
     id="verticalTabs"
@@ -497,7 +497,7 @@ exports[`should render expandable vertical tabs 1`] = `
         <button
           aria-labelledby="generated-id-text generated-id-button"
           class="pf-v6-c-button pf-m-plain"
-          data-ouia-component-id="OUIA-Generated-Button-plain-:r14:"
+          data-ouia-component-id="OUIA-Generated-Button-plain-:r1o:"
           data-ouia-component-type="PF6/Button"
           data-ouia-safe="true"
           id="generated-id-button"
@@ -689,7 +689,7 @@ exports[`should render filled tabs 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-tabs pf-m-animate-current pf-m-fill pf-m-initializing-accent"
-    data-ouia-component-id="OUIA-Generated-Tabs-:r1d:"
+    data-ouia-component-id="OUIA-Generated-Tabs-:r21:"
     data-ouia-component-type="PF6/Tabs"
     data-ouia-safe="true"
     id="filledTabs"
@@ -806,7 +806,7 @@ exports[`should render simple tabs 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-tabs pf-m-animate-current pf-m-initializing-accent"
-    data-ouia-component-id="OUIA-Generated-Tabs-:rn:"
+    data-ouia-component-id="OUIA-Generated-Tabs-:r1b:"
     data-ouia-component-type="PF6/Tabs"
     data-ouia-safe="true"
     id="simpleTabs"
@@ -965,7 +965,7 @@ exports[`should render subtabs 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-tabs pf-m-animate-current pf-m-initializing-accent"
-    data-ouia-component-id="OUIA-Generated-Tabs-:r1f:"
+    data-ouia-component-id="OUIA-Generated-Tabs-:r23:"
     data-ouia-component-type="PF6/Tabs"
     data-ouia-safe="true"
     id="primarieTabs"
@@ -1051,7 +1051,7 @@ exports[`should render subtabs 1`] = `
   >
     <div
       class="pf-v6-c-tabs pf-m-animate-current pf-m-subtab pf-m-initializing-accent"
-      data-ouia-component-id="OUIA-Generated-Tabs-:r1h:"
+      data-ouia-component-id="OUIA-Generated-Tabs-:r25:"
       data-ouia-component-type="PF6/Tabs"
       data-ouia-safe="true"
       id="subtabs"
@@ -1194,7 +1194,7 @@ exports[`should render tablist aria-label when provided 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-tabs pf-m-animate-current pf-m-initializing-accent"
-    data-ouia-component-id="OUIA-Generated-Tabs-:r2j:"
+    data-ouia-component-id="OUIA-Generated-Tabs-:r37:"
     data-ouia-component-type="PF6/Tabs"
     data-ouia-safe="true"
     id="tabListLabelTabs"
@@ -1284,7 +1284,7 @@ exports[`should render tablist aria-labelledby when provided 1`] = `
   </h2>
   <div
     class="pf-v6-c-tabs pf-m-animate-current pf-m-initializing-accent"
-    data-ouia-component-id="OUIA-Generated-Tabs-:r2l:"
+    data-ouia-component-id="OUIA-Generated-Tabs-:r39:"
     data-ouia-component-type="PF6/Tabs"
     data-ouia-safe="true"
     id="tabListLabelledByTabs"
@@ -1369,7 +1369,7 @@ exports[`should render tabs with eventKey Strings 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-tabs pf-m-animate-current pf-m-initializing-accent"
-    data-ouia-component-id="OUIA-Generated-Tabs-:r1j:"
+    data-ouia-component-id="OUIA-Generated-Tabs-:r27:"
     data-ouia-component-type="PF6/Tabs"
     data-ouia-safe="true"
     id="eventKeyTabs"
@@ -1487,7 +1487,7 @@ exports[`should render tabs with no bottom border 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-tabs pf-m-animate-current pf-m-no-border-bottom pf-m-initializing-accent"
-    data-ouia-component-id="OUIA-Generated-Tabs-:r21:"
+    data-ouia-component-id="OUIA-Generated-Tabs-:r2l:"
     data-ouia-component-type="PF6/Tabs"
     data-ouia-safe="true"
     id="noBottomBorderTabs"
@@ -1604,7 +1604,7 @@ exports[`should render tabs with separate content 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-tabs pf-m-animate-current pf-m-initializing-accent"
-    data-ouia-component-id="OUIA-Generated-Tabs-:r1l:"
+    data-ouia-component-id="OUIA-Generated-Tabs-:r29:"
     data-ouia-component-type="PF6/Tabs"
     data-ouia-safe="true"
     id="separateTabs"
@@ -1731,7 +1731,7 @@ exports[`should render uncontrolled tabs 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-tabs pf-m-animate-current pf-m-initializing-accent"
-    data-ouia-component-id="OUIA-Generated-Tabs-:rv:"
+    data-ouia-component-id="OUIA-Generated-Tabs-:r1j:"
     data-ouia-component-type="PF6/Tabs"
     data-ouia-safe="true"
     style="--pf-v6-c-tabs--link-accent--length: 0px; --pf-v6-c-tabs--link-accent--start: 0px;"
@@ -1889,7 +1889,7 @@ exports[`should render vertical tabs 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-tabs pf-m-animate-current pf-m-vertical pf-m-initializing-accent"
-    data-ouia-component-id="OUIA-Generated-Tabs-:r11:"
+    data-ouia-component-id="OUIA-Generated-Tabs-:r1l:"
     data-ouia-component-type="PF6/Tabs"
     data-ouia-safe="true"
     id="verticalTabs"


### PR DESCRIPTION
Closes #12094 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Navigation-style tabs (`nav`/`isNav`) can now auto-select from the current URL hash (`#...`). Hidden, disabled, and `aria-disabled` tabs are skipped. If there’s no hash match, selection falls back to the configured active tab. Clicking a nav tab updates the URL hash accordingly (without full page navigation).
* **Tests**
  * Added automated coverage for hash-based selection, fallback behavior, skipping hidden/disabled tabs, and verifying link/hash behavior for both controlled and uncontrolled tabs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->