### PR TITLE
fix(CI): update surge preview URL

### DIFF
--- a/.github/upload-preview.mjs
+++ b/.github/upload-preview.mjs
@@ -18,7 +18,7 @@ if (!uploadFolder) {
 }
 
 const uploadFolderName = path.basename(uploadFolder);
-let uploadURL = `${repo}-${prnum ? `pr-${prnum}` : prbranch}`.replace(/[/|.]/g, '-');
+let uploadURL = `pf-react-${prnum ? `pr-${prnum}` : prbranch}`.replace(/[/|.]/g, '-');
 
 switch (uploadFolderName) {
   case 'coverage':
@@ -26,7 +26,7 @@ switch (uploadFolderName) {
     break;
   case 'public':
     if (!prnum && prbranch === 'main') {
-      uploadURL = 'react-staging.patternfly.org';
+      uploadURL = 'pf-react-staging.patternfly.org';
     } else {
       uploadURL += '.surge.sh';
     }


### PR DESCRIPTION
Backports a change from main to the 6.2.x release branch.

Intended to address what appear to be permission issues with surge reporting that our surge account does not have the permission to publish to the patternfly-react-6-2-x.surge.sh branch.