### PR TITLE
chore(docs): Updated remaining TimesIcon to RhMicronsCloseIcon

### DIFF
--- a/packages/code-connect/components/DualListSelector/DualListHeader.figma.tsx
+++ b/packages/code-connect/components/DualListSelector/DualListHeader.figma.tsx
@@ -1,6 +1,6 @@
 import figma from '@figma/code-connect';
 import { Button, ButtonVariant, DualListSelectorPane, SearchInput } from '@patternfly/react-core';
-import RhMicronsCloseIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+import RhMicronsCloseIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-close-icon';
 
 // Documentation for DualListHeader can be found at https://www.patternfly.org/components/dual-list-selector
 

--- a/packages/code-connect/components/DualListSelector/DualListHeader.figma.tsx
+++ b/packages/code-connect/components/DualListSelector/DualListHeader.figma.tsx
@@ -1,6 +1,6 @@
 import figma from '@figma/code-connect';
 import { Button, ButtonVariant, DualListSelectorPane, SearchInput } from '@patternfly/react-core';
-import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+import RhMicronsCloseIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
 
 // Documentation for DualListHeader can be found at https://www.patternfly.org/components/dual-list-selector
 
@@ -9,7 +9,7 @@ figma.connect(
   'https://www.figma.com/design/aEBBvq0J3EPXxHvv6WgDx9/PatternFly-6--Components-Test?node-id=21279-116172',
   {
     props: {
-      icon: <TimesIcon />, // placeholder icon
+      icon: <RhMicronsCloseIcon />, // placeholder icon
 
       // string
       itemInformation: figma.string('Item information'),

--- a/packages/react-core/src/components/HelperText/examples/HelperText.md
+++ b/packages/react-core/src/components/HelperText/examples/HelperText.md
@@ -9,7 +9,7 @@ import { Fragment } from 'react';
 import InfoIcon from '@patternfly/react-icons/dist/esm/icons/info-icon';
 import QuestionIcon from '@patternfly/react-icons/dist/esm/icons/question-icon';
 import CheckIcon from '@patternfly/react-icons/dist/esm/icons/check-icon';
-import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+import RhMicronsCloseIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
 import ExclamationIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-icon';
 
 ## Examples

--- a/packages/react-core/src/components/HelperText/examples/HelperText.md
+++ b/packages/react-core/src/components/HelperText/examples/HelperText.md
@@ -9,7 +9,7 @@ import { Fragment } from 'react';
 import InfoIcon from '@patternfly/react-icons/dist/esm/icons/info-icon';
 import QuestionIcon from '@patternfly/react-icons/dist/esm/icons/question-icon';
 import CheckIcon from '@patternfly/react-icons/dist/esm/icons/check-icon';
-import RhMicronsCloseIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+import RhMicronsCloseIcon from  '@patternfly/react-icons/dist/esm/icons/rh-microns-close-icon';
 import ExclamationIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-icon';
 
 ## Examples

--- a/packages/react-core/src/components/HelperText/examples/HelperTextWithCustomIcon.tsx
+++ b/packages/react-core/src/components/HelperText/examples/HelperTextWithCustomIcon.tsx
@@ -4,7 +4,7 @@ import InfoIcon from '@patternfly/react-icons/dist/esm/icons/info-icon';
 import QuestionIcon from '@patternfly/react-icons/dist/esm/icons/question-icon';
 import ExclamationIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-icon';
 import CheckIcon from '@patternfly/react-icons/dist/esm/icons/check-icon';
-import RhMicronsCloseIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+import RhMicronsCloseIcon from '@patternfly/react-icons/dist/esm/icons/rh-microns-close-icon';
 
 export const HelperTextWithCustomIcon: React.FunctionComponent = () => (
   <Fragment>

--- a/packages/react-core/src/components/HelperText/examples/HelperTextWithCustomIcon.tsx
+++ b/packages/react-core/src/components/HelperText/examples/HelperTextWithCustomIcon.tsx
@@ -4,7 +4,7 @@ import InfoIcon from '@patternfly/react-icons/dist/esm/icons/info-icon';
 import QuestionIcon from '@patternfly/react-icons/dist/esm/icons/question-icon';
 import ExclamationIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-icon';
 import CheckIcon from '@patternfly/react-icons/dist/esm/icons/check-icon';
-import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+import RhMicronsCloseIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
 
 export const HelperTextWithCustomIcon: React.FunctionComponent = () => (
   <Fragment>
@@ -27,7 +27,7 @@ export const HelperTextWithCustomIcon: React.FunctionComponent = () => (
       </HelperTextItem>
     </HelperText>
     <HelperText>
-      <HelperTextItem variant="error" icon={<TimesIcon />}>
+      <HelperTextItem variant="error" icon={<RhMicronsCloseIcon />}>
         This is error helper text
       </HelperTextItem>
     </HelperText>

--- a/packages/react-core/src/demos/CustomMenus/CustomMenus.md
+++ b/packages/react-core/src/demos/CustomMenus/CustomMenus.md
@@ -20,7 +20,7 @@ import ThIcon from '@patternfly/react-icons/dist/esm/icons/th-icon';
 import brandImg from '../assets/PF-IconLogo.svg';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import CaretDownIcon from '@patternfly/react-icons/dist/esm/icons/caret-down-icon';
-import RhMicronsCloseIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+import RhMicronsCloseIcon from  '@patternfly/react-icons/dist/esm/icons/rh-microns-close-icon';
 import avatarImg from '../assets/avatarImg.svg';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Menu/menu';

--- a/packages/react-core/src/demos/CustomMenus/CustomMenus.md
+++ b/packages/react-core/src/demos/CustomMenus/CustomMenus.md
@@ -20,7 +20,7 @@ import ThIcon from '@patternfly/react-icons/dist/esm/icons/th-icon';
 import brandImg from '../assets/PF-IconLogo.svg';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import CaretDownIcon from '@patternfly/react-icons/dist/esm/icons/caret-down-icon';
-import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+import RhMicronsCloseIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
 import avatarImg from '../assets/avatarImg.svg';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Menu/menu';

--- a/packages/react-core/src/demos/HelperText.md
+++ b/packages/react-core/src/demos/HelperText.md
@@ -9,7 +9,7 @@ import RhUiWarningFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-wa
 import RhUiCheckCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-check-circle-fill-icon';
 import RhUiErrorFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-error-fill-icon';
 import CheckIcon from '@patternfly/react-icons/dist/esm/icons/check-icon';
-import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+import RhMicronsCloseIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
 
 ## Demos
 

--- a/packages/react-core/src/demos/HelperText.md
+++ b/packages/react-core/src/demos/HelperText.md
@@ -9,7 +9,7 @@ import RhUiWarningFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-wa
 import RhUiCheckCircleFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-check-circle-fill-icon';
 import RhUiErrorFillIcon from '@patternfly/react-icons/dist/esm/icons/rh-ui-error-fill-icon';
 import CheckIcon from '@patternfly/react-icons/dist/esm/icons/check-icon';
-import RhMicronsCloseIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+import RhMicronsCloseIcon from  '@patternfly/react-icons/dist/esm/icons/rh-microns-close-icon';
 
 ## Demos
 

--- a/packages/react-core/src/demos/Toolbar.md
+++ b/packages/react-core/src/demos/Toolbar.md
@@ -11,7 +11,7 @@ import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external
 import DownloadIcon from '@patternfly/react-icons/dist/esm/icons/download-icon';
 import CogIcon from '@patternfly/react-icons/dist/esm/icons/cog-icon';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
-import RhMicronsCloseIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+import RhMicronsCloseIcon from  '@patternfly/react-icons/dist/esm/icons/rh-microns-close-icon';
 import { DashboardWrapper } from '@patternfly/react-core/dist/js/demos/DashboardWrapper';
 
 ## Demos

--- a/packages/react-core/src/demos/Toolbar.md
+++ b/packages/react-core/src/demos/Toolbar.md
@@ -11,7 +11,7 @@ import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external
 import DownloadIcon from '@patternfly/react-icons/dist/esm/icons/download-icon';
 import CogIcon from '@patternfly/react-icons/dist/esm/icons/cog-icon';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
-import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+import RhMicronsCloseIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
 import { DashboardWrapper } from '@patternfly/react-core/dist/js/demos/DashboardWrapper';
 
 ## Demos

--- a/packages/react-icons/README.md
+++ b/packages/react-icons/README.md
@@ -83,13 +83,13 @@ You can import or reference static SVG files directly:
 
 ```jsx
 // In HTML
-<img src="/icons/static/times-icon.svg" alt="Close" />
+<img src="/icons/static/rh-microns-close-icon.svg" alt="Close" />
 
 // In CSS
 .close-icon {
-  background-image: url('/icons/static/times-icon.svg');
+  background-image: url('/icons/static/rh-microns-close-icon.svg');
 }
 
 // Direct file path
-import RhMicronsCloseIcon from '@patternfly/react-icons/dist/static/times-icon.svg';
+import RhMicronsCloseIcon from '@patternfly/react-icons/dist/static/rh-microns-close-icon.svg';
 ```

--- a/packages/react-icons/README.md
+++ b/packages/react-icons/README.md
@@ -5,7 +5,7 @@ PatternFly Icons as React Components.
 ## Usage
 
 ```tsx
-import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+import RhMicronsCloseIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
 
 const closeIcon = <TimesIcon />;
 ```
@@ -47,7 +47,7 @@ optimization: {
 Use ESM module imports to enable tree shaking with no additional setup required.
 
 ```JS
-import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+import RhMicronsCloseIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
 ```
 
 To enable tree shaking with named imports for CJS modules, utilize [babel-plugin-transform-imports](https://www.npmjs.com/package/babel-plugin-transform-imports) and update a babel.config.js file to utilize the plugin:
@@ -91,5 +91,5 @@ You can import or reference static SVG files directly:
 }
 
 // Direct file path
-import timesIcon from '@patternfly/react-icons/dist/static/times-icon.svg';
+import RhMicronsCloseIcon from '@patternfly/react-icons/dist/static/times-icon.svg';
 ```

--- a/packages/react-icons/README.md
+++ b/packages/react-icons/README.md
@@ -7,7 +7,7 @@ PatternFly Icons as React Components.
 ```tsx
 import RhMicronsCloseIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
 
-const closeIcon = <TimesIcon />;
+const closeIcon = <RhMicronsCloseIcon />;
 ```
 
 For a list of the available icons please refer to the [PatternFly react docs](https://pf-react-staging.patternfly.org/icons)

--- a/packages/react-icons/README.md
+++ b/packages/react-icons/README.md
@@ -5,7 +5,7 @@ PatternFly Icons as React Components.
 ## Usage
 
 ```tsx
-import RhMicronsCloseIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+import RhMicronsCloseIcon from  '@patternfly/react-icons/dist/esm/icons/rh-microns-close-icon';
 
 const closeIcon = <RhMicronsCloseIcon />;
 ```
@@ -47,7 +47,7 @@ optimization: {
 Use ESM module imports to enable tree shaking with no additional setup required.
 
 ```JS
-import RhMicronsCloseIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+import RhMicronsCloseIcon from  '@patternfly/react-icons/dist/esm/icons/rh-microns-close-icon';
 ```
 
 To enable tree shaking with named imports for CJS modules, utilize [babel-plugin-transform-imports](https://www.npmjs.com/package/babel-plugin-transform-imports) and update a babel.config.js file to utilize the plugin:


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #12323

Update all instances of imported `TimesIcon` to import `RhMicronsCloseIcon` instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized close icon usage across components, demos, and examples by switching all instances to a unified close icon.

* **Documentation**
  * Updated README, demo content, and example snippets to reflect the revised close icon in usage and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->