### PR TITLE
fix(react-icons): add sideEffects: false to dist/esm/package.json

### DIFF
--- a/packages/react-icons/scripts/ensureEsmPackageJson.mjs
+++ b/packages/react-icons/scripts/ensureEsmPackageJson.mjs
@@ -9,4 +9,4 @@ const esmPackageJsonPath = join(__dirname, '../dist/esm/package.json');
 mkdirSync(dirname(esmPackageJsonPath), { recursive: true });
 
 // Write package.json to mark ESM directory as a module
-writeFileSync(esmPackageJsonPath, JSON.stringify({ type: 'module' }, null, 2));
+writeFileSync(esmPackageJsonPath, JSON.stringify({ type: 'module', sideEffects: false }, null, 2));

--- a/yarn.lock
+++ b/yarn.lock
@@ -17300,15 +17300,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.2.2":
-  version: 10.2.5
-  resolution: "minimatch@npm:10.2.5"
-  dependencies:
-    brace-expansion: "npm:^5.0.5"
-  checksum: 10c0/6bb058bd6324104b9ec2f763476a35386d05079c1f5fe4fbf1f324a25237cd4534d6813ecd71f48208f4e635c1221899bef94c3c89f7df55698fe373aaae20fd
-  languageName: node
-  linkType: hard
-
 "minimatch@npm:^3.0.2, minimatch@npm:^3.0.4, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"


### PR DESCRIPTION
**What**: Closes #12313

The generated `dist/esm/package.json` only contains `{"type": "module"}`, which shadows the root `package.json`'s `"sideEffects": false` declaration. Webpack resolves the nearest `package.json` for each module, so all icons under `dist/esm/` are treated as having side effects, breaking tree-shaking and bundling all 2846 icons (~7MB) regardless of usage.

This adds "sideEffects": false to the generated file.

**Additional issues**: Found OCP, which saw a ~5MB bundle size increase after upgrading to prerelease PatternFly packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized ESM package configuration to enable better tree-shaking and reduce bundle sizes in applications using this package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->