### PR TITLE
feat(Menu toggle): Added support for a adding styling for a menu toggle in a form

### DIFF
--- a/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
+++ b/packages/react-core/src/components/MenuToggle/MenuToggle.tsx
@@ -45,6 +45,8 @@ export interface MenuToggleProps
   isFullHeight?: boolean;
   /** Flag indicating the toggle takes up the full width of its parent */
   isFullWidth?: boolean;
+  /** @beta Flag indicating the toggle is placed inside a form */
+  isInForm?: boolean;
   /** Flag indicating the toggle contains placeholder text */
   isPlaceholder?: boolean;
   /** @beta Flag indicating the toggle has circular styling. Can only be applied to plain toggles. */
@@ -83,6 +85,7 @@ class MenuToggleBase extends Component<MenuToggleProps> {
     isDisabled: false,
     isFullWidth: false,
     isFullHeight: false,
+    isInForm: false,
     isPlaceholder: false,
     isCircle: false,
     size: 'default',
@@ -99,6 +102,7 @@ class MenuToggleBase extends Component<MenuToggleProps> {
       isDisabled,
       isFullHeight,
       isFullWidth,
+      isInForm,
       isPlaceholder,
       isCircle,
       isSettings,
@@ -179,9 +183,10 @@ class MenuToggleBase extends Component<MenuToggleProps> {
             variant === 'secondary' && styles.modifiers.secondary,
             status && styles.modifiers[status],
             (isPlain || isPlainText) && styles.modifiers.plain,
-            isPlainText && 'pf-m-text',
+            isPlainText && styles.modifiers.text,
             isFullHeight && styles.modifiers.fullHeight,
             isFullWidth && styles.modifiers.fullWidth,
+            isInForm && styles.modifiers.form,
             isDisabled && styles.modifiers.disabled,
             isPlaceholder && styles.modifiers.placeholder,
             isSettings && styles.modifiers.settings,

--- a/packages/react-core/src/components/MenuToggle/__tests__/MenuToggle.test.tsx
+++ b/packages/react-core/src/components/MenuToggle/__tests__/MenuToggle.test.tsx
@@ -57,6 +57,13 @@ describe('Old Snapshot tests - remove when refactoring', () => {
 
 const toggleVariants = ['default', 'plain', 'primary', 'plainText', 'secondary', 'typeahead'];
 
+test(`Renders with classes ${styles.modifiers.plain} and ${styles.modifiers.text} when variant="plainText" is passed`, () => {
+  render(<MenuToggle variant="plainText">Toggle</MenuToggle>);
+  const toggle = screen.getByRole('button');
+  expect(toggle).toHaveClass(styles.modifiers.plain);
+  expect(toggle).toHaveClass(styles.modifiers.text);
+});
+
 test(`Renders with class ${styles.modifiers.small} when size="sm" is passed`, () => {
   render(<MenuToggle size="sm">Toggle</MenuToggle>);
   expect(screen.getByRole('button')).toHaveClass(styles.modifiers.small);
@@ -99,6 +106,16 @@ test('split toggle passes onClick', async () => {
 
   await user.click(screen.getByRole(`button`) as Element);
   expect(mockClick).toHaveBeenCalled();
+});
+
+test(`Renders with class ${styles.modifiers.form} when isInForm is passed`, () => {
+  render(<MenuToggle isInForm>Toggle</MenuToggle>);
+  expect(screen.getByRole('button')).toHaveClass(styles.modifiers.form);
+});
+
+test(`Does not render class ${styles.modifiers.form} when isInForm is false`, () => {
+  render(<MenuToggle isInForm={false}>Toggle</MenuToggle>);
+  expect(screen.getByRole('button')).not.toHaveClass(styles.modifiers.form);
 });
 
 test(`Renders with class ${styles.modifiers.placeholder} when isPlaceholder is passed`, () => {

--- a/packages/react-core/src/components/MenuToggle/examples/MenuToggle.md
+++ b/packages/react-core/src/components/MenuToggle/examples/MenuToggle.md
@@ -179,6 +179,14 @@ In the following example, the toggle fills the width of its parent as the window
 
 ```
 
+### Toggle in a form
+
+When a menu toggle is used inside a form, pass the `isInForm` property so the toggle receives form-appropriate styling.
+
+```ts file="MenuToggleInForm.tsx"
+
+```
+
 ### Typeahead toggle
 
 To create a typeahead toggle, pass in `variant="typeahead"` to the `<MenuToggle>`. Then, pass a `<TextInputGroup>` component as a child of the `<MenuToggle>`.

--- a/packages/react-core/src/components/MenuToggle/examples/MenuToggleInForm.tsx
+++ b/packages/react-core/src/components/MenuToggle/examples/MenuToggleInForm.tsx
@@ -1,0 +1,7 @@
+import { MenuToggle } from '@patternfly/react-core';
+
+export const MenuToggleInForm = (): JSX.Element => (
+  <MenuToggle isInForm aria-label="Menu toggle in a form">
+    In form
+  </MenuToggle>
+);


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #12279, #12325

- Added beta boolean prop i`sInForm` (default false). When true, the root toggle element gets the `pf-m-form` modifier.
- Added test to  `isInForm`
- made change to no use hard coded `pf-m-text`
- Added a test for when `variant="plainText` that asserts the toggle has `pf-m-plain` and `pf-m-text` modifiers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a beta prop to MenuToggle to enable form-specific styling when used inside forms.
  * Improved plainText variant styling to use the correct text modifier for more consistent appearance.

* **Documentation**
  * Added example and guidance demonstrating MenuToggle usage inside a form.

* **Tests**
  * Added tests verifying plainText styling and the form-specific styling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->