### PR TITLE
fix(createIcon): Fix broken API in createIcon.tsx

### DIFF
--- a/packages/react-icons/scripts/writeIcons.mjs
+++ b/packages/react-icons/scripts/writeIcons.mjs
@@ -7,9 +7,9 @@ import { pfToRhIcons } from './icons/pfToRhIcons.mjs';
 import * as url from 'url';
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
-// Import createIcon from compiled dist (build:esm must run first)
+// Import createIconBase from compiled dist (build:esm must run first)
 const createIconModule = await import('../dist/esm/createIcon.js');
-const createIcon = createIconModule.createIcon;
+const createIconBase = createIconModule.createIconBase;
 
 const outDir = join(__dirname, '../dist');
 const staticDir = join(outDir, 'static');
@@ -27,7 +27,7 @@ exports.${jsName}Config = {
   icon: ${JSON.stringify(icon)},
   rhUiIcon: ${rhUiIcon ? JSON.stringify(rhUiIcon) : 'null'},
 };
-exports.${jsName} = require('../createIcon').createIcon(exports.${jsName}Config);
+exports.${jsName} = require('../createIcon').createIconBase(exports.${jsName}Config);
 exports["default"] = exports.${jsName};
     `.trim()
   );
@@ -36,7 +36,7 @@ exports["default"] = exports.${jsName};
 const writeESMExport = (fname, jsName, icon, rhUiIcon = null) => {
   outputFileSync(
     join(outDir, 'esm/icons', `${fname}.js`),
-    `import { createIcon } from '../createIcon.js';
+    `import { createIconBase } from '../createIcon.js';
 
 export const ${jsName}Config = {
   name: '${jsName}',
@@ -44,7 +44,7 @@ export const ${jsName}Config = {
   rhUiIcon: ${rhUiIcon ? JSON.stringify(rhUiIcon) : 'null'},
 };
 
-export const ${jsName} = createIcon(${jsName}Config);
+export const ${jsName} = createIconBase(${jsName}Config);
 
 export default ${jsName};
     `.trim()
