### PR TITLE
chore(docs): removes dead link in react-core README

### DIFF
--- a/packages/react-core/README.md
+++ b/packages/react-core/README.md
@@ -45,9 +45,6 @@ export default <Button variant="primary">Button</Button>;
 
 All component documentation is available on [PatternFly.org](https://www.patternfly.org/components/about-modal).
 
-#### Advanced usage
-1. [Applying Overpass font](https://github.com/patternfly/patternfly-react/blob/main/ADVANCED-USAGE-README.md#Applying-Overpass-font)
-
 ### Contribution guidelines
 All React contributors must first be [PatternFly community contributors](https://www.patternfly.org/contribute/about). If you are already a PatternFly community contributor, check out the [React contribution guidelines](https://github.com/patternfly/patternfly-react/tree/main/CONTRIBUTING.md) to make React contributions.
 


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**:  Closes: #12350 

Removes a dead link in the `react-core` package README

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the "Advanced usage" section from the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->