@@ -68,7 +68,7 @@ export default ${jsName};
 };
 
 /**
- * Generates a static SVG string from icon data using createIcon
+ * Generates a static SVG string from icon data using createIconBase
  * @param {string} iconName The name of the icon
  * @param {object} icon The icon data object
  * @returns {string} Static SVG markup
@@ -76,8 +76,8 @@ export default ${jsName};
 function generateStaticSVG(iconName, icon) {
   const jsName = `${toCamel(iconName)}Icon`;
 
-  // Create icon component using createIcon
-  const IconComponent = createIcon({
+  // Create icon component using createIconBase
+  const IconComponent = createIconBase({
     name: jsName,
     icon
   });

--- a/packages/react-icons/src/__tests__/createIcon.test.tsx
+++ b/packages/react-icons/src/__tests__/createIcon.test.tsx
@@ -2,9 +2,9 @@ import { render, screen } from '@testing-library/react';
 import {
   IconDefinition,
   CreateIconBaseProps,
+  CreateIconLegacyProps,
   createIcon,
   createIconBase,
-  LegacyFlatIconDefinition,
   SVGPathObject
 } from '../createIcon';
 
@@ -71,7 +71,7 @@ test('sets correct svgPath if string', () => {
 });
 
 test('accepts legacy flat createIcon({ svgPath }) shape', () => {
-  const legacyDef: LegacyFlatIconDefinition = {
+  const legacyDef: CreateIconLegacyProps = {
     name: 'LegacyIcon',
     width: 10,
     height: 20,

--- a/packages/react-icons/src/__tests__/createIcon.test.tsx
+++ b/packages/react-icons/src/__tests__/createIcon.test.tsx
@@ -1,5 +1,12 @@
 import { render, screen } from '@testing-library/react';
-import { IconDefinition, CreateIconProps, createIcon, LegacyFlatIconDefinition, SVGPathObject } from '../createIcon';
+import {
+  IconDefinition,
+  CreateIconBaseProps,
+  createIcon,
+  createIconBase,
+  LegacyFlatIconDefinition,
+  SVGPathObject
+} from '../createIcon';
 
 const multiPathIcon: IconDefinition = {
   name: 'IconName',
@@ -28,24 +35,24 @@ const rhStandardIcon: IconDefinition = {
   svgClassName: 'pf-v6-icon-rh-standard'
 };
 
-const iconDef: CreateIconProps = {
+const iconDef: CreateIconBaseProps = {
   name: 'SinglePathIconName',
   icon: singlePathIcon
 };
 
-const iconDefWithArrayPath: CreateIconProps = {
+const iconDefWithArrayPath: CreateIconBaseProps = {
   name: 'MultiPathIconName',
   icon: multiPathIcon
 };
 
-const iconDefWithRhStandard: CreateIconProps = {
+const iconDefWithRhStandard: CreateIconBaseProps = {
   name: 'RhStandardIconName',
   icon: rhStandardIcon
 };
 
-const SVGIcon = createIcon(iconDef);
-const SVGArrayIcon = createIcon(iconDefWithArrayPath);
-const RhStandardIcon = createIcon(iconDefWithRhStandard);
+const SVGIcon = createIconBase(iconDef);
+const SVGArrayIcon = createIconBase(iconDefWithArrayPath);
+const RhStandardIcon = createIconBase(iconDefWithRhStandard);
 
 test('sets correct viewBox', () => {
   render(<SVGIcon />);
@@ -76,8 +83,8 @@ test('accepts legacy flat createIcon({ svgPath }) shape', () => {
   expect(screen.getByRole('img', { hidden: true }).querySelector('path')).toHaveAttribute('d', 'legacy-path');
 });
 
-test('accepts CreateIconProps with nested icon using deprecated svgPath field', () => {
-  const nestedLegacyPath: CreateIconProps = {
+test('createIconBase accepts nested icon with deprecated svgPath field', () => {
+  const nestedLegacyPath: CreateIconBaseProps = {
     name: 'NestedLegacyPathIcon',
     icon: {
       width: 8,
@@ -85,7 +92,7 @@ test('accepts CreateIconProps with nested icon using deprecated svgPath field', 
       svgPath: 'nested-legacy-d'
     }
   };
-  const NestedIcon = createIcon(nestedLegacyPath);
+  const NestedIcon = createIconBase(nestedLegacyPath);
   render(<NestedIcon />);
   expect(screen.getByRole('img', { hidden: true }).querySelector('path')).toHaveAttribute('d', 'nested-legacy-d');
 });
@@ -105,15 +112,13 @@ test('does not set svgClassName when noDefaultStyle is true', () => {
   expect(screen.getByRole('img', { hidden: true })).not.toHaveClass('pf-v6-icon-rh-standard');
 });
 
-test('throws when nested CreateIconProps omits icon', () => {
+test('throws when createIconBase omits icon', () => {
   expect(() =>
-    createIcon({
+    createIconBase({
       name: 'MissingDefaultIcon',
       rhUiIcon: null
-    })
-  ).toThrow(
-    '@patternfly/react-icons: createIcon requires an `icon` definition when using nested CreateIconProps (name: MissingDefaultIcon).'
-  );
+    } as any)
+  ).toThrow('@patternfly/react-icons: createIconBase requires an `icon` definition (name: MissingDefaultIcon).');
 });
 
 test('sets correct svgPath if array', () => {
@@ -187,13 +192,13 @@ describe('rh-ui mapping: nested SVGs, set prop, and warnings', () => {
     svgPathData: rhUiPath
   };
 
-  const dualConfig: CreateIconProps = {
+  const dualConfig: CreateIconBaseProps = {
     name: 'DualMappedIcon',
     icon: defaultIconDef,
     rhUiIcon: rhUiIconDef
   };
 
-  const DualMappedIcon = createIcon(dualConfig);
+  const DualMappedIcon = createIconBase(dualConfig);
 
   test('renders two nested inner svgs when rhUiIcon is set and `set` is omitted (swap layout)', () => {
     render(<DualMappedIcon />);
@@ -225,7 +230,7 @@ describe('rh-ui mapping: nested SVGs, set prop, and warnings', () => {
   test('set="rh-ui" with no rhUiIcon mapping falls back to default and warns', () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     try {
-      const IconNoRhMapping = createIcon({
+      const IconNoRhMapping = createIconBase({
         name: 'NoRhMappingIcon',
         icon: defaultIconDef,
         rhUiIcon: null

--- a/packages/react-icons/src/__tests__/createIcon.test.tsx
+++ b/packages/react-icons/src/__tests__/createIcon.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import {
   IconDefinition,
   CreateIconBaseProps,
-  CreateIconLegacyProps,
+  CreateIconProps,
   createIcon,
   createIconBase,
   SVGPathObject
@@ -71,7 +71,7 @@ test('sets correct svgPath if string', () => {
 });
 
 test('accepts legacy flat createIcon({ svgPath }) shape', () => {
-  const legacyDef: CreateIconLegacyProps = {
+  const legacyDef: CreateIconProps = {
     name: 'LegacyIcon',
     width: 10,
     height: 20,

--- a/packages/react-icons/src/__tests__/createIcon.test.tsx
+++ b/packages/react-icons/src/__tests__/createIcon.test.tsx
@@ -1,5 +1,7 @@
+// eslint-disable-next-line no-restricted-imports -- test file excluded from package tsconfig; default import satisfies TS/JSX
+import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { IconDefinition, CreateIconProps, createIcon, SVGPathObject } from '../createIcon';
+import { IconDefinition, CreateIconProps, createIcon, LegacyFlatIconDefinition, SVGPathObject } from '../createIcon';
 
 const multiPathIcon: IconDefinition = {
   name: 'IconName',
@@ -57,7 +59,37 @@ test('sets correct viewBox', () => {
 
 test('sets correct svgPath if string', () => {
   render(<SVGIcon />);
-  expect(screen.getByRole('img', { hidden: true }).querySelector('path')).toHaveAttribute('d', iconDef.svgPath);
+  expect(screen.getByRole('img', { hidden: true }).querySelector('path')).toHaveAttribute(
+    'd',
+    singlePathIcon.svgPathData
+  );
+});
+
+test('accepts legacy flat createIcon({ svgPath }) shape', () => {
+  const legacyDef: LegacyFlatIconDefinition = {
+    name: 'LegacyIcon',
+    width: 10,
+    height: 20,
+    svgPath: 'legacy-path',
+    svgClassName: 'legacy-svg'
+  };
+  const LegacySVGIcon = createIcon(legacyDef);
+  render(<LegacySVGIcon />);
+  expect(screen.getByRole('img', { hidden: true }).querySelector('path')).toHaveAttribute('d', 'legacy-path');
+});
+
+test('accepts CreateIconProps with nested icon using deprecated svgPath field', () => {
+  const nestedLegacyPath: CreateIconProps = {
+    name: 'NestedLegacyPathIcon',
+    icon: {
+      width: 8,
+      height: 8,
+      svgPath: 'nested-legacy-d'
+    }
+  };
+  const NestedIcon = createIcon(nestedLegacyPath);
+  render(<NestedIcon />);
+  expect(screen.getByRole('img', { hidden: true }).querySelector('path')).toHaveAttribute('d', 'nested-legacy-d');
 });
 
 test('sets correct svgClassName by default', () => {
@@ -126,4 +158,78 @@ test('aria-labelledby matches title id', () => {
 test('additional props should be spread to the root svg element', () => {
   render(<SVGIcon data-testid="icon" />);
   expect(screen.getByTestId('icon')).toBeInTheDocument();
+});
+
+describe('rh-ui mapping: nested SVGs, set prop, and warnings', () => {
+  const defaultPath = 'M0 0-default';
+  const rhUiPath = 'M0 0-rh-ui';
+
+  const defaultIconDef: IconDefinition = {
+    name: 'DefaultVariant',
+    width: 16,
+    height: 16,
+    svgPathData: defaultPath
+  };
+
+  const rhUiIconDef: IconDefinition = {
+    name: 'RhUiVariant',
+    width: 16,
+    height: 16,
+    svgPathData: rhUiPath
+  };
+
+  const dualConfig: CreateIconProps = {
+    name: 'DualMappedIcon',
+    icon: defaultIconDef,
+    rhUiIcon: rhUiIconDef
+  };
+
+  const DualMappedIcon = createIcon(dualConfig);
+
+  test('renders two nested inner svgs when rhUiIcon is set and `set` is omitted (swap layout)', () => {
+    render(<DualMappedIcon />);
+    const root = screen.getByRole('img', { hidden: true });
+    expect(root).toHaveClass('pf-v6-svg');
+    const innerSvgs = root.querySelectorAll(':scope > svg');
+    expect(innerSvgs).toHaveLength(2);
+    expect(root?.querySelector('.pf-v6-icon-default path')).toHaveAttribute('d', defaultPath);
+    expect(root?.querySelector('.pf-v6-icon-rh-ui path')).toHaveAttribute('d', rhUiPath);
+  });
+
+  test('set="default" renders a single flat svg using the default icon paths', () => {
+    render(<DualMappedIcon set="default" />);
+    const root = screen.getByRole('img', { hidden: true });
+    expect(root.querySelectorAll(':scope > svg')).toHaveLength(0);
+    expect(root).toHaveAttribute('viewBox', '0 0 16 16');
+    expect(root.querySelector('path')).toHaveAttribute('d', defaultPath);
+    expect(root.querySelectorAll('svg')).toHaveLength(0);
+  });
+
+  test('set="rh-ui" renders a single flat svg using the rh-ui icon paths', () => {
+    render(<DualMappedIcon set="rh-ui" />);
+    const root = screen.getByRole('img', { hidden: true });
+    expect(root.querySelectorAll(':scope > svg')).toHaveLength(0);
+    expect(root.querySelector('path')).toHaveAttribute('d', rhUiPath);
+    expect(root.querySelectorAll('svg')).toHaveLength(0);
+  });
+
+  test('set="rh-ui" with no rhUiIcon mapping falls back to default and warns', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const IconNoRhMapping = createIcon({
+      name: 'NoRhMappingIcon',
+      icon: defaultIconDef,
+      rhUiIcon: null
+    });
+
+    render(<IconNoRhMapping set="rh-ui" />);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Set "rh-ui" was provided for NoRhMappingIcon, but no rh-ui icon data exists for this icon. The default icon will be rendered.'
+    );
+    const root = screen.getByRole('img', { hidden: true });
+    expect(root.querySelector('path')).toHaveAttribute('d', defaultPath);
+    expect(root.querySelectorAll('svg')).toHaveLength(0);
+
+    warnSpy.mockRestore();
+  });
 });

--- a/packages/react-icons/src/__tests__/createIcon.test.tsx
+++ b/packages/react-icons/src/__tests__/createIcon.test.tsx
@@ -1,5 +1,3 @@
-// eslint-disable-next-line no-restricted-imports -- test file excluded from package tsconfig; default import satisfies TS/JSX
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { IconDefinition, CreateIconProps, createIcon, LegacyFlatIconDefinition, SVGPathObject } from '../createIcon';
 
@@ -105,6 +103,17 @@ test('sets svgClassName when noDefaultStyle is false', () => {
 test('does not set svgClassName when noDefaultStyle is true', () => {
   render(<RhStandardIcon noDefaultStyle />);
   expect(screen.getByRole('img', { hidden: true })).not.toHaveClass('pf-v6-icon-rh-standard');
+});
+
+test('throws when nested CreateIconProps omits icon', () => {
+  expect(() =>
+    createIcon({
+      name: 'MissingDefaultIcon',
+      rhUiIcon: null
+    })
+  ).toThrow(
+    '@patternfly/react-icons: createIcon requires an `icon` definition when using nested CreateIconProps (name: MissingDefaultIcon).'
+  );
 });
 
 test('sets correct svgPath if array', () => {
@@ -215,21 +224,23 @@ describe('rh-ui mapping: nested SVGs, set prop, and warnings', () => {
 
   test('set="rh-ui" with no rhUiIcon mapping falls back to default and warns', () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-    const IconNoRhMapping = createIcon({
-      name: 'NoRhMappingIcon',
-      icon: defaultIconDef,
-      rhUiIcon: null
-    });
+    try {
+      const IconNoRhMapping = createIcon({
+        name: 'NoRhMappingIcon',
+        icon: defaultIconDef,
+        rhUiIcon: null
+      });
 
-    render(<IconNoRhMapping set="rh-ui" />);
+      render(<IconNoRhMapping set="rh-ui" />);
 
-    expect(warnSpy).toHaveBeenCalledWith(
-      'Set "rh-ui" was provided for NoRhMappingIcon, but no rh-ui icon data exists for this icon. The default icon will be rendered.'
-    );
-    const root = screen.getByRole('img', { hidden: true });
-    expect(root.querySelector('path')).toHaveAttribute('d', defaultPath);
-    expect(root.querySelectorAll('svg')).toHaveLength(0);
-
-    warnSpy.mockRestore();
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Set "rh-ui" was provided for NoRhMappingIcon, but no rh-ui icon data exists for this icon. The default icon will be rendered.'
+      );
+      const root = screen.getByRole('img', { hidden: true });
+      expect(root.querySelector('path')).toHaveAttribute('d', defaultPath);
+      expect(root.querySelectorAll('svg')).toHaveLength(0);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/packages/react-icons/src/__tests__/createIcon.test.tsx
+++ b/packages/react-icons/src/__tests__/createIcon.test.tsx
@@ -79,20 +79,6 @@ test('accepts flat createIcon({ svgPath }) shape', () => {
   expect(screen.getByRole('img', { hidden: true }).querySelector('path')).toHaveAttribute('d', 'legacy-path');
 });
 
-test('createIconBase accepts nested icon with deprecated svgPath field', () => {
-  const nestedLegacyPath: CreateIconBaseProps = {
-    name: 'NestedLegacyPathIcon',
-    icon: {
-      width: 8,
-      height: 8,
-      svgPath: 'nested-legacy-d'
-    }
-  };
-  const NestedIcon = createIconBase(nestedLegacyPath);
-  render(<NestedIcon />);
-  expect(screen.getByRole('img', { hidden: true }).querySelector('path')).toHaveAttribute('d', 'nested-legacy-d');
-});
-
 test('sets correct svgClassName by default', () => {
   render(<RhStandardIcon />);
   expect(screen.getByRole('img', { hidden: true })).toHaveClass('pf-v6-icon-rh-standard');
@@ -106,15 +92,6 @@ test('sets svgClassName when noDefaultStyle is false', () => {
 test('does not set svgClassName when noDefaultStyle is true', () => {
   render(<RhStandardIcon noDefaultStyle />);
   expect(screen.getByRole('img', { hidden: true })).not.toHaveClass('pf-v6-icon-rh-standard');
-});
-
-test('throws when createIconBase omits icon', () => {
-  expect(() =>
-    createIconBase({
-      name: 'MissingDefaultIcon',
-      rhUiIcon: null
-    })
-  ).toThrow('@patternfly/react-icons: createIconBase requires an `icon` definition (name: MissingDefaultIcon).');
 });
 
 test('sets correct svgPath if array', () => {
@@ -243,5 +220,16 @@ describe('rh-ui mapping: nested SVGs, set prop, and warnings', () => {
     } finally {
       warnSpy.mockRestore();
     }
+  });
+
+  test('warns when createIconBase omits icon', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    createIconBase({
+      name: 'MissingDefaultIcon',
+      rhUiIcon: null
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      '@patternfly/react-icons: createIconBase is missing an `icon` definition (name: MissingDefaultIcon).'
+    );
   });
 });

--- a/packages/react-icons/src/__tests__/createIcon.test.tsx
+++ b/packages/react-icons/src/__tests__/createIcon.test.tsx
@@ -1,12 +1,8 @@
 import { render, screen } from '@testing-library/react';
-import {
-  IconDefinition,
-  CreateIconBaseProps,
-  CreateIconProps,
-  createIcon,
-  createIconBase,
-  SVGPathObject
-} from '../createIcon';
+import { IconDefinition, CreateIconProps, createIcon, createIconBase, SVGPathObject } from '../createIcon';
+
+/** Mirrors the non-exported argument type of {@link createIconBase} for tests. */
+type CreateIconBaseProps = Parameters<typeof createIconBase>[0];
 
 const multiPathIcon: IconDefinition = {
   name: 'IconName',
@@ -70,7 +66,7 @@ test('sets correct svgPath if string', () => {
   );
 });
 
-test('accepts legacy flat createIcon({ svgPath }) shape', () => {
+test('accepts flat createIcon({ svgPath }) shape', () => {
   const legacyDef: CreateIconProps = {
     name: 'LegacyIcon',
     width: 10,
@@ -117,7 +113,7 @@ test('throws when createIconBase omits icon', () => {
     createIconBase({
       name: 'MissingDefaultIcon',
       rhUiIcon: null
-    } as any)
+    })
   ).toThrow('@patternfly/react-icons: createIconBase requires an `icon` definition (name: MissingDefaultIcon).');
 });
 

--- a/packages/react-icons/src/createIcon.tsx
+++ b/packages/react-icons/src/createIcon.tsx
@@ -5,21 +5,48 @@ export interface SVGPathObject {
   className?: string;
 }
 
-export interface IconDefinition {
+export interface IconDefinitionBase {
   name?: string;
   width: number;
   height: number;
-  svgPathData: string | SVGPathObject[];
   xOffset?: number;
   yOffset?: number;
   svgClassName?: string;
 }
 
+/**
+ * SVG path content for one icon variant (default or rh-ui). At runtime at least one of
+ * `svgPathData` or `svgPath` must be set; if both are present, `svgPathData` is used.
+ */
+export interface IconDefinition extends IconDefinitionBase {
+  svgPathData?: string | SVGPathObject[];
+  /**
+   * @deprecated Use {@link IconDefinition.svgPathData} instead.
+   */
+  svgPath?: string | SVGPathObject[];
+}
+
+/** Narrows {@link IconDefinition} to the preferred shape with required `svgPathData`. */
+export type IconDefinitionWithSvgPathData = Required<Pick<IconDefinition, 'svgPathData'>> & IconDefinition;
+
+/**
+ * @deprecated Use {@link IconDefinition} with `svgPathData` instead.
+ * Narrows {@link IconDefinition} to the legacy shape with required `svgPath`.
+ */
+export type IconDefinitionWithSvgPath = Required<Pick<IconDefinition, 'svgPath'>> & IconDefinition;
+
+/** When passing `icon` or `rhUiIcon` keys (nested form), `icon` is required at runtime. */
 export interface CreateIconProps {
   name?: string;
   icon?: IconDefinition;
   rhUiIcon?: IconDefinition | null;
 }
+
+/**
+ * @deprecated The previous `createIcon` accepted a flat {@link IconDefinition} with top-level
+ * `svgPath`. Pass {@link CreateIconProps} with a nested `icon` field instead.
+ */
+export type LegacyFlatIconDefinition = IconDefinition;
 
 export interface SVGIconProps extends Omit<React.HTMLProps<SVGElement>, 'ref'> {
   title?: string;
@@ -32,7 +59,70 @@ export interface SVGIconProps extends Omit<React.HTMLProps<SVGElement>, 'ref'> {
 
 let currentId = 0;
 
-const createSvg = (icon: IconDefinition, iconClassName: string) => {
+/** Returns path data from `svgPathData` or deprecated `svgPath` (prefers `svgPathData` when both exist). */
+function resolveSvgPathData(icon: IconDefinition): string | SVGPathObject[] {
+  if ('svgPathData' in icon && icon.svgPathData !== undefined) {
+    return icon.svgPathData;
+  }
+  if ('svgPath' in icon && icon.svgPath !== undefined) {
+    return icon.svgPath;
+  }
+  throw new Error('@patternfly/react-icons: IconDefinition must define svgPathData or svgPath');
+}
+
+/** Produces a single {@link IconDefinitionWithSvgPathData} for internal rendering. */
+function normalizeIconDefinition(icon: IconDefinition): IconDefinitionWithSvgPathData {
+  return {
+    name: icon.name,
+    width: icon.width,
+    height: icon.height,
+    svgPathData: resolveSvgPathData(icon),
+    xOffset: icon.xOffset,
+    yOffset: icon.yOffset,
+    svgClassName: icon.svgClassName
+  };
+}
+
+/** True when the argument uses the nested `CreateIconProps` shape (`icon` and/or `rhUiIcon` keys). */
+function isNestedCreateIconProps(arg: object): arg is CreateIconProps {
+  return 'icon' in arg || 'rhUiIcon' in arg;
+}
+
+/** Props after resolving legacy `svgPath` and flat `createIcon` arguments. */
+interface NormalizedCreateIconProps {
+  name?: string;
+  icon?: IconDefinitionWithSvgPathData;
+  rhUiIcon: IconDefinitionWithSvgPathData | null;
+}
+
+/**
+ * Coerces legacy flat or nested props into normalized {@link NormalizedCreateIconProps}.
+ * Nested input must include a non-null `icon` or throws.
+ */
+function normalizeCreateIconArg(arg: CreateIconProps | LegacyFlatIconDefinition): NormalizedCreateIconProps {
+  if (isNestedCreateIconProps(arg)) {
+    const p = arg as CreateIconProps;
+    if (p.icon == null) {
+      const label = p.name != null ? ` (name: ${String(p.name)})` : '';
+      throw new Error(
+        `@patternfly/react-icons: createIcon requires an \`icon\` definition when using nested CreateIconProps${label}.`
+      );
+    }
+    return {
+      name: p.name,
+      icon: normalizeIconDefinition(p.icon),
+      rhUiIcon: p.rhUiIcon != null ? normalizeIconDefinition(p.rhUiIcon) : null
+    };
+  }
+  return {
+    name: (arg as LegacyFlatIconDefinition).name,
+    icon: normalizeIconDefinition(arg as IconDefinition),
+    rhUiIcon: null
+  };
+}
+
+/** Renders an inner `<svg>` with viewBox and path(s) for the dual-SVG (CSS swap) layout. */
+const createSvg = (icon: IconDefinitionWithSvgPathData, iconClassName: string) => {
   const { xOffset, yOffset, width, height, svgPathData, svgClassName } = icon ?? {};
   const _xOffset = xOffset ?? 0;
   const _yOffset = yOffset ?? 0;
@@ -64,9 +154,33 @@ const createSvg = (icon: IconDefinition, iconClassName: string) => {
 };
 
 /**
- * Factory to create Icon class components for consumers
+ * Builds a React **class** component that renders a PatternFly SVG icon (`role="img"`, optional `<title>` for a11y).
+ *
+ * **Argument shape — pick one:**
+ *
+ * 1. **`CreateIconProps` (preferred)** — `{ name?, icon?, rhUiIcon? }`. Dimensions and path data sit on `icon`
+ *    (and optionally on `rhUiIcon` for Red Hat UI–mapped icons). If the object **has an `icon` or `rhUiIcon` key**
+ *    (including `rhUiIcon: null`), this shape is assumed.
+ *
+ * 2. **Legacy flat `IconDefinition`** — the same fields as `icon`, but at the **top level** (no nested `icon`).
+ *    Still accepted so existing callers are not broken. Prefer migrating to `CreateIconProps`.
+ *
+ * **Path data on each `IconDefinition`:** use `svgPathData` (string or {@link SVGPathObject}[]). The old name
+ * `svgPath` is deprecated but still read; `svgPathData` wins if both are present.
+ *
+ * **Default vs RH UI rendering:** If `rhUiIcon` is set and the consumer does **not** pass `set` on the component,
+ *    the output is an outer `<svg.pf-v6-svg>` containing **two** inner `<svg>`s (default + rh-ui) so CSS can swap
+ *    which variant is visible. If `set` is `"default"` or `"rh-ui"`, a **single** flat `<svg>` is rendered for that
+ *    variant. Requesting `set="rh-ui"` when there is no `rhUiIcon` falls back to the default glyph and logs a
+ *    `console.warn` (see implementation).
+ *
+ * @param arg Icon configuration: either {@link CreateIconProps} (nested `icon` / `rhUiIcon`) or a legacy flat
+ *    {@link LegacyFlatIconDefinition}. Runtime detection follows the rules in **Argument shape** above.
+ * @returns A `ComponentClass<SVGIconProps>` — render it as `<YourIcon />` or with `title`, `className`, `set`, etc.
  */
-export function createIcon({ name, icon, rhUiIcon = null }: CreateIconProps): React.ComponentClass<SVGIconProps> {
+export function createIcon(arg: CreateIconProps | LegacyFlatIconDefinition): React.ComponentClass<SVGIconProps> {
+  const { name, icon, rhUiIcon = null } = normalizeCreateIconArg(arg);
+
   return class SVGIcon extends Component<SVGIconProps> {
     static displayName = name;
 
@@ -76,10 +190,7 @@ export function createIcon({ name, icon, rhUiIcon = null }: CreateIconProps): Re
       noDefaultStyle: false
     };
 
-    constructor(props: SVGIconProps) {
-      super(props);
-    }
-
+    /** Renders one root `<svg>`; either a single variant or nested inner SVGs for RH UI swap. */
     render() {
       const { title, className: propsClassName, set, noDefaultStyle, ...props } = this.props;
 
@@ -98,8 +209,10 @@ export function createIcon({ name, icon, rhUiIcon = null }: CreateIconProps): Re
       }
 
       if ((set === undefined && rhUiIcon === null) || set !== undefined) {
-        const iconData = set !== undefined && set === 'rh-ui' && rhUiIcon !== null ? rhUiIcon : icon;
-        const { xOffset, yOffset, width, height, svgPathData, svgClassName } = iconData ?? {};
+        const iconData: IconDefinitionWithSvgPathData | undefined =
+          set !== undefined && set === 'rh-ui' && rhUiIcon !== null ? rhUiIcon : icon;
+        const { xOffset, yOffset, width, height, svgPathData, svgClassName } =
+          iconData ?? ({} as Partial<IconDefinitionWithSvgPathData>);
         const _xOffset = xOffset ?? 0;
         const _yOffset = yOffset ?? 0;
         const viewBox = [_xOffset, _yOffset, width, height].join(' ');

--- a/packages/react-icons/src/createIcon.tsx
+++ b/packages/react-icons/src/createIcon.tsx
@@ -16,7 +16,7 @@ export interface IconDefinitionBase {
 
 /**
  * On-disk / nested icon data: `svgPathData` (preferred) or deprecated `svgPath` (at least one is required at
- * runtime for rendering; if both are set, `svgPathData` takes precedence in {@link resolveSvgPathData}).
+ * runtime for rendering; if both are set, `svgPathData` takes precedence when path data is resolved).
  */
 export interface IconDefinition extends IconDefinitionBase {
   svgPathData?: string | SVGPathObject[];
@@ -25,12 +25,6 @@ export interface IconDefinition extends IconDefinitionBase {
    */
   svgPath?: string | SVGPathObject[];
 }
-
-/**
- * {@link createIconBase} and rendering use this after {@link resolveSvgPathData} — not part of the public
- * type surface.
- */
-type NormalizedIconDefinition = Required<Pick<IconDefinition, 'svgPathData'>> & IconDefinition;
 
 /**
  * Nested (current) public API: `{ icon, rhUiIcon?, name? }` as produced by the icon generator and
@@ -43,24 +37,17 @@ export interface CreateIconBaseProps {
 }
 
 /**
- * **Flat (legacy) public API** for {@link createIcon} only — not an alias of {@link IconDefinition} so
- * the legacy shape is obvious at the call site. `createIcon` maps this to {@link CreateIconBaseProps}.
+ * @deprecated Prefer {@link createIconBase} with a nested {@link IconDefinition} using `svgPathData` instead
+ * of this flat `createIcon` shape and legacy `svgPath` field.
  */
-export interface CreateIconLegacyProps {
+export interface CreateIconProps {
   name?: string;
   width: number;
   height: number;
   xOffset?: number;
   yOffset?: number;
-  svgPathData?: string | SVGPathObject[];
-  /**
-   * @deprecated Use {@link CreateIconLegacyProps.svgPathData} instead.
-   */
   svgPath?: string | SVGPathObject[];
   svgClassName?: string;
-  /**
-   * Optional second variant for the `set="rh-ui"` / nested-inner-SVG layout, matching {@link createIconBase}.
-   */
   rhUiIcon?: IconDefinition | null;
 }
 
@@ -75,44 +62,19 @@ export interface SVGIconProps extends Omit<React.HTMLProps<SVGElement>, 'ref'> {
 
 let currentId = 0;
 
-/** Returns path data from `svgPathData` or deprecated `svgPath` (prefers `svgPathData` when both exist). */
-function resolveSvgPathData(icon: IconDefinition): string | SVGPathObject[] {
-  if ('svgPathData' in icon && icon.svgPathData !== undefined) {
-    return icon.svgPathData;
-  }
-  if ('svgPath' in icon && icon.svgPath !== undefined) {
-    return icon.svgPath;
-  }
-  throw new Error('@patternfly/react-icons: IconDefinition must define svgPathData or svgPath');
-}
-
-/** Produces a single {@link NormalizedIconDefinition} for internal rendering. */
-function normalizeIconDefinition(icon: IconDefinition): NormalizedIconDefinition {
-  return {
-    name: icon.name,
-    width: icon.width,
-    height: icon.height,
-    svgPathData: resolveSvgPathData(icon),
-    xOffset: icon.xOffset,
-    yOffset: icon.yOffset,
-    svgClassName: icon.svgClassName
-  };
-}
-
-/** Renders <path> element(s) from resolved (normalized) path data. */
-function pathElementsFromResolvedData(svgPathData: string | SVGPathObject[]): ReactNode {
-  return Array.isArray(svgPathData) ? (
+/** Renders the same path markup as the historical `createIcon` implementation. */
+function getSvgPaths(svgPathData: string | SVGPathObject[] | undefined): ReactNode {
+  return svgPathData && Array.isArray(svgPathData) ? (
     svgPathData.map((pathObject, index) => (
       <path className={pathObject.className} key={`${pathObject.path}-${index}`} d={pathObject.path} />
     ))
   ) : (
-    <path d={svgPathData} />
+    <path d={svgPathData as string} />
   );
 }
 
-/** Renders an inner `<svg>` with viewBox and path(s) for the dual-SVG (CSS swap) layout. */
-const createSvg = (icon: NormalizedIconDefinition, iconClassName: string) => {
-  const { xOffset, yOffset, width, height, svgPathData, svgClassName } = icon;
+const createSvg = (icon: IconDefinition, iconClassName: string) => {
+  const { xOffset, yOffset, width, height, svgPathData, svgClassName } = icon ?? {};
   const _xOffset = xOffset ?? 0;
   const _yOffset = yOffset ?? 0;
   const viewBox = [_xOffset, _yOffset, width, height].join(' ');
@@ -128,61 +90,28 @@ const createSvg = (icon: NormalizedIconDefinition, iconClassName: string) => {
 
   return (
     <svg viewBox={viewBox} className={classNames.join(' ')}>
-      {pathElementsFromResolvedData(svgPathData)}
+      {getSvgPaths(svgPathData)}
     </svg>
   );
 };
 
 /**
- * Preferred factory for **nested** icon config (`icon` and optional `rhUiIcon`). Package-generated icons use this.
- *
- * @param name Optional display name for the component; falls back to `icon.name` when not set.
- * @see {@link createIcon} for the legacy **flat** argument shape.
+ * Factory for the nested / current icon API. Behavior matches the pre-split `createIcon` on `main` (this name
+ * replaces the original export). For path mapping from the flat `svgPath` shape, use {@link createIcon} only.
  */
 export function createIconBase({
   name,
   icon,
   rhUiIcon = null
 }: CreateIconBaseProps): React.ComponentClass<SVGIconProps> {
-  if (icon == null) {
-    const label = name != null ? ` (name: ${String(name)})` : '';
-    throw new Error(`@patternfly/react-icons: createIconBase requires an \`icon\` definition${label}.`);
-  }
-  const normalizedIcon = normalizeIconDefinition(icon);
-  const normalizedRhUiIcon = rhUiIcon != null ? normalizeIconDefinition(rhUiIcon) : null;
-  const displayName = name ?? icon.name;
-
   return class SVGIcon extends Component<SVGIconProps> {
-    static displayName = displayName;
+    static displayName = name;
 
     id = `icon-title-${currentId++}`;
-
-    private warnedMissingRhUi = false;
 
     static defaultProps: SVGIconProps = {
       noDefaultStyle: false
     };
-
-    private warnIfMissingRhUiMapping = () => {
-      if (this.warnedMissingRhUi) {
-        return;
-      }
-      if (this.props.set === 'rh-ui' && normalizedRhUiIcon === null) {
-        this.warnedMissingRhUi = true;
-        // eslint-disable-next-line no-console -- intentional dev-facing warning for invalid set/rh-ui pairing
-        console.warn(
-          `Set "rh-ui" was provided for ${displayName}, but no rh-ui icon data exists for this icon. The default icon will be rendered.`
-        );
-      }
-    };
-
-    componentDidMount() {
-      this.warnIfMissingRhUiMapping();
-    }
-
-    componentDidUpdate() {
-      this.warnIfMissingRhUiMapping();
-    }
 
     /** Renders one root `<svg>`; either a single variant or nested inner SVGs for RH UI swap. */
     render() {
@@ -195,10 +124,16 @@ export function createIconBase({
         classNames.push(propsClassName);
       }
 
-      if (set !== undefined || normalizedRhUiIcon === null) {
-        const iconData: NormalizedIconDefinition =
-          set === 'rh-ui' && normalizedRhUiIcon !== null ? normalizedRhUiIcon : normalizedIcon;
-        const { xOffset, yOffset, width, height, svgPathData, svgClassName } = iconData;
+      if (set === 'rh-ui' && rhUiIcon === null) {
+        // eslint-disable-next-line no-console -- same behavior as main branch createIcon
+        console.warn(
+          `Set "rh-ui" was provided for ${name}, but no rh-ui icon data exists for this icon. The default icon will be rendered.`
+        );
+      }
+
+      if ((set === undefined && rhUiIcon === null) || set !== undefined) {
+        const iconData = set !== undefined && set === 'rh-ui' && rhUiIcon !== null ? rhUiIcon : icon;
+        const { xOffset, yOffset, width, height, svgPathData, svgClassName } = iconData ?? {};
         const _xOffset = xOffset ?? 0;
         const _yOffset = yOffset ?? 0;
         const viewBox = [_xOffset, _yOffset, width, height].join(' ');
@@ -206,8 +141,6 @@ export function createIconBase({
         if (svgClassName && !noDefaultStyle) {
           classNames.push(svgClassName);
         }
-
-        const svgPaths = pathElementsFromResolvedData(svgPathData);
 
         return (
           <svg
@@ -222,7 +155,7 @@ export function createIconBase({
             {...(props as Omit<React.SVGProps<SVGElement>, 'ref'>)} // Lie.
           >
             {hasTitle && <title id={this.id}>{title}</title>}
-            {svgPaths}
+            {getSvgPaths(svgPathData)}
           </svg>
         );
       }
@@ -238,8 +171,8 @@ export function createIconBase({
           {...(props as Omit<React.SVGProps<SVGElement>, 'ref'>)} // Lie.
         >
           {hasTitle && <title id={this.id}>{title}</title>}
-          {createSvg(normalizedIcon, 'pf-v6-icon-default')}
-          {normalizedRhUiIcon && createSvg(normalizedRhUiIcon, 'pf-v6-icon-rh-ui')}
+          {icon && createSvg(icon, 'pf-v6-icon-default')}
+          {rhUiIcon && createSvg(rhUiIcon, 'pf-v6-icon-rh-ui')}
         </svg>
       );
     }
@@ -247,11 +180,11 @@ export function createIconBase({
 }
 
 /**
- * Flat **legacy** entry point: turn {@link CreateIconLegacyProps} into a nested
- * `icon: IconDefinition` with `svgPathData` resolved, then call {@link createIconBase} (all legacy mapping
- * lives in this function). Prefer {@link createIconBase} for the nested `icon` / `rhUiIcon` shape.
+ * Flat **legacy** entry point: turn {@link CreateIconProps} (`svgPath` + layout fields) into a nested
+ * `icon: IconDefinition` with `svgPathData` set from `svgPath`, then call {@link createIconBase}. Use
+ * {@link createIconBase} directly for nested `icon` objects that already use `svgPathData`.
  */
-export function createIcon(legacy: CreateIconLegacyProps): React.ComponentClass<SVGIconProps> {
+export function createIcon(legacy: CreateIconProps): React.ComponentClass<SVGIconProps> {
   const { rhUiIcon = null, ...flat } = legacy;
   const icon: IconDefinition = {
     name: flat.name,
@@ -260,8 +193,7 @@ export function createIcon(legacy: CreateIconLegacyProps): React.ComponentClass<
     xOffset: flat.xOffset,
     yOffset: flat.yOffset,
     svgClassName: flat.svgClassName,
-    // Fold deprecated svgPath (and de-dupe vs svgPathData) in one place, then omit svgPath in the object.
-    svgPathData: resolveSvgPathData(flat as IconDefinition)
+    svgPathData: flat.svgPath
   };
   return createIconBase({ name: icon.name, icon, rhUiIcon });
 }

--- a/packages/react-icons/src/createIcon.tsx
+++ b/packages/react-icons/src/createIcon.tsx
@@ -18,9 +18,7 @@ export interface IconDefinition {
   yOffset?: number;
   svgClassName?: string;
   svgPathData?: string | SVGPathObject[];
-  /**
-   * @deprecated Use {@link IconDefinition.svgPathData} instead.
-   */
+  /** @deprecated Use `svgPathData` for nested definitions. */
   svgPath?: string | SVGPathObject[];
 }
 

--- a/packages/react-icons/src/createIcon.tsx
+++ b/packages/react-icons/src/createIcon.tsx
@@ -35,16 +35,32 @@ export type IconDefinitionWithSvgPathData = Required<Pick<IconDefinition, 'svgPa
  */
 export type IconDefinitionWithSvgPath = Required<Pick<IconDefinition, 'svgPath'>> & IconDefinition;
 
-/** When passing `icon` or `rhUiIcon` keys (nested form), `icon` is required at runtime. */
-export interface CreateIconProps {
+/**
+ * Props for {@link createIconBase} — nested icon definition(s). Used by generated icons and callers
+ * that already structure data as `{ icon, rhUiIcon? }`.
+ */
+export interface CreateIconBaseProps {
   name?: string;
-  icon?: IconDefinition;
+  icon: IconDefinition;
   rhUiIcon?: IconDefinition | null;
 }
 
 /**
- * @deprecated The previous `createIcon` accepted a flat {@link IconDefinition} with top-level
- * `svgPath`. Pass {@link CreateIconProps} with a nested `icon` field instead.
+ * @deprecated Use {@link CreateIconBaseProps} instead.
+ */
+export type CreateIconProps = CreateIconBaseProps;
+
+/**
+ * Props for {@link createIcon} — flat {@link IconDefinition} fields at the top level, optionally with
+ * `rhUiIcon`, matching the pre–nested-config API.
+ */
+export type CreateIconLegacyProps = IconDefinition & {
+  rhUiIcon?: IconDefinition | null;
+};
+
+/**
+ * @deprecated The previous `createIcon` accepted only a flat {@link IconDefinition}. Use {@link createIcon}
+ * for that shape, or {@link createIconBase} with nested `icon` / `rhUiIcon`.
  */
 export type LegacyFlatIconDefinition = IconDefinition;
 
@@ -83,44 +99,6 @@ function normalizeIconDefinition(icon: IconDefinition): IconDefinitionWithSvgPat
   };
 }
 
-/** True when the argument uses the nested `CreateIconProps` shape (`icon` and/or `rhUiIcon` keys). */
-function isNestedCreateIconProps(arg: object): arg is CreateIconProps {
-  return 'icon' in arg || 'rhUiIcon' in arg;
-}
-
-/** Props after resolving legacy `svgPath` and flat `createIcon` arguments. */
-interface NormalizedCreateIconProps {
-  name?: string;
-  icon?: IconDefinitionWithSvgPathData;
-  rhUiIcon: IconDefinitionWithSvgPathData | null;
-}
-
-/**
- * Coerces legacy flat or nested props into normalized {@link NormalizedCreateIconProps}.
- * Nested input must include a non-null `icon` or throws.
- */
-function normalizeCreateIconArg(arg: CreateIconProps | LegacyFlatIconDefinition): NormalizedCreateIconProps {
-  if (isNestedCreateIconProps(arg)) {
-    const p = arg as CreateIconProps;
-    if (p.icon == null) {
-      const label = p.name != null ? ` (name: ${String(p.name)})` : '';
-      throw new Error(
-        `@patternfly/react-icons: createIcon requires an \`icon\` definition when using nested CreateIconProps${label}.`
-      );
-    }
-    return {
-      name: p.name,
-      icon: normalizeIconDefinition(p.icon),
-      rhUiIcon: p.rhUiIcon != null ? normalizeIconDefinition(p.rhUiIcon) : null
-    };
-  }
-  return {
-    name: (arg as LegacyFlatIconDefinition).name,
-    icon: normalizeIconDefinition(arg as IconDefinition),
-    rhUiIcon: null
-  };
-}
-
 /** Renders an inner `<svg>` with viewBox and path(s) for the dual-SVG (CSS swap) layout. */
 const createSvg = (icon: IconDefinitionWithSvgPathData, iconClassName: string) => {
   const { xOffset, yOffset, width, height, svgPathData, svgClassName } = icon ?? {};
@@ -154,35 +132,26 @@ const createSvg = (icon: IconDefinitionWithSvgPathData, iconClassName: string) =
 };
 
 /**
- * Builds a React **class** component that renders a PatternFly SVG icon (`role="img"`, optional `<title>` for a11y).
+ * Preferred factory for **nested** icon config (`icon` and optional `rhUiIcon`). Package-generated icons use this.
  *
- * **Argument shape — pick one:**
- *
- * 1. **`CreateIconProps` (preferred)** — `{ name?, icon?, rhUiIcon? }`. Dimensions and path data sit on `icon`
- *    (and optionally on `rhUiIcon` for Red Hat UI–mapped icons). If the object **has an `icon` or `rhUiIcon` key**
- *    (including `rhUiIcon: null`), this shape is assumed.
- *
- * 2. **Legacy flat `IconDefinition`** — the same fields as `icon`, but at the **top level** (no nested `icon`).
- *    Still accepted so existing callers are not broken. Prefer migrating to `CreateIconProps`.
- *
- * **Path data on each `IconDefinition`:** use `svgPathData` (string or {@link SVGPathObject}[]). The old name
- * `svgPath` is deprecated but still read; `svgPathData` wins if both are present.
- *
- * **Default vs RH UI rendering:** If `rhUiIcon` is set and the consumer does **not** pass `set` on the component,
- *    the output is an outer `<svg.pf-v6-svg>` containing **two** inner `<svg>`s (default + rh-ui) so CSS can swap
- *    which variant is visible. If `set` is `"default"` or `"rh-ui"`, a **single** flat `<svg>` is rendered for that
- *    variant. Requesting `set="rh-ui"` when there is no `rhUiIcon` falls back to the default glyph and logs a
- *    `console.warn` (see implementation).
- *
- * @param arg Icon configuration: either {@link CreateIconProps} (nested `icon` / `rhUiIcon`) or a legacy flat
- *    {@link LegacyFlatIconDefinition}. Runtime detection follows the rules in **Argument shape** above.
- * @returns A `ComponentClass<SVGIconProps>` — render it as `<YourIcon />` or with `title`, `className`, `set`, etc.
+ * @param name Optional display name for the component; falls back to `icon.name` when not set.
+ * @see {@link createIcon} for the legacy **flat** argument shape.
  */
-export function createIcon(arg: CreateIconProps | LegacyFlatIconDefinition): React.ComponentClass<SVGIconProps> {
-  const { name, icon, rhUiIcon = null } = normalizeCreateIconArg(arg);
+export function createIconBase({
+  name,
+  icon,
+  rhUiIcon = null
+}: CreateIconBaseProps): React.ComponentClass<SVGIconProps> {
+  if (icon == null) {
+    const label = name != null ? ` (name: ${String(name)})` : '';
+    throw new Error(`@patternfly/react-icons: createIconBase requires an \`icon\` definition${label}.`);
+  }
+  const normalizedIcon = normalizeIconDefinition(icon);
+  const normalizedRhUiIcon = rhUiIcon != null ? normalizeIconDefinition(rhUiIcon) : null;
+  const displayName = name ?? icon.name;
 
   return class SVGIcon extends Component<SVGIconProps> {
-    static displayName = name;
+    static displayName = displayName;
 
     id = `icon-title-${currentId++}`;
 
@@ -201,16 +170,16 @@ export function createIcon(arg: CreateIconProps | LegacyFlatIconDefinition): Rea
         classNames.push(propsClassName);
       }
 
-      if (set === 'rh-ui' && rhUiIcon === null) {
+      if (set === 'rh-ui' && normalizedRhUiIcon === null) {
         // eslint-disable-next-line no-console
         console.warn(
-          `Set "rh-ui" was provided for ${name}, but no rh-ui icon data exists for this icon. The default icon will be rendered.`
+          `Set "rh-ui" was provided for ${displayName}, but no rh-ui icon data exists for this icon. The default icon will be rendered.`
         );
       }
 
-      if ((set === undefined && rhUiIcon === null) || set !== undefined) {
+      if ((set === undefined && normalizedRhUiIcon === null) || set !== undefined) {
         const iconData: IconDefinitionWithSvgPathData | undefined =
-          set !== undefined && set === 'rh-ui' && rhUiIcon !== null ? rhUiIcon : icon;
+          set !== undefined && set === 'rh-ui' && normalizedRhUiIcon !== null ? normalizedRhUiIcon : normalizedIcon;
         const { xOffset, yOffset, width, height, svgPathData, svgClassName } =
           iconData ?? ({} as Partial<IconDefinitionWithSvgPathData>);
         const _xOffset = xOffset ?? 0;
@@ -259,11 +228,24 @@ export function createIcon(arg: CreateIconProps | LegacyFlatIconDefinition): Rea
             {...(props as Omit<React.SVGProps<SVGElement>, 'ref'>)} // Lie.
           >
             {hasTitle && <title id={this.id}>{title}</title>}
-            {icon && createSvg(icon, 'pf-v6-icon-default')}
-            {rhUiIcon && createSvg(rhUiIcon, 'pf-v6-icon-rh-ui')}
+            {normalizedIcon && createSvg(normalizedIcon, 'pf-v6-icon-default')}
+            {normalizedRhUiIcon && createSvg(normalizedRhUiIcon, 'pf-v6-icon-rh-ui')}
           </svg>
         );
       }
     }
   };
+}
+
+/**
+ * Legacy-friendly factory: **flat** {@link IconDefinition} fields (plus optional `rhUiIcon`) and delegates to
+ * {@link createIconBase}. For nested configs, use {@link createIconBase} directly.
+ */
+export function createIcon(props: CreateIconLegacyProps): React.ComponentClass<SVGIconProps> {
+  const { rhUiIcon, ...icon } = props;
+  return createIconBase({
+    name: icon.name,
+    icon,
+    rhUiIcon: rhUiIcon ?? null
+  });
 }

--- a/packages/react-icons/src/createIcon.tsx
+++ b/packages/react-icons/src/createIcon.tsx
@@ -5,20 +5,18 @@ export interface SVGPathObject {
   className?: string;
 }
 
-export interface IconDefinitionBase {
+/**
+ * Serialized / nested icon data (e.g. from the icon generator or JSON), not the flat {@link CreateIconProps}
+ * shape. `svgPathData` is preferred; deprecated `svgPath` is still supported (at least one path field is
+ * required at runtime; if both are set, `svgPathData` takes precedence).
+ */
+export interface IconDefinition {
   name?: string;
   width: number;
   height: number;
   xOffset?: number;
   yOffset?: number;
   svgClassName?: string;
-}
-
-/**
- * On-disk / nested icon data: `svgPathData` (preferred) or deprecated `svgPath` (at least one is required at
- * runtime for rendering; if both are set, `svgPathData` takes precedence when path data is resolved).
- */
-export interface IconDefinition extends IconDefinitionBase {
   svgPathData?: string | SVGPathObject[];
   /**
    * @deprecated Use {@link IconDefinition.svgPathData} instead.

--- a/packages/react-icons/src/createIcon.tsx
+++ b/packages/react-icons/src/createIcon.tsx
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import { Component, type ReactNode } from 'react';
 
 export interface SVGPathObject {
   path: string;
@@ -51,18 +51,28 @@ export interface CreateIconBaseProps {
 export type CreateIconProps = CreateIconBaseProps;
 
 /**
- * Props for {@link createIcon} — flat {@link IconDefinition} fields at the top level, optionally with
- * `rhUiIcon`, matching the pre–nested-config API.
+ * The **flat (legacy) public API** for {@link createIcon}: the same path/view fields as
+ * {@link IconDefinition} at the top level, plus optional `rhUiIcon` for the dual-`set` layout.
+ * `createIcon` is the only entry that accepts this shape; it maps to {@link CreateIconBaseProps} and calls
+ * {@link createIconBase} (see {@link createIcon}).
  */
-export type CreateIconLegacyProps = IconDefinition & {
+export interface CreateIconLegacyProps {
+  name?: string;
+  width: number;
+  height: number;
+  xOffset?: number;
+  yOffset?: number;
+  svgPathData?: string | SVGPathObject[];
+  /**
+   * @deprecated Use {@link CreateIconLegacyProps.svgPathData} instead.
+   */
+  svgPath?: string | SVGPathObject[];
+  svgClassName?: string;
+  /**
+   * Optional second variant for the `set="rh-ui"` / nested-inner-SVG layout, matching {@link createIconBase}.
+   */
   rhUiIcon?: IconDefinition | null;
-};
-
-/**
- * @deprecated The previous `createIcon` accepted only a flat {@link IconDefinition}. Use {@link createIcon}
- * for that shape, or {@link createIconBase} with nested `icon` / `rhUiIcon`.
- */
-export type LegacyFlatIconDefinition = IconDefinition;
+}
 
 export interface SVGIconProps extends Omit<React.HTMLProps<SVGElement>, 'ref'> {
   title?: string;
@@ -99,14 +109,25 @@ function normalizeIconDefinition(icon: IconDefinition): IconDefinitionWithSvgPat
   };
 }
 
+/** Renders <path> element(s) from resolved (normalized) path data. */
+function pathElementsFromResolvedData(svgPathData: string | SVGPathObject[]): ReactNode {
+  return Array.isArray(svgPathData) ? (
+    svgPathData.map((pathObject, index) => (
+      <path className={pathObject.className} key={`${pathObject.path}-${index}`} d={pathObject.path} />
+    ))
+  ) : (
+    <path d={svgPathData} />
+  );
+}
+
 /** Renders an inner `<svg>` with viewBox and path(s) for the dual-SVG (CSS swap) layout. */
 const createSvg = (icon: IconDefinitionWithSvgPathData, iconClassName: string) => {
-  const { xOffset, yOffset, width, height, svgPathData, svgClassName } = icon ?? {};
+  const { xOffset, yOffset, width, height, svgPathData, svgClassName } = icon;
   const _xOffset = xOffset ?? 0;
   const _yOffset = yOffset ?? 0;
   const viewBox = [_xOffset, _yOffset, width, height].join(' ');
 
-  const classNames = [];
+  const classNames: string[] = [];
 
   if (svgClassName) {
     classNames.push(svgClassName);
@@ -115,18 +136,9 @@ const createSvg = (icon: IconDefinitionWithSvgPathData, iconClassName: string) =
     classNames.push(iconClassName);
   }
 
-  const svgPaths =
-    svgPathData && Array.isArray(svgPathData) ? (
-      svgPathData.map((pathObject, index) => (
-        <path className={pathObject.className} key={`${pathObject.path}-${index}`} d={pathObject.path} />
-      ))
-    ) : (
-      <path d={svgPathData as string} />
-    );
-
   return (
     <svg viewBox={viewBox} className={classNames.join(' ')}>
-      {svgPaths}
+      {pathElementsFromResolvedData(svgPathData)}
     </svg>
   );
 };
@@ -155,9 +167,32 @@ export function createIconBase({
 
     id = `icon-title-${currentId++}`;
 
+    private warnedMissingRhUi = false;
+
     static defaultProps: SVGIconProps = {
       noDefaultStyle: false
     };
+
+    private warnIfMissingRhUiMapping = () => {
+      if (this.warnedMissingRhUi) {
+        return;
+      }
+      if (this.props.set === 'rh-ui' && normalizedRhUiIcon === null) {
+        this.warnedMissingRhUi = true;
+        // eslint-disable-next-line no-console -- intentional dev-facing warning for invalid set/rh-ui pairing
+        console.warn(
+          `Set "rh-ui" was provided for ${displayName}, but no rh-ui icon data exists for this icon. The default icon will be rendered.`
+        );
+      }
+    };
+
+    componentDidMount() {
+      this.warnIfMissingRhUiMapping();
+    }
+
+    componentDidUpdate() {
+      this.warnIfMissingRhUiMapping();
+    }
 
     /** Renders one root `<svg>`; either a single variant or nested inner SVGs for RH UI swap. */
     render() {
@@ -170,18 +205,10 @@ export function createIconBase({
         classNames.push(propsClassName);
       }
 
-      if (set === 'rh-ui' && normalizedRhUiIcon === null) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          `Set "rh-ui" was provided for ${displayName}, but no rh-ui icon data exists for this icon. The default icon will be rendered.`
-        );
-      }
-
-      if ((set === undefined && normalizedRhUiIcon === null) || set !== undefined) {
-        const iconData: IconDefinitionWithSvgPathData | undefined =
-          set !== undefined && set === 'rh-ui' && normalizedRhUiIcon !== null ? normalizedRhUiIcon : normalizedIcon;
-        const { xOffset, yOffset, width, height, svgPathData, svgClassName } =
-          iconData ?? ({} as Partial<IconDefinitionWithSvgPathData>);
+      if (set !== undefined || normalizedRhUiIcon === null) {
+        const iconData: IconDefinitionWithSvgPathData =
+          set === 'rh-ui' && normalizedRhUiIcon !== null ? normalizedRhUiIcon : normalizedIcon;
+        const { xOffset, yOffset, width, height, svgPathData, svgClassName } = iconData;
         const _xOffset = xOffset ?? 0;
         const _yOffset = yOffset ?? 0;
         const viewBox = [_xOffset, _yOffset, width, height].join(' ');
@@ -190,14 +217,7 @@ export function createIconBase({
           classNames.push(svgClassName);
         }
 
-        const svgPaths =
-          svgPathData && Array.isArray(svgPathData) ? (
-            svgPathData.map((pathObject, index) => (
-              <path className={pathObject.className} key={`${pathObject.path}-${index}`} d={pathObject.path} />
-            ))
-          ) : (
-            <path d={svgPathData as string} />
-          );
+        const svgPaths = pathElementsFromResolvedData(svgPathData);
 
         return (
           <svg
@@ -215,37 +235,34 @@ export function createIconBase({
             {svgPaths}
           </svg>
         );
-      } else {
-        return (
-          <svg
-            className={classNames.join(' ')}
-            fill="currentColor"
-            aria-labelledby={hasTitle ? this.id : null}
-            aria-hidden={hasTitle ? null : true}
-            role="img"
-            width="1em"
-            height="1em"
-            {...(props as Omit<React.SVGProps<SVGElement>, 'ref'>)} // Lie.
-          >
-            {hasTitle && <title id={this.id}>{title}</title>}
-            {normalizedIcon && createSvg(normalizedIcon, 'pf-v6-icon-default')}
-            {normalizedRhUiIcon && createSvg(normalizedRhUiIcon, 'pf-v6-icon-rh-ui')}
-          </svg>
-        );
       }
+      return (
+        <svg
+          className={classNames.join(' ')}
+          fill="currentColor"
+          aria-labelledby={hasTitle ? this.id : null}
+          aria-hidden={hasTitle ? null : true}
+          role="img"
+          width="1em"
+          height="1em"
+          {...(props as Omit<React.SVGProps<SVGElement>, 'ref'>)} // Lie.
+        >
+          {hasTitle && <title id={this.id}>{title}</title>}
+          {createSvg(normalizedIcon, 'pf-v6-icon-default')}
+          {normalizedRhUiIcon && createSvg(normalizedRhUiIcon, 'pf-v6-icon-rh-ui')}
+        </svg>
+      );
     }
   };
 }
 
 /**
- * Legacy-friendly factory: **flat** {@link IconDefinition} fields (plus optional `rhUiIcon`) and delegates to
- * {@link createIconBase}. For nested configs, use {@link createIconBase} directly.
+ * Legacy **flat** factory: maps {@link CreateIconLegacyProps} to {@link CreateIconBaseProps} and calls
+ * {@link createIconBase} (all remapping lives here; `createIconBase` only implements rendering). For the
+ * nested `icon` / `rhUiIcon` shape, use {@link createIconBase} directly.
  */
-export function createIcon(props: CreateIconLegacyProps): React.ComponentClass<SVGIconProps> {
-  const { rhUiIcon, ...icon } = props;
-  return createIconBase({
-    name: icon.name,
-    icon,
-    rhUiIcon: rhUiIcon ?? null
-  });
+export function createIcon(legacy: CreateIconLegacyProps): React.ComponentClass<SVGIconProps> {
+  const { rhUiIcon = null, ...iconFields } = legacy;
+  const icon: IconDefinition = iconFields;
+  return createIconBase({ name: icon.name, icon, rhUiIcon });
 }

--- a/packages/react-icons/src/createIcon.tsx
+++ b/packages/react-icons/src/createIcon.tsx
@@ -15,8 +15,8 @@ export interface IconDefinitionBase {
 }
 
 /**
- * SVG path content for one icon variant (default or rh-ui). At runtime at least one of
- * `svgPathData` or `svgPath` must be set; if both are present, `svgPathData` is used.
+ * On-disk / nested icon data: `svgPathData` (preferred) or deprecated `svgPath` (at least one is required at
+ * runtime for rendering; if both are set, `svgPathData` takes precedence in {@link resolveSvgPathData}).
  */
 export interface IconDefinition extends IconDefinitionBase {
   svgPathData?: string | SVGPathObject[];
@@ -26,18 +26,15 @@ export interface IconDefinition extends IconDefinitionBase {
   svgPath?: string | SVGPathObject[];
 }
 
-/** Narrows {@link IconDefinition} to the preferred shape with required `svgPathData`. */
-export type IconDefinitionWithSvgPathData = Required<Pick<IconDefinition, 'svgPathData'>> & IconDefinition;
-
 /**
- * @deprecated Use {@link IconDefinition} with `svgPathData` instead.
- * Narrows {@link IconDefinition} to the legacy shape with required `svgPath`.
+ * {@link createIconBase} and rendering use this after {@link resolveSvgPathData} — not part of the public
+ * type surface.
  */
-export type IconDefinitionWithSvgPath = Required<Pick<IconDefinition, 'svgPath'>> & IconDefinition;
+type NormalizedIconDefinition = Required<Pick<IconDefinition, 'svgPathData'>> & IconDefinition;
 
 /**
- * Props for {@link createIconBase} — nested icon definition(s). Used by generated icons and callers
- * that already structure data as `{ icon, rhUiIcon? }`.
+ * Nested (current) public API: `{ icon, rhUiIcon?, name? }` as produced by the icon generator and
+ * `createIconBase` consumers.
  */
 export interface CreateIconBaseProps {
   name?: string;
@@ -46,15 +43,8 @@ export interface CreateIconBaseProps {
 }
 
 /**
- * @deprecated Use {@link CreateIconBaseProps} instead.
- */
-export type CreateIconProps = CreateIconBaseProps;
-
-/**
- * The **flat (legacy) public API** for {@link createIcon}: the same path/view fields as
- * {@link IconDefinition} at the top level, plus optional `rhUiIcon` for the dual-`set` layout.
- * `createIcon` is the only entry that accepts this shape; it maps to {@link CreateIconBaseProps} and calls
- * {@link createIconBase} (see {@link createIcon}).
+ * **Flat (legacy) public API** for {@link createIcon} only — not an alias of {@link IconDefinition} so
+ * the legacy shape is obvious at the call site. `createIcon` maps this to {@link CreateIconBaseProps}.
  */
 export interface CreateIconLegacyProps {
   name?: string;
@@ -96,8 +86,8 @@ function resolveSvgPathData(icon: IconDefinition): string | SVGPathObject[] {
   throw new Error('@patternfly/react-icons: IconDefinition must define svgPathData or svgPath');
 }
 
-/** Produces a single {@link IconDefinitionWithSvgPathData} for internal rendering. */
-function normalizeIconDefinition(icon: IconDefinition): IconDefinitionWithSvgPathData {
+/** Produces a single {@link NormalizedIconDefinition} for internal rendering. */
+function normalizeIconDefinition(icon: IconDefinition): NormalizedIconDefinition {
   return {
     name: icon.name,
     width: icon.width,
@@ -121,7 +111,7 @@ function pathElementsFromResolvedData(svgPathData: string | SVGPathObject[]): Re
 }
 
 /** Renders an inner `<svg>` with viewBox and path(s) for the dual-SVG (CSS swap) layout. */
-const createSvg = (icon: IconDefinitionWithSvgPathData, iconClassName: string) => {
+const createSvg = (icon: NormalizedIconDefinition, iconClassName: string) => {
   const { xOffset, yOffset, width, height, svgPathData, svgClassName } = icon;
   const _xOffset = xOffset ?? 0;
   const _yOffset = yOffset ?? 0;
@@ -206,7 +196,7 @@ export function createIconBase({
       }
 
       if (set !== undefined || normalizedRhUiIcon === null) {
-        const iconData: IconDefinitionWithSvgPathData =
+        const iconData: NormalizedIconDefinition =
           set === 'rh-ui' && normalizedRhUiIcon !== null ? normalizedRhUiIcon : normalizedIcon;
         const { xOffset, yOffset, width, height, svgPathData, svgClassName } = iconData;
         const _xOffset = xOffset ?? 0;
@@ -257,12 +247,21 @@ export function createIconBase({
 }
 
 /**
- * Legacy **flat** factory: maps {@link CreateIconLegacyProps} to {@link CreateIconBaseProps} and calls
- * {@link createIconBase} (all remapping lives here; `createIconBase` only implements rendering). For the
- * nested `icon` / `rhUiIcon` shape, use {@link createIconBase} directly.
+ * Flat **legacy** entry point: turn {@link CreateIconLegacyProps} into a nested
+ * `icon: IconDefinition` with `svgPathData` resolved, then call {@link createIconBase} (all legacy mapping
+ * lives in this function). Prefer {@link createIconBase} for the nested `icon` / `rhUiIcon` shape.
  */
 export function createIcon(legacy: CreateIconLegacyProps): React.ComponentClass<SVGIconProps> {
-  const { rhUiIcon = null, ...iconFields } = legacy;
-  const icon: IconDefinition = iconFields;
+  const { rhUiIcon = null, ...flat } = legacy;
+  const icon: IconDefinition = {
+    name: flat.name,
+    width: flat.width,
+    height: flat.height,
+    xOffset: flat.xOffset,
+    yOffset: flat.yOffset,
+    svgClassName: flat.svgClassName,
+    // Fold deprecated svgPath (and de-dupe vs svgPathData) in one place, then omit svgPath in the object.
+    svgPathData: resolveSvgPathData(flat as IconDefinition)
+  };
   return createIconBase({ name: icon.name, icon, rhUiIcon });
 }

--- a/packages/react-icons/src/createIcon.tsx
+++ b/packages/react-icons/src/createIcon.tsx
@@ -74,7 +74,7 @@ function getSvgPaths(svgPathData: string | SVGPathObject[] | undefined): ReactNo
 }
 
 const createSvg = (icon: IconDefinition, iconClassName: string) => {
-  const { xOffset, yOffset, width, height, svgPathData, svgClassName } = icon ?? {};
+  const { xOffset, yOffset, width, height, svgPathData, svgPath, svgClassName } = icon ?? {};
   const _xOffset = xOffset ?? 0;
   const _yOffset = yOffset ?? 0;
   const viewBox = [_xOffset, _yOffset, width, height].join(' ');
@@ -90,7 +90,7 @@ const createSvg = (icon: IconDefinition, iconClassName: string) => {
 
   return (
     <svg viewBox={viewBox} className={classNames.join(' ')}>
-      {getSvgPaths(svgPathData)}
+      {getSvgPaths(svgPathData ?? svgPath)}
     </svg>
   );
 };
@@ -104,6 +104,11 @@ export function createIconBase({
   icon,
   rhUiIcon = null
 }: CreateIconBaseProps): React.ComponentClass<SVGIconProps> {
+  if (icon == null) {
+    throw new Error(
+      `@patternfly/react-icons: createIconBase requires an \`icon\` definition (name: ${name ?? 'unknown'}).`
+    );
+  }
   return class SVGIcon extends Component<SVGIconProps> {
     static displayName = name;
 
@@ -133,7 +138,7 @@ export function createIconBase({
 
       if ((set === undefined && rhUiIcon === null) || set !== undefined) {
         const iconData = set !== undefined && set === 'rh-ui' && rhUiIcon !== null ? rhUiIcon : icon;
-        const { xOffset, yOffset, width, height, svgPathData, svgClassName } = iconData ?? {};
+        const { xOffset, yOffset, width, height, svgPathData, svgPath, svgClassName } = iconData ?? {};
         const _xOffset = xOffset ?? 0;
         const _yOffset = yOffset ?? 0;
         const viewBox = [_xOffset, _yOffset, width, height].join(' ');
@@ -155,7 +160,7 @@ export function createIconBase({
             {...(props as Omit<React.SVGProps<SVGElement>, 'ref'>)} // Lie.
           >
             {hasTitle && <title id={this.id}>{title}</title>}
-            {getSvgPaths(svgPathData)}
+            {getSvgPaths(svgPathData ?? svgPath)}
           </svg>
         );
       }

--- a/packages/react-icons/src/createIcon.tsx
+++ b/packages/react-icons/src/createIcon.tsx
@@ -6,7 +6,7 @@ export interface SVGPathObject {
 }
 
 /** Icon data format */
-export interface IconDefinition {
+export interface IconData {
   name?: string;
   width: number;
   height: number;
@@ -14,22 +14,17 @@ export interface IconDefinition {
   yOffset?: number;
   svgClassName?: string;
   svgPathData?: string | SVGPathObject[];
-  /** @deprecated Use `svgPathData` for nested definitions. */
-  svgPath?: string | SVGPathObject[];
 }
 
-/** Argument shape for {@link createIconBase} (module-private interface, not exported). */
+/** Internal API props  */
 interface CreateIconBaseProps {
   name?: string;
-  icon?: IconDefinition;
-  rhUiIcon?: IconDefinition | null;
+  icon?: IconData;
+  rhUiIcon?: IconData | null;
 }
 
-/**
- * Flat props shape for {@link createIcon}: layout fields plus `svgPath` (mapped to {@link IconDefinition.svgPathData}
- * on the nested `icon` before calling {@link createIconBase}).
- */
-export interface CreateIconProps {
+/** Public API props */
+export interface IconDefinition {
   name?: string;
   width: number;
   height: number;
@@ -37,9 +32,10 @@ export interface CreateIconProps {
   yOffset?: number;
   svgPath?: string | SVGPathObject[];
   svgClassName?: string;
-  rhUiIcon?: IconDefinition | null;
+  rhUiIcon?: IconData | null;
 }
 
+/** Additional svg props */
 export interface SVGIconProps extends Omit<React.HTMLProps<SVGElement>, 'ref'> {
   title?: string;
   className?: string;
@@ -51,7 +47,7 @@ export interface SVGIconProps extends Omit<React.HTMLProps<SVGElement>, 'ref'> {
 
 let currentId = 0;
 
-/** Renders `<path>` elements from `svgPathData` (string `d` or array of `{ path, className? }`). */
+/** Returns svg path(s) from a given svg data object. */
 function getSvgPaths(svgPathData: string | SVGPathObject[] | undefined): ReactNode {
   return svgPathData && Array.isArray(svgPathData) ? (
     svgPathData.map((pathObject, index) => (
@@ -62,9 +58,8 @@ function getSvgPaths(svgPathData: string | SVGPathObject[] | undefined): ReactNo
   );
 }
 
-const createSvg = (icon: IconDefinition, iconClassName: string) => {
+const createInnerSvg = (icon: IconData, iconClassName: string) => {
   const { xOffset, yOffset, width, height, svgPathData, svgClassName } = icon ?? {};
-  const resolvedPathData = svgPathData ?? icon?.svgPath;
   const _xOffset = xOffset ?? 0;
   const _yOffset = yOffset ?? 0;
   const viewBox = [_xOffset, _yOffset, width, height].join(' ');
@@ -80,21 +75,20 @@ const createSvg = (icon: IconDefinition, iconClassName: string) => {
 
   return (
     <svg viewBox={viewBox} className={classNames.join(' ')}>
-      {getSvgPaths(resolvedPathData)}
+      {getSvgPaths(svgPathData)}
     </svg>
   );
 };
 
 /**
- * Nested icon factory (used by generated icon modules under `dist`). Omitted from published typings when
- * `stripInternal` is enabled; use {@link createIcon} for the flat `svgPath` + layout props shape.
- *
+ * Internal API for creating icons. Subject to change at any time. Please use `createIcon` instead.
  * @internal
  */
 export function createIconBase({ name, icon, rhUiIcon = null }: CreateIconBaseProps): ComponentClass<SVGIconProps> {
   if (icon == null) {
-    throw new Error(
-      `@patternfly/react-icons: createIconBase requires an \`icon\` definition (name: ${name ?? 'unknown'}).`
+    // eslint-disable-next-line no-console
+    console.warn(
+      `@patternfly/react-icons: createIconBase is missing an \`icon\` definition (name: ${name ?? 'unknown'}).`
     );
   }
   return class SVGIcon extends Component<SVGIconProps> {
@@ -106,10 +100,6 @@ export function createIconBase({ name, icon, rhUiIcon = null }: CreateIconBasePr
       noDefaultStyle: false
     };
 
-    /**
-     * One root `<svg>`: a single flat variant when `set` is defined, or when `set` is omitted and `rhUiIcon` is
-     * null; when `set` is omitted and `rhUiIcon` is set, nested inner `<svg>`s (default + RH UI swap layout).
-     */
     render() {
       const { title, className: propsClassName, set, noDefaultStyle, ...props } = this.props;
 
@@ -121,7 +111,7 @@ export function createIconBase({ name, icon, rhUiIcon = null }: CreateIconBasePr
       }
 
       if (set === 'rh-ui' && rhUiIcon === null) {
-        // eslint-disable-next-line no-console -- same behavior as main branch createIcon
+        // eslint-disable-next-line no-console
         console.warn(
           `Set "rh-ui" was provided for ${name}, but no rh-ui icon data exists for this icon. The default icon will be rendered.`
         );
@@ -130,7 +120,6 @@ export function createIconBase({ name, icon, rhUiIcon = null }: CreateIconBasePr
       if ((set === undefined && rhUiIcon === null) || set !== undefined) {
         const iconData = set !== undefined && set === 'rh-ui' && rhUiIcon !== null ? rhUiIcon : icon;
         const { xOffset, yOffset, width, height, svgPathData, svgClassName } = iconData ?? {};
-        const resolvedPathData = svgPathData ?? iconData?.svgPath;
         const _xOffset = xOffset ?? 0;
         const _yOffset = yOffset ?? 0;
         const viewBox = [_xOffset, _yOffset, width, height].join(' ');
@@ -152,7 +141,7 @@ export function createIconBase({ name, icon, rhUiIcon = null }: CreateIconBasePr
             {...(props as Omit<React.SVGProps<SVGElement>, 'ref'>)} // Lie.
           >
             {hasTitle && <title id={this.id}>{title}</title>}
-            {getSvgPaths(resolvedPathData)}
+            {getSvgPaths(svgPathData)}
           </svg>
         );
       }
@@ -168,22 +157,18 @@ export function createIconBase({ name, icon, rhUiIcon = null }: CreateIconBasePr
           {...(props as Omit<React.SVGProps<SVGElement>, 'ref'>)} // Lie.
         >
           {hasTitle && <title id={this.id}>{title}</title>}
-          {icon && createSvg(icon, 'pf-v6-icon-default')}
-          {rhUiIcon && createSvg(rhUiIcon, 'pf-v6-icon-rh-ui')}
+          {icon && createInnerSvg(icon, 'pf-v6-icon-default')}
+          {rhUiIcon && createInnerSvg(rhUiIcon, 'pf-v6-icon-rh-ui')}
         </svg>
       );
     }
   };
 }
 
-/**
- * Maps {@link CreateIconProps} (flat layout + `svgPath`) to a nested {@link IconDefinition} (`svgPath` →
- * `svgPathData`), then returns the component class from {@link createIconBase}. Generated icon modules call
- * {@link createIconBase} directly with nested data (see `@internal` on `createIconBase`).
- */
-export function createIcon(props: CreateIconProps): ComponentClass<SVGIconProps> {
+/** Public API for creating icons. Will be maintained up to breaking releases. */
+export function createIcon(props: IconDefinition): ComponentClass<SVGIconProps> {
   const { rhUiIcon = null, ...rest } = props;
-  const icon: IconDefinition = {
+  const icon: IconData = {
     name: rest.name,
     width: rest.width,
     height: rest.height,

--- a/packages/react-icons/src/createIcon.tsx
+++ b/packages/react-icons/src/createIcon.tsx
@@ -1,15 +1,11 @@
-import { Component, type ReactNode } from 'react';
+import { Component, type ComponentClass, type ReactNode } from 'react';
 
 export interface SVGPathObject {
   path: string;
   className?: string;
 }
 
-/**
- * Serialized / nested icon data (e.g. from the icon generator or JSON), not the flat {@link CreateIconProps}
- * shape. `svgPathData` is preferred; deprecated `svgPath` is still supported (at least one path field is
- * required at runtime; if both are set, `svgPathData` takes precedence).
- */
+/** Icon data format */
 export interface IconDefinition {
   name?: string;
   width: number;
@@ -22,19 +18,16 @@ export interface IconDefinition {
   svgPath?: string | SVGPathObject[];
 }
 
-/**
- * Nested (current) public API: `{ icon, rhUiIcon?, name? }` as produced by the icon generator and
- * `createIconBase` consumers.
- */
-export interface CreateIconBaseProps {
+/** Argument shape for {@link createIconBase} (module-private interface, not exported). */
+interface CreateIconBaseProps {
   name?: string;
-  icon: IconDefinition;
+  icon?: IconDefinition;
   rhUiIcon?: IconDefinition | null;
 }
 
 /**
- * @deprecated Prefer {@link createIconBase} with a nested {@link IconDefinition} using `svgPathData` instead
- * of this flat `createIcon` shape and legacy `svgPath` field.
+ * Flat props shape for {@link createIcon}: layout fields plus `svgPath` (mapped to {@link IconDefinition.svgPathData}
+ * on the nested `icon` before calling {@link createIconBase}).
  */
 export interface CreateIconProps {
   name?: string;
@@ -58,7 +51,7 @@ export interface SVGIconProps extends Omit<React.HTMLProps<SVGElement>, 'ref'> {
 
 let currentId = 0;
 
-/** Renders the same path markup as the historical `createIcon` implementation. */
+/** Renders `<path>` elements from `svgPathData` (string `d` or array of `{ path, className? }`). */
 function getSvgPaths(svgPathData: string | SVGPathObject[] | undefined): ReactNode {
   return svgPathData && Array.isArray(svgPathData) ? (
     svgPathData.map((pathObject, index) => (
@@ -70,7 +63,8 @@ function getSvgPaths(svgPathData: string | SVGPathObject[] | undefined): ReactNo
 }
 
 const createSvg = (icon: IconDefinition, iconClassName: string) => {
-  const { xOffset, yOffset, width, height, svgPathData, svgPath, svgClassName } = icon ?? {};
+  const { xOffset, yOffset, width, height, svgPathData, svgClassName } = icon ?? {};
+  const resolvedPathData = svgPathData ?? icon?.svgPath;
   const _xOffset = xOffset ?? 0;
   const _yOffset = yOffset ?? 0;
   const viewBox = [_xOffset, _yOffset, width, height].join(' ');
@@ -86,20 +80,18 @@ const createSvg = (icon: IconDefinition, iconClassName: string) => {
 
   return (
     <svg viewBox={viewBox} className={classNames.join(' ')}>
-      {getSvgPaths(svgPathData ?? svgPath)}
+      {getSvgPaths(resolvedPathData)}
     </svg>
   );
 };
 
 /**
- * Factory for the nested / current icon API. Behavior matches the pre-split `createIcon` on `main` (this name
- * replaces the original export). For path mapping from the flat `svgPath` shape, use {@link createIcon} only.
+ * Nested icon factory (used by generated icon modules under `dist`). Omitted from published typings when
+ * `stripInternal` is enabled; use {@link createIcon} for the flat `svgPath` + layout props shape.
+ *
+ * @internal
  */
-export function createIconBase({
-  name,
-  icon,
-  rhUiIcon = null
-}: CreateIconBaseProps): React.ComponentClass<SVGIconProps> {
+export function createIconBase({ name, icon, rhUiIcon = null }: CreateIconBaseProps): ComponentClass<SVGIconProps> {
   if (icon == null) {
     throw new Error(
       `@patternfly/react-icons: createIconBase requires an \`icon\` definition (name: ${name ?? 'unknown'}).`
@@ -114,7 +106,10 @@ export function createIconBase({
       noDefaultStyle: false
     };
 
-    /** Renders one root `<svg>`; either a single variant or nested inner SVGs for RH UI swap. */
+    /**
+     * One root `<svg>`: a single flat variant when `set` is defined, or when `set` is omitted and `rhUiIcon` is
+     * null; when `set` is omitted and `rhUiIcon` is set, nested inner `<svg>`s (default + RH UI swap layout).
+     */
     render() {
       const { title, className: propsClassName, set, noDefaultStyle, ...props } = this.props;
 
@@ -134,7 +129,8 @@ export function createIconBase({
 
       if ((set === undefined && rhUiIcon === null) || set !== undefined) {
         const iconData = set !== undefined && set === 'rh-ui' && rhUiIcon !== null ? rhUiIcon : icon;
-        const { xOffset, yOffset, width, height, svgPathData, svgPath, svgClassName } = iconData ?? {};
+        const { xOffset, yOffset, width, height, svgPathData, svgClassName } = iconData ?? {};
+        const resolvedPathData = svgPathData ?? iconData?.svgPath;
         const _xOffset = xOffset ?? 0;
         const _yOffset = yOffset ?? 0;
         const viewBox = [_xOffset, _yOffset, width, height].join(' ');
@@ -156,7 +152,7 @@ export function createIconBase({
             {...(props as Omit<React.SVGProps<SVGElement>, 'ref'>)} // Lie.
           >
             {hasTitle && <title id={this.id}>{title}</title>}
-            {getSvgPaths(svgPathData ?? svgPath)}
+            {getSvgPaths(resolvedPathData)}
           </svg>
         );
       }
@@ -181,20 +177,20 @@ export function createIconBase({
 }
 
 /**
- * Flat **legacy** entry point: turn {@link CreateIconProps} (`svgPath` + layout fields) into a nested
- * `icon: IconDefinition` with `svgPathData` set from `svgPath`, then call {@link createIconBase}. Use
- * {@link createIconBase} directly for nested `icon` objects that already use `svgPathData`.
+ * Maps {@link CreateIconProps} (flat layout + `svgPath`) to a nested {@link IconDefinition} (`svgPath` →
+ * `svgPathData`), then returns the component class from {@link createIconBase}. Generated icon modules call
+ * {@link createIconBase} directly with nested data (see `@internal` on `createIconBase`).
  */
-export function createIcon(legacy: CreateIconProps): React.ComponentClass<SVGIconProps> {
-  const { rhUiIcon = null, ...flat } = legacy;
+export function createIcon(props: CreateIconProps): ComponentClass<SVGIconProps> {
+  const { rhUiIcon = null, ...rest } = props;
   const icon: IconDefinition = {
-    name: flat.name,
-    width: flat.width,
-    height: flat.height,
-    xOffset: flat.xOffset,
-    yOffset: flat.yOffset,
-    svgClassName: flat.svgClassName,
-    svgPathData: flat.svgPath
+    name: rest.name,
+    width: rest.width,
+    height: rest.height,
+    xOffset: rest.xOffset,
+    yOffset: rest.yOffset,
+    svgClassName: rest.svgClassName,
+    svgPathData: rest.svgPath
   };
   return createIconBase({ name: icon.name, icon, rhUiIcon });
 }

--- a/packages/react-icons/tsconfig.json
+++ b/packages/react-icons/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/esm",
+    "stripInternal": true,
     "rootDirs": [
       "src",
       "src/icons",


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #12328 


What was changed:
- Support both the new shape (`CreateIconProps` with `icon` / `rhUiIcon`) and the legacy flat `createIcon({ … svgPath … })` by normalizing at runtime (detect via `icon` / `rhUiIcon` keys).
- Accept `svgPath` or `svgPathData` on `IconDefinition`; resolve to `svgPathData` internally (`svgPathData` wins if both are set).
- Export `LegacyFlatIconDefinition` as an alias for migration/typing.
- Tests: Legacy + new `createIcon` shapes; RH UI (nested swap markup, `set` prop, missing-map warning).
- Docs: expanded JSDoc on createIcon (@param / @returns).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Icons now accept both legacy (flat) and modern (nested) definition formats for broader compatibility.
  * Mapping supports dual modes that render either nested or flat SVGs based on the requested set.

* **Bug Fixes**
  * Improved SVG selection and fallback behavior with clearer warnings and a specific error when a required nested icon definition is missing.

* **Tests**
  * Added coverage for legacy inputs, deprecated fields, rh‑ui mapping behaviors, warnings, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